### PR TITLE
perf(analytics): parallelize health queries + cap agent-stats fetch + perf logs [E-023:S10]

### DIFF
--- a/apps/web/src/app/api/analytics/agent-stats/route.ts
+++ b/apps/web/src/app/api/analytics/agent-stats/route.ts
@@ -22,7 +22,9 @@ export async function GET(request: Request) {
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new AnalyticsService(dbClient);
+    const t0 = Date.now();
     const data = await service.getAgentStats(projectId, agentId);
+    console.log(`[perf] GET /api/analytics/agent-stats agent=${agentId} ${Date.now() - t0}ms`);
     return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/analytics/health/route.ts
+++ b/apps/web/src/app/api/analytics/health/route.ts
@@ -20,7 +20,9 @@ export async function GET(request: Request) {
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new AnalyticsService(dbClient);
+    const t0 = Date.now();
     const data = await service.getProjectHealth(projectId);
+    console.log(`[perf] GET /api/analytics/health project=${projectId} ${Date.now() - t0}ms`);
     return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/analytics/overview/route.ts
+++ b/apps/web/src/app/api/analytics/overview/route.ts
@@ -20,7 +20,9 @@ export async function GET(request: Request) {
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new AnalyticsService(dbClient);
+    const t0 = Date.now();
     const data = await service.getOverview(projectId);
+    console.log(`[perf] GET /api/analytics/overview project=${projectId} ${Date.now() - t0}ms`);
     return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/analytics/velocity-history/route.ts
+++ b/apps/web/src/app/api/analytics/velocity-history/route.ts
@@ -20,7 +20,9 @@ export async function GET(request: Request) {
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new AnalyticsService(dbClient);
+    const t0 = Date.now();
     const data = await service.getVelocityHistory(projectId);
+    console.log(`[perf] GET /api/analytics/velocity-history project=${projectId} ${Date.now() - t0}ms`);
     return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/services/analytics.ts
+++ b/apps/web/src/services/analytics.ts
@@ -252,10 +252,13 @@ export class AnalyticsService {
       .single();
     if (mb.error) throw new Error('Agent not found in project');
 
+    // Cap at 1000 recent runs to avoid unbounded fetch on high-volume agents
     const { data } = await this.supabase
       .from('agent_runs')
       .select('status, input_tokens, output_tokens, cost_usd, duration_ms')
-      .eq('agent_id', agentId);
+      .eq('agent_id', agentId)
+      .order('created_at', { ascending: false })
+      .limit(1000);
 
     const runs = (data ?? []) as AgentRunRow[];
     const completed = runs.filter((r) => r.status === 'completed');
@@ -273,12 +276,30 @@ export class AnalyticsService {
   }
 
   async getProjectHealth(projectId: string): Promise<ProjectHealth> {
-    const { data: activeSprint } = await this.supabase
-      .from('sprints')
-      .select('id, title, start_date, end_date')
-      .eq('project_id', projectId)
-      .eq('status', 'active')
-      .single();
+    // Run sprint lookup + count-only queries in parallel to avoid sequential round trips
+    const [sprintResult, memosResult, unassignedResult] = await Promise.all([
+      this.supabase
+        .from('sprints')
+        .select('id, title, start_date, end_date')
+        .eq('project_id', projectId)
+        .eq('status', 'active')
+        .single(),
+      this.supabase
+        .from('memos')
+        .select('*', { count: 'exact', head: true })
+        .eq('project_id', projectId)
+        .eq('status', 'open'),
+      this.supabase
+        .from('stories')
+        .select('*', { count: 'exact', head: true })
+        .eq('project_id', projectId)
+        .is('assignee_id', null)
+        .neq('status', 'done'),
+    ]);
+
+    const activeSprint = sprintResult.data;
+    const openMemoCount = memosResult.count ?? 0;
+    const unassignedCount = unassignedResult.count ?? 0;
 
     const stories = activeSprint
       ? await this.supabase.from('stories').select('status, story_points').eq('sprint_id', activeSprint.id)
@@ -287,22 +308,6 @@ export class AnalyticsService {
     const storyRows = (stories.data ?? []) as StoryRow[];
     const total = storyRows.length;
     const done = storyRows.filter((s) => s.status === 'done').length;
-
-    const { data: openMemos } = await this.supabase
-      .from('memos')
-      .select('id')
-      .eq('project_id', projectId)
-      .eq('status', 'open');
-
-    const { data: unassigned } = await this.supabase
-      .from('stories')
-      .select('id')
-      .eq('project_id', projectId)
-      .is('assignee_id', null)
-      .neq('status', 'done');
-
-    const openMemoCount = openMemos?.length ?? 0;
-    const unassignedCount = unassigned?.length ?? 0;
 
     return {
       active_sprint: activeSprint ?? null,


### PR DESCRIPTION
## Summary

E-023:S10 — 504 다발 구간 안정화 + 무거운 요청 감량

### AC1: 504 상위 발생 구간 식별

코드베이스 전수 조사 결과, 사용자 체감 504의 주요 원인:

| 구간 | 병목 유형 | 심각도 |
|---|---|---|
| `GET /api/analytics/health` | 4회 순차 Supabase 쿼리 | HIGH (대시보드 매 진입 시 호출) |
| `GET /api/analytics/agent-stats` | agent_runs 무제한 페치 | HIGH (에이전트 다량 사용 시) |
| `GET /api/analytics/overview` | 전체 stories/tasks/memos 무제한 페치 | MEDIUM |
| `GET /api/cron/retry-agent-runs` | 50회 순차 retry loop | HIGH (cron, 사용자 직접 체감 낮음) |

### AC2: 관측 포인트 확보

4개 analytics 라우트에 `[perf]` CloudWatch 로그 추가:
```
[perf] GET /api/analytics/health project=X 127ms
[perf] GET /api/analytics/overview project=X 340ms
[perf] GET /api/analytics/agent-stats agent=Y 89ms
[perf] GET /api/analytics/velocity-history project=X 43ms
```

### AC3: 즉시 완화 — 2건

**Fix 1: `getProjectHealth()` — 4 순차 → 2 병렬**

Before: sprint 조회 → stories 조회 → memos 카운트 → unassigned 카운트 (순차 4회)
After: [sprint + memos HEAD + unassigned HEAD] 병렬 → stories (sprint 결과 후)

- memos/unassigned 카운트: `{ count: 'exact', head: true }` — 행 데이터 전송 없음
- 예상 절감: 3-4 round trip → 2 round trip (~60% latency 감소)

**Fix 2: `getAgentStats()` — 무제한 페치 캡**

`.limit(1000)` + `.order('created_at', { ascending: false })` 추가  
에이전트 런이 수천 건 이상 쌓인 경우 OOM/timeout 방지

### AC4: 검증

- tsc --noEmit: 신규 에러 없음 (기존 SaaS billing 15개만)
- 구조적 개선으로 동일 흐름에서 DB round trip 감소

### AC5: 후속 범위 (E-023:S8 연계)

`getOverview()`는 전체 stories/tasks/memos를 행 단위로 페치 — DB 집계 RPC로 교체 필요. 별도 스토리 권장.

## Test plan

- [ ] `GET /api/analytics/health` 응답 정상 (sprint/memos/unassigned 카운트 일치)
- [ ] `GET /api/analytics/agent-stats` 응답 정상 (limit 1000 이내)
- [ ] CloudWatch에서 `[perf]` 로그 확인 가능
- [ ] tsc PASS
- [ ] 기존 analytics 응답 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)