### PR TITLE
fix(dispatch): MCP send_memo BYOA webhook dispatch 미연동 버그

### DIFF
--- a/apps/web/src/services/memo-event-dispatcher.test.ts
+++ b/apps/web/src/services/memo-event-dispatcher.test.ts
@@ -88,6 +88,7 @@ function createDispatcherSupabaseStub(options?: {
             if (column === 'id') idFilter = String(value);
             return builder;
           }),
+          not: vi.fn(() => builder),
           single: vi.fn(async () => {
             const member = teamMembers.find((row) => !idFilter || row.id === idFilter) ?? null;
             return member ? { data: member, error: null } : { data: null, error: { message: 'not found' } };
@@ -913,5 +914,45 @@ describe('MemoEventDispatcher', () => {
     await dispatcher.pollOnce();
 
     expect(fetchFn).toHaveBeenCalledTimes(60);
+  });
+
+  it('dispatches to BYOA member webhook_url directly without creating agent_runs', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('OK', { status: 200 }));
+    const byoaMember = {
+      id: 'byoa-member-1',
+      org_id: 'org-1',
+      project_id: 'project-1',
+      type: 'human',
+      name: 'Jay',
+      webhook_url: 'https://discord.com/api/webhooks/123/abc',
+      is_active: true,
+    };
+    const { supabase, state } = createDispatcherSupabaseStub({
+      teamMembers: [byoaMember],
+      deployment: null,
+    });
+    const dispatcher = new MemoEventDispatcher({ supabase: supabase as never, fetchFn: fetchFn as never });
+
+    const result = await dispatcher.dispatchMemoIfNeeded({
+      id: 'memo-byoa-1',
+      org_id: 'org-1',
+      project_id: 'project-1',
+      title: 'BYOA task',
+      content: 'hello BYOA',
+      memo_type: 'task',
+      status: 'open',
+      assigned_to: 'byoa-member-1',
+      created_by: 'human-sender',
+      updated_at: '2026-04-22T10:00:00.000Z',
+      created_at: '2026-04-22T10:00:00.000Z',
+    }, 'realtime');
+
+    expect(result).toEqual({ status: 'dispatched' });
+    expect(state.insertedRuns).toHaveLength(0);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/123/abc',
+      expect.objectContaining({ method: 'POST' }),
+    );
   });
 });

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -409,6 +409,7 @@ export class MemoEventDispatcher {
 
     // managed agent 조회 → 없으면 BYOA fallback (webhook_url 있는 팀 멤버)
     let agent = await this.getAgentById(memo, routing.dispatchAgentId);
+    const isByoa = !agent;
     if (!agent) {
       agent = await this.getByoaMember(memo, routing.dispatchAgentId);
     }
@@ -419,6 +420,64 @@ export class MemoEventDispatcher {
         `⚠️ 에이전트(${routing.dispatchAgentId})가 비활성 상태이거나 배포가 구성되지 않아 웹훅 발송이 스킵되었습니다.`,
       );
       return { status: 'skipped', reason: 'assignee_not_active_agent' };
+    }
+
+    // BYOA: agent_runs 레코드 없이 webhook_url로 직접 발송
+    // createRun()은 agent_id가 type='agent'인 팀원이어야 하는 제약이 있어
+    // BYOA 멤버(human + webhook_url)는 insert 실패 후 dispatch가 abort됨.
+    if (isByoa) {
+      const webhook = await this.resolveWebhook(agent, memo.project_id);
+      if (!webhook) {
+        await this.logAudit(agent.id, memo, 'memo_dispatch.byoa_webhook_missing', 'warn', {
+          dispatch_key: dispatchKey,
+        });
+        return { status: 'skipped', reason: 'byoa_webhook_missing' };
+      }
+      try {
+        const outbound = this.buildWebhookPayload({
+          webhookUrl: webhook.url,
+          memo,
+          agent,
+          deploymentId: null,
+          runId: dispatchKey,
+          source,
+          dispatchKey,
+          routing,
+        });
+        const response = await fetchWithTimeout(
+          this.fetchFn,
+          webhook.url,
+          {
+            method: 'POST',
+            redirect: 'manual',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(webhook.secret ? { 'X-Webhook-Secret': webhook.secret } : {}),
+            },
+            body: JSON.stringify(outbound.body),
+          },
+          this.webhookTimeoutMs,
+        );
+        if (!response.ok) {
+          const body = await response.text();
+          this.logger.warn('[MemoEventDispatcher] BYOA webhook dispatch failed', {
+            agent_id: agent.id,
+            memo_id: memo.id,
+            status: response.status,
+            body: body.slice(0, 200),
+          });
+          return { status: 'failed', reason: `byoa_webhook_${response.status}` };
+        }
+        return { status: 'dispatched' };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'unknown_dispatch_error';
+        this.logger.error('[MemoEventDispatcher] BYOA webhook exception', {
+          agent_id: agent.id,
+          memo_id: memo.id,
+          error: message,
+        });
+        return { status: 'failed', reason: 'byoa_webhook_exception' };
+      }
     }
 
     const deployment = routing.matchedRule?.deployment_id


### PR DESCRIPTION
## Summary

- `MemoEventDispatcher.dispatchMemo()`에서 BYOA 멤버(type≠'agent', webhook_url 있음) 대상 dispatch 시 `createRun()`을 우회하도록 수정
- `createRun()`은 `agent_runs.agent_id`가 type='agent' 팀원이어야 한다는 DB 제약을 암묵적으로 가정함 — BYOA 멤버 insert 실패 시 dispatch abort
- BYOA 경로 감지 후 `resolveWebhook()` → 직접 fetch → `{ status: 'dispatched' }` 반환으로 단락 처리
- managed agent 경로(deployment+agent_runs)는 기존 로직 그대로 유지

## Test plan

- [x] `dispatches to BYOA member webhook_url directly without creating agent_runs` 신규 테스트 추가 및 통과
- [x] 기존 dispatcher 테스트 20개 전체 통과
- [x] `memo-assignment-dispatch`, `memo-reply-webhook-dispatch` 관련 테스트 통과
- [x] `pnpm build` PASS

Closes story: fd435923-a469-4ef6-a272-b5726211eb0e

🤖 Generated with [Claude Code](https://claude.com/claude-code)