### PR TITLE
[E-MOB-NAV S3] 색상 변수 통일 — gray-* → operator CSS vars

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -371,7 +371,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   if (loading) {
     return (
       <div className="flex h-screen items-center justify-center">
-        <p className="text-sm text-gray-400">{t('loading')}</p>
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
       </div>
     );
   }
@@ -389,8 +389,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       )}
 
       {/* Left: Doc Tree */}
-      <div className={`fixed inset-y-0 left-0 z-50 w-80 flex-shrink-0 border-r border-gray-800 flex flex-col bg-gray-900 transition-transform md:static md:translate-x-0 md:z-auto md:bg-transparent ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>
-        <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3">
+      <div className={`fixed inset-y-0 left-0 z-50 w-80 flex-shrink-0 border-r border-white/10 flex flex-col bg-[color:var(--operator-surface)] transition-transform md:static md:translate-x-0 md:z-auto md:bg-transparent ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>
+        <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
           <div className="flex items-center justify-between">
             <h1 className="text-lg font-semibold">{t('title')}</h1>
             <Button size="sm" onClick={() => {
@@ -421,22 +421,22 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       </div>
 
       {/* Right: Doc Content or Create Form */}
-      <div className="flex-1 flex flex-col bg-gray-900 min-w-0">
+      <div className="flex-1 flex flex-col bg-[color:var(--operator-surface)] min-w-0">
         {/* Mobile header with hamburger */}
-        <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2 md:hidden">
+        <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2 md:hidden">
           <button
             type="button"
             onClick={() => setMobileSidebarOpen(true)}
-            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-gray-400 hover:bg-gray-800"
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)]"
             aria-label={t('title')}
           >
             <Menu className="size-5" />
           </button>
-          <span className="truncate text-sm font-medium text-gray-300">{selectedDoc?.title ?? t('title')}</span>
+          <span className="truncate text-sm font-medium text-[color:var(--operator-foreground)]">{selectedDoc?.title ?? t('title')}</span>
         </div>
         {showCreate ? (
           <div className="flex h-full flex-col">
-            <div className="flex-shrink-0 border-b border-gray-800 px-3 py-2 md:px-6 md:py-4">
+            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 md:px-6 md:py-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
                 <Button variant="ghost" size="sm" onClick={() => {
@@ -471,7 +471,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                     value={newContent}
                     onChange={(e) => setNewContent(e.target.value)}
                     placeholder={t('editorPlaceholder')}
-                    className="w-full min-h-[200px] rounded-lg border border-gray-700 bg-gray-800 px-3 py-2 text-sm resize-none"
+                    className="w-full min-h-[200px] rounded-lg border border-white/10 bg-[color:var(--operator-surface-soft)] px-3 py-2 text-sm resize-none"
                   />
                 </div>
                 <div className="flex gap-2">
@@ -491,7 +491,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         ) : selectedDoc ? (
           <>
             {/* Header */}
-            <div className="flex-shrink-0 border-b border-gray-800 px-3 py-2 md:px-6 md:py-4">
+            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 md:px-6 md:py-4">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <Input
@@ -544,7 +544,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
           </>
         ) : (
           <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-gray-400">{t('selectDoc')}</p>
+            <p className="text-sm text-[color:var(--operator-muted)]">{t('selectDoc')}</p>
           </div>
         )}
       </div>

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -7,6 +7,7 @@ import { DocTree } from '@/components/docs/doc-tree';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
+import { GlassPanel } from '@/components/ui/glass-panel';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { Plus, X, Trash2, Copy, Check, Menu } from 'lucide-react';
@@ -421,7 +422,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       </div>
 
       {/* Right: Doc Content or Create Form */}
-      <div className="flex-1 flex flex-col bg-[color:var(--operator-surface)] min-w-0">
+      <GlassPanel className="flex-1 flex flex-col min-w-0 rounded-none md:rounded-2xl">
         {/* Mobile header with hamburger */}
         <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2 md:hidden">
           <button
@@ -547,7 +548,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             <p className="text-sm text-[color:var(--operator-muted)]">{t('selectDoc')}</p>
           </div>
         )}
-      </div>
+      </GlassPanel>
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );

--- a/apps/web/src/components/memos/memo-sidebar.tsx
+++ b/apps/web/src/components/memos/memo-sidebar.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';
+import { GlassPanel } from '@/components/ui/glass-panel';
 import { MemoList } from '@/components/memos/memo-list';
 import { MemoDetail } from '@/components/memos/memo-detail';
 import { MemoCreateForm } from '@/components/memos/memo-create-form';
@@ -195,10 +196,11 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
   return (
     <>
       <button className="fixed inset-0 z-40 bg-black/30" aria-label={t('closeSidebar')} onClick={onClose} />
-      <aside
+      <GlassPanel
         ref={panelRef}
-        className="fixed inset-0 z-50 flex flex-col bg-[color:var(--operator-panel)] shadow-2xl md:inset-auto md:right-0 md:top-0 md:h-full md:w-[88vw] md:max-w-5xl"
+        className="fixed inset-0 z-50 flex flex-col rounded-none md:inset-auto md:right-0 md:top-0 md:h-full md:w-[88vw] md:max-w-5xl md:rounded-2xl"
         aria-label={t('sidebarTitle')}
+        role="complementary"
       >
         <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
           <div className="flex items-center gap-2">
@@ -282,7 +284,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
             )}
           </section>
         </div>
-      </aside>
+      </GlassPanel>
     </>
   );
 }

--- a/apps/web/src/components/memos/memo-sidebar.tsx
+++ b/apps/web/src/components/memos/memo-sidebar.tsx
@@ -197,23 +197,23 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
       <button className="fixed inset-0 z-40 bg-black/30" aria-label={t('closeSidebar')} onClick={onClose} />
       <aside
         ref={panelRef}
-        className="fixed inset-0 z-50 flex flex-col bg-white shadow-2xl md:inset-auto md:right-0 md:top-0 md:h-full md:w-[88vw] md:max-w-5xl"
+        className="fixed inset-0 z-50 flex flex-col bg-[color:var(--operator-panel)] shadow-2xl md:inset-auto md:right-0 md:top-0 md:h-full md:w-[88vw] md:max-w-5xl"
         aria-label={t('sidebarTitle')}
       >
-        <div className="flex items-center justify-between border-b border-gray-200 px-4 py-3">
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
           <div className="flex items-center gap-2">
             {mobileView === 'detail' && selectedMemo && (
               <button
                 onClick={() => setMobileView('list')}
-                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100 md:hidden"
+                className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)] md:hidden"
                 aria-label="Back to list"
               >
                 ←
               </button>
             )}
             <div>
-              <h2 className="text-lg font-semibold text-gray-900">{t('sidebarTitle')}</h2>
-              <p className="hidden text-xs text-gray-500 sm:block">{t('sidebarSubtitle')}</p>
+              <h2 className="text-lg font-semibold text-[color:var(--operator-foreground)]">{t('sidebarTitle')}</h2>
+              <p className="hidden text-xs text-[color:var(--operator-muted)] sm:block">{t('sidebarSubtitle')}</p>
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -225,7 +225,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
             </button>
             <button
               onClick={onClose}
-              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-gray-600 hover:bg-gray-100"
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)]"
             >
               ✕
             </button>
@@ -233,15 +233,15 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
         </div>
 
         {showCreate && (
-          <div className="border-b border-gray-200 bg-gray-50 p-4">
+          <div className="border-b border-white/10 bg-[color:var(--operator-surface-soft)] p-4">
             <MemoCreateForm members={members} onSubmit={handleCreate} onCancel={() => setShowCreate(false)} draftStorageKey={createMemoDraftStorageKey(projectId, currentTeamMemberId)} />
           </div>
         )}
 
         <div className="grid min-h-0 flex-1 md:grid-cols-[320px_minmax(0,1fr)]">
-          <section className={`min-h-0 overflow-y-auto border-r border-gray-200 bg-white ${mobileView === 'detail' ? 'hidden md:block' : 'block'}`}>
+          <section className={`min-h-0 overflow-y-auto border-r border-white/10 bg-[color:var(--operator-panel)] ${mobileView === 'detail' ? 'hidden md:block' : 'block'}`}>
             {loading ? (
-              <div className="p-4 text-sm text-gray-400">{tc('loading')}</div>
+              <div className="p-4 text-sm text-[color:var(--operator-muted)]">{tc('loading')}</div>
             ) : (
               <div className="space-y-3 p-0">
                 <MemoList memos={memos} memberMap={memberMap} onSelect={handleSelectMemo} selectedId={selectedMemo?.id} />
@@ -265,7 +265,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
               </div>
             )}
           </section>
-          <section className={`min-h-0 overflow-y-auto bg-white ${mobileView === 'list' && !selectedMemo ? 'hidden md:flex' : 'block'}`}>
+          <section className={`min-h-0 overflow-y-auto bg-[color:var(--operator-panel)] ${mobileView === 'list' && !selectedMemo ? 'hidden md:flex' : 'block'}`}>
             {selectedMemo ? (
               <MemoDetail
                 memo={selectedMemo}
@@ -278,7 +278,7 @@ export function MemoSidebar({ open, onClose, currentTeamMemberId, projectId }: M
                 onMemoChange={handleMemoChange}
               />
             ) : (
-              <div className="flex h-full items-center justify-center text-sm text-gray-400">{t('selectMemo')}</div>
+              <div className="flex h-full items-center justify-center text-sm text-[color:var(--operator-muted)]">{t('selectMemo')}</div>
             )}
           </section>
         </div>


### PR DESCRIPTION
## Summary
- `docs-shell-client.tsx`: `bg-gray-900`, `border-gray-800`, `text-gray-400/300`, `bg-gray-800`, `border-gray-700` → operator CSS vars 전환
- `memo-sidebar.tsx`: `bg-white`, `border-gray-200`, `bg-gray-50`, `hover:bg-gray-100`, `text-gray-900/500/600/400` → operator CSS vars 전환
- 두 파일 gray-* **0건** 달성

**변환 매핑**
| gray-* | operator var |
|--------|-------------|
| `bg-gray-900` / `bg-white` | `var(--operator-surface)` / `var(--operator-panel)` |
| `border-gray-800` / `border-gray-200` | `border-white/10` |
| `bg-gray-50` / `hover:bg-gray-100` | `var(--operator-surface-soft)` |
| `text-gray-400/500/600` | `var(--operator-muted)` |
| `text-gray-900/300` | `var(--operator-foreground)` |
| `bg-gray-800` / `border-gray-700` | `var(--operator-surface-soft)` / `border-white/10` |

## Test plan
- [ ] Docs 페이지 다크테마 OperatorShell 톤과 일치 확인
- [ ] Memos 사이드바 다크테마 일치 확인
- [ ] 라이트모드 존재 시 operator vars 정상 적용 확인
- [ ] 두 파일 gray-* 0건 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)