### PR TITLE
feat(E-POLAR:S3): org_usage 카운터 + Entitlement middleware (5SP)

### DIFF
--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -8,6 +8,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { checkResourceLimit } from '@/lib/check-feature';
+import { checkEntitlement } from '@/lib/entitlement';
 import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
@@ -57,6 +58,8 @@ export async function POST(request: Request) {
     if (!ossMode) {
       const check = await checkResourceLimit(dbClient!, me.org_id, 'max_docs', 'docs');
       if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Document limit reached. Upgrade to Team.', 403);
+      const ent = await checkEntitlement(supabase, me.org_id, 'docs');
+      if (!ent.allowed) return apiError('quota_exceeded', `Doc quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'docs', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
     }
     const parsed = await parseBody(request, createDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createDocRepository(dbClient);

--- a/apps/web/src/app/api/invitations/route.ts
+++ b/apps/web/src/app/api/invitations/route.ts
@@ -3,6 +3,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { checkMemberLimit } from '@/lib/check-feature';
+import { checkMemberEntitlement } from '@/lib/entitlement';
 import { parseBody, createInvitationSchema } from '@sprintable/shared';
 import { isOssMode } from '@/lib/storage/factory';
 
@@ -65,6 +66,8 @@ export async function POST(request: Request) {
       if (!memberCheck.allowed) {
         return apiError('UPGRADE_REQUIRED', memberCheck.reason ?? 'Member limit reached', 403);
       }
+      const ent = await checkMemberEntitlement(supabase, me.org_id);
+      if (!ent.allowed) return apiError('quota_exceeded', `Member quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'members', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
     }
 
     // project_id가 지정된 경우 해당 프로젝트가 org에 속하는지 검증

--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -7,7 +7,10 @@ import { parseBody, createMemoSchema } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createMemoRepository, createTeamMemberRepository, createProjectRepository, isOssMode } from '@/lib/storage/factory';
+import { checkEntitlement } from '@/lib/entitlement';
+import { incrementUsage } from '@/lib/usage-tracker';
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { apiError } from '@/lib/api-response';
 
 export async function POST(request: Request) {
   try {
@@ -29,6 +32,11 @@ export async function POST(request: Request) {
       );
     }
 
+    if (!isOssMode()) {
+      const ent = await checkEntitlement(supabase, me.org_id, 'memos');
+      if (!ent.allowed) return apiError('quota_exceeded', `Memo quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'memos', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
+    }
+
     const parsed = await parseBody(request, createMemoSchema);
     if (!parsed.success) return parsed.response;
     const body = parsed.data;
@@ -45,6 +53,7 @@ export async function POST(request: Request) {
       project_id: me.project_id,
       created_by: me.id,
     } as CreateMemoInput);
+    void incrementUsage(me.org_id, 'memos');
     return apiSuccess(memo, undefined, 201);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -2,6 +2,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { checkProjectLimit } from '@/lib/check-feature';
+import { checkEntitlement } from '@/lib/entitlement';
 import { parseBody, createProjectSchema } from '@sprintable/shared';
 import { isOssMode, createProjectRepository } from '@/lib/storage/factory';
 
@@ -101,6 +102,8 @@ export async function POST(request: Request) {
     if (!projectCheck.allowed) {
       return apiError('UPGRADE_REQUIRED', projectCheck.reason ?? 'Project limit reached. Upgrade to Team.', 403);
     }
+    const ent = await checkEntitlement(supabase, orgId, 'projects');
+    if (!ent.allowed) return apiError('quota_exceeded', `Project quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'projects', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
 
     const creatorName = user.user_metadata?.name
       || user.user_metadata?.full_name

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -7,6 +7,8 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { checkResourceLimit } from '@/lib/check-feature';
+import { checkEntitlement } from '@/lib/entitlement';
+import { incrementUsage } from '@/lib/usage-tracker';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
 
@@ -22,6 +24,8 @@ export async function POST(request: Request) {
     if (!ossMode) {
       const check = await checkResourceLimit(dbClient!, me.org_id, 'max_stories', 'stories');
       if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Story limit reached. Upgrade to Team.', 403);
+      const ent = await checkEntitlement(supabase, me.org_id, 'stories');
+      if (!ent.allowed) return apiError('quota_exceeded', `Story quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'stories', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
     }
 
     const rawBody = await request.json();
@@ -32,6 +36,7 @@ export async function POST(request: Request) {
     const repo = await createStoryRepository(dbClient);
     const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
     const story = await service.create(parsed.data as CreateStoryInput);
+    void incrementUsage(me.org_id, 'stories');
     return apiSuccess(story, undefined, 201);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/lib/entitlement.ts
+++ b/apps/web/src/lib/entitlement.ts
@@ -1,0 +1,100 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { isOssMode } from '@/lib/storage/factory';
+
+export type EntitlementResource = 'stories' | 'memos' | 'docs' | 'members' | 'projects' | 'api_calls';
+
+interface TierQuota {
+  stories: number;
+  memos: number;
+  docs: number;
+  members: number;
+  projects: number;
+  api_calls: number;
+}
+
+const UNLIMITED = 999_999_999;
+
+export const TIER_QUOTAS: Record<string, TierQuota> = {
+  free: { members: 5, projects: 1, stories: 100, memos: 500, docs: 50, api_calls: 10_000 },
+  team: { members: 20, projects: 5, stories: 1_000, memos: 5_000, docs: 500, api_calls: 100_000 },
+  pro: { members: UNLIMITED, projects: UNLIMITED, stories: UNLIMITED, memos: UNLIMITED, docs: UNLIMITED, api_calls: UNLIMITED },
+};
+
+export interface EntitlementResult {
+  allowed: boolean;
+  current: number;
+  limit: number;
+  upgradeUrl: string;
+}
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+async function getOrgTier(supabase: SupabaseClient, orgId: string): Promise<string> {
+  const { data } = await supabase
+    .from('org_subscriptions')
+    .select('tier, status')
+    .eq('org_id', orgId)
+    .maybeSingle();
+  if (!data || data.status === 'expired' || data.status === 'past_due') return 'free';
+  return data.tier ?? 'free';
+}
+
+export async function checkEntitlement(
+  supabase: SupabaseClient,
+  orgId: string,
+  resource: EntitlementResource,
+): Promise<EntitlementResult> {
+  if (isOssMode()) return { allowed: true, current: 0, limit: UNLIMITED, upgradeUrl: '/upgrade' };
+
+  const tier = await getOrgTier(supabase, orgId);
+  const quota = TIER_QUOTAS[tier] ?? TIER_QUOTAS['free']!;
+  const limit = quota[resource];
+  const upgradeUrl = '/upgrade';
+
+  if (limit === UNLIMITED) return { allowed: true, current: 0, limit, upgradeUrl };
+
+  let current = 0;
+
+  if (resource === 'members') {
+    const { count } = await supabase
+      .from('org_members')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else if (resource === 'projects') {
+    const { count } = await supabase
+      .from('projects')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else if (resource === 'docs') {
+    // docs is cumulative, not monthly
+    const { count } = await supabase
+      .from('docs')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else {
+    // monthly resources: stories, memos, api_calls
+    const { data: usage } = await supabase
+      .from('org_usage')
+      .select(resource)
+      .eq('org_id', orgId)
+      .eq('period', currentPeriod())
+      .maybeSingle();
+    current = (usage as Record<string, number> | null)?.[resource] ?? 0;
+  }
+
+  return { allowed: current < limit, current, limit, upgradeUrl };
+}
+
+export async function checkMemberEntitlement(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<EntitlementResult> {
+  return checkEntitlement(supabase, orgId, 'members');
+}

--- a/apps/web/src/lib/usage-tracker.ts
+++ b/apps/web/src/lib/usage-tracker.ts
@@ -1,0 +1,45 @@
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { isOssMode } from '@/lib/storage/factory';
+import type { EntitlementResource } from './entitlement';
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+/** Increment a monthly-bucketed usage counter. No-op in OSS mode. */
+export async function incrementUsage(
+  orgId: string,
+  resource: Extract<EntitlementResource, 'stories' | 'memos' | 'api_calls'>,
+  count = 1,
+): Promise<void> {
+  if (isOssMode()) return;
+  try {
+    const supabase = createSupabaseAdminClient();
+    const period = currentPeriod();
+    // UPSERT row, then increment
+    await supabase.rpc('increment_org_usage', { _org_id: orgId, _period: period, _resource: resource, _count: count });
+  } catch {
+    // usage tracking is best-effort — never block the main operation
+  }
+}
+
+export interface OrgUsage {
+  stories: number;
+  memos: number;
+  docs: number;
+  api_calls: number;
+  period: string;
+}
+
+export async function getCurrentUsage(orgId: string): Promise<OrgUsage | null> {
+  if (isOssMode()) return null;
+  const supabase = createSupabaseAdminClient();
+  const { data } = await supabase
+    .from('org_usage')
+    .select('stories, memos, docs, api_calls, period')
+    .eq('org_id', orgId)
+    .eq('period', currentPeriod())
+    .maybeSingle();
+  return data as OrgUsage | null;
+}

--- a/packages/db/supabase/migrations/20260422130000_org_usage.sql
+++ b/packages/db/supabase/migrations/20260422130000_org_usage.sql
@@ -1,0 +1,54 @@
+-- org_usage: monthly resource counters per org
+CREATE TABLE IF NOT EXISTS org_usage (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id UUID NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  period TEXT NOT NULL,  -- 'YYYY-MM' for monthly resources
+  stories INT NOT NULL DEFAULT 0,
+  memos INT NOT NULL DEFAULT 0,
+  docs INT NOT NULL DEFAULT 0,
+  api_calls INT NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE(org_id, period)
+);
+
+ALTER TABLE org_usage ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "org members can view usage"
+  ON org_usage FOR SELECT
+  USING (
+    org_id IN (
+      SELECT org_id FROM org_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- Atomic increment helper (service_role only)
+CREATE OR REPLACE FUNCTION increment_org_usage(
+  _org_id UUID,
+  _period TEXT,
+  _resource TEXT,
+  _count INT DEFAULT 1
+) RETURNS void LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO org_usage (org_id, period, stories, memos, docs, api_calls)
+  VALUES (_org_id, _period, 0, 0, 0, 0)
+  ON CONFLICT (org_id, period) DO NOTHING;
+
+  IF _resource = 'stories' THEN
+    UPDATE org_usage SET stories = stories + _count, updated_at = now()
+    WHERE org_id = _org_id AND period = _period;
+  ELSIF _resource = 'memos' THEN
+    UPDATE org_usage SET memos = memos + _count, updated_at = now()
+    WHERE org_id = _org_id AND period = _period;
+  ELSIF _resource = 'docs' THEN
+    UPDATE org_usage SET docs = docs + _count, updated_at = now()
+    WHERE org_id = _org_id AND period = _period;
+  ELSIF _resource = 'api_calls' THEN
+    UPDATE org_usage SET api_calls = api_calls + _count, updated_at = now()
+    WHERE org_id = _org_id AND period = _period;
+  END IF;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION increment_org_usage FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION increment_org_usage TO service_role;


### PR DESCRIPTION
## Summary
- `org_usage` DDL migration (`20260422130000`) — UNIQUE(org_id, period), RLS, atomic `increment_org_usage()` RPC
- `lib/entitlement.ts` — TIER_QUOTAS (free/team/pro), `checkEntitlement()`, `checkMemberEntitlement()`
- `lib/usage-tracker.ts` — `incrementUsage()` (best-effort), `getCurrentUsage()`
- 5개 API route에 quota check 연동

## 티어별 쿼터
| 자원 | Free | Team | Pro |
|---|---|---|---|
| members | 5 | 20 | ∞ |
| projects | 1 | 5 | ∞ |
| stories/mo | 100 | 1,000 | ∞ |
| memos/mo | 500 | 5,000 | ∞ |
| docs (누적) | 50 | 500 | ∞ |
| api_calls/mo | 10K | 100K | ∞ |

## AC Checklist
- [x] org_usage DDL 적용
- [x] 스토리 생성 → increment → 초과 시 402
- [x] 메모 생성 → increment → 초과 시 402
- [x] 팀멤버 초대 → count 체크 → 초과 시 402
- [x] docs 생성 → 누적 count 체크 → 초과 시 402
- [x] projects 생성 → count 체크 → 초과 시 402
- [x] 402 응답에 resource/current/limit/upgradeUrl 포함
- [x] isOssMode() → skip (unlimited)
- [x] pnpm build 성공

## 미결 (PO 확인 필요)
- AC5 "api_calls 초과 → Free 429 / Paid meter ingest": `pm-api middleware`가 어떤 route인지 코드베이스에서 식별 불가. entitlement 인프라(`checkEntitlement(supabase, orgId, 'api_calls')` + `incrementUsage(orgId, 'api_calls')`)는 완성. 적용할 route 지정해주시면 즉시 연결 가능.

## Test Plan
- [ ] Free org에서 stories 100개 초과 POST → 402 `quota_exceeded` 확인
- [ ] Team org에서 1,000개 초과 → 402, Pro → 통과
- [ ] 팀멤버 5명 초과(Free) → invitations POST → 402 확인
- [ ] isOssMode()=true → 모든 체크 skip 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)