### PR TITLE
feat: 웹훅 정합성 (E-PLATFORM-FOUNDATION S10)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -203,12 +203,12 @@ export default function SettingsPage() {
     await fetch('/api/notification-settings', {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ channel: 'web', event_type: eventType, enabled: newEnabled }),
+      body: JSON.stringify({ channel: 'in_app', event_type: eventType, enabled: newEnabled }),
     });
     setSettings((prev) => {
       const existing = prev.find((s) => s.event_type === eventType && s.channel === 'web');
       if (existing) return prev.map((s) => (s.id === existing.id ? { ...s, enabled: newEnabled } : s));
-      return [...prev, { id: `temp-${eventType}`, channel: 'web', event_type: eventType, enabled: newEnabled }];
+      return [...prev, { id: `temp-${eventType}`, channel: 'in_app', event_type: eventType, enabled: newEnabled }];
     });
   };
 

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -206,14 +206,14 @@ export default function SettingsPage() {
       body: JSON.stringify({ channel: 'in_app', event_type: eventType, enabled: newEnabled }),
     });
     setSettings((prev) => {
-      const existing = prev.find((s) => s.event_type === eventType && s.channel === 'web');
+      const existing = prev.find((s) => s.event_type === eventType && s.channel === 'in_app');
       if (existing) return prev.map((s) => (s.id === existing.id ? { ...s, enabled: newEnabled } : s));
       return [...prev, { id: `temp-${eventType}`, channel: 'in_app', event_type: eventType, enabled: newEnabled }];
     });
   };
 
   const getEnabled = (eventType: string) => {
-    const setting = settings.find((s) => s.event_type === eventType && s.channel === 'web');
+    const setting = settings.find((s) => s.event_type === eventType && s.channel === 'in_app');
     return setting?.enabled ?? true;
   };
 

--- a/apps/web/src/app/api/webhooks/config/route.ts
+++ b/apps/web/src/app/api/webhooks/config/route.ts
@@ -3,6 +3,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { isOssMode } from '@/lib/storage/factory';
 import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
 
 /** GET — 내 웹훅 설정 목록 */
 export async function GET() {
@@ -77,6 +78,34 @@ export async function PUT(request: Request) {
       if (error) throw error;
     }
 
+    return apiSuccess({ ok: true });
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+/** DELETE — 웹훅 설정 삭제 (admin만) */
+export async function DELETE(request: Request) {
+  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden('Team member not found');
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const { searchParams } = new URL(request.url);
+    const id = searchParams.get('id');
+    if (!id) return ApiErrors.badRequest('id required');
+
+    const { error } = await supabase
+      .from('webhook_configs')
+      .delete()
+      .eq('id', id)
+      .eq('org_id', me.org_id);
+
+    if (error) throw error;
     return apiSuccess({ ok: true });
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -22,25 +22,7 @@ export async function GET(request: Request) {
   } catch (err: unknown) { return handleApiError(err); }
 }
 
-export async function PUT(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
-  try {
-    const supabase = await createSupabaseServerClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
-    const me = await getMyTeamMember(supabase, user);
-    if (!me) return ApiErrors.forbidden();
-    await requireOrgAdmin(supabase, me.org_id);
-    const body = await request.json();
-    const targetId = body.member_id ?? me.id;
-    const { data: target } = await supabase.from('team_members').select('id').eq('id', targetId).eq('project_id', me.project_id).single();
-    if (!target) return ApiErrors.badRequest('target member not in project');
-    const { data, error } = await supabase.from('webhook_configs').upsert({
-      org_id: me.org_id, member_id: targetId,
-      url: body.url, secret: body.secret ?? null,
-      events: body.events ?? [], is_active: body.is_active ?? true,
-    }, { onConflict: 'member_id' }).select().single();
-    if (error) throw error;
-    return apiSuccess(data);
-  } catch (err: unknown) { return handleApiError(err); }
+// Deprecated: use PUT /api/webhooks/config instead (supports project_id scoping)
+export async function PUT() {
+  return apiError('GONE', 'Use PUT /api/webhooks/config instead.', 410);
 }

--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -36,7 +36,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
 
       const isDiscord = member.webhook_url.includes('discord.com') || member.webhook_url.includes('discordapp.com');
       const body = isDiscord
-        ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
+        ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}` })
         : JSON.stringify({ text: `*${title}*\n${description}` });
 
       await fetch(member.webhook_url, {
@@ -119,7 +119,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
 
     const isDiscord = webhookUrl.includes('discord.com') || webhookUrl.includes('discordapp.com');
     const body = isDiscord
-      ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
+      ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}` })
       : JSON.stringify({ text: `*${title}*\n${description}` });
 
     const headers: Record<string, string> = {

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -674,18 +674,6 @@ export class MemoEventDispatcher {
         format,
         body: {
           content: `${title}\n${description.substring(0, 500)}`,
-          embeds: [
-            {
-              title,
-              description,
-              color: 0x3B82F6,
-              fields: [
-                { name: 'Agent', value: truncateText(agent.name, 1024, 'Unknown agent'), inline: true },
-                { name: 'Type', value: truncateText(memo.memo_type, 1024, 'memo'), inline: true },
-              ],
-              timestamp: memo.created_at,
-            },
-          ],
         },
       };
     }

--- a/packages/db/supabase/migrations/20260424160000_webhook_integrity.sql
+++ b/packages/db/supabase/migrations/20260424160000_webhook_integrity.sql
@@ -1,0 +1,15 @@
+-- E-PLATFORM-FOUNDATION S10 — 웹훅 정합성
+
+-- 1. notification_settings.channel 'web' → 'in_app' 마이그레이션
+--    (Settings UI가 'web' 대신 'in_app'을 사용하도록 수정됨에 따른 기존 row 정리)
+UPDATE public.notification_settings
+   SET channel = 'in_app'
+ WHERE channel = 'web';
+
+-- 2. channel CHECK 제약 재정의 (in_app, email, webhook, slack, discord — 'web' 제거)
+ALTER TABLE public.notification_settings
+  DROP CONSTRAINT IF EXISTS notification_settings_channel_check;
+
+ALTER TABLE public.notification_settings
+  ADD CONSTRAINT notification_settings_channel_check
+    CHECK (channel IN ('in_app', 'email', 'webhook', 'slack', 'discord'));


### PR DESCRIPTION
## E-PLATFORM-FOUNDATION S10 — 웹훅 정합성 (2SP) — 에픽 마지막 스토리

### 변경 내용

**AC1 ✅ — notification_settings channel 'in_app' 통일**
- `settings/page.tsx`: `channel: 'web'` → `channel: 'in_app'` 3곳 교체
- 마이그레이션 `20260424160000_webhook_integrity.sql`:
  - 기존 `channel = 'web'` row → `'in_app'` 업데이트
  - `notification_settings_channel_check` 제약 재정의 ('web' 제거)

**AC2 ✅ — 레거시 /api/webhooks PUT deprecated**
- `apps/web/src/app/api/webhooks/route.ts` PUT: `onConflict: 'member_id'` 충돌 해소
- 410 GONE 반환 + "Use PUT /api/webhooks/config instead." 안내
- Settings UI는 이미 `/api/webhooks/config` 사용 중

**AC3 ✅ — webhook_configs DELETE — admin만**
- `apps/web/src/app/api/webhooks/config/route.ts`: DELETE 핸들러 추가
- `requireOrgAdmin` + `org_id` 스코프 필터 적용
- RLS(`webhook_configs_delete_admin`)와 API 레벨 이중 보호

**AC4 ✅ — Discord 발송 content-only 통일**
- `memo-event-dispatcher.ts`: discord format `embeds` 배열 제거 → `content`만
- `memo-assignment-dispatch.ts`: OSS + SaaS 경로 2곳 `embeds` 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)