### PR TITLE
feat(sec-s3): API Key scope 접근 범위 제한

### DIFF
--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -17,12 +17,13 @@ export async function POST(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
       const { id: teamMemberId } = await params;
-      const body = await request.json().catch(() => ({})) as { expires_at?: string };
+      const body = await request.json().catch(() => ({})) as { expires_at?: string; scope?: string[] };
       const { apiKey, keyPrefix, keyHash } = generateApiKey();
       const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
       const expiresAt = body.expires_at ?? defaultExpiry;
+      const scope = body.scope ?? ['read', 'write'];
       const repo = await createAgentApiKeyRepository();
-      const row = await repo.create({ teamMemberId, keyPrefix, keyHash, expiresAt });
+      const row = await repo.create({ teamMemberId, keyPrefix, keyHash, expiresAt, scope });
       return apiSuccess({ ...row, api_key: apiKey }, undefined, 201);
     } catch (err: unknown) { return handleApiError(err); }
   }
@@ -31,6 +32,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     const supabase = await createSupabaseServerClient();
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
+
+    // AC4: API Key로 접근 시 admin scope 필요
+    if (me.type === 'agent' && !me.scope?.includes('admin')) {
+      return ApiErrors.insufficientScope('admin');
+    }
 
     // Admin 권한 확인
     const { data: myMember } = await supabase
@@ -61,10 +67,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     }
 
     // API Key 생성
-    const body = await request.json().catch(() => ({})) as { expires_at?: string };
+    const body = await request.json().catch(() => ({})) as { expires_at?: string; scope?: string[] };
     const { apiKey, keyPrefix, keyHash } = generateApiKey();
     const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
     const expiresAt = body.expires_at ?? defaultExpiry;
+    const scope = body.scope ?? ['read', 'write'];
 
     // DB에 저장
     const { data: apiKeyRow, error: insertError } = await supabase
@@ -74,8 +81,9 @@ export async function POST(request: Request, { params }: RouteParams) {
         key_prefix: keyPrefix,
         key_hash: keyHash,
         expires_at: expiresAt,
+        scope,
       })
-      .select('id, key_prefix, created_at, expires_at')
+      .select('id, key_prefix, created_at, expires_at, scope')
       .single();
 
     if (insertError || !apiKeyRow) {

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,16 +1,22 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { getMyTeamMember } from '@/lib/auth-helpers';
+import { getMyTeamMember, getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
 
 export async function DELETE(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ id: string }> },
 ) {
   if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Member management is not supported in OSS mode.', 501);
   try {
     const supabase = await createSupabaseServerClient();
+    // AC4: API Key로 접근하는 에이전트는 admin scope 필요
+    const meScope = await getAuthContext(supabase, request);
+    if (meScope?.type === 'agent' && !meScope.scope?.includes('admin')) {
+      return ApiErrors.insufficientScope('admin');
+    }
+
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return ApiErrors.unauthorized();
 

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -80,6 +80,13 @@ export async function POST(request: Request) {
   }
   try {
     const supabase = await createSupabaseServerClient();
+    // AC4: API Key로 접근하는 에이전트는 admin scope 필요
+    const { getAuthContext } = await import('@/lib/auth-helpers');
+    const meScope = await getAuthContext(supabase, request);
+    if (meScope?.type === 'agent' && !meScope.scope?.includes('admin')) {
+      return ApiErrors.insufficientScope('admin');
+    }
+
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return ApiErrors.unauthorized();
 

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -15,6 +15,9 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/components/ui/toast';
 
+const SCOPES = ['read', 'write', 'admin'] as const;
+type Scope = typeof SCOPES[number];
+
 interface ApiKey {
   id: string;
   key_prefix: string;
@@ -22,6 +25,7 @@ interface ApiKey {
   last_used_at: string | null;
   revoked_at: string | null;
   expires_at: string | null;
+  scope: string[] | null;
 }
 
 interface AgentApiKeyManagerProps {
@@ -34,6 +38,7 @@ export function AgentApiKeyManager({ agentId, agentName }: AgentApiKeyManagerPro
   const [loading, setLoading] = useState(false);
   const [newKeyDialog, setNewKeyDialog] = useState(false);
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
+  const [selectedScopes, setSelectedScopes] = useState<Scope[]>(['read', 'write']);
   const { addToast } = useToast();
 
   // Load API keys on mount
@@ -64,6 +69,8 @@ export function AgentApiKeyManager({ agentId, agentName }: AgentApiKeyManagerPro
     try {
       const response = await fetch(`/api/agents/${agentId}/api-key`, {
         method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: selectedScopes }),
       });
       if (!response.ok) throw new Error('Failed to generate API key');
       const result = await response.json();
@@ -138,6 +145,26 @@ export function AgentApiKeyManager({ agentId, agentName }: AgentApiKeyManagerPro
             Generate API Key
           </Button>
         </div>
+        <div className="flex gap-4 mt-3">
+          <p className="text-xs text-muted-foreground self-center">Scope:</p>
+          {SCOPES.map((scope) => (
+            <label key={scope} className="flex items-center gap-1.5 text-xs cursor-pointer">
+              <input
+                type="checkbox"
+                checked={selectedScopes.includes(scope)}
+                onChange={(e) => {
+                  if (e.target.checked) {
+                    setSelectedScopes((prev) => [...prev, scope]);
+                  } else {
+                    setSelectedScopes((prev) => prev.filter((s) => s !== scope));
+                  }
+                }}
+                className="h-3 w-3"
+              />
+              <span className={scope === 'admin' ? 'text-orange-500 font-medium' : ''}>{scope}</span>
+            </label>
+          ))}
+        </div>
       </div>
 
       {apiKeys.length === 0 ? (
@@ -150,7 +177,12 @@ export function AgentApiKeyManager({ agentId, agentName }: AgentApiKeyManagerPro
               className="flex items-center justify-between p-3 border rounded-md"
             >
               <div>
-                <p className="font-mono text-sm">{key.key_prefix}...</p>
+                <div className="flex items-center gap-2">
+                  <p className="font-mono text-sm">{key.key_prefix}...</p>
+                  {(key.scope ?? ['read', 'write']).map((s) => (
+                    <span key={s} className={`text-xs px-1.5 py-0.5 rounded font-medium ${s === 'admin' ? 'bg-orange-100 text-orange-700' : 'bg-muted text-muted-foreground'}`}>{s}</span>
+                  ))}
+                </div>
                 <p className="text-xs text-muted-foreground">
                   Created: {new Date(key.created_at).toLocaleDateString()}
                   {key.last_used_at &&

--- a/apps/web/src/lib/api-response.ts
+++ b/apps/web/src/lib/api-response.ts
@@ -60,6 +60,7 @@ export function apiUpgradeRequired(message: string, meterType: string, status = 
 export const ApiErrors = {
   unauthorized: () => apiError('UNAUTHORIZED', 'Unauthorized', 401),
   forbidden: (msg = 'Forbidden') => apiError('FORBIDDEN', msg, 403),
+  insufficientScope: (required: string) => apiError('FORBIDDEN', 'Insufficient scope', 403, { error: 'insufficient_scope', required }),
   notFound: (msg = 'Not found') => apiError('NOT_FOUND', msg, 404),
   badRequest: (msg: string) => apiError('BAD_REQUEST', msg, 400),
   validationFailed: (issues: Array<{ path: string; message: string }>) =>

--- a/apps/web/src/lib/auth-api-key.ts
+++ b/apps/web/src/lib/auth-api-key.ts
@@ -7,6 +7,7 @@ export interface TeamMemberContext {
   project_id: string;
   name: string;
   type: 'human' | 'agent';
+  scope?: string[];
 }
 
 /**
@@ -58,7 +59,7 @@ export async function getTeamMemberFromApiKey(
   // RLS 우회 필요 - admin client 사용
   const { data: apiKeyRow, error: keyError } = await adminClient
     .from('agent_api_keys')
-    .select('id, team_member_id, revoked_at, expires_at')
+    .select('id, team_member_id, revoked_at, expires_at, scope')
     .eq('key_hash', keyHash)
     .is('revoked_at', null)
     .maybeSingle();
@@ -67,10 +68,13 @@ export async function getTeamMemberFromApiKey(
     return null;
   }
 
-  // AC3: 만료 키 거부 (expires_at=NULL이면 무기한 유효)
+  // 만료 키 거부 (expires_at=NULL이면 무기한 유효)
   if (apiKeyRow.expires_at && new Date(apiKeyRow.expires_at) < new Date()) {
     return null;
   }
+
+  // AC6: scope=NULL이면 ['read','write'] 기본값 적용 (admin 제외 하위호환)
+  const scope: string[] = (apiKeyRow.scope as string[] | null) ?? ['read', 'write'];
 
   // 2. team_member 조회
   // RLS 우회 필요 - admin client 사용
@@ -97,6 +101,7 @@ export async function getTeamMemberFromApiKey(
     project_id: member.project_id as string,
     name: member.name as string,
     type: member.type as 'human' | 'agent',
+    scope,
   };
 }
 

--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -201,6 +201,7 @@ export async function getAuthContext(
   project_id: string;
   project_name: string;
   type?: 'human' | 'agent';
+  scope?: string[];
   rateLimitExceeded?: boolean;
   rateLimitRemaining?: number;
   rateLimitResetAt?: number;
@@ -239,6 +240,7 @@ export async function getAuthContext(
         project_id: apiKeyMember.project_id,
         project_name: '', // API Key 인증은 project_name이 없음 (필요시 별도 조회)
         type: apiKeyMember.type,
+        scope: apiKeyMember.scope,
         rateLimitExceeded: !allowed,
         rateLimitRemaining: remaining,
         rateLimitResetAt: resetAt,

--- a/packages/core-storage/src/interfaces/IAgentApiKeyRepository.ts
+++ b/packages/core-storage/src/interfaces/IAgentApiKeyRepository.ts
@@ -7,6 +7,7 @@ export interface AgentApiKey {
   revoked_at: string | null;
   last_used_at: string | null;
   expires_at: string | null;
+  scope: string[] | null;
 }
 
 export interface CreateAgentApiKeyInput {
@@ -14,6 +15,7 @@ export interface CreateAgentApiKeyInput {
   keyPrefix: string;
   keyHash: string;
   expiresAt?: string | null;
+  scope?: string[];
 }
 
 export interface IAgentApiKeyRepository {

--- a/packages/db/supabase/migrations/20260424002000_agent_api_keys_scope.sql
+++ b/packages/db/supabase/migrations/20260424002000_agent_api_keys_scope.sql
@@ -1,0 +1,7 @@
+-- E-SEC-HARDENING:S3 — agent_api_keys scope 접근 범위 제한
+-- 정책(§7, §13 P0-4) 구현
+
+ALTER TABLE public.agent_api_keys
+  ADD COLUMN IF NOT EXISTS scope text[] DEFAULT '{read,write}';
+
+COMMENT ON COLUMN public.agent_api_keys.scope IS 'API Key 권한 범위 (read, write, admin). NULL=["read","write"] 하위호환';

--- a/packages/storage-sqlite/src/SqliteAgentApiKeyRepository.ts
+++ b/packages/storage-sqlite/src/SqliteAgentApiKeyRepository.ts
@@ -13,16 +13,21 @@ export class SqliteAgentApiKeyRepository implements IAgentApiKeyRepository {
     const id = randomUUID();
     const now = new Date().toISOString();
     const expiresAt = input.expiresAt ?? null;
+    const scope = JSON.stringify(input.scope ?? ['read', 'write']);
     this.db.prepare(
-      'INSERT INTO agent_api_keys (id, team_member_id, key_prefix, key_hash, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)'
-    ).run(id, input.teamMemberId, input.keyPrefix, input.keyHash, now, expiresAt);
+      'INSERT INTO agent_api_keys (id, team_member_id, key_prefix, key_hash, created_at, expires_at, scope) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).run(id, input.teamMemberId, input.keyPrefix, input.keyHash, now, expiresAt, scope);
     return { id, key_prefix: input.keyPrefix, created_at: now };
   }
 
   async list(teamMemberId: string): Promise<AgentApiKey[]> {
-    return this.db.prepare(
+    const rows = this.db.prepare(
       'SELECT * FROM agent_api_keys WHERE team_member_id = ? ORDER BY created_at DESC'
-    ).all(teamMemberId) as unknown as AgentApiKey[];
+    ).all(teamMemberId) as Array<Record<string, unknown>>;
+    return rows.map((row) => ({
+      ...row,
+      scope: row.scope ? JSON.parse(row.scope as string) as string[] : ['read', 'write'],
+    })) as unknown as AgentApiKey[];
   }
 
   async revoke(keyId: string): Promise<void> {

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -262,7 +262,8 @@ function initSchema(db: DatabaseSync): void {
       created_at TEXT NOT NULL,
       revoked_at TEXT,
       last_used_at TEXT,
-      expires_at TEXT
+      expires_at TEXT,
+      scope TEXT DEFAULT '["read","write"]'
     );
 
     CREATE INDEX IF NOT EXISTS idx_agent_runs_org_project ON agent_runs(org_id, project_id);


### PR DESCRIPTION
## 배경

현재 API Key에 scope 필드 없음 → agent 컨텍스트로 전 API 접근 가능. 읽기만 필요한 에이전트도 쓰기/삭제 가능.

## 변경 파일 (11파일)

| 파일 | 변경 |
|------|------|
| `migrations/20260424002000_agent_api_keys_scope.sql` | `scope text[] DEFAULT '{read,write}'` 추가 |
| `IAgentApiKeyRepository.ts` | `AgentApiKey.scope` + `CreateAgentApiKeyInput.scope` 추가 |
| `SqliteAgentApiKeyRepository.ts` | create scope JSON + list scope JSON.parse |
| `storage-sqlite/db.ts` | SQLite scope TEXT 컬럼 추가 |
| `auth-api-key.ts` | `TeamMemberContext.scope` + getTeamMemberFromApiKey scope 반환 |
| `auth-helpers.ts` | `getAuthContext` 반환 타입 + scope 전파 |
| `api-response.ts` | `ApiErrors.insufficientScope(required)` 헬퍼 추가 |
| `api/agents/[id]/api-key/route.ts` | POST scope 수신/저장/scope 체크, GET scope select |
| `api/team-members/route.ts` | POST 멤버 추가 agent admin scope 체크 |
| `api/team-members/[id]/route.ts` | DELETE 멤버 삭제 agent admin scope 체크 |
| `agent-api-key-manager.tsx` | read/write/admin 체크박스 + 키 목록 scope 배지 |

## AC

- **AC1** ✅ `scope text[] DEFAULT '{read,write}'` migration + SQLite 양쪽
- **AC2** ✅ UI read/write/admin 체크박스, 키 목록 scope 배지 (admin=오렌지)
- **AC3** ✅ `getAuthContext()` 반환에 scope 포함
- **AC4** ✅ POST agents api-key, POST/DELETE team-members admin scope 체크
- **AC5** ✅ 403 `{ error: 'insufficient_scope', required: 'admin' }` (ApiErrors.insufficientScope)
- **AC6** ✅ scope=NULL → `['read','write']` 기본값 (admin 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)