### PR TITLE
[E-LANDING:S4] Add NEXT_PUBLIC_COOKIE_DOMAIN for cross-subdomain auth

### DIFF
--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -3,8 +3,10 @@
 import { createBrowserClient } from '@supabase/ssr';
 
 export function createSupabaseBrowserClient() {
+  const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
   return createBrowserClient(
     process.env['NEXT_PUBLIC_SUPABASE_URL']!,
     process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
+    cookieDomain ? { cookieOptions: { domain: cookieDomain } } : undefined,
   );
 }

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -16,8 +16,12 @@ export async function createSupabaseServerClient() {
         },
         setAll(cookiesToSet: Array<{ name: string; value: string; options: Record<string, unknown> }>) {
           try {
+            const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
             for (const { name, value, options } of cookiesToSet) {
-              cookieStore.set(name, value, options as Parameters<typeof cookieStore.set>[2]);
+              cookieStore.set(name, value, {
+                ...(options as Parameters<typeof cookieStore.set>[2]),
+                ...(cookieDomain ? { domain: cookieDomain } : {}),
+              });
             }
           } catch {
             // Server Component에서는 set 불가 — 무시


### PR DESCRIPTION
## Summary

- `NEXT_PUBLIC_COOKIE_DOMAIN` env var 추가 — Supabase server/browser client 쿠키에 도메인 적용
- 설정 시: 쿠키가 `.sprintable.ai` 도메인으로 설정되어 `sprintable.ai` ↔ `app.sprintable.ai` 간 인증 상태 공유
- 미설정 시: 기존 동작 유지 (OSS/로컬 환경 영향 없음)

## 변경 파일

- `apps/web/src/lib/supabase/server.ts` — setAll에서 cookieDomain 적용
- `apps/web/src/lib/supabase/client.ts` — createBrowserClient에 cookieOptions.domain 적용

## Amplify 환경변수 (이미 설정됨)

```
APP_BASE_URL=https://app.sprintable.ai
NEXT_PUBLIC_APP_URL=https://app.sprintable.ai
NEXT_PUBLIC_COOKIE_DOMAIN=.sprintable.ai
```

## 연관 작업

E-LANDING:S4 도메인 라우팅 전환의 AC4(앱 URL 전환) + AC5(쿠키 도메인) 대응.
DNS/Amplify 도메인 변경(AC1~AC3)은 Cloudflare 접근 권한 확보 후 진행 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)