### PR TITLE
feat(mobile): E-MOB-NAV-2 S1 — 헤더/GNB border-radius 제거 (edge-to-edge)

### DIFF
--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -234,8 +234,8 @@ export function OperatorShell({
           </GlassPanel>
         </aside>
 
-        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-2 pt-2 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
-          <GlassPanel className="sticky top-3 z-30 mb-4 flex items-center justify-between gap-4 px-4 py-3">
+        <div className="flex min-h-screen min-w-0 flex-1 flex-col px-2 sm:px-4 lg:px-5 lg:pb-5" style={{ paddingBottom: 'max(5rem, calc(env(safe-area-inset-bottom) + 4rem))' }}>
+          <GlassPanel className="sticky top-0 z-30 mb-4 -mx-2 rounded-none sm:-mx-4 lg:-mx-5 flex items-center justify-between gap-4 px-4 py-3">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               <div className="shrink-0 whitespace-nowrap text-[10px] font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{shellT('projectLabel')}</div>
               {projectMemberships.length > 0 ? (
@@ -299,8 +299,8 @@ export function OperatorShell({
         </div>
       </div>
 
-      <div className="fixed inset-x-3 bottom-3 z-40 lg:hidden" style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}>
-        <GlassPanel className="grid grid-cols-5 gap-1 px-2 py-2">
+      <div className="fixed inset-x-0 bottom-0 z-40 lg:hidden">
+        <GlassPanel className="grid grid-cols-5 gap-1 rounded-none px-2 py-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
           {MOBILE_NAV_ITEMS.map((item) => {
             const Icon = item.icon;
             const isActive = pathname === item.href || pathname.startsWith(item.href);


### PR DESCRIPTION
## Summary
- 헤더 GlassPanel: `rounded-none` + `sticky top-0` + `-mx-2 sm:-mx-4 lg:-mx-5` (parent padding 상쇄 → edge-to-edge)
- 모바일 하단 GNB: `rounded-none` + `inset-x-0 bottom-0` (floating → edge-to-edge)
- GNB safe area: `pb-[max(0.5rem,env(safe-area-inset-bottom))]` 로 홈 인디케이터 영역 처리
- GlassPanel 컴포넌트 자체 미수정 — className override (twMerge)

## AC Checklist
- [x] AC-1: 헤더 GlassPanel `rounded-none`, 좌우 edge-to-edge
- [x] AC-2: 모바일 하단 GNB `rounded-none`, 좌우 edge-to-edge
- [x] AC-3: sticky top-0 / fixed bottom-0 유지
- [x] AC-4: GlassPanel 컴포넌트 자체 수정 없음

## Test plan
- [ ] 모바일 뷰포트(375px): 헤더 좌우 여백 없는 full-width 확인
- [ ] 모바일 뷰포트: 하단 GNB floating 없이 화면 하단 밀착 확인
- [ ] 데스크탑(1280px+): 헤더가 사이드바 우측 영역 전체 폭 차지 확인
- [ ] iOS Safe area: GNB 텍스트/아이콘이 홈 인디케이터에 가리지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)