### PR TITLE
fix(oss): inline config in middleware.ts — Next.js 정적 분석 호환

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,1 +1,7 @@
-export { proxy as middleware, proxyConfig as config } from './proxy';
+export { proxy as middleware } from './proxy';
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
PR #27 머지 후 추가 발견된 이슈.

config re-export는 Next.js 정적 분석에서 인식 불가 ("It mustnt be reexported").
middleware.ts에서 config를 inline으로 정의.

변경:
- export { proxy as middleware } 유지
- export const config = { matcher: [...] } inline 정의
- proxyConfig re-export 제거

Generated with Claude Code