### PR TITLE
feat(memos): 메모 멘션 자동완성 UI (story 4faf8fbc)

### DIFF
--- a/apps/web/src/components/memos/memo-composer.tsx
+++ b/apps/web/src/components/memos/memo-composer.tsx
@@ -23,6 +23,7 @@ function applyMention(value: string, cursorPos: number, name: string): { text: s
 interface MentionMember {
   id: string;
   name: string;
+  role?: string | null;
 }
 
 interface MemoComposerProps {
@@ -89,7 +90,7 @@ export function MemoComposer({
       .then((r) => r.json())
       .then((json) => {
         if (cancelled) return;
-        const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string }) => ({ id: m.id, name: m.name }));
+        const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string; role?: string | null }) => ({ id: m.id, name: m.name, role: m.role }));
         const q = mentionQuery.toLowerCase();
         setMentionMembers(q ? all.filter((m) => m.name.toLowerCase().includes(q)) : all);
         setMentionIndex(0);
@@ -282,7 +283,7 @@ export function MemoComposer({
           className="w-full rounded-md border border-input px-3 py-2 text-sm focus:border-ring focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
         />
         {mentionMembers.length > 0 && (
-          <ul className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-64 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+          <ul className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-[min(16rem,100%)] overflow-y-auto rounded-md border border-border bg-popover shadow-md">
             {mentionMembers.map((member, idx) => (
               <li key={member.id}>
                 <button
@@ -291,6 +292,7 @@ export function MemoComposer({
                   className={`w-full px-3 py-2 text-left text-sm transition ${idx === mentionIndex ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
                 >
                   <span className="font-medium text-primary">@</span>{member.name}
+                  {member.role ? <span className="ml-2 text-xs opacity-60">{member.role}</span> : null}
                 </button>
               </li>
             ))}


### PR DESCRIPTION
## Summary

- `@` 입력 시 팀 멤버 드롭다운 표시 (이름+역할 필터링 포함)
- 선택 시 `@{정확한 DB name}` 삽입, 커서 위치 유지
- 키보드 탐색 ↑↓/Enter/Tab/Escape 지원
- 메모 작성(create)과 reply_memo 작성 모두 동일 `MemoComposer` 사용
- 모바일 드롭다운 너비 `w-64` → `w-[min(16rem,100%)]` 보정

## AC 체크리스트

- [x] AC1: `@` 입력 시 팀 멤버 드롭다운 표시
- [x] AC2: 멤버 이름+역할 표시, 이름 필터링
- [x] AC3: 선택 시 `@{정확한 DB name}` 삽입
- [x] AC4: reply_memo 작성에서도 동일 동작 (MemoComposer 공유)
- [x] AC5: 키보드 탐색 ↑↓+Enter 지원
- [x] AC6: 모바일 정상 표시 (드롭다운 너비 보정)

## Test plan

- [ ] 메모 작성 화면에서 `@` 입력 → 드롭다운 표시 확인
- [ ] 이름 일부 입력 시 필터링 확인, role 레이블 표시 확인
- [ ] ↑↓ 탐색 → Enter 선택 → `@이름 ` 삽입 확인
- [ ] 답신(reply) 작성란에서도 동일하게 동작 확인
- [ ] 모바일(375px) 뷰에서 드롭다운 잘림 없음 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)