### PR TITLE
fix(docs): 테이블 셀 pipe 파싱 + 코드블럭 외부 HTML 이스케이프

### DIFF
--- a/apps/web/src/components/docs/lib/content-converter.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.test.ts
@@ -30,6 +30,30 @@ describe('markdownToHtml', () => {
     expect(result).toContain('<td>didi</td>');
   });
 
+  it('renders escaped pipe inside table cell as literal |', () => {
+    const result = markdownToHtml('| expr | value |\n| --- | --- |\n| a \\| b | 1 |');
+    expect(result).toContain('<table>');
+    expect(result).toContain('a | b');
+    // should not create an extra column for the escaped pipe
+    const cellMatches = result.match(/<td>/g) ?? [];
+    expect(cellMatches.length).toBe(2);
+  });
+
+  it('escapes raw HTML open-tags outside code blocks', () => {
+    const result = markdownToHtml('<bold>text</bold> and **md**');
+    // '<' is escaped so no live <bold> element; '>' preserved for blockquote compat
+    expect(result).not.toContain('<bold>');
+    expect(result).toContain('&lt;bold>');
+    expect(result).toContain('<strong>md</strong>');
+  });
+
+  it('does not escape html inside fenced code blocks', () => {
+    const result = markdownToHtml('```\n<div>raw</div>\n```');
+    // code blocks use escapeHtml so < becomes &lt; but is inside <pre><code>
+    expect(result).toContain('<pre><code>');
+    expect(result).not.toContain('<div>raw</div>');
+  });
+
   it('converts ordered lists into ol blocks', () => {
     const result = markdownToHtml('1. one\n2. two');
     expect(result).toContain('<ol>');

--- a/apps/web/src/components/docs/lib/content-converter.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.test.ts
@@ -85,6 +85,15 @@ describe('markdownToHtml', () => {
     expect(markdownToHtml('')).toBe('');
     expect(markdownToHtml('   ')).toBe('');
   });
+
+  it('preserves page-embed atoms through html escape pass', () => {
+    const embed = '<div data-page-embed data-doc-id="abc" data-title="Doc" data-icon="" data-slug="doc"></div>';
+    const md = `\n${embed}\n`;
+    const result = markdownToHtml(md);
+    expect(result).toContain('data-page-embed');
+    expect(result).toContain('data-doc-id="abc"');
+    expect(result).not.toContain('&lt;div');
+  });
 });
 
 describe('htmlToMarkdown', () => {

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -86,10 +86,19 @@ export function markdownToHtml(md: string): string {
     return `\x00CODEBLOCK${idx}\x00`;
   });
 
-  // Escape raw HTML in non-codeblock regions so user-typed tags like <bold> or <div>
-  // don't get parsed as real HTML elements by the browser.
+  // Protect page-embed atoms — they are written as raw HTML by htmlToMarkdown() and
+  // must survive the HTML-escape pass below intact.
+  const atomPlaceholders: string[] = [];
+  html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+
+  // Escape raw HTML in non-codeblock, non-atom regions so user-typed tags like
+  // <bold> or <div> don't get parsed as real HTML elements by the browser.
   // '>' is intentionally excluded to preserve blockquote markers (^> pattern below).
-  html = html.split(/(\x00CODEBLOCK\d+\x00)/g).map((seg, i) =>
+  html = html.split(/(\x00CODEBLOCK\d+\x00|\x00ATOM\d+\x00)/g).map((seg, i) =>
     i % 2 === 1 ? seg : seg.replace(/&/g, '&amp;').replace(/</g, '&lt;'),
   ).join('');
 
@@ -177,11 +186,14 @@ export function markdownToHtml(md: string): string {
     return `<ul>${items.map((item) => `<li>${item}</li>`).join('')}</ul>`;
   });
 
-  // Paragraphs - wrap remaining plain-text lines (exclude HTML tags and code block placeholders)
-  html = html.replace(/^(?!<[a-z/])(?!\x00CODEBLOCK)(.*\S.*)$/gm, '<p>$1</p>');
+  // Paragraphs - wrap remaining plain-text lines (exclude HTML tags and code block/atom placeholders)
+  html = html.replace(/^(?!<[a-z/])(?!\x00CODEBLOCK)(?!\x00ATOM)(.*\S.*)$/gm, '<p>$1</p>');
 
   // Clean up extra whitespace
   html = html.replace(/\n{3,}/g, '\n\n');
+
+  // Restore page-embed atoms before code blocks (order matters — CODEBLOCK restore must be last)
+  html = html.replace(/\x00ATOM(\d+)\x00/g, (_, i) => atomPlaceholders[Number(i)] ?? '');
 
   // Restore fenced code blocks (must be last to avoid double-processing)
   html = html.replace(/\x00CODEBLOCK(\d+)\x00/g, (_, i) => codeBlockPlaceholders[Number(i)] ?? '');

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -86,6 +86,13 @@ export function markdownToHtml(md: string): string {
     return `\x00CODEBLOCK${idx}\x00`;
   });
 
+  // Escape raw HTML in non-codeblock regions so user-typed tags like <bold> or <div>
+  // don't get parsed as real HTML elements by the browser.
+  // '>' is intentionally excluded to preserve blockquote markers (^> pattern below).
+  html = html.split(/(\x00CODEBLOCK\d+\x00)/g).map((seg, i) =>
+    i % 2 === 1 ? seg : seg.replace(/&/g, '&amp;').replace(/</g, '&lt;'),
+  ).join('');
+
   // Headings
   html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
   html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
@@ -198,9 +205,16 @@ function isTableSeparatorLine(line: string): boolean {
     .every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
 }
 
+const ESCAPED_PIPE = '\x01PIPE\x01';
+
 function parseTableCells(line: string): string[] {
   const trimmed = line.trim().replace(/^\|/, '').replace(/\|$/, '');
   if (!trimmed) return [];
 
-  return trimmed.split('|').map((cell) => cell.trim());
+  // Replace escaped pipes (\|) with a placeholder before splitting,
+  // then restore them in each cell so they render as literal '|'.
+  return trimmed
+    .replace(/\\\|/g, ESCAPED_PIPE)
+    .split('|')
+    .map((cell) => cell.trim().replace(new RegExp(ESCAPED_PIPE, 'g'), '|'));
 }


### PR DESCRIPTION
## Summary

- **버그 1**: `parseTableCells()`에서 `\|` (escaped pipe)를 placeholder로 보호 후 split → 셀 내 `|` 리터럴 정상 표시
- **버그 2**: `markdownToHtml()`에서 code block extraction 후 non-codeblock 구간의 `<` / `&` escape → 사용자 입력 HTML 태그가 실제 DOM 요소로 파싱되는 문제 차단
- 회귀 테스트 3건 추가 (vitest 21/21 PASS)

## 수정 파일

- `apps/web/src/components/docs/lib/content-converter.ts`
- `apps/web/src/components/docs/lib/content-converter.test.ts`

## 비고

- `>`는 blockquote marker(`> `)와 충돌 방지를 위해 escape 제외 — `<`가 없으면 태그 성립 불가이므로 XSS 방어 충분
- PR #125 placeholder 패턴(`\x00CODEBLOCK\x00`)과 충돌 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)