### PR TITLE
feat(api): list_team_members webhook_url 노출 (story 2027c7f3)

### DIFF
--- a/apps/web/src/app/api/members/route.test.ts
+++ b/apps/web/src/app/api/members/route.test.ts
@@ -56,7 +56,7 @@ describe('GET /api/members', () => {
 
   it('returns 200 with team members list', async () => {
     const members = [
-      { id: 'member-alpha', name: 'Alpha Owner', type: 'human', role: 'owner', is_active: true },
+      { id: 'member-alpha', name: 'Alpha Owner', type: 'human', role: 'owner', is_active: true, webhook_url: null },
     ];
     const supabase = { from: vi.fn(() => createQueryStub(members)) };
     createSupabaseServerClient.mockResolvedValue(supabase);

--- a/apps/web/src/app/api/members/route.ts
+++ b/apps/web/src/app/api/members/route.ts
@@ -20,7 +20,7 @@ export async function GET(request: Request) {
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const { data, error } = await dbClient
       .from('team_members')
-      .select('id, name, type, role, is_active')
+      .select('id, name, type, role, is_active, webhook_url')
       .eq('project_id', projectId)
       .eq('is_active', true)
       .order('name');

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -45,7 +45,7 @@ export async function GET(request: Request) {
 
     let query = supabase
       .from('team_members')
-      .select('id, name, type, role, user_id, project_id, is_active')
+      .select('id, name, type, role, user_id, project_id, is_active, webhook_url')
       .order('name');
 
     if (!includeInactive) query = query.eq('is_active', true);


### PR DESCRIPTION
## Summary
- `/api/members` select 쿼리에 `webhook_url` 필드 추가 (MCP `list_team_members` 도구 경유)
- `/api/team-members` GET select 쿼리에 동일 추가
- DevOps 에이전트가 웹훅 헬스체크 시 프로그래밍적으로 webhook_url 조회 가능

## Changes
- 3파일, +3/-3 (select 문자열에 `webhook_url` 추가)

## Test plan
- [x] `apps/web/src/app/api/members/route.test.ts` — PASS
- [x] `apps/web/src/app/api/team-members/route.test.ts` — PASS
- [ ] MCP `list_team_members` 호출 시 webhook_url 필드 포함 확인
- [ ] webhook_url null인 멤버는 null 표시 확인
- [ ] pnpm build 성공

🐘 담롱 온찬 (DevOps) — 본인이 발견한 갭, 본인이 수정