### PR TITLE
feat(oss): S-OSS-MOCKUPS — mockup/attachment/policy 라우트 OSS 분기

### DIFF
--- a/apps/web/src/app/api/mcp/mockups/route.ts
+++ b/apps/web/src/app/api/mcp/mockups/route.ts
@@ -5,6 +5,7 @@ import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { MockupService } from '@/services/mockup';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { checkResourceLimit } from '@/lib/check-feature';
+import { isOssMode } from '@/lib/storage/factory';
 
 // MCP tool action schemas
 const ListMockupsSchema = z.object({
@@ -68,6 +69,7 @@ const McpRequestSchema = z.discriminatedUnion('action', [
 ]);
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/memos/attachments/route.ts
+++ b/apps/web/src/app/api/memos/attachments/route.ts
@@ -1,7 +1,8 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { getMyTeamMember } from '@/lib/auth-helpers';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024;
 const ALLOWED_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif']);
@@ -25,6 +26,7 @@ function sanitizeFilename(name: string) {
 }
 
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Attachments are not available in OSS mode.', 501);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/memos/convert/route.ts
+++ b/apps/web/src/app/api/memos/convert/route.ts
@@ -2,9 +2,11 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getMyTeamMember } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
 
 /** POST — 메모를 스토리로 전환 */
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Memo conversion is not available in OSS mode.', 501);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/mockups/[id]/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/route.ts
@@ -2,12 +2,14 @@ import { parseBody, updateMockupPageSchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { MockupService } from '@/services/mockup';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 목업 상세 (컴포넌트 포함) */
 export async function GET(_request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -22,6 +24,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
 /** PUT — 목업 수정 (컴포넌트 트리 일괄 교체) */
 export async function PUT(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -39,6 +42,7 @@ export async function PUT(request: Request, { params }: RouteParams) {
 
 /** DELETE — 목업 소프트 삭제 */
 export async function DELETE(_request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();

--- a/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
@@ -1,11 +1,13 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 시나리오 목록 */
 export async function GET(_request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiSuccess([]);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -25,6 +27,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
 /** POST — 시나리오 생성 */
 export async function POST(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -45,6 +48,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
 /** PATCH — 시나리오 수정 */
 export async function PATCH(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -67,6 +71,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
 /** DELETE — 시나리오 삭제 (default 불가) */
 export async function DELETE(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();

--- a/apps/web/src/app/api/mockups/[id]/versions/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/versions/route.ts
@@ -1,11 +1,13 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 버전 히스토리 */
 export async function GET(_request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiSuccess([]);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
@@ -25,6 +27,7 @@ export async function GET(_request: Request, { params }: RouteParams) {
 
 /** POST — 버전 복원 */
 export async function POST(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();

--- a/apps/web/src/app/api/mockups/route.ts
+++ b/apps/web/src/app/api/mockups/route.ts
@@ -6,9 +6,11 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { checkResourceLimit } from '@/lib/check-feature';
 import { apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
 
 /** GET — 목업 목록 (페이지네이션) */
 export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess([]);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -29,6 +31,7 @@ export async function GET(request: Request) {
 
 /** POST — 목업 생성 */
 export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Mockups are not available in OSS mode.', 501);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/app/api/policy-documents/route.ts
+++ b/apps/web/src/app/api/policy-documents/route.ts
@@ -2,8 +2,10 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { PolicyDocumentService } from '@/services/policy-document';
+import { isOssMode } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess([]);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
## Summary
- 목업 5개 라우트: GET → `[]`, POST/PUT/DELETE → 501
- 메모 첨부파일 업로드: POST → 501
- 메모 스토리 전환: POST → 501
- 정책 문서 목록: GET → `[]`
- 8파일 +26/-3, 타입 에러 없음, 전체 테스트 918/918 통과

## AC 충족
1. 목업 GET → 빈 배열, POST/PUT/DELETE → 501 ✅
2. 첨부파일 → 501 ✅
3. 정책 문서 → 빈 배열 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)