### PR TITLE
fix(mob): 전역 터치 타겟 44px 확보 (S-MOB-TOUCH)

### DIFF
--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -289,7 +289,7 @@ export function OperatorShell({
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'flex flex-col items-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium',
+                  'flex min-h-[44px] flex-col items-center justify-center gap-1 rounded-2xl px-2 py-2 text-[11px] font-medium',
                   isActive ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]' : 'text-[color:var(--operator-muted)]',
                 )}
               >

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -25,16 +25,16 @@ const buttonVariants = cva(
       },
       size: {
         default:
-          "h-9 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+          "h-9 min-h-11 min-w-11 gap-1.5 px-3 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
         xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
         sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
-        lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
-        icon: "size-8",
+        lg: "h-9 min-h-11 min-w-11 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        icon: "size-11",
         "icon-xs":
           "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
         "icon-sm":
           "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
-        "icon-lg": "size-9",
+        "icon-lg": "size-11",
       },
     },
     defaultVariants: {

--- a/apps/web/src/components/ui/operator-control.tsx
+++ b/apps/web/src/components/ui/operator-control.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 const operatorControlClassName = 'rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] outline-none transition focus:border-[color:var(--operator-primary)]/35';
 
 export function OperatorInput({ className, ...props }: React.ComponentProps<typeof Input>) {
-  return <Input className={cn(operatorControlClassName, 'h-10 bg-[color:var(--operator-surface-soft)]', className)} {...props} />;
+  return <Input className={cn(operatorControlClassName, 'h-11 bg-[color:var(--operator-surface-soft)]', className)} {...props} />;
 }
 
 export function OperatorTextarea({ className, ...props }: React.ComponentProps<'textarea'>) {
@@ -20,7 +20,7 @@ export function OperatorTextarea({ className, ...props }: React.ComponentProps<'
 export function OperatorSelect({ className, ...props }: React.ComponentProps<'select'>) {
   return (
     <select
-      className={cn(operatorControlClassName, 'h-10 w-full pr-8', className)}
+      className={cn(operatorControlClassName, 'h-11 w-full pr-8', className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- OperatorInput/Select: `h-10` → `h-11` (40px → 44px)
- Button default/lg: `min-h-11 min-w-11` 추가
- Button icon/icon-lg: `size-8/9` → `size-11` (44px)
- Bottom nav 링크: `min-h-[44px] justify-center` 추가

## Test plan
- [ ] 입력 필드/셀렉트 높이 44px 확인
- [ ] 버튼 기본/lg 최소 44px 터치 영역 확인
- [ ] 아이콘 버튼 44x44px
- [ ] 하단 네비 각 탭 44px 높이 확인
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)