### PR TITLE
[E-MOB-NAV S6] Settings 사이드바 모바일 드로어 전환

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/layout.tsx
+++ b/apps/web/src/app/(authenticated)/settings/layout.tsx
@@ -2,8 +2,8 @@ import { ReactNode } from 'react';
 import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { isOssMode } from '@/lib/storage/factory';
-import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 import { PageHeader } from '@/components/ui/page-header';
+import { SettingsLayoutClient } from './settings-layout-client';
 
 export default async function SettingsLayout({ children }: { children: ReactNode }) {
   if (isOssMode()) {
@@ -14,12 +14,9 @@ export default async function SettingsLayout({ children }: { children: ReactNode
           title="Settings"
           description="Manage your account, projects, and preferences"
         />
-        <div className="flex flex-1">
-          <SettingsSidebar isAdmin={true} currentProjectId={OSS_PROJECT_ID} />
-          <main className="flex-1 p-6">
-            {children}
-          </main>
-        </div>
+        <SettingsLayoutClient isAdmin={true} currentProjectId={OSS_PROJECT_ID}>
+          {children}
+        </SettingsLayoutClient>
       </div>
     );
   }
@@ -61,12 +58,9 @@ export default async function SettingsLayout({ children }: { children: ReactNode
         title="Settings"
         description="Manage your account, projects, and preferences"
       />
-      <div className="flex flex-1">
-        <SettingsSidebar isAdmin={isAdmin} currentProjectId={currentProject?.project_id} />
-        <main className="flex-1 p-6">
-          {children}
-        </main>
-      </div>
+      <SettingsLayoutClient isAdmin={isAdmin} currentProjectId={currentProject?.project_id}>
+        {children}
+      </SettingsLayoutClient>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { Menu } from 'lucide-react';
+import { SettingsSidebar } from '@/components/settings/settings-sidebar';
+import { GlassPanel } from '@/components/ui/glass-panel';
+
+interface SettingsLayoutClientProps {
+  children: React.ReactNode;
+  isAdmin: boolean;
+  currentProjectId?: string;
+}
+
+export function SettingsLayoutClient({ children, isAdmin, currentProjectId }: SettingsLayoutClientProps) {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  return (
+    <div className="flex flex-1">
+      {/* Mobile drawer overlay */}
+      {drawerOpen && (
+        <button
+          type="button"
+          className="fixed inset-0 z-40 bg-black/55 backdrop-blur-[2px] md:hidden"
+          aria-label="Close menu"
+          onClick={() => setDrawerOpen(false)}
+        />
+      )}
+
+      {/* Mobile drawer */}
+      {drawerOpen && (
+        <div className="fixed inset-y-0 left-0 z-50 w-[min(80vw,18rem)] p-3 md:hidden">
+          <GlassPanel className="flex h-full flex-col overflow-y-auto">
+            <SettingsSidebar
+              isAdmin={isAdmin}
+              currentProjectId={currentProjectId}
+              onItemClick={() => setDrawerOpen(false)}
+            />
+          </GlassPanel>
+        </div>
+      )}
+
+      {/* Desktop sidebar */}
+      <div className="hidden md:block">
+        <SettingsSidebar isAdmin={isAdmin} currentProjectId={currentProjectId} />
+      </div>
+
+      {/* Main content */}
+      <main className="min-w-0 flex-1 p-4 md:p-6">
+        {/* Mobile header */}
+        <div className="mb-4 flex items-center gap-3 md:hidden">
+          <button
+            type="button"
+            onClick={() => setDrawerOpen(true)}
+            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)]"
+            aria-label="Open settings menu"
+          >
+            <Menu className="size-5" />
+          </button>
+          <span className="text-sm font-semibold text-[color:var(--operator-foreground)]">Settings</span>
+        </div>
+        {children}
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/settings-sidebar.tsx
+++ b/apps/web/src/components/settings/settings-sidebar.tsx
@@ -10,6 +10,7 @@ import { cn } from '@/lib/utils';
 interface SettingsSidebarProps {
   isAdmin: boolean;
   currentProjectId?: string;
+  onItemClick?: () => void;
 }
 
 interface NavGroup {
@@ -60,7 +61,7 @@ const NAV_GROUPS: NavGroup[] = [
   },
 ];
 
-export function SettingsSidebar({ isAdmin, currentProjectId }: SettingsSidebarProps) {
+export function SettingsSidebar({ isAdmin, currentProjectId, onItemClick }: SettingsSidebarProps) {
   const t = useTranslations('settings');
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -124,6 +125,7 @@ export function SettingsSidebar({ isAdmin, currentProjectId }: SettingsSidebarPr
                       <Link
                         key={item.key}
                         href={item.hash}
+                        onClick={onItemClick}
                         className={cn(
                           'block rounded-lg px-3 py-2 text-sm transition',
                           active
@@ -153,6 +155,7 @@ export function SettingsSidebar({ isAdmin, currentProjectId }: SettingsSidebarPr
                           target.scrollIntoView({ behavior: 'smooth', block: 'start' });
                           window.history.replaceState(null, '', item.hash);
                         }
+                        onItemClick?.();
                       }}
                     >
                       {t(item.labelKey)}


### PR DESCRIPTION
## Summary
- `settings-layout-client.tsx` 신규: 드로어 상태 관리 client 컴포넌트
  - 모바일: `hidden` 기본, 햄버거 버튼 → `GlassPanel + backdrop overlay` 드로어
  - 드로어 폭: `w-[min(80vw,18rem)]`
  - 데스크톱(`md+`): 기존 `w-64` 사이드바 그대로 유지
- `settings/layout.tsx`: 서버 컴포넌트 유지, `SettingsSidebar` 직접 렌더 → `SettingsLayoutClient`로 위임
- `settings-sidebar.tsx`: `onItemClick` prop 추가 — 항목 선택 시 드로어 자동 닫힘

## Test plan
- [ ] 모바일(375px) 기본 상태에서 사이드바 숨김 확인
- [ ] 햄버거 버튼 탭 시 GlassPanel 드로어 열림 확인
- [ ] 메뉴 항목 선택 시 드로어 자동 닫힘 확인
- [ ] 데스크톱(`md+`) 기존 w-64 사이드바 유지 확인
- [ ] OSS 모드 + SaaS 모드 양쪽 렌더 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)