### PR TITLE
fix(rls): 메모 RLS multi-membership 호환 수정

### DIFF
--- a/packages/db/supabase/migrations/20260420093000_memo_rls_multi_membership.sql
+++ b/packages/db/supabase/migrations/20260420093000_memo_rls_multi_membership.sql
@@ -13,7 +13,7 @@ STABLE
 SET search_path = public
 AS $$
   SELECT id FROM public.team_members
-  WHERE user_id = auth.uid() AND type = 'human' AND org_id = _org_id;
+  WHERE user_id = auth.uid() AND type = 'human' AND org_id = _org_id AND is_active = true;
 $$;
 
 -- ============================================================

--- a/packages/db/supabase/migrations/20260420093000_memo_rls_multi_membership.sql
+++ b/packages/db/supabase/migrations/20260420093000_memo_rls_multi_membership.sql
@@ -1,0 +1,98 @@
+-- BUG — 메모 RLS multi-membership 호환 수정
+-- get_my_team_member_id_for_org(LIMIT 1)이 멀티 프로젝트 유저의 INSERT를 차단하는 버그 수정
+-- 새 SETOF 함수 추가 + 5개 INSERT/UPDATE 정책 교체
+
+-- ============================================================
+-- 1. 새 Helper: 유저의 모든 team_member ID 반환 (org-scoped, LIMIT 없음)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.get_my_team_member_ids_for_org(_org_id uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT id FROM public.team_members
+  WHERE user_id = auth.uid() AND type = 'human' AND org_id = _org_id;
+$$;
+
+-- ============================================================
+-- 2. memos_insert — created_by 위조 방지 (multi-membership 호환)
+-- ============================================================
+DROP POLICY IF EXISTS "memos_insert" ON public.memos;
+CREATE POLICY "memos_insert" ON public.memos FOR INSERT
+  WITH CHECK (
+    org_id IN (SELECT public.get_user_org_ids())
+    AND created_by IN (SELECT public.get_my_team_member_ids_for_org(org_id))
+  );
+
+-- ============================================================
+-- 3. memo_replies_insert — created_by 위조 방지 (multi-membership 호환)
+-- ============================================================
+DROP POLICY IF EXISTS "memo_replies_insert" ON public.memo_replies;
+CREATE POLICY "memo_replies_insert" ON public.memo_replies FOR INSERT
+  WITH CHECK (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND created_by IN (
+      SELECT public.get_my_team_member_ids_for_org(m.org_id)
+      FROM public.memos m WHERE m.id = memo_id
+    )
+  );
+
+-- ============================================================
+-- 4. memo_doc_links_insert — created_by 위조 방지 (multi-membership 호환)
+-- ============================================================
+DROP POLICY IF EXISTS "memo_doc_links_insert" ON public.memo_doc_links;
+CREATE POLICY "memo_doc_links_insert" ON public.memo_doc_links FOR INSERT
+  WITH CHECK (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND doc_id IN (
+      SELECT d.id
+      FROM public.docs d
+      JOIN public.memos m ON m.project_id = d.project_id
+      WHERE m.id = memo_id
+        AND m.org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND created_by IN (
+      SELECT public.get_my_team_member_ids_for_org(m.org_id)
+      FROM public.memos m WHERE m.id = memo_id
+    )
+  );
+
+-- ============================================================
+-- 5. memo_reads_insert — team_member_id 위조 방지 (multi-membership 호환)
+-- ============================================================
+DROP POLICY IF EXISTS "memo_reads_insert" ON public.memo_reads;
+CREATE POLICY "memo_reads_insert" ON public.memo_reads FOR INSERT
+  WITH CHECK (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND team_member_id IN (
+      SELECT public.get_my_team_member_ids_for_org(m.org_id)
+      FROM public.memos m WHERE m.id = memo_id
+    )
+  );
+
+-- ============================================================
+-- 6. memo_reads_update — team_member_id 위조 방지 (multi-membership 호환)
+-- ============================================================
+DROP POLICY IF EXISTS "memo_reads_update" ON public.memo_reads;
+CREATE POLICY "memo_reads_update" ON public.memo_reads FOR UPDATE
+  USING (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND team_member_id IN (
+      SELECT public.get_my_team_member_ids_for_org(m.org_id)
+      FROM public.memos m WHERE m.id = memo_id
+    )
+  );

--- a/packages/db/supabase/migrations/20260420100000_memo_rls_is_active_fix.sql
+++ b/packages/db/supabase/migrations/20260420100000_memo_rls_is_active_fix.sql
@@ -1,0 +1,13 @@
+-- BUG 보강 — get_my_team_member_ids_for_org is_active 필터 누락 수정
+-- 20260420093000의 함수 정의에서 AND is_active = true 누락 → 재정의
+
+CREATE OR REPLACE FUNCTION public.get_my_team_member_ids_for_org(_org_id uuid)
+RETURNS SETOF uuid
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public
+AS $$
+  SELECT id FROM public.team_members
+  WHERE user_id = auth.uid() AND type = 'human' AND org_id = _org_id AND is_active = true;
+$$;


### PR DESCRIPTION
## 문제

`get_my_team_member_id_for_org` 함수가 `LIMIT 1`로 단일 UUID만 반환해, 동일 org에 복수 프로젝트 멤버십을 가진 유저가 메모 관련 INSERT를 하면 RLS 정책에서 차단되는 버그.

**영향 테이블**: `memos`, `memo_replies`, `memo_doc_links`, `memo_reads`

## 수정

`get_my_team_member_ids_for_org` (SETOF uuid, LIMIT 없음) 함수 신설 후 5개 INSERT/UPDATE 정책 교체:

| 정책 | 변경 |
|------|------|
| `memos_insert` | `= get_my_team_member_id_for_org` → `IN (SELECT get_my_team_member_ids_for_org)` |
| `memo_replies_insert` | 동일 |
| `memo_doc_links_insert` | 동일 |
| `memo_reads_insert` | 동일 |
| `memo_reads_update` | 동일 |

기존 `get_my_team_member_id_for_org` 함수는 유지 (하위호환, SELECT 정책에서 계속 사용).

## 마이그레이션

`packages/db/supabase/migrations/20260420093000_memo_rls_multi_membership.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)