### PR TITLE
fix(mob-polish-1): toast safe-area + login/onboarding mobile padding

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -23,7 +23,7 @@ export default function LoginPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-8 shadow-lg">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
         <div className="flex flex-col items-center gap-3 text-center">
           <SprintableLogo
             variant="stacked"
@@ -39,7 +39,7 @@ export default function LoginPage() {
         <div className="space-y-3">
           <button
             onClick={() => handleOAuthLogin('google')}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+            className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
           >
             <svg className="h-5 w-5" viewBox="0 0 24 24">
               <path
@@ -64,7 +64,7 @@ export default function LoginPage() {
 
           <button
             onClick={() => handleOAuthLogin('github')}
-            className="flex w-full items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800"
+            className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800"
           >
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -132,7 +132,7 @@ export function OnboardingForm() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-8 shadow-lg">
+      <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
         <div className="text-center">
           <h1 className="text-2xl font-bold text-gray-900">
             {step === 'org' ? t('createOrg') : t('createProject')}

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -70,7 +70,7 @@ export function ToastContainer({
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+    <div className="fixed right-4 z-50 flex flex-col gap-2" style={{ bottom: 'max(1rem, calc(env(safe-area-inset-bottom) + 1rem))' }}>
       {toasts.map((t) => (
         <Toast key={t.id} item={t} onDismiss={onDismiss} />
       ))}


### PR DESCRIPTION
## Summary
- toast: `bottom-4` → `max(1rem, safe-area-inset-bottom + 1rem)` inline style. 노치/홈인디케이터 디바이스에서 시스템 UI에 가려지는 이슈 해소
- login/page.tsx: 카드 `p-8` → `p-4 sm:p-8`. OAuth 버튼 `min-h-[44px]` 추가
- onboarding-form.tsx: 카드 `p-8` → `p-4 sm:p-8`

## Test plan
- [ ] iPhone SE(375px) 등 소형 화면에서 login 카드 패딩 정상 확인
- [ ] iPhone X+ 노치 디바이스에서 토스트 safe-area 아래 위치 확인
- [ ] OAuth 버튼 최소 44px 높이 확인
- [ ] onboarding 화면 소형 화면 패딩 확인
- [ ] pnpm build 통과 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)