### PR TITLE
feat(ux): 메모 스레드 답글 접기/펼치기 (S-UX-MEMOS-THREAD-COLLAPSE)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -220,7 +220,9 @@
     "repliesCountBadge": "{count} replies",
     "sidebarTitle": "Memo Sidebar",
     "sidebarSubtitle": "Open memos, reply, and create new ones from anywhere",
-    "closeSidebar": "Close memo sidebar"
+    "closeSidebar": "Close memo sidebar",
+    "expandReplies": "Show {count} earlier replies",
+    "collapseReplies": "Hide earlier replies"
   },
   "login": {
     "title": "Sprintable",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -220,7 +220,9 @@
     "repliesCountBadge": "{count}개 답글",
     "sidebarTitle": "메모 사이드바",
     "sidebarSubtitle": "모든 페이지에서 메모를 바로 확인하고 답글할 수 있습니다",
-    "closeSidebar": "메모 사이드바 닫기"
+    "closeSidebar": "메모 사이드바 닫기",
+    "expandReplies": "이전 답글 {count}건 보기",
+    "collapseReplies": "답글 접기"
   },
   "login": {
     "title": "Sprintable",

--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -17,10 +17,19 @@ interface MemoThreadProps {
  * Thread-based conversation view for memo
  * Replaces traditional detail panel with messaging UX
  */
+const REPLY_COLLAPSE_THRESHOLD = 3;
+
 export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThreadProps) {
   const t = useTranslations('memos');
   const [replyContent, setReplyContent] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [repliesExpanded, setRepliesExpanded] = useState(false);
+
+  const allReplies = memo.replies ?? [];
+  const hiddenCount = Math.max(0, allReplies.length - REPLY_COLLAPSE_THRESHOLD);
+  const visibleReplies = repliesExpanded || hiddenCount === 0
+    ? allReplies
+    : allReplies.slice(allReplies.length - REPLY_COLLAPSE_THRESHOLD);
 
   const handleSubmitReply = async () => {
     if (!replyContent.trim() || isSubmitting) return;
@@ -81,8 +90,19 @@ export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThre
             isCurrentUser={memo.created_by === currentUserId}
           />
 
-          {/* Replies */}
-          {memo.replies?.map((reply) => (
+          {/* Replies — collapse when > 3 */}
+          {hiddenCount > 0 && (
+            <button
+              type="button"
+              onClick={() => setRepliesExpanded((v) => !v)}
+              className="w-full rounded-xl border border-white/8 bg-white/4 py-2 text-center text-xs font-medium text-gray-400 transition hover:bg-white/8 hover:text-gray-200"
+            >
+              {repliesExpanded
+                ? t('collapseReplies')
+                : t('expandReplies', { count: hiddenCount })}
+            </button>
+          )}
+          {visibleReplies.map((reply) => (
             <ThreadMessage
               key={reply.id}
               content={reply.content}


### PR DESCRIPTION
## Summary
- 답글이 3건 초과일 때 오래된 답글 숨김 (최신 3건만 표시)
- '이전 답글 N건 보기' 버튼으로 전체 펼치기/접기 토글
- i18n: `expandReplies`, `collapseReplies` 키 추가 (en/ko)

## Test plan
- [ ] 답글 3건 이하 → 버튼 없음, 전체 표시
- [ ] 답글 4건 이상 → '이전 답글 N건 보기' 버튼 표시
- [ ] 버튼 클릭 → 전체 펼침 / 재클릭 → 다시 접힘
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)