### PR TITLE
fix(oss): getAuthContext() OSS 모드 API Key 인증 복구 (E-AUTH-HARDENING S1)

### DIFF
--- a/apps/web/src/lib/auth-helpers.test.ts
+++ b/apps/web/src/lib/auth-helpers.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { isOssMode, hashApiKey, prepareMock, getDbMock } = vi.hoisted(() => ({
+  isOssMode: vi.fn(),
+  hashApiKey: vi.fn(),
+  prepareMock: vi.fn(),
+  getDbMock: vi.fn(),
+}));
+
+vi.mock('@/lib/storage/factory', () => ({ isOssMode }));
+vi.mock('@/lib/auth-api-key', () => ({ hashApiKey }));
+vi.mock('@sprintable/storage-sqlite', () => ({
+  OSS_ORG_ID: 'oss-org',
+  OSS_PROJECT_ID: 'oss-proj',
+  OSS_MEMBER_ID: 'oss-member',
+  getDb: getDbMock,
+}));
+
+import { getAuthContext } from './auth-helpers';
+
+describe('getAuthContext — OSS 모드', () => {
+  beforeEach(() => {
+    isOssMode.mockReset();
+    hashApiKey.mockReset();
+    prepareMock.mockReset();
+    getDbMock.mockReset();
+    isOssMode.mockReturnValue(true);
+    hashApiKey.mockReturnValue('hashed-key');
+    getDbMock.mockReturnValue({ prepare: prepareMock });
+  });
+
+  it('유효한 API Key → type: agent 반환', async () => {
+    const getMock = vi.fn()
+      .mockReturnValueOnce({ id: 'key-1', team_member_id: 'member-1' })
+      .mockReturnValueOnce({ id: 'member-1', org_id: 'oss-org', project_id: 'oss-proj', type: 'agent' });
+    const runMock = vi.fn();
+    prepareMock.mockReturnValue({ get: getMock, run: runMock });
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer sk_live_test123' },
+    });
+
+    const result = await getAuthContext({} as never, request);
+
+    expect(result?.type).toBe('agent');
+    expect(result?.id).toBe('member-1');
+    expect(runMock).toHaveBeenCalledOnce();
+  });
+
+  it('API Key 없음 → human fallback', async () => {
+    const request = new Request('http://localhost');
+
+    const result = await getAuthContext({} as never, request);
+
+    expect(result?.type).toBe('human');
+    expect(result?.id).toBe('oss-member');
+    expect(prepareMock).not.toHaveBeenCalled();
+  });
+
+  it('revoked_at 설정 key → human fallback', async () => {
+    prepareMock.mockReturnValue({ get: vi.fn().mockReturnValue(null), run: vi.fn() });
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer sk_live_revoked' },
+    });
+
+    const result = await getAuthContext({} as never, request);
+
+    expect(result?.type).toBe('human');
+    expect(result?.id).toBe('oss-member');
+  });
+
+  it('expires_at 만료 key → human fallback', async () => {
+    prepareMock.mockReturnValue({ get: vi.fn().mockReturnValue(null), run: vi.fn() });
+
+    const request = new Request('http://localhost', {
+      headers: { Authorization: 'Bearer sk_live_expired' },
+    });
+
+    const result = await getAuthContext({} as never, request);
+
+    expect(result?.type).toBe('human');
+    expect(result?.id).toBe('oss-member');
+  });
+});

--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -206,9 +206,43 @@ export async function getAuthContext(
   rateLimitRemaining?: number;
   rateLimitResetAt?: number;
 } | null> {
-  // 1. OSS_MODE — Supabase 없이 고정 멤버 반환 (Bearer 포함 모든 경로)
+  // 1. OSS_MODE — Supabase 없이 SQLite 기반 인증
   if (isOssMode()) {
-    const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } = await import('@sprintable/storage-sqlite');
+    const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID, getDb } = await import('@sprintable/storage-sqlite');
+
+    const authHeader = request.headers.get('Authorization');
+    const xApiKey = request.headers.get('x-api-key');
+    const rawApiKey = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : (xApiKey ?? null);
+
+    if (rawApiKey) {
+      const { hashApiKey } = await import('./auth-api-key');
+      const db = getDb();
+      const keyHash = hashApiKey(rawApiKey);
+      const now = new Date().toISOString();
+
+      const keyRow = db.prepare(
+        'SELECT id, team_member_id FROM agent_api_keys WHERE key_hash = ? AND revoked_at IS NULL AND (expires_at IS NULL OR expires_at > ?) LIMIT 1'
+      ).get(keyHash, now) as { id: string; team_member_id: string } | null;
+
+      if (keyRow) {
+        const member = db.prepare(
+          'SELECT id, org_id, project_id, type FROM team_members WHERE id = ? AND is_active = 1 LIMIT 1'
+        ).get(keyRow.team_member_id) as { id: string; org_id: string; project_id: string; type: string } | null;
+
+        if (member) {
+          db.prepare('UPDATE agent_api_keys SET last_used_at = ? WHERE id = ?').run(now, keyRow.id);
+          return {
+            id: member.id,
+            org_id: member.org_id,
+            project_id: member.project_id,
+            project_name: 'My Project',
+            type: member.type as 'human' | 'agent',
+          };
+        }
+      }
+    }
+
+    // API Key 없거나 인증 실패 시 고정 human 반환 (하위 호환)
     return {
       id: OSS_MEMBER_ID,
       org_id: OSS_ORG_ID,


### PR DESCRIPTION
## Summary

- OSS 모드에서 `getAuthContext()`가 Bearer/x-api-key 헤더를 무시하고 항상 고정 human을 반환하던 버그 수정
- API Key 헤더가 있으면 `hashApiKey()`로 SHA-256 해싱 후 SQLite `agent_api_keys` 테이블에서 조회
- `revoked_at IS NULL` + `expires_at > now` 두 조건 모두 검증
- 인증 성공 시 `team_members` 테이블에서 실제 member 컨텍스트(type 포함) 반환 + `last_used_at` 갱신
- API Key 없거나 인증 실패 시 기존 고정 human 반환 (하위 호환 유지)

## Test plan

- [ ] OSS 모드에서 유효한 API Key로 요청 → `type: 'agent'` 컨텍스트 반환 확인
- [ ] OSS 모드에서 API Key 없이 요청 → 기존 고정 human 반환 확인
- [ ] 만료된/revoked API Key로 요청 → fallback human 반환 확인
- [ ] SaaS 모드 영향 없음 확인 (OSS 블록 조기 반환 구조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)