### PR TITLE
fix(oss): middleware.ts 실종 복구 + Supabase 강제생성 차단 (S-OSS-HOTFIX)

### DIFF
--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -205,7 +205,19 @@ export async function getAuthContext(
   rateLimitRemaining?: number;
   rateLimitResetAt?: number;
 } | null> {
-  // 1. API Key 인증 시도 (admin client로 RLS 우회)
+  // 1. OSS_MODE — Supabase 없이 고정 멤버 반환 (Bearer 포함 모든 경로)
+  if (isOssMode()) {
+    const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } = await import('@sprintable/storage-sqlite');
+    return {
+      id: OSS_MEMBER_ID,
+      org_id: OSS_ORG_ID,
+      project_id: OSS_PROJECT_ID,
+      project_name: 'My Project',
+      type: 'human',
+    };
+  }
+
+  // 2. API Key 인증 시도 (admin client로 RLS 우회, SaaS 전용)
   const authHeader = request.headers.get('Authorization');
   if (authHeader?.startsWith('Bearer ')) {
     const { getTeamMemberFromRequest } = await import('./auth-api-key');
@@ -229,18 +241,6 @@ export async function getAuthContext(
         rateLimitResetAt: resetAt,
       };
     }
-  }
-
-  // 2. OSS_MODE — API key 없는 브라우저 fetch는 기본 유저로 자동 인증 (AC-6)
-  if (isOssMode()) {
-    const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } = await import('@sprintable/storage-sqlite');
-    return {
-      id: OSS_MEMBER_ID,
-      org_id: OSS_ORG_ID,
-      project_id: OSS_PROJECT_ID,
-      project_name: 'My Project',
-      type: 'human',
-    };
   }
 
   // 3. OAuth 세션 인증 시도

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -2,11 +2,13 @@ import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 
 export async function createSupabaseServerClient() {
+  const supabaseUrl = process.env['NEXT_PUBLIC_SUPABASE_URL'] ?? 'http://localhost:54321';
+  const supabaseAnonKey = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY'] ?? 'placeholder';
   const cookieStore = await cookies();
 
   return createServerClient(
-    process.env['NEXT_PUBLIC_SUPABASE_URL']!,
-    process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
+    supabaseUrl,
+    supabaseAnonKey,
     {
       cookies: {
         getAll() {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as middleware, proxyConfig as config } from './proxy';


### PR DESCRIPTION
Bug 1: middleware.ts
- PR #23에서 proxy.ts로 리네임 후 Next.js가 middleware를 못 찾는 문제
- apps/web/src/middleware.ts 생성: proxy/proxyConfig re-export

Bug 2: API routes Supabase client 강제생성
- createSupabaseServerClient(): NEXT_PUBLIC_SUPABASE_URL 없을 때 placeholder 사용 — 생성 자체는 안전
- getAuthContext(): isOssMode() 체크를 Bearer/OAuth 경로 앞으로 이동 — createSupabaseAdminClient() throw 방지

Test: tsc 통과 / vitest 138 PASS (agent-runs 1건 기존 실패 — 내 변경 무관, main에서도 동일 실패)

Generated with Claude Code