### PR TITLE
fix(oss): add isOssMode() guard to dashboard/layout.tsx (S-OSS-DASHBOARD)

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
+import { isOssMode } from '@/lib/storage/factory';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { getMyMembershipContext } from '@/lib/auth-helpers';
+import { getMyMembershipContext, getOssUserContext } from '@/lib/auth-helpers';
 import { DashboardShell } from './dashboard-shell';
 
 export default async function DashboardLayout({
@@ -8,6 +9,21 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
+  if (isOssMode()) {
+    const { me, memberships } = await getOssUserContext();
+    return (
+      <DashboardShell
+        currentTeamMemberId={me?.id}
+        orgId={me?.org_id}
+        projectId={me?.project_id}
+        projectName={me?.project_name}
+        projectMemberships={memberships.map((membership) => ({ projectId: membership.project_id, projectName: membership.project_name }))}
+      >
+        {children}
+      </DashboardShell>
+    );
+  }
+
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();


### PR DESCRIPTION
OSS 모드에서 /dashboard → supabase.auth.getUser() null → /login → /dashboard 무한 리다이렉트 수정.

(authenticated)/layout.tsx 패턴 동일하게 적용:
- isOssMode() 분기: getOssUserContext() → DashboardShell 반환
- SaaS 경로 무변경

Generated with Claude Code