### PR TITLE
[E-MOB-NAV S7] 헤더 모바일 ProjectSwitcher 겹침 수정

### DIFF
--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -236,10 +236,10 @@ export function OperatorShell({
 
         <div className="flex min-h-screen min-w-0 flex-1 flex-col px-2 pt-2 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
           <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
-            <div className="min-w-0 flex-1">
-              <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <div className="shrink-0 whitespace-nowrap text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
               {projectMemberships.length > 0 ? (
-                <div className="mt-0.5 lg:hidden">
+                <div className="min-w-0 flex-1 lg:hidden">
                   <ProjectSwitcher
                     projects={projectMemberships}
                     currentProjectId={projectId}

--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -236,18 +236,18 @@ export function OperatorShell({
 
         <div className="flex min-h-screen min-w-0 flex-1 flex-col px-2 pt-2 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
           <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
-            <div className="min-w-0">
+            <div className="min-w-0 flex-1">
               <div className="text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
               {projectMemberships.length > 0 ? (
                 <div className="mt-0.5 lg:hidden">
                   <ProjectSwitcher
                     projects={projectMemberships}
                     currentProjectId={projectId}
-                    className="min-h-[44px] max-w-[180px]"
+                    className="min-h-[44px] w-full"
                   />
                 </div>
               ) : null}
-              <div className={`truncate font-heading text-sm font-bold text-[color:var(--operator-foreground)]${projectMemberships.length > 0 ? ' hidden lg:block' : ''}`}>{projectName ?? (projectId ? shellT('projectAttached') : shellT('projectPending'))}</div>
+              <div className={cn('truncate font-heading text-sm font-bold text-[color:var(--operator-foreground)]', projectMemberships.length > 0 && 'hidden lg:block')}>{projectName ?? (projectId ? shellT('projectAttached') : shellT('projectPending'))}</div>
             </div>
             <div className="hidden max-w-xl flex-1 items-center gap-3 lg:flex">
               {projectMemberships.length > 0 ? (
@@ -261,7 +261,7 @@ export function OperatorShell({
                 {shellT('searchPlaceholder')}
               </div>
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex shrink-0 items-center gap-2">
               <OperatorIconButton
                 onClick={() => {
                   const searchInput = document.querySelector<HTMLInputElement>('[data-search-input]');


### PR DESCRIPTION
## Summary
- 좌측 `div.min-w-0` → `min-w-0 flex-1`: ProjectSwitcher가 flex-1로 남은 공간 차지, 우측 아이콘 영역 침범 차단
- 우측 `div.flex.items-center.gap-2` → `shrink-0` 추가: 아이콘 영역 고정 폭 유지
- ProjectSwitcher `max-w-[180px]` → `w-full`: flex-1 컨테이너 내에서 전체 폭 활용, 긴 프로젝트명도 truncate 정상 동작
- template literal → `cn()` 유틸리티 사용 (PR #50 코드리뷰 nit 해소)

## Test plan
- [ ] 영어 locale 모바일(375px)에서 ProjectSwitcher chevron 터치 가능 확인
- [ ] 한국어 locale 동일 확인
- [ ] 긴 프로젝트명 truncate 정상 동작 확인
- [ ] 우측 아이콘 (Search/Locale/Memo/Inbox/Settings) 위치 변화 없음 확인
- [ ] 데스크톱(lg+) 기존 레이아웃 변경 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)