### PR TITLE
fix(mcp): send_memo assigned_to_ids 멀티 assignee 지원

### DIFF
--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -44,10 +44,13 @@ export function registerMemosTools(server: McpServer) {
     title: z.string().optional(),
     content: z.string(),
     memo_type: z.string().optional(),
-    assigned_to: z.string().optional().describe('Team member ID to assign'),
-  }, async (body) => {
+    assigned_to: z.string().optional().describe('Single team member ID (legacy, use assigned_to_ids for multiple)'),
+    assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to assign (supports multiple assignees)'),
+  }, async ({ assigned_to, assigned_to_ids, ...rest }) => {
     try {
-      const data = await pmApi('/api/memos', { method: 'POST', body: JSON.stringify(body) });
+      const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
+      const payload = { ...rest, ...(resolvedIds ? { assigned_to_ids: resolvedIds } : {}) };
+      const data = await pmApi('/api/memos', { method: 'POST', body: JSON.stringify(payload) });
       return ok(data);
     } catch (e) { return handleError(e); }
   });

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -656,17 +656,32 @@ describe('memos tools via pmApi', () => {
     expect(result).toEqual({ data: { id: 'memo-new', content: 'Hello world' } });
   });
 
-  it('send_memo calls POST /api/memos', async () => {
+  it('send_memo — assigned_to 단일 ID는 assigned_to_ids 배열로 변환', async () => {
     stubFetch((url, init) => {
       expect(url).toBe('http://test-pm-api/api/memos');
       expect(init?.method).toBe('POST');
       const body = JSON.parse(init?.body as string);
-      expect(body).toMatchObject({ content: 'Kickoff memo', assigned_to: 'member-alpha' });
+      expect(body).toMatchObject({ content: 'Kickoff memo', assigned_to_ids: ['member-alpha'] });
+      expect(body).not.toHaveProperty('assigned_to');
       return new Response(JSON.stringify({ data: { id: 'memo-sent', content: 'Kickoff memo' } }), { status: 200 });
     });
 
     const result = await harness.invoke('send_memo', { content: 'Kickoff memo', assigned_to: 'member-alpha' });
     expect(result).toEqual({ data: { id: 'memo-sent', content: 'Kickoff memo' } });
+  });
+
+  it('send_memo — assigned_to_ids 멀티 assignee 직접 전달', async () => {
+    stubFetch((url, init) => {
+      expect(url).toBe('http://test-pm-api/api/memos');
+      expect(init?.method).toBe('POST');
+      const body = JSON.parse(init?.body as string);
+      expect(body).toMatchObject({ content: 'Multi memo', assigned_to_ids: ['id1', 'id2'] });
+      expect(body).not.toHaveProperty('assigned_to');
+      return new Response(JSON.stringify({ data: { id: 'memo-multi', content: 'Multi memo' } }), { status: 200 });
+    });
+
+    const result = await harness.invoke('send_memo', { content: 'Multi memo', assigned_to_ids: ['id1', 'id2'] });
+    expect(result).toEqual({ data: { id: 'memo-multi', content: 'Multi memo' } });
   });
 
   it('list_my_memos calls GET /api/memos with assigned_to filter', async () => {


### PR DESCRIPTION
## Summary
- `send_memo` 스키마에 `assigned_to_ids?: string[]` 파라미터 추가
- `assigned_to_ids` 존재 시 우선 사용, fallback: `assigned_to` 단일 ID → `[id]` 배열 변환
- 기존 `assigned_to` 단일 호출 하위호환 유지

## Test plan
- [ ] `send_memo({ content, assigned_to_ids: ["id1","id2"] })` — 2명 assignee 발송 확인
- [ ] `send_memo({ content, assigned_to: "id1" })` — 기존 단일 호환 확인
- [ ] MCP 빌드 통과

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)