### PR TITLE
feat: 과금 계층 이원화 해소 — checkEntitlement 단일화 (E-DATA-INTEGRITY S9)

### DIFF
--- a/apps/web/src/lib/check-feature.ts
+++ b/apps/web/src/lib/check-feature.ts
@@ -1,6 +1,8 @@
 // OSS stub — 실제 구현은 @moonklabs/sprintable-saas 에 있으며
 // SaaS 결합 빌드 시 submodule overlay로 덮어쓴다.
 // OSS 단독 빌드에서는 모든 feature gate가 allowed로 해석된다.
+// @deprecated E-DATA-INTEGRITY S9: SaaS overlay의 2계층 구현은 checkEntitlement()로 전환됨.
+// 이 OSS stub은 agent_orchestration/stt_recording 등 비결제 gate 용도로만 유지.
 import type { SupabaseClient } from '@supabase/supabase-js';
 
 export interface FeatureCheckResult {


### PR DESCRIPTION
## Summary
- OSS `check-feature.ts` stub에 `@deprecated` 마킹 — SaaS 2계층 구현이 `checkEntitlement`로 전환됨, 비결제 gate(agent_orchestration 등) 용도로만 유지

## Changes
- `apps/web/src/lib/check-feature.ts` — deprecated 주석 추가 (Phase 4에서 완전 제거 예정)

> SaaS 메인 변경 (5개 API route + check-feature.ts deprecated)은 sprintable-saas PR로 별도 제출

## AC Checklist
- [x] AC1: OSS 빌드 정상 (기존 e2e playwright 에러 외 신규 에러 없음)
- [x] AC2: check-feature stub deprecated 마킹 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)