### PR TITLE
feat: MCP vote_retro_item v2 통일 + pg_cron standup nudge 등록 (E-DATA-INTEGRITY S8)

### DIFF
--- a/packages/db/supabase/migrations/20260424140000_pg_cron_standup_nudge.sql
+++ b/packages/db/supabase/migrations/20260424140000_pg_cron_standup_nudge.sql
@@ -1,0 +1,17 @@
+-- E-DATA-INTEGRITY S8: pg_cron으로 nudge_standup_deadline() 일별 실행 등록
+-- nudge_standup_deadline() 함수는 20260401021000_agent_webhook_nudge.sql에 정의됨
+
+-- 1. pg_cron 확장 활성화 (Supabase Pro+에서 지원, cron 스키마 자동 생성)
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- 2. 기존 동일 이름 잡 존재 시 안전 제거 (재실행 idempotent 보장)
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'nudge-standup-deadline';
+
+-- 3. 매일 UTC 14:00 (KST 23:00) 실행 등록
+SELECT cron.schedule(
+  'nudge-standup-deadline',
+  '0 14 * * *',
+  'SELECT public.nudge_standup_deadline()'
+);

--- a/packages/mcp-server/src/tools/retro.ts
+++ b/packages/mcp-server/src/tools/retro.ts
@@ -57,15 +57,16 @@ export function registerRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('vote_retro_item', 'Vote on retro item (uses retro_votes for duplicate protection)', {
+  server.tool('vote_retro_item', 'Vote on retro item via retro-sessions endpoint (retro_votes, duplicate-protected). voter_id defaults to caller identity.', {
     session_id: z.string().describe('Retro session ID (use get_retro_session to obtain)'),
     item_id: z.string(),
     project_id: z.string(),
-  }, async ({ session_id, item_id, project_id }) => {
+    voter_id: z.string().optional().describe('Explicit voter ID; omit to use caller identity'),
+  }, async ({ session_id, item_id, project_id, voter_id }) => {
     try {
       const data = await pmApi(`/api/retro-sessions/${session_id}/items/${item_id}/vote?project_id=${encodeURIComponent(project_id)}`, {
         method: 'POST',
-        body: JSON.stringify({}),
+        body: JSON.stringify(voter_id ? { voter_id } : {}),
       });
       return ok(data);
     } catch (e) {


### PR DESCRIPTION
## Summary
- `vote_retro_item` MCP 도구에 `voter_id` optional 파라미터 추가 — v2(`vote_retro_item_v2`)와 인터페이스 통일. 이미 `/api/retro-sessions` 경로(retro_votes INSERT, 중복 방지) 사용 중이므로 API 변경 없음
- pg_cron 마이그레이션으로 `nudge_standup_deadline()` 매일 UTC 14:00 (KST 23:00) 자동 실행 등록. idempotent 처리(동일 잡명 기존 제거 후 재등록)

## Changes
- `packages/mcp-server/src/tools/retro.ts` — voter_id optional 파라미터 + description 명확화
- `packages/db/supabase/migrations/20260424140000_pg_cron_standup_nudge.sql` — pg_cron 확장 + cron.schedule 등록

## AC Checklist
- [x] AC1: `vote_retro_item` 도구가 `/api/retro-sessions` 경로 경유, `retro_votes` INSERT 사용 확인
- [x] AC2: `voter_id` optional 파라미터로 v2와 인터페이스 통일
- [x] AC3: pg_cron 마이그레이션으로 `nudge_standup_deadline()` UTC 14:00 등록
- [x] AC4: idempotent — 동일 잡명 존재 시 기존 제거 후 재등록

## Test plan
- [ ] `vote_retro_item` 호출 시 voter_id 생략 → me.id로 동작 확인
- [ ] `vote_retro_item` 호출 시 voter_id 명시 → 해당 voter_id로 동작 확인
- [ ] migration 적용 후 `cron.job` 테이블에 `nudge-standup-deadline` 등록 확인
- [ ] 수동 `SELECT public.nudge_standup_deadline()` 실행 → notifications 테이블 `standup_reminder` INSERT 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)