### PR TITLE
fix(api): current-project GET fallback when cookie missing

### DIFF
--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -18,7 +18,35 @@ export async function GET() {
 
     const cookieStore = await cookies();
     const projectId = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value ?? null;
-    if (!projectId) return apiSuccess({ project_id: null, project_name: null, org_id: null });
+
+    if (!projectId) {
+      const { data: firstMembership } = await supabase
+        .from('team_members')
+        .select('project_id, org_id, projects(name)')
+        .eq('user_id', user.id)
+        .eq('type', 'human')
+        .eq('is_active', true)
+        .limit(1)
+        .maybeSingle();
+
+      if (!firstMembership) return apiSuccess({ project_id: null, project_name: null, org_id: null });
+
+      cookieStore.set(CURRENT_PROJECT_COOKIE, firstMembership.project_id, {
+        path: '/',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365,
+      });
+
+      const firstProject = Array.isArray(firstMembership.projects)
+        ? firstMembership.projects.find(Boolean)
+        : firstMembership.projects;
+
+      return apiSuccess({
+        project_id: firstMembership.project_id,
+        project_name: (firstProject as { name: string } | null)?.name ?? null,
+        org_id: firstMembership.org_id,
+      });
+    }
 
     const { data: membership } = await supabase
       .from('team_members')


### PR DESCRIPTION
## Summary
- `/api/current-project` GET handler가 `sprintable_current_project_id` 쿠키 없을 때 `null` 반환하던 버그 수정
- 쿠키 유실 시 `team_members`에서 user의 첫 활성 프로젝트를 fallback으로 반환
- fallback 성공 시 쿠키도 함께 설정 (이후 요청 정상 경로)

## Root Cause
도메인 분리 후 기존 쿠키 유실 → `project_id: null` → Settings Agent API Keys 미노출

## Changes
`apps/web/src/app/api/current-project/route.ts` GET handler:
- 쿠키 없을 때 즉시 null 반환 → `team_members` fallback 조회 후 반환

## Test plan
- [ ] 쿠키 없는 상태로 `/api/current-project` GET → 첫 프로젝트 반환 확인
- [ ] 쿠키 설정 후 재요청 → 기존 경로 정상 동작
- [ ] Settings > Agent API Keys 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)