### PR TITLE
feat: 초대 모달 역할 선택 드롭다운 추가 (E-PLATFORM-FOUNDATION S4)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -79,6 +79,7 @@ export default function SettingsPage() {
   const [creatingProject, setCreatingProject] = useState(false);
   const [projectActionMessage, setProjectActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [inviteEmail, setInviteEmail] = useState('');
+  const [inviteRole, setInviteRole] = useState<'member' | 'admin'>('member');
   const [inviting, setInviting] = useState(false);
   const [inviteResult, setInviteResult] = useState<string | null>(null);
   const [invitations, setInvitations] = useState<InvitationItem[]>([]);
@@ -519,6 +520,10 @@ export default function SettingsPage() {
                 <option value="">{t('orgWideInvite')}</option>
                 {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
               </OperatorSelect>
+              <OperatorSelect value={inviteRole} onChange={(e) => setInviteRole(e.target.value as 'member' | 'admin')}>
+                <option value="member">Member</option>
+                <option value="admin">Admin</option>
+              </OperatorSelect>
               <Button
                 variant="hero"
                 size="lg"
@@ -528,13 +533,14 @@ export default function SettingsPage() {
                   const res = await fetch('/api/invitations', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ email: inviteEmail.trim(), ...(inviteProjectId ? { project_id: inviteProjectId } : {}) }),
+                    body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole, ...(inviteProjectId ? { project_id: inviteProjectId } : {}) }),
                   });
                   if (res.ok) {
                     const json = await res.json();
                     setInviteResult(json.data.invite_url);
                     setInviteEmail('');
                     setInviteProjectId('');
+                    setInviteRole('member');
                     await refreshInvitations();
                   }
                   setInviting(false);


### PR DESCRIPTION
## Summary
초대 폼에 `role` 선택 드롭다운 추가 (member/admin, 기본값 member)

## Changes
- `settings/page.tsx`: `inviteRole` state 추가 + `OperatorSelect` 드롭다운 삽입 + API 호출에 `role` 파라미터 포함 + 초대 완료 후 member로 초기화

## AC Checklist
- [x] AC1: 초대 모달에 역할 선택 드롭다운 (admin/member)
- [x] AC2: API에 `role` 파라미터 전달 (`/api/invitations` POST 기존 지원)
- [x] AC3: 기본값 member, 초대 완료 후 리셋

🤖 Generated with [Claude Code](https://claude.com/claude-code)