### PR TITLE
fix(memo): send_memo 웹훅 자동 발송 버그 수정

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.test.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.test.ts
@@ -1,93 +1,114 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  createSupabaseAdminClient,
-  dispatchMemoIfNeeded,
-  stop,
-  MemoEventDispatcher,
-} = vi.hoisted(() => {
-  const createSupabaseAdminClient = vi.fn(() => ({ tag: 'admin-supabase' }));
-  const dispatchMemoIfNeeded = vi.fn();
-  const stop = vi.fn();
-  const MemoEventDispatcher = vi.fn(function MemoEventDispatcher() {
-    return {
-      dispatchMemoIfNeeded,
-      stop,
-    };
-  });
-
-  return {
-    createSupabaseAdminClient,
-    dispatchMemoIfNeeded,
-    stop,
-    MemoEventDispatcher,
-  };
-});
-
-vi.mock('@/lib/supabase/admin', () => ({
-  createSupabaseAdminClient,
+const { createSupabaseAdminClient } = vi.hoisted(() => ({
+  createSupabaseAdminClient: vi.fn(),
 }));
 
-vi.mock('./memo-event-dispatcher', () => ({
-  MemoEventDispatcher,
+vi.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient }));
+
+vi.mock('@/lib/storage/factory', () => ({
+  isOssMode: vi.fn(() => false),
+  createTeamMemberRepository: vi.fn(),
 }));
 
 import { dispatchMemoAssignmentImmediately } from './memo-assignment-dispatch';
 
+const baseMemo = {
+  id: 'memo-1',
+  org_id: 'org-1',
+  project_id: 'proj-1',
+  title: 'Test Memo',
+  content: 'Please review',
+  memo_type: 'task',
+  status: 'open',
+  assigned_to: 'agent-1',
+  created_by: 'human-1',
+  metadata: null,
+  updated_at: '2026-04-22T00:00:00.000Z',
+  created_at: '2026-04-22T00:00:00.000Z',
+};
+
+function makeSupabase(results: Record<string, unknown>) {
+  return {
+    from: vi.fn((table: string) => {
+      const payload = results[table] ?? { data: null, error: null };
+      return {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue(payload),
+      };
+    }),
+  };
+}
+
 describe('dispatchMemoAssignmentImmediately', () => {
+  const mockFetch = vi.fn();
+
   beforeEach(() => {
-    createSupabaseAdminClient.mockClear();
-    dispatchMemoIfNeeded.mockReset();
-    stop.mockReset();
-    MemoEventDispatcher.mockClear();
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
   });
 
-  it('dispatches assigned open memos immediately through the memo dispatcher', async () => {
-    await dispatchMemoAssignmentImmediately({
-      id: 'memo-1',
-      org_id: 'org-1',
-      project_id: 'project-1',
-      title: 'Urgent memo',
-      content: 'Please review',
-      memo_type: 'task',
-      status: 'open',
-      assigned_to: 'agent-1',
-      created_by: 'human-1',
-      metadata: { source: 'discord' },
-      updated_at: '2026-04-10T09:00:00.000Z',
-      created_at: '2026-04-10T09:00:00.000Z',
-    });
-
-    expect(createSupabaseAdminClient).toHaveBeenCalledTimes(1);
-    expect(MemoEventDispatcher).toHaveBeenCalledWith({
-      supabase: { tag: 'admin-supabase' },
-      logger: console,
-    });
-    expect(dispatchMemoIfNeeded).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'memo-1', assigned_to: 'agent-1' }),
-      'realtime',
-    );
-    expect(stop).toHaveBeenCalledTimes(1);
-  });
-
-  it('skips unassigned memos', async () => {
-    await dispatchMemoAssignmentImmediately({
-      id: 'memo-2',
-      org_id: 'org-1',
-      project_id: 'project-1',
-      title: null,
-      content: 'FYI',
-      memo_type: 'memo',
-      status: 'open',
-      assigned_to: null,
-      created_by: 'human-1',
-      metadata: null,
-      updated_at: '2026-04-10T09:00:00.000Z',
-      created_at: '2026-04-10T09:00:00.000Z',
-    });
-
+  it('skips unassigned memos without calling supabase', async () => {
+    await dispatchMemoAssignmentImmediately({ ...baseMemo, assigned_to: null });
     expect(createSupabaseAdminClient).not.toHaveBeenCalled();
-    expect(dispatchMemoIfNeeded).not.toHaveBeenCalled();
-    expect(stop).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('skips non-open memos without calling supabase', async () => {
+    await dispatchMemoAssignmentImmediately({ ...baseMemo, status: 'resolved' });
+    expect(createSupabaseAdminClient).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends webhook via team_members.webhook_url when webhook_configs is empty', async () => {
+    const supabase = makeSupabase({
+      webhook_configs: { data: null, error: null },
+      team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/token' }, error: null },
+    });
+    createSupabaseAdminClient.mockReturnValue(supabase);
+
+    await dispatchMemoAssignmentImmediately(baseMemo);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/1/token',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('prefers webhook_configs url over team_members.webhook_url', async () => {
+    const supabase = makeSupabase({
+      webhook_configs: { data: { url: 'https://discord.com/api/webhooks/2/config', secret: null }, error: null },
+      team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/fallback' }, error: null },
+    });
+    createSupabaseAdminClient.mockReturnValue(supabase);
+
+    await dispatchMemoAssignmentImmediately(baseMemo);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://discord.com/api/webhooks/2/config',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('logs console.error and skips fetch when no webhook url found', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const supabase = makeSupabase({
+      webhook_configs: { data: null, error: null },
+      team_members: { data: null, error: null },
+    });
+    createSupabaseAdminClient.mockReturnValue(supabase);
+
+    await dispatchMemoAssignmentImmediately(baseMemo);
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[MemoDispatch]'),
+      expect.anything(),
+    );
+    errorSpy.mockRestore();
   });
 });

--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -1,5 +1,4 @@
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
-import { MemoEventDispatcher } from './memo-event-dispatcher';
 import { buildAbsoluteMemoLink } from './app-url';
 
 export interface DispatchableMemo {
@@ -54,20 +53,86 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     return;
   }
 
+  // SaaS: webhook_configs → team_members.webhook_url 직접 전송 (agent_runs 불필요)
   try {
-    const dispatcher = new MemoEventDispatcher({
-      supabase: createSupabaseAdminClient(),
-      logger: console,
+    const supabase = createSupabaseAdminClient();
+    const assigneeId = memo.assigned_to;
+
+    // webhook_configs: project_id 기준 우선
+    const { data: projectConfig } = await supabase
+      .from('webhook_configs')
+      .select('url, secret')
+      .eq('org_id', memo.org_id)
+      .eq('member_id', assigneeId)
+      .eq('project_id', memo.project_id)
+      .eq('is_active', true)
+      .limit(1)
+      .maybeSingle();
+
+    let webhookUrl: string | null = null;
+    let webhookSecret: string | null = null;
+
+    if (projectConfig?.url) {
+      webhookUrl = projectConfig.url as string;
+      webhookSecret = (projectConfig.secret as string | null) ?? null;
+    } else {
+      // webhook_configs: org 기본값
+      const { data: defaultConfig } = await supabase
+        .from('webhook_configs')
+        .select('url, secret')
+        .eq('org_id', memo.org_id)
+        .eq('member_id', assigneeId)
+        .is('project_id', null)
+        .eq('is_active', true)
+        .limit(1)
+        .maybeSingle();
+
+      if (defaultConfig?.url) {
+        webhookUrl = defaultConfig.url as string;
+        webhookSecret = (defaultConfig.secret as string | null) ?? null;
+      } else {
+        // fallback: team_members.webhook_url
+        const { data: member } = await supabase
+          .from('team_members')
+          .select('webhook_url')
+          .eq('id', assigneeId)
+          .eq('org_id', memo.org_id)
+          .eq('project_id', memo.project_id)
+          .eq('is_active', true)
+          .maybeSingle();
+
+        webhookUrl = (member?.webhook_url as string | null) ?? null;
+      }
+    }
+
+    if (!webhookUrl) {
+      console.error('[MemoDispatch] no webhook url for assignee:', assigneeId);
+      return;
+    }
+
+    const memoLabel = memo.title?.trim() ? `"${memo.title.trim()}"` : `#${memo.id.slice(0, 8)}`;
+    const title = `📋 메모 배정: ${memoLabel}`;
+    const preview = memo.content.replace(/\s+/g, ' ').trim().slice(0, 200);
+    const memoLink = buildAbsoluteMemoLink(memo.id, process.env.NEXT_PUBLIC_APP_URL);
+    const description = `${preview}\n\n${memoLink}`;
+
+    const isDiscord = webhookUrl.includes('discord.com') || webhookUrl.includes('discordapp.com');
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (webhookSecret) headers['X-Webhook-Secret'] = webhookSecret;
+
+    const body = isDiscord
+      ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
+      : JSON.stringify({ text: `*${title}*\n${description}` });
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers,
+      body,
+      signal: AbortSignal.timeout(10_000),
     });
 
-    const result = await dispatcher.dispatchMemoIfNeeded(memo, 'realtime');
-    await dispatcher.stop();
-
-    if (result.status === 'skipped') {
-      console.error(
-        '[MemoDispatch] dispatch skipped:',
-        result.reason ?? 'unknown_reason',
-      );
+    if (!response.ok) {
+      console.error('[MemoDispatch] webhook responded with HTTP', response.status, 'for assignee:', assigneeId);
     }
   } catch (error) {
     console.error(


### PR DESCRIPTION
## Summary

- `MemoEventDispatcher` (agent_runs insert 의존) 제거 → reply webhook과 동일한 직접 전송 방식으로 변경
- `webhook_configs` (project_id 기준) → `webhook_configs` (org default) → `team_members.webhook_url` 순서로 조회
- Discord/generic format 자동 감지
- 실패 시 `console.error` 로깅 (AC3: silent fail 제거)

## Root Cause

기존 `MemoEventDispatcher` 경로:
1. `createRun()` → `agent_runs` 테이블 INSERT (여러 컬럼 의존)
2. INSERT 실패 시 `result.status === 'failed'` 반환 → 로깅 없이 silent return
3. webhook 전송 안 됨

reply webhook은 `agent_runs` 없이 직접 fetch → 동작 확인됨.

## AC Checklist

- [x] AC1: send_memo → 에이전트 webhook_url 자동 POST
- [x] AC2: reply_memo는 기존대로 (변경 없음)
- [x] AC3: 실패 시 `console.error` 로깅
- [x] AC4: 기존 메모 생성 기능 영향 없음

## Test plan

- [ ] `send_memo` MCP 도구로 메모 생성 → Discord 웹훅 도착 확인
- [ ] `pnpm build` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)