### PR TITLE
feat(oss): S-OSS-DOMAIN-FACTORY — Story/Sprint/Notification/Doc factory 전환

### DIFF
--- a/apps/web/src/app/api/docs/[id]/comments/route.ts
+++ b/apps/web/src/app/api/docs/[id]/comments/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseBody, createDocCommentSchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
@@ -6,6 +7,7 @@ import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { notifyDocCommentMentions } from '@/services/doc-comment-notifications';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,8 +18,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new DocsService(dbClient);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     return apiSuccess(await service.getComments(id));
   } catch (err: unknown) { return handleApiError(err); }
 }
@@ -29,9 +33,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const parsed = await parseBody(request, createDocCommentSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const service = new DocsService(dbClient);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     const comment = await service.addComment({ doc_id: id, content: body.content, created_by: me.id });
 
     try {

--- a/apps/web/src/app/api/docs/[id]/revisions/route.ts
+++ b/apps/web/src/app/api/docs/[id]/revisions/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { DocsService } from '@/services/docs';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,8 +16,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new DocsService(dbClient);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     return apiSuccess(await service.getRevisions(id));
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseBody, updateDocSchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
@@ -5,6 +6,7 @@ import { DocsService } from '@/services/docs';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,9 +17,11 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const parsed = await parseBody(request, updateDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const service = new DocsService(dbClient);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     const doc = await service.updateDoc(id, {
       ...body,
       created_by: me.id,
@@ -42,8 +46,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new DocsService(dbClient);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     return apiSuccess(await service.getDocTimestamp(id));
   } catch (err: unknown) { return handleApiError(err); }
 }
@@ -55,8 +61,10 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new DocsService(dbClient);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     await service.deleteDoc(id);
     return apiSuccess({ ok: true });
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -1,10 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { DocsService } from '@/services/docs';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 /**
  * Extract all doc IDs referenced by page-embed nodes from an HTML string.
@@ -63,14 +64,6 @@ async function collectTransitiveEmbeds(
 
 /**
  * GET /api/docs/preview?q=<slug-or-uuid>
- *
- * Returns the minimal preview fields needed by page-embed blocks:
- *   { id, title, icon, slug, embedChain }
- *
- * `embedChain` lists all doc IDs transitively embedded by the target doc.
- * Clients use this to detect indirect circular embeds (A→B→A).
- *
- * Accepts both UUID and slug via the `q` parameter.
  */
 export async function GET(request: Request) {
   try {
@@ -79,17 +72,20 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded)
       return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
     const q = searchParams.get('q')?.trim();
     if (!q) return ApiErrors.badRequest('q is required');
 
-    const service = new DocsService(dbClient);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     const doc = await service.getDocPreview(me.project_id, q);
     if (!doc) return ApiErrors.notFound('Document not found');
 
-    const embedChain = await collectTransitiveEmbeds(dbClient, me.project_id, doc.id);
+    // OSS: skip embed chain traversal (no raw Supabase client available)
+    const embedChain = dbClient ? await collectTransitiveEmbeds(dbClient, me.project_id, doc.id) : [];
 
     return apiSuccess({
       id: doc.id,

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseBody, createDocSchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
@@ -7,6 +8,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { checkResourceLimit } from '@/lib/check-feature';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
   try {
@@ -14,11 +16,13 @@ export async function GET(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
-    const service = new DocsService(dbClient);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     const slug = searchParams.get('slug');
     if (slug) return apiSuccess(await service.getDoc(projectId, slug));
 
@@ -48,11 +52,15 @@ export async function POST(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const check = await checkResourceLimit(dbClient, me.org_id, 'max_docs', 'docs');
-    if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Document limit reached. Upgrade to Team.', 403);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    if (!ossMode) {
+      const check = await checkResourceLimit(dbClient!, me.org_id, 'max_docs', 'docs');
+      if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Document limit reached. Upgrade to Team.', 403);
+    }
     const parsed = await parseBody(request, createDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const service = new DocsService(dbClient);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     const doc = await service.createDoc({
       org_id: me.org_id, project_id: me.project_id,
       title: body.title, slug: body.slug ?? '', content: body.content ?? '', content_format: body.content_format ?? 'markdown',

--- a/apps/web/src/app/api/memos/[id]/linked-docs/route.ts
+++ b/apps/web/src/app/api/memos/[id]/linked-docs/route.ts
@@ -42,7 +42,9 @@ export async function POST(request: Request, { params }: RouteParams) {
       const memo = await memoService.getById(id);
       const title = body.title?.trim() || memo.title || memo.content.slice(0, 80) || 'Untitled doc';
       const slug = slugify(title) || `memo-${id.slice(0, 8)}`;
-      const docsService = new DocsService(dbClient as SupabaseClient);
+      const { createDocRepository } = await import('@/lib/storage/factory');
+      const docRepo = await createDocRepository(dbClient);
+      const docsService = new DocsService(docRepo, dbClient as SupabaseClient | undefined);
       createdDoc = await docsService.createDoc({
         org_id: me.org_id,
         project_id: me.project_id,

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -6,6 +6,7 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { attachNotificationHrefs } from '@/services/notification-navigation';
 import { parseBody, updateNotificationSchema } from '@sprintable/shared';
+import { isOssMode, createNotificationRepository } from '@/lib/storage/factory';
 
 /** GET — 알림 목록 (안읽음 우선, 최신순) */
 export async function GET(request: Request) {
@@ -14,13 +15,25 @@ export async function GET(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient: SupabaseClient | undefined = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
     const typeFilter = searchParams.get('type');
     const unreadOnly = searchParams.get('unread') === 'true';
 
-    let query = dbClient
+    if (ossMode) {
+      const repo = await createNotificationRepository();
+      const notifications = await repo.list({
+        user_id: me.id,
+        is_read: unreadOnly ? false : undefined,
+        limit: 50,
+      });
+      const unreadCount = notifications.filter((n) => !n.is_read).length;
+      return apiSuccess(notifications, { unreadCount });
+    }
+
+    let query = dbClient!
       .from('notifications')
       .select('*')
       .eq('user_id', me.id)
@@ -34,8 +47,7 @@ export async function GET(request: Request) {
     const { data, error } = await query;
     if (error) throw error;
 
-    // 안읽음 카운트 - 병렬 처리
-    let countQuery = dbClient
+    let countQuery = dbClient!
       .from('notifications')
       .select('id', { count: 'exact', head: true })
       .eq('user_id', me.id)
@@ -45,11 +57,10 @@ export async function GET(request: Request) {
 
     const [countResult, notifications] = await Promise.all([
       countQuery,
-      attachNotificationHrefs(dbClient, data ?? []),
+      attachNotificationHrefs(dbClient!, data ?? []),
     ]);
 
     const { count } = countResult;
-
     return apiSuccess(notifications, { unreadCount: count ?? 0 });
   } catch (err: unknown) {
     return handleApiError(err);
@@ -63,36 +74,44 @@ export async function PATCH(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient: SupabaseClient | undefined = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const parsed = await parseBody(request, updateNotificationSchema);
     if (!parsed.success) return parsed.response;
     const body = parsed.data;
 
+    if (ossMode) {
+      const repo = await createNotificationRepository();
+      if (body.markAllRead) {
+        await repo.markAllRead(me.id);
+        return apiSuccess({ ok: true });
+      }
+      if (body.id) {
+        await repo.markRead(body.id, me.id);
+        return apiSuccess({ ok: true });
+      }
+      return ApiErrors.badRequest('id or markAllRead required');
+    }
+
     if (body.markAllRead) {
-      // 전체 읽음 (type 필터 optional)
-      let query = dbClient
+      let query = dbClient!
         .from('notifications')
         .update({ is_read: true })
         .eq('user_id', me.id)
         .eq('is_read', false);
-
       if (body.type) query = query.eq('type', body.type);
-
       const { error } = await query;
-
       if (error) throw error;
       return apiSuccess({ ok: true });
     }
 
     if (body.id) {
-      // 단일 읽음 토글
-      const { error } = await dbClient
+      const { error } = await dbClient!
         .from('notifications')
         .update({ is_read: body.is_read ?? true })
         .eq('id', body.id)
         .eq('user_id', me.id);
-
       if (error) throw error;
       return apiSuccess({ ok: true });
     }

--- a/apps/web/src/app/api/sprints/[id]/activate/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/activate/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,9 +17,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.activate(id);
     return apiSuccess(sprint);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/burndown/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/burndown/route.test.ts
@@ -21,6 +21,10 @@ function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNot
   const chain = () => q;
   q.select = vi.fn(chain);
   q.eq = vi.fn(chain);
+  q.is = vi.fn(chain);
+  q.order = vi.fn(chain);
+  q.limit = vi.fn(chain);
+  q.lt = vi.fn(chain);
   q.single = vi.fn(() =>
     opts.singleNotFound
       ? Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } })

--- a/apps/web/src/app/api/sprints/[id]/burndown/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/burndown/route.ts
@@ -5,6 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { SprintService, NotFoundError } from '@/services/sprint';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,9 +17,11 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const data = await service.getBurndown(id);
     return apiSuccess(data);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.test.ts
@@ -21,6 +21,10 @@ function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNot
   const chain = () => q;
   q.select = vi.fn(chain);
   q.eq = vi.fn(chain);
+  q.is = vi.fn(chain);
+  q.order = vi.fn(chain);
+  q.limit = vi.fn(chain);
+  q.lt = vi.fn(chain);
   q.single = vi.fn(() =>
     opts.singleNotFound
       ? Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } })

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.ts
@@ -5,6 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { SprintService, NotFoundError } from '@/services/sprint';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,13 +17,15 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
     const date = searchParams.get('date');
     if (!date) return ApiErrors.badRequest('date required');
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const data = await service.checkin(id, date);
     return apiSuccess(data);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,9 +17,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.close(id);
     return apiSuccess(sprint);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/kickoff/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/kickoff/route.test.ts
@@ -21,6 +21,10 @@ function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNot
   const chain = () => q;
   q.select = vi.fn(chain);
   q.eq = vi.fn(chain);
+  q.is = vi.fn(chain);
+  q.order = vi.fn(chain);
+  q.limit = vi.fn(chain);
+  q.lt = vi.fn(chain);
   q.insert = vi.fn(() => (opts.insertOk !== false ? Promise.resolve({ error: null }) : Promise.resolve({ error: { message: 'insert failed' } })));
   q.single = vi.fn(() =>
     opts.singleNotFound

--- a/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
@@ -5,6 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { SprintService, NotFoundError } from '@/services/sprint';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,10 +17,12 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const body = await request.json().catch(() => ({})) as { message?: string };
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const data = await service.kickoff(id, body.message);
     return apiSuccess(data);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { SprintService } from '@/services/sprint';
@@ -5,6 +6,7 @@ import { handleApiError } from '@/lib/api-error';
 import { parseBody, updateSprintSchema } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,9 +18,11 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.getById(id);
     return apiSuccess(sprint);
   } catch (err: unknown) {
@@ -34,11 +38,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const parsed = await parseBody(request, updateSprintSchema);
     if (!parsed.success) return parsed.response;
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.update(id, parsed.data);
     return apiSuccess(sprint);
   } catch (err: unknown) {
@@ -54,9 +60,11 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     await service.delete(id);
     return apiSuccess({ ok: true });
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/route.ts
+++ b/apps/web/src/app/api/sprints/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { SprintService, type CreateSprintInput } from '@/services/sprint';
@@ -5,6 +6,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, createSprintSchema } from '@sprintable/shared';
+import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 // POST /api/sprints — 생성
 export async function POST(request: Request) {
@@ -13,11 +15,13 @@ export async function POST(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const parsed = await parseBody(request, createSprintSchema);
     if (!parsed.success) return parsed.response;
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.create(parsed.data as CreateSprintInput);
     return apiSuccess(sprint, undefined, 201);
   } catch (err: unknown) {
@@ -32,10 +36,12 @@ export async function GET(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
-    const service = new SprintService(dbClient);
+    const repo = await createSprintRepository(dbClient);
+    const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprints = await service.list({
       project_id: searchParams.get('project_id') ?? undefined,
       status: searchParams.get('status') ?? undefined,

--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,13 +16,15 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const url = new URL(request.url);
     const limit = url.searchParams.get('limit');
     const cursor = url.searchParams.get('cursor');
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const activities = await service.getActivities(id, {
       limit: limit ? parseInt(limit, 10) : 20,
       cursor: cursor ?? undefined,
@@ -28,7 +32,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 
     const hasMore = limit && activities.length > parseInt(limit, 10);
     const data = hasMore ? activities.slice(0, -1) : activities;
-    const nextCursor = hasMore && data.length > 0 ? data[data.length - 1]?.created_at : null;
+    const nextCursor = hasMore && data.length > 0 ? (data[data.length - 1] as { created_at?: string })?.created_at : null;
 
     return apiSuccess(data, { nextCursor });
   } catch (err: unknown) {

--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,13 +16,15 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const url = new URL(request.url);
     const limit = url.searchParams.get('limit');
     const cursor = url.searchParams.get('cursor');
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const comments = await service.getComments(id, {
       limit: limit ? parseInt(limit, 10) : 20,
       cursor: cursor ?? undefined,
@@ -43,14 +47,16 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const body = await request.json();
     if (!body.content || typeof body.content !== 'string') {
       return ApiErrors.badRequest('content is required');
     }
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const comment = await service.addComment({
       story_id: id,
       content: body.content,

--- a/apps/web/src/app/api/stories/[id]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/route.ts
@@ -1,10 +1,12 @@
 import { parseBody, updateStorySchema } from '@sprintable/shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,9 +17,11 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const serviceClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new StoryService(serviceClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const story = await service.getByIdWithDetails(id);
 
     // Agent scope 검증: cross-project 접근 차단
@@ -38,10 +42,12 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const parsed = await parseBody(request, updateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const story = await service.update(id, body);
     return apiSuccess(story);
   } catch (err: unknown) {
@@ -56,9 +62,11 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     await service.delete(id);
     return apiSuccess({ ok: true });
   } catch (err: unknown) {

--- a/apps/web/src/app/api/stories/backlog/route.ts
+++ b/apps/web/src/app/api/stories/backlog/route.ts
@@ -1,9 +1,11 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
   try {
@@ -11,13 +13,15 @@ export async function GET(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const stories = await service.backlog(projectId);
     return apiSuccess(stories);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/stories/bulk/route.ts
+++ b/apps/web/src/app/api/stories/bulk/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseBody, bulkUpdateStorySchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
@@ -5,6 +6,7 @@ import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 // PATCH /api/stories/bulk — 벌크 수정 (칸반 드래그앤드롭용)
 export async function PATCH(request: Request) {
@@ -13,14 +15,16 @@ export async function PATCH(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const parsed = await parseBody(request, bulkUpdateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     if (!Array.isArray(body.items) || body.items.length === 0) {
       return ApiErrors.badRequest('items array required');
     }
 
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const results = await service.bulkUpdate(body.items);
     return apiSuccess(results);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { parseBody, createStorySchema } from '@sprintable/shared';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
@@ -7,6 +8,7 @@ import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { checkResourceLimit } from '@/lib/check-feature';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
 export async function POST(request: Request) {
   try {
@@ -14,17 +16,21 @@ export async function POST(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const check = await checkResourceLimit(dbClient, me.org_id, 'max_stories', 'stories');
-    if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Story limit reached. Upgrade to Team.', 403);
+    if (!ossMode) {
+      const check = await checkResourceLimit(dbClient!, me.org_id, 'max_stories', 'stories');
+      if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Story limit reached. Upgrade to Team.', 403);
+    }
 
     const rawBody = await request.json();
     if (!rawBody.project_id) rawBody.project_id = me.project_id;
     if (!rawBody.org_id) rawBody.org_id = me.org_id;
     const parsed = createStorySchema.safeParse(rawBody);
     if (!parsed.success) return apiError('VALIDATION_ERROR', JSON.stringify(parsed.error.issues), 400);
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const story = await service.create(parsed.data as CreateStoryInput);
     return apiSuccess(story, undefined, 201);
   } catch (err: unknown) {
@@ -38,14 +44,16 @@ export async function GET(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
     const { searchParams } = new URL(request.url);
     const pageInput = parseCursorPageInput({
       limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
       cursor: searchParams.get('cursor'),
     }, { defaultLimit: 50, maxLimit: 100 });
-    const service = new StoryService(dbClient);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const stories = await service.list({
       sprint_id: searchParams.get('sprint_id') ?? undefined,
       epic_id: searchParams.get('epic_id') ?? undefined,

--- a/apps/web/src/services/agent-builtin-tools.test.ts
+++ b/apps/web/src/services/agent-builtin-tools.test.ts
@@ -191,7 +191,7 @@ function createSupabaseStub(seed?: Partial<Tables>) {
         limit(count: number) { state.limitCount = count; return query; },
         async maybeSingle() {
           if (state.pendingInsert) {
-            const row = { id: makeId(tables[table].length + 1), created_at: '2026-04-07T00:00:00.000Z', updated_at: '2026-04-07T00:00:00.000Z', ...state.pendingInsert };
+            const row = { id: makeId(tables[table].length + 1), created_at: '2026-04-07T00:00:00.000Z', updated_at: '2026-04-07T00:00:00.000Z', deleted_at: null, ...state.pendingInsert };
             tables[table].push(row);
             return { data: row, error: null };
           }
@@ -200,7 +200,7 @@ function createSupabaseStub(seed?: Partial<Tables>) {
         },
         async single() {
           if (state.pendingInsert) {
-            const row = { id: makeId(tables[table].length + 1), created_at: '2026-04-07T00:00:00.000Z', updated_at: '2026-04-07T00:00:00.000Z', ...state.pendingInsert };
+            const row = { id: makeId(tables[table].length + 1), created_at: '2026-04-07T00:00:00.000Z', updated_at: '2026-04-07T00:00:00.000Z', deleted_at: null, ...state.pendingInsert };
             tables[table].push(row);
             return { data: row, error: null };
           }

--- a/apps/web/src/services/agent-builtin-tools.ts
+++ b/apps/web/src/services/agent-builtin-tools.ts
@@ -255,7 +255,7 @@ export class AgentBuiltinToolService {
     } = {},
   ) {
     this.memoService = options.memoService ?? MemoService.fromSupabase(supabase);
-    this.storyService = options.storyService ?? new StoryService(supabase);
+    this.storyService = options.storyService ?? StoryService.fromSupabase(supabase);
     this._epicService = options.epicService ?? null;
     this.auditLogger = options.auditLogger;
     this.fetchFn = options.fetchFn ?? fetch;

--- a/apps/web/src/services/docs.test.ts
+++ b/apps/web/src/services/docs.test.ts
@@ -47,7 +47,7 @@ describe('DocsService.updateDoc', () => {
 
   it('applies optimistic concurrency when expected_updated_at is provided', async () => {
     const { supabase, updateBuilder } = createDocsSupabase();
-    const service = new DocsService(supabase as never);
+    const service = new DocsService({} as never, supabase as never);
 
     const result = await service.updateDoc('doc-1', {
       content: 'updated',
@@ -68,7 +68,7 @@ describe('DocsService.updateDoc', () => {
       currentUpdatedAt: '2026-04-09T15:21:00.000Z',
     });
     updateBuilder.maybeSingle.mockResolvedValue({ data: null, error: null });
-    const service = new DocsService(supabase as never);
+    const service = new DocsService({} as never, supabase as never);
 
     await expect(service.updateDoc('doc-1', {
       content: 'stale update',
@@ -85,7 +85,7 @@ describe('DocsService.updateDoc', () => {
 
   it('allows explicit overwrite after a conflict acknowledgement', async () => {
     const { supabase, updateBuilder } = createDocsSupabase();
-    const service = new DocsService(supabase as never);
+    const service = new DocsService({} as never, supabase as never);
 
     await service.updateDoc('doc-1', {
       content: 'overwrite me',

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -1,46 +1,34 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { IDocRepository, CreateDocInput, UpdateDocInput } from '@sprintable/core-storage';
+import { SupabaseDocRepository } from '@sprintable/storage-supabase';
 
 export class DocsService {
-  constructor(private readonly supabase: SupabaseClient) {}
+  private readonly repo: IDocRepository;
+  private readonly supabase: SupabaseClient | null;
+
+  constructor(repo: IDocRepository, supabase?: SupabaseClient) {
+    this.repo = repo;
+    this.supabase = supabase ?? null;
+  }
+
+  static fromSupabase(supabase: SupabaseClient): DocsService {
+    return new DocsService(new SupabaseDocRepository(supabase), supabase);
+  }
 
   async list(projectId: string, input?: { limit?: number; cursor?: string | null }) {
-    let query = this.supabase
-      .from('docs')
-      .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
-      .eq('project_id', projectId)
-      .order('updated_at', { ascending: false });
-    if (input?.cursor) query = query.lt('updated_at', input.cursor);
-    if (input?.limit) query = query.limit(input.limit + 1);
-    const { data, error } = await query;
-    if (error) throw error;
-    return data;
+    return this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined });
   }
 
   async getTree(projectId: string) {
-    const { data, error } = await this.supabase
-      .from('docs')
-      .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
-      .eq('project_id', projectId)
-      .order('sort_order');
-    if (error) throw error;
-    return data;
+    return this.repo.getTree(projectId);
   }
 
   async getDoc(projectId: string, slug: string) {
-    const { data, error } = await this.supabase
-      .from('docs')
-      .select('*')
-      .eq('project_id', projectId)
-      .eq('slug', slug)
-      .single();
-    if (error) throw error;
-    return data;
+    return this.repo.getBySlug(projectId, slug);
   }
 
-  async createDoc(input: { org_id: string; project_id: string; title: string; slug: string; content?: string; content_format?: 'markdown' | 'html'; icon?: string | null; tags?: string[]; parent_id?: string; is_folder?: boolean; created_by: string }) {
-    const { data, error } = await this.supabase.from('docs').insert(input).select().single();
-    if (error) throw error;
-    return data;
+  async createDoc(input: CreateDocInput) {
+    return this.repo.create(input);
   }
 
   async updateDoc(
@@ -57,103 +45,111 @@ export class DocsService {
       force_overwrite?: boolean;
     },
   ) {
-    const { expected_updated_at, force_overwrite, ...fields } = input;
+    const { expected_updated_at, force_overwrite, created_by: _created_by, ...fields } = input;
 
-    let query = this.supabase.from('docs').update(fields).eq('id', id);
+    if (this.supabase) {
+      let query = this.supabase.from('docs').update(fields).eq('id', id);
+      if (expected_updated_at && !force_overwrite) query = query.eq('updated_at', expected_updated_at);
+      const { data, error } = await query.select().maybeSingle();
+      if (error) throw error;
 
-    if (expected_updated_at && !force_overwrite) {
-      query = query.eq('updated_at', expected_updated_at);
-    }
-
-    const { data, error } = await query.select().maybeSingle();
-    if (error) throw error;
-
-    if (!data) {
-      if (expected_updated_at && !force_overwrite) {
-        const { data: current, error: fetchErr } = await this.supabase
-          .from('docs')
-          .select('updated_at')
-          .eq('id', id)
-          .single();
-        if (fetchErr) throw fetchErr;
-
-        const err = new Error('Document was modified by another user');
-        (err as Error & { code?: string; server_updated_at?: string }).code = 'CONFLICT';
-        (err as Error & { code?: string; server_updated_at?: string }).server_updated_at = current.updated_at;
-        throw err;
+      if (!data) {
+        if (expected_updated_at && !force_overwrite) {
+          const { data: current, error: fetchErr } = await this.supabase.from('docs').select('updated_at').eq('id', id).single();
+          if (fetchErr) throw fetchErr;
+          const err = new Error('Document was modified by another user');
+          (err as Error & { code?: string; server_updated_at?: string }).code = 'CONFLICT';
+          (err as Error & { code?: string; server_updated_at?: string }).server_updated_at = current.updated_at;
+          throw err;
+        }
+        throw new Error(`Document not found: ${id}`);
       }
 
-      throw new Error(`Document not found: ${id}`);
+      // 리비전은 DB 트리거(trg_docs_auto_revision)가 자동 생성
+      if (fields.content !== undefined) {
+        await this.supabase.rpc('trim_doc_revisions', { _doc_id: id, _keep: 50 });
+      }
+      return data;
     }
 
-    // 리비전은 DB 트리거(trg_docs_auto_revision)가 자동 생성.
-    // content 변경 시 50개 초과분만 정리 (SID:365)
-    if (fields.content !== undefined) {
-      await this.supabase.rpc('trim_doc_revisions', { _doc_id: id, _keep: 50 });
-    }
-
-    return data;
+    return this.repo.update(id, fields as UpdateDocInput);
   }
 
   /** Fetch only updated_at for lightweight polling */
   async getDocTimestamp(id: string) {
-    const { data, error } = await this.supabase
-      .from('docs')
-      .select('updated_at')
-      .eq('id', id)
-      .single();
-    if (error) throw error;
-    return data;
+    if (this.supabase) {
+      const { data, error } = await this.supabase.from('docs').select('updated_at').eq('id', id).single();
+      if (error) throw error;
+      return data;
+    }
+    const doc = await this.repo.getById(id);
+    return { updated_at: doc.updated_at };
   }
 
   async getRevisions(docId: string) {
+    if (!this.supabase) return [];
     const { data, error } = await this.supabase.from('doc_revisions').select('*').eq('doc_id', docId).order('created_at', { ascending: false });
     if (error) throw error;
     return data;
   }
 
   async getComments(docId: string) {
+    if (!this.supabase) return [];
     const { data, error } = await this.supabase.from('doc_comments').select('*').eq('doc_id', docId).order('created_at');
     if (error) throw error;
     return data;
   }
 
   async addComment(input: { doc_id: string; content: string; created_by: string }) {
+    if (!this.supabase) throw new Error('Comments not supported in OSS mode');
     const { data, error } = await this.supabase.from('doc_comments').insert(input).select().single();
     if (error) throw error;
     return data;
   }
 
   async deleteDoc(id: string) {
-    // soft delete
-    const { error } = await this.supabase.from('docs').update({ deleted_at: new Date().toISOString() }).eq('id', id);
-    if (error) throw error;
+    if (this.supabase) {
+      const { error } = await this.supabase.from('docs').update({ deleted_at: new Date().toISOString() }).eq('id', id);
+      if (error) throw error;
+      return;
+    }
+    await this.repo.delete(id, '');
   }
 
   /** Fetch preview fields (id, title, icon, slug, content) by UUID or slug */
   async getDocPreview(projectId: string, q: string) {
     const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(q);
-    let builder = this.supabase
-      .from('docs')
-      .select('id, title, icon, slug, content')
-      .eq('project_id', projectId);
-    builder = isUuid ? builder.eq('id', q) : builder.eq('slug', q);
-    const { data, error } = await builder.maybeSingle();
-    if (error) throw error;
-    return data as { id: string; title: string; icon: string | null; slug: string; content: string | null } | null;
+    if (this.supabase) {
+      let builder = this.supabase.from('docs').select('id, title, icon, slug, content').eq('project_id', projectId);
+      builder = isUuid ? builder.eq('id', q) : builder.eq('slug', q);
+      const { data, error } = await builder.maybeSingle();
+      if (error) throw error;
+      return data as { id: string; title: string; icon: string | null; slug: string; content: string | null } | null;
+    }
+    try {
+      const doc = isUuid ? await this.repo.getById(q) : await this.repo.getBySlug(projectId, q);
+      return { id: doc.id, title: doc.title, icon: doc.icon, slug: doc.slug, content: doc.content };
+    } catch {
+      return null;
+    }
   }
 
   async search(projectId: string, query: string, input?: { limit?: number; cursor?: string | null }) {
-    let builder = this.supabase
-      .from('docs')
-      .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
-      .eq('project_id', projectId)
-      .or(`title.ilike.%${query}%,content.ilike.%${query}%`)
-      .order('updated_at', { ascending: false });
-    if (input?.cursor) builder = builder.lt('updated_at', input.cursor);
-    if (input?.limit) builder = builder.limit(input.limit + 1);
-    const { data, error } = await builder;
-    if (error) throw error;
-    return data;
+    if (this.supabase) {
+      let builder = this.supabase
+        .from('docs')
+        .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
+        .eq('project_id', projectId)
+        .or(`title.ilike.%${query}%,content.ilike.%${query}%`)
+        .order('updated_at', { ascending: false });
+      if (input?.cursor) builder = builder.lt('updated_at', input.cursor);
+      if (input?.limit) builder = builder.limit(input.limit + 1);
+      const { data, error } = await builder;
+      if (error) throw error;
+      return data;
+    }
+    // OSS: title-only search via list (content search not supported in SQLite repo)
+    const all = await this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined });
+    return all.filter((d) => d.title.toLowerCase().includes(query.toLowerCase()));
   }
 }

--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -1,5 +1,9 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { ISprintRepository, CreateSprintInput, UpdateSprintInput } from '@sprintable/core-storage';
+import { SupabaseSprintRepository } from '@sprintable/storage-supabase';
 import { requireOrgAdmin } from '@/lib/admin-check';
+
+export { CreateSprintInput, UpdateSprintInput };
 
 export class NotFoundError extends Error {
   constructor(message: string) { super(message); this.name = 'NotFoundError'; }
@@ -9,24 +13,18 @@ export class ForbiddenError extends Error {
   constructor(message: string) { super(message); this.name = 'ForbiddenError'; }
 }
 
-export interface CreateSprintInput {
-  project_id: string;
-  org_id: string;
-  title: string;
-  start_date: string;
-  end_date: string;
-  team_size?: number;
-}
-
-export interface UpdateSprintInput {
-  title?: string;
-  start_date?: string;
-  end_date?: string;
-  team_size?: number;
-}
-
 export class SprintService {
-  constructor(private readonly supabase: SupabaseClient) {}
+  private readonly repo: ISprintRepository;
+  private readonly supabase: SupabaseClient | null;
+
+  constructor(repo: ISprintRepository, supabase?: SupabaseClient) {
+    this.repo = repo;
+    this.supabase = supabase ?? null;
+  }
+
+  static fromSupabase(supabase: SupabaseClient): SprintService {
+    return new SprintService(new SupabaseSprintRepository(supabase), supabase);
+  }
 
   async create(input: CreateSprintInput) {
     if (!input.title?.trim()) throw new Error('title is required');
@@ -34,132 +32,57 @@ export class SprintService {
     if (!input.end_date) throw new Error('end_date is required');
     if (!input.project_id) throw new Error('project_id is required');
     if (!input.org_id) throw new Error('org_id is required');
-
-    const { data, error } = await this.supabase
-      .from('sprints')
-      .insert({
-        project_id: input.project_id,
-        org_id: input.org_id,
-        title: input.title.trim(),
-        start_date: input.start_date,
-        end_date: input.end_date,
-        team_size: input.team_size ?? null,
-        status: 'planning',
-      })
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-    return data;
+    return this.repo.create(input);
   }
 
   async list(filters: { project_id?: string; status?: string }) {
-    let query = this.supabase.from('sprints').select('*').order('created_at', { ascending: false });
-
-    if (filters.project_id) query = query.eq('project_id', filters.project_id);
-    if (filters.status) query = query.eq('status', filters.status);
-
-    const { data, error } = await query;
-    if (error) throw error;
-    return data;
+    return this.repo.list(filters);
   }
 
   async getById(id: string) {
-    const { data, error } = await this.supabase
-      .from('sprints')
-      .select('*')
-      .eq('id', id)
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') throw new NotFoundError('Sprint not found');
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
+    try {
+      return await this.repo.getById(id);
+    } catch (err) {
+      if (err instanceof Error && (err.name === 'NotFoundError' || (err as { code?: string }).code === 'PGRST116')) {
+        throw new NotFoundError('Sprint not found');
+      }
+      throw err;
     }
-    return data;
   }
 
   async update(id: string, input: UpdateSprintInput) {
-    // allowlist: status, velocity, org_id, project_id 변경 차단
     const ALLOWED_FIELDS: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size'];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) {
       if (key in input) sanitized[key] = input[key];
     }
-
-    if (Object.keys(sanitized).length === 0) {
-      throw new Error('No valid fields to update');
-    }
-
-    // 존재 여부 확인
+    if (Object.keys(sanitized).length === 0) throw new Error('No valid fields to update');
     await this.getById(id);
-
-    const { data, error } = await this.supabase
-      .from('sprints')
-      .update(sanitized)
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') throw new NotFoundError('Sprint not found');
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-    return data;
+    return this.repo.update(id, sanitized as UpdateSprintInput);
   }
 
   async delete(id: string) {
     const sprint = await this.getById(id);
-    await requireOrgAdmin(this.supabase, sprint.org_id as string);
-
-    // 스토리 할당된 스프린트 삭제 불가
-    const { data: stories } = await this.supabase
-      .from('stories')
-      .select('id')
-      .eq('sprint_id', id)
-      .limit(1);
-
-    if (stories && stories.length > 0) {
-      throw new Error('Cannot delete sprint with assigned stories');
+    if (this.supabase) {
+      await requireOrgAdmin(this.supabase, sprint.org_id as string);
+      const { data: stories } = await this.supabase.from('stories').select('id').eq('sprint_id', id).limit(1);
+      if (stories && stories.length > 0) throw new Error('Cannot delete sprint with assigned stories');
     }
-
-    const { error } = await this.supabase.from('sprints').update({ deleted_at: new Date().toISOString() }).eq('id', id);
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
+    await this.repo.delete(id, sprint.org_id as string);
   }
 
   async activate(id: string) {
     const sprint = await this.getById(id);
-    if (sprint.status !== 'planning') {
-      throw new Error(`Cannot activate sprint with status: ${sprint.status}`);
-    }
-
-    const { data, error } = await this.supabase
-      .from('sprints')
-      .update({ status: 'active' })
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-    return data;
+    if (sprint.status !== 'planning') throw new Error(`Cannot activate sprint with status: ${sprint.status}`);
+    return this.repo.update(id, { status: 'active' });
   }
 
   async getBurndown(id: string) {
     const sprint = await this.getById(id);
-    const { data: stories, error } = await this.supabase
-      .from('stories')
-      .select('story_points, status, updated_at')
-      .eq('sprint_id', id);
+    if (!this.supabase) {
+      return { sprint, total_points: 0, done_points: 0, remaining_points: 0, completion_pct: 0, stories_count: 0, done_count: 0 };
+    }
+    const { data: stories, error } = await this.supabase.from('stories').select('story_points, status, updated_at').eq('sprint_id', id);
     if (error) throw error;
     const totalPoints = (stories ?? []).reduce((sum, s) => sum + ((s.story_points as number) ?? 0), 0);
     const donePoints = (stories ?? []).filter((s) => s.status === 'done').reduce((sum, s) => sum + ((s.story_points as number) ?? 0), 0);
@@ -176,17 +99,12 @@ export class SprintService {
 
   async kickoff(id: string, message?: string) {
     const sprint = await this.getById(id);
+    if (!this.supabase) return { notified: 0 };
+
     const { data: members, error: membersError } = await this.supabase
-      .from('team_members')
-      .select('id')
-      .eq('project_id', sprint.project_id as string)
-      .eq('is_active', true);
+      .from('team_members').select('id').eq('project_id', sprint.project_id as string).eq('is_active', true);
     if (membersError) throw membersError;
-    const { data: project } = await this.supabase
-      .from('projects')
-      .select('org_id')
-      .eq('id', sprint.project_id as string)
-      .single();
+    const { data: project } = await this.supabase.from('projects').select('org_id').eq('id', sprint.project_id as string).single();
     const notifications = (members ?? []).map((member) => ({
       org_id: project?.org_id as string,
       user_id: member.id as string,
@@ -205,21 +123,16 @@ export class SprintService {
 
   async checkin(id: string, date: string) {
     const sprint = await this.getById(id);
+    if (!this.supabase) {
+      return { total_stories: 0, total_points: 0, done_points: 0, completion_pct: 0, missing_standups: [] };
+    }
     const { data: stories, error: storiesError } = await this.supabase
-      .from('stories')
-      .select('status, story_points, assignee_id')
-      .eq('sprint_id', id);
+      .from('stories').select('status, story_points, assignee_id').eq('sprint_id', id);
     if (storiesError) throw storiesError;
     const { data: members } = await this.supabase
-      .from('team_members')
-      .select('id, name')
-      .eq('project_id', sprint.project_id as string)
-      .eq('is_active', true);
+      .from('team_members').select('id, name').eq('project_id', sprint.project_id as string).eq('is_active', true);
     const { data: standups } = await this.supabase
-      .from('standup_entries')
-      .select('author_id')
-      .eq('project_id', sprint.project_id as string)
-      .eq('date', date);
+      .from('standup_entries').select('author_id').eq('project_id', sprint.project_id as string).eq('date', date);
     const standupAuthors = new Set((standups ?? []).map((s) => s.author_id as string));
     const missing = (members ?? []).filter((m) => !standupAuthors.has(m.id as string));
     const totalPts = (stories ?? []).reduce((sum, s) => sum + ((s.story_points as number) ?? 0), 0);
@@ -235,33 +148,14 @@ export class SprintService {
 
   async close(id: string) {
     const sprint = await this.getById(id);
-    if (sprint.status !== 'active') {
-      throw new Error(`Cannot close sprint with status: ${sprint.status}`);
+    if (sprint.status !== 'active') throw new Error(`Cannot close sprint with status: ${sprint.status}`);
+
+    let velocity = 0;
+    if (this.supabase) {
+      const { data: doneStories } = await this.supabase.from('stories').select('story_points').eq('sprint_id', id).eq('status', 'done');
+      velocity = (doneStories ?? []).reduce((sum, s) => sum + (s.story_points ?? 0), 0);
     }
 
-    // velocity 자동 계산: 완료된 스토리의 story_points 합
-    const { data: doneStories } = await this.supabase
-      .from('stories')
-      .select('story_points')
-      .eq('sprint_id', id)
-      .eq('status', 'done');
-
-    const velocity = (doneStories ?? []).reduce(
-      (sum, s) => sum + (s.story_points ?? 0),
-      0,
-    );
-
-    const { data, error } = await this.supabase
-      .from('sprints')
-      .update({ status: 'closed', velocity })
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-    return data;
+    return this.repo.update(id, { status: 'closed', velocity } as UpdateSprintInput);
   }
 }

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -1,38 +1,10 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { IStoryRepository, CreateStoryInput, UpdateStoryInput, BulkUpdateItem, StoryListFilters } from '@sprintable/core-storage';
+import { SupabaseStoryRepository } from '@sprintable/storage-supabase';
 import { NotFoundError, ForbiddenError } from './sprint';
 import { requireOrgAdmin } from '@/lib/admin-check';
 
-export interface CreateStoryInput {
-  project_id: string;
-  org_id: string;
-  title: string;
-  epic_id?: string | null;
-  sprint_id?: string | null;
-  assignee_id?: string | null;
-  status?: string;
-  priority?: string;
-  story_points?: number | null;
-  description?: string | null;
-  meeting_id?: string | null;
-}
-
-export interface UpdateStoryInput {
-  title?: string;
-  status?: string;
-  priority?: string;
-  story_points?: number | null;
-  description?: string | null;
-  epic_id?: string | null;
-  sprint_id?: string | null;
-  assignee_id?: string | null;
-}
-
-export interface BulkUpdateItem {
-  id: string;
-  status?: string;
-  sprint_id?: string | null;
-  assignee_id?: string | null;
-}
+export type { CreateStoryInput, UpdateStoryInput, BulkUpdateItem };
 
 /** 유효한 상태 전이 맵 (SID:357) */
 const VALID_TRANSITIONS: Record<string, string[]> = {
@@ -51,107 +23,72 @@ export class InvalidTransitionError extends Error {
 }
 
 export class StoryService {
-  constructor(private readonly supabase: SupabaseClient) {}
+  private readonly repo: IStoryRepository;
+  private readonly supabase: SupabaseClient | null;
+
+  constructor(repo: IStoryRepository, supabase?: SupabaseClient) {
+    this.repo = repo;
+    this.supabase = supabase ?? null;
+  }
+
+  static fromSupabase(supabase: SupabaseClient): StoryService {
+    return new StoryService(new SupabaseStoryRepository(supabase), supabase);
+  }
 
   async create(input: CreateStoryInput) {
     if (!input.title?.trim()) throw new Error('title is required');
     if (!input.project_id) throw new Error('project_id is required');
     if (!input.org_id) throw new Error('org_id is required');
 
-    const { data, error } = await this.supabase
-      .from('stories')
-      .insert({
-        project_id: input.project_id,
-        org_id: input.org_id,
-        title: input.title.trim(),
-        epic_id: input.epic_id ?? null,
-        sprint_id: input.sprint_id ?? null,
-        assignee_id: input.assignee_id ?? null,
-        status: input.status ?? 'backlog',
-        priority: input.priority ?? 'medium',
-        story_points: input.story_points ?? null,
-        description: input.description ?? null,
-        meeting_id: input.meeting_id ?? null,
-      })
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
+    if (this.supabase) {
+      const { data, error } = await this.supabase
+        .from('stories')
+        .insert({
+          project_id: input.project_id,
+          org_id: input.org_id,
+          title: input.title.trim(),
+          epic_id: input.epic_id ?? null,
+          sprint_id: input.sprint_id ?? null,
+          assignee_id: input.assignee_id ?? null,
+          status: input.status ?? 'backlog',
+          priority: input.priority ?? 'medium',
+          story_points: input.story_points ?? null,
+          description: input.description ?? null,
+          meeting_id: input.meeting_id ?? null,
+        })
+        .select()
+        .single();
+      if (error) {
+        if (error.code === '42501') throw new ForbiddenError('Permission denied');
+        throw error;
+      }
+      // 알림은 DB trigger(notify_story_assignee)가 자동 처리
+      return data;
     }
 
-    // 알림은 DB trigger(notify_story_assignee)가 자동 처리
-    return data;
+    return this.repo.create(input);
   }
 
-  async list(filters: {
-    sprint_id?: string;
-    epic_id?: string;
-    assignee_id?: string;
-    status?: string;
-    project_id?: string;
-    q?: string;
-    unassigned?: boolean;
-    limit?: number;
-    cursor?: string | null;
-  }) {
-    let query = this.supabase.from('stories').select('*').order('created_at', { ascending: false });
-
-    if (filters.sprint_id) query = query.eq('sprint_id', filters.sprint_id);
-    if (filters.epic_id) query = query.eq('epic_id', filters.epic_id);
-    if (filters.assignee_id) query = query.eq('assignee_id', filters.assignee_id);
-    if (filters.unassigned) query = query.is('assignee_id', null);
-    if (filters.status) query = query.eq('status', filters.status);
-    if (filters.project_id) query = query.eq('project_id', filters.project_id);
-    if (filters.q) query = query.ilike('title', `%${filters.q}%`);
-    if (filters.cursor) query = query.lt('created_at', filters.cursor);
-    if (filters.limit) query = query.limit(filters.limit + 1);
-
-    const { data, error } = await query;
-    if (error) throw error;
-    return data;
+  async list(filters: StoryListFilters) {
+    return this.repo.list(filters);
   }
 
   async backlog(projectId: string) {
-    const { data, error } = await this.supabase
-      .from('stories')
-      .select('*')
-      .eq('project_id', projectId)
-      .is('sprint_id', null)
-      .order('created_at', { ascending: false });
-
-    if (error) throw error;
-    return data;
+    return this.repo.backlog(projectId);
   }
 
   async getById(id: string) {
-    const { data, error } = await this.supabase
-      .from('stories')
-      .select('*')
-      .eq('id', id)
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') throw new NotFoundError('Story not found');
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
+    try {
+      return await this.repo.getById(id);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'NotFoundError') throw new NotFoundError('Story not found');
+      if (err instanceof Error && (err as { code?: string }).code === 'PGRST116') throw new NotFoundError('Story not found');
+      throw err;
     }
-    return data;
   }
 
   async getByIdWithDetails(id: string) {
-    const story = await this.getById(id);
-
-    const { data: tasks } = await this.supabase
-      .from('tasks')
-      .select('*')
-      .eq('story_id', id)
-      .order('created_at');
-
-    // NOTE: story comments 스키마가 아직 없으므로 tasks만 포함
-    // story comments는 별도 스키마/AC 확정 후 추가 예정
-    return { ...story, tasks: tasks ?? [] };
+    return this.repo.getByIdWithDetails(id);
   }
 
   async update(id: string, input: UpdateStoryInput) {
@@ -174,8 +111,8 @@ export class StoryService {
       if (!validNext || !validNext.includes(input.status)) {
         throw new InvalidTransitionError(currentStatus, input.status);
       }
-      // done → in-review는 admin만
-      if (currentStatus === 'done') {
+      // done → in-review는 admin만 (OSS: single user = always admin)
+      if (currentStatus === 'done' && this.supabase) {
         try {
           await requireOrgAdmin(this.supabase, existing.org_id as string);
         } catch {
@@ -184,125 +121,34 @@ export class StoryService {
       }
     }
 
-    const { data, error } = await this.supabase
-      .from('stories')
-      .update(sanitized)
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === 'PGRST116') throw new NotFoundError('Story not found');
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-
-    // 알림은 DB trigger(notify_story_assignee)가 자동 처리
-    return data;
+    return this.repo.update(id, sanitized as UpdateStoryInput);
   }
 
   async delete(id: string) {
     const story = await this.getById(id);
-    // done 상태 스토리 DELETE도 admin 권한 필요 (SID:357)
-    await requireOrgAdmin(this.supabase, story.org_id as string);
-
-    // FK ON DELETE CASCADE가 소속 tasks 자동 삭제
-    // 연관 tasks도 soft delete (soft delete이므로 FK CASCADE 미발동)
-    const { error: childError } = await this.supabase.from('tasks').update({ deleted_at: new Date().toISOString() }).eq('story_id', id);
-    if (childError) throw new Error(`Failed to soft-delete tasks: ${childError.message}`);
-
-    const { error } = await this.supabase.from('stories').update({ deleted_at: new Date().toISOString() }).eq('id', id);
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
+    if (this.supabase) {
+      // done 상태 스토리 DELETE도 admin 권한 필요 (SID:357)
+      await requireOrgAdmin(this.supabase, story.org_id as string);
+      const { error: childError } = await this.supabase.from('tasks').update({ deleted_at: new Date().toISOString() }).eq('story_id', id);
+      if (childError) throw new Error(`Failed to soft-delete tasks: ${childError.message}`);
     }
+    await this.repo.delete(id);
   }
 
   async bulkUpdate(items: BulkUpdateItem[]) {
-    const results = [];
-    for (const item of items) {
-      const { id, ...updates } = item;
-      const result = await this.update(id, updates);
-      results.push(result);
-    }
-    return results;
+    return this.repo.bulkUpdate(items);
   }
 
-  // ============================================================
-  // Comments
-  // ============================================================
   async addComment(input: { story_id: string; content: string; created_by: string }) {
     if (!input.content?.trim()) throw new Error('content is required');
-
-    // Get story to extract org_id and project_id
-    const story = await this.getById(input.story_id);
-
-    const { data, error } = await this.supabase
-      .from('story_comments')
-      .insert({
-        story_id: input.story_id,
-        org_id: story.org_id,
-        project_id: story.project_id,
-        content: input.content.trim(),
-        created_by: input.created_by,
-      })
-      .select()
-      .single();
-
-    if (error) {
-      if (error.code === '42501') throw new ForbiddenError('Permission denied');
-      throw error;
-    }
-
-    return data;
+    return this.repo.addComment({ ...input, content: input.content.trim() });
   }
 
   async getComments(storyId: string, options?: { limit?: number; cursor?: string }) {
-    let query = this.supabase
-      .from('story_comments')
-      .select('*')
-      .eq('story_id', storyId)
-      .is('deleted_at', null)
-      .order('created_at', { ascending: false });
-
-    if (options?.cursor) {
-      query = query.lt('created_at', options.cursor);
-    }
-
-    if (options?.limit) {
-      query = query.limit(options.limit + 1);
-    }
-
-    const { data, error } = await query;
-    if (error) throw error;
-
-    return data ?? [];
+    return this.repo.getComments(storyId, options);
   }
 
-  // ============================================================
-  // Activities
-  // ============================================================
   async getActivities(storyId: string, options?: { limit?: number; cursor?: string }) {
-    let query = this.supabase
-      .from('story_activities')
-      .select('*')
-      .eq('story_id', storyId)
-      .order('created_at', { ascending: false });
-
-    if (options?.cursor) {
-      query = query.lt('created_at', options.cursor);
-    }
-
-    if (options?.limit) {
-      query = query.limit(options.limit + 1);
-    }
-
-    const { data, error } = await query;
-    if (error) throw error;
-
-    return data ?? [];
+    return this.repo.getActivities(storyId, options);
   }
-
-  // 알림은 DB trigger(notify_story_assignee)가 SECURITY DEFINER로 자동 처리
-  // RLS 우회하여 호출 주체(admin/member)와 무관하게 notifications INSERT 보장
 }


### PR DESCRIPTION
## Summary

- `StoryService`, `SprintService`, `DocsService` 생성자를 `IXxxRepository` 기반으로 리팩터링 (`static fromSupabase()` SaaS 호환 유지)
- `/api/stories`, `/api/sprints`, `/api/notifications`, `/api/docs` 및 모든 하위 라우트에 `isOssMode() + createXxxRepository(dbClient)` 패턴 적용
- OSS 모드: Supabase 없이 SQLite 레포지토리로 CRUD 동작
- `SprintService` Supabase 의존 메서드(burndown/kickoff/checkin/close)는 `this.supabase` 가드로 OSS 스텁 처리
- `DocsService` 고급 기능(revisions/comments/conflict detection)은 Supabase 있을 때만 활성화
- `agent-builtin-tools.ts` `StoryService.fromSupabase()` 로 전환

## Test plan

- [x] `pnpm tsc --noEmit` — 타입 오류 0
- [x] `vitest run` — 707 passed, 2 skipped (pre-existing 1건 제외)
- [ ] OSS 빌드 + 연기: `/api/stories`, `/api/sprints`, `/api/notifications`, `/api/docs` 수동 확인
- [ ] SaaS 기존 동작 regression 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)