### PR TITLE
fix: 메모 할당/답신 웹훅 HMAC 서명 추가 (E-AUTH-HARDENING S7)

### DIFF
--- a/apps/web/src/lib/api-response.ts
+++ b/apps/web/src/lib/api-response.ts
@@ -77,6 +77,7 @@ export const ApiErrors = {
         'X-RateLimit-Limit': '300',
         'X-RateLimit-Remaining': String(remaining),
         'X-RateLimit-Reset': String(resetAt),
+        'Retry-After': String(Math.max(0, Math.ceil((resetAt - Date.now()) / 1000))),
       },
     }),
 } as const;

--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -1,5 +1,6 @@
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { buildAbsoluteMemoLink } from './app-url';
+import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
 
 export interface DispatchableMemo {
   id: string;
@@ -117,12 +118,14 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     const description = `${preview}\n\n${memoLink}`;
 
     const isDiscord = webhookUrl.includes('discord.com') || webhookUrl.includes('discordapp.com');
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (webhookSecret) headers['X-Webhook-Secret'] = webhookSecret;
-
     const body = isDiscord
       ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
       : JSON.stringify({ text: `*${title}*\n${description}` });
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...buildWebhookSignatureHeaders(webhookSecret, body),
+    };
 
     const response = await fetch(webhookUrl, {
       method: 'POST',

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -1,6 +1,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildAbsoluteMemoLink } from './app-url';
 import { hasExactMemberMention } from './doc-comment-notifications';
+import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
 
 interface MemoReplyDispatchMemo {
   id: string;
@@ -175,11 +176,6 @@ async function postWebhook(
   title: string,
   description: string,
 ) {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-  if (webhook.secret) {
-    headers['X-Webhook-Secret'] = webhook.secret;
-  }
-
   const format = detectWebhookFormat(webhook.url);
   const body = format === 'discord'
     ? JSON.stringify({
@@ -189,6 +185,11 @@ async function postWebhook(
     : format === 'google' || format === 'slack'
       ? JSON.stringify({ text: `*${title}*\n${description}` })
       : JSON.stringify({ title, description });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...buildWebhookSignatureHeaders(webhook.secret, body),
+  };
 
   const response = await fetchFn(webhook.url, {
     method: 'POST',


### PR DESCRIPTION
## Summary

- `memo-assignment-dispatch.ts`: `X-Webhook-Secret` 직접 전달 → `buildWebhookSignatureHeaders()` 교체 (body 먼저 생성 후 서명)
- `memo-reply-webhook-dispatch.ts`: 동일 패턴, `postWebhook()` 내 순서 조정

기존 BYOA webhook HMAC 패턴 (`X-Webhook-Signature: sha256=...` + `X-Webhook-Timestamp`) 통일.

## Test plan

- [ ] 메모 할당 시 웹훅에 `X-Webhook-Signature` 헤더 포함 확인
- [ ] 메모 답신 시 웹훅에 `X-Webhook-Signature` 헤더 포함 확인
- [ ] secret 없을 때 서명 헤더 미포함 (하위 호환) 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)