### PR TITLE
fix: org_subscriptions/org_usage FK REFERENCES orgs → organizations (E-INFRA-BLOCKERS S1)

### DIFF
--- a/packages/db/supabase/migrations/20260422120000_org_subscriptions.sql
+++ b/packages/db/supabase/migrations/20260422120000_org_subscriptions.sql
@@ -1,7 +1,7 @@
 -- org_subscriptions: tracks Polar billing state per org
 CREATE TABLE IF NOT EXISTS org_subscriptions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  org_id UUID NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   polar_customer_id TEXT NOT NULL,
   polar_subscription_id TEXT,
   tier TEXT NOT NULL DEFAULT 'free',

--- a/packages/db/supabase/migrations/20260422130000_org_usage.sql
+++ b/packages/db/supabase/migrations/20260422130000_org_usage.sql
@@ -1,7 +1,7 @@
 -- org_usage: monthly resource counters per org
 CREATE TABLE IF NOT EXISTS org_usage (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  org_id UUID NOT NULL REFERENCES orgs(id) ON DELETE CASCADE,
+  org_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
   period TEXT NOT NULL,  -- 'YYYY-MM' for monthly resources
   stories INT NOT NULL DEFAULT 0,
   memos INT NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Summary
- Polar Live 전환 직접 블로커 수정
- `org_subscriptions`/`org_usage` 마이그레이션의 `REFERENCES orgs(id)` → `REFERENCES organizations(id)` 수정
- `orgs` 테이블이 존재하지 않아 마이그레이션 적용 실패하던 FK 제약 위반 해소

## Changes
- `packages/db/supabase/migrations/20260422120000_org_subscriptions.sql` — FK 수정
- `packages/db/supabase/migrations/20260422130000_org_usage.sql` — FK 수정

## AC Checklist
- [x] AC1: `REFERENCES orgs(id)` → `REFERENCES organizations(id)` 2개 파일 모두 수정
- [x] AC2: 변경 최소화 — FK 라인만 수정, 나머지 스키마 무변경
- [ ] AC3: 로컬 `supabase db reset` 정상 통과 (담롱군 배포 시 검증)
- [ ] AC4: 프로덕션 마이그레이션 적용 후 테이블 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)