### PR TITLE
fix(mobile): E-MOB-NAV-2 S3 — Docs 드로어 dim/제목 표시 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -380,18 +380,28 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const sidebarContent = (
     <>
       <div className="flex-shrink-0 border-b border-white/10 px-4 py-3">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-2">
           <h1 className="text-lg font-semibold">{t('title')}</h1>
-          <Button size="sm" onClick={() => {
-            setShowCreate(true);
-            setNewTitle('');
-            setNewSlug('');
-            setNewContent('');
-            setNewParentId(null);
-            setSlugManuallyEdited(false);
-          }}>
-            <Plus className="h-4 w-4" />
-          </Button>
+          <div className="flex items-center gap-1">
+            <Button size="sm" onClick={() => {
+              setShowCreate(true);
+              setNewTitle('');
+              setNewSlug('');
+              setNewContent('');
+              setNewParentId(null);
+              setSlugManuallyEdited(false);
+            }}>
+              <Plus className="h-4 w-4" />
+            </Button>
+            <button
+              type="button"
+              className="flex min-h-[36px] min-w-[36px] items-center justify-center rounded-xl text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)] md:hidden"
+              onClick={() => setMobileSidebarOpen(false)}
+              aria-label="Close sidebar"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto p-2">

--- a/apps/web/src/components/docs/docs-shell.tsx
+++ b/apps/web/src/components/docs/docs-shell.tsx
@@ -35,7 +35,7 @@ export function DocsShell({
             onClick={() => onMobileSidebarOpenChange?.(false)}
           />
           <div className="absolute inset-y-0 left-0 w-[min(85vw,20rem)] p-3">
-            <GlassPanel className="flex h-full min-h-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/92 shadow-[0_24px_80px_rgba(0,0,0,0.42)]">
+            <GlassPanel className="flex h-full min-h-0 flex-col border-white/8 bg-[color:var(--operator-surface-soft)]/92 shadow-[0_24px_80px_rgba(0,0,0,0.42)]">
               {sidebar}
             </GlassPanel>
           </div>


### PR DESCRIPTION
## Summary
- **문서 제목 미표시 수정**: mobile drawer GlassPanel에 `flex-col` 추가 — 기존 `flex` 만으로는 header·tree가 수평 배치되어 제목이 overflow/이상 위치로 렌더링됨
- **드로어 닫기 추가**: sidebarContent 헤더에 X 버튼 (`md:hidden`) 추가 — backdrop이 `z-50`으로 hamburger 버튼을 덮어도 drawer 내부 X 버튼으로 닫기 가능

## AC Checklist
- [x] AC-1: 드로어 내부 X 버튼으로 탭하여 닫기 가능 (md:hidden — 데스크탑 미노출)
- [x] AC-2: 드로어 사이드바 flex-col 수정으로 문서 제목 정상 렌더링

## Root Cause
mobile drawer `GlassPanel className="flex h-full ..."` → flex-direction: row (기본값) → sidebarContent의 두 자식(header div, tree div)이 수평 배치 → title/icon 이상 위치

## Test plan
- [ ] 모바일(375px): 햄버거 메뉴 열기 → X 버튼으로 닫기 확인
- [ ] 모바일: 드로어 열렸을 때 "Docs" 제목 + 문서 트리 수직 배치 확인
- [ ] 데스크탑: 사이드바에 X 버튼 미노출 확인 (md:hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)