### PR TITLE
fix(board): Close 버튼 race condition 근본 수정 — selectedStory deps 제거

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -73,7 +73,8 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [selectedEpicId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
-  const isClosingStoryRef = useRef(false);
+  const selectedStoryRef = useRef<KanbanStory | null>(null);
+  selectedStoryRef.current = selectedStory;
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
@@ -139,7 +140,6 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [searchParams, router]);
 
   const handleCloseStory = useCallback(() => {
-    isClosingStoryRef.current = true;
     setSelectedStory(null);
 
     // URL에서 스토리 ID 제거
@@ -149,21 +149,19 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [searchParams, router]);
 
   // URL에서 스토리 ID 읽어서 자동으로 패널 열기
+  // selectedStory를 deps에서 제외: setSelectedStory(null) 호출 시 effect가 재발화하면
+  // searchParams에 ?story= 가 아직 남아있어 패널이 즉시 재오픈되는 race condition ���생.
+  // selectedStoryRef(항상 최신값)로 비교해 중복 오픈만 방지한다.
   useEffect(() => {
     const storyId = searchParams.get('story');
-    // closing 중에는 effect 스킵 — setSelectedStory(null) 직후 searchParams가 아직
-    // ?story= 를 포함한 상태로 effect가 재발화해 패널이 재오픈되는 race condition 방지
-    if (isClosingStoryRef.current) {
-      if (!storyId) isClosingStoryRef.current = false;
-      return;
-    }
     if (storyId && stories.length > 0) {
       const story = stories.find((s) => s.id === storyId);
-      if (story && (!selectedStory || selectedStory.id !== storyId)) {
+      if (story && (!selectedStoryRef.current || selectedStoryRef.current.id !== storyId)) {
         void handleStoryClick(story);
       }
     }
-  }, [searchParams, stories, selectedStory, handleStoryClick]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, stories, handleStoryClick]);
 
   const filteredStories = stories.filter((s) => {
     if (selectedEpicId && s.epic_id !== selectedEpicId) return false;

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -211,7 +211,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
             <h2 className="text-lg font-semibold text-foreground">{story.title}</h2>
             <StatusBadge status={story.status} label={statusLabel} />
           </div>
-          <button onClick={onClose} className="rounded-md border border-border px-3 py-2 text-muted-foreground transition hover:text-foreground hover:bg-muted/50">✕</button>
+          <button type="button" onClick={onClose} className="rounded-md border border-border px-3 py-2 text-muted-foreground transition hover:text-foreground hover:bg-muted/50">✕</button>
         </div>
         <div className="flex-1 overflow-y-auto p-5">
           <div className="space-y-5">


### PR DESCRIPTION
## RC 수정 — PR #95 후속

PR #95의 `isClosingStoryRef` 플래그 방식은 Next.js 15의 `startTransition` 기반 라우터 때문에 플래그 초기화 타이밍이 race를 완전히 막지 못했음.

## 근본 원인

`useEffect` deps에 `selectedStory`가 포함되어, `setSelectedStory(null)` 시 effect 재발화 → `searchParams`에 `?story=` 아직 존재 → 패널 즉시 재오픈.

## 수정

- `isClosingStoryRef` 제거
- `selectedStoryRef = useRef(null)` 추가 (항상 최신값 동기화)
- `useEffect` deps에서 `selectedStory` 제거 → close 시 effect 재발화 자체 차단
- `selectedStoryRef.current` 로 중복 오픈 방지 유지
- close 버튼에 `type="button"` 명시

## 변경 파일
- `kanban-board.tsx` +9/-11
- `story-detail-panel.tsx` +1/-1

Story: 511e389c-3b95-4d93-9519-891228655e1c (RC follow-up)