### PR TITLE
[E-MOB-NAV S5] MemoSidebar 다크테마 정합 — 하위 컴포넌트 gray-* 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
@@ -180,7 +180,7 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
   if (loading) {
     return (
       <div className="flex h-screen items-center justify-center">
-        <p className="text-sm text-gray-400">{t('loading')}</p>
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
       </div>
     );
   }
@@ -188,8 +188,8 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
   return (
     <div className="flex h-screen">
       {/* Left: Message Feed */}
-      <div className="w-80 flex-shrink-0 border-r border-gray-800 flex flex-col">
-        <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3">
+      <div className="w-80 flex-shrink-0 border-r border-white/10 flex flex-col">
+        <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
           <div className="flex items-center justify-between">
             <h1 className="text-lg font-semibold">{t('title')}</h1>
             <Button
@@ -210,10 +210,10 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
       </div>
 
       {/* Right: Thread View or Create Form */}
-      <div className="flex-1 flex flex-col bg-gray-900">
+      <div className="flex-1 flex flex-col bg-[color:var(--operator-surface)]">
         {showCreate ? (
           <div className="flex h-full flex-col">
-            <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3">
+            <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
               <div className="flex items-center justify-between">
                 <h2 className="text-lg font-semibold">{t('createTitle')}</h2>
                 <Button
@@ -242,7 +242,7 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
           />
         ) : (
           <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-gray-400">{t('selectMemo')}</p>
+            <p className="text-sm text-[color:var(--operator-muted)]">{t('selectMemo')}</p>
           </div>
         )}
       </div>

--- a/apps/web/src/app/(authenticated)/memos/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/page.tsx
@@ -11,7 +11,7 @@ export default function MemosPage() {
   if (!currentTeamMemberId) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <p className="text-sm text-gray-400">{t('noTeamMember')}</p>
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('noTeamMember')}</p>
       </div>
     );
   }

--- a/apps/web/src/components/memos/memo-detail.tsx
+++ b/apps/web/src/components/memos/memo-detail.tsx
@@ -444,7 +444,7 @@ export function MemoDetail({
         </div>
       </div>
 
-      <div className="sticky bottom-0 border-t border-border/60 bg-white p-4">
+      <div className="sticky bottom-0 border-t border-white/10 bg-[color:var(--operator-panel)] p-4">
         <MemoComposer
           collaboration={collaboration}
           value={replyContent}

--- a/apps/web/src/components/memos/memo-feed.tsx
+++ b/apps/web/src/components/memos/memo-feed.tsx
@@ -20,13 +20,13 @@ export function MemoFeed({ memos, onSelectMemo, selectedMemoId }: MemoFeedProps)
   if (memos.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-12 text-center">
-        <p className="text-sm text-gray-400">{t('noMemos')}</p>
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('noMemos')}</p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col divide-y divide-gray-800">
+    <div className="flex flex-col divide-y divide-white/10">
       {memos.map((memo) => (
         <MemoFeedItem
           key={memo.id}
@@ -54,19 +54,19 @@ function MemoFeedItem({ memo, isSelected, onClick }: MemoFeedItemProps) {
       onClick={onClick}
       className={`
         flex w-full flex-col gap-2 px-4 py-3 text-left transition-colors
-        hover:bg-gray-800/50
-        ${isSelected ? 'bg-gray-800' : ''}
+        hover:bg-white/5
+        ${isSelected ? 'bg-[color:var(--operator-primary)]/14' : ''}
         ${hasUnread ? 'font-semibold' : ''}
       `}
     >
       <div className="flex items-start justify-between gap-2">
         <div className="flex-1 min-w-0">
           {memo.title && (
-            <div className="text-sm text-gray-100 truncate">
+            <div className="text-sm text-[color:var(--operator-foreground)] truncate">
               {memo.title}
             </div>
           )}
-          <div className="text-sm text-gray-400 line-clamp-2 mt-1">
+          <div className="text-sm text-[color:var(--operator-muted)] line-clamp-2 mt-1">
             {memo.content}
           </div>
         </div>
@@ -78,7 +78,7 @@ function MemoFeedItem({ memo, isSelected, onClick }: MemoFeedItemProps) {
           </div>
         )}
       </div>
-      <div className="flex items-center gap-2 text-xs text-gray-500">
+      <div className="flex items-center gap-2 text-xs text-[color:var(--operator-muted)]">
         <span>{new Date(memo.created_at).toLocaleDateString()}</span>
         {(memo.reply_count ?? 0) > 0 && (
           <>

--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -56,15 +56,15 @@ export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThre
   return (
     <div className="flex h-full flex-col">
       {/* Thread header */}
-      <div className="flex-shrink-0 border-b border-gray-800 px-4 py-3">
+      <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
         <div className="flex items-start justify-between gap-4">
           <div className="flex-1 min-w-0">
             {memo.title && (
-              <h2 className="text-lg font-semibold text-gray-100 truncate">
+              <h2 className="text-lg font-semibold text-[color:var(--operator-foreground)] truncate">
                 {memo.title}
               </h2>
             )}
-            <div className="mt-1 text-sm text-gray-400">
+            <div className="mt-1 text-sm text-[color:var(--operator-muted)]">
               {new Date(memo.created_at).toLocaleString()}
             </div>
           </div>
@@ -96,7 +96,7 @@ export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThre
             <button
               type="button"
               onClick={() => setRepliesExpanded((v) => !v)}
-              className="w-full rounded-xl border border-white/8 bg-white/4 py-2 text-center text-xs font-medium text-gray-400 transition hover:bg-white/8 hover:text-gray-200"
+              className="w-full rounded-xl border border-white/8 bg-white/4 py-2 text-center text-xs font-medium text-[color:var(--operator-muted)] transition hover:bg-white/8 hover:text-[color:var(--operator-foreground)]"
             >
               {repliesExpanded
                 ? t('collapseReplies')
@@ -118,7 +118,7 @@ export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThre
 
       {/* Reply input */}
       {memo.status === 'open' && (
-        <div className="flex-shrink-0 border-t border-gray-800 px-4 py-3">
+        <div className="flex-shrink-0 border-t border-white/10 px-4 py-3">
           <div className="flex gap-2">
             <Textarea
               value={replyContent}
@@ -136,7 +136,7 @@ export function MemoThread({ memo, currentUserId, onReply, onResolve }: MemoThre
               {isSubmitting ? t('sending') : t('send')}
             </Button>
           </div>
-          <div className="mt-2 text-xs text-gray-500">
+          <div className="mt-2 text-xs text-[color:var(--operator-muted)]">
             {t('replyHint')}
           </div>
         </div>
@@ -173,7 +173,7 @@ function ThreadMessage({ content, authorId, timestamp, isCurrentUser, reviewType
       <div
         className={`
           max-w-[80%] rounded-lg px-4 py-3
-          ${isCurrentUser ? 'bg-blue-600 text-white' : 'bg-gray-800 text-gray-100'}
+          ${isCurrentUser ? 'bg-blue-600 text-white' : 'bg-[color:var(--operator-surface-soft)] text-[color:var(--operator-foreground)]'}
           ${reviewType === 'approve' ? 'border-2 border-green-500' : ''}
           ${reviewType === 'request_changes' ? 'border-2 border-red-500' : ''}
         `}
@@ -181,7 +181,7 @@ function ThreadMessage({ content, authorId, timestamp, isCurrentUser, reviewType
         <div className="whitespace-pre-wrap break-words text-sm">
           {renderWithMentions(content, isCurrentUser)}
         </div>
-        <div className={`mt-2 text-xs ${isCurrentUser ? 'text-blue-200' : 'text-gray-500'}`}>
+        <div className={`mt-2 text-xs ${isCurrentUser ? 'text-blue-200' : 'text-[color:var(--operator-muted)]'}`}>
           {new Date(timestamp).toLocaleTimeString()}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- `memo-feed.tsx`: `divide-gray-800`, `hover:bg-gray-800/50`, `bg-gray-800`, `text-gray-100/400/500` → operator CSS vars
- `memo-thread.tsx`: `border-gray-800`, `bg-gray-800`, `text-gray-100/400/500` → operator CSS vars
- `memo-detail.tsx`: `bg-white` (sticky 리플라이 입력 영역) → `var(--operator-panel)`
- `memos-feed-client.tsx`: `border-gray-800`, `bg-gray-900`, `text-gray-400` → operator CSS vars
- `memos/page.tsx`: `text-gray-400` → `var(--operator-muted)`

**5개 파일 gray-*/white 0건 달성**

## Test plan
- [ ] MemoSidebar 열림 시 OperatorShell과 동일 다크톤 확인
- [ ] 메모 목록 선택 상태 (primary/14 배경) 가독성 확인
- [ ] 채팅 버블 — 내 메시지(파란) / 상대 메시지(operator-surface-soft) 구분 확인
- [ ] 리플라이 입력창 sticky 영역 배경 확인
- [ ] 모바일 전체화면 + 데스크톱 사이드 패널 모두 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)