### PR TITLE
feat: 알림 정합성 (E-PLATFORM-FOUNDATION S9)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -879,6 +879,7 @@
     "filterAll": "All",
     "filter_story": "Story",
     "filter_memo": "Memo",
+    "filter_task": "Task",
     "filter_reward": "Reward",
     "filter_info": "Info",
     "filter_warning": "Warning",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -879,6 +879,7 @@
     "filterAll": "전체",
     "filter_story": "스토리",
     "filter_memo": "메모",
+    "filter_task": "태스크",
     "filter_reward": "리워드",
     "filter_info": "안내",
     "filter_warning": "경고",

--- a/apps/web/src/lib/notification-types.ts
+++ b/apps/web/src/lib/notification-types.ts
@@ -1,0 +1,3 @@
+export const NOTIFICATION_TYPES = ['memo', 'story', 'task', 'reward', 'info', 'warning', 'system'] as const;
+
+export type NotificationType = typeof NOTIFICATION_TYPES[number];

--- a/apps/web/src/services/agent-builtin-tools.ts
+++ b/apps/web/src/services/agent-builtin-tools.ts
@@ -366,6 +366,16 @@ export class AgentBuiltinToolService {
           .select('id, org_id, project_id, title, content, memo_type, status, assigned_to, created_by, created_at, updated_at')
           .single();
 
+        // memo_assignees upsert — trg_memo_assignees_notify 발동하여 알림 보장
+        if (!error && data && args.assigned_to) {
+          await this.supabase
+            .from('memo_assignees')
+            .upsert(
+              { memo_id: memo.id, member_id: args.assigned_to, assigned_by: ctx.memo.created_by },
+              { onConflict: 'memo_id,member_id', ignoreDuplicates: true },
+            );
+        }
+
         if (error || !data) throw error ?? new Error('memo update failed');
         return { memo: this.presentMemo(data as MemoScope) };
       }

--- a/apps/web/src/services/notification-display.test.ts
+++ b/apps/web/src/services/notification-display.test.ts
@@ -8,6 +8,7 @@ import {
 const translations: Record<string, string> = {
   filter_story: '스토리',
   filter_memo: '메모',
+  filter_task: '태스크',
   filter_reward: '리워드',
   filter_info: '안내',
   filter_warning: '경고',
@@ -28,5 +29,13 @@ describe('notification-display', () => {
     expect(INBOX_FILTER_TYPES).toContain('warning');
     expect(NOTIFICATION_TYPE_ICONS.info).toBe('ℹ️');
     expect(NOTIFICATION_TYPE_ICONS.warning).toBe('⚠️');
+  });
+
+  it('includes task type in filter list and icons', () => {
+    const t = (key: string) => translations[key] ?? key;
+
+    expect(INBOX_FILTER_TYPES).toContain('task');
+    expect(NOTIFICATION_TYPE_ICONS.task).toBe('📋');
+    expect(getInboxNotificationLabel(t, 'task')).toBe('태스크');
   });
 });

--- a/apps/web/src/services/notification-display.ts
+++ b/apps/web/src/services/notification-display.ts
@@ -1,13 +1,16 @@
+import { NOTIFICATION_TYPES } from '@/lib/notification-types';
+
 export const NOTIFICATION_TYPE_ICONS: Record<string, string> = {
   story: '📌',
   memo: '💬',
+  task: '📋',
   reward: '🏆',
   info: 'ℹ️',
   warning: '⚠️',
   system: '🔧',
 };
 
-export const INBOX_FILTER_TYPES = ['', 'story', 'memo', 'reward', 'info', 'warning', 'system'] as const;
+export const INBOX_FILTER_TYPES = ['', ...NOTIFICATION_TYPES] as const;
 
 export function getInboxNotificationLabel(
   t: (key: string) => string,
@@ -18,6 +21,8 @@ export function getInboxNotificationLabel(
       return t('filter_story');
     case 'memo':
       return t('filter_memo');
+    case 'task':
+      return t('filter_task');
     case 'reward':
       return t('filter_reward');
     case 'info':

--- a/packages/db/supabase/migrations/20260424150000_memo_assignees_notification_trigger.sql
+++ b/packages/db/supabase/migrations/20260424150000_memo_assignees_notification_trigger.sql
@@ -1,0 +1,52 @@
+-- E-PLATFORM-FOUNDATION S9 — memo_assignees 다중 assignee 알림 트리거
+--
+-- 기존 memos.assigned_to(단일) 기반 트리거를 memo_assignees(다중) 기반으로 이전한다.
+-- 기존 트리거는 DROP하여 중복 알림을 방지한다.
+
+-- 1. 기존 memos.assigned_to 기반 트리거 제거 (memo_assignees 트리거로 일원화)
+DROP TRIGGER IF EXISTS trg_memo_notify_assignee ON public.memos;
+DROP FUNCTION IF EXISTS public.notify_memo_assignee();
+
+-- 2. memo_assignees AFTER INSERT 트리거 — row 단위 알림
+CREATE OR REPLACE FUNCTION public.notify_memo_assignees_row()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_org_id   uuid;
+  v_title    text;
+  v_content  text;
+  v_user_id  uuid;
+BEGIN
+  SELECT org_id, title, content
+    INTO v_org_id, v_title, v_content
+    FROM public.memos
+   WHERE id = NEW.memo_id;
+
+  SELECT user_id
+    INTO v_user_id
+    FROM public.team_members
+   WHERE id = NEW.member_id;
+
+  IF v_user_id IS NOT NULL AND v_org_id IS NOT NULL THEN
+    INSERT INTO public.notifications (org_id, user_id, type, title, body, reference_type, reference_id)
+    VALUES (
+      v_org_id,
+      v_user_id,
+      'memo',
+      '새 메모',
+      '"' || COALESCE(v_title, LEFT(v_content, 50)) || '" 메모가 할당되었습니다.',
+      'memo',
+      NEW.memo_id
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_memo_assignees_notify
+  AFTER INSERT ON public.memo_assignees
+  FOR EACH ROW EXECUTE FUNCTION public.notify_memo_assignees_row();


### PR DESCRIPTION
## E-PLATFORM-FOUNDATION S9 — 알림 정합성 (2SP)

### 변경 내용

**AC1 — NotificationInbox type='task' 필터 추가**
- `lib/notification-types.ts` 신설: `NOTIFICATION_TYPES` const + `NotificationType` 타입 (단일 source of truth)
- `notification-display.ts`: `NOTIFICATION_TYPE_ICONS`에 task 아이콘(📋) 추가, `INBOX_FILTER_TYPES`에 'task' 포함, `getInboxNotificationLabel` case 추가
- `en.json` / `ko.json`: `filter_task` 번역 키 추가

**AC2 — 메모 다중 assignee 전원 알림 트리거**
- 마이그레이션 `20260424150000_memo_assignees_notification_trigger.sql`
  - 기존 `memos.assigned_to` 기반 트리거(단일) DROP
  - `memo_assignees` AFTER INSERT 트리거 신규 — `member_id` → `team_members.user_id` JOIN 후 notifications INSERT

**AC3 — 이벤트 enum 단일 정의 통일**
- `lib/notification-types.ts`에서 `['memo', 'story', 'task', 'reward', 'info', 'warning', 'system']` 단일 정의
- `notification-display.ts`에서 import

**AC4 — regression 없음**
- `notification-display.test.ts` 3/3 PASS (task 케이스 추가)

🤖 Generated with [Claude Code](https://claude.com/claude-code)