### PR TITLE
feat: task status enum 통일 + content-converter XSS 테스트 (E-DATA-INTEGRITY S7)

### DIFF
--- a/apps/web/src/components/docs/lib/content-converter.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.test.ts
@@ -94,6 +94,23 @@ describe('markdownToHtml', () => {
     expect(result).toContain('data-doc-id="abc"');
     expect(result).not.toContain('&lt;div');
   });
+
+  it('neutralizes XSS in heading text (E-MINOR-BUGS regression guard)', () => {
+    const result = markdownToHtml('# <script>alert("xss")</script>Title');
+    expect(result).not.toContain('<script>');
+    expect(result).toContain('&lt;script>');
+  });
+
+  it('neutralizes XSS in inline content', () => {
+    const result = markdownToHtml('Hello <img src=x onerror=alert(1)> world');
+    expect(result).not.toContain('<img src=x');
+    expect(result).toContain('&lt;img');
+  });
+
+  it('neutralizes javascript: href in links', () => {
+    const result = markdownToHtml('[click](javascript:alert(1))');
+    expect(result).not.toContain('javascript:alert');
+  });
 });
 
 describe('htmlToMarkdown', () => {

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -124,8 +124,11 @@ export function markdownToHtml(md: string): string {
   // Images (before links — both use []() syntax)
   html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
 
-  // Links
-  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+  // Links — sanitize javascript: hrefs
+  html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_m, text, href) => {
+    const safeHref = /^javascript:/i.test(href.trim()) ? '#' : href;
+    return `<a href="${safeHref}">${text}</a>`;
+  });
 
   // GFM tables
   html = html.replace(/(?:^\|.*\|\s*$\n?){2,}/gm, (tableBlock) => {

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -130,17 +130,19 @@ export const updateSprintSchema = z.object({
 export { createStorySchema, updateStorySchema, bulkUpdateStoriesSchema as bulkUpdateStorySchema, VALID_STORY_TRANSITIONS, STORY_STATUSES, STORY_PRIORITIES, STORY_SP_VALUES } from './stories';
 
 // ─── Task ────────────────────────────────────
+export const TASK_STATUSES = ['todo', 'in-progress', 'done'] as const;
+
 export const createTaskSchema = z.object({
   story_id: z.string().min(1),
   title: z.string().min(1),
   assignee_id: z.string().optional().nullable(),
-  status: z.string().optional(),
+  status: z.enum(TASK_STATUSES).optional(),
   story_points: z.number().optional().nullable(),
 });
 
 export const updateTaskSchema = z.object({
   title: z.string().min(1).optional(),
-  status: z.string().optional(),
+  status: z.enum(TASK_STATUSES).optional(),
   assignee_id: z.string().optional().nullable(),
   story_points: z.number().optional().nullable(),
 });


### PR DESCRIPTION
## Summary

- **shared/schemas**: `TASK_STATUSES` 상수 + `createTaskSchema`/`updateTaskSchema` status `z.string()` → `z.enum(['todo','in-progress','done'])`
- **content-converter.ts**: 링크 변환 시 `javascript:` href → `'#'` 치환 (XSS 취약점 수정)
- **content-converter.test.ts**: XSS 페이로드 회귀 테스트 3종 추가 (총 25 케이스, 전량 PASS)
  - heading 내 `<script>` sanitize 검증
  - inline `<img onerror>` sanitize 검증
  - `javascript:` href sanitize 검증

## Test plan

- [ ] `pnpm vitest run content-converter.test.ts` → 25 PASS 확인
- [ ] task status='invalid' → 400 Zod validation 확인
- [ ] task status='todo'/'in-progress'/'done' → 정상 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)