### PR TITLE
[E-MOB-NAV S4] Docs 셸 모바일 재구현 — DocsShell 표준 패턴

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -7,10 +7,10 @@ import { DocTree } from '@/components/docs/doc-tree';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
-import { GlassPanel } from '@/components/ui/glass-panel';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { Plus, X, Trash2, Copy, Check, Menu } from 'lucide-react';
+import { DocsShell } from '@/components/docs/docs-shell';
 
 interface Doc {
   id: string;
@@ -377,54 +377,49 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     );
   }
 
-  return (
-    <div className="flex h-screen">
-      {/* Mobile sidebar overlay */}
-      {mobileSidebarOpen && (
-        <button
-          type="button"
-          className="fixed inset-0 z-40 bg-black/50 md:hidden"
-          aria-label="Close sidebar"
-          onClick={() => setMobileSidebarOpen(false)}
-        />
-      )}
-
-      {/* Left: Doc Tree */}
-      <div className={`fixed inset-y-0 left-0 z-50 w-80 flex-shrink-0 border-r border-white/10 flex flex-col bg-[color:var(--operator-surface)] transition-transform md:static md:translate-x-0 md:z-auto md:bg-transparent ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}`}>
-        <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
-          <div className="flex items-center justify-between">
-            <h1 className="text-lg font-semibold">{t('title')}</h1>
-            <Button size="sm" onClick={() => {
-              setShowCreate(true);
-              setNewTitle('');
-              setNewSlug('');
-              setNewContent('');
-              setNewParentId(null);
-              setSlugManuallyEdited(false);
-            }}>
-              <Plus className="h-4 w-4" />
-            </Button>
-          </div>
-        </div>
-        <div className="flex-1 overflow-y-auto p-2">
-          <DocTree
-            docs={tree}
-            selectedSlug={selectedDoc?.slug || null}
-            onSelect={handleSelectDoc}
-            onReorder={handleReorder}
-            onMove={handleMove}
-            onMoveDenied={handleMoveDenied}
-            onRename={handleRename}
-            onDelete={handleDeleteDoc}
-            onAddChild={handleAddChild}
-          />
+  const sidebarContent = (
+    <>
+      <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-semibold">{t('title')}</h1>
+          <Button size="sm" onClick={() => {
+            setShowCreate(true);
+            setNewTitle('');
+            setNewSlug('');
+            setNewContent('');
+            setNewParentId(null);
+            setSlugManuallyEdited(false);
+          }}>
+            <Plus className="h-4 w-4" />
+          </Button>
         </div>
       </div>
+      <div className="flex-1 overflow-y-auto p-2">
+        <DocTree
+          docs={tree}
+          selectedSlug={selectedDoc?.slug || null}
+          onSelect={(doc) => { handleSelectDoc(doc); setMobileSidebarOpen(false); }}
+          onReorder={handleReorder}
+          onMove={handleMove}
+          onMoveDenied={handleMoveDenied}
+          onRename={handleRename}
+          onDelete={handleDeleteDoc}
+          onAddChild={handleAddChild}
+        />
+      </div>
+    </>
+  );
 
-      {/* Right: Doc Content or Create Form */}
-      <GlassPanel className="flex-1 flex flex-col min-w-0 rounded-none md:rounded-2xl">
+  return (
+    <>
+      <DocsShell
+        sidebar={sidebarContent}
+        mobileSidebarOpen={mobileSidebarOpen}
+        onMobileSidebarOpenChange={setMobileSidebarOpen}
+        className="min-h-[calc(100vh-8rem)]"
+      >
         {/* Mobile header with hamburger */}
-        <div className="flex items-center gap-2 border-b border-white/10 px-3 py-2 md:hidden">
+        <div className="flex flex-shrink-0 items-center gap-2 border-b border-white/10 px-3 py-2 md:hidden">
           <button
             type="button"
             onClick={() => setMobileSidebarOpen(true)}
@@ -548,8 +543,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             <p className="text-sm text-[color:var(--operator-muted)]">{t('selectDoc')}</p>
           </div>
         )}
-      </GlassPanel>
+      </DocsShell>
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
-    </div>
+    </>
   );
 }

--- a/apps/web/src/components/docs/docs-shell.tsx
+++ b/apps/web/src/components/docs/docs-shell.tsx
@@ -21,7 +21,7 @@ export function DocsShell({
         <GlassPanel className="hidden min-w-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/75 md:block">
           {sidebar}
         </GlassPanel>
-        <GlassPanel className="min-w-0 overflow-hidden">
+        <GlassPanel className="flex min-h-0 flex-1 flex-col overflow-hidden">
           {children}
         </GlassPanel>
       </div>
@@ -34,7 +34,7 @@ export function DocsShell({
             className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
             onClick={() => onMobileSidebarOpenChange?.(false)}
           />
-          <div className="absolute inset-y-0 left-0 w-[min(88vw,22rem)] p-3">
+          <div className="absolute inset-y-0 left-0 w-[min(85vw,20rem)] p-3">
             <GlassPanel className="flex h-full min-h-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/92 shadow-[0_24px_80px_rgba(0,0,0,0.42)]">
               {sidebar}
             </GlassPanel>


### PR DESCRIPTION
## Summary
- `docs-shell-client.tsx`: 커스텀 `-translate-x-full` 트랜지션 패턴 완전 제거 → `DocsShell` wrapper 활용
  - 모바일 사이드바: `GlassPanel + backdrop overlay` 표준 패턴 (DocsShell 기존 구현 재사용)
  - DocTree 선택 시 `setMobileSidebarOpen(false)` 자동 닫힘 추가
  - 독립 overlay button 제거 (DocsShell 내부에서 처리)
- `docs-shell.tsx`:
  - content GlassPanel에 `flex flex-col` 추가 (children 세로 레이아웃 지원)
  - 모바일 사이드바 폭: `w-[min(88vw,22rem)]` → `w-[min(85vw,20rem)]`

## Test plan
- [ ] 모바일에서 햄버거 탭 시 GlassPanel + backdrop overlay로 사이드바 열림 확인
- [ ] DocTree에서 문서 선택 시 사이드바 자동 닫힘 확인
- [ ] 사이드바 닫힘 시 콘텐츠 영역 전체 폭 사용 확인
- [ ] 문서 편집 동작 정상 확인
- [ ] 데스크톱 2-column 레이아웃 변경 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)