### PR TITLE
feat: stories 스키마 강화 — Zod + CHECK + acceptance_criteria (E-DATA-INTEGRITY S3)

### DIFF
--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -13,6 +13,7 @@ export interface Story {
   priority: string;
   story_points: number | null;
   description: string | null;
+  acceptance_criteria: string | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -29,6 +30,7 @@ export interface CreateStoryInput {
   priority?: string;
   story_points?: number | null;
   description?: string | null;
+  acceptance_criteria?: string | null;
   meeting_id?: string | null;
 }
 
@@ -38,6 +40,7 @@ export interface UpdateStoryInput {
   priority?: string;
   story_points?: number | null;
   description?: string | null;
+  acceptance_criteria?: string | null;
   epic_id?: string | null;
   sprint_id?: string | null;
   assignee_id?: string | null;

--- a/packages/db/supabase/migrations/20260424110000_story_schema_enhancement.sql
+++ b/packages/db/supabase/migrations/20260424110000_story_schema_enhancement.sql
@@ -1,0 +1,34 @@
+-- E-DATA-INTEGRITY S3: stories 테이블 스키마 강화
+-- priority CHECK + story_points 피보나치 CHECK + acceptance_criteria 컬럼
+
+-- 1. priority 무효값 정리 → 'medium'으로 교정
+UPDATE stories
+  SET priority = 'medium'
+  WHERE priority NOT IN ('critical', 'high', 'medium', 'low');
+
+-- 2. priority CHECK 제약 추가
+ALTER TABLE stories
+  ADD CONSTRAINT stories_priority_check
+    CHECK (priority IN ('critical', 'high', 'medium', 'low'));
+
+-- 3. story_points 비표준 값 → 가장 가까운 피보나치로 마이그레이션
+UPDATE stories SET story_points =
+  CASE
+    WHEN story_points <= 1  THEN 1
+    WHEN story_points <= 2  THEN 2
+    WHEN story_points <= 3  THEN 3
+    WHEN story_points <= 6  THEN 5
+    WHEN story_points <= 10 THEN 8
+    WHEN story_points <= 17 THEN 13
+    ELSE 21
+  END
+WHERE story_points IS NOT NULL
+  AND story_points NOT IN (1, 2, 3, 5, 8, 13, 21);
+
+-- 4. story_points CHECK 제약 추가 (NULL 또는 피보나치만 허용)
+ALTER TABLE stories
+  ADD CONSTRAINT stories_sp_check
+    CHECK (story_points IS NULL OR story_points IN (1, 2, 3, 5, 8, 13, 21));
+
+-- 5. acceptance_criteria 컬럼 추가 (nullable)
+ALTER TABLE stories ADD COLUMN IF NOT EXISTS acceptance_criteria TEXT;

--- a/packages/mcp-server/src/tools/stories.ts
+++ b/packages/mcp-server/src/tools/stories.ts
@@ -41,8 +41,9 @@ export function registerStoriesTools(server: McpServer) {
     sprint_id: z.string().optional(),
     assignee_id: z.string().optional(),
     priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
-    story_points: z.number().optional(),
+    story_points: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(5), z.literal(8), z.literal(13), z.literal(21)]).optional(),
     description: z.string().optional(),
+    acceptance_criteria: z.string().optional(),
   }, async (body) => {
     try {
       const data = await pmApi('/api/stories', { method: 'POST', body: JSON.stringify(body) });
@@ -53,9 +54,10 @@ export function registerStoriesTools(server: McpServer) {
   server.tool('update_story', 'Update story', {
     story_id: z.string(),
     title: z.string().optional(),
-    priority: z.string().optional(),
-    story_points: z.number().optional(),
+    priority: z.enum(['low', 'medium', 'high', 'critical']).optional(),
+    story_points: z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(5), z.literal(8), z.literal(13), z.literal(21)]).optional(),
     description: z.string().optional(),
+    acceptance_criteria: z.string().optional(),
     assignee_id: z.string().optional(),
     epic_id: z.string().optional(),
   }, async ({ story_id, ...updates }) => {

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod/v4';
 
-const storyStatusEnum = z.enum(['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done']);
+export const STORY_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done'] as const;
+export const STORY_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
+export const STORY_SP_VALUES = [1, 2, 3, 5, 8, 13, 21] as const;
+
+const storyStatusEnum = z.enum(STORY_STATUSES);
+const storyPriorityEnum = z.enum(STORY_PRIORITIES);
+const storySpSchema = z.union([
+  z.literal(1), z.literal(2), z.literal(3), z.literal(5),
+  z.literal(8), z.literal(13), z.literal(21),
+]);
 
 export const createStorySchema = z.object({
   project_id: z.string().min(1),
@@ -10,18 +19,20 @@ export const createStorySchema = z.object({
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),
   status: storyStatusEnum.optional(),
-  priority: z.string().optional(),
-  story_points: z.number().optional().nullable(),
+  priority: storyPriorityEnum.optional(),
+  story_points: storySpSchema.optional().nullable(),
   description: z.string().optional().nullable(),
+  acceptance_criteria: z.string().optional().nullable(),
   meeting_id: z.string().uuid().optional().nullable(),
 });
 
 export const updateStorySchema = z.object({
   title: z.string().min(1).optional(),
   status: storyStatusEnum.optional(),
-  priority: z.string().optional(),
-  story_points: z.number().optional().nullable(),
+  priority: storyPriorityEnum.optional(),
+  story_points: storySpSchema.optional().nullable(),
   description: z.string().optional().nullable(),
+  acceptance_criteria: z.string().optional().nullable(),
   epic_id: z.string().optional().nullable(),
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),

--- a/packages/storage-sqlite/src/SqliteStoryRepository.ts
+++ b/packages/storage-sqlite/src/SqliteStoryRepository.ts
@@ -13,9 +13,9 @@ export class SqliteStoryRepository implements IStoryRepository {
     const id = randomUUID();
     const now = new Date().toISOString();
     this.db.prepare(`
-      INSERT INTO stories (id, org_id, project_id, epic_id, sprint_id, assignee_id, title, status, priority, story_points, description, meeting_id, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, input.org_id, input.project_id, input.epic_id ?? null, input.sprint_id ?? null, input.assignee_id ?? null, input.title.trim(), input.status ?? 'backlog', input.priority ?? 'medium', input.story_points ?? null, input.description ?? null, input.meeting_id ?? null, now, now);
+      INSERT INTO stories (id, org_id, project_id, epic_id, sprint_id, assignee_id, title, status, priority, story_points, description, acceptance_criteria, meeting_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.org_id, input.project_id, input.epic_id ?? null, input.sprint_id ?? null, input.assignee_id ?? null, input.title.trim(), input.status ?? 'backlog', input.priority ?? 'medium', input.story_points ?? null, input.description ?? null, input.acceptance_criteria ?? null, input.meeting_id ?? null, now, now);
     return this.getById(id);
   }
 
@@ -56,7 +56,7 @@ export class SqliteStoryRepository implements IStoryRepository {
   }
 
   async update(id: string, input: UpdateStoryInput): Promise<Story> {
-    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'epic_id', 'sprint_id', 'assignee_id'];
+    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria', 'epic_id', 'sprint_id', 'assignee_id'];
     const sets: string[] = [];
     const params: SqlParam[] = [];
     for (const key of ALLOWED) {

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -16,6 +16,7 @@ export function getDb(): DatabaseSync {
   }
   initSchema(_db);
   migrateLegacyStoryStatuses(_db);
+  migrateStorySchema(_db);
   migrateEpicSchema(_db);
   seedOssDefaults(_db);
   return _db;
@@ -52,6 +53,7 @@ function initSchema(db: DatabaseSync): void {
       priority TEXT NOT NULL DEFAULT 'medium',
       story_points INTEGER,
       description TEXT,
+      acceptance_criteria TEXT,
       meeting_id TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
@@ -283,6 +285,22 @@ function migrateLegacyStoryStatuses(db: DatabaseSync): void {
     UPDATE stories SET status = 'in-progress' WHERE status = 'in_progress';
     UPDATE stories SET status = 'in-review' WHERE status = 'review';
   `);
+}
+
+function migrateStorySchema(db: DatabaseSync): void {
+  try { db.exec(`ALTER TABLE stories ADD COLUMN acceptance_criteria TEXT`); } catch { /* already exists */ }
+  // 비표준 priority → 'medium'
+  db.exec(`UPDATE stories SET priority = 'medium' WHERE priority NOT IN ('critical','high','medium','low')`);
+  // 비표준 story_points → 가장 가까운 피보나치
+  db.exec(`UPDATE stories SET story_points = CASE
+    WHEN story_points <= 1  THEN 1
+    WHEN story_points <= 2  THEN 2
+    WHEN story_points <= 3  THEN 3
+    WHEN story_points <= 6  THEN 5
+    WHEN story_points <= 10 THEN 8
+    WHEN story_points <= 17 THEN 13
+    ELSE 21
+  END WHERE story_points IS NOT NULL AND story_points NOT IN (1,2,3,5,8,13,21)`);
 }
 
 function migrateEpicSchema(db: DatabaseSync): void {


### PR DESCRIPTION
## Summary

- **migration**: `priority CHECK (critical/high/medium/low)` + SP 피보나치 교정+CHECK + `acceptance_criteria TEXT`
- **IStoryRepository**: `Story`/`CreateStoryInput`/`UpdateStoryInput`에 `acceptance_criteria` 추가
- **shared schemas**: `STORY_STATUSES/PRIORITIES/SP_VALUES` 상수화 + priority enum + SP 피보나치 union + acceptance_criteria
- **db.ts**: stories CREATE TABLE 업데이트 + `migrateStorySchema()` (기존 DB 컬럼 추가 + priority/SP 교정)
- **SqliteStoryRepository**: INSERT 15컬럼, UPDATE ALLOWED 확장
- **MCP stories.ts**: `add_story`/`update_story` 파라미터 강화 (SP 피보나치 enum, acceptance_criteria)

## SP 피보나치 교정 규칙

| 기존 값 | 교정 결과 |
|---|---|
| 1 | 1 |
| 2 | 2 |
| 3 | 3 |
| 4~6 | 5 |
| 7~10 | 8 |
| 11~17 | 13 |
| 18+ | 21 |

## Test plan

- [ ] priority='invalid' INSERT → CHECK violation 확인
- [ ] story_points=4 INSERT → Zod validation 400 확인
- [ ] story_points=5 INSERT → 정상 저장
- [ ] acceptance_criteria 포함 POST/PATCH → 저장 확인
- [ ] MCP add_story acceptance_criteria 파라미터 정상 동작
- [ ] 기존 DB 비표준 SP 교정 확인 (migrateStorySchema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)