### PR TITLE
feat: 스토리 상태 전이 single source + acceptance_criteria 연동 (E-DATA-INTEGRITY S4)

### DIFF
--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -27,11 +27,11 @@ export interface KanbanMember {
   type: string;
 }
 
+import { VALID_STORY_TRANSITIONS } from '@sprintable/shared';
+
+// done→in-review는 admin만 허용 (백엔드 검증) — 프론트엔드에서는 done 드래그 허용 안 함
 export const VALID_TRANSITIONS: Record<string, string[]> = {
-  backlog: ['ready-for-dev'],
-  'ready-for-dev': ['in-progress', 'backlog'],
-  'in-progress': ['in-review', 'ready-for-dev'],
-  'in-review': ['done', 'in-progress'],
+  ...VALID_STORY_TRANSITIONS,
   done: [],
 };
 

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -3,17 +3,11 @@ import type { IStoryRepository, CreateStoryInput, UpdateStoryInput, BulkUpdateIt
 import { SupabaseStoryRepository } from '@sprintable/storage-supabase';
 import { NotFoundError, ForbiddenError } from './sprint';
 import { requireOrgAdmin, isOrgAdmin } from '@/lib/admin-check';
+import { VALID_STORY_TRANSITIONS } from '@sprintable/shared';
 
 export type { CreateStoryInput, UpdateStoryInput, BulkUpdateItem };
 
-/** 유효한 상태 전이 맵 (SID:357) */
-const VALID_TRANSITIONS: Record<string, string[]> = {
-  'backlog': ['ready-for-dev'],
-  'ready-for-dev': ['in-progress', 'backlog'],
-  'in-progress': ['in-review', 'ready-for-dev'],
-  'in-review': ['done', 'in-progress'],
-  'done': ['in-review'], // admin만
-};
+const VALID_TRANSITIONS = VALID_STORY_TRANSITIONS;
 
 export class InvalidTransitionError extends Error {
   constructor(from: string, to: string) {
@@ -95,7 +89,7 @@ export class StoryService {
 
   async update(id: string, input: UpdateStoryInput) {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
-      'title', 'status', 'priority', 'story_points', 'description',
+      'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
       'epic_id', 'sprint_id', 'assignee_id',
     ];
     const sanitized: Record<string, unknown> = {};

--- a/packages/mcp-server/src/tools/stories.ts
+++ b/packages/mcp-server/src/tools/stories.ts
@@ -106,7 +106,7 @@ export function registerStoriesTools(server: McpServer) {
 
   server.tool('update_story_status', 'Update story status', {
     story_id: z.string(),
-    status: z.string().describe('backlog | ready-for-dev | in-progress | in-review | done'),
+    status: z.enum(['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done']),
   }, async ({ story_id, status }) => {
     try {
       const data = await pmApi(`/api/stories/${encodeURIComponent(story_id)}`, {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -120,7 +120,7 @@ export const updateSprintSchema = z.object({
 });
 
 // ─── Story ───────────────────────────────────
-export { createStorySchema, updateStorySchema, bulkUpdateStoriesSchema as bulkUpdateStorySchema } from './stories';
+export { createStorySchema, updateStorySchema, bulkUpdateStoriesSchema as bulkUpdateStorySchema, VALID_STORY_TRANSITIONS, STORY_STATUSES, STORY_PRIORITIES, STORY_SP_VALUES } from './stories';
 
 // ─── Task ────────────────────────────────────
 export const createTaskSchema = z.object({

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -4,6 +4,18 @@ export const STORY_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-re
 export const STORY_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
 export const STORY_SP_VALUES = [1, 2, 3, 5, 8, 13, 21] as const;
 
+/**
+ * 유효한 스토리 상태 전이 맵 (단일 소스)
+ * done→in-review는 admin만 허용 — 백엔드 StoryService에서 별도 체크
+ */
+export const VALID_STORY_TRANSITIONS: Record<string, string[]> = {
+  backlog: ['ready-for-dev'],
+  'ready-for-dev': ['in-progress', 'backlog'],
+  'in-progress': ['in-review', 'ready-for-dev'],
+  'in-review': ['done', 'in-progress'],
+  done: ['in-review'],
+};
+
 const storyStatusEnum = z.enum(STORY_STATUSES);
 const storyPriorityEnum = z.enum(STORY_PRIORITIES);
 const storySpSchema = z.union([


### PR DESCRIPTION
## Summary

- `shared/schemas/stories.ts`: `VALID_STORY_TRANSITIONS` 상수 추가 (백엔드+프론트 단일 소스)
- `shared/schemas/index.ts`: `VALID_STORY_TRANSITIONS`/`STORY_STATUSES` 등 추가 export
- `services/story.ts`: 로컬 `VALID_TRANSITIONS` → shared import 교체 + `ALLOWED_FIELDS`에 `acceptance_criteria` 추가 (S3 연동)
- `kanban/types.ts`: `VALID_TRANSITIONS` → shared import 교체 (done: [] 프론트 오버라이드 유지 — admin 전용 역전이를 UI에서 숨김)
- MCP `update_story_status`: `z.string()` → `z.enum([STORY_STATUSES])` 강화

## 상태 전이 규칙 (single source)

```
backlog → ready-for-dev
ready-for-dev → in-progress, backlog
in-progress → in-review, ready-for-dev
in-review → done, in-progress
done → in-review (admin만, 백엔드 StoryService에서 별도 체크)
```

## Test plan

- [ ] `backlog→in-progress` PATCH → 400 (건너뛰기 차단)
- [ ] `done→backlog` PATCH 일반 → 403
- [ ] `done→in-review` admin PATCH → 200
- [ ] acceptance_criteria PATCH → 정상 저장
- [ ] MCP update_story_status enum 외 값 → validation 에러
- [ ] 프론트엔드 칸반 done 컬럼 드래그 불가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)