### PR TITLE
fix(sec-s6): DELETE RLS 일괄 봉쇄 — 6테이블

### DIFF
--- a/packages/db/supabase/migrations/20260424004000_rls_delete_6tables.sql
+++ b/packages/db/supabase/migrations/20260424004000_rls_delete_6tables.sql
@@ -1,0 +1,51 @@
+-- E-SEC-HARDENING:S6 — DELETE RLS 일괄 봉쇄 (6테이블)
+-- 정책(policy-webhook §2, policy-standup §2, policy-retrospective §2)
+
+-- AC1: webhook_configs
+CREATE POLICY "webhook_configs_delete_admin"
+  ON public.webhook_configs FOR DELETE
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- AC2: standup_entries
+CREATE POLICY "standup_entries_delete_admin"
+  ON public.standup_entries FOR DELETE
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- AC3: retro_sessions
+CREATE POLICY "retro_sessions_delete_admin"
+  ON public.retro_sessions FOR DELETE
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- AC4: retro_items (session_id → retro_sessions.org_id)
+CREATE POLICY "retro_items_delete_admin"
+  ON public.retro_items FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.retro_sessions rs
+      WHERE rs.id = session_id
+        AND rs.org_id IN (SELECT public.get_user_admin_org_ids())
+    )
+  );
+
+-- AC5: retro_votes (item_id → retro_items → retro_sessions.org_id)
+CREATE POLICY "retro_votes_delete_admin"
+  ON public.retro_votes FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.retro_items ri
+      JOIN public.retro_sessions rs ON rs.id = ri.session_id
+      WHERE ri.id = item_id
+        AND rs.org_id IN (SELECT public.get_user_admin_org_ids())
+    )
+  );
+
+-- AC6: retro_actions (session_id → retro_sessions.org_id)
+CREATE POLICY "retro_actions_delete_admin"
+  ON public.retro_actions FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.retro_sessions rs
+      WHERE rs.id = session_id
+        AND rs.org_id IN (SELECT public.get_user_admin_org_ids())
+    )
+  );


### PR DESCRIPTION
## 배경

6개 테이블에 DELETE RLS 정책 누락 — 인증된 사용자라면 누구나 삭제 가능.

## 변경 파일 (1파일)

`packages/db/supabase/migrations/20260424004000_rls_delete_6tables.sql` 신규

## AC

| AC | 테이블 | 정책 |
|----|--------|------|
| AC1 | `webhook_configs` | `org_id IN get_user_admin_org_ids()` |
| AC2 | `standup_entries` | `org_id IN get_user_admin_org_ids()` |
| AC3 | `retro_sessions` | `org_id IN get_user_admin_org_ids()` |
| AC4 | `retro_items` | JOIN `retro_sessions` → org_id |
| AC5 | `retro_votes` | JOIN `retro_items` → `retro_sessions` → org_id |
| AC6 | `retro_actions` | JOIN `retro_sessions` → org_id |
| AC7 | migration | 단일 파일 일괄 적용 ✅ |

`get_user_admin_org_ids()` = owner + admin 역할 (기존 함수 재사용).

🤖 Generated with [Claude Code](https://claude.com/claude-code)