### PR TITLE
fix: settings admin 체크 — organization_members/org_members → team_members

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/layout.tsx
+++ b/apps/web/src/app/(authenticated)/settings/layout.tsx
@@ -36,21 +36,22 @@ export default async function SettingsLayout({ children }: { children: ReactNode
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return null;
 
-  // Check if admin
-  const { data: orgMember } = await supabase
-    .from('organization_members')
-    .select('role')
-    .eq('user_id', user.id)
-    .single();
-
-  const isAdmin = orgMember?.role === 'owner' || orgMember?.role === 'admin';
-
   // Get current project
   const { data: currentProject } = await supabase
     .from('current_project')
     .select('project_id')
     .eq('user_id', user.id)
     .maybeSingle();
+
+  // Check if admin
+  const { data: orgMember } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('user_id', user.id)
+    .eq('project_id', currentProject?.project_id ?? '')
+    .maybeSingle();
+
+  const isAdmin = orgMember?.role === 'owner' || orgMember?.role === 'admin';
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/apps/web/src/lib/admin-check.ts
+++ b/apps/web/src/lib/admin-check.ts
@@ -10,11 +10,12 @@ export async function requireOrgAdmin(supabase: SupabaseClient, orgId: string) {
   if (!user) throw new ForbiddenError('Not authenticated');
 
   const { data } = await supabase
-    .from('org_members')
+    .from('team_members')
     .select('role')
     .eq('org_id', orgId)
     .eq('user_id', user.id)
-    .single();
+    .limit(1)
+    .maybeSingle();
 
   if (!data || !['owner', 'admin'].includes(data.role as string)) {
     throw new ForbiddenError('Admin access required for delete operations');


### PR DESCRIPTION
## Summary

- `settings/layout.tsx`: `organization_members` (존재하지 않는 테이블) → `team_members` + `project_id` 필터
  - `current_project` 먼저 조회 후 `team_members`에서 role 체크하도록 순서 변경
- `admin-check.ts`: `org_members` (존재하지 않는 테이블) → `team_members`, `.single()` → `.limit(1).maybeSingle()`

## Root Cause

`organization_members` / `org_members` 테이블이 DB에 없는. 실제 테이블은 `team_members` (org_id + user_id + role 포함).

## Test plan

- [ ] /settings 접근 시 owner 계정 `isAdmin=true` 확인
- [ ] 프로젝트명 변경 정상 동작 확인
- [ ] pnpm build (pre-existing 에러 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)