### PR TITLE
fix(oss): SQLite 스토리 기본 status todo → backlog 전이 불가 버그

### DIFF
--- a/packages/storage-sqlite/src/SqliteStoryRepository.ts
+++ b/packages/storage-sqlite/src/SqliteStoryRepository.ts
@@ -15,7 +15,7 @@ export class SqliteStoryRepository implements IStoryRepository {
     this.db.prepare(`
       INSERT INTO stories (id, org_id, project_id, epic_id, sprint_id, assignee_id, title, status, priority, story_points, description, meeting_id, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, input.org_id, input.project_id, input.epic_id ?? null, input.sprint_id ?? null, input.assignee_id ?? null, input.title.trim(), input.status ?? 'todo', input.priority ?? 'medium', input.story_points ?? null, input.description ?? null, input.meeting_id ?? null, now, now);
+    `).run(id, input.org_id, input.project_id, input.epic_id ?? null, input.sprint_id ?? null, input.assignee_id ?? null, input.title.trim(), input.status ?? 'backlog', input.priority ?? 'medium', input.story_points ?? null, input.description ?? null, input.meeting_id ?? null, now, now);
     return this.getById(id);
   }
 


### PR DESCRIPTION
## Summary

- `SqliteStoryRepository.create()`의 기본 status가 `todo`였으나 `VALID_TRANSITIONS`에 `todo` 키 없음 → 생성 직후 어떤 상태로도 전이 불가
- Supabase 기본값(`backlog`)과 일치하도록 `'todo'` → `'backlog'` 변경 (1 line fix)

## Test plan
- [ ] OSS_MODE=true, POST /api/stories → status: backlog
- [ ] PATCH status=ready-for-dev → 200 성공
- [ ] vitest 707 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)