### PR TITLE
fix(rls): memo_assignees INSERT multi-membership 호환 수정 + 경고 응답 포함

### DIFF
--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -431,6 +431,7 @@ export class MemoService {
 
       if (assigneeError) {
         console.warn('[MemoService.create] Failed to insert memo_assignees:', assigneeError.message);
+        (data as unknown as Record<string, unknown>)._assignee_warning = `memo_assignees insert failed: ${assigneeError.message}`;
       }
     }
 

--- a/packages/db/supabase/migrations/20260420120000_memo_assignees_rls_multi_membership.sql
+++ b/packages/db/supabase/migrations/20260420120000_memo_assignees_rls_multi_membership.sql
@@ -1,0 +1,19 @@
+-- BUG — memo_assignees INSERT RLS multi-membership 호환 수정
+-- PR #76 패치 누락분: memo_assignees_insert_org_member가 project_id JOIN 패턴 그대로여서
+-- 복수 프로젝트 멤버십 유저의 INSERT 거부. get_my_team_member_ids_for_org() 패턴으로 교체.
+
+DROP POLICY IF EXISTS "memo_assignees_insert_org_member" ON public.memo_assignees;
+CREATE POLICY "memo_assignees_insert_org_member"
+  ON public.memo_assignees
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+    )
+    AND assigned_by IN (
+      SELECT public.get_my_team_member_ids_for_org(m.org_id)
+      FROM public.memos m WHERE m.id = memo_assignees.memo_id
+    )
+  );


### PR DESCRIPTION
## Summary
- `memo_assignees_insert_org_member` 정책을 `get_my_team_member_ids_for_org()` 패턴으로 교체
  - 기존 `project_id JOIN` 패턴 → 복수 프로젝트 멤버십 유저 INSERT 거부 버그 수정
- `MemoService.create()` assigneeError 시 `_assignee_warning` 필드로 응답에 경고 포함

## Test plan
- [ ] 복수 프로젝트 멤버십 유저로 메모 발송 → `memo_assignees` INSERT 정상 확인
- [ ] assigneeError 발생 시 응답에 `_assignee_warning` 필드 포함 확인
- [ ] TypeScript 빌드 통과

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)