### PR TITLE
feat: 메모 정합성 — memo_type CHECK + 필수 assignee 검증 (E-DATA-INTEGRITY S6)

### DIFF
--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -3,7 +3,7 @@ import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { MemoService, type CreateMemoInput } from '@/services/memo';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { parseBody, createMemoSchema } from '@sprintable/shared';
+import { parseBody, createMemoSchema, MEMO_TYPES_REQUIRING_ASSIGNEE } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createMemoRepository, createTeamMemberRepository, createProjectRepository, isOssMode } from '@/lib/storage/factory';
@@ -33,8 +33,14 @@ export async function POST(request: Request) {
     const parsed = await parseBody(request, createMemoSchema);
     if (!parsed.success) return parsed.response;
     const body = parsed.data;
-    // [DIAG] Track assigned_to_ids propagation through schema parsing
-    console.warn('[POST /api/memos] parsed assigned_to_ids:', JSON.stringify(body.assigned_to_ids));
+
+    // task/request/feedback 타입은 assigned_to 필수
+    if (body.memo_type && (MEMO_TYPES_REQUIRING_ASSIGNEE as readonly string[]).includes(body.memo_type)) {
+      const hasAssignee = (body.assigned_to_ids && body.assigned_to_ids.length > 0) || body.assigned_to;
+      if (!hasAssignee) {
+        return apiError('BAD_REQUEST', `memo_type '${body.memo_type}' requires at least one assignee`, 400);
+      }
+    }
     const dbClient = isOssMode() ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const repo = await createMemoRepository(dbClient);
     const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;

--- a/packages/db/supabase/migrations/20260424130000_memo_integrity.sql
+++ b/packages/db/supabase/migrations/20260424130000_memo_integrity.sql
@@ -1,0 +1,20 @@
+-- E-DATA-INTEGRITY S6: memos 테이블 정합성 강화
+
+-- 1. 기존 CHECK 위반 memo_type 정리 → 'memo'로 교정
+UPDATE memos
+  SET memo_type = 'memo'
+  WHERE memo_type NOT IN (
+    'memo', 'task', 'checklist', 'decision', 'request', 'handoff',
+    'feedback', 'announcement', 'general', 'system_workflow_update'
+  );
+
+-- 2. memo_type CHECK 제약 추가
+ALTER TABLE memos
+  ADD CONSTRAINT memos_type_check
+    CHECK (memo_type IN (
+      'memo', 'task', 'checklist', 'decision', 'request', 'handoff',
+      'feedback', 'announcement', 'general', 'system_workflow_update'
+    ));
+
+-- 3. memos SELECT RLS deleted_at IS NULL — 이미 20260401020000_rls_soft_delete.sql에서 적용됨
+--    (확인 완료, 추가 migration 불필요)

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -1,10 +1,17 @@
 import { z } from 'zod/v4';
 
 // ─── Memo ────────────────────────────────────
+export const MEMO_TYPES = [
+  'memo', 'task', 'checklist', 'decision', 'request', 'handoff',
+  'feedback', 'announcement', 'general', 'system_workflow_update',
+] as const;
+
+export const MEMO_TYPES_REQUIRING_ASSIGNEE = ['task', 'request', 'feedback'] as const;
+
 export const createMemoSchema = z.object({
   title: z.string().optional().nullable(),
   content: z.string().min(1),
-  memo_type: z.string().optional(),
+  memo_type: z.enum(MEMO_TYPES).optional(),
   assigned_to: z.string().optional().nullable(), // DEPRECATED: use assigned_to_ids
   assigned_to_ids: z.array(z.string()).optional(), // New: supports multiple assignees
   supersedes_id: z.string().optional().nullable(),


### PR DESCRIPTION
## Summary

- **migration**: 기존 비표준 `memo_type` → `'memo'` 교정 후 `memos_type_check CHECK (memo_type IN (...))` 추가
- **shared/schemas**: `MEMO_TYPES` (10개) + `MEMO_TYPES_REQUIRING_ASSIGNEE` 상수 추가, `memo_type` → `z.enum(MEMO_TYPES)` 강화
- **POST /api/memos**: `'task'`, `'request'`, `'feedback'` 타입 생성 시 `assigned_to_ids` 또는 `assigned_to` 필수 → 없으면 400
- **memos SELECT RLS `deleted_at IS NULL`**: `20260401020000_rls_soft_delete.sql`에 이미 적용됨 (migration 불필요, 확인 완료)

## memo_type 확정 목록 (코드 전수 조사 기반)

`memo`, `task`, `checklist`, `decision`, `request`, `handoff`, `feedback`, `announcement`, `general`, `system_workflow_update`

## Test plan

- [ ] memo_type='invalid' POST → 400 Zod validation 확인
- [ ] memo_type='task' + assigned_to 없음 → 400 확인
- [ ] memo_type='task' + assigned_to_ids=['uuid'] → 201 정상 생성
- [ ] memo_type='memo' + assigned_to 없음 → 201 정상 생성 (필수 아님)
- [ ] migration CHECK 위반 INSERT 시도 → DB constraint error 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)