### PR TITLE
fix(sec-s1): API Key owner 발급 허용 + agent_api_keys DELETE RLS 추가

### DIFF
--- a/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
@@ -34,7 +34,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       .eq('id', me.id)
       .single();
 
-    if (!myMember || myMember.role !== 'admin') {
+    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
       return ApiErrors.forbidden('Admin only');
     }
 

--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       .eq('id', me.id)
       .single();
 
-    if (!myMember || myMember.role !== 'admin') {
+    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
       return ApiErrors.forbidden('Admin only');
     }
 
@@ -114,7 +114,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       .eq('id', me.id)
       .single();
 
-    if (!myMember || myMember.role !== 'admin') {
+    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
       return ApiErrors.forbidden('Admin only');
     }
 

--- a/packages/db/supabase/migrations/20260424000000_agent_api_keys_delete_rls.sql
+++ b/packages/db/supabase/migrations/20260424000000_agent_api_keys_delete_rls.sql
@@ -1,0 +1,13 @@
+-- E-SEC-HARDENING:S1 — agent_api_keys DELETE RLS 추가
+-- 정책(§13 P0-2): org admin(owner+admin)만 삭제 가능
+
+-- DELETE: org admin(owner+admin)만 삭제 가능
+CREATE POLICY "agent_api_keys_delete_admin"
+  ON public.agent_api_keys FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.id = team_member_id
+        AND tm.org_id IN (SELECT public.get_user_admin_org_ids())
+    )
+  );


### PR DESCRIPTION
## 배경

- API Key 발급 라우트가 `role === 'admin'`만 허용 → owner 역할 사용자 발급 불가
- DB RLS는 `get_user_admin_org_ids()`로 owner+admin 모두 허용 — 런타임과 불일치
- `agent_api_keys` DELETE RLS 정책 누락 → 삭제 무방비

## 변경 파일 (3파일)

| 파일 | 변경 |
|------|------|
| `api/agents/[id]/api-key/route.ts` | POST+GET role 체크: `!== 'admin'` → `!['owner','admin'].includes()` |
| `api/agents/[id]/api-key/[keyId]/route.ts` | DELETE role 체크 동일 수정 |
| `migrations/20260424000000_agent_api_keys_delete_rls.sql` | DELETE RLS 정책 추가 (owner+admin만) |

## AC

- **AC1** ✅ owner 역할로 `POST /api/agents/{id}/api-key` 호출 시 키 발급 가능
- **AC2** ✅ `['owner','admin'].includes(role)` 체크로 변경 (3곳)
- **AC3** ✅ `agent_api_keys_delete_admin` RLS 정책 추가
- **AC4** ✅ Supabase migration 추가 / SQLite는 OSS 모드 role 체크 없음(로컬 단일사용자)
- **AC5** ✅ pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)