### PR TITLE
feat: auth/callback 온보딩 분기 — 초대 vs 직접 가입 (E-PLATFORM-FOUNDATION S5)

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -5,14 +5,30 @@ import { resolveAppUrl } from '@/services/app-url';
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
-  const next = searchParams.get('next') ?? '/dashboard';
+  const next = searchParams.get('next');
   const origin = resolveAppUrl(null);
 
   if (code) {
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
-      return NextResponse.redirect(`${origin}${next}`);
+      // next 파라미터가 있으면 (초대 플로우 등) 그대로 리다이렉트
+      if (next) return NextResponse.redirect(`${origin}${next}`);
+
+      // next 없으면 (직접 가입) org 소속 여부로 온보딩/대시보드 분기
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: membership } = await supabase
+          .from('org_members')
+          .select('org_id')
+          .eq('user_id', user.id)
+          .limit(1)
+          .maybeSingle();
+
+        return NextResponse.redirect(membership ? `${origin}/dashboard` : `${origin}/onboarding`);
+      }
+
+      return NextResponse.redirect(`${origin}/dashboard`);
     }
   }
 


### PR DESCRIPTION
## Summary
`auth/callback`에서 직접 가입 vs 초대 가입을 명시적으로 분기

## Changes
`app/auth/callback/route.ts`:
- `next` 파라미터 있으면 (초대 플로우) → 그대로 `next`로 리다이렉트
- `next` 없으면 (직접 가입) → `org_members` 조회 후 분기:
  - org 있음 → `/dashboard` (초대 이미 수락된 경우도 포함)
  - org 없음 → `/onboarding` (신규 직접 가입자)

## AC Checklist
- [x] AC1: 초대 링크로 가입한 사용자 온보딩 스킵 (next=/invite?token=... → invite accept → org 소속 → dashboard)
- [x] AC2: 바로 초대한 조직의 프로젝트로 랜딩 (`/api/invitations/accept`에서 project_id 쿠키 설정 이미 완료)
- [x] AC3: 직접 가입자는 org 없으면 `/onboarding` 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)