### PR TITLE
fix(mob): 메모 사이드바 모바일 풀스크린 대응 (S-MOB-MEMO-SIDEBAR)

### DIFF
--- a/apps/web/src/components/memos/memo-detail.tsx
+++ b/apps/web/src/components/memos/memo-detail.tsx
@@ -444,7 +444,7 @@ export function MemoDetail({
         </div>
       </div>
 
-      <div className="border-t border-border/60 p-4">
+      <div className="sticky bottom-0 border-t border-border/60 bg-white p-4">
         <MemoComposer
           collaboration={collaboration}
           value={replyContent}

--- a/apps/web/src/components/memos/memo-sidebar.tsx
+++ b/apps/web/src/components/memos/memo-sidebar.tsx
@@ -30,6 +30,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
   const panelRef = useRef<HTMLDivElement | null>(null);
   const { clear, suppress, shouldIgnore } = useMemoRefreshGuard();
 
@@ -131,6 +132,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
 
   const handleSelectMemo = useCallback(async (memo: MemoSummaryState) => {
     await fetchMemoDetail(memo.id);
+    setMobileView('detail');
   }, [fetchMemoDetail]);
 
   const handleReply = useCallback(async (memoId: string, content: string) => {
@@ -195,13 +197,24 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
       <button className="fixed inset-0 z-40 bg-black/30" aria-label={t('closeSidebar')} onClick={onClose} />
       <aside
         ref={panelRef}
-        className="fixed right-0 top-0 z-50 flex h-full w-full max-w-5xl flex-col bg-white shadow-2xl md:w-[88vw]"
+        className="fixed inset-0 z-50 flex flex-col bg-white shadow-2xl md:inset-auto md:right-0 md:top-0 md:h-full md:w-[88vw] md:max-w-5xl"
         aria-label={t('sidebarTitle')}
       >
         <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">{t('sidebarTitle')}</h2>
-            <p className="text-xs text-gray-500">{t('sidebarSubtitle')}</p>
+          <div className="flex items-center gap-2">
+            {mobileView === 'detail' && selectedMemo && (
+              <button
+                onClick={() => setMobileView('list')}
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 md:hidden"
+                aria-label="Back to list"
+              >
+                ←
+              </button>
+            )}
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900">{t('sidebarTitle')}</h2>
+              <p className="hidden text-xs text-gray-500 sm:block">{t('sidebarSubtitle')}</p>
+            </div>
           </div>
           <div className="flex items-center gap-2">
             <button
@@ -210,7 +223,12 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
             >
               {t('newMemo')}
             </button>
-            <button onClick={onClose} className="rounded-lg px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100">✕</button>
+            <button
+              onClick={onClose}
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100"
+            >
+              ✕
+            </button>
           </div>
         </div>
 
@@ -221,7 +239,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
         )}
 
         <div className="grid min-h-0 flex-1 md:grid-cols-[320px_minmax(0,1fr)]">
-          <section className="min-h-0 overflow-y-auto border-r border-gray-200 bg-white">
+          <section className={`min-h-0 overflow-y-auto border-r border-gray-200 bg-white ${mobileView === 'detail' ? 'hidden md:block' : 'block'}`}>
             {loading ? (
               <div className="p-4 text-sm text-gray-400">{tc('loading')}</div>
             ) : (
@@ -247,7 +265,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
               </div>
             )}
           </section>
-          <section className="min-h-0 overflow-y-auto bg-white">
+          <section className={`min-h-0 overflow-y-auto bg-white ${mobileView === 'list' && !selectedMemo ? 'hidden md:flex' : 'block'}`}>
             {selectedMemo ? (
               <MemoDetail
                 memo={selectedMemo}


### PR DESCRIPTION
## Summary
- aside panel: 모바일 `inset-0` 풀스크린, md+ `right-0 top-0 w-[88vw]`
- 닫기 버튼 `min-h-[44px] min-w-[44px]` (Apple HIG 44px 터치 타겟)
- 모바일 리스트↔상세 토글: 메모 선택 시 상세 표시, 뒤로가기 버튼 추가
- memo-detail 답신 입력창 `sticky bottom-0 bg-white` (키보드 올라올 때 가림 방지)

## Test plan
- [ ] 모바일에서 사이드바 `inset-0` 풀스크린 표시 확인
- [ ] 메모 클릭 시 상세로 전환, ← 버튼으로 리스트 복귀
- [ ] md+ 에서 기존 2컬럼 레이아웃 정상 동작
- [ ] 닫기 버튼 44px 터치 타겟 확인
- [ ] 모바일 키보드 올라올 때 답신 입력창 표시 유지
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)