### PR TITLE
fix(mob): 칸반 보드 모바일 반응형 (S-MOB-KANBAN)

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -75,7 +75,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
 
   const epicMap: Record<string, string> = {};
   for (const e of epics) epicMap[e.id] = e.title;
@@ -337,7 +337,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       />
 
       <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-        <div className="flex flex-col gap-4 md:flex-row md:overflow-x-auto md:pb-4">
+        <div className="flex flex-col gap-3 md:flex-row md:gap-4 md:overflow-x-auto md:pb-4">
           {COLUMNS.map((col) => (
             <KanbanColumn
               key={col.id}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -43,7 +43,7 @@ export function KanbanColumn({ id, label, stories, epicMap, memberMap, dragStatu
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-h-[320px] w-full min-w-[280px] flex-col rounded-3xl border p-4 transition md:w-[320px] ${
+      className={`flex min-h-[320px] w-full flex-col rounded-3xl border p-4 transition md:w-[320px] md:min-w-[280px] ${
         isOver && isValidTarget
           ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/12 shadow-[0_0_0_1px_rgba(182,196,255,0.2)]'
           : isValidTarget

--- a/apps/web/src/components/kanban/kanban-filters.tsx
+++ b/apps/web/src/components/kanban/kanban-filters.tsx
@@ -30,20 +30,20 @@ export function KanbanFilters({
   const t = useTranslations('board');
 
   return (
-    <div className="flex flex-wrap items-center gap-3">
-      <OperatorSelect value={selectedSprintId} onChange={(e) => onSprintChange(e.target.value)} className="w-auto min-w-[180px]">
+    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+      <OperatorSelect value={selectedSprintId} onChange={(e) => onSprintChange(e.target.value)} className="w-full sm:w-auto sm:min-w-[180px]">
         <option value="">{t('allSprints')}</option>
         {sprints.map((sprint) => (
           <option key={sprint.id} value={sprint.id}>{sprint.title}</option>
         ))}
       </OperatorSelect>
-      <OperatorSelect value={selectedEpicId} onChange={(e) => onEpicChange(e.target.value)} className="w-auto min-w-[180px]">
+      <OperatorSelect value={selectedEpicId} onChange={(e) => onEpicChange(e.target.value)} className="w-full sm:w-auto sm:min-w-[180px]">
         <option value="">{t('allEpics')}</option>
         {epics.map((epic) => (
           <option key={epic.id} value={epic.id}>{epic.title}</option>
         ))}
       </OperatorSelect>
-      <OperatorSelect value={selectedAssigneeId} onChange={(e) => onAssigneeChange(e.target.value)} className="w-auto min-w-[180px]">
+      <OperatorSelect value={selectedAssigneeId} onChange={(e) => onAssigneeChange(e.target.value)} className="w-full sm:w-auto sm:min-w-[180px]">
         <option value="">{t('allAssignees')}</option>
         {members.map((member) => (
           <option key={member.id} value={member.id}>{member.name}</option>


### PR DESCRIPTION
## Summary
- `kanban-column`: `min-w-[280px]` → `md:min-w-[280px]` (모바일 가로 오버플로우 제거)
- `kanban-filters`: 셀렉트 `w-full` on mobile, `sm:w-auto sm:min-w-[180px]` on sm+
- `kanban-board`: 모바일 `gap-3`, 데스크탑 `md:gap-4` 최적화
- PointerSensor `distance: 8`으로 터치 오발동 방지

## Test plan
- [ ] 모바일(< 640px)에서 칸반 컬럼이 세로 스택으로 w-full 표시
- [ ] 모바일에서 필터 셀렉트 풀폭 표시
- [ ] 데스크탑에서 가로 스크롤 정상 동작
- [ ] 터치 드래그 앤 드롭 동작 확인
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)