### PR TITLE
fix(bug): 에이전트 추가 UI + API key 발급 UI 연결 (OSS+SaaS)

### DIFF
--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -9,12 +9,12 @@ import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
   if (isOssMode()) {
-    const { OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
+    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id') ?? OSS_PROJECT_ID;
+    const type = searchParams.get('type') as 'human' | 'agent' | null;
     const repo = await createTeamMemberRepository();
-    const { OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId });
+    const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId, ...(type ? { type } : {}) });
     return apiSuccess(members);
   }
   try {
@@ -61,7 +61,23 @@ export async function GET(request: Request) {
 
 /** POST — 프로젝트 멤버 추가/재활성화 */
 export async function POST(request: Request) {
-  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Member management is not supported in OSS mode.', 501);
+  if (isOssMode()) {
+    const parsed = await parseBody(request, createTeamMemberSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+    if (body.type !== 'agent') return apiError('NOT_IMPLEMENTED', 'Only agent members are supported in OSS mode.', 501);
+    if (!body.name) return ApiErrors.badRequest('name required for agent');
+    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+    const repo = await createTeamMemberRepository();
+    const member = await repo.create({
+      org_id: OSS_ORG_ID,
+      project_id: body.project_id ?? OSS_PROJECT_ID,
+      name: body.name,
+      type: 'agent',
+      role: body.role ?? 'member',
+    });
+    return apiSuccess(member, undefined, 201);
+  }
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Badge } from '@/components/ui/badge';
+import { useToast } from '@/components/ui/toast';
 
 interface AgentMember {
   id: string;
@@ -34,6 +35,9 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
   const [loading, setLoading] = useState(true);
   const [issuing, setIssuing] = useState<string | null>(null);
   const [revoking, setRevoking] = useState<string | null>(null);
+  const [newAgentName, setNewAgentName] = useState('');
+  const [adding, setAdding] = useState(false);
+  const { addToast } = useToast();
 
   const fetchAgents = useCallback(async () => {
     setLoading(true);
@@ -78,6 +82,28 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
     }
   }, [fetchAgents]);
 
+  const handleAddAgent = useCallback(async () => {
+    const name = newAgentName.trim();
+    if (!name) return;
+    setAdding(true);
+    try {
+      const res = await fetch('/api/team-members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId, name, type: 'agent' }),
+      });
+      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      if (!res.ok) {
+        addToast({ type: 'error', title: '에이전트 추가 실패', body: json?.error?.message ?? 'Failed to add agent' });
+        return;
+      }
+      setNewAgentName('');
+      await fetchAgents();
+    } finally {
+      setAdding(false);
+    }
+  }, [newAgentName, projectId, fetchAgents, addToast]);
+
   if (loading) return <div className="text-sm text-muted-foreground">Loading...</div>;
 
   return (
@@ -89,6 +115,24 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
         </div>
       </SectionCardHeader>
       <SectionCardBody>
+        <div className="mb-6 flex gap-2">
+          <input
+            type="text"
+            value={newAgentName}
+            onChange={(e) => setNewAgentName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void handleAddAgent(); }}
+            placeholder="에이전트 이름"
+            className="flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={!newAgentName.trim() || adding}
+            onClick={() => void handleAddAgent()}
+          >
+            {adding ? '추가 중...' : '+ 에이전트 추가'}
+          </Button>
+        </div>
         {agents.length === 0 && (
           <p className="text-sm text-muted-foreground">No agent team members in this project.</p>
         )}


### PR DESCRIPTION
## Summary
- **AC1**: Settings `agent-api-keys-section.tsx`에 에이전트 추가 폼 신설 (name 입력 + Enter/버튼 트리거)
- **AC2**: 추가 즉시 에이전트 목록 갱신 → 기존 `+ 새 API Key 발급` 버튼으로 즉시 key 발급 가능
- **AC3**: OSS mode `POST /api/team-members` type=agent 지원 추가 + GET `?type=agent` 필터 OSS에 전달

## Changed files
- `apps/web/src/app/api/team-members/route.ts`
  - GET OSS handler: `type` 쿼리 파라미터 → `repo.list({ type })` 에 전달
  - POST OSS handler: 기존 501 블랭킷 → `type === 'agent'` 한정으로 SQLite repo.create() 실행
- `apps/web/src/components/settings/agent-api-keys-section.tsx`
  - `newAgentName`, `adding` 상태 + `handleAddAgent()` 추가
  - SectionCardBody 상단에 이름 입력 + 에이전트 추가 버튼 UI 추가

## Test plan
- [ ] Settings → Agent API Keys 섹션 → 이름 입력 → `+ 에이전트 추가` 클릭 → 목록에 즉시 반영
- [ ] 추가된 에이전트 row에서 `+ 새 API Key 발급` → 노란 one-time key 박스 표시
- [ ] OSS 모드: `POST /api/team-members` `{type: 'agent', name: '...'}` → 201 + SQLite 저장
- [ ] SaaS 모드: 기존 POST 플로우 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)