### PR TITLE
fix(memo-dispatch): BYOA 에이전트 webhook_url 직접 발송 지원

### DIFF
--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -407,7 +407,11 @@ export class MemoEventDispatcher {
       return { status: 'skipped', reason: 'self_loop_prevented' };
     }
 
-    const agent = await this.getAgentById(memo, routing.dispatchAgentId);
+    // managed agent 조회 → 없으면 BYOA fallback (webhook_url 있는 팀 멤버)
+    let agent = await this.getAgentById(memo, routing.dispatchAgentId);
+    if (!agent) {
+      agent = await this.getByoaMember(memo, routing.dispatchAgentId);
+    }
     if (!agent) {
       await this.postSystemReply(
         memo,
@@ -649,6 +653,21 @@ export class MemoEventDispatcher {
     const member = data as TeamMemberRow;
     if (member.type !== 'agent' || !member.is_active) return null;
     return member;
+  }
+
+  /** BYOA fallback: deployment 없어도 webhook_url이 있는 팀 멤버 반환 */
+  private async getByoaMember(memo: MemoRow, memberId: string): Promise<TeamMemberRow | null> {
+    const { data, error } = await this.options.supabase
+      .from('team_members')
+      .select('id, org_id, project_id, type, name, webhook_url, is_active')
+      .eq('id', memberId)
+      .eq('org_id', memo.org_id)
+      .eq('project_id', memo.project_id)
+      .not('webhook_url', 'is', null)
+      .single();
+
+    if (error || !data) return null;
+    return data as TeamMemberRow;
   }
 
   private async getDeploymentById(memo: MemoRow, agentId: string, deploymentId: string): Promise<AgentDeploymentRow | null> {


### PR DESCRIPTION
## Summary
- `getAgentById()` null 반환 시 `getByoaMember()` fallback 추가
- `agent_deployments` 레코드 없는 BYOA 멤버도 `team_members.webhook_url` 있으면 dispatch 정상 진행
- managed agent 경로(deployment 기반)는 기존대로 유지

## Changes
- `memo-event-dispatcher.ts`: `let agent` + BYOA fallback 분기
- `getByoaMember()` private method 신설 — `webhook_url IS NOT NULL` 조건만

## Test plan
- [ ] managed agent (type='agent', deployment 있음) — 기존 경로 정상
- [ ] BYOA member (webhook_url만 있음, deployment 없음) — fallback 경로 dispatch 성공
- [ ] webhook_url 없는 멤버 — skipped 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)