### PR TITLE
fix(mobile): E-MOB-IA S5 — lg breakpoint 통일 + GNB 가림 수정 + MemoList Slack 패턴

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -413,7 +413,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   const editorContent = showCreate ? (
           <div className="flex h-full flex-col">
-            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 md:px-6 md:py-4">
+            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 lg:px-6 lg:py-4">
               <div className="flex items-center justify-between">
                 <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
                 <Button variant="ghost" size="sm" onClick={() => {
@@ -424,7 +424,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 </Button>
               </div>
             </div>
-            <div className="flex-1 overflow-y-auto px-3 py-3 md:px-6 md:py-6">
+            <div className="flex-1 overflow-y-auto px-3 py-3 lg:px-6 lg:py-6">
               <div className="space-y-4 max-w-3xl">
                 <div>
                   <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
@@ -468,7 +468,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         ) : selectedDoc ? (
           <>
             {/* Header */}
-            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 md:px-6 md:py-4">
+            <div className="flex-shrink-0 border-b border-white/10 px-3 py-2 lg:px-6 lg:py-4">
               <div className="flex items-center justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <Input
@@ -491,7 +491,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             </div>
 
             {/* Content — always-editable tiptap */}
-            <div className="flex-1 overflow-y-auto px-3 py-3 md:px-6 md:py-6">
+            <div className="flex-1 overflow-y-auto px-3 py-3 lg:px-6 lg:py-6">
               <DocEditor
                 value={content}
                 contentFormat={contentFormat}
@@ -527,15 +527,15 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   return (
     <>
-      {/* Desktop layout (md+) — unchanged 2-panel DocsShell */}
-      <div className="hidden md:block">
+      {/* Desktop layout (lg+) — unchanged 2-panel DocsShell */}
+      <div className="hidden lg:block">
         <DocsShell sidebar={sidebarContent} className="min-h-[calc(100vh-8rem)]">
           {editorContent}
         </DocsShell>
       </div>
 
-      {/* Mobile layout (< md) — list ↔ detail full-screen */}
-      <div className="md:hidden">
+      {/* Mobile layout (< lg) — list ↔ detail full-screen */}
+      <div className="lg:hidden">
         {mobileView === 'detail' ? (
           <div className="space-y-2">
             <button

--- a/apps/web/src/app/(authenticated)/memos/memos-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-client.tsx
@@ -112,7 +112,7 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
   const [workspaceReady, setWorkspaceReady] = useState(false);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
+  const [mobileView, setMobileView] = useState<'list' | 'detail'>(searchParams.get('id') ? 'detail' : 'list');
 
   const selectedMemoIdRef = useRef(selectedMemo?.id);
   const loadedWorkspaceKeyRef = useRef<string | null>(null);
@@ -440,6 +440,7 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
     (async () => {
       if (cancelled) return;
       await selectMemoById(target?.id ?? deepId, { updateUrl: false });
+      if (!cancelled) setMobileView('detail');
     })().catch(() => {});
 
     return () => {
@@ -682,11 +683,11 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
   );
 
   return (
-    <div className="min-h-screen bg-background p-4 md:p-6">
+    <div className="bg-background p-4 lg:p-6">
       <div className="mx-auto max-w-7xl space-y-4">
 
-        {/* ── Mobile header + compact stats (< md) ───────── */}
-        <div className="md:hidden">
+        {/* ── Mobile header + compact stats (< lg) ───────── */}
+        <div className="lg:hidden">
           <div className="mb-3 flex items-center justify-between">
             <h1 className="text-lg font-semibold text-foreground">{t('title')}</h1>
             <button
@@ -703,8 +704,8 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
           </div>
         </div>
 
-        {/* ── Desktop stats 4-card grid (md+) ─────────────── */}
-        <SectionCard className="hidden md:block">
+        {/* ── Desktop stats 4-card grid (lg+) ─────────────── */}
+        <SectionCard className="hidden lg:block">
           <SectionCardHeader>
             <div className="flex flex-wrap items-start justify-between gap-3">
               <div className="space-y-1">
@@ -716,7 +717,7 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
               </button>
             </div>
           </SectionCardHeader>
-          <SectionCardBody className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <SectionCardBody className="grid gap-3 lg:grid-cols-2 xl:grid-cols-4">
             <div className="rounded-xl bg-muted/40 p-3">
               <div className="text-xs text-muted-foreground">{t('statsOpen')}</div>
               <div className="text-2xl font-semibold">{stats.open}</div>
@@ -736,9 +737,9 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
           </SectionCardBody>
         </SectionCard>
 
-        {/* ── Mobile compact channel filter (< md, list view only) ── */}
+        {/* ── Mobile compact channel filter (< lg, list view only) ── */}
         {mobileView === 'list' && (
-          <div className="space-y-2 md:hidden">
+          <div className="space-y-2 lg:hidden">
             <select
               value={channel}
               onChange={(e) => handleChannelChange(e.target.value as WorkspaceChannel)}
@@ -752,8 +753,8 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
           </div>
         )}
 
-        {/* ── Desktop full filter section (md+) ─────────────── */}
-        <SectionCard className="hidden md:block">
+        {/* ── Desktop full filter section (lg+) ─────────────── */}
+        <SectionCard className="hidden lg:block">
           <SectionCardBody className="space-y-4">
             <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_240px_240px_280px]">
               <div className="space-y-2 min-w-0">
@@ -869,8 +870,8 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
           </SectionCardBody>
         </SectionCard>
 
-        {/* ── Desktop: create form + queue toggle + contextual panel (md+) ── */}
-        <div className="hidden md:block">
+        {/* ── Desktop: create form + queue toggle + contextual panel (lg+) ── */}
+        <div className="hidden lg:block">
           <div className="space-y-4">
             {showCreate ? (
               <MemoCreateForm
@@ -938,8 +939,8 @@ export function MemosClient({ currentTeamMemberId, projectId }: MemosClientProps
           </div>
         </div>
 
-        {/* ── Mobile: full-screen list ↔ detail (< md) ─────── */}
-        <div className="md:hidden">
+        {/* ── Mobile: full-screen list ↔ detail (< lg) ─────── */}
+        <div className="lg:hidden">
           {showCreate ? (
             <div className="space-y-3">
               <button

--- a/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
+++ b/apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx
@@ -18,14 +18,14 @@ export function SettingsLayoutClient({ children, isAdmin, currentProjectId }: Se
 
   return (
     <div className="flex flex-1">
-      {/* Desktop sidebar (md+) */}
-      <div className="hidden md:block">
+      {/* Desktop sidebar (lg+) */}
+      <div className="hidden lg:block">
         <SettingsSidebar isAdmin={isAdmin} currentProjectId={currentProjectId} />
       </div>
 
-      {/* Mobile list view (< md) */}
+      {/* Mobile list view (< lg) */}
       {mobileView === 'list' && (
-        <div className="flex-1 p-3 md:hidden">
+        <div className="flex-1 p-3 lg:hidden">
           <GlassPanel className="flex flex-col">
             <SettingsSidebar
               isAdmin={isAdmin}
@@ -40,9 +40,9 @@ export function SettingsLayoutClient({ children, isAdmin, currentProjectId }: Se
       )}
 
       {/* Settings content: desktop always, mobile only in detail view */}
-      <main className={cn('min-w-0 flex-1 p-4 md:p-6', mobileView === 'list' && 'hidden md:block')}>
+      <main className={cn('min-w-0 flex-1 p-4 lg:p-6', mobileView === 'list' && 'hidden lg:block')}>
         {/* Mobile detail back button */}
-        <div className="mb-4 flex items-center gap-2 md:hidden">
+        <div className="mb-4 flex items-center gap-2 lg:hidden">
           <button
             type="button"
             onClick={() => setMobileView('list')}

--- a/apps/web/src/components/docs/docs-shell.tsx
+++ b/apps/web/src/components/docs/docs-shell.tsx
@@ -17,8 +17,8 @@ export function DocsShell({
 }) {
   return (
     <>
-      <div className={cn('grid gap-2 md:gap-4 md:grid-cols-[280px_minmax(0,1fr)]', className)}>
-        <GlassPanel className="hidden min-w-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/75 md:block">
+      <div className={cn('grid gap-2 lg:gap-4 lg:grid-cols-[280px_minmax(0,1fr)]', className)}>
+        <GlassPanel className="hidden min-w-0 overflow-y-auto border-white/8 bg-[color:var(--operator-surface-soft)]/75 lg:block">
           {sidebar}
         </GlassPanel>
         <GlassPanel className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/src/components/memos/memo-list.tsx
+++ b/apps/web/src/components/memos/memo-list.tsx
@@ -63,36 +63,47 @@ export function MemoList({ memos, memberMap, onSelect, selectedId }: MemoListPro
             selectedId === m.id && 'bg-primary/5',
           )}
         >
-          {/* Slack-style: sender + date header */}
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1.5">
+          {/* Mobile (< lg): Slack conversation style — no badges */}
+          <div className="lg:hidden">
+            <div className="mb-1 flex items-center justify-between gap-2">
               <span className="truncate text-xs font-semibold text-foreground">
                 {m.created_by ? (memberMap[m.created_by] ?? tc('unknown')) : tc('deletedUser')}
               </span>
-              {m.assigned_to ? (
-                <span className="shrink-0 text-xs text-muted-foreground">→ {memberMap[m.assigned_to] || tc('unknown')}</span>
-              ) : null}
-              <Badge variant="outline" className="shrink-0 text-[10px]">{getMemoTypeLabel(m.memo_type)}</Badge>
+              <span className="shrink-0 text-[10px] text-muted-foreground">{formatLocaleDateOnly(m.created_at, locale)}</span>
             </div>
-            <span className="shrink-0 text-[10px] text-muted-foreground">{formatLocaleDateOnly(m.created_at, locale)}</span>
+            <p className="line-clamp-2 text-sm text-foreground">
+              {m.title || m.content.slice(0, 120)}
+            </p>
+            {m.reply_count ? (
+              <p className="mt-1 text-[10px] text-muted-foreground">{t('repliesCountBadge', { count: m.reply_count })}</p>
+            ) : null}
           </div>
 
-          {/* Title / content preview */}
-          <p className="truncate text-sm font-medium text-foreground">
-            {m.title || m.content.slice(0, 72)}
-          </p>
-          {m.title && (
-            <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
-              {m.project_name ? `${m.project_name} · ` : ''}{m.content.slice(0, 80)}
-            </p>
-          )}
-
-          {/* Compact footer: reply count + status */}
-          <div className="mt-1.5 flex items-center justify-between gap-2">
-            <span className="text-[10px] text-muted-foreground">
-              {m.reply_count ? t('repliesCountBadge', { count: m.reply_count }) : ''}
-            </span>
-            <StatusBadge status={m.status} label={getMemoStatusLabel(m.status)} />
+          {/* Desktop (lg+): full info — title + status + badges */}
+          <div className="hidden lg:block">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className="truncate text-sm font-semibold text-foreground">
+                  {m.title || m.content.slice(0, 72)}
+                </p>
+                <p className="line-clamp-2 text-xs text-muted-foreground">
+                  {m.project_name ? `${m.project_name} · ` : ''}{m.content.slice(0, 120)}
+                </p>
+              </div>
+              <StatusBadge status={m.status} label={getMemoStatusLabel(m.status)} />
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="outline">{getMemoTypeLabel(m.memo_type)}</Badge>
+              {m.reply_count ? <Badge variant="secondary">{t('repliesCountBadge', { count: m.reply_count })}</Badge> : null}
+              <span>{m.created_by ? (memberMap[m.created_by] ?? tc('unknown')) : tc('deletedUser')}</span>
+              {m.assigned_to ? (
+                <>
+                  <span>→</span>
+                  <span>{memberMap[m.assigned_to] || tc('unknown')}</span>
+                </>
+              ) : null}
+              <span className="ml-auto">{formatLocaleDateOnly(m.created_at, locale)}</span>
+            </div>
           </div>
         </button>
       ))}


### PR DESCRIPTION
## Summary
- **AC-1~3** memos-client.tsx: 모든 `md:` → `lg:` breakpoint 통일 (mobile/desktop 분기)
- **AC-4** `min-h-screen` 제거 → GNB 하단 네비 항상 표시
- **AC-5** `?id=` URL param 있을 때 `mobileView` 초기값 `'detail'` + deepId effect에서도 `setMobileView('detail')`
- **AC-6** docs-shell-client.tsx: `md:` → `lg:` breakpoint 통일
- **AC-7** settings-layout-client.tsx: `md:` → `lg:` breakpoint 통일
- **docs-shell.tsx**: `md:grid-cols/md:block` → `lg:grid-cols/lg:block`
- **AC-8** memo-list.tsx: 모바일(`< lg`) Slack 대화형 렌더 (배지 없음, sender+date 헤더, line-clamp-2 미리보기, reply count만)
- **AC-9** 데스크톱(`lg+`) 기존 레이아웃 유지

## Files Changed
- `apps/web/src/app/(authenticated)/memos/memos-client.tsx`
- `apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx`
- `apps/web/src/app/(authenticated)/settings/settings-layout-client.tsx`
- `apps/web/src/components/docs/docs-shell.tsx`
- `apps/web/src/components/memos/memo-list.tsx`

## Test plan
- [ ] 768px~1023px 구간: 모바일 레이아웃 표시 (GNB 하단 표시, 데스크톱 2-panel 없음)
- [ ] 1024px+: 데스크톱 레이아웃 표시
- [ ] 메모 페이지 GNB 하단 네비 항상 보임 (min-h-screen 제거)
- [ ] `?id=` URL 직접 접근 시 상세 뷰로 바로 전환
- [ ] 모바일 MemoList: Slack 스타일 (배지 없음, sender+date, 본문 2줄)
- [ ] 데스크톱 MemoList: 기존 배지+상태 레이아웃 유지
- [ ] Docs/Settings list↔detail 전환 lg 기준으로 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)