### PR TITLE
fix(i18n): add missing translation keys — docs.noProject, common.back/next/close, standup.cancel

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -20,7 +20,10 @@
     "locale_ko": "한국어",
     "upgradeRequired": "Upgrade Required",
     "upgradePlan": "Upgrade Plan",
-    "operatorSurface": "Operator surface"
+    "operatorSurface": "Operator surface",
+    "back": "Back",
+    "next": "Next",
+    "close": "Close"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -671,6 +674,7 @@
   },
   "standup": {
     "title": "Daily Standup",
+    "cancel": "Cancel",
     "surfaceDescription": "Update your standup and review the team state on one operator surface.",
     "entryDate": "Date",
     "myStandupDescription": "Capture what you did, what you will do, and what is blocked.",
@@ -763,6 +767,7 @@
     "title": "Documentation",
     "searchPlaceholder": "Search docs...",
     "noDocs": "No documents",
+    "noProject": "No project selected",
     "selectDoc": "Select a document",
     "lastUpdated": "Last updated",
     "newDoc": "New Document",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -20,7 +20,10 @@
     "locale_ko": "한국어",
     "upgradeRequired": "업그레이드가 필요합니다",
     "upgradePlan": "요금제 업그레이드",
-    "operatorSurface": "운영 표면"
+    "operatorSurface": "운영 표면",
+    "back": "이전",
+    "next": "다음",
+    "close": "닫기"
   },
   "nav": {
     "dashboard": "대시보드",
@@ -671,6 +674,7 @@
   },
   "standup": {
     "title": "데일리 스탠드업",
+    "cancel": "취소",
     "surfaceDescription": "오늘 기준 내 스탠드업과 팀 상태를 같은 표면에서 정리합니다.",
     "entryDate": "기준 날짜",
     "myStandupDescription": "오늘 한 일, 할 일, blocker를 한 번에 업데이트합니다.",
@@ -763,6 +767,7 @@
     "title": "문서",
     "searchPlaceholder": "문서 검색...",
     "noDocs": "문서가 없습니다",
+    "noProject": "프로젝트가 선택되지 않았습니다",
     "selectDoc": "문서를 선택하세요",
     "lastUpdated": "최종 수정",
     "newDoc": "새 문서",


### PR DESCRIPTION
## Summary

- **E-035:S1** — 번역키 raw 노출 전수 점검 후 누락 키 추가

### 누락 키 전수 확인 결과 (AC3)

namespace-aware 스캔으로 발견된 7개 참조 → 5개 고유 키 추가:

| 키 | 파일 | 비고 |
|---|---|---|
| `docs.noProject` | `app/(authenticated)/docs/page.tsx:14` | projectId 없을 때 폴백 메시지 |
| `common.back` | `components/agents/agent-deployment-wizard.tsx:891` | 위저드 이전 버튼 |
| `common.next` | `components/agents/agent-deployment-wizard.tsx:895` | 위저드 다음 버튼 |
| `common.close` | `components/agents/agent-deployment-wizard.tsx:934` | 배포 실패 다이얼로그 닫기 |
| `standup.cancel` | `components/standup/standup-review-card.tsx:299,340,379` | 피드백 폼 취소 (3곳) |

### AC 체크

- [x] AC1: `t('createMemo')` → `t('createTitle')` — 이미 수정된 상태 (main 기준 no-op)
- [x] AC2: `dashboard-nav.tsx` — 파일 자체가 없음 (이미 삭제됨)
- [x] AC3: 누락 번역키 전수 점검 + 추가 완료 (7개 참조, 5개 키)

## Test plan

- [ ] 빌드 통과 (tsc --noEmit: 기존 SaaS billing 에러만, 신규 에러 없음)
- [ ] `/docs` 진입 시 프로젝트 미선택 상태에서 번역키 raw 노출 없음
- [ ] 에이전트 배포 위저드 Back/Next/Close 버튼 번역 정상 노출
- [ ] 스탠드업 리뷰 카드 피드백 폼 Cancel 버튼 번역 정상 노출
- [ ] ko/en 언어 전환 시 모두 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)