### PR TITLE
feat(ux): Docs 코드블록 복사 버튼 + 마크다운 전체 복사

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -9,7 +9,7 @@ import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { Plus, X, Trash2 } from 'lucide-react';
+import { Plus, X, Trash2, Copy, Check } from 'lucide-react';
 
 interface Doc {
   id: string;
@@ -85,6 +85,19 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [contentFormat, setContentFormat] = useState<'markdown' | 'html'>('markdown');
+  const [mdCopied, setMdCopied] = useState(false);
+
+  const handleCopyMarkdown = useCallback(async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content);
+      }
+    } catch {
+      // clipboard unavailable
+    }
+    setMdCopied(true);
+    window.setTimeout(() => setMdCopied(false), 1600);
+  }, [content]);
 
   // Create form states
   const [showCreate, setShowCreate] = useState(false);
@@ -466,6 +479,9 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 </div>
                 <div className="flex items-center gap-3">
                   <SaveStatusIndicator status={saveStatus} t={t} />
+                  <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
+                    {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+                  </Button>
                   <Button variant="ghost" size="sm" onClick={handleDelete}>
                     <Trash2 className="h-4 w-4" />
                   </Button>

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -13,6 +13,7 @@ import Placeholder from '@tiptap/extension-placeholder';
 import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
+import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -57,7 +58,8 @@ export function DocEditor({
 
   const editor = useEditor({
     extensions: [
-      StarterKit,
+      StarterKit.configure({ codeBlock: false }),
+      CodeBlockWithCopy,
       Link.configure({ openOnClick: false }),
       Image,
       Table.configure({ resizable: true }),

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+
+function CodeBlockView({ node }: ReactNodeViewProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    const text = node.textContent;
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(text);
+      }
+    } catch {
+      // clipboard unavailable — still show feedback
+    }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }, [node.textContent]);
+
+  return (
+    <NodeViewWrapper className="my-4 not-prose">
+      <div className="rounded-2xl border border-white/10 bg-[#0b1120]">
+        <div className="flex justify-end px-3 pt-2">
+          <button
+            type="button"
+            contentEditable={false}
+            onClick={handleCopy}
+            className="rounded-full border border-white/12 bg-white/8 px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-muted-foreground transition hover:border-primary/35 hover:text-foreground"
+          >
+            {copied ? '복사됨' : '복사'}
+          </button>
+        </div>
+        <pre className="overflow-x-auto p-4 text-[13px] leading-6 text-slate-200">
+          <NodeViewContent />
+        </pre>
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+export const CodeBlockWithCopy = Node.create({
+  name: 'codeBlock',
+  group: 'block',
+  content: 'text*',
+  marks: '',
+  code: true,
+  defining: true,
+
+  addAttributes() {
+    return {
+      language: {
+        default: null,
+        parseHTML: (element) =>
+          element.getAttribute('data-language') ??
+          (element.firstElementChild as HTMLElement | null)?.className.replace('language-', '') ??
+          null,
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes['language']) return {};
+          return {
+            'data-language': attributes['language'],
+            class: `language-${attributes['language']}`,
+          };
+        },
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'pre', preserveWhitespace: 'full' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['pre', mergeAttributes(HTMLAttributes), ['code', {}, 0]];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Alt-c': () => this.editor.commands.toggleNode(this.name, 'paragraph'),
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(CodeBlockView);
+  },
+});


### PR DESCRIPTION
## Summary

- **S-UX-DOCS-COPY-CODE**: TipTap 커스텀 NodeView `CodeBlockWithCopy` — 코드블록 우상단 복사 버튼, 클릭 시 클립보드 복사 + '복사됨' 1.6s 피드백. StarterKit `codeBlock: false` 후 교체.
- **S-UX-DOCS-COPY-MD**: 문서 헤더 Copy 아이콘 버튼 — 마크다운 원문 전체 복사, 완료 시 Check 아이콘 1.6s 전환.

## Test plan
- [ ] Docs 코드블록 클릭 → 클립보드 복사 + '복사됨' 피드백
- [ ] 문서 헤더 Copy 버튼 → 마크다운 원문 복사 + Check 아이콘 전환
- [ ] 다크모드 정상
- [ ] tsc 0 errors, vitest 707 passed
- [ ] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)