### PR TITLE
feat(sec-s5): BYOA webhook HMAC-SHA256 서명 추가

### DIFF
--- a/apps/web/src/lib/webhook-signature.ts
+++ b/apps/web/src/lib/webhook-signature.ts
@@ -1,0 +1,24 @@
+import { createHmac } from 'crypto';
+
+/**
+ * HMAC-SHA256 웹훅 서명 생성 (AC1~AC4)
+ *
+ * 서명 대상: `${timestamp}.${body}`
+ * 헤더: X-Webhook-Signature: sha256={hex}, X-Webhook-Timestamp: {ts}
+ *
+ * AC5: secret이 없으면 undefined 반환 → 헤더 미포함 (하위호환)
+ */
+export function buildWebhookSignatureHeaders(
+  secret: string | null | undefined,
+  body: string,
+): Record<string, string> {
+  if (!secret) return {};
+  const timestamp = Date.now().toString();
+  const signature = createHmac('sha256', secret)
+    .update(`${timestamp}.${body}`)
+    .digest('hex');
+  return {
+    'X-Webhook-Signature': `sha256=${signature}`,
+    'X-Webhook-Timestamp': timestamp,
+  };
+}

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -1,5 +1,6 @@
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
 import { AgentRoutingRuleService, RoutingPolicyError, type RoutingEvaluationResult, type RoutingRuleSummary } from './agent-routing-rule';
+import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
 
 type DispatchSource = 'realtime' | 'polling';
 
@@ -466,7 +467,7 @@ export class MemoEventDispatcher {
             redirect: 'manual',
             headers: {
               'Content-Type': 'application/json',
-              ...(webhook.secret ? { 'X-Webhook-Secret': webhook.secret } : {}),
+              ...buildWebhookSignatureHeaders(webhook.secret, JSON.stringify(outbound.body)),
             },
             body: JSON.stringify(outbound.body),
           },

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -578,7 +578,7 @@ export class MemoEventDispatcher {
           redirect: 'manual',
           headers: {
             'Content-Type': 'application/json',
-            ...(webhook.secret ? { 'X-Webhook-Secret': webhook.secret } : {}),
+            ...buildWebhookSignatureHeaders(webhook.secret, JSON.stringify(outbound.body)),
           },
           body: JSON.stringify(outbound.body),
         },

--- a/apps/web/src/services/webhook-notify.ts
+++ b/apps/web/src/services/webhook-notify.ts
@@ -1,4 +1,5 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
+import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
 
 interface WebhookPayload {
   event: string;
@@ -28,13 +29,16 @@ export async function fireWebhooks(
 
   await Promise.allSettled(
     matching.map(async (config) => {
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (config.secret) headers['X-Webhook-Secret'] = config.secret;
+      const body = JSON.stringify(payload);
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        ...buildWebhookSignatureHeaders(config.secret, body),
+      };
 
       await fetch(config.url, {
         method: 'POST',
         headers,
-        body: JSON.stringify(payload),
+        body,
         signal: AbortSignal.timeout(10_000),
       });
     }),


### PR DESCRIPTION
## 배경

아웃바운드 webhook에 서명 없어 스푸핑 가능. `webhook_configs.secret` 컬럼 미사용 상태.

## 변경 파일 (3파일)

| 파일 | 변경 |
|------|------|
| `lib/webhook-signature.ts` | `buildWebhookSignatureHeaders()` HMAC-SHA256 유틸 (신규) |
| `services/webhook-notify.ts` | `fireWebhooks()` HMAC 서명 적용 |
| `services/memo-event-dispatcher.ts` | 메모 배정 + 메모 답장 dispatch 2경로 HMAC 서명 적용 |

## 서명 알고리즘

```
timestamp = Date.now().toString()
signingInput = `${timestamp}.${body}`
signature = HMAC-SHA256(secret, signingInput).hex()
→ X-Webhook-Signature: sha256={signature}
→ X-Webhook-Timestamp: {timestamp}
```

## AC

- **AC1** ✅ `webhook_configs.secret`으로 HMAC-SHA256 서명 생성
- **AC2** ✅ `X-Webhook-Signature: sha256={hex}` 헤더 포함
- **AC3** ✅ 서명 대상: `timestamp.body`
- **AC4** ✅ `X-Webhook-Timestamp` 헤더 추가
- **AC5** ✅ secret=NULL → 서명 헤더 미포함 (하위호환)
- **AC6** ✅ `fireWebhooks()` + 메모 배정 + 메모 답장 3경로 전부 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)