### PR TITLE
feat(mob-docs): docs sidebar mobile drawer + tree indent cap

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -9,7 +9,7 @@ import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { Plus, X, Trash2, Copy, Check } from 'lucide-react';
+import { Plus, X, Trash2, Copy, Check, Menu } from 'lucide-react';
 
 interface Doc {
   id: string;
@@ -80,6 +80,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [tree, setTree] = useState<Doc[]>([]);
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
   const [loading, setLoading] = useState(true);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   // Always-editable content states
   const [title, setTitle] = useState('');
@@ -161,6 +162,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     const params = new URLSearchParams(searchParams);
     params.set('slug', slug);
     router.replace(`?${params.toString()}`);
+    setMobileSidebarOpen(false);
   }, [fetchDoc, router, searchParams]);
 
   const handleReorder = useCallback(async (docId: string, newSortOrder: number, siblings: Doc[]) => {
@@ -376,8 +378,18 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   return (
     <div className="flex h-screen">
+      {/* Mobile sidebar overlay */}
+      {mobileSidebarOpen && (
+        <button
+          type="button"
+          className="fixed inset-0 z-40 bg-black/50 md:hidden"
+          aria-label="Close sidebar"
+          onClick={() => setMobileSidebarOpen(false)}
+        />
+      )}
+
       {/* Left: Doc Tree */}
-      <div className="w-80 flex-shrink-0 border-r border-gray-800 flex flex-col">
+      <div className={`fixed inset-y-0 left-0 z-50 w-80 flex-shrink-0 border-r border-gray-800 flex flex-col bg-gray-900 transition-transform md:static md:translate-x-0 md:z-auto md:bg-transparent ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>
         <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3">
           <div className="flex items-center justify-between">
             <h1 className="text-lg font-semibold">{t('title')}</h1>
@@ -409,7 +421,19 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       </div>
 
       {/* Right: Doc Content or Create Form */}
-      <div className="flex-1 flex flex-col bg-gray-900">
+      <div className="flex-1 flex flex-col bg-gray-900 min-w-0">
+        {/* Mobile header with hamburger */}
+        <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2 md:hidden">
+          <button
+            type="button"
+            onClick={() => setMobileSidebarOpen(true)}
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-gray-400 hover:bg-gray-800"
+            aria-label={t('title')}
+          >
+            <Menu className="size-5" />
+          </button>
+          <span className="truncate text-sm font-medium text-gray-300">{selectedDoc?.title ?? t('title')}</span>
+        </div>
         {showCreate ? (
           <div className="flex h-full flex-col">
             <div className="flex-shrink-0 border-b border-gray-800 px-6 py-4">

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -147,7 +147,7 @@ function TreeNode({
               ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)] shadow-[inset_0_0_0_1px_rgba(182,196,255,0.14)]'
               : 'text-[color:var(--operator-foreground)]/88 hover:bg-white/6 hover:text-[color:var(--operator-foreground)]',
           )}
-          style={{ paddingLeft: `${depth * 18 + 12}px` }}
+          style={{ paddingLeft: `${Math.min(depth * 14 + 8, 72)}px` }}
           {...attributes}
           {...listeners}
         >
@@ -206,7 +206,7 @@ function TreeNode({
           ) : (
             <p
               className="py-1 text-[11px] italic text-[color:var(--operator-muted)]"
-              style={{ paddingLeft: `${(depth + 1) * 18 + 28}px` }}
+              style={{ paddingLeft: `${Math.min((depth + 1) * 14 + 24, 88)}px` }}
             >
               {emptyFolderLabel}
             </p>

--- a/apps/web/src/components/docs/policy-doc-browser.tsx
+++ b/apps/web/src/components/docs/policy-doc-browser.tsx
@@ -179,10 +179,10 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
         drawerOpen={policyPanelDrawerOpen}
         onDrawerOpenChange={setPolicyPanelDrawerOpen}
         drawerAriaLabel={t('openPolicySprints')}
-        className="min-h-[70vh]"
+        className="min-h-0 flex-1"
         inlineColumnsClassName="2xl:grid-cols-[280px_minmax(0,1fr)]"
       >
-        <div className="grid min-h-[70vh] gap-4 p-4 xl:grid-cols-[320px_minmax(0,1fr)]">
+        <div className="grid gap-4 p-4 xl:grid-cols-[320px_minmax(0,1fr)]">
         <SectionCard className="border-white/8 bg-white/4">
           <SectionCardHeader>
             <div className="space-y-3">


### PR DESCRIPTION
## Summary
- docs-shell-client: sidebar를 mobile에서 slide-in drawer로 전환. 햄버거 버튼 + overlay 추가. doc 선택 시 자동 닫힘
- policy-doc-browser: `min-h-[70vh]` 제거 → `min-h-0 flex-1`로 변경. 모바일 overflow 방지
- doc-tree: depth indent `depth*18+12px` → `Math.min(depth*14+8, 72)px`로 축소·캡핑. 깊은 트리 모바일 수평 overflow 방지

## Test plan
- [ ] Mobile(<md): 햄버거 버튼 → sidebar drawer open/close 확인
- [ ] doc 클릭 시 drawer 자동 닫힘 확인
- [ ] 깊이 3+ 폴더 트리에서 수평 overflow 없음 확인
- [ ] md+ desktop: 기존 고정 sidebar 동일하게 표시 확인
- [ ] pnpm build 통과 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)