### PR TITLE
feat(ux): 대시보드 위젯 갱신 시각 + 스프린트 링크 (S-UX-DASHBOARD-WIDGET)

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -13,8 +13,10 @@ import { GlassPanel } from '@/components/ui/glass-panel';
 import { Button } from '@/components/ui/button';
 import { OperatorStatCard } from '@/components/ui/operator-stat-card';
 import { formatLocaleDateOnly, formatLocaleDateTime } from '@/lib/i18n';
+import { WidgetRefreshTime } from '@/components/ui/widget-refresh-time';
 
 export default async function DashboardPage() {
+  const fetchedAt = new Date().toISOString();
   const supabase = await createSupabaseServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
@@ -204,6 +206,7 @@ export default async function DashboardPage() {
                   <div className="text-sm text-[color:var(--operator-muted)]">{t('noAssignedStories')}</div>
                 </div>
               )}
+              <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
 
@@ -211,12 +214,17 @@ export default async function DashboardPage() {
             <SectionCardHeader><div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('sprintHealth')}</div></SectionCardHeader>
             <SectionCardBody className="space-y-3">
               {(activeSprints ?? []).length ? activeSprints!.map((s) => (
-                <div key={s.id} className="rounded-2xl border border-white/8 bg-white/4 p-3">
+                <Link
+                  key={s.id}
+                  href={`/board?sprint_id=${s.id}`}
+                  className="block rounded-2xl border border-white/8 bg-white/4 p-3 transition hover:border-white/16 hover:bg-white/8"
+                >
                   <div className="font-medium text-[color:var(--operator-foreground)]">{s.title}</div>
                   <div className="mt-1 text-xs text-[color:var(--operator-muted)]">{formatLocaleDateOnly(s.start_date, locale)} ~ {formatLocaleDateOnly(s.end_date, locale)}</div>
                   <div className="mt-2"><StatusBadge status={s.status} label={getSprintStatusLabel(s.status)} /></div>
-                </div>
+                </Link>
               )) : <EmptyState title={t('noActiveSprints')} description={t('noActiveSprintsDescription')} />}
+              <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
 
@@ -229,6 +237,7 @@ export default async function DashboardPage() {
                   <div className="text-xs text-[color:var(--operator-muted)]">/{doc.slug}</div>
                 </div>
               )) : <EmptyState title={t('noDocsYet')} description={t('noDocsYetDescription')} />}
+              <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
 
@@ -241,6 +250,7 @@ export default async function DashboardPage() {
                   <div className="text-xs text-[color:var(--operator-muted)]">{formatLocaleDateTime(doc.created_at, locale)}</div>
                 </div>
               )) : <EmptyState title={t('noPolicyDocs')} description={t('noPolicyDocsDescription')} />}
+              <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
 
@@ -258,6 +268,7 @@ export default async function DashboardPage() {
                   <div className="text-xs text-[color:var(--operator-muted)]">{formatLocaleDateTime(memo.created_at, locale)}</div>
                 </div>
               )) : <EmptyState title={t('noOpenMemos')} description={t('noOpenMemosDescription')} />}
+              <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
         </div>

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -53,7 +53,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [loadingMoreEpics, setLoadingMoreEpics] = useState(false);
   const [loadingMoreStoryTasks, setLoadingMoreStoryTasks] = useState(false);
 
-  const [selectedSprintId, setSelectedSprintId] = useState('');
+  const [selectedSprintId, setSelectedSprintId] = useState(() => searchParams.get('sprint_id') ?? '');
   const [selectedEpicId, setSelectedEpicId] = useState(() => searchParams.get('epic_id') ?? '');
   const [selectedAssigneeId, setSelectedAssigneeId] = useState('');
 

--- a/apps/web/src/components/ui/widget-refresh-time.tsx
+++ b/apps/web/src/components/ui/widget-refresh-time.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+function getRelativeLabel(fetchedAtMs: number): string {
+  const diffSec = Math.floor((Date.now() - fetchedAtMs) / 1000);
+  if (diffSec < 60) return '방금 갱신';
+  const diffMin = Math.floor(diffSec / 60);
+  if (diffMin < 60) return `갱신 ${diffMin}분 전`;
+  const diffHr = Math.floor(diffMin / 60);
+  return `갱신 ${diffHr}시간 전`;
+}
+
+interface WidgetRefreshTimeProps {
+  fetchedAt: string;
+}
+
+export function WidgetRefreshTime({ fetchedAt }: WidgetRefreshTimeProps) {
+  const fetchedAtMs = new Date(fetchedAt).getTime();
+  const [label, setLabel] = useState(() => getRelativeLabel(fetchedAtMs));
+
+  useEffect(() => {
+    const timer = setInterval(() => setLabel(getRelativeLabel(fetchedAtMs)), 30_000);
+    return () => clearInterval(timer);
+  }, [fetchedAtMs]);
+
+  return <span className="text-xs text-[color:var(--operator-muted)]">{label}</span>;
+}


### PR DESCRIPTION
## Summary
- 각 위젯 섹션 하단에 '갱신 N분 전' 상대 시각 표시 (`WidgetRefreshTime` 클라이언트 컴포넌트)
- 스프린트 헬스 위젯 아이템 클릭 시 `/board?sprint_id=xxx` 로 이동
- 보드: `selectedSprintId` 초기값을 URL `sprint_id` 파라미터로 읽도록 수정

## Test plan
- [ ] 대시보드 진입 시 각 위젯 하단에 '방금 갱신' 표시
- [ ] 30초 후 갱신 시각 업데이트 확인
- [ ] 스프린트 헬스 위젯 아이템 클릭 → `/board?sprint_id=xxx` 이동
- [ ] 보드 도착 시 해당 스프린트로 필터 적용 확인
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)