### PR TITLE
fix: routing self-loop forwardTo redirect (E-MEMO-DISPATCH:S12)

### DIFF
--- a/apps/web/src/services/memo-event-dispatcher.test.ts
+++ b/apps/web/src/services/memo-event-dispatcher.test.ts
@@ -955,4 +955,94 @@ describe('MemoEventDispatcher', () => {
       expect.objectContaining({ method: 'POST' }),
     );
   });
+
+  it('redirects to forwardToAgentId when self-loop is detected', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }));
+    const routingRuleService = {
+      evaluateMemo: vi.fn(async () => ({
+        matchedRule: { id: 'rule-kickoff', agent_id: 'agent-po' },
+        dispatchAgentId: 'agent-po',
+        originalAssignedTo: 'agent-po',
+        autoReplyMode: 'process_and_forward',
+        forwardToAgentId: 'agent-dev',
+      })),
+    };
+    const { supabase, state } = createDispatcherSupabaseStub({
+      teamMembers: [
+        {
+          id: 'agent-dev',
+          org_id: 'org-1',
+          project_id: 'project-1',
+          type: 'agent',
+          name: 'Nwachukwu',
+          webhook_url: 'https://agent-dev.example.com/webhook',
+          is_active: true,
+        },
+      ],
+    });
+    const dispatcher = new MemoEventDispatcher({
+      supabase: supabase as never,
+      fetchFn: fetchFn as never,
+      routingRuleService: routingRuleService as never,
+    });
+
+    const result = await dispatcher.dispatchMemoIfNeeded({
+      id: 'memo-kickoff-1',
+      org_id: 'org-1',
+      project_id: 'project-1',
+      title: '[킥오프] self-loop redirect',
+      content: 'kickoff from PO',
+      memo_type: 'kickoff',
+      status: 'open',
+      assigned_to: 'agent-po',
+      created_by: 'agent-po',
+      updated_at: '2026-04-22T10:00:00.000Z',
+      created_at: '2026-04-22T10:00:00.000Z',
+    }, 'realtime');
+
+    expect(result).toMatchObject({ status: 'dispatched' });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith(
+      'https://agent-dev.example.com/webhook',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(state.insertedRuns).toHaveLength(1);
+    expect(state.insertedRuns[0]).toMatchObject({ agent_id: 'agent-dev' });
+  });
+
+  it('returns self_loop_prevented when self-loop detected and no forwardToAgentId', async () => {
+    const fetchFn = vi.fn();
+    const routingRuleService = {
+      evaluateMemo: vi.fn(async () => ({
+        matchedRule: { id: 'rule-no-forward' },
+        dispatchAgentId: 'agent-1',
+        originalAssignedTo: 'agent-1',
+        autoReplyMode: 'process_and_report',
+        forwardToAgentId: null,
+      })),
+    };
+    const { supabase } = createDispatcherSupabaseStub();
+    const dispatcher = new MemoEventDispatcher({
+      supabase: supabase as never,
+      fetchFn: fetchFn as never,
+      routingRuleService: routingRuleService as never,
+    });
+
+    const result = await dispatcher.dispatchMemoIfNeeded({
+      id: 'memo-self-loop-1',
+      org_id: 'org-1',
+      project_id: 'project-1',
+      title: 'self loop no forward',
+      content: 'self loop',
+      memo_type: 'task',
+      status: 'open',
+      assigned_to: 'agent-1',
+      created_by: 'agent-1',
+      updated_at: '2026-04-22T10:00:00.000Z',
+      created_at: '2026-04-22T10:00:00.000Z',
+    }, 'realtime');
+
+    expect(result).toEqual({ status: 'skipped', reason: 'self_loop_prevented' });
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -404,7 +404,13 @@ export class MemoEventDispatcher {
     }
 
     if (memo.created_by === routing.dispatchAgentId) {
-      if (routing.forwardToAgentId) {
+      // forwardToAgentId가 있고 redirect target도 self-loop가 아닌 경우에만 redirect
+      if (routing.forwardToAgentId && routing.forwardToAgentId !== memo.created_by) {
+        await this.logAudit(routing.dispatchAgentId, memo, 'memo_dispatch.self_loop_redirect', 'info', {
+          dispatch_key: dispatchKey,
+          from_agent_id: routing.dispatchAgentId,
+          to_agent_id: routing.forwardToAgentId,
+        });
         routing = { ...routing, dispatchAgentId: routing.forwardToAgentId, forwardToAgentId: null };
       } else {
         return { status: 'skipped', reason: 'self_loop_prevented' };

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -404,7 +404,15 @@ export class MemoEventDispatcher {
     }
 
     if (memo.created_by === routing.dispatchAgentId) {
-      return { status: 'skipped', reason: 'self_loop_prevented' };
+      if (routing.forwardToAgentId) {
+        routing = { ...routing, dispatchAgentId: routing.forwardToAgentId, forwardToAgentId: null };
+      } else {
+        return { status: 'skipped', reason: 'self_loop_prevented' };
+      }
+    }
+
+    if (!routing.dispatchAgentId) {
+      return { status: 'skipped', reason: 'routing_target_missing' };
     }
 
     // managed agent 조회 → 없으면 BYOA fallback (webhook_url 있는 팀 멤버)


### PR DESCRIPTION
## Summary

- `dispatchMemo()` self-loop 체크(`created_by === dispatchAgentId`)에서 `forwardToAgentId`가 있으면 해당 에이전트로 redirect
- PO(오르테가)가 킥오프 메모 발송 시 routing rule `dispatchAgentId=PO, forwardToAgentId=DEV` 구조에서 self_loop_prevented로 웹훅 미발송되던 버그 수정
- `forwardToAgentId` 없는 genuine self-loop는 기존대로 skipped 반환

## Changes

**`memo-event-dispatcher.ts`**
- L406: self_loop 감지 시 `forwardToAgentId` 존재 여부 분기
- redirect 후 TS narrowing 재적용을 위한 null guard 추가

**`memo-event-dispatcher.test.ts`**
- `redirects to forwardToAgentId when self-loop is detected` — redirect 성공 + agent-dev에게 dispatch 검증
- `returns self_loop_prevented when self-loop detected and no forwardToAgentId` — 기존 동작 회귀 없음 검증

## AC

1. MCP send_memo (PO 발신) → routing rule forwardTo DEV → DEV webhook 수신 ✓
2. forwardToAgentId 없는 self-loop → self_loop_prevented skipped (기존 동작 유지) ✓
3. 웹 UI 경로 회귀 없음 ✓
4. pnpm build PASS ✓ / tests 22/22 PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)