### PR TITLE
feat(oss): OSS webhook dispatch for memo assignment + reply (S-OSS-MEMO-WEBHOOK)

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -1,5 +1,7 @@
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { MemoEventDispatcher } from './memo-event-dispatcher';
+import { buildAbsoluteMemoLink } from './app-url';
+import { isOssMode } from '@/lib/storage/factory';
 
 export interface DispatchableMemo {
   id: string;
@@ -18,6 +20,39 @@ export interface DispatchableMemo {
 
 export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) {
   if (!memo.assigned_to || memo.status !== 'open') return;
+
+  if (isOssMode()) {
+    try {
+      const { createTeamMemberRepository } = await import('@/lib/storage/factory');
+      const teamMemberRepo = await createTeamMemberRepository();
+      const member = await teamMemberRepo.getById(memo.assigned_to).catch(() => null);
+      if (!member?.webhook_url) return;
+
+      const memoLabel = memo.title?.trim() ? `"${memo.title.trim()}"` : `#${memo.id.slice(0, 8)}`;
+      const title = `📋 메모 배정: ${memoLabel}`;
+      const preview = memo.content.replace(/\s+/g, ' ').trim().slice(0, 200);
+      const memoLink = buildAbsoluteMemoLink(memo.id, process.env.NEXT_PUBLIC_APP_URL);
+      const description = `${preview}\n\n${memoLink}`;
+
+      const isDiscord = member.webhook_url.includes('discord.com') || member.webhook_url.includes('discordapp.com');
+      const body = isDiscord
+        ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
+        : JSON.stringify({ text: `*${title}*\n${description}` });
+
+      await fetch(member.webhook_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (error) {
+      console.warn(
+        '[MemoDispatch] OSS assignment dispatch failed:',
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+    return;
+  }
 
   try {
     const dispatcher = new MemoEventDispatcher({

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -38,7 +38,7 @@ interface WebhookConfigRow {
 type Logger = Pick<Console, 'warn' | 'error'>;
 
 export interface DispatchWorkflowMemoReplyWebhooksOptions {
-  supabase: SupabaseClient;
+  supabase?: SupabaseClient;
   memo: MemoReplyDispatchMemo;
   reply: MemoReplyDispatchReply;
   logger?: Logger;
@@ -182,6 +182,8 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const logger = options.logger ?? console;
   const fetchFn = options.fetchFn ?? fetch;
   const { memo, reply, supabase } = options;
+
+  if (!supabase) return { status: 'skipped', reason: 'oss_mode' };
 
   if (isSystemFailureReply(reply.content)) {
     return { status: 'skipped', reason: 'system_failure_comment' };


### PR DESCRIPTION
## Summary

- **memo-assignment-dispatch.ts**: isOssMode() 분기 추가. OSS 모드에서 createTeamMemberRepository()로 assignee의 webhook_url 조회 후 직접 HTTP POST. Discord/Slack 포맷 자동 감지. SaaS 경로(MemoEventDispatcher) 무변경.
- **memo-reply-webhook-dispatch.ts**: DispatchWorkflowMemoReplyWebhooksOptions.supabase 옵셔널화. !supabase 시 { status: skipped, reason: oss_mode } early return. OSS reply 웹훅은 MemoService.dispatchOssReplyWebhooks() 담당 (PR #24).

## Test plan

- [ ] tsc --noEmit 타입 에러 없음
- [ ] vitest run 139 파일 / 708 테스트 PASS
- [ ] OSS 모드: 메모 배정 시 assignee webhook_url로 HTTP POST 수신 확인
- [ ] SaaS 모드: 기존 MemoEventDispatcher 경로 정상 동작 확인

Generated with Claude Code