### PR TITLE
fix: add x-api-key header fallback for CDN Authorization strip

### DIFF
--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -218,12 +218,15 @@ export async function getAuthContext(
   }
 
   // 2. API Key 인증 시도 (admin client로 RLS 우회, SaaS 전용)
+  // x-api-key 헤더는 Authorization 헤더가 CDN에서 strip될 때를 위한 fallback
   const authHeader = request.headers.get('Authorization');
-  if (authHeader?.startsWith('Bearer ')) {
-    const { getTeamMemberFromRequest } = await import('./auth-api-key');
+  const xApiKey = request.headers.get('x-api-key');
+  const rawApiKey = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (xApiKey ?? null);
+  if (rawApiKey) {
+    const { getTeamMemberFromApiKey } = await import('./auth-api-key');
     const { createSupabaseAdminClient } = await import('./supabase/admin');
     const adminClient = createSupabaseAdminClient();
-    const apiKeyMember = await getTeamMemberFromRequest(adminClient, request);
+    const apiKeyMember = await getTeamMemberFromApiKey(adminClient, rawApiKey);
 
     if (apiKeyMember) {
       // Rate limiting (에이전트만)

--- a/packages/mcp-server/src/pm-api.ts
+++ b/packages/mcp-server/src/pm-api.ts
@@ -46,6 +46,7 @@ export async function pmApi<T = unknown>(path: string, init: PmApiInit = {}): Pr
   const url = `${_pmApiUrl}${path}`;
   const headers: Record<string, string> = {
     Authorization: `Bearer ${_agentApiKey}`,
+    'x-api-key': _agentApiKey, // fallback for environments where Authorization header is stripped by CDN
     'Content-Type': 'application/json',
     ...init.headers,
   };


### PR DESCRIPTION
## 문제

CloudFront가 `/api/me`, `/api/v1/*` 경로에서 `Authorization` 헤더를 strip하는 반면, `/api/memos`에는 전달됨. 경로별 캐시 동작 차이로 인한 것.

결과: Bearer API key 인증이 해당 경로에서 항상 실패 → 401.

## 변경 사항

**`getAuthContext` (`auth-helpers.ts`)**
- `x-api-key` 헤더도 체크하도록 확장
- `Authorization: Bearer` 없으면 `x-api-key` fallback 사용
- `getTeamMemberFromApiKey`를 직접 호출 (raw key 기반)

**`pmApi` (`pm-api.ts`)**
- `x-api-key: {agentApiKey}` 헤더 추가 전송 (CDN strip workaround)
- `Authorization: Bearer` 는 그대로 유지 (기존 경로 호환)

## 테스트
- 기존 221/221 PASS
- `/api/memos` 경로 영향 없음 (Authorization 정상 전달 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)