### PR TITLE
fix(mob): 오퍼레이터 쉘 모바일 최적화 (S-MOB-SHELL)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
@@ -18,6 +18,10 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Sprintable — The PM tool where agents are teammates",
   description: "AI-powered sprint management. Kanban, memos, standups, retros, MCP server — with AI agents as first-class team members.",
+};
+
+export const viewport: Viewport = {
+  viewportFit: 'cover',
 };
 
 export default async function RootLayout({

--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -17,6 +17,7 @@ import {
   LayoutDashboard,
   MessageSquareMore,
   PenTool,
+  Search,
   Settings,
   Trophy,
   Users,
@@ -233,7 +234,7 @@ export function OperatorShell({
           </GlassPanel>
         </aside>
 
-        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-3 pb-24 pt-3 sm:px-4 lg:px-5 lg:pb-5">
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-3 pt-3 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
           <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
             <div className="min-w-0">
               <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
@@ -252,6 +253,16 @@ export function OperatorShell({
               </div>
             </div>
             <div className="flex items-center gap-2">
+              <OperatorIconButton
+                onClick={() => {
+                  const searchInput = document.querySelector<HTMLInputElement>('[data-search-input]');
+                  searchInput?.focus();
+                }}
+                aria-label={shellT('searchPlaceholder')}
+                className="lg:hidden"
+              >
+                <Search className="size-4" />
+              </OperatorIconButton>
               <div className="lg:hidden">
                 <LocaleSwitcher />
               </div>
@@ -279,7 +290,7 @@ export function OperatorShell({
         </div>
       </div>
 
-      <div className="fixed inset-x-3 bottom-3 z-40 lg:hidden">
+      <div className="fixed inset-x-3 bottom-3 z-40 lg:hidden" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
         <GlassPanel className="grid grid-cols-5 gap-1 px-2 py-2">
           {MOBILE_NAV_ITEMS.map((item) => {
             const Icon = item.icon;


### PR DESCRIPTION
## Summary
- `viewport-fit=cover` 추가 (Next.js Viewport export)
- pb-24 → `max(5rem, calc(env(safe-area-inset-bottom)+4rem))` dynamic padding
- 하단 네비 컨테이너에 `env(safe-area-inset-bottom)` 적용 (iPhone 홈 인디케이터)
- 모바일 헤더에 Search 아이콘 버튼 추가 (lg:hidden)

## Test plan
- [ ] iPhone 노치/홈 인디케이터 기기에서 하단 네비 겹침 없음
- [ ] 콘텐츠 영역 하단 네비와 겹치지 않는 패딩 확인
- [ ] 모바일 헤더 검색 버튼 표시
- [ ] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)