### PR TITLE
feat(sec-s2): API Key expires_at 만료 정책 추가

### DIFF
--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -17,8 +17,10 @@ export async function POST(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
       const { id: teamMemberId } = await params;
+      const body = await request.json().catch(() => ({})) as { expires_at?: string };
       const { apiKey, keyPrefix, keyHash } = generateApiKey();
-      const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+      const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+      const expiresAt = body.expires_at ?? defaultExpiry;
       const repo = await createAgentApiKeyRepository();
       const row = await repo.create({ teamMemberId, keyPrefix, keyHash, expiresAt });
       return apiSuccess({ ...row, api_key: apiKey }, undefined, 201);
@@ -59,8 +61,10 @@ export async function POST(request: Request, { params }: RouteParams) {
     }
 
     // API Key 생성
+    const body = await request.json().catch(() => ({})) as { expires_at?: string };
     const { apiKey, keyPrefix, keyHash } = generateApiKey();
-    const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
+    const expiresAt = body.expires_at ?? defaultExpiry;
 
     // DB에 저장
     const { data: apiKeyRow, error: insertError } = await supabase
@@ -124,7 +128,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     // API Key 목록 조회
     const { data: keys, error } = await supabase
       .from('agent_api_keys')
-      .select('id, team_member_id, key_prefix, created_at, revoked_at, last_used_at')
+      .select('id, team_member_id, key_prefix, created_at, revoked_at, last_used_at, expires_at')
       .eq('team_member_id', teamMemberId);
 
     if (error) throw error;

--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -18,8 +18,9 @@ export async function POST(request: Request, { params }: RouteParams) {
     try {
       const { id: teamMemberId } = await params;
       const { apiKey, keyPrefix, keyHash } = generateApiKey();
+      const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
       const repo = await createAgentApiKeyRepository();
-      const row = await repo.create({ teamMemberId, keyPrefix, keyHash });
+      const row = await repo.create({ teamMemberId, keyPrefix, keyHash, expiresAt });
       return apiSuccess({ ...row, api_key: apiKey }, undefined, 201);
     } catch (err: unknown) { return handleApiError(err); }
   }
@@ -59,6 +60,7 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     // API Key 생성
     const { apiKey, keyPrefix, keyHash } = generateApiKey();
+    const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
 
     // DB에 저장
     const { data: apiKeyRow, error: insertError } = await supabase
@@ -67,8 +69,9 @@ export async function POST(request: Request, { params }: RouteParams) {
         team_member_id: teamMemberId,
         key_prefix: keyPrefix,
         key_hash: keyHash,
+        expires_at: expiresAt,
       })
-      .select('id, key_prefix, created_at')
+      .select('id, key_prefix, created_at, expires_at')
       .single();
 
     if (insertError || !apiKeyRow) {

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -21,6 +21,7 @@ interface ApiKey {
   created_at: string;
   last_used_at: string | null;
   revoked_at: string | null;
+  expires_at: string | null;
 }
 
 interface AgentApiKeyManagerProps {
@@ -156,6 +157,21 @@ export function AgentApiKeyManager({ agentId, agentName }: AgentApiKeyManagerPro
                     ` • Last used: ${new Date(key.last_used_at).toLocaleDateString()}`}
                   {key.revoked_at && ` • Revoked: ${new Date(key.revoked_at).toLocaleDateString()}`}
                 </p>
+                {key.expires_at && !key.revoked_at && (() => {
+                  const expiresDate = new Date(key.expires_at);
+                  const daysLeft = Math.ceil((expiresDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24));
+                  const isExpired = daysLeft <= 0;
+                  const isWarning = daysLeft > 0 && daysLeft <= 7;
+                  return (
+                    <p className={`text-xs mt-0.5 ${isExpired ? 'text-destructive font-medium' : isWarning ? 'text-orange-500 font-medium' : 'text-muted-foreground'}`}>
+                      {isExpired
+                        ? `Expired ${expiresDate.toLocaleDateString()}`
+                        : isWarning
+                          ? `⚠ Expires in ${daysLeft} day${daysLeft === 1 ? '' : 's'} (${expiresDate.toLocaleDateString()})`
+                          : `Expires: ${expiresDate.toLocaleDateString()}`}
+                    </p>
+                  );
+                })()}
               </div>
               {!key.revoked_at && (
                 <Button

--- a/apps/web/src/lib/auth-api-key.ts
+++ b/apps/web/src/lib/auth-api-key.ts
@@ -58,12 +58,17 @@ export async function getTeamMemberFromApiKey(
   // RLS 우회 필요 - admin client 사용
   const { data: apiKeyRow, error: keyError } = await adminClient
     .from('agent_api_keys')
-    .select('id, team_member_id, revoked_at')
+    .select('id, team_member_id, revoked_at, expires_at')
     .eq('key_hash', keyHash)
     .is('revoked_at', null)
     .maybeSingle();
 
   if (keyError || !apiKeyRow) {
+    return null;
+  }
+
+  // AC3: 만료 키 거부 (expires_at=NULL이면 무기한 유효)
+  if (apiKeyRow.expires_at && new Date(apiKeyRow.expires_at) < new Date()) {
     return null;
   }
 

--- a/packages/core-storage/src/interfaces/IAgentApiKeyRepository.ts
+++ b/packages/core-storage/src/interfaces/IAgentApiKeyRepository.ts
@@ -6,12 +6,14 @@ export interface AgentApiKey {
   created_at: string;
   revoked_at: string | null;
   last_used_at: string | null;
+  expires_at: string | null;
 }
 
 export interface CreateAgentApiKeyInput {
   teamMemberId: string;
   keyPrefix: string;
   keyHash: string;
+  expiresAt?: string | null;
 }
 
 export interface IAgentApiKeyRepository {

--- a/packages/db/supabase/migrations/20260424001000_agent_api_keys_expires_at.sql
+++ b/packages/db/supabase/migrations/20260424001000_agent_api_keys_expires_at.sql
@@ -1,0 +1,7 @@
+-- E-SEC-HARDENING:S2 — agent_api_keys expires_at 만료 정책
+-- 정책(§8 보안 현황, §13 P0-3) 구현
+
+ALTER TABLE public.agent_api_keys
+  ADD COLUMN IF NOT EXISTS expires_at timestamptz;
+
+COMMENT ON COLUMN public.agent_api_keys.expires_at IS '키 만료 시각 (NULL=무기한, 기본 발급 90일)';

--- a/packages/storage-sqlite/src/SqliteAgentApiKeyRepository.ts
+++ b/packages/storage-sqlite/src/SqliteAgentApiKeyRepository.ts
@@ -12,9 +12,10 @@ export class SqliteAgentApiKeyRepository implements IAgentApiKeyRepository {
   async create(input: CreateAgentApiKeyInput): Promise<Pick<AgentApiKey, 'id' | 'key_prefix' | 'created_at'>> {
     const id = randomUUID();
     const now = new Date().toISOString();
+    const expiresAt = input.expiresAt ?? null;
     this.db.prepare(
-      'INSERT INTO agent_api_keys (id, team_member_id, key_prefix, key_hash, created_at) VALUES (?, ?, ?, ?, ?)'
-    ).run(id, input.teamMemberId, input.keyPrefix, input.keyHash, now);
+      'INSERT INTO agent_api_keys (id, team_member_id, key_prefix, key_hash, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, input.teamMemberId, input.keyPrefix, input.keyHash, now, expiresAt);
     return { id, key_prefix: input.keyPrefix, created_at: now };
   }
 

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -261,7 +261,8 @@ function initSchema(db: DatabaseSync): void {
       key_hash TEXT NOT NULL,
       created_at TEXT NOT NULL,
       revoked_at TEXT,
-      last_used_at TEXT
+      last_used_at TEXT,
+      expires_at TEXT
     );
 
     CREATE INDEX IF NOT EXISTS idx_agent_runs_org_project ON agent_runs(org_id, project_id);


### PR DESCRIPTION
## 배경

현재 API Key는 만료 없이 무기한 유효 → 키 유출 시 revoke 전까지 영구 악용 가능.

## 변경 파일 (7파일)

| 파일 | 변경 |
|------|------|
| `migrations/20260424001000_agent_api_keys_expires_at.sql` | `expires_at timestamptz NULL` 컬럼 추가 |
| `IAgentApiKeyRepository.ts` | `AgentApiKey.expires_at` + `CreateAgentApiKeyInput.expiresAt` 추가 |
| `SqliteAgentApiKeyRepository.ts` | create INSERT에 expires_at 추가 |
| `storage-sqlite/db.ts` | SQLite 스키마 expires_at TEXT 컬럼 추가 |
| `auth-api-key.ts` | 만료 키 거부 (`expires_at < now()` → null 반환) |
| `api/agents/[id]/api-key/route.ts` | 발급 시 기본 90일 만료 설정 (OSS+Supabase) |
| `agent-api-key-manager.tsx` | 만료일 표시 + 7일 이내 ⚠ 경고, 만료됨 red 표시 |

## AC

- **AC1** ✅ `expires_at timestamptz NULL` migration 추가
- **AC2** ✅ 발급 시 기본 90일 만료 (`Date.now() + 90d`)
- **AC3** ✅ 인증 시 만료 체크 → 401 거부
- **AC4** ✅ UI 만료일 표시 + 7일 이내 오렌지 경고 + 만료됨 red
- **AC5** ✅ `expires_at=NULL` → 무기한 (하위호환)
- **AC6** ✅ Supabase migration + SQLite 스키마/repository 양쪽 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)