### PR TITLE
fix(dispatch): silent skip 사용자 알림 + 로그 레벨 상향 (E-MEMO-DISPATCH:S3)

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -60,10 +60,17 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
       logger: console,
     });
 
-    await dispatcher.dispatchMemoIfNeeded(memo, 'realtime');
+    const result = await dispatcher.dispatchMemoIfNeeded(memo, 'realtime');
     await dispatcher.stop();
+
+    if (result.status === 'skipped') {
+      console.error(
+        '[MemoDispatch] dispatch skipped:',
+        result.reason ?? 'unknown_reason',
+      );
+    }
   } catch (error) {
-    console.warn(
+    console.error(
       '[MemoDispatch] immediate assignment dispatch failed:',
       error instanceof Error ? error.message : String(error),
     );

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -409,6 +409,11 @@ export class MemoEventDispatcher {
 
     const agent = await this.getAgentById(memo, routing.dispatchAgentId);
     if (!agent) {
+      await this.postSystemReply(
+        memo,
+        routing.dispatchAgentId,
+        `⚠️ 에이전트(${routing.dispatchAgentId})가 비활성 상태이거나 배포가 구성되지 않아 웹훅 발송이 스킵되었습니다.`,
+      );
       return { status: 'skipped', reason: 'assignee_not_active_agent' };
     }
 
@@ -767,6 +772,15 @@ export class MemoEventDispatcher {
       run_id: runId,
       details,
     });
+  }
+
+  private async postSystemReply(memo: MemoRow, createdBy: string, content: string) {
+    const { error } = await this.options.supabase
+      .from('memo_replies')
+      .insert({ memo_id: memo.id, content, created_by: createdBy, review_type: 'system' });
+    if (error) {
+      this.logger.warn('[MemoEventDispatcher] Failed to post system reply:', error.message);
+    }
   }
 
   private async logAudit(


### PR DESCRIPTION
## Summary
- `memo-event-dispatcher.ts`: `assignee_not_active_agent` skip 경로에 `postSystemReply()` 추가 → 메모 답글로 비활성 에이전트 경고 알림 (review_type: 'system')
- `memo-assignment-dispatch.ts`: `DispatchResult.status === 'skipped'` 캡처 후 `console.error` 상향 (기존 warn), 일반 에러도 warn→error 상향

## Test plan
- [ ] 비활성 에이전트 assignee 메모 생성 시 시스템 답글 수신 확인
- [ ] 멀티 assignee 중 일부 skip 시 각 skipped assignee별 시스템 답글 포함 확인
- [ ] TypeScript 빌드 통과
- [ ] CI 전종 통과

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)