### PR TITLE
copy: reposition as memo-first delegation system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Sprintable
 
-**Agents run the sprint. You review.**
+**Delegate work in plain language. Sprintable turns it into action.**
 
-Sprintable is a project management system built for AI agent teams. Instead of a human managing tickets, agents receive assignments via webhook, do the work, and reply — waking up the next agent in the chain. You set the rules; the sprint runs itself.
+Sprintable is a memo-first delegation system for human and AI teams.
+You start with a memo written in business language. Sprintable routes it through webhooks, connected agents pick it up through MCP, and every handoff stays in one thread.
 
-> "Think of it like spinning up a side project locally and letting your agents drive it."
+Instead of manually orchestrating agents or forcing people to model work as ticket trees upfront, Sprintable lets delegation start naturally and structure emerge as needed.
 
 ---
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -477,11 +477,11 @@
     "navPricing": "Pricing",
     "github": "GitHub",
     "badge": "New",
-    "badgeText": "v2.0: multi-agent orchestration for real sprint teams",
+    "badgeText": "Memo-first. Webhook-triggered. MCP-connected.",
     "hero": {
-      "eyebrow": "Open-source PM + agent ops",
-      "headline": "From BYOA pilots to agent teams that ship",
-      "subheadline": "Sprintable gives buyers one clear story: start with your own AI agents, keep delivery visible in the sprint surface, then upgrade to hosted orchestration when the team needs a durable command chain.",
+      "eyebrow": "The delegation layer for human and AI teams",
+      "headline": "Delegate work in plain language.",
+      "subheadline": "Sprintable turns your business requests into executable workflows across human and AI teams — without making you manage the orchestration yourself.",
       "audiences": [
         "Founders shipping with AI",
         "Operators running multi-agent workflows",
@@ -645,7 +645,7 @@
       "primary": "Start free",
       "secondary": "Read docs"
     },
-    "footerDesc": "Open-source PM and agent operations surface for teams that want delivery proof, not AI hype.",
+    "footerDesc": "The memo-first delegation system for human and AI teams. Open-source, self-hostable, MCP-native.",
     "footerDocs": "Documentation",
     "footerChangelog": "Changelog",
     "footerCompany": "Company",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -477,11 +477,11 @@
     "navPricing": "요금제",
     "github": "GitHub",
     "badge": "New",
-    "badgeText": "v2.0: 실제 스프린트 팀을 위한 멀티에이전트 오케스트레이션",
+    "badgeText": "메모 기반. 웹훅 트리거. MCP 연결.",
     "hero": {
-      "eyebrow": "오픈소스 PM + 에이전트 운영 표면",
-      "headline": "BYOA 실험에서 실제로 배포하는 에이전트 팀까지",
-      "subheadline": "Sprintable은 구매자가 바로 이해할 수 있는 하나의 흐름을 제공합니다. 먼저 팀이 이미 쓰는 AI 에이전트로 시작하고, 스프린트 표면 안에서 전달 과정을 보이게 유지한 뒤, 팀에 durable한 command chain이 필요해질 때 hosted orchestration으로 확장하는 구조입니다.",
+      "eyebrow": "사람과 AI 팀을 위한 위임 레이어",
+      "headline": "일상 언어로 업무를 위임하세요.",
+      "subheadline": "Sprintable은 비즈니스 요청을 사람과 AI 팀 전체에 걸친 실행 가능한 워크플로우로 전환합니다 — 오케스트레이션을 직접 관리할 필요 없이.",
       "audiences": [
         "AI와 함께 직접 배포하는 창업자",
         "멀티에이전트 워크플로우를 운영하는 오퍼레이터",
@@ -645,7 +645,7 @@
       "primary": "무료로 시작",
       "secondary": "문서 보기"
     },
-    "footerDesc": "AI 과장이 아니라 실제 전달 증거를 보여주고 싶은 팀을 위한 오픈소스 PM + agent operations 표면입니다.",
+    "footerDesc": "사람과 AI 팀을 위한 메모 기반 위임 시스템. 오픈소스, 셀프호스팅, MCP 네이티브.",
     "footerDocs": "문서",
     "footerChangelog": "변경 로그",
     "footerCompany": "회사",

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -1,6 +1,8 @@
 # Sprintable — Full LLM Reference
 
-Delegate work in plain language. Sprintable turns it into action. Sprintable is a memo-first delegation system for human and AI teams. Agents receive work via webhook, operate via MCP, and hand off via memo replies.
+Delegate work in plain language. Sprintable turns it into action.
+
+Sprintable is a memo-first delegation system for human and AI teams. Agents receive work via webhook, operate via MCP, and hand off via memo replies.
 
 Quick start: https://sprintable.ai/llms.txt
 

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -1,6 +1,6 @@
 # Sprintable — Full LLM Reference
 
-Sprintable is an AI-native project management system. Agents receive work via webhook, operate via MCP, and hand off via memo replies.
+Delegate work in plain language. Sprintable turns it into action. Sprintable is a memo-first delegation system for human and AI teams. Agents receive work via webhook, operate via MCP, and hand off via memo replies.
 
 Quick start: https://sprintable.ai/llms.txt
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,8 @@
 # Sprintable
 
-Sprintable is an AI-native project management system where agents run the sprint autonomously via a memo-webhook cycle.
+Delegate work in plain language. Sprintable turns it into action.
+
+Sprintable is a memo-first delegation system for human and AI teams.
 
 ## Core Concept
 


### PR DESCRIPTION
## Summary
- README hero: "Agents run the sprint" → "Delegate work in plain language. Sprintable turns it into action."
- llms.txt / llms-full.txt: "AI-native project management system" → delegation-focused first line
- Landing page i18n (en/ko): headline, subheadline, eyebrow, badge, footer updated to delegation positioning
- No logic changes — copy only

## Context
GPT + Oscar 독립 분석 결과 도출된 최종 포지셔닝:
- **외부 메인**: "Delegate work in plain language. Sprintable turns it into action."
- **제품 정체성**: "Sprintable is a memo-first delegation system for human and AI teams."
- **내부 철학**: "Delegation is the first-class primitive. Memo is its default human interface."

## Test plan
- [ ] Landing page renders correctly (en/ko)
- [ ] llms.txt / llms-full.txt accessible at /llms.txt, /llms-full.txt
- [ ] README displays correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)