### PR TITLE
fix(docs): markdownToHtml 코드블럭 렌더링 버그 수정

### DIFF
--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -77,11 +77,13 @@ export function htmlToMarkdown(html: string): string {
 export function markdownToHtml(md: string): string {
   if (!md.trim()) return '';
 
-  let html = md;
-
-  // Code blocks (fenced)
-  html = html.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
-    return `<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`;
+  // Extract fenced code blocks first to prevent other transforms from modifying their content.
+  // Subsequent regex passes use gm flags which would otherwise corrupt multi-line code blocks.
+  const codeBlockPlaceholders: string[] = [];
+  let html = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+    const idx = codeBlockPlaceholders.length;
+    codeBlockPlaceholders.push(`<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`);
+    return `\x00CODEBLOCK${idx}\x00`;
   });
 
   // Headings
@@ -168,11 +170,14 @@ export function markdownToHtml(md: string): string {
     return `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>`;
   });
 
-  // Paragraphs - wrap remaining plain-text lines
-  html = html.replace(/^(?!<[a-z/])(.*\S.*)$/gm, '<p>$1</p>');
+  // Paragraphs - wrap remaining plain-text lines (exclude HTML tags and code block placeholders)
+  html = html.replace(/^(?!<[a-z/])(?!\x00CODEBLOCK)(.*\S.*)$/gm, '<p>$1</p>');
 
   // Clean up extra whitespace
   html = html.replace(/\n{3,}/g, '\n\n');
+
+  // Restore fenced code blocks (must be last to avoid double-processing)
+  html = html.replace(/\x00CODEBLOCK(\d+)\x00/g, (_, i) => codeBlockPlaceholders[Number(i)] ?? '');
 
   return html.trim();
 }


### PR DESCRIPTION
## Summary

- `markdownToHtml()` 함수에서 fenced code block 내부 줄이 ordered list / paragraph 정규식(`gm` 플래그)에 의해 변환되는 버그 수정
- 코드블럭을 null 문자 placeholder로 먼저 교체 → 모든 변환 완료 후 복원하는 방식으로 처리
- paragraph 정규식에 `(?!\x00CODEBLOCK)` 추가로 placeholder 줄 명시적 제외

## Root Cause

`markdownToHtml()`이 코드 펜스를 `<pre><code>...</code></pre>`로 변환한 뒤, 이후 `gm` 플래그를 사용하는 정규식들이 `<pre>` 내부 각 줄에도 적용되어:
1. ordered list 정규식 — `2. line2`, `3. line3` 패턴을 `<ol>` 변환
2. paragraph 정규식 — 코드블럭 2번째 줄부터 `<p>` 태그로 감싸버림

결과: 코드블럭 첫 줄만 블럭 안에 표시, 나머지는 일반 텍스트로 개행, 번호 불렛이 리스트로 오파싱.

## Test plan

- [ ] 멀티라인 코드블럭 전체가 하나의 블럭으로 정상 렌더링
- [ ] 코드블럭 내 개행이 블럭을 종료하지 않음
- [ ] 코드블럭 내 `2. 3.` 번호 불렛이 리스트로 파싱되지 않음
- [ ] 기존 docs 전체 코드블럭 정상 확인
- [ ] `pnpm build` 성공 (✅ 로컬 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)