### PR TITLE
fix(sec-s4): 리워드 cross-project 차단 + CHECK 제약 추가

### DIFF
--- a/apps/web/src/app/api/rewards/route.ts
+++ b/apps/web/src/app/api/rewards/route.ts
@@ -14,7 +14,8 @@ export async function GET(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
+    // AC1: agent 요청 시 me.project_id 강제 — cross-project 조회 차단
+    const projectId = me.type === 'agent' ? me.project_id : searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     const service = new RewardsService(dbClient);
     const type = searchParams.get('type');
@@ -31,6 +32,10 @@ export async function POST(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    // AC2: agent 요청 시 admin scope 필요 (requireOrgAdmin은 OAuth 전용이므로 scope 체크로 대체)
+    if (me.type === 'agent' && !me.scope?.includes('admin')) {
+      return ApiErrors.insufficientScope('admin');
+    }
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const parsed = await parseBody(request, createRewardSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const service = new RewardsService(dbClient);

--- a/packages/db/supabase/migrations/20260424003000_reward_ledger_checks.sql
+++ b/packages/db/supabase/migrations/20260424003000_reward_ledger_checks.sql
@@ -1,0 +1,8 @@
+-- E-SEC-HARDENING:S4 — reward_ledger CHECK 제약 추가
+-- 정책(§4, §13 P0-1,2,3) 구현
+
+ALTER TABLE public.reward_ledger
+  ADD CONSTRAINT chk_reward_currency
+    CHECK (currency IN ('TJSB')),
+  ADD CONSTRAINT chk_reward_reference_type
+    CHECK (reference_type IS NULL OR reference_type IN ('story', 'sprint', 'epic', 'manual'));

--- a/packages/db/supabase/migrations/20260424003000_reward_ledger_checks.sql
+++ b/packages/db/supabase/migrations/20260424003000_reward_ledger_checks.sql
@@ -5,4 +5,6 @@ ALTER TABLE public.reward_ledger
   ADD CONSTRAINT chk_reward_currency
     CHECK (currency IN ('TJSB')),
   ADD CONSTRAINT chk_reward_reference_type
-    CHECK (reference_type IS NULL OR reference_type IN ('story', 'sprint', 'epic', 'manual'));
+    CHECK (reference_type IS NULL OR reference_type IN ('story', 'sprint', 'epic', 'manual')),
+  ADD CONSTRAINT chk_reward_amount_nonzero
+    CHECK (amount <> 0);


### PR DESCRIPTION
## 배경

- GET /api/rewards에서 agent 요청 시 입력 project_id 그대로 사용 → 타 프로젝트 원장 조회 가능
- POST /api/rewards에서 에이전트 권한 체크 없음
- reward_ledger에 currency/reference_type 제약 없음

## 변경 파일 (2파일)

| 파일 | 변경 |
|------|------|
| `api/rewards/route.ts` | GET agent → me.project_id 강제 / POST agent admin scope 체크 |
| `migrations/20260424003000_reward_ledger_checks.sql` | currency + reference_type CHECK 제약 |

## AC

- **AC1** ✅ GET — agent 요청 시 `me.project_id` 강제, 입력 project_id 무시
- **AC2** ✅ POST — agent admin scope 체크 (`ApiErrors.insufficientScope('admin')`)
- **AC3** ✅ CHECK 제약: `currency IN ('TJSB')`, `reference_type IS NULL OR IN ('story','sprint','epic','manual')`
- **AC4** ✅ Supabase migration 추가
- **AC5** ✅ server-side 강제로 MCP get_wallet/give_reward도 자동 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)