### PR TITLE
feat(oss): OSS guards for SaaS-only routes (Slack/webhook/cron/usage)

### DIFF
--- a/apps/web/src/app/api/cron/agent-session-recovery/route.ts
+++ b/apps/web/src/app/api/cron/agent-session-recovery/route.ts
@@ -1,11 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { AgentSessionLifecycleService } from '@/services/agent-session-lifecycle';
 import { resumeSessionCandidates } from '@/services/agent-session-resume';
 
 const CRON_SECRET = process.env.CRON_SECRET;
 
 export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess({ ok: true, skipped: true });
   const authHeader = request.headers.get('authorization');
   if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {
     return apiError('UNAUTHORIZED', 'Unauthorized', 401);

--- a/apps/web/src/app/api/cron/anonymize/route.ts
+++ b/apps/web/src/app/api/cron/anonymize/route.ts
@@ -1,10 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 import { apiSuccess, apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 const CRON_SECRET = process.env.CRON_SECRET;
 
 /** POST — 30일 경과 탈퇴 유저 PII 익명화 + auth 삭제 (cron에서 호출) */
 export async function POST(request: Request) {
+  if (isOssMode()) return apiSuccess({ ok: true, skipped: true });
   // 크론 인증
   const authHeader = request.headers.get('authorization');
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {

--- a/apps/web/src/app/api/cron/hitl-timeouts/route.ts
+++ b/apps/web/src/app/api/cron/hitl-timeouts/route.ts
@@ -1,10 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { AgentHitlTimeoutService } from '@/services/agent-hitl-timeout';
 
 const CRON_SECRET = process.env.CRON_SECRET;
 
 export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess({ ok: true, skipped: true });
   const authHeader = request.headers.get('authorization');
   if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {
     return apiError('UNAUTHORIZED', 'Unauthorized', 401);

--- a/apps/web/src/app/api/cron/retry-agent-runs/route.ts
+++ b/apps/web/src/app/api/cron/retry-agent-runs/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { apiSuccess, apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { AgentRetryService } from '@/services/agent-retry';
 import { fireWebhooks } from '@/services/webhook-notify';
 
@@ -16,6 +17,7 @@ const CRON_SECRET = process.env.CRON_SECRET;
  * GET /api/cron/retry-agent-runs?secret=CRON_SECRET
  */
 export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess({ ok: true, skipped: true });
   // cron 인증
   const authHeader = request.headers.get('authorization');
   if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {

--- a/apps/web/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.ts
@@ -1,10 +1,12 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getMyTeamMember } from '@/lib/auth-helpers';
-import { ApiErrors } from '@/lib/api-response';
+import { apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { buildSlackConnectUrl } from '@/services/slack-channel-mapping';
 
 export async function GET() {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const supabase = await createSupabaseServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return ApiErrors.unauthorized();

--- a/apps/web/src/app/api/settings/slack-integration/route.ts
+++ b/apps/web/src/app/api/settings/slack-integration/route.ts
@@ -3,7 +3,8 @@ import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import {
   buildSlackConnectUrl,
   isExpiredIsoTimestamp,
@@ -51,6 +52,7 @@ function buildConnectUrl(orgId: string, projectId: string) {
 }
 
 export async function GET() {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const ctx = await requireAdminContext();
     if ('error' in ctx) return ctx.error;
@@ -140,6 +142,7 @@ export async function GET() {
 }
 
 export async function PUT(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const ctx = await requireAdminContext();
     if ('error' in ctx) return ctx.error;

--- a/apps/web/src/app/api/usage/route.ts
+++ b/apps/web/src/app/api/usage/route.ts
@@ -1,10 +1,12 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 
 /** GET /api/usage — AC5: 조직의 현재 월 usage meters */
 export async function GET() {
+  if (isOssMode()) return apiSuccess([]);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/v1/bridge/slack/events/route.ts
+++ b/apps/web/src/app/api/v1/bridge/slack/events/route.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { BridgeInboundService } from '@/services/bridge-inbound';
 import {
   normalizeSlackEvent,
@@ -11,6 +12,7 @@ import {
 } from '@/services/slack-inbound';
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const signingSecret = process.env['SLACK_SIGNING_SECRET'];
   if (!signingSecret) {
     return apiError('CONFIGURATION_ERROR', 'Slack signing secret not configured', 500);

--- a/apps/web/src/app/api/v1/bridge/slack/interactions/route.ts
+++ b/apps/web/src/app/api/v1/bridge/slack/interactions/route.ts
@@ -1,4 +1,6 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { BridgeInboundService } from '@/services/bridge-inbound';
 import { AgentHitlService, HitlConflictError } from '@/services/agent-hitl';
 import { syncSlackHitlRequestState, type SlackHitlRequestContext } from '@/services/slack-hitl';
@@ -64,6 +66,7 @@ async function loadHitlRequest(supabase: Pick<SupabaseClient, 'from'>, requestId
 }
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const signingSecret = process.env['SLACK_SIGNING_SECRET'];
   if (!signingSecret) {
     return Response.json({ text: 'Slack signing secret missing' }, { status: 500 });

--- a/apps/web/src/app/api/v1/bridge/teams/events/route.ts
+++ b/apps/web/src/app/api/v1/bridge/teams/events/route.ts
@@ -1,8 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { BridgeInboundService } from '@/services/bridge-inbound';
 import { getTeamsSourceChannelId, normalizeTeamsActivity, resolveTeamsInboundConfig, shouldIgnoreTeamsActivity, verifyTeamsRequest, type TeamsActivity } from '@/services/teams-inbound';
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !serviceRoleKey) {

--- a/apps/web/src/app/api/webhooks/agent-runtime/route.ts
+++ b/apps/web/src/app/api/webhooks/agent-runtime/route.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { z } from 'zod';
 import { apiError, apiSuccess } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { AgentExecutionLoop } from '@/services/agent-execution-loop';
 
 const routingSchema = z.object({
@@ -136,6 +137,7 @@ async function validateWebhookSecret(
 }
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const supabase = createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.SUPABASE_SERVICE_ROLE_KEY!,

--- a/apps/web/src/app/api/webhooks/config/route.ts
+++ b/apps/web/src/app/api/webhooks/config/route.ts
@@ -1,10 +1,12 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 
 /** GET — 내 웹훅 설정 목록 */
 export async function GET() {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -26,6 +28,7 @@ export async function GET() {
 
 /** PUT — 웹훅 설정 upsert */
 export async function PUT(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -2,9 +2,11 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { requireOrgAdmin } from '@/lib/admin-check';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -21,6 +23,7 @@ export async function GET(request: Request) {
 }
 
 export async function PUT(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- Slack/Teams + 웹훅 라우트 (9건): `isOssMode()` → 503 NOT_AVAILABLE
- Cron 라우트 (4건): `isOssMode()` → 200 `{ok:true, skipped:true}` (스케줄러 실패 방지)
- `/api/usage`: `isOssMode()` → 빈 배열 (NullSubscription 패턴 일관성)

## 변경 라우트 (13건)
| 라우트 | OSS 동작 |
|--------|---------|
| `settings/slack-integration` GET/PUT | 503 |
| `integrations/slack/connect` GET | 503 |
| `v1/bridge/slack/events` POST | 503 |
| `v1/bridge/slack/interactions` POST | 503 |
| `v1/bridge/teams/events` POST | 503 |
| `webhooks` GET/PUT | 503 |
| `webhooks/config` GET/PUT | 503 |
| `webhooks/agent-runtime` POST | 503 |
| `cron/agent-session-recovery` GET | 200 no-op |
| `cron/anonymize` POST | 200 no-op |
| `cron/hitl-timeouts` GET | 200 no-op |
| `cron/retry-agent-runs` GET | 200 no-op |
| `usage` GET | `[]` |

## Test plan
- [x] `pnpm type-check` — 0 errors
- [x] `pnpm test` — 146 files, 918 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)