### PR TITLE
fix(mcp): list_my_memos created_by 필터 추가 + search_memos 중복 제거 (story 9138b28f)

### DIFF
--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -83,6 +83,7 @@ export async function GET(request: Request) {
       org_id: me.org_id,
       project_id: searchParams.get('project_id') ?? undefined,
       assigned_to: searchParams.get('assigned_to') ?? undefined,
+      created_by: searchParams.get('created_by') ?? undefined,
       status: searchParams.get('status') ?? undefined,
       q: searchParams.get('q') ?? undefined,
       limit: pageInput.limit,

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -457,11 +457,12 @@ export class MemoService {
     return data;
   }
 
-  async list(filters: { org_id?: string; project_id?: string; assigned_to?: string; status?: string; limit?: number; cursor?: string | null; q?: string }) {
+  async list(filters: { org_id?: string; project_id?: string; assigned_to?: string; created_by?: string; status?: string; limit?: number; cursor?: string | null; q?: string }) {
     const memos = await this.repo.list({
       org_id: filters.org_id,
       project_id: filters.project_id,
       assigned_to: filters.assigned_to,
+      created_by: filters.created_by,
       status: filters.status,
       q: filters.q,
       cursor: filters.cursor ?? undefined,

--- a/packages/core-storage/src/interfaces/IMemoRepository.ts
+++ b/packages/core-storage/src/interfaces/IMemoRepository.ts
@@ -52,6 +52,7 @@ export interface MemoListFilters extends PaginationOptions {
   org_id?: string;
   project_id?: string;
   assigned_to?: string;
+  created_by?: string;
   status?: string;
   q?: string;
 }

--- a/packages/mcp-server/src/tools/analytics.ts
+++ b/packages/mcp-server/src/tools/analytics.ts
@@ -85,25 +85,6 @@ export function registerAnalyticsTools(server: McpServer) {
     },
   );
 
-  // GET /api/memos?q=
-  server.tool(
-    'search_memos',
-    'Search memos by title or content',
-    {
-      project_id: z.string().describe('Project ID'),
-      query: z.string().describe('Search query'),
-    },
-    async ({ project_id, query }) => {
-      try {
-        const params = new URLSearchParams({ project_id, q: query });
-        const data = await pmApi(`/api/memos?${params.toString()}`);
-        return ok(data);
-      } catch (e) {
-        return err(e instanceof PmApiError ? e.message : String(e));
-      }
-    },
-  );
-
   // GET /api/stories?status=in-review
   server.tool(
     'get_blocked_stories',

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -56,14 +56,16 @@ export function registerMemosTools(server: McpServer) {
   });
 
   server.tool('list_my_memos', 'List memos assigned to or created by a member', {
-    assigned_to: z.string().optional().describe('Team member ID'),
+    assigned_to: z.string().optional().describe('Filter by assigned team member ID'),
+    created_by: z.string().optional().describe('Filter by creator team member ID'),
     project_id: z.string().optional(),
     status: z.string().optional(),
-  }, async ({ assigned_to, project_id, status }) => {
+  }, async ({ assigned_to, created_by, project_id, status }) => {
     try {
       const params = new URLSearchParams();
       if (project_id) params.set('project_id', project_id);
       if (assigned_to) params.set('assigned_to', assigned_to);
+      if (created_by) params.set('created_by', created_by);
       if (status) params.set('status', status);
       const qs = params.toString();
       const data = await pmApi(`/api/memos${qs ? `?${qs}` : ''}`);

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -695,6 +695,17 @@ describe('memos tools via pmApi', () => {
     expect(result).toEqual({ data: [{ id: 'memo-alpha', assigned_to: 'member-alpha' }] });
   });
 
+  it('list_my_memos calls GET /api/memos with created_by filter', async () => {
+    stubFetch((url) => {
+      expect(url).toContain('/api/memos');
+      expect(url).toContain('created_by=member-alpha');
+      return new Response(JSON.stringify({ data: [{ id: 'memo-beta', created_by: 'member-alpha' }] }), { status: 200 });
+    });
+
+    const result = await harness.invoke('list_my_memos', { created_by: 'member-alpha' });
+    expect(result).toEqual({ data: [{ id: 'memo-beta', created_by: 'member-alpha' }] });
+  });
+
   it('read_memo calls GET /api/memos/:id', async () => {
     stubFetch((url) => {
       expect(url).toBe('http://test-pm-api/api/memos/memo-alpha');
@@ -1011,18 +1022,6 @@ describe('analytics tools via pmApi', () => {
 
     const result = await harness.invoke('search_stories', { project_id: 'project-alpha', query: 'alpha' });
     expect(result).toEqual({ data: [{ id: 'story-alpha', title: 'Alpha story' }] });
-  });
-
-  it('search_memos calls GET /api/memos with q param', async () => {
-    stubFetch((url) => {
-      expect(url).toContain('/api/memos?');
-      expect(url).toContain('project_id=project-alpha');
-      expect(url).toContain('q=alpha');
-      return new Response(JSON.stringify({ data: [{ id: 'memo-alpha', title: 'Alpha memo' }] }), { status: 200 });
-    });
-
-    const result = await harness.invoke('search_memos', { project_id: 'project-alpha', query: 'alpha' });
-    expect(result).toEqual({ data: [{ id: 'memo-alpha', title: 'Alpha memo' }] });
   });
 
   it('get_blocked_stories calls GET /api/stories with status=in-review', async () => {

--- a/packages/storage-sqlite/src/SqliteMemoRepository.ts
+++ b/packages/storage-sqlite/src/SqliteMemoRepository.ts
@@ -44,6 +44,7 @@ export class SqliteMemoRepository implements IMemoRepository {
     if (filters.org_id && !filters.project_id) { sql += ' AND org_id = ?'; params.push(filters.org_id); }
     if (filters.project_id) { sql += ' AND project_id = ?'; params.push(filters.project_id); }
     if (filters.assigned_to) { sql += ' AND assigned_to = ?'; params.push(filters.assigned_to); }
+    if (filters.created_by) { sql += ' AND created_by = ?'; params.push(filters.created_by); }
     if (filters.status) { sql += ' AND status = ?'; params.push(filters.status); }
     if (filters.q?.trim()) {
       sql += ' AND (title LIKE ? OR content LIKE ?)';

--- a/packages/storage-supabase/src/SupabaseMemoRepository.ts
+++ b/packages/storage-supabase/src/SupabaseMemoRepository.ts
@@ -46,6 +46,7 @@ export class SupabaseMemoRepository implements IMemoRepository {
     if (filters.org_id && !filters.project_id) query = query.eq('org_id', filters.org_id);
     if (filters.project_id) query = query.eq('project_id', filters.project_id);
     if (filters.assigned_to) query = query.eq('assigned_to', filters.assigned_to);
+    if (filters.created_by) query = query.eq('created_by', filters.created_by);
     if (filters.status) query = query.eq('status', filters.status);
     if (filters.q?.trim()) query = query.or(`title.ilike.%${filters.q.trim()}%,content.ilike.%${filters.q.trim()}%`);
     if (filters.cursor) query = query.lt('created_at', filters.cursor);


### PR DESCRIPTION
## Summary

- `list_my_memos` MCP 도구가 `assigned_to`만 지원해 까심군처럼 메모를 `created_by`로 조회하는 케이스 실패하던 버그 수정
- `created_by` 필터를 `MemoListFilters` → SQLite/Supabase 리포지토리 → `MemoService.list()` → `/api/memos` GET → MCP 도구까지 전파
- `analytics.ts`의 `search_memos` 도구 제거 — `list_memos + q param`과 동일 엔드포인트/기능 중복
- `comm.ts`는 현재 main에 존재하지 않음 (OSS-SPLIT 과정에서 이미 제거됨) — AC1 충족

## AC 체크리스트

- [x] AC1: comm.ts 쪽 중복 제거 — 이미 제거됨, 재확인
- [x] AC2: list_memos/search_memos 중복 정리 — `search_memos` analytics.ts에서 제거
- [x] AC3: pnpm build + test 통과 — 299 tests passed

## 변경 파일

- `packages/core-storage/src/interfaces/IMemoRepository.ts` — `MemoListFilters.created_by` 추가
- `packages/storage-sqlite/src/SqliteMemoRepository.ts` — `created_by` WHERE 조건 추가
- `packages/storage-supabase/src/SupabaseMemoRepository.ts` — `created_by` eq 필터 추가
- `apps/web/src/services/memo.ts` — `MemoService.list()` 필터 확장
- `apps/web/src/app/api/memos/route.ts` — `created_by` searchParam 전달
- `packages/mcp-server/src/tools/memos.ts` — `list_my_memos` `created_by` param 추가
- `packages/mcp-server/src/tools/analytics.ts` — `search_memos` 제거
- `packages/mcp-server/src/tools/smoke.test.ts` — `search_memos` 테스트 제거 + `created_by` 케이스 추가

## Test plan

- [x] 빌드: `pnpm --filter=@sprintable/mcp-server build` 성공
- [x] 테스트: 299 tests passed
- [ ] `list_my_memos` with `created_by=<kassim_id>` → 까심군이 작성한 메모 반환 확인
- [ ] `list_my_memos` with `assigned_to=<id>` — 기존 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)