### PR TITLE
fix(mob): 설정 페이지 폼 레이아웃 태블릿 대응 (S-MOB-SETTINGS)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -397,7 +397,7 @@ export default function SettingsPage() {
               </div>
             ))}
           </div>
-          <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px_auto]">
+          <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
             <OperatorInput
               type="url"
               value={newWebhookUrl}
@@ -470,7 +470,7 @@ export default function SettingsPage() {
           ) : null}
 
           {isAdmin ? (
-            <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
               <OperatorInput
                 value={newProjectName}
                 onChange={(event) => setNewProjectName(event.target.value)}
@@ -581,7 +581,7 @@ export default function SettingsPage() {
             </div>
           </SectionCardHeader>
           <SectionCardBody className="space-y-4">
-            <div className="grid gap-3 lg:grid-cols-[220px_minmax(0,1fr)_auto]">
+            <div className="grid gap-3 md:grid-cols-[220px_minmax(0,1fr)_auto]">
               <OperatorSelect value={memberProjectId} onChange={(e) => setMemberProjectId(e.target.value)}>
                 <option value="">{t('selectProject')}</option>
                 {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}


### PR DESCRIPTION
## Summary
- 설정 폼 그리드 3개: `lg:grid-cols-*` → `md:grid-cols-*` 변경
- 모바일(< 768px): 1열 세로 스택, 태블릿(md+): 다열 레이아웃

## Test plan
- [ ] 모바일(< 768px): 입력 필드 세로 스택 확인
- [ ] 태블릿(768px+): 웹훅/프로젝트/멤버 폼 다열 표시
- [ ] 초대 폼 `md:flex-row` 정상 동작
- [ ] 삭제 확인 모달 모바일 패딩 정상
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)