### PR TITLE
feat(memos): E-MOB-IA S4 — mobile Slack-pattern UX

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/memos-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-client.tsx
@@ -697,11 +697,9 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
               {t('newMemo')}
             </button>
           </div>
-          <div className="flex items-center gap-4 overflow-x-auto rounded-xl bg-muted/30 px-3 py-2">
-            <span className="shrink-0 text-xs text-muted-foreground">{t('statsOpen')} <strong className="text-foreground">{stats.open}</strong></span>
-            <span className="shrink-0 text-xs text-muted-foreground">{t('statsAssigned')} <strong className="text-foreground">{stats.assigned}</strong></span>
-            <span className="shrink-0 text-xs text-muted-foreground">{t('statsReplies')} <strong className="text-foreground">{stats.replies}</strong></span>
-            <span className="shrink-0 text-xs text-muted-foreground">{t('statsSavedViews')} <strong className="text-foreground">{stats.views}</strong></span>
+          <div className="flex items-center gap-4 rounded-xl bg-muted/30 px-3 py-2">
+            <span className="text-xs text-muted-foreground">{t('statsOpen')} <strong className="text-foreground">{stats.open}</strong></span>
+            <span className="text-xs text-muted-foreground">{t('statsAssigned')} <strong className="text-foreground">{stats.assigned}</strong></span>
           </div>
         </div>
 
@@ -741,22 +739,15 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
         {/* ── Mobile compact channel filter (< md, list view only) ── */}
         {mobileView === 'list' && (
           <div className="space-y-2 md:hidden">
-            <div className="flex gap-2 overflow-x-auto pb-1">
-              {CHANNEL_ORDER.map((id) => {
-                const active = channel === id;
-                const count = channelCounts[id];
-                return (
-                  <button
-                    key={id}
-                    type="button"
-                    onClick={() => handleChannelChange(id)}
-                    className={`shrink-0 rounded-full border px-3 py-1 text-xs font-medium transition ${active ? 'border-primary bg-primary text-primary-foreground' : 'border-input bg-muted/50 text-foreground hover:bg-muted'}`}
-                  >
-                    {channelLabelMap[id]} <span className="opacity-70">{count}</span>
-                  </button>
-                );
-              })}
-            </div>
+            <select
+              value={channel}
+              onChange={(e) => handleChannelChange(e.target.value as WorkspaceChannel)}
+              className="w-full rounded-xl border border-input bg-[color:var(--operator-surface-soft)] px-3 py-2 text-sm text-foreground"
+            >
+              {CHANNEL_ORDER.map((id) => (
+                <option key={id} value={id}>{channelLabelMap[id]} ({channelCounts[id]})</option>
+              ))}
+            </select>
             <Input value={searchQuery} onChange={(event) => handleSearchChange(event.target.value)} placeholder={t('searchMemosPlaceholder')} />
           </div>
         )}

--- a/apps/web/src/components/memos/memo-list.tsx
+++ b/apps/web/src/components/memos/memo-list.tsx
@@ -63,29 +63,36 @@ export function MemoList({ memos, memberMap, onSelect, selectedId }: MemoListPro
             selectedId === m.id && 'bg-primary/5',
           )}
         >
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 flex-1 space-y-1">
-              <p className="truncate text-sm font-semibold text-foreground">
-                {m.title || m.content.slice(0, 72)}
-              </p>
-              <p className="line-clamp-2 text-xs text-muted-foreground">
-                {m.project_name ? `${m.project_name} · ` : ''}{m.content.slice(0, 120)}
-              </p>
+          {/* Slack-style: sender + date header */}
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <span className="truncate text-xs font-semibold text-foreground">
+                {m.created_by ? (memberMap[m.created_by] ?? tc('unknown')) : tc('deletedUser')}
+              </span>
+              {m.assigned_to ? (
+                <span className="shrink-0 text-xs text-muted-foreground">→ {memberMap[m.assigned_to] || tc('unknown')}</span>
+              ) : null}
+              <Badge variant="outline" className="shrink-0 text-[10px]">{getMemoTypeLabel(m.memo_type)}</Badge>
             </div>
-            <StatusBadge status={m.status} label={getMemoStatusLabel(m.status)} />
+            <span className="shrink-0 text-[10px] text-muted-foreground">{formatLocaleDateOnly(m.created_at, locale)}</span>
           </div>
 
-          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-            <Badge variant="outline">{getMemoTypeLabel(m.memo_type)}</Badge>
-            {m.reply_count ? <Badge variant="secondary">{t('repliesCountBadge', { count: m.reply_count })}</Badge> : null}
-            <span>{m.created_by ? (memberMap[m.created_by] ?? tc('unknown')) : tc('deletedUser')}</span>
-            {m.assigned_to ? (
-              <>
-                <span>→</span>
-                <span>{memberMap[m.assigned_to] || tc('unknown')}</span>
-              </>
-            ) : null}
-            <span className="ml-auto">{formatLocaleDateOnly(m.created_at, locale)}</span>
+          {/* Title / content preview */}
+          <p className="truncate text-sm font-medium text-foreground">
+            {m.title || m.content.slice(0, 72)}
+          </p>
+          {m.title && (
+            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+              {m.project_name ? `${m.project_name} · ` : ''}{m.content.slice(0, 80)}
+            </p>
+          )}
+
+          {/* Compact footer: reply count + status */}
+          <div className="mt-1.5 flex items-center justify-between gap-2">
+            <span className="text-[10px] text-muted-foreground">
+              {m.reply_count ? t('repliesCountBadge', { count: m.reply_count }) : ''}
+            </span>
+            <StatusBadge status={m.status} label={getMemoStatusLabel(m.status)} />
           </div>
         </button>
       ))}


### PR DESCRIPTION
## Summary
- **AC-1** Stats 영역 `overflow-x-auto` 제거 → 2개 핵심 수치(open/assigned)만 표시
- **AC-2** 채널 필터 pill 버튼 → `<select>` 드롭다운으로 교체 (가로 스크롤 제거)
- **AC-3** 가로 스크롤 유발 `overflow-x-auto` 모바일 전면 제거
- **AC-4** MemoList Slack 패턴: sender+date 헤더 라인 → 제목/내용 프리뷰 → reply count+status 컴팩트 푸터

## Files Changed
- `apps/web/src/app/(authenticated)/memos/memos-client.tsx`
- `apps/web/src/components/memos/memo-list.tsx`

## Test plan
- [ ] 모바일(<md) stats strip: open/assigned 2개만 표시, 가로 스크롤 없음
- [ ] 모바일 채널 필터: select 드롭다운으로 채널 전환 정상 동작
- [ ] MemoList: sender+date 헤더 → 제목+본문 프리뷰 → 답신수+상태 레이아웃 확인
- [ ] 데스크탑(md+) 레이아웃 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)