### PR TITLE
feat: 조직 생성 전용 API + 브라우저 직접 insert 제거 (E-PLATFORM-FOUNDATION S6)

### DIFF
--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -23,17 +23,16 @@ export async function POST(request: Request) {
     }
     const { name, slug } = parsed.data;
 
-    // slug 유니크 검증
-    const { data: existingSlug } = await supabase
+    // admin client — slug 유니크 검증 시 RLS가 다른 org를 숨기는 것을 방지
+    const admin = createSupabaseAdminClient();
+
+    const { data: existingSlug } = await admin
       .from('organizations')
       .select('id')
       .eq('slug', slug)
       .maybeSingle();
 
     if (existingSlug) return apiError('CONFLICT', 'Slug is already taken', 409);
-
-    // service_role로 INSERT (RLS bypass — 인증 확인은 위에서 완료)
-    const admin = createSupabaseAdminClient();
 
     const { data: org, error: orgError } = await admin
       .from('organizations')

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -40,7 +40,10 @@ export async function POST(request: Request) {
       .select('id, name, slug')
       .single();
 
-    if (orgError) throw orgError;
+    if (orgError) {
+      if (orgError.code === '23505') return apiError('CONFLICT', 'Slug is already taken', 409);
+      throw orgError;
+    }
 
     // 생성자를 org_members에 owner로 등록
     const { error: memberError } = await admin

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -1,0 +1,57 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { z } from 'zod/v4';
+
+const createOrgSchema = z.object({
+  name: z.string().trim().min(1),
+  slug: z.string().trim().min(1).regex(/^[a-z0-9가-힣-]+$/, 'slug must be lowercase alphanumeric or Korean'),
+});
+
+// POST /api/organizations — create org + register creator as owner
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const body = await request.json() as unknown;
+    const parsed = createOrgSchema.safeParse(body);
+    if (!parsed.success) {
+      return apiError('VALIDATION_ERROR', JSON.stringify(parsed.error.issues), 400);
+    }
+    const { name, slug } = parsed.data;
+
+    // slug 유니크 검증
+    const { data: existingSlug } = await supabase
+      .from('organizations')
+      .select('id')
+      .eq('slug', slug)
+      .maybeSingle();
+
+    if (existingSlug) return apiError('CONFLICT', 'Slug is already taken', 409);
+
+    // service_role로 INSERT (RLS bypass — 인증 확인은 위에서 완료)
+    const admin = createSupabaseAdminClient();
+
+    const { data: org, error: orgError } = await admin
+      .from('organizations')
+      .insert({ name, slug })
+      .select('id, name, slug')
+      .single();
+
+    if (orgError) throw orgError;
+
+    // 생성자를 org_members에 owner로 등록
+    const { error: memberError } = await admin
+      .from('org_members')
+      .insert({ org_id: org.id, user_id: user.id, role: 'owner' });
+
+    if (memberError) throw memberError;
+
+    return apiSuccess(org, undefined, 201);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -40,19 +40,20 @@ export function OnboardingForm() {
     setLoading(true);
     setError('');
 
-    const { data, error: insertError } = await supabase
-      .from('organizations')
-      .insert({ name: orgName.trim(), slug: orgSlug.trim() })
-      .select('id')
-      .single();
+    const res = await fetch('/api/organizations', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: orgName.trim(), slug: orgSlug.trim() }),
+    });
+    const json = await res.json();
 
-    if (insertError) {
-      setError(insertError.message);
+    if (!res.ok) {
+      setError(json?.error?.message ?? t('createOrgFailed'));
       setLoading(false);
       return;
     }
 
-    setOrgId(data.id);
+    setOrgId(json.data.id);
     setStep('project');
     setLoading(false);
   };


### PR DESCRIPTION
## Summary
- `POST /api/organizations` 신규 생성 — 서버 측 조직 생성 + owner 등록
- `onboarding-form.tsx` 브라우저 Supabase 직접 insert 제거 → API 호출로 전환

## Changes
| 파일 | 내용 |
|---|---|
| `app/api/organizations/route.ts` | POST 엔드포인트: name/slug 검증, slug 유니크 체크, organizations INSERT + org_members owner 등록 |
| `app/onboarding/onboarding-form.tsx` | handleCreateOrg: 직접 insert → `fetch('/api/organizations')` |

## AC Checklist
- [x] AC1: POST /api/organizations (name, slug 파라미터)
- [x] AC2: 생성자를 org_members에 owner role로 자동 등록
- [x] AC3: 기본 프로젝트 자동 생성 — 기존 handleCreateProject(/api/projects) flow 유지
- [x] AC4: 브라우저 직접 organizations insert 코드 제거
- [x] AC5: slug 유니크 검증 + RLS bypass (admin client)

🤖 Generated with [Claude Code](https://claude.com/claude-code)