### PR TITLE
feat: epics 스키마 강화 — CHECK 제약 + 계약서 컬럼 4개 (E-DATA-INTEGRITY S1)

### DIFF
--- a/packages/core-storage/src/interfaces/IEpicRepository.ts
+++ b/packages/core-storage/src/interfaces/IEpicRepository.ts
@@ -13,6 +13,10 @@ export interface Epic {
   status: string;
   priority: string;
   description: string | null;
+  objective: string | null;
+  success_criteria: string | null;
+  target_sp: number | null;
+  target_date: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -25,6 +29,10 @@ export interface CreateEpicInput {
   status?: string;
   priority?: string;
   description?: string | null;
+  objective?: string | null;
+  success_criteria?: string | null;
+  target_sp?: number | null;
+  target_date?: string | null;
 }
 
 export interface UpdateEpicInput {
@@ -32,6 +40,10 @@ export interface UpdateEpicInput {
   status?: string;
   priority?: string;
   description?: string | null;
+  objective?: string | null;
+  success_criteria?: string | null;
+  target_sp?: number | null;
+  target_date?: string | null;
 }
 
 export interface EpicListFilters extends PaginationOptions {

--- a/packages/db/supabase/migrations/20260424100000_epic_schema_enhancement.sql
+++ b/packages/db/supabase/migrations/20260424100000_epic_schema_enhancement.sql
@@ -1,0 +1,18 @@
+-- E-DATA-INTEGRITY S1: epics 테이블 스키마 강화
+-- status CHECK 제약 + 계약서 컬럼 4개 추가
+
+-- 1. 기존 status 무효값 정리 (open → active)
+UPDATE epics
+  SET status = 'active'
+  WHERE status NOT IN ('draft', 'active', 'done', 'archived');
+
+-- 2. status CHECK 제약 추가
+ALTER TABLE epics
+  ADD CONSTRAINT epics_status_check
+    CHECK (status IN ('draft', 'active', 'done', 'archived'));
+
+-- 3. 계약서 컬럼 4개 추가 (전부 nullable)
+ALTER TABLE epics ADD COLUMN IF NOT EXISTS objective        TEXT;
+ALTER TABLE epics ADD COLUMN IF NOT EXISTS success_criteria TEXT;
+ALTER TABLE epics ADD COLUMN IF NOT EXISTS target_sp        INTEGER;
+ALTER TABLE epics ADD COLUMN IF NOT EXISTS target_date      DATE;

--- a/packages/mcp-server/src/tools/epics.ts
+++ b/packages/mcp-server/src/tools/epics.ts
@@ -21,6 +21,10 @@ export function registerEpicsTools(server: McpServer) {
     title: z.string(),
     priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
     description: z.string().optional(),
+    objective: z.string().optional(),
+    success_criteria: z.string().optional(),
+    target_sp: z.number().int().positive().optional(),
+    target_date: z.string().optional(),
   }, async (body) => {
     try {
       const data = await pmApi('/api/epics', { method: 'POST', body: JSON.stringify(body) });
@@ -31,9 +35,13 @@ export function registerEpicsTools(server: McpServer) {
   server.tool('update_epic', 'Update epic', {
     epic_id: z.string(),
     title: z.string().optional(),
-    status: z.string().optional(),
+    status: z.enum(['draft', 'active', 'done', 'archived']).optional(),
     priority: z.string().optional(),
     description: z.string().optional(),
+    objective: z.string().optional(),
+    success_criteria: z.string().optional(),
+    target_sp: z.number().int().positive().optional(),
+    target_date: z.string().optional(),
   }, async ({ epic_id, ...updates }) => {
     try {
       const data = await pmApi(`/api/epics/${encodeURIComponent(epic_id)}`, {

--- a/packages/shared/src/schemas/epics.ts
+++ b/packages/shared/src/schemas/epics.ts
@@ -1,17 +1,27 @@
 import { z } from 'zod/v4';
 
+export const EPIC_STATUSES = ['draft', 'active', 'done', 'archived'] as const;
+
 export const createEpicSchema = z.object({
   project_id: z.string().min(1),
   org_id: z.string().min(1),
   title: z.string().min(1),
-  status: z.string().optional(),
+  status: z.enum(EPIC_STATUSES).optional(),
   priority: z.string().optional(),
   description: z.string().optional().nullable(),
+  objective: z.string().optional().nullable(),
+  success_criteria: z.string().optional().nullable(),
+  target_sp: z.number().int().positive().optional().nullable(),
+  target_date: z.string().optional().nullable(),
 });
 
 export const updateEpicSchema = z.object({
   title: z.string().min(1).optional(),
-  status: z.string().optional(),
+  status: z.enum(EPIC_STATUSES).optional(),
   priority: z.string().optional(),
   description: z.string().optional().nullable(),
+  objective: z.string().optional().nullable(),
+  success_criteria: z.string().optional().nullable(),
+  target_sp: z.number().int().positive().optional().nullable(),
+  target_date: z.string().optional().nullable(),
 });

--- a/packages/storage-sqlite/src/SqliteEpicRepository.ts
+++ b/packages/storage-sqlite/src/SqliteEpicRepository.ts
@@ -12,9 +12,9 @@ export class SqliteEpicRepository implements IEpicRepository {
     const id = randomUUID();
     const now = new Date().toISOString();
     this.db.prepare(`
-      INSERT INTO epics (id, org_id, project_id, title, status, priority, description, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, input.org_id, input.project_id, input.title.trim(), input.status ?? 'open', input.priority ?? 'medium', input.description ?? null, now, now);
+      INSERT INTO epics (id, org_id, project_id, title, status, priority, description, objective, success_criteria, target_sp, target_date, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.org_id, input.project_id, input.title.trim(), input.status ?? 'active', input.priority ?? 'medium', input.description ?? null, input.objective ?? null, input.success_criteria ?? null, input.target_sp ?? null, input.target_date ?? null, now, now);
     return this.getById(id);
   }
 
@@ -45,7 +45,7 @@ export class SqliteEpicRepository implements IEpicRepository {
   }
 
   async update(id: string, input: UpdateEpicInput): Promise<Epic> {
-    const ALLOWED: (keyof UpdateEpicInput)[] = ['title', 'status', 'priority', 'description'];
+    const ALLOWED: (keyof UpdateEpicInput)[] = ['title', 'status', 'priority', 'description', 'objective', 'success_criteria', 'target_sp', 'target_date'];
     const sets: string[] = [];
     const params: SqlParam[] = [];
     for (const key of ALLOWED) {

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -16,6 +16,7 @@ export function getDb(): DatabaseSync {
   }
   initSchema(_db);
   migrateLegacyStoryStatuses(_db);
+  migrateEpicSchema(_db);
   seedOssDefaults(_db);
   return _db;
 }
@@ -27,9 +28,13 @@ function initSchema(db: DatabaseSync): void {
       org_id TEXT NOT NULL,
       project_id TEXT NOT NULL,
       title TEXT NOT NULL,
-      status TEXT NOT NULL DEFAULT 'open',
+      status TEXT NOT NULL DEFAULT 'active',
       priority TEXT NOT NULL DEFAULT 'medium',
       description TEXT,
+      objective TEXT,
+      success_criteria TEXT,
+      target_sp INTEGER,
+      target_date TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       deleted_at TEXT
@@ -278,6 +283,21 @@ function migrateLegacyStoryStatuses(db: DatabaseSync): void {
     UPDATE stories SET status = 'in-progress' WHERE status = 'in_progress';
     UPDATE stories SET status = 'in-review' WHERE status = 'review';
   `);
+}
+
+function migrateEpicSchema(db: DatabaseSync): void {
+  // 기존 DB에 새 컬럼 추가 (없으면 추가, 이미 있으면 무시)
+  const newColumns: [string, string][] = [
+    ['objective', 'TEXT'],
+    ['success_criteria', 'TEXT'],
+    ['target_sp', 'INTEGER'],
+    ['target_date', 'TEXT'],
+  ];
+  for (const [col, type] of newColumns) {
+    try { db.exec(`ALTER TABLE epics ADD COLUMN ${col} ${type}`); } catch { /* already exists */ }
+  }
+  // 기존 'open' status → 'active' 정리
+  db.exec(`UPDATE epics SET status = 'active' WHERE status = 'open'`);
 }
 
 function seedOssDefaults(db: DatabaseSync): void {


### PR DESCRIPTION
## Summary

- **migration**: `status CHECK (IN 'draft','active','done','archived')` + 컬럼 4개 (`objective`, `success_criteria`, `target_sp`, `target_date`)
- **IEpicRepository**: `Epic`/`CreateEpicInput`/`UpdateEpicInput` 인터페이스에 새 필드 추가
- **shared schemas**: `EPIC_STATUSES` enum 상수화 + Zod 검증 강화 (status enum, target_sp 양수)
- **db.ts**: SQLite CREATE TABLE 업데이트 + `migrateEpicSchema()` (기존 DB 컬럼 추가, `open→active` 정리)
- **SqliteEpicRepository**: `create()` INSERT 13개 컬럼, `update()` ALLOWED 확장
- **MCP epics.ts**: `add_epic`/`update_epic` 파라미터 확장 (status enum 강화)

## Test plan

- [ ] 기존 `status='open'` 에픽 → `'active'`로 자동 정리 확인
- [ ] `status='invalid'` INSERT 시도 → CHECK violation 에러 확인
- [ ] POST /api/epics에 `objective`, `success_criteria`, `target_sp`, `target_date` 포함 → 저장 확인
- [ ] PATCH /api/epics/[id]로 계약서 필드 수정 → 정상 반영 확인
- [ ] MCP `add_epic`/`update_epic` 새 파라미터 정상 동작 확인
- [ ] 기존 에픽 조회 (`GET /api/epics`) 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)