### PR TITLE
feat(mob-kanban-listview): mobile list view for kanban board

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -8,6 +8,7 @@ import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOve
 import { Button } from '@/components/ui/button';
 import { KanbanColumn } from './kanban-column';
 import { KanbanFilters } from './kanban-filters';
+import { KanbanListView } from './kanban-list-view';
 import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
@@ -336,38 +337,52 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         onAssigneeChange={setSelectedAssigneeId}
       />
 
-      <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
-        <div className="flex flex-col gap-3 md:flex-row md:gap-4 md:overflow-x-auto md:pb-4">
-          {COLUMNS.map((col) => (
-            <KanbanColumn
-              key={col.id}
-              id={col.id}
-              label={t(col.i18nKey)}
-              stories={storiesByColumn(col.id)}
-              epicMap={epicMap}
-              memberMap={memberMap}
-              dragStatus={dragStatus}
-              onStoryClick={handleStoryClick}
-              onEditStory={handleEditStory}
-              onChangeStatus={handleChangeStatus}
-              onAssignStory={handleAssignStory}
-              onDeleteStory={handleDeleteStory}
-            />
-          ))}
-        </div>
-        <DragOverlayCompat adjustScale={false} className="cursor-grabbing">
-          {activeStory && (
-            <div className="rotate-3 scale-105">
-              <StoryCard
-                story={activeStory}
-                epicName={activeStory.epic_id ? epicMap[activeStory.epic_id] : undefined}
-                assigneeName={activeStory.assignee_id ? memberMap[activeStory.assignee_id] : undefined}
-                onClick={() => {}}
+      {/* Mobile list view (hidden on md+) */}
+      <div className="md:hidden">
+        <KanbanListView
+          stories={filteredStories}
+          epicMap={epicMap}
+          memberMap={memberMap}
+          onStoryClick={handleStoryClick}
+          onChangeStatus={handleChangeStatus}
+        />
+      </div>
+
+      {/* Desktop kanban (hidden below md) */}
+      <div className="hidden md:block">
+        <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
+          <div className="flex flex-row gap-4 overflow-x-auto pb-4">
+            {COLUMNS.map((col) => (
+              <KanbanColumn
+                key={col.id}
+                id={col.id}
+                label={t(col.i18nKey)}
+                stories={storiesByColumn(col.id)}
+                epicMap={epicMap}
+                memberMap={memberMap}
+                dragStatus={dragStatus}
+                onStoryClick={handleStoryClick}
+                onEditStory={handleEditStory}
+                onChangeStatus={handleChangeStatus}
+                onAssignStory={handleAssignStory}
+                onDeleteStory={handleDeleteStory}
               />
-            </div>
-          )}
-        </DragOverlayCompat>
-      </DndContext>
+            ))}
+          </div>
+          <DragOverlayCompat adjustScale={false} className="cursor-grabbing">
+            {activeStory && (
+              <div className="rotate-3 scale-105">
+                <StoryCard
+                  story={activeStory}
+                  epicName={activeStory.epic_id ? epicMap[activeStory.epic_id] : undefined}
+                  assigneeName={activeStory.assignee_id ? memberMap[activeStory.assignee_id] : undefined}
+                  onClick={() => {}}
+                />
+              </div>
+            )}
+          </DragOverlayCompat>
+        </DndContext>
+      </div>
 
       {nextCursor || epicsNextCursor ? (
         <div className="flex flex-wrap items-center justify-center gap-2">

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+import { useTranslations } from 'next-intl';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Badge } from '@/components/ui/badge';
+import { COLUMNS, VALID_TRANSITIONS, type KanbanStory } from './types';
+
+const PRIORITY_BADGE: Record<string, 'default' | 'info' | 'success' | 'destructive' | 'outline'> = {
+  critical: 'destructive',
+  high: 'outline',
+  medium: 'info',
+  low: 'default',
+};
+
+interface KanbanListViewProps {
+  stories: KanbanStory[];
+  epicMap: Record<string, string>;
+  memberMap: Record<string, string>;
+  onStoryClick: (story: KanbanStory) => void;
+  onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
+}
+
+interface ListStoryRowProps {
+  story: KanbanStory;
+  epicMap: Record<string, string>;
+  memberMap: Record<string, string>;
+  onStoryClick: (story: KanbanStory) => void;
+  onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
+}
+
+function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus }: ListStoryRowProps) {
+  const t = useTranslations('board');
+  const [statusOpen, setStatusOpen] = useState(false);
+  const validNext = VALID_TRANSITIONS[story.status] ?? [];
+
+  const handleStatusChange = useCallback(
+    async (newStatus: string) => {
+      setStatusOpen(false);
+      await onChangeStatus(story.id, newStatus);
+    },
+    [story.id, onChangeStatus],
+  );
+
+  const currentColumn = COLUMNS.find((c) => c.id === story.status);
+
+  return (
+    <div className="relative flex items-center gap-3 rounded-2xl border border-white/6 bg-[color:var(--operator-surface-soft)] px-4 py-3 transition-all hover:bg-white/6">
+      <button
+        className="min-h-[44px] flex-1 text-left"
+        onClick={() => onStoryClick(story)}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          {story.epic_id && epicMap[story.epic_id] && (
+            <Badge variant="info" className="text-[10px]">{epicMap[story.epic_id]}</Badge>
+          )}
+          {story.priority && (
+            <Badge variant={PRIORITY_BADGE[story.priority] ?? 'default'} className="text-[10px] capitalize">{story.priority as string}</Badge>
+          )}
+          {story.story_points != null && (
+            <span className="text-[10px] text-[color:var(--operator-muted)]">{t('storyPointsBadge', { count: story.story_points })}</span>
+          )}
+        </div>
+        <p className="mt-1 text-sm font-medium text-[color:var(--operator-foreground)] line-clamp-2">{story.title}</p>
+        {story.assignee_id && memberMap[story.assignee_id] && (
+          <p className="mt-1 text-xs text-[color:var(--operator-muted)]">{memberMap[story.assignee_id]}</p>
+        )}
+      </button>
+
+      <div className="relative shrink-0">
+        <button
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl border border-white/10 bg-white/5 px-2 text-xs text-[color:var(--operator-muted)] transition hover:bg-white/10"
+          onClick={(e) => {
+            e.stopPropagation();
+            setStatusOpen((prev) => !prev);
+          }}
+        >
+          <span className="max-w-[80px] truncate">{currentColumn ? t(currentColumn.i18nKey) : story.status}</span>
+          <ChevronDown className="ml-1 size-3 shrink-0" />
+        </button>
+
+        {statusOpen && validNext.length > 0 && (
+          <div className="absolute right-0 top-full z-50 mt-1 min-w-[140px] rounded-xl border border-white/10 bg-[color:var(--operator-panel)] p-1 shadow-lg">
+            {validNext.map((nextStatus) => {
+              const col = COLUMNS.find((c) => c.id === nextStatus);
+              if (!col) return null;
+              return (
+                <button
+                  key={nextStatus}
+                  className="w-full rounded-lg px-3 py-2 text-left text-sm text-[color:var(--operator-foreground)] hover:bg-white/8"
+                  onClick={() => void handleStatusChange(nextStatus)}
+                >
+                  {t(col.i18nKey)}
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface StatusGroupProps {
+  columnId: string;
+  label: string;
+  stories: KanbanStory[];
+  epicMap: Record<string, string>;
+  memberMap: Record<string, string>;
+  onStoryClick: (story: KanbanStory) => void;
+  onChangeStatus: (storyId: string, newStatus: string) => Promise<void>;
+}
+
+function StatusGroup({ columnId, label, stories, epicMap, memberMap, onStoryClick, onChangeStatus }: StatusGroupProps) {
+  const [expanded, setExpanded] = useState(columnId !== 'done');
+
+  return (
+    <div>
+      <button
+        className="flex w-full items-center gap-2 rounded-2xl px-3 py-2.5 text-sm font-semibold text-[color:var(--operator-foreground)] hover:bg-white/5"
+        onClick={() => setExpanded((p) => !p)}
+      >
+        {expanded ? <ChevronDown className="size-4 shrink-0" /> : <ChevronRight className="size-4 shrink-0" />}
+        <span>{label}</span>
+        <span className="ml-auto rounded-full bg-white/8 px-2 py-0.5 text-xs text-[color:var(--operator-muted)]">{stories.length}</span>
+      </button>
+
+      {expanded && (
+        <div className={cn('mt-1 space-y-2 pl-2', stories.length === 0 && 'pb-2')}>
+          {stories.length === 0 ? (
+            <p className="px-3 text-xs text-[color:var(--operator-muted)]">—</p>
+          ) : (
+            stories.map((story) => (
+              <ListStoryRow
+                key={story.id}
+                story={story}
+                epicMap={epicMap}
+                memberMap={memberMap}
+                onStoryClick={onStoryClick}
+                onChangeStatus={onChangeStatus}
+              />
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function KanbanListView({ stories, epicMap, memberMap, onStoryClick, onChangeStatus }: KanbanListViewProps) {
+  const t = useTranslations('board');
+
+  return (
+    <div className="space-y-2">
+      {COLUMNS.map((col) => {
+        const colStories = stories.filter((s) => s.status === col.id);
+        return (
+          <StatusGroup
+            key={col.id}
+            columnId={col.id}
+            label={t(col.i18nKey)}
+            stories={colStories}
+            epicMap={epicMap}
+            memberMap={memberMap}
+            onStoryClick={onStoryClick}
+            onChangeStatus={onChangeStatus}
+          />
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- 모바일(<md)에서 칸반 DnD 대신 상태별 그룹 리스트 뷰 렌더링
- 상태 그룹(Backlog/Ready/In Progress/In Review/Done) 접기/펼치기 지원. Done은 기본 접힘
- 스토리 행 탭 → 상세 패널 열기. 우측 상태 버튼 → VALID_TRANSITIONS 기반 상태 변경 드롭다운
- 44px 터치 타겟 준수
- md+ desktop: 기존 DnD 칸반 보드 그대로 유지

## Test plan
- [ ] 모바일(<md)에서 리스트 뷰 표시 확인
- [ ] 상태 그룹 접기/펼치기 동작 확인
- [ ] 스토리 탭 → 상세 패널 열림 확인
- [ ] 상태 변경 드롭다운에서 유효한 다음 상태만 표시 확인 (e.g. done → 빈 목록)
- [ ] md+ desktop에서 기존 칸반 보드 정상 표시 확인
- [ ] pnpm build 통과 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)