### PR TITLE
feat(e-baos-s9): add /llms-baos.txt dynamic route for BAO/S enrollment doc

### DIFF
--- a/apps/web/src/app/llms-baos.txt/route.ts
+++ b/apps/web/src/app/llms-baos.txt/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+
+export const dynamic = 'force-dynamic';
+
+const PROJECT_ID = 'f3e6ed64-447d-4b1c-ad78-a00cfba715a7';
+const DOC_SLUG = 'baos-enrollment-guide-agent';
+
+export async function GET() {
+  try {
+    const supabase = isOssMode() ? undefined : createSupabaseAdminClient();
+    const repo = await createDocRepository(supabase);
+    const doc = await repo.getBySlug(PROJECT_ID, DOC_SLUG);
+
+    if (!doc) {
+      return new NextResponse('Not Found', { status: 404 });
+    }
+
+    return new NextResponse(doc.content ?? '', {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/plain; charset=utf-8',
+        'Cache-Control': 'public, max-age=3600',
+      },
+    });
+  } catch {
+    return new NextResponse('Internal Server Error', { status: 500 });
+  }
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,6 +5,7 @@ const PUBLIC_EXACT = [
   '/',
   '/llms.txt',
   '/llms-full.txt',
+  '/llms-baos.txt',
 ];
 
 const PUBLIC_PREFIX = [


### PR DESCRIPTION
## Summary
- `apps/web/src/app/llms-baos.txt/route.ts` 신규 — docs DB에서 slug `baos-enrollment-guide-agent` 조회 → `text/plain`, `Cache-Control: public, max-age=3600`
- `apps/web/src/proxy.ts` — `PUBLIC_EXACT`에 `/llms-baos.txt` 추가 (인증 없이 접근 가능)
- 문서 없으면 404, 예외 시 500 반환
- OSS 모드: `createDocRepository()` SQLite 경유 / SaaS 모드: `createSupabaseAdminClient()` service_role 경유

## Story
E-BAOS:S9 (0f5b84bc-3e01-4cb5-8397-7a977a2dbf5f)

## Test plan
- [ ] `GET /llms-baos.txt` → 200, `Content-Type: text/plain`, BAO/S 문서 내용 반환
- [ ] `Cache-Control: public, max-age=3600` 헤더 확인
- [ ] slug 미존재 시 404 반환
- [ ] 인증 없이 접근 가능 (proxy.ts PUBLIC_EXACT 확인)
- [ ] pnpm build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)