### PR TITLE
feat(docs): update_doc API에 parent_id(폴더 이동) 필드 추가

### DIFF
--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -30,10 +30,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     });
     return apiSuccess(doc);
   } catch (err: unknown) {
-    const maybeConflict = err as Error & { code?: string };
-    if (maybeConflict.code === 'CONFLICT') {
-      return apiError('CONFLICT', maybeConflict.message, 409);
-    }
+    const e = err as Error & { code?: string };
+    if (e.code === 'CONFLICT') return apiError('CONFLICT', e.message, 409);
+    if (e.code === 'NOT_FOUND') return apiError('NOT_FOUND', e.message, 404);
+    if (e.code === 'BAD_REQUEST') return apiError('BAD_REQUEST', e.message, 400);
     return handleApiError(err);
   }
 }

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -40,6 +40,7 @@ export class DocsService {
       icon?: string | null;
       tags?: string[];
       sort_order?: number;
+      parent_id?: string | null;
       created_by?: string;
       expected_updated_at?: string;
       force_overwrite?: boolean;
@@ -48,6 +49,18 @@ export class DocsService {
     const { expected_updated_at, force_overwrite, created_by: _created_by, ...fields } = input;
 
     if (this.supabase) {
+      // AC4: parent_id가 UUID면 해당 폴더 존재 여부 검증
+      if (fields.parent_id != null) {
+        const { data: parentDoc, error: parentErr } = await this.supabase
+          .from('docs')
+          .select('id, is_folder')
+          .eq('id', fields.parent_id)
+          .maybeSingle();
+        if (parentErr) throw parentErr;
+        if (!parentDoc) throw Object.assign(new Error(`Parent folder not found: ${fields.parent_id}`), { code: 'NOT_FOUND' });
+        if (!parentDoc.is_folder) throw Object.assign(new Error(`Target is not a folder: ${fields.parent_id}`), { code: 'BAD_REQUEST' });
+      }
+
       let query = this.supabase.from('docs').update(fields).eq('id', id);
       if (expected_updated_at && !force_overwrite) query = query.eq('updated_at', expected_updated_at);
       const { data, error } = await query.select().maybeSingle();

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -48,9 +48,9 @@ export class DocsService {
   ) {
     const { expected_updated_at, force_overwrite, created_by: _created_by, ...fields } = input;
 
-    if (this.supabase) {
-      // AC4: parent_id가 UUID면 해당 폴더 존재 여부 검증
-      if (fields.parent_id != null) {
+    // AC4: parent_id가 UUID면 해당 폴더 존재 여부 검증 (Supabase + OSS 공통)
+    if (fields.parent_id != null) {
+      if (this.supabase) {
         const { data: parentDoc, error: parentErr } = await this.supabase
           .from('docs')
           .select('id, is_folder')
@@ -59,8 +59,15 @@ export class DocsService {
         if (parentErr) throw parentErr;
         if (!parentDoc) throw Object.assign(new Error(`Parent folder not found: ${fields.parent_id}`), { code: 'NOT_FOUND' });
         if (!parentDoc.is_folder) throw Object.assign(new Error(`Target is not a folder: ${fields.parent_id}`), { code: 'BAD_REQUEST' });
+      } else {
+        let parentDoc: { is_folder?: boolean } | null = null;
+        try { parentDoc = await this.repo.getById(fields.parent_id); } catch { /* not found */ }
+        if (!parentDoc) throw Object.assign(new Error(`Parent folder not found: ${fields.parent_id}`), { code: 'NOT_FOUND' });
+        if (!parentDoc.is_folder) throw Object.assign(new Error(`Target is not a folder: ${fields.parent_id}`), { code: 'BAD_REQUEST' });
       }
+    }
 
+    if (this.supabase) {
       let query = this.supabase.from('docs').update(fields).eq('id', id);
       if (expected_updated_at && !force_overwrite) query = query.eq('updated_at', expected_updated_at);
       const { data, error } = await query.select().maybeSingle();

--- a/packages/mcp-server/src/tools/docs.ts
+++ b/packages/mcp-server/src/tools/docs.ts
@@ -42,13 +42,14 @@ export function registerDocsTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  server.tool('update_doc', 'Update doc content/title', {
+  server.tool('update_doc', 'Update doc content/title/parent folder', {
     doc_id: z.string(),
     title: z.string().optional(),
     content: z.string().optional(),
     content_format: z.enum(['markdown', 'html']).optional(),
     icon: z.string().optional(),
     tags: z.array(z.string()).optional(),
+    parent_id: z.string().nullable().optional().describe('Folder doc ID to move into, or null to move to root'),
     expected_updated_at: z.string().optional().describe('ISO timestamp for optimistic concurrency check'),
     force_overwrite: z.boolean().optional().describe('Skip conflict check and force write'),
   }, async ({ doc_id, ...updates }) => {

--- a/packages/shared/src/schemas/docs.ts
+++ b/packages/shared/src/schemas/docs.ts
@@ -18,6 +18,7 @@ export const updateDocSchema = z.object({
   icon: z.string().optional().nullable(),
   tags: z.array(z.string()).optional(),
   sort_order: z.number().optional(),
+  parent_id: z.string().nullable().optional(),
 });
 
 export const docCommentSchema = z.object({


### PR DESCRIPTION
## 변경 사항

`update_doc` API에 `parent_id` 필드가 없어 문서 폴더 이동 불가 → 추가 완료.

## 수정 파일

| 파일 | 내용 |
|------|------|
| `packages/shared/src/schemas/docs.ts` | `updateDocSchema`에 `parent_id: string \| null` 추가 |
| `apps/web/src/services/docs.ts` | `updateDoc` input 타입 + parent 존재/폴더 검증 |
| `apps/web/src/app/api/docs/[id]/route.ts` | NOT_FOUND(404) / BAD_REQUEST(400) 에러 처리 |
| `packages/mcp-server/src/tools/docs.ts` | `update_doc` 도구 파라미터에 `parent_id` 추가 |

## AC 체크

- **AC1** ✅ update_doc API에 parent_id 파라미터 추가
- **AC2** ✅ 유효한 folder doc ID → 해당 폴더 하위로 이동 (Supabase update + OSS repo.update)
- **AC3** ✅ null → 루트 이동 (parent_id: null 그대로 DB 반영)
- **AC4** ✅ 미존재 parent_id → 404, is_folder=false → 400
- **AC5** ✅ pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)