### PR TITLE
feat: workflow_versions DB 마이그레이션 + API (E-WORKFLOW-VIZ S1)

### DIFF
--- a/apps/web/src/app/api/v1/workflow-versions/[id]/rollback/route.ts
+++ b/apps/web/src/app/api/v1/workflow-versions/[id]/rollback/route.ts
@@ -1,0 +1,37 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { apiError, ApiErrors, apiSuccess } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { AgentRoutingRuleService } from '@/services/agent-routing-rule';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { requireAgentOrchestration } from '@/lib/require-agent-orchestration';
+import { isOssMode } from '@/lib/storage/factory';
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Not available in OSS mode.', 501);
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const gateResponse = await requireAgentOrchestration(supabase, me.org_id);
+    if (gateResponse) return gateResponse;
+
+    const { id } = await params;
+    if (!id) return ApiErrors.badRequest('id required');
+
+    const service = new AgentRoutingRuleService(supabase);
+    const rules = await service.rollbackToVersion(id, { orgId: me.org_id, projectId: me.project_id }, me.id);
+    return apiSuccess(rules);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/apps/web/src/app/api/v1/workflow-versions/route.ts
+++ b/apps/web/src/app/api/v1/workflow-versions/route.ts
@@ -1,0 +1,29 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { apiError, ApiErrors, apiSuccess } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { AgentRoutingRuleService } from '@/services/agent-routing-rule';
+import { requireAgentOrchestration } from '@/lib/require-agent-orchestration';
+import { isOssMode } from '@/lib/storage/factory';
+
+export async function GET(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Not available in OSS mode.', 501);
+
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    const gateResponse = await requireAgentOrchestration(supabase, me.org_id);
+    if (gateResponse) return gateResponse;
+
+    const service = new AgentRoutingRuleService(supabase);
+    const versions = await service.listVersions({ orgId: me.org_id, projectId: me.project_id });
+    return apiSuccess(versions);
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/apps/web/src/services/agent-routing-rule.test.ts
+++ b/apps/web/src/services/agent-routing-rule.test.ts
@@ -157,6 +157,18 @@ function createReplaceRulesSupabaseStub({
         };
       }
 
+      if (table === 'workflow_versions') {
+        return {
+          insert: async () => ({ error: null }),
+          select() { return this; },
+          eq() { return this; },
+          order() { return this; },
+          then(resolve: (value: { data: unknown[]; error: null }) => unknown) {
+            return Promise.resolve({ data: [], error: null }).then(resolve);
+          },
+        };
+      }
+
       throw new Error(`Unexpected table ${table}`);
     },
   };

--- a/apps/web/src/services/agent-routing-rule.ts
+++ b/apps/web/src/services/agent-routing-rule.ts
@@ -419,6 +419,45 @@ function matchesMemoType(conditions: RoutingRuleConditions, memoType: string): b
   return conditions.memo_type.includes(memoType.trim().toLowerCase());
 }
 
+export interface WorkflowVersionSummary {
+  id: string;
+  org_id: string;
+  project_id: string;
+  version: number;
+  snapshot: RoutingRuleSnapshotItem[];
+  change_summary: {
+    added_rules: number;
+    removed_rules: number;
+    changed_rules: number;
+  };
+  created_by: string | null;
+  created_at: string;
+}
+
+interface WorkflowVersionRow {
+  id: string;
+  org_id: string;
+  project_id: string;
+  version: number;
+  snapshot: unknown;
+  change_summary: unknown;
+  created_by: string | null;
+  created_at: string;
+}
+
+function presentVersion(row: WorkflowVersionRow): WorkflowVersionSummary {
+  return {
+    id: row.id,
+    org_id: row.org_id,
+    project_id: row.project_id,
+    version: row.version,
+    snapshot: (row.snapshot as RoutingRuleSnapshotItem[]) ?? [],
+    change_summary: (row.change_summary as WorkflowVersionSummary['change_summary']) ?? { added_rules: 0, removed_rules: 0, changed_rules: 0 },
+    created_by: row.created_by,
+    created_at: row.created_at,
+  };
+}
+
 export class AgentRoutingRuleService {
   constructor(private readonly supabase: SupabaseClient) {}
 
@@ -600,7 +639,103 @@ export class AgentRoutingRuleService {
     });
 
     if (error) throw error;
-    return this.listRules(scope);
+
+    const newRules = await this.listRules(scope);
+    await this.saveVersion({
+      orgId: input.orgId,
+      projectId: input.projectId,
+      actorId: input.actorId,
+      currentRules,
+      newRules,
+    });
+
+    return newRules;
+  }
+
+  private async saveVersion(input: {
+    orgId: string;
+    projectId: string;
+    actorId: string;
+    currentRules: RoutingRuleSummary[];
+    newRules: RoutingRuleSummary[];
+  }): Promise<void> {
+    const { data: versionData } = await this.supabase.rpc('next_workflow_version', {
+      p_project_id: input.projectId,
+    });
+
+    const currentSet = new Map(input.currentRules.map((r) => [r.id, r]));
+    const newSet = new Map(input.newRules.map((r) => [r.id, r]));
+    const addedRules = input.newRules.filter((r) => !currentSet.has(r.id)).length;
+    const removedRules = input.currentRules.filter((r) => !newSet.has(r.id)).length;
+    const changedRules = input.newRules.filter((r) => {
+      const prev = currentSet.get(r.id);
+      return prev && JSON.stringify(createRoutingRuleSnapshotItem(prev)) !== JSON.stringify(createRoutingRuleSnapshotItem(r));
+    }).length;
+
+    const actorMember = await this.supabase
+      .from('team_members')
+      .select('id')
+      .eq('id', input.actorId)
+      .single();
+
+    const createdBy = actorMember.data?.id ?? null;
+
+    await this.supabase.from('workflow_versions').insert({
+      org_id: input.orgId,
+      project_id: input.projectId,
+      version: versionData ?? 1,
+      snapshot: input.newRules.map((r) => createRoutingRuleSnapshotItem(r)),
+      change_summary: { added_rules: addedRules, removed_rules: removedRules, changed_rules: changedRules },
+      created_by: createdBy,
+    });
+  }
+
+  async listVersions(scope: RoutingScope): Promise<WorkflowVersionSummary[]> {
+    const { data, error } = await this.supabase
+      .from('workflow_versions')
+      .select('*')
+      .eq('org_id', scope.orgId)
+      .eq('project_id', scope.projectId)
+      .order('version', { ascending: false });
+
+    if (error) throw error;
+    return (data ?? []).map((row) => presentVersion(row as WorkflowVersionRow));
+  }
+
+  async rollbackToVersion(
+    versionId: string,
+    scope: RoutingScope,
+    actorId: string,
+  ): Promise<RoutingRuleSummary[]> {
+    const { data, error } = await this.supabase
+      .from('workflow_versions')
+      .select('*')
+      .eq('id', versionId)
+      .eq('org_id', scope.orgId)
+      .eq('project_id', scope.projectId)
+      .single();
+
+    if (error || !data) throw new NotFoundError('Workflow version not found');
+
+    const version = presentVersion(data as WorkflowVersionRow);
+    return this.replaceRules({
+      orgId: scope.orgId,
+      projectId: scope.projectId,
+      actorId,
+      items: version.snapshot.map((item) => ({
+        agent_id: item.agent_id,
+        persona_id: item.persona_id,
+        deployment_id: item.deployment_id,
+        name: item.name,
+        priority: item.priority,
+        match_type: item.match_type,
+        conditions: item.conditions,
+        action: item.action,
+        target_runtime: item.target_runtime,
+        target_model: item.target_model,
+        is_enabled: item.is_enabled,
+      })),
+    });
   }
 
   async deleteRule(id: string, scope: RoutingScope): Promise<{ ok: true; id: string }> {

--- a/packages/db/supabase/migrations/20260421070000_workflow_versions.sql
+++ b/packages/db/supabase/migrations/20260421070000_workflow_versions.sql
@@ -1,0 +1,81 @@
+-- E-WORKFLOW-VIZ:S1 — workflow_versions 버전 이력 테이블
+
+-- ============================================================
+-- 1. workflow_versions 테이블
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.workflow_versions (
+  id              uuid        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  org_id          uuid        NOT NULL,
+  project_id      uuid        NOT NULL,
+  version         integer     NOT NULL,
+  snapshot        jsonb       NOT NULL DEFAULT '[]',
+  change_summary  jsonb       NOT NULL DEFAULT '{}',
+  created_by      uuid        REFERENCES public.team_members(id) ON DELETE SET NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+
+  UNIQUE (project_id, version)
+);
+
+COMMENT ON TABLE public.workflow_versions IS '워크플로우 라우팅 규칙 버전 이력';
+COMMENT ON COLUMN public.workflow_versions.snapshot IS '저장 시점의 agent_routing_rules 전체 배열 (JSONB)';
+COMMENT ON COLUMN public.workflow_versions.change_summary IS '변경 요약: added_rules, removed_rules, changed_rules 카운트';
+
+CREATE INDEX idx_workflow_versions_project_id ON public.workflow_versions(project_id, version DESC);
+CREATE INDEX idx_workflow_versions_org_id ON public.workflow_versions(org_id);
+
+-- ============================================================
+-- 2. RLS
+-- ============================================================
+ALTER TABLE public.workflow_versions ENABLE ROW LEVEL SECURITY;
+
+-- org 멤버는 읽기 가능
+CREATE POLICY "workflow_versions_select_org_member"
+  ON public.workflow_versions
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.org_id = workflow_versions.org_id
+        AND tm.user_id = auth.uid()
+        AND tm.deleted_at IS NULL
+    )
+  );
+
+-- org admin만 insert 가능 (service_role 포함)
+CREATE POLICY "workflow_versions_insert_org_admin"
+  ON public.workflow_versions
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.org_id = workflow_versions.org_id
+        AND tm.user_id = auth.uid()
+        AND tm.role = 'admin'
+        AND tm.deleted_at IS NULL
+    )
+  );
+
+-- service_role bypass (agent writes)
+CREATE POLICY "workflow_versions_service_role_all"
+  ON public.workflow_versions
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- ============================================================
+-- 3. next_workflow_version() — project 내 auto-increment
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.next_workflow_version(p_project_id uuid)
+RETURNS integer
+LANGUAGE sql
+VOLATILE
+AS $$
+  SELECT COALESCE(MAX(version), 0) + 1
+  FROM public.workflow_versions
+  WHERE project_id = p_project_id;
+$$;
+
+COMMENT ON FUNCTION public.next_workflow_version IS 'project_id 기준 다음 버전 번호 반환';


### PR DESCRIPTION
## Summary

- `workflow_versions` 테이블 신설 (버전 이력 추적, RLS 포함)
- `next_workflow_version()` SQL 함수 (project_id 기준 auto-increment)
- `AgentRoutingRuleService.replaceRules()` 내 자동 버전 스냅샷 저장 훅 추가
- `GET /api/v1/workflow-versions` — 프로젝트 버전 목록 최신순 조회
- `POST /api/v1/workflow-versions/:id/rollback` — 특정 버전으로 롤백 (org admin 전용)

## AC 검증

- [x] AC1: workflow_versions 테이블 (id, org_id, project_id, version, snapshot, change_summary, created_by, created_at)
- [x] AC2: RLS — org member read / org admin + service_role write
- [x] AC3: replaceRules 호출 시 자동 버전 저장
- [x] AC4: GET /api/v1/workflow-versions 엔드포인트
- [x] AC5: POST /api/v1/workflow-versions/:id/rollback 엔드포인트
- [x] AC6: version 번호 project 내 auto-increment (next_workflow_version 함수)
- [x] AC7: 기존 agent-routing-rules API 동작 변경 없음 (하위 호환)

## Test plan

- [ ] `pnpm build` PASS 확인
- [ ] PUT /api/v1/agent-routing-rules 호출 후 workflow_versions에 행 생성 확인
- [ ] GET /api/v1/workflow-versions 버전 목록 반환 확인
- [ ] POST /api/v1/workflow-versions/:id/rollback 롤백 후 규칙 복원 확인
- [ ] non-admin 롤백 시도 → 403 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)