### PR TITLE
fix(auth): Amplify OAuth redirect localhost 수정

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,11 +1,13 @@
 import { createServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { resolveAppUrl } from '@/services/app-url';
 
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url);
+  const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
   const next = searchParams.get('next') ?? '/dashboard';
+  const origin = resolveAppUrl(null);
 
   if (code) {
     const cookieStore = await cookies();


### PR DESCRIPTION
## Summary
- Amplify SSR Lambda 내부에서 `request.url` origin이 `localhost:3000`으로 잡히는 문제 수정
- `resolveAppUrl()`로 `APP_BASE_URL` env var 우선 사용하도록 변경
- Amplify branch env에 `APP_BASE_URL=https://main.d1lv1pwwa1f9wo.amplifyapp.com` 추가 완료

## Test plan
- [ ] Amplify 배포 후 OAuth 로그인 → dashboard 정상 리다이렉트 확인
- [ ] localhost:3000 개발 환경에서도 fallback 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)