### PR TITLE
feat: 에픽 상태 전이 검증 + CRUD 권한 분리 (E-DATA-INTEGRITY S2)

### DIFF
--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -5,7 +5,8 @@ import { EpicService } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { createEpicRepository } from '@/lib/storage/factory';
+import { createEpicRepository, isOssMode } from '@/lib/storage/factory';
+import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -40,7 +41,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     const repo = await createEpicRepository(dbClient);
     const service = new EpicService(repo);
-    return apiSuccess(await service.update(id, parsed.data));
+    try {
+      return apiSuccess(await service.update(id, parsed.data, { org_id: me.org_id, project_id: me.project_id }));
+    } catch (e: unknown) {
+      const err = e as Error & { code?: string };
+      if (err.code === 'INVALID_TRANSITION') return apiError('BAD_REQUEST', err.message, 400);
+      throw e;
+    }
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -51,6 +58,15 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    // 권한 체크: admin/owner만 에픽 삭제 가능
+    if (!isOssMode() && me.type !== 'agent') {
+      const role = await getEpicActorRole(supabase, me.id);
+      if (!role || !hasEpicRole(role, 'admin')) {
+        return apiError('FORBIDDEN', 'Epic deletion requires admin or owner role', 403);
+      }
+    }
+
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const repo = await createEpicRepository(dbClient);
     const service = new EpicService(repo);

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -7,6 +7,8 @@ import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createEpicRepository } from '@/lib/storage/factory';
+import { isOssMode } from '@/lib/storage/factory';
+import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
 
 export async function GET(request: Request) {
   try {
@@ -40,6 +42,14 @@ export async function POST(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+
+    // 권한 체크: agent 또는 admin/owner만 에픽 생성 가능
+    if (!isOssMode() && me.type !== 'agent') {
+      const role = await getEpicActorRole(supabase, me.id);
+      if (!role || !hasEpicRole(role, 'admin')) {
+        return apiError('FORBIDDEN', 'Epic creation requires admin or owner role', 403);
+      }
+    }
 
     let rawBody: unknown;
     try {

--- a/apps/web/src/lib/epic-permissions.ts
+++ b/apps/web/src/lib/epic-permissions.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const ALLOWED_TRANSITIONS: Record<string, string[]> = {
+  draft: ['active'],
+  active: ['done', 'archived'],
+  done: [],
+  archived: [],
+};
+
+export function validateStatusTransition(from: string, to: string): void {
+  const allowed = ALLOWED_TRANSITIONS[from] ?? [];
+  if (!allowed.includes(to)) {
+    throw Object.assign(
+      new Error(`Cannot transition epic from '${from}' to '${to}'`),
+      { code: 'INVALID_TRANSITION' },
+    );
+  }
+}
+
+const ROLE_RANK: Record<string, number> = { owner: 3, admin: 2, member: 1 };
+
+export async function getEpicActorRole(
+  supabase: SupabaseClient,
+  memberId: string,
+): Promise<string | null> {
+  const { data } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('id', memberId)
+    .maybeSingle();
+  return (data as { role: string } | null)?.role ?? null;
+}
+
+export function hasEpicRole(role: string, minRole: 'admin' | 'owner'): boolean {
+  return (ROLE_RANK[role] ?? 0) >= (ROLE_RANK[minRole] ?? 999);
+}

--- a/apps/web/src/services/epic.ts
+++ b/apps/web/src/services/epic.ts
@@ -1,5 +1,6 @@
 import type { IEpicRepository, CreateEpicInput, UpdateEpicInput, RepositoryScopeContext } from '@sprintable/core-storage';
 export type { CreateEpicInput, UpdateEpicInput } from '@sprintable/core-storage';
+import { validateStatusTransition } from '@/lib/epic-permissions';
 
 export class EpicService {
   constructor(private readonly repository: IEpicRepository) {}
@@ -23,7 +24,11 @@ export class EpicService {
     return this.repository.getByIdWithStories(id, scope);
   }
 
-  async update(id: string, input: UpdateEpicInput) {
+  async update(id: string, input: UpdateEpicInput, scope?: RepositoryScopeContext) {
+    if (input.status) {
+      const current = await this.repository.getById(id, scope);
+      validateStatusTransition(current.status, input.status);
+    }
     return this.repository.update(id, input);
   }
 


### PR DESCRIPTION
## Summary

- `epic-permissions.ts`: `validateStatusTransition()` (전이 규칙 테이블) + `getEpicActorRole()` + `hasEpicRole()` 유틸
- `EpicService.update()`: status 변경 시 현재 epic 조회 → 전이 규칙 검증 → 위반 시 `INVALID_TRANSITION` 코드 에러
- `POST /api/epics`: agent 또는 admin/owner만 허용, member → 403
- `DELETE /api/epics/[id]`: admin/owner만 허용, member → 403
- PATCH 전이 위반 → 400 + `"Cannot transition epic from 'X' to 'Y'"`
- OSS 모드 / BYOA agent는 권한 체크 제외

## 허용 전이 규칙

```
draft → active
active → done
active → archived
(그 외 모든 전이 거부)
```

## Test plan

- [ ] `draft→active` PATCH → 200
- [ ] `active→done` PATCH → 200
- [ ] `done→active` PATCH → 400 + 에러 메시지 확인
- [ ] `active→draft` PATCH → 400
- [ ] member 계정 POST /api/epics → 403
- [ ] admin 계정 POST /api/epics → 201
- [ ] member 계정 DELETE → 403
- [ ] admin 계정 DELETE → 200
- [ ] OSS 모드 권한 체크 없이 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)