### PR TITLE
feat(e-landing-s5): redirect root page to /login or /dashboard

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,16 @@
-import { LandingPage } from '@/components/landing/landing-page';
+import { redirect } from 'next/navigation';
+import { isOssMode } from '@/lib/storage/factory';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 
-export default function RootPage() {
-  return <LandingPage />;
+export default async function RootPage() {
+  if (isOssMode()) {
+    redirect('/dashboard');
+  }
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  redirect(user ? '/dashboard' : '/login');
 }


### PR DESCRIPTION
## Summary
- `app.sprintable.ai/` 미인증 → `/login` 리다이렉트
- `app.sprintable.ai/` 인증 → `/dashboard` 리다이렉트
- OSS 모드는 항상 `/dashboard`로 리다이렉트 (기존 `(authenticated)/layout.tsx` 패턴 동일)
- 기존 `LandingPage` 컴포넌트 렌더링 제거

## Changes
- `apps/web/src/app/page.tsx`: +14/-3 (async server component, redirect only)

## Story
E-LANDING:S5 (28c7cf47-2f7f-4159-852a-4896d19994c6) AC-1

## Test plan
- [ ] 미인증 상태로 app.sprintable.ai 접속 → /login 리다이렉트 확인
- [ ] 인증 상태로 app.sprintable.ai 접속 → /dashboard 리다이렉트 확인
- [ ] pnpm build PASS (기존 에러 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)