### PR TITLE
feat: Settings 프로젝트 인라인 편집 폼 (E-PLATFORM-FOUNDATION S8)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -196,7 +196,7 @@
     "author": "Author",
     "assigneeLabel": "Assignee",
     "replyCount": "Reply count",
-    "repliesCountBadge": "{count, plural, one {1 reply} other {# replies}}",
+    "repliesCountBadge": "{count} replies",
     "latestReply": "Latest reply",
     "timeline": "Timeline",
     "noTimelineEvents": "No timeline events yet.",
@@ -223,7 +223,6 @@
     "createAndLinkDoc": "Create and link doc",
     "createDocFailed": "Failed to create doc.",
     "linkDocFailed": "Failed to link doc.",
-    "repliesCountBadge": "{count} replies",
     "sidebarTitle": "Memo Sidebar",
     "sidebarSubtitle": "Open memos, reply, and create new ones from anywhere",
     "closeSidebar": "Close memo sidebar",
@@ -467,7 +466,9 @@
         "api_key": "API key",
         "api_token": "API token"
       }
-    }
+    },
+    "projectUpdated": "Project updated.",
+    "projectUpdateFailed": "Failed to update project."
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -196,7 +196,7 @@
     "author": "작성자",
     "assigneeLabel": "담당자",
     "replyCount": "답글 수",
-    "repliesCountBadge": "{count, plural, other {답글 #개}}",
+    "repliesCountBadge": "{count}개 답글",
     "latestReply": "최근 답글",
     "timeline": "타임라인",
     "noTimelineEvents": "타임라인 이벤트가 아직 없습니다.",
@@ -223,7 +223,6 @@
     "createAndLinkDoc": "문서 생성 후 연결",
     "createDocFailed": "문서 생성에 실패했습니다.",
     "linkDocFailed": "문서 연결에 실패했습니다.",
-    "repliesCountBadge": "{count}개 답글",
     "sidebarTitle": "메모 사이드바",
     "sidebarSubtitle": "모든 페이지에서 메모를 바로 확인하고 답글할 수 있습니다",
     "closeSidebar": "메모 사이드바 닫기",
@@ -467,7 +466,9 @@
         "api_key": "API 키",
         "api_token": "API 토큰"
       }
-    }
+    },
+    "projectUpdated": "프로젝트가 업데이트됐인.",
+    "projectUpdateFailed": "프로젝트 업데이트에 실패했인."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -467,8 +467,8 @@
         "api_token": "API 토큰"
       }
     },
-    "projectUpdated": "프로젝트가 업데이트됐인.",
-    "projectUpdateFailed": "프로젝트 업데이트에 실패했인."
+    "projectUpdated": "프로젝트가 업데이트되었습니다.",
+    "projectUpdateFailed": "프로젝트 업데이트에 실패했습니다."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -250,6 +250,7 @@ export default function SettingsPage() {
       setProjects((prev) => prev.map((p) => p.id === editingProjectId ? { ...p, name: json.data.name, description: json.data.description } : p));
       setEditingProjectId(null);
       setProjectActionMessage({ type: 'success', text: t('projectUpdated') });
+      router.refresh();
     } else {
       const json = await res.json().catch(() => null);
       setProjectActionMessage({ type: 'error', text: json?.error?.message ?? t('projectUpdateFailed') });

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -78,6 +78,10 @@ export default function SettingsPage() {
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [creatingProject, setCreatingProject] = useState(false);
   const [projectActionMessage, setProjectActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [editingProjectId, setEditingProjectId] = useState<string | null>(null);
+  const [editProjectName, setEditProjectName] = useState('');
+  const [editProjectDescription, setEditProjectDescription] = useState('');
+  const [savingProject, setSavingProject] = useState(false);
   const [inviteEmail, setInviteEmail] = useState('');
   const [inviteRole, setInviteRole] = useState<'member' | 'admin'>('member');
   const [inviting, setInviting] = useState(false);
@@ -232,6 +236,26 @@ export default function SettingsPage() {
 
     return Array.from(deduped.values()).sort((a, b) => a.name.localeCompare(b.name));
   }, [orgMembers, projectMembers]);
+
+  const handleUpdateProject = async () => {
+    if (!editingProjectId || !editProjectName.trim()) return;
+    setSavingProject(true);
+    const res = await fetch(`/api/projects/${editingProjectId}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: editProjectName.trim(), description: editProjectDescription.trim() || null }),
+    });
+    if (res.ok) {
+      const json = await res.json();
+      setProjects((prev) => prev.map((p) => p.id === editingProjectId ? { ...p, name: json.data.name, description: json.data.description } : p));
+      setEditingProjectId(null);
+      setProjectActionMessage({ type: 'success', text: t('projectUpdated') });
+    } else {
+      const json = await res.json().catch(() => null);
+      setProjectActionMessage({ type: 'error', text: json?.error?.message ?? t('projectUpdateFailed') });
+    }
+    setSavingProject(false);
+  };
 
   const handleCreateProject = async () => {
     if (!newProjectName.trim()) return;
@@ -447,14 +471,50 @@ export default function SettingsPage() {
           <div className="space-y-2">
             {projects.length > 0 ? (
               projects.map((project) => (
-                <div key={project.id} className="flex items-start justify-between gap-3 rounded-md border border-border bg-muted/30 px-4 py-3">
-                  <div className="min-w-0">
-                    <div className="font-medium text-foreground">{project.name}</div>
-                    {project.description ? (
-                      <div className="mt-1 text-sm text-muted-foreground">{project.description}</div>
-                    ) : null}
-                  </div>
-                  {project.id === currentProjectId ? <Badge variant="info">{t('currentProjectBadge')}</Badge> : null}
+                <div key={project.id} className="rounded-md border border-border bg-muted/30 px-4 py-3">
+                  {editingProjectId === project.id ? (
+                    <div className="space-y-2">
+                      <OperatorInput
+                        value={editProjectName}
+                        onChange={(e) => setEditProjectName(e.target.value)}
+                        placeholder={t('projectNamePlaceholder')}
+                      />
+                      <OperatorInput
+                        value={editProjectDescription}
+                        onChange={(e) => setEditProjectDescription(e.target.value)}
+                        placeholder={t('projectDescriptionPlaceholder')}
+                      />
+                      <div className="flex gap-2">
+                        <Button variant="hero" size="sm" onClick={handleUpdateProject} disabled={!editProjectName.trim() || savingProject}>
+                          {savingProject ? '...' : tc('save')}
+                        </Button>
+                        <Button variant="ghost" size="sm" onClick={() => setEditingProjectId(null)}>
+                          {tc('cancel')}
+                        </Button>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="font-medium text-foreground">{project.name}</div>
+                        {project.description ? (
+                          <div className="mt-1 text-sm text-muted-foreground">{project.description}</div>
+                        ) : null}
+                      </div>
+                      <div className="flex shrink-0 items-center gap-2">
+                        {project.id === currentProjectId ? <Badge variant="info">{t('currentProjectBadge')}</Badge> : null}
+                        {isAdmin ? (
+                          <Button variant="ghost" size="sm" onClick={() => {
+                            setEditingProjectId(project.id);
+                            setEditProjectName(project.name);
+                            setEditProjectDescription(project.description ?? '');
+                          }}>
+                            {tc('edit')}
+                          </Button>
+                        ) : null}
+                      </div>
+                    </div>
+                  )}
                 </div>
               ))
             ) : (


### PR DESCRIPTION
## Summary
- Settings > Projects 섹션에 프로젝트 이름/설명 인라인 편집 폼 추가
- GNB 프로젝트 전환 드롭다운은 기존 `operator-shell.tsx`에 이미 구현됨 (`lg:hidden` breakpoint)

## Changes
| 파일 | 내용 |
|---|---|
| `settings/page.tsx` | `handleUpdateProject` + `editingProjectId/Name/Description` state + 인라인 편집 UI |
| `messages/en.json`, `messages/ko.json` | `projectUpdated`, `projectUpdateFailed` 번역 키 추가 |

## AC Checklist
- [x] AC1: Settings > Projects — 이름/설명 수정 폼 (PATCH /api/projects/[id], admin만)
- [x] AC2: 프로젝트 멤버 목록 표시 — 기존 `section id="members"` 유지
- [x] AC3: GNB 프로젝트 전환 드롭다운 — 기존 `operator-shell.tsx` ProjectSwitcher 이미 존재
- [x] AC4: 현재 프로젝트 표시 + 클릭 시 전환 — 기존 구현 유지
- [x] AC5: 모바일에서도 접근 가능 — `lg:hidden` breakpoint (스펙 필수 반영)
- [x] 선생님 선호도: sticky 헤더 + rounded-none (기존 GlassPanel 유지), `lg:hidden` breakpoint 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)