### PR TITLE
feat(ux): 보드 전이 시각화 + 에픽 필터 URL 동기화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -103,7 +103,8 @@
     "editStory": "Edit Story",
     "changeStatus": "Change Status",
     "assignMember": "Assign Member",
-    "deleteStory": "Delete Story"
+    "deleteStory": "Delete Story",
+    "validDrop": "Drop here"
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -103,7 +103,8 @@
     "editStory": "스토리 수정",
     "changeStatus": "상태 변경",
     "assignMember": "담당자 변경",
-    "deleteStory": "스토리 삭제"
+    "deleteStory": "스토리 삭제",
+    "validDrop": "이동 가능"
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -11,7 +11,7 @@ import { KanbanFilters } from './kanban-filters';
 import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
-import { COLUMNS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId } from './types';
+import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId } from './types';
 
 type DragOverlayCompatProps = {
   children?: React.ReactNode;
@@ -54,8 +54,22 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [loadingMoreStoryTasks, setLoadingMoreStoryTasks] = useState(false);
 
   const [selectedSprintId, setSelectedSprintId] = useState('');
-  const [selectedEpicId, setSelectedEpicId] = useState('');
+  const [selectedEpicId, setSelectedEpicId] = useState(() => searchParams.get('epic_id') ?? '');
   const [selectedAssigneeId, setSelectedAssigneeId] = useState('');
+
+  // Sync epic_id to URL
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (selectedEpicId) {
+      params.set('epic_id', selectedEpicId);
+    } else {
+      params.delete('epic_id');
+    }
+    const storyId = searchParams.get('story');
+    if (!storyId) {
+      router.replace(params.toString() ? `?${params.toString()}` : window.location.pathname, { scroll: false });
+    }
+  }, [selectedEpicId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
@@ -180,6 +194,14 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     const story = stories.find((s) => s.id === storyId);
     if (!story || story.status === newStatus) return;
 
+    // 유효하지 않은 전이 사전 차단 — API 호출 없이 즉시 피드백
+    const validNext = VALID_TRANSITIONS[story.status] ?? [];
+    if (!validNext.includes(newStatus)) {
+      setTransitionError(t('invalidTransition'));
+      setTimeout(() => setTransitionError(null), 4000);
+      return;
+    }
+
     // 낙관적 업데이트
     setStories((prev) =>
       prev.map((s) => (s.id === storyId ? { ...s, status: newStatus } : s)),
@@ -291,6 +313,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [fetchData]);
 
   const activeStory = activeId ? stories.find((s) => s.id === activeId) : null;
+  const dragStatus = activeStory?.status ?? null;
 
   if (loading) return <KanbanSkeleton />;
 
@@ -323,6 +346,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
               stories={storiesByColumn(col.id)}
               epicMap={epicMap}
               memberMap={memberMap}
+              dragStatus={dragStatus}
               onStoryClick={handleStoryClick}
               onEditStory={handleEditStory}
               onChangeStatus={handleChangeStatus}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -6,6 +6,7 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useTranslations } from 'next-intl';
 import { StoryCard } from './story-card';
 import type { KanbanStory } from './types';
+import { VALID_TRANSITIONS } from './types';
 import { Badge } from '@/components/ui/badge';
 
 
@@ -23,6 +24,7 @@ interface KanbanColumnProps {
   stories: KanbanStory[];
   epicMap: Record<string, string>;
   memberMap: Record<string, string>;
+  dragStatus?: string | null;
   onStoryClick: (story: KanbanStory) => void;
   onEditStory?: (storyId: string) => void;
   onChangeStatus?: (storyId: string, newStatus: string) => void;
@@ -30,18 +32,32 @@ interface KanbanColumnProps {
   onDeleteStory?: (storyId: string) => void;
 }
 
-export function KanbanColumn({ id, label, stories, epicMap, memberMap, onStoryClick, onEditStory, onChangeStatus, onAssignStory, onDeleteStory }: KanbanColumnProps) {
+export function KanbanColumn({ id, label, stories, epicMap, memberMap, dragStatus, onStoryClick, onEditStory, onChangeStatus, onAssignStory, onDeleteStory }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
+
+  const isDragging = dragStatus != null;
+  const isValidTarget = isDragging && (VALID_TRANSITIONS[dragStatus] ?? []).includes(id);
+  const isInvalidTarget = isDragging && !isValidTarget && dragStatus !== id;
 
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-h-[320px] w-full min-w-[280px] flex-col rounded-3xl border p-4 transition md:w-[320px] ${isOver
-        ? 'border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/10 shadow-[0_0_0_1px_rgba(182,196,255,0.16)]'
-        : 'border-white/8 bg-[color:var(--operator-surface-soft)]/55'
+      className={`flex min-h-[320px] w-full min-w-[280px] flex-col rounded-3xl border p-4 transition md:w-[320px] ${
+        isOver && isValidTarget
+          ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/12 shadow-[0_0_0_1px_rgba(182,196,255,0.2)]'
+          : isValidTarget
+          ? 'border-emerald-400/25 bg-emerald-400/5'
+          : isInvalidTarget
+          ? 'border-white/5 bg-[color:var(--operator-surface-soft)]/30 opacity-45'
+          : 'border-white/8 bg-[color:var(--operator-surface-soft)]/55'
       }`}
     >
+      {isDragging && isValidTarget && (
+        <div className="mb-2 rounded-xl border border-emerald-400/20 bg-emerald-400/8 px-2 py-1 text-center text-[10px] font-medium uppercase tracking-widest text-emerald-400/70">
+          {t('validDrop')}
+        </div>
+      )}
       <div className="mb-3 flex items-center justify-between gap-2">
         <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{label}</h3>
         <Badge variant="info">{stories.length}</Badge>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -27,6 +27,14 @@ export interface KanbanMember {
   type: string;
 }
 
+export const VALID_TRANSITIONS: Record<string, string[]> = {
+  backlog: ['ready-for-dev'],
+  'ready-for-dev': ['in-progress', 'backlog'],
+  'in-progress': ['in-review', 'ready-for-dev'],
+  'in-review': ['done', 'in-progress'],
+  done: [],
+};
+
 export const COLUMNS = [
   { id: 'backlog', i18nKey: 'backlog' },
   { id: 'ready-for-dev', i18nKey: 'readyForDev' },


### PR DESCRIPTION
## Summary

**S-UX-BOARD-TRANSITION-VIZ**
- `VALID_TRANSITIONS` 맵을 `types.ts`에 추가 (story.ts 서버 로직과 동기화)
- 드래그 중 유효 컬럼 → emerald 하이라이트 + 'Drop here' 배지, 무효 컬럼 → opacity-45 dim
- `handleDragEnd`: 무효 전이는 API 호출 없이 즉시 차단 + 에러 토스트

**S-UX-BOARD-EPIC-FILTER**
- 에픽 필터 상태를 `epic_id` URL query param에 동기화 — 새로고침/공유 시 필터 유지

## Test plan
- [ ] 스토리 드래그 시 유효 컬럼 초록 하이라이트, 무효 컬럼 dim 확인
- [ ] 무효 컬럼 드롭 시 API 호출 없이 에러 메시지 표시
- [ ] 에픽 필터 선택 후 URL에 `epic_id` 반영, 새로고침 후 필터 유지
- [ ] tsc 0 errors, vitest 707 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)