### PR TITLE
feat(mobile): E-MOB-IA S3 — Settings list↔detail full-screen 전환, 햄버거 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { Menu } from 'lucide-react';
+import { ChevronLeft } from 'lucide-react';
 import { SettingsSidebar } from '@/components/settings/settings-sidebar';
 import { GlassPanel } from '@/components/ui/glass-panel';
+import { LocaleSwitcher } from '@/components/locale-switcher';
+import { cn } from '@/lib/utils';
 
 interface SettingsLayoutClientProps {
   children: React.ReactNode;
@@ -12,51 +14,43 @@ interface SettingsLayoutClientProps {
 }
 
 export function SettingsLayoutClient({ children, isAdmin, currentProjectId }: SettingsLayoutClientProps) {
-  const [drawerOpen, setDrawerOpen] = useState(false);
+  const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
 
   return (
     <div className="flex flex-1">
-      {/* Mobile drawer overlay */}
-      {drawerOpen && (
-        <button
-          type="button"
-          className="fixed inset-0 z-40 bg-black/55 backdrop-blur-[2px] md:hidden"
-          aria-label="Close menu"
-          onClick={() => setDrawerOpen(false)}
-        />
-      )}
-
-      {/* Mobile drawer */}
-      {drawerOpen && (
-        <div className="fixed inset-y-0 left-0 z-50 w-[min(80vw,18rem)] p-3 md:hidden">
-          <GlassPanel className="flex h-full flex-col overflow-y-auto">
-            <SettingsSidebar
-              isAdmin={isAdmin}
-              currentProjectId={currentProjectId}
-              onItemClick={() => setDrawerOpen(false)}
-            />
-          </GlassPanel>
-        </div>
-      )}
-
-      {/* Desktop sidebar */}
+      {/* Desktop sidebar (md+) */}
       <div className="hidden md:block">
         <SettingsSidebar isAdmin={isAdmin} currentProjectId={currentProjectId} />
       </div>
 
-      {/* Main content */}
-      <main className="min-w-0 flex-1 p-4 md:p-6">
-        {/* Mobile header */}
-        <div className="mb-4 flex items-center gap-3 md:hidden">
+      {/* Mobile list view (< md) */}
+      {mobileView === 'list' && (
+        <div className="flex-1 p-3 md:hidden">
+          <GlassPanel className="flex flex-col">
+            <SettingsSidebar
+              isAdmin={isAdmin}
+              currentProjectId={currentProjectId}
+              onItemClick={() => setMobileView('detail')}
+            />
+            <div className="border-t border-white/10 px-4 py-3">
+              <LocaleSwitcher />
+            </div>
+          </GlassPanel>
+        </div>
+      )}
+
+      {/* Settings content: desktop always, mobile only in detail view */}
+      <main className={cn('min-w-0 flex-1 p-4 md:p-6', mobileView === 'list' && 'hidden md:block')}>
+        {/* Mobile detail back button */}
+        <div className="mb-4 flex items-center gap-2 md:hidden">
           <button
             type="button"
-            onClick={() => setDrawerOpen(true)}
-            className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)]"
-            aria-label="Open settings menu"
+            onClick={() => setMobileView('list')}
+            className="flex items-center gap-1 py-1 text-sm text-[color:var(--operator-muted)] hover:text-[color:var(--operator-foreground)]"
           >
-            <Menu className="size-5" />
+            <ChevronLeft className="size-4" />
+            Settings
           </button>
-          <span className="text-sm font-semibold text-[color:var(--operator-foreground)]">Settings</span>
         </div>
         {children}
       </main>


### PR DESCRIPTION
## Summary
Docs PR #63 패턴과 동일하게 Settings 모바일 UX를 햄버거+드로어에서 list↔detail full-screen 전환으로 변경.

**Mobile (< md):**
- SettingsSidebar list full-width 메인 뷰 → 항목 탭 → 설정 상세 full-screen
- 상세 뷰 좌상단 `← Settings` (ChevronLeft) 버튼으로 리스트 복귀
- 햄버거 버튼 + 드로어 overlay 완전 제거
- LocaleSwitcher를 모바일 리스트 뷰 하단에 배치 (AC-6: Header에서 제거됐으므로 Settings에서 접근)

**Desktop (md+):**
- 사이드바 + 콘텐츠 레이아웃 완전 보존

**구현:**
- `mobileView: 'list' | 'detail'` state
- `drawerOpen` state 제거 (드로어 패턴 제거)
- `Menu` lucide import 제거, `ChevronLeft` 추가
- `LocaleSwitcher` import 추가
- `cn` 유틸 import 추가

## AC Checklist
- [x] AC-1: 모바일 Settings 진입 시 설정 메뉴 리스트 full-width 표시
- [x] AC-2: 메뉴 항목 선택 시 설정 상세 full-screen 전환
- [x] AC-3: ChevronLeft 뒤로가기 → 메뉴 리스트 복귀
- [x] AC-4: 햄버거 + 드로어 overlay 제거
- [x] AC-5: 데스크탑 기존 레이아웃 유지
- [x] AC-6: LocaleSwitcher Settings 모바일 뷰 내 접근 가능

## Test plan
- [ ] 모바일(375px): Settings 진입 시 메뉴 리스트 전체 화면 표시
- [ ] 모바일: 메뉴 항목 탭 → 설정 상세 full-screen 전환
- [ ] 모바일: `← Settings` 버튼 탭 → 메뉴 리스트 복귀
- [ ] 모바일: 메뉴 리스트 하단 LocaleSwitcher 노출 확인
- [ ] 데스크탑(1280px+): 사이드바 + 콘텐츠 레이아웃 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)