### PR TITLE
feat(oss): SQLite-based project/assignee validation in MemoService.create() (S-OSS-DOMAIN-TRIAGE)

### DIFF
--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -6,7 +6,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, createMemoSchema } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
-import { createMemoRepository, createTeamMemberRepository, isOssMode } from '@/lib/storage/factory';
+import { createMemoRepository, createTeamMemberRepository, createProjectRepository, isOssMode } from '@/lib/storage/factory';
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export async function POST(request: Request) {
@@ -37,7 +37,8 @@ export async function POST(request: Request) {
     const dbClient = isOssMode() ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const repo = await createMemoRepository(dbClient);
     const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;
-    const service = new MemoService(repo, dbClient as SupabaseClient | undefined, teamMemberRepo);
+    const projectRepo = isOssMode() ? await createProjectRepository() : undefined;
+    const service = new MemoService(repo, dbClient as SupabaseClient | undefined, teamMemberRepo, projectRepo);
     const memo = await service.create({
       ...body,
       org_id: me.org_id,

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
-import type { IMemoRepository, ITeamMemberRepository, Memo, MemoReply } from '@sprintable/core-storage';
+import type { IMemoRepository, ITeamMemberRepository, IProjectRepository, Memo, MemoReply } from '@sprintable/core-storage';
 import { SupabaseMemoRepository } from '@sprintable/storage-supabase';
 import { dispatchMemoAssignmentImmediately, type DispatchableMemo } from './memo-assignment-dispatch';
 import { dispatchWorkflowMemoReplyWebhooks } from './memo-reply-webhook-dispatch';
@@ -53,15 +53,18 @@ export class MemoService {
   private readonly repo: IMemoRepository;
   private readonly supabase: SupabaseClient | null;
   private readonly teamMemberRepo: ITeamMemberRepository | null;
+  private readonly projectRepo: IProjectRepository | null;
 
   constructor(
     repo: IMemoRepository,
     supabase?: SupabaseClient,
     teamMemberRepo?: ITeamMemberRepository,
+    projectRepo?: IProjectRepository,
   ) {
     this.repo = repo;
     this.supabase = supabase ?? null;
     this.teamMemberRepo = teamMemberRepo ?? null;
+    this.projectRepo = projectRepo ?? null;
   }
 
   static fromSupabase(supabase: SupabaseClient): MemoService {
@@ -380,6 +383,26 @@ export class MemoService {
           .eq('project_id', input.project_id)
           .single();
         if (!prevMemo) throw new Error('supersedes_id must reference a memo in the same project');
+      }
+    } else if (this.projectRepo && this.teamMemberRepo) {
+      const project = await this.projectRepo.getById(input.project_id).catch(() => null);
+      if (!project || project.org_id !== input.org_id) throw new Error('project_id must belong to the same organization');
+
+      const author = await this.teamMemberRepo.getById(input.created_by).catch(() => null);
+      if (!author || author.org_id !== input.org_id || author.project_id !== input.project_id || !author.is_active) {
+        throw new Error('created_by must be an active team member in the same project');
+      }
+
+      if (assigneeIds.length > 0) {
+        const resolvedAssignees = await Promise.all(
+          assigneeIds.map((id) => this.teamMemberRepo!.getById(id).catch(() => null)),
+        );
+        const valid = resolvedAssignees.filter(
+          (m) => m && m.org_id === input.org_id && m.project_id === input.project_id,
+        );
+        if (valid.length !== assigneeIds.length) {
+          throw new Error('All assigned_to_ids must be team members in the same project');
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- MemoService에 optional projectRepo (IProjectRepository) 4번째 생성자 파라미터 추가
- create() OSS 분기: projectRepo.getById()로 project 존재/org 검증, teamMemberRepo.getById()로 author/assignee 검증
- api/memos POST: isOssMode() 시 createProjectRepository() 생성 후 MemoService에 전달
- SaaS 경로(if this.supabase) 무변경, fromSupabase() 정적 팩토리 무변경

## Test plan

- [ ] tsc --noEmit 타입 에러 없음
- [ ] vitest run 139 파일 / 708 테스트 PASS
- [ ] OSS_MODE=true: 유효한 project_id로 메모 생성 성공 확인
- [ ] OSS_MODE=true: 존재하지 않는 project_id로 메모 생성 시 400 에러 확인
- [ ] OSS_MODE=true: 유효한 assignee_id로 메모 생성 성공 확인

Generated with Claude Code