### PR TITLE
feat(E-POLAR:S4): 쿼터 80% 배너 + 402 Upgrade 모달 (3SP)

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -3,6 +3,8 @@ import { isOssMode } from '@/lib/storage/factory';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getMyMembershipContext, getOssUserContext } from '@/lib/auth-helpers';
 import { DashboardShell } from '../dashboard/dashboard-shell';
+import { UpgradeBanner } from '@/components/upgrade-banner';
+import { UpgradeModal } from '@/components/upgrade-modal';
 
 export default async function AuthenticatedLayout({
   children,
@@ -40,6 +42,8 @@ export default async function AuthenticatedLayout({
         projectName={me?.project_name}
         projectMemberships={memberships.map((membership) => ({ projectId: membership.project_id, projectName: membership.project_name }))}
       >
+        <UpgradeBanner />
+        <UpgradeModal />
         {children}
       </DashboardShell>
     );

--- a/apps/web/src/app/(authenticated)/meetings/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/meetings/[id]/page.tsx
@@ -8,7 +8,6 @@ import { AudioRecorder } from '@/components/meetings/audio-recorder';
 import { AiSummarizeButton } from '@/components/meetings/ai-summarize-button';
 import { RouteErrorState } from '@/components/ui/route-error-state';
 import { PageSkeleton } from '@/components/ui/page-skeleton';
-import { UpgradeModal } from '@/components/upgrade-modal';
 import { useUpgradeGuard } from '@/hooks/use-upgrade-guard';
 import { readApiClientError } from '@/lib/api-client-error';
 
@@ -48,13 +47,7 @@ export default function MeetingDetailPage() {
   const [editingSummary, setEditingSummary] = useState(false);
   const [summaryDraft, setSummaryDraft] = useState('');
   const [savingSummary, setSavingSummary] = useState(false);
-  const {
-    guardedFetch,
-    showModal: showUpgradeModal,
-    meterType: upgradeMeterType,
-    closeModal: closeUpgradeModal,
-    triggerUpgrade,
-  } = useUpgradeGuard();
+  const { guardedFetch, triggerUpgrade } = useUpgradeGuard();
 
   const updateMeeting = useCallback(async (patch: Partial<MeetingDetail>, fallbackMessage: string) => {
     const response = await fetch(`/api/meetings/${meetingId}`, {
@@ -377,8 +370,6 @@ export default function MeetingDetailPage() {
         </section>
       )}
 
-      {/* AC4: UpgradeModal */}
-      {showUpgradeModal && <UpgradeModal meterType={upgradeMeterType} onClose={closeUpgradeModal} />}
     </div>
   );
 }

--- a/apps/web/src/app/api/usage/route.ts
+++ b/apps/web/src/app/api/usage/route.ts
@@ -3,10 +3,15 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { isOssMode } from '@/lib/storage/factory';
 import { getMyTeamMember } from '@/lib/auth-helpers';
+import { TIER_QUOTAS } from '@/lib/entitlement';
 
-/** GET /api/usage — AC5: 조직의 현재 월 usage meters */
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
 export async function GET() {
-  if (isOssMode()) return apiSuccess([]);
+  if (isOssMode()) return apiSuccess(null);
   try {
     const supabase = await createSupabaseServerClient();
     const { data: { user } } = await supabase.auth.getUser();
@@ -15,16 +20,29 @@ export async function GET() {
     const me = await getMyTeamMember(supabase, user);
     if (!me) return ApiErrors.forbidden();
 
-    const now = new Date();
-    const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+    const [{ data: sub }, { data: usageRow }] = await Promise.all([
+      supabase
+        .from('org_subscriptions')
+        .select('tier, status')
+        .eq('org_id', me.org_id)
+        .maybeSingle(),
+      supabase
+        .from('org_usage')
+        .select('stories, memos, docs, api_calls')
+        .eq('org_id', me.org_id)
+        .eq('period', currentPeriod())
+        .maybeSingle(),
+    ]);
 
-    const { data: meters } = await supabase
-      .from('usage_meters')
-      .select('meter_type, current_value, limit_value, period_start, period_end')
-      .eq('org_id', me.org_id)
-      .gte('period_start', periodStart.toISOString())
-      .order('meter_type');
+    const tier = (!sub || sub.status === 'expired' || sub.status === 'past_due') ? 'free' : (sub.tier ?? 'free');
+    const quotas = TIER_QUOTAS[tier] ?? TIER_QUOTAS['free']!;
+    const usage = {
+      stories: usageRow?.stories ?? 0,
+      memos: usageRow?.memos ?? 0,
+      docs: usageRow?.docs ?? 0,
+      api_calls: usageRow?.api_calls ?? 0,
+    };
 
-    return apiSuccess(meters ?? []);
+    return apiSuccess({ tier, usage, quotas });
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/components/upgrade-banner.tsx
+++ b/apps/web/src/components/upgrade-banner.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+interface UsageData {
+  tier: string;
+  usage: Record<string, number>;
+  quotas: Record<string, number>;
+}
+
+const RESOURCE_LABELS: Record<string, string> = {
+  stories: '스토리',
+  memos: '메모',
+  docs: '문서',
+  api_calls: 'API 호출',
+};
+
+const DISMISS_KEY = 'upgrade-banner-dismissed';
+
+function getHighestUsagePercent(data: UsageData): { resource: string; percent: number; current: number; limit: number } | null {
+  const monthly = ['stories', 'memos', 'api_calls'] as const;
+  let highest: { resource: string; percent: number; current: number; limit: number } | null = null;
+
+  for (const r of monthly) {
+    const limit = data.quotas[r] ?? 0;
+    if (limit >= 999_999_999) continue;
+    const current = data.usage[r] ?? 0;
+    const percent = limit > 0 ? Math.round((current / limit) * 100) : 0;
+    if (percent >= 80 && (!highest || percent > highest.percent)) {
+      highest = { resource: r, percent, current, limit };
+    }
+  }
+  return highest;
+}
+
+export function UpgradeBanner() {
+  const [alert, setAlert] = useState<{ resource: string; percent: number; current: number; limit: number } | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    if (sessionStorage.getItem(DISMISS_KEY)) {
+      setDismissed(true);
+      return;
+    }
+    fetch('/api/usage')
+      .then((r) => r.json())
+      .then((body) => {
+        if (body?.data) setAlert(getHighestUsagePercent(body.data));
+      })
+      .catch(() => {});
+  }, []);
+
+  function dismiss() {
+    sessionStorage.setItem(DISMISS_KEY, '1');
+    setDismissed(true);
+  }
+
+  if (dismissed || !alert) return null;
+
+  return (
+    <div className="flex items-center justify-between gap-3 bg-amber-500/10 px-4 py-2.5 text-sm text-amber-700 dark:bg-amber-500/15 dark:text-amber-400">
+      <span>
+        <strong>{RESOURCE_LABELS[alert.resource] ?? alert.resource}</strong>를{' '}
+        {alert.current}/{alert.limit}개 사용 중 ({alert.percent}%) —{' '}
+        <Link href="/upgrade" className="font-medium underline underline-offset-2">
+          Team으로 업그레이드
+        </Link>
+        하면 {alert.percent >= 100 ? '계속 사용할 수 있습니다.' : '한도를 대폭 늘릴 수 있습니다.'}
+      </span>
+      <button
+        onClick={dismiss}
+        aria-label="배너 닫기"
+        className="shrink-0 rounded p-0.5 hover:bg-amber-500/20"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/upgrade-modal.tsx
+++ b/apps/web/src/components/upgrade-modal.tsx
@@ -1,28 +1,74 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
 
-/** AC4: 한도 초과 시 표시되는 업그레이드 모달 */
-export function UpgradeModal({ meterType, onClose }: { meterType: string; onClose: () => void }) {
-  const t = useTranslations('usage');
+interface QuotaExceededDetail {
+  resource: string;
+  current: number;
+  limit: number;
+  upgradeUrl?: string;
+}
+
+const RESOURCE_LABELS: Record<string, string> = {
+  stories: '스토리',
+  memos: '메모',
+  docs: '문서',
+  members: '팀 멤버',
+  projects: '프로젝트',
+  api_calls: 'API 호출',
+};
+
+export function UpgradeModal() {
+  const router = useRouter();
+  const [detail, setDetail] = useState<QuotaExceededDetail | null>(null);
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const d = (e as CustomEvent<QuotaExceededDetail>).detail;
+      setDetail(d);
+    }
+    window.addEventListener('quota-exceeded', handler);
+    return () => window.removeEventListener('quota-exceeded', handler);
+  }, []);
+
+  if (!detail) return null;
+
+  const label = RESOURCE_LABELS[detail.resource] ?? detail.resource;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="mx-4 w-full max-w-md rounded-xl bg-white p-6 shadow-xl">
-        <h3 className="text-lg font-bold text-gray-900">⚠️ {t('limitReached')}</h3>
-        <p className="mt-2 text-sm text-gray-600">
-          {t('limitDesc', { meter: t(meterType) })}
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm" role="dialog" aria-modal="true">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-card p-6 shadow-xl">
+        <h2 className="font-heading text-lg font-semibold">쿼터 초과</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          <strong>{label}</strong> 한도({detail.limit}개)에 도달했습니다.
+          현재 {detail.current}개 사용 중입니다.
         </p>
-        <div className="mt-4 flex gap-3">
-          <button onClick={onClose} className="flex-1 rounded-lg border py-2 text-sm text-gray-700">
-            {t('close')}
-          </button>
-          <Link href="/pricing" className="flex-1 rounded-lg bg-purple-600 py-2 text-center text-sm font-medium text-white hover:bg-purple-700">
-            {t('upgrade')}
-          </Link>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Team 또는 Pro 플랜으로 업그레이드하면 한도가 대폭 늘어납니다.
+        </p>
+        <div className="mt-5 flex gap-2">
+          <Button
+            className="flex-1"
+            onClick={() => {
+              setDetail(null);
+              router.push('/upgrade');
+            }}
+          >
+            업그레이드
+          </Button>
+          <Button variant="outline" className="flex-1" onClick={() => setDetail(null)}>
+            닫기
+          </Button>
         </div>
       </div>
     </div>
   );
+}
+
+/** Call this from any API error handler when a 402 quota_exceeded is received. */
+export function dispatchQuotaExceeded(detail: QuotaExceededDetail) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('quota-exceeded', { detail }));
 }

--- a/apps/web/src/hooks/use-upgrade-guard.ts
+++ b/apps/web/src/hooks/use-upgrade-guard.ts
@@ -1,39 +1,40 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { readApiClientError } from '@/lib/api-client-error';
+import { dispatchQuotaExceeded } from '@/components/upgrade-modal';
 
 /**
- * AC4: API 403 + UPGRADE_REQUIRED 감지 → UpgradeModal 표시
+ * Wraps fetch calls and detects 402 quota_exceeded / 403 UPGRADE_REQUIRED,
+ * dispatching a global 'quota-exceeded' event to trigger UpgradeModal.
  */
 export function useUpgradeGuard() {
-  const [showModal, setShowModal] = useState(false);
-  const [meterType, setMeterType] = useState('');
-
   const guardedFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
     const res = await fetch(input, init);
 
-    if (res.status === 403) {
+    if (res.status === 402 || res.status === 403) {
       try {
         const payload = await readApiClientError(res.clone(), `Request failed (${res.status})`);
-        if (payload.code === 'UPGRADE_REQUIRED') {
-          setMeterType(payload.meterType ?? '');
-          setShowModal(true);
+        if (payload.code === 'quota_exceeded' || payload.code === 'UPGRADE_REQUIRED') {
+          dispatchQuotaExceeded({
+            resource: (payload.details?.['resource'] as string) ?? payload.meterType ?? 'unknown',
+            current: (payload.details?.['current'] as number) ?? 0,
+            limit: (payload.details?.['limit'] as number) ?? 0,
+            upgradeUrl: (payload.details?.['upgradeUrl'] as string) ?? '/upgrade',
+          });
         }
       } catch {
-        // not JSON
+        // not JSON — ignore
       }
     }
 
     return res;
   }, []);
 
-  const closeModal = useCallback(() => setShowModal(false), []);
-
+  // Legacy compat: meetings page calls triggerUpgrade manually
   const triggerUpgrade = useCallback((meter: string) => {
-    setMeterType(meter);
-    setShowModal(true);
+    dispatchQuotaExceeded({ resource: meter, current: 0, limit: 0 });
   }, []);
 
-  return { guardedFetch, showModal, meterType, closeModal, triggerUpgrade };
+  return { guardedFetch, triggerUpgrade };
 }


### PR DESCRIPTION
## Summary
- `GET /api/usage` 업데이트: org_subscriptions.tier + org_usage 기반 (`{ tier, usage, quotas }` 반환)
- `UpgradeBanner` — 쿼터 80% 도달 시 상단 배너 (sessionStorage dismiss)
- `UpgradeModal` — global `quota-exceeded` CustomEvent 기반 모달 (`dispatchQuotaExceeded()` helper)
- `use-upgrade-guard` — 402/403 감지 → 글로벌 모달 이벤트 발송으로 통합
- authenticated layout에 UpgradeBanner + UpgradeModal 연결 (SaaS 전용)

## 주요 변경
| 파일 | 내용 |
|---|---|
| `api/usage/route.ts` | org_subscriptions + org_usage 기반으로 교체 |
| `components/upgrade-banner.tsx` | 신규: 80% 배너 |
| `components/upgrade-modal.tsx` | 재작성: CustomEvent 기반 |
| `hooks/use-upgrade-guard.ts` | 402/403 통합 감지 |
| `(authenticated)/layout.tsx` | UpgradeBanner + UpgradeModal 연결 |
| `meetings/[id]/page.tsx` | 직접 렌더링 → 글로벌 이벤트 방식 마이그레이션 |

## AC Checklist
- [x] 쿼터 80% 배너 표시 (sessionStorage dismiss)
- [x] 402 quota_exceeded → UpgradeModal 자동 팝업
- [x] 기존 403 UPGRADE_REQUIRED도 동일 모달 처리
- [x] /upgrade 링크 연결 (S1 embedded checkout 페이지)
- [x] 모바일/데스크톱 반응형
- [x] isOssMode() skip (OSS는 UpgradeBanner/UpgradeModal 렌더 안 됨)
- [x] pnpm build 성공

## Test Plan
- [ ] Free org에서 stories 80개 → UpgradeBanner 표시 확인
- [ ] 배너 ✕ 클릭 → 세션 내 다시 표시 안 됨 확인
- [ ] stories POST → 402 응답 시 UpgradeModal 자동 팝업 확인
- [ ] 모달 내 업그레이드 버튼 → /upgrade 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)