### PR TITLE
[E-MOB-NAV S2] 모바일 패딩 최적화 — 중첩 패딩 제거 72px→40px

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -436,7 +436,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         </div>
         {showCreate ? (
           <div className="flex h-full flex-col">
-            <div className="flex-shrink-0 border-b border-gray-800 px-6 py-4">
+            <div className="flex-shrink-0 border-b border-gray-800 px-3 py-2 md:px-6 md:py-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
                 <Button variant="ghost" size="sm" onClick={() => {
@@ -447,7 +447,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 </Button>
               </div>
             </div>
-            <div className="flex-1 overflow-y-auto px-6 py-6">
+            <div className="flex-1 overflow-y-auto px-3 py-3 md:px-6 md:py-6">
               <div className="space-y-4 max-w-3xl">
                 <div>
                   <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
@@ -491,7 +491,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         ) : selectedDoc ? (
           <>
             {/* Header */}
-            <div className="flex-shrink-0 border-b border-gray-800 px-6 py-4">
+            <div className="flex-shrink-0 border-b border-gray-800 px-3 py-2 md:px-6 md:py-4">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <Input
@@ -514,7 +514,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             </div>
 
             {/* Content — always-editable tiptap */}
-            <div className="flex-1 overflow-y-auto px-6 py-6">
+            <div className="flex-1 overflow-y-auto px-3 py-3 md:px-6 md:py-6">
               <DocEditor
                 value={content}
                 contentFormat={contentFormat}

--- a/apps/web/src/components/docs/docs-shell.tsx
+++ b/apps/web/src/components/docs/docs-shell.tsx
@@ -17,7 +17,7 @@ export function DocsShell({
 }) {
   return (
     <>
-      <div className={cn('grid gap-4 md:grid-cols-[280px_minmax(0,1fr)]', className)}>
+      <div className={cn('grid gap-2 md:gap-4 md:grid-cols-[280px_minmax(0,1fr)]', className)}>
         <GlassPanel className="hidden min-w-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/75 md:block">
           {sidebar}
         </GlassPanel>

--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -234,7 +234,7 @@ export function OperatorShell({
           </GlassPanel>
         </aside>
 
-        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-3 pt-3 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-2 pt-2 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
           <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
             <div className="min-w-0">
               <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>

--- a/apps/web/src/components/ui/glass-panel.tsx
+++ b/apps/web/src/components/ui/glass-panel.tsx
@@ -6,7 +6,7 @@ export function GlassPanel({ className, ...props }: React.ComponentProps<'div'>)
     <div
       data-slot="glass-panel"
       className={cn(
-        'rounded-3xl border border-white/10 bg-[color:var(--operator-panel)]/80 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-xl',
+        'rounded-2xl border border-white/10 bg-[color:var(--operator-panel)]/80 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-xl md:rounded-3xl',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- `operator-shell.tsx` Main Content Area: `px-3 pt-3` → `px-2 pt-2` (모바일만, sm/lg 유지)
- `docs-shell-client.tsx` 콘텐츠 헤더·본문 4곳: `px-6 py-4/6` → `px-3 py-2/3 md:px-6 md:py-4/6`
- `docs-shell.tsx`: `gap-4` → `gap-2 md:gap-4`
- `glass-panel.tsx`: `rounded-3xl` → `rounded-2xl md:rounded-3xl`

**패딩 계산 (모바일, per-side)**
| | 수정 전 | 수정 후 |
|--|---------|---------|
| OperatorShell | 12px | 8px |
| Docs 콘텐츠 | 24px | 12px |
| **합계 (양측)** | **72px** | **40px** |

데스크톱(md+) 레이아웃 변경 없음.

## Test plan
- [ ] 모바일(375px) Docs 페이지 총 수평 패딩 40px 이내 확인
- [ ] 데스크톱(1280px) Docs 레이아웃 변경 없음 확인
- [ ] 다른 페이지(Dashboard, Kanban 등) 레이아웃 회귀 없음 확인
- [ ] GlassPanel rounded-2xl 모바일 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)