### PR TITLE
fix(dispatch): reply_memo @멘션 웹훅 2종 버그 수정 (story 3b46c7bf)

### DIFF
--- a/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
@@ -6,6 +6,7 @@ function createSupabaseStub(options?: {
   priorReplies?: Array<Record<string, unknown>>;
   members?: Array<Record<string, unknown>>;
   webhookConfigs?: Array<Record<string, unknown>>;
+  memoAssignees?: Array<Record<string, unknown>>;
 }) {
   const priorReplies = options?.priorReplies ?? [
     { created_by: 'member-3', content: 'Earlier note from @Paulo Ortega' },
@@ -19,6 +20,7 @@ function createSupabaseStub(options?: {
     { org_id: 'org-1', member_id: 'member-1', project_id: 'project-1', is_active: true, url: 'https://discord.com/api/webhooks/member-1/project', secret: null },
     { org_id: 'org-1', member_id: 'member-3', project_id: null, is_active: true, url: 'https://discord.com/api/webhooks/member-3/default', secret: null },
   ];
+  const memoAssignees = options?.memoAssignees ?? [];
 
   const supabase = {
     from(table: string) {
@@ -38,6 +40,16 @@ function createSupabaseStub(options?: {
           eq() { return this; },
           then(resolve: (value: { data: unknown[]; error: null }) => unknown) {
             return Promise.resolve({ data: priorReplies, error: null }).then(resolve);
+          },
+        };
+      }
+
+      if (table === 'memo_assignees') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          then(resolve: (value: { data: unknown[]; error: null }) => unknown) {
+            return Promise.resolve({ data: memoAssignees, error: null }).then(resolve);
           },
         };
       }
@@ -177,5 +189,70 @@ describe('dispatchWorkflowMemoReplyWebhooks', () => {
 
     expect(result).toEqual({ status: 'skipped', reason: 'discord_source_memo' });
     expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it('dispatches to first-name mention with Korean honorific (e.g. @까심군)', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }));
+    const supabase = createSupabaseStub();
+
+    const result = await dispatchWorkflowMemoReplyWebhooks({
+      supabase,
+      fetchFn: fetchFn as typeof fetch,
+      appUrl: 'https://app.example.com',
+      memo: {
+        id: 'memo-1',
+        org_id: 'org-1',
+        project_id: 'project-1',
+        title: 'QA 요청',
+        created_by: 'member-1',
+        assigned_to: null,
+        metadata: null,
+      },
+      reply: {
+        id: 'reply-2',
+        memo_id: 'memo-1',
+        content: '@까심군 QA 검증 바라는.',
+        created_by: 'member-3',
+      },
+    });
+
+    expect(result.status).toBe('sent');
+    const calledUrls = fetchFn.mock.calls.map((call) => call[0]);
+    expect(calledUrls).toContain('https://discord.com/api/webhooks/member-1/project');
+    expect(calledUrls).toContain('https://discord.com/api/webhooks/member-2/direct');
+  });
+
+  it('includes memo_assignees in participant set', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }));
+    const supabase = createSupabaseStub({
+      memoAssignees: [{ member_id: 'member-2' }],
+      priorReplies: [],
+    });
+
+    const result = await dispatchWorkflowMemoReplyWebhooks({
+      supabase,
+      fetchFn: fetchFn as typeof fetch,
+      appUrl: 'https://app.example.com',
+      memo: {
+        id: 'memo-1',
+        org_id: 'org-1',
+        project_id: 'project-1',
+        title: 'Assignee test',
+        created_by: 'member-1',
+        assigned_to: null,
+        metadata: null,
+      },
+      reply: {
+        id: 'reply-3',
+        memo_id: 'memo-1',
+        content: '작업 완료 보고.',
+        created_by: 'member-3',
+      },
+    });
+
+    expect(result.status).toBe('sent');
+    const calledUrls = fetchFn.mock.calls.map((call) => call[0]);
+    expect(calledUrls).toContain('https://discord.com/api/webhooks/member-1/project');
+    expect(calledUrls).toContain('https://discord.com/api/webhooks/member-2/direct');
   });
 });

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildAbsoluteMemoLink } from './app-url';
+import { hasExactMemberMention } from './doc-comment-notifications';
 
 interface MemoReplyDispatchMemo {
   id: string;
@@ -99,15 +100,38 @@ function buildPreview(content: string, maxLength = 50) {
   return `${normalized.slice(0, maxLength)}…`;
 }
 
+// Korean honorific suffixes that may follow a first-name mention (e.g. "@까심군" for "까심 아르야")
+const KOREAN_HONORIFIC_RE = /^(군|신|쿤|님|씨)/u;
+
+function hasMentionWithHonorific(content: string, namePart: string): boolean {
+  const token = `@${namePart}`;
+  let idx = content.indexOf(token);
+  while (idx !== -1) {
+    const pre = idx > 0 ? content[idx - 1] : undefined;
+    const after = content.slice(idx + token.length);
+    const prefixOk = !pre || /[\s([{<'""']/u.test(pre);
+    const suffixOk = !after || /[\s)\]}>,'""'.!?;:]/.test(after[0]) || KOREAN_HONORIFIC_RE.test(after);
+    if (prefixOk && suffixOk) return true;
+    idx = content.indexOf(token, idx + token.length);
+  }
+  return false;
+}
+
 function extractMentionedMemberIds(contents: string[], members: TeamMemberRow[]) {
   const targets = new Set<string>();
 
   for (const member of members) {
     const name = member.name?.trim();
     if (!name) continue;
-    if (contents.some((content) => content.includes(`@${name}`))) {
-      targets.add(member.id);
-    }
+
+    const firstName = name.includes(' ') ? name.split(/\s+/)[0] : null;
+
+    const matched = contents.some((content) =>
+      hasExactMemberMention(content, name) ||
+      (firstName !== null && hasMentionWithHonorific(content, firstName)),
+    );
+
+    if (matched) targets.add(member.id);
   }
 
   return targets;
@@ -193,7 +217,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
     return { status: 'skipped', reason: 'discord_source_memo' };
   }
 
-  const [membersResult, priorRepliesResult] = await Promise.all([
+  const [membersResult, priorRepliesResult, assigneesResult] = await Promise.all([
     supabase
       .from('team_members')
       .select('id, name, webhook_url, is_active')
@@ -203,6 +227,10 @@ export async function dispatchWorkflowMemoReplyWebhooks(
     supabase
       .from('memo_replies')
       .select('created_by, content')
+      .eq('memo_id', memo.id),
+    supabase
+      .from('memo_assignees')
+      .select('member_id')
       .eq('memo_id', memo.id),
   ]);
 
@@ -216,6 +244,9 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const participants = new Set<string>();
   participants.add(memo.created_by);
   if (memo.assigned_to) participants.add(memo.assigned_to);
+  for (const row of (assigneesResult.data ?? [])) {
+    participants.add((row as { member_id: string }).member_id);
+  }
   for (const priorReply of priorReplies) {
     participants.add(priorReply.created_by);
   }


### PR DESCRIPTION
## Root Cause
1. `extractMentionedMemberIds` — `content.includes(@name)` 단순 매칭. `@까심군` vs DB name `까심 아르야` → 미탐지
2. participants 구성에 `memo_assignees` 미포함 — multi-assignee 웹훅 누락

## Fix
1. **멘션 매칭** — `hasExactMemberMention(content, fullName)` (doc-comment-notifications 패턴) + `hasMentionWithHonorific(content, firstName)` (한국어 존칭 suffix 인식: 군/신/쿤/님/씨)
2. **memo_assignees** — `Promise.all` 3번째 쿼리로 `memo_assignees` 조회, 모든 assignee를 participants에 추가

## AC
- [ ] AC1: 원인 특정 ✅ (위 2종)
- [ ] AC2: reply_memo @까심군 멘션 → 웹훅 도달
- [ ] AC3: 테스트 통과

Closes story 3b46c7bf | Related: #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)