### PR TITLE
fix(oss): Epic/Sprint POST schema project_id strip 버그

### DIFF
--- a/apps/web/src/app/api/sprints/route.ts
+++ b/apps/web/src/app/api/sprints/route.ts
@@ -3,9 +3,9 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { SprintService, type CreateSprintInput } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { parseBody, createSprintSchema } from '@sprintable/shared';
+import { createSprintSchema } from '@sprintable/shared';
 import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
 
 // POST /api/sprints — 생성
@@ -18,8 +18,14 @@ export async function POST(request: Request) {
     const ossMode = isOssMode();
     const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
 
-    const parsed = await parseBody(request, createSprintSchema);
-    if (!parsed.success) return parsed.response;
+    let rawBody: unknown;
+    try { rawBody = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
+    if (!rawBody || typeof rawBody !== 'object') return apiError('BAD_REQUEST', 'Body must be an object', 400);
+    const body = rawBody as Record<string, unknown>;
+    if (!body.project_id) body.project_id = me.project_id;
+    if (!body.org_id) body.org_id = me.org_id;
+    const parsed = createSprintSchema.safeParse(body);
+    if (!parsed.success) return apiError('VALIDATION_ERROR', JSON.stringify(parsed.error.issues), 400);
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as SupabaseClient | undefined);
     const sprint = await service.create(parsed.data as CreateSprintInput);

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -87,8 +87,8 @@ export const createMemoLinkedDocSchema = z.object({
 
 // ─── Epic ────────────────────────────────────
 export const createEpicSchema = z.object({
-  project_id: z.string().min(1),
-  org_id: z.string().min(1),
+  project_id: z.string().min(1).optional(),
+  org_id: z.string().min(1).optional(),
   title: z.string().min(1),
   status: z.string().optional(),
   priority: z.string().optional(),
@@ -104,8 +104,8 @@ export const updateEpicSchema = z.object({
 
 // ─── Sprint ──────────────────────────────────
 export const createSprintSchema = z.object({
-  project_id: z.string().min(1),
-  org_id: z.string().min(1),
+  project_id: z.string().min(1).optional(),
+  org_id: z.string().min(1).optional(),
   title: z.string().min(1),
   start_date: z.string().min(1),
   end_date: z.string().min(1),

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -87,6 +87,8 @@ export const createMemoLinkedDocSchema = z.object({
 
 // ─── Epic ────────────────────────────────────
 export const createEpicSchema = z.object({
+  project_id: z.string().min(1),
+  org_id: z.string().min(1),
   title: z.string().min(1),
   status: z.string().optional(),
   priority: z.string().optional(),
@@ -102,6 +104,8 @@ export const updateEpicSchema = z.object({
 
 // ─── Sprint ──────────────────────────────────
 export const createSprintSchema = z.object({
+  project_id: z.string().min(1),
+  org_id: z.string().min(1),
   title: z.string().min(1),
   start_date: z.string().min(1),
   end_date: z.string().min(1),


### PR DESCRIPTION
## Summary

- `createEpicSchema`/`createSprintSchema` (`packages/shared/src/schemas/index.ts`)에 `project_id`/`org_id` 필드 누락 → Zod strip으로 EpicService.create() throw
- Sprint POST route: `parseBody` 직접 호출로 `me.project_id`/`org_id` 주입 누락 → epic route와 동일한 manual body read + inject 패턴으로 통일

## Test plan
- [ ] OSS_MODE=true, POST /api/epics → 201
- [ ] OSS_MODE=true, POST /api/sprints → 201
- [ ] 707 vitest 통과 (pre-existing 1 실패 제외)
- [ ] tsc 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)