### PR TITLE
feat(oss): OSS mode stub for settings/layout.tsx server page

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/layout.tsx
+++ b/apps/web/src/app/(authenticated)/settings/layout.tsx
@@ -3,8 +3,25 @@ import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 import { PageHeader } from '@/components/ui/page-header';
+import { isOssMode } from '@/lib/storage/factory';
 
 export default async function SettingsLayout({ children }: { children: ReactNode }) {
+  if (isOssMode()) {
+    const { OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
+    return (
+      <div className="flex min-h-screen flex-col">
+        <PageHeader
+          title="Settings"
+          description="Manage your account, projects, and preferences"
+        />
+        <div className="flex flex-1">
+          <SettingsSidebar isAdmin={true} currentProjectId={OSS_PROJECT_ID} />
+          <main className="flex-1 p-6">{children}</main>
+        </div>
+      </div>
+    );
+  }
+
   const cookieStore = await cookies();
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,


### PR DESCRIPTION
## Summary
- `settings/layout.tsx`가 `createServerClient` + `supabase.auth.getUser()` 직접 호출로 OSS_MODE에서 500 발생
- `isOssMode()` 얼리 리턴 추가 → `OSS_PROJECT_ID`와 `isAdmin=true`로 렌더링
- 나머지 대상 페이지 12건은 모두 `'use client'` — SSR Supabase 호출 없음, `(authenticated)/layout.tsx`로 이미 보호됨

## 변경 파일
| 파일 | 수정 내용 |
|------|---------|
| `settings/layout.tsx` | `isOssMode()` 얼리 리턴, `OSS_PROJECT_ID`/`isAdmin=true` |

## 검증
- 기타 페이지 (mockups/meetings/board/docs/inbox/retro/rewards) grep 확인 → SSR Supabase 호출 0건
- client-side API 오류는 AC-4 명시에 따라 별도 커버

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 146 files, 918 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)