### PR TITLE
fix(board): 보드 스토리 Close 버튼 race condition 수정

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ComponentType } from 'react';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
@@ -73,6 +73,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [selectedEpicId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
+  const isClosingStoryRef = useRef(false);
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
@@ -138,6 +139,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [searchParams, router]);
 
   const handleCloseStory = useCallback(() => {
+    isClosingStoryRef.current = true;
     setSelectedStory(null);
 
     // URL에서 스토리 ID 제거
@@ -149,6 +151,12 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   // URL에서 스토리 ID 읽어서 자동으로 패널 열기
   useEffect(() => {
     const storyId = searchParams.get('story');
+    // closing 중에는 effect 스킵 — setSelectedStory(null) 직후 searchParams가 아직
+    // ?story= 를 포함한 상태로 effect가 재발화해 패널이 재오픈되는 race condition 방지
+    if (isClosingStoryRef.current) {
+      if (!storyId) isClosingStoryRef.current = false;
+      return;
+    }
     if (storyId && stories.length > 0) {
       const story = stories.find((s) => s.id === storyId);
       if (story && (!selectedStory || selectedStory.id !== storyId)) {


### PR DESCRIPTION
## 원인

`handleCloseStory` 에서 `setSelectedStory(null)` 을 호출한 직후 React가 re-render되면서 auto-open `useEffect` 가 재발화. 이 시점에 `searchParams` 는 아직 `?story=` 를 포함하고 있어, `selectedStory === null` 조건과 맞물려 패널이 즉시 재오픈됨.

## 수정

`isClosingStoryRef` (`useRef(false)`) 플래그 추가:
- `handleCloseStory` 진입 시 `true` 설정
- `useEffect` 에서 플래그가 `true` 이면 skip
- `searchParams` 에서 `?story=` 가 사라지면 플래그 초기화

## 테스트
1. 보드에서 스토리 카드 클릭 → 상세 패널 열림
2. Close(✕) 버튼 클릭 → 패널 닫힘 유지 확인
3. URL `?story=` 파라미터 제거 확인
4. 다시 스토리 클릭 → 정상 오픈 확인

Story: 511e389c-3b95-4d93-9519-891228655e1c