### PR TITLE
fix(mob-polish-2): agent filter stack + dashboard grid + dropdown height + upgrade modal

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -167,7 +167,7 @@ export default async function DashboardPage() {
             </SectionCardHeader>
             <SectionCardBody className="space-y-4">
               {/* Story Status Counts */}
-              <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+              <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2 md:grid-cols-4">
                 <div className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
                   <div className="text-2xl font-bold text-[color:var(--operator-primary-soft)]">{storyCounts.inProgress}</div>
                   <div className="text-xs text-[color:var(--operator-muted)]">{t('inProgress')}</div>

--- a/apps/web/src/components/agents/agent-runs-list.tsx
+++ b/apps/web/src/components/agents/agent-runs-list.tsx
@@ -184,18 +184,20 @@ export function AgentRunsList() {
 
       <SectionCard>
         <SectionCardHeader>
-          <div className="flex flex-wrap items-center gap-2">
-            {STATUS_FILTERS.map((s) => (
-              <Button
-                key={s}
-                variant={statusFilter === s ? 'hero' : 'glass'}
-                size="sm"
-                onClick={() => setStatusFilter(s)}
-              >
-                {s === ALL_RUN_STATUS_FILTER ? t('filterAll') : t(`status_${s}`)}
-              </Button>
-            ))}
-            <div className="ml-auto flex items-center gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center">
+            <div className="flex flex-wrap items-center gap-2">
+              {STATUS_FILTERS.map((s) => (
+                <Button
+                  key={s}
+                  variant={statusFilter === s ? 'hero' : 'glass'}
+                  size="sm"
+                  onClick={() => setStatusFilter(s)}
+                >
+                  {s === ALL_RUN_STATUS_FILTER ? t('filterAll') : t(`status_${s}`)}
+                </Button>
+              ))}
+            </div>
+            <div className="flex items-center gap-2 sm:ml-auto">
               <input
                 type="date"
                 value={fromDate}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -41,7 +41,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-[calc(100vh-4rem)] max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>

--- a/apps/web/src/components/ui/upgrade-modal.tsx
+++ b/apps/web/src/components/ui/upgrade-modal.tsx
@@ -12,7 +12,7 @@ export function UpgradeModal({ message, onClose }: UpgradeModalProps) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl">
+      <div className="w-full max-w-[calc(100%-2rem)] rounded-2xl bg-white p-6 shadow-xl sm:max-w-sm">
         <div className="text-center">
           <div className="mb-3 text-4xl">🚀</div>
           <h3 className="text-lg font-semibold text-gray-900">{t('upgradeRequired')}</h3>


### PR DESCRIPTION
## Summary
- agent-runs-list: 날짜 필터 영역 모바일에서 `flex-col` 스택. `sm:flex-row` + `sm:ml-auto`으로 desktop 레이아웃 유지
- dashboard: 스토리 카운트 위젯 `grid-cols-2` → `grid-cols-1 min-[360px]:grid-cols-2`. 극소형(<360px) 화면 대응
- dropdown-menu: `max-h-[calc(100vh-4rem)]` fallback 추가. base-ui CSS 변수 미지원 시 뷰포트 초과 방지
- upgrade-modal: `max-w-sm` → `max-w-[calc(100%-2rem)] sm:max-w-sm`. 소형 화면 좌우 여백 보장

## Test plan
- [ ] Agent 페이지 모바일에서 날짜 필터 세로 스택 확인
- [ ] 360px 미만 화면에서 dashboard 카운트 위젯 1열 확인
- [ ] 긴 드롭다운(Project switcher 등)에서 스크롤 가능한지 확인
- [ ] upgrade 모달 소형 화면에서 화면 밖 잘림 없음 확인
- [ ] pnpm build 통과 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)