### PR TITLE
[HOTFIX] proxy.ts matcher 무효화 + callback 쿠키 domain 통일

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/layout.tsx
+++ b/apps/web/src/app/(authenticated)/settings/layout.tsx
@@ -1,6 +1,5 @@
 import { ReactNode } from 'react';
-import { cookies } from 'next/headers';
-import { createServerClient } from '@supabase/ssr';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { isOssMode } from '@/lib/storage/factory';
 import { PageHeader } from '@/components/ui/page-header';
 import { SettingsLayoutClient } from './settings-layout-client';
@@ -21,17 +20,7 @@ export default async function SettingsLayout({ children }: { children: ReactNode
     );
   }
 
-  const cookieStore = await cookies();
-  const supabase = createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: () => {},
-      },
-    }
-  );
+  const supabase = await createSupabaseServerClient();
 
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return null;

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,5 +1,4 @@
-import { createServerClient } from '@supabase/ssr';
-import { cookies } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { resolveAppUrl } from '@/services/app-url';
 
@@ -10,23 +9,7 @@ export async function GET(request: Request) {
   const origin = resolveAppUrl(null);
 
   if (code) {
-    const cookieStore = await cookies();
-    const supabase = createServerClient(
-      process.env['NEXT_PUBLIC_SUPABASE_URL']!,
-      process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
-      {
-        cookies: {
-          getAll() {
-            return cookieStore.getAll();
-          },
-          setAll(cookiesToSet: Array<{ name: string; value: string; options: Record<string, unknown> }>) {
-            for (const { name, value, options } of cookiesToSet) {
-              cookieStore.set(name, value, options as Parameters<typeof cookieStore.set>[2]);
-            }
-          },
-        },
-      },
-    );
+    const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
       return NextResponse.redirect(`${origin}${next}`);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -109,7 +109,7 @@ export async function proxy(request: NextRequest) {
   return supabaseResponse;
 }
 
-export const proxyConfig = {
+export const config = {
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],


### PR DESCRIPTION
## Summary
- P0: `proxy.ts` — `proxyConfig` → `config` (Next.js matcher 활성화)
- P1: `auth/callback/route.ts` — 인라인 createServerClient → createSupabaseServerClient() 교체 (쿠키 domain 통일)

## Root Cause
1. proxy.ts의 matcher export 이름이 `proxyConfig`여서 Next.js가 무시 → 정적 파일 포함 모든 요청에서 getUser() 호출 → refresh token 동시 폭주
2. auth/callback이 인라인 client 사용으로 NEXT_PUBLIC_COOKIE_DOMAIN 미적용 → host-only/domain 쿠키 중복

## Test plan
- [ ] proxy matcher 활성화 확인 (빌드 출력 "ƒ Proxy" 표시)
- [ ] auth callback 쿠키 domain 통일 확인
- [ ] 로그인 → refresh token 정상 갱신 확인
- [ ] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)