### PR TITLE
feat: 스프린트 정합성 — 날짜 CHECK + active unique + rollover (E-DATA-INTEGRITY S5)

### DIFF
--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -74,6 +74,22 @@ export class SprintService {
   async activate(id: string) {
     const sprint = await this.getById(id);
     if (sprint.status !== 'planning') throw new Error(`Cannot activate sprint with status: ${sprint.status}`);
+
+    // 프로젝트당 active 스프린트 1개 강제 (DB UNIQUE INDEX와 이중 검증)
+    if (this.supabase) {
+      const { data: active } = await this.supabase
+        .from('sprints')
+        .select('id, title')
+        .eq('project_id', sprint.project_id as string)
+        .eq('status', 'active')
+        .is('deleted_at', null)
+        .limit(1)
+        .maybeSingle();
+      if (active) {
+        throw new ForbiddenError(`Active sprint already exists: "${active.title}". Close it before activating another.`);
+      }
+    }
+
     return this.repo.update(id, { status: 'active' });
   }
 
@@ -151,11 +167,46 @@ export class SprintService {
     if (sprint.status !== 'active') throw new Error(`Cannot close sprint with status: ${sprint.status}`);
 
     let velocity = 0;
+    let rolledOver = 0;
+
     if (this.supabase) {
+      // velocity 계산
       const { data: doneStories } = await this.supabase.from('stories').select('story_points').eq('sprint_id', id).eq('status', 'done');
       velocity = (doneStories ?? []).reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+
+      // rollover: 미완료 스토리(status != 'done') 처리
+      const { data: incomplete } = await this.supabase
+        .from('stories')
+        .select('id')
+        .eq('sprint_id', id)
+        .neq('status', 'done');
+
+      if (incomplete && incomplete.length > 0) {
+        const incompleteIds = incomplete.map((s) => s.id as string);
+
+        // 다음 active 또는 planning 스프린트 탐색 (같은 프로젝트, 시작일 오름차순)
+        const { data: nextSprint } = await this.supabase
+          .from('sprints')
+          .select('id')
+          .eq('project_id', sprint.project_id as string)
+          .in('status', ['active', 'planning'])
+          .neq('id', id)
+          .is('deleted_at', null)
+          .order('start_date', { ascending: true })
+          .limit(1)
+          .maybeSingle();
+
+        const nextSprintId = nextSprint?.id ?? null;
+        await this.supabase
+          .from('stories')
+          .update({ sprint_id: nextSprintId })
+          .in('id', incompleteIds);
+
+        rolledOver = incompleteIds.length;
+      }
     }
 
-    return this.repo.update(id, { status: 'closed', velocity } as UpdateSprintInput);
+    const closed = await this.repo.update(id, { status: 'closed', velocity } as UpdateSprintInput);
+    return { ...closed, rolled_over: rolledOver };
   }
 }

--- a/packages/db/supabase/migrations/20260424120000_sprint_integrity.sql
+++ b/packages/db/supabase/migrations/20260424120000_sprint_integrity.sql
@@ -1,0 +1,16 @@
+-- E-DATA-INTEGRITY S5: 스프린트 정합성 — 날짜/활성/Rollover
+
+-- 1. 날짜 역전 데이터 정리 (start_date >= end_date인 행 → end_date를 start_date + 14일로 교정)
+UPDATE sprints
+  SET end_date = (start_date::date + interval '14 days')::date
+  WHERE start_date >= end_date;
+
+-- 2. start_date < end_date CHECK 제약 추가
+ALTER TABLE sprints
+  ADD CONSTRAINT sprints_date_check
+    CHECK (start_date < end_date);
+
+-- 3. 프로젝트당 active 스프린트 1개 강제 (partial unique index)
+CREATE UNIQUE INDEX IF NOT EXISTS sprints_active_unique
+  ON sprints(project_id)
+  WHERE status = 'active' AND deleted_at IS NULL;

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -276,6 +276,9 @@ function initSchema(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS idx_agent_runs_org_project ON agent_runs(org_id, project_id);
     CREATE INDEX IF NOT EXISTS idx_agent_runs_created_at ON agent_runs(created_at);
     CREATE INDEX IF NOT EXISTS idx_agent_api_keys_team_member ON agent_api_keys(team_member_id);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS sprints_active_unique
+      ON sprints(project_id) WHERE status = 'active' AND deleted_at IS NULL;
   `);
 }
 


### PR DESCRIPTION
## Summary

- **migration**: `start_date < end_date` CHECK + `sprints_active_unique` partial unique index (프로젝트당 active 1개)
- **`SprintService.activate()`**: Supabase 경유 시 기존 active 스프린트 존재하면 `ForbiddenError` → 400 반환 (DB unique index와 이중 검증)
- **`SprintService.close()`**: 미완료 스토리(status != 'done') rollover:
  - 같은 프로젝트의 다음 active/planning 스프린트 탐색 → 있으면 이동
  - 없으면 `sprint_id = NULL` (backlog 해제)
  - `rolled_over` 카운트 반환
- **`db.ts`**: SQLite `sprints_active_unique` partial unique index 추가

## Test plan

- [ ] 기존 active 스프린트 있을 때 activate → 400 확인
- [ ] `start_date >= end_date` 스프린트 생성 → CHECK violation 확인
- [ ] close 시 미완료 스토리 → 다음 스프린트로 이동 확인
- [ ] close 시 다음 스프린트 없음 → sprint_id=NULL (backlog) 확인
- [ ] `rolled_over` 카운트 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)