### PR TITLE
fix: tooManyRequests Retry-After 헤더 추가 (E-AUTH-HARDENING S5 RC)

### DIFF
--- a/apps/web/src/lib/api-response.ts
+++ b/apps/web/src/lib/api-response.ts
@@ -77,6 +77,7 @@ export const ApiErrors = {
         'X-RateLimit-Limit': '300',
         'X-RateLimit-Remaining': String(remaining),
         'X-RateLimit-Reset': String(resetAt),
+        'Retry-After': String(Math.max(0, Math.ceil((resetAt - Date.now()) / 1000))),
       },
     }),
 } as const;


### PR DESCRIPTION
## Summary

`ApiErrors.tooManyRequests()`에 RFC 7231 표준 `Retry-After` 헤더 추가.

`resetAt` (ms epoch) 기준으로 현재 시각과의 차이를 초 단위로 계산.

## Test plan

- [ ] 429 응답 헤더에 `Retry-After: <seconds>` 포함 확인
- [ ] 기존 `X-RateLimit-*` 헤더 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)