### PR TITLE
fix(sprint): close() velocity DB 저장 버그 수정

### DIFF
--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -10,6 +10,7 @@ export interface Sprint {
   start_date: string;
   end_date: string;
   team_size: number | null;
+  velocity: number | null;
   created_at: string;
   updated_at: string;
 }
@@ -29,6 +30,7 @@ export interface UpdateSprintInput {
   end_date?: string;
   team_size?: number;
   status?: string;
+  velocity?: number | null;
 }
 
 export interface SprintListFilters extends PaginationOptions {

--- a/packages/storage-sqlite/src/SqliteSprintRepository.ts
+++ b/packages/storage-sqlite/src/SqliteSprintRepository.ts
@@ -47,7 +47,7 @@ export class SqliteSprintRepository implements ISprintRepository {
   }
 
   async update(id: string, input: UpdateSprintInput): Promise<Sprint> {
-    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status'];
+    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status', 'velocity'];
     const sets: string[] = [];
     const params: SqlParam[] = [];
     for (const key of ALLOWED) {

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -151,6 +151,7 @@ function initSchema(db: DatabaseSync): void {
       start_date TEXT NOT NULL,
       end_date TEXT NOT NULL,
       team_size INTEGER,
+      velocity INTEGER,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       deleted_at TEXT

--- a/packages/storage-supabase/src/SupabaseSprintRepository.ts
+++ b/packages/storage-supabase/src/SupabaseSprintRepository.ts
@@ -59,7 +59,7 @@ export class SupabaseSprintRepository implements ISprintRepository {
   }
 
   async update(id: string, input: UpdateSprintInput): Promise<Sprint> {
-    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status'];
+    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status', 'velocity'];
     const patch: Record<string, unknown> = {};
     for (const key of ALLOWED) {
       if (key in input) patch[key] = input[key];


### PR DESCRIPTION
## 원인

`sprint.ts:159` — `this.repo.update(id, { status: 'closed', velocity })`로 velocity를 전달하지만, 두 repository 구현체의 ALLOWED 필드에 `velocity`가 없어 silently 무시됨. SQLite 스키마에는 컬럼 자체 없음.

## 수정 파일 (4파일)

| 파일 | 변경 |
|------|------|
| `packages/core-storage/src/interfaces/ISprintRepository.ts` | `Sprint.velocity` + `UpdateSprintInput.velocity` 추가 |
| `packages/storage-supabase/src/SupabaseSprintRepository.ts` | ALLOWED에 `velocity` 추가 |
| `packages/storage-sqlite/src/SqliteSprintRepository.ts` | ALLOWED에 `velocity` 추가 |
| `packages/storage-sqlite/src/db.ts` | sprints 테이블에 `velocity INTEGER` 컬럼 추가 |

## AC

- **AC1** ✅ SupabaseSprintRepository ALLOWED에 velocity 추가
- **AC2** ✅ SqliteSprintRepository ALLOWED에 velocity 추가
- **AC3** ✅ SQLite sprints 스키마 velocity INTEGER 컬럼 추가
- **AC4** ✅ 저장 후 조회 시 velocity 반환 (ALLOWED 통과로 DB 반영)
- **AC5** ✅ pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)