### PR TITLE
fix(mcp-server): eliminate pnpm install WARN for missing bin

### DIFF
--- a/Dockerfile.oss
+++ b/Dockerfile.oss
@@ -16,7 +16,7 @@ COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/storage-sqlite/package.json packages/storage-sqlite/package.json
 COPY packages/storage-supabase/package.json packages/storage-supabase/package.json
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # ─── Stage 2: Build ───
 FROM node:22-alpine AS builder

--- a/packages/mcp-server/bin/sprintable-mcp.js
+++ b/packages/mcp-server/bin/sprintable-mcp.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import('../dist/index.js')

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "prepare": "tsc",
     "dev": "node --env-file=../../.env --import tsx src/index.ts",
     "type-check": "tsc --noEmit"
   },

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -6,7 +6,7 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "sprintable-mcp": "./dist/index.js"
+    "sprintable-mcp": "./bin/sprintable-mcp.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary
- `bin` 필드가 `dist/index.js`를 직접 가리켜 fresh install 시 파일이 없어 WARN 발생
- `bin/sprintable-mcp.js` shim 파일 추가 (항상 존재, git 커밋)하여 WARN 제거
- `prepare` 스크립트로 install 시 자동 빌드 (`dist/` 생성) 보장

## Test plan
- [ ] `rm -rf node_modules && pnpm install` 실행 시 WARN 없이 완료 확인
- [ ] `node_modules/.bin/sprintable-mcp` 심볼릭 링크 정상 생성 확인