### PR TITLE
fix(oss): dynamic import factory in memo-assignment-dispatch — Edge Runtime 호환

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -1,7 +1,6 @@
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { MemoEventDispatcher } from './memo-event-dispatcher';
 import { buildAbsoluteMemoLink } from './app-url';
-import { isOssMode } from '@/lib/storage/factory';
 
 export interface DispatchableMemo {
   id: string;
@@ -21,9 +20,10 @@ export interface DispatchableMemo {
 export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) {
   if (!memo.assigned_to || memo.status !== 'open') return;
 
+  const { isOssMode, createTeamMemberRepository } = await import('@/lib/storage/factory');
+
   if (isOssMode()) {
     try {
-      const { createTeamMemberRepository } = await import('@/lib/storage/factory');
       const teamMemberRepo = await createTeamMemberRepository();
       const member = await teamMemberRepo.getById(memo.assigned_to).catch(() => null);
       if (!member?.webhook_url) return;


### PR DESCRIPTION
isOssMode() 정적 import가 Edge 번들에 storage-sqlite(node:crypto/path/sqlite) 포함시키는 문제 수정.

chain: instrumentation.ts → background-runtime.ts → teams-outbound-dispatcher.ts → memo.ts → memo-assignment-dispatch.ts → [factory 정적 import] → storage-sqlite

수정:
- import { isOssMode } from @/lib/storage/factory 정적 import 제거
- 함수 내 await import(@/lib/storage/factory) 단일 dynamic import로 대체
- isOssMode + createTeamMemberRepository 동시에 가져오므로 내부 중복 import 제거

Generated with Claude Code