### PR TITLE
fix(oss): delete middleware.ts — Next.js 16 proxy.ts 충돌 해소

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,0 @@
-export { proxy as middleware } from './proxy';
-
-export const config = {
-  matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
-};


### PR DESCRIPTION
Next.js 16은 middleware.ts + proxy.ts 동시 존재 금지.
proxy.ts가 이미 Next.js proxy 역할 + proxyConfig export 포함.
middleware.ts 삭제.

Generated with Claude Code