### PR TITLE
[HOTFIX] settings/layout: setAll 빈 함수 → createSupabaseServerClient 교체

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/layout.tsx
+++ b/apps/web/src/app/(authenticated)/settings/layout.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
-import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/ssr';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { isOssMode } from '@/lib/storage/factory';
 import { PageHeader } from '@/components/ui/page-header';
 import { SettingsLayoutClient } from './settings-layout-client';
@@ -21,17 +20,7 @@ export default async function SettingsLayout({ children }: { children: ReactNode
     );
   }
 
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: () => {},
-      },
-    }
-  );
+  const supabase = await createSupabaseServerClient();
 
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return null;


### PR DESCRIPTION
## 원인

`apps/web/src/app/(authenticated)/settings/layout.tsx`가 `createServerClient`를 인라인으로 직접 생성하면서 `setAll: () => {}` 빈 함수를 사용.

Supabase SSR 클라이언트가 `getUser()` 호출 시 액세스 토큰이 만료되어 리프레시를 수행해도 `setAll`이 no-op이라 **새 토큰이 쿠키에 저장되지 않음**. 브라우저는 이미 사용된 refresh_token을 계속 보내게 되어:

1. `400 refresh_token_already_used`
2. `429 over_request_rate_limit` (무한 재시도)

## 수정

| Before | After |
|--------|-------|
| `createServerClient(...)` + `setAll: () => {}` | `await createSupabaseServerClient()` |

공통 헬퍼 `createSupabaseServerClient()`는 이미 `try { cookieStore.set() } catch {}` 패턴으로 올바르게 구현되어 있음. `NEXT_PUBLIC_COOKIE_DOMAIN` 지원도 추가됨.

## 테스트 포인트

- 설정 페이지 진입 시 정상 렌더링
- 액세스 토큰 만료 후 재진입 시 무한루프 없음
- OSS 모드 동작 변경 없음 (isOssMode() 분기 그대로)

🤖 Generated with [Claude Code](https://claude.com/claude-code)