### PR TITLE
fix(mobile): E-MOB-NAV-2 S2 — 보드 스토리 카드 overflow 수정

### DIFF
--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -63,7 +63,7 @@ export function KanbanColumn({ id, label, stories, epicMap, memberMap, dragStatu
         <Badge variant="info">{stories.length}</Badge>
       </div>
       <SortableContextCompat items={stories.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-        <div className="flex flex-1 flex-col gap-3">
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
           {stories.length === 0 ? (
             <p className="rounded-2xl border border-dashed border-white/10 px-3 py-8 text-center text-xs text-[color:var(--operator-muted)]">{t('noStories')}</p>
           ) : null}

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -46,9 +46,9 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
   const currentColumn = COLUMNS.find((c) => c.id === story.status);
 
   return (
-    <div className="relative flex items-center gap-3 rounded-2xl border border-white/6 bg-[color:var(--operator-surface-soft)] px-4 py-3 transition-all hover:bg-white/6">
+    <div className="relative flex min-w-0 items-center gap-3 overflow-hidden rounded-2xl border border-white/6 bg-[color:var(--operator-surface-soft)] px-4 py-3 transition-all hover:bg-white/6">
       <button
-        className="min-h-[44px] flex-1 text-left"
+        className="min-h-[44px] min-w-0 flex-1 text-left"
         onClick={() => onStoryClick(story)}
       >
         <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -134,7 +134,7 @@ export function StoryCard({ story, epicName, assigneeName, onClick, onEdit, onCh
       {...listeners}
       onClick={onClick}
       onContextMenu={handleContextMenu}
-      className="group relative cursor-pointer overflow-hidden rounded-2xl border border-white/8 bg-[color:var(--operator-panel)]/78 p-3 shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
+      className="group relative w-full cursor-pointer overflow-hidden rounded-2xl border border-white/8 bg-[color:var(--operator-panel)]/78 p-3 shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
     >
       {epicName && story.epic_id ? (
         <Badge variant={getEpicColor(story.epic_id)} className="mb-2 max-w-full truncate">


### PR DESCRIPTION
## Summary
- `ListStoryRow`: outer div에 `min-w-0 overflow-hidden` 추가, `flex-1` 버튼에 `min-w-0` 추가 → 모바일에서 카드가 뷰포트 폭 초과하지 않음
- `KanbanColumn` inner flex div: `min-w-0` 추가 (AC-3 flex 부모 보강)
- `StoryCard` root: `w-full` 추가 → flex child 사이징 명시

## AC Checklist
- [x] AC-1: 모바일 KanbanListView 카드 화면 폭 초과 없음
- [x] AC-2: 긴 제목 `line-clamp-2` 처리 (기존 유지 + flex 제약 추가)
- [x] AC-3: flex 부모에 `min-w-0` 보강
- [x] AC-4: 데스크탑 칸반 레이아웃 변경 없음 (KanbanColumn은 `hidden md:block` 래퍼 안에서만 노출)

## Test plan
- [ ] 모바일(375px): 긴 제목 스토리 카드가 화면 밖으로 튀어나오지 않는지 확인
- [ ] 모바일: 에픽 뱃지 + 우선순위 뱃지 flex-wrap 정상 표시 확인
- [ ] 데스크탑(1280px+): 칸반 보드 레이아웃 회귀 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)