### PR TITLE
[HOTFIX] 모바일 헤더 ProjectSwitcher 미렌더링 수정

### DIFF
--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -238,7 +238,16 @@ export function OperatorShell({
           <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
             <div className="min-w-0">
               <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
-              <div className="truncate font-heading text-sm font-bold text-[color:var(--operator-foreground)]">{projectName ?? (projectId ? shellT('projectAttached') : shellT('projectPending'))}</div>
+              {projectMemberships.length > 0 ? (
+                <div className="mt-0.5 lg:hidden">
+                  <ProjectSwitcher
+                    projects={projectMemberships}
+                    currentProjectId={projectId}
+                    className="min-h-[44px] max-w-[180px]"
+                  />
+                </div>
+              ) : null}
+              <div className={`truncate font-heading text-sm font-bold text-[color:var(--operator-foreground)]${projectMemberships.length > 0 ? ' hidden lg:block' : ''}`}>{projectName ?? (projectId ? shellT('projectAttached') : shellT('projectPending'))}</div>
             </div>
             <div className="hidden max-w-xl flex-1 items-center gap-3 lg:flex">
               {projectMemberships.length > 0 ? (


### PR DESCRIPTION
## Summary
- `operator-shell.tsx:243` 의 `hidden lg:flex` div 안에만 있던 ProjectSwitcher가 모바일에서 완전히 숨겨지는 문제 수정
- 모바일 헤더 좌측 프로젝트 라벨 영역에 `lg:hidden` ProjectSwitcher(native select) 추가
- 데스크톱 레이아웃 (기존 중앙 영역의 `lg:flex` ProjectSwitcher) 완전 유지
- 터치 타겟 `min-h-[44px]` 적용

## Test plan
- [ ] 모바일(< lg) 뷰포트에서 헤더 좌측에 프로젝트 선택 select 노출 확인
- [ ] 프로젝트 선택 시 페이지 정상 전환 확인
- [ ] 데스크톱(≥ lg)에서 기존 중앙 switcher 유지 확인 (모바일 select는 hidden)
- [ ] 프로젝트 멤버십 없을 때 기존 프로젝트명 텍스트 표시 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)