### PR TITLE
feat: webhook_deliveries 테이블 + 재시도 로직 (E-NOTIFY-WEBHOOK S2)

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.test.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.test.ts
@@ -31,6 +31,18 @@ const baseMemo = {
 function makeSupabase(results: Record<string, unknown>) {
   return {
     from: vi.fn((table: string) => {
+      if (table === 'webhook_deliveries') {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: 'delivery-1' }, error: null }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
       const payload = results[table] ?? { data: null, error: null };
       return {
         select: vi.fn().mockReturnThis(),
@@ -81,7 +93,7 @@ describe('dispatchMemoAssignmentImmediately', () => {
 
   it('prefers webhook_configs url over team_members.webhook_url', async () => {
     const supabase = makeSupabase({
-      webhook_configs: { data: { url: 'https://discord.com/api/webhooks/2/config', secret: null }, error: null },
+      webhook_configs: { data: { id: 'config-1', url: 'https://discord.com/api/webhooks/2/config', secret: null }, error: null },
       team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/fallback' }, error: null },
     });
     createSupabaseAdminClient.mockReturnValue(supabase);

--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -1,6 +1,7 @@
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { buildAbsoluteMemoLink } from './app-url';
 import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
+import { WebhookDeliveryService } from './webhook-delivery.service';
 
 export interface DispatchableMemo {
   id: string;
@@ -62,7 +63,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     // webhook_configs: project_id 기준 우선
     const { data: projectConfig } = await supabase
       .from('webhook_configs')
-      .select('url, secret')
+      .select('id, url, secret')
       .eq('org_id', memo.org_id)
       .eq('member_id', assigneeId)
       .eq('project_id', memo.project_id)
@@ -72,15 +73,17 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
 
     let webhookUrl: string | null = null;
     let webhookSecret: string | null = null;
+    let webhookConfigId: string | null = null;
 
     if (projectConfig?.url) {
       webhookUrl = projectConfig.url as string;
       webhookSecret = (projectConfig.secret as string | null) ?? null;
+      webhookConfigId = projectConfig.id as string;
     } else {
       // webhook_configs: org 기본값
       const { data: defaultConfig } = await supabase
         .from('webhook_configs')
-        .select('url, secret')
+        .select('id, url, secret')
         .eq('org_id', memo.org_id)
         .eq('member_id', assigneeId)
         .is('project_id', null)
@@ -91,8 +94,9 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
       if (defaultConfig?.url) {
         webhookUrl = defaultConfig.url as string;
         webhookSecret = (defaultConfig.secret as string | null) ?? null;
+        webhookConfigId = defaultConfig.id as string;
       } else {
-        // fallback: team_members.webhook_url
+        // fallback: team_members.webhook_url (config_id 없음)
         const { data: member } = await supabase
           .from('team_members')
           .select('webhook_url')
@@ -127,15 +131,17 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
       ...buildWebhookSignatureHeaders(webhookSecret, body),
     };
 
-    const response = await fetch(webhookUrl, {
-      method: 'POST',
+    const ok = await new WebhookDeliveryService(supabase).dispatch({
+      org_id: memo.org_id,
+      webhook_config_id: webhookConfigId,
+      event_type: 'memo.assigned',
+      url: webhookUrl,
       headers,
       body,
-      signal: AbortSignal.timeout(10_000),
     });
 
-    if (!response.ok) {
-      console.error('[MemoDispatch] webhook responded with HTTP', response.status, 'for assignee:', assigneeId);
+    if (!ok) {
+      console.error('[MemoDispatch] webhook delivery failed for assignee:', assigneeId);
     }
   } catch (error) {
     console.error(

--- a/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
@@ -17,8 +17,8 @@ function createSupabaseStub(options?: {
     { id: 'member-3', name: '디디 은와추쿠', webhook_url: null, is_active: true },
   ];
   const webhookConfigs = options?.webhookConfigs ?? [
-    { org_id: 'org-1', member_id: 'member-1', project_id: 'project-1', is_active: true, url: 'https://discord.com/api/webhooks/member-1/project', secret: null },
-    { org_id: 'org-1', member_id: 'member-3', project_id: null, is_active: true, url: 'https://discord.com/api/webhooks/member-3/default', secret: null },
+    { id: 'config-1', org_id: 'org-1', member_id: 'member-1', project_id: 'project-1', is_active: true, url: 'https://discord.com/api/webhooks/member-1/project', secret: null },
+    { id: 'config-3', org_id: 'org-1', member_id: 'member-3', project_id: null, is_active: true, url: 'https://discord.com/api/webhooks/member-3/default', secret: null },
   ];
   const memoAssignees = options?.memoAssignees ?? [];
 
@@ -73,6 +73,19 @@ function createSupabaseStub(options?: {
             }) ?? null;
             return { data, error: null };
           },
+        };
+      }
+
+      if (table === 'webhook_deliveries') {
+        return {
+          insert: vi.fn().mockReturnValue({
+            select: vi.fn().mockReturnValue({
+              single: vi.fn().mockResolvedValue({ data: { id: 'delivery-1' }, error: null }),
+            }),
+          }),
+          update: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
         };
       }
 

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -2,6 +2,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { buildAbsoluteMemoLink } from './app-url';
 import { hasExactMemberMention } from './doc-comment-notifications';
 import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
+import { WebhookDeliveryService } from './webhook-delivery.service';
 
 interface MemoReplyDispatchMemo {
   id: string;
@@ -33,6 +34,7 @@ interface MemoReplyParticipantRow {
 }
 
 interface WebhookConfigRow {
+  id: string;
   url: string;
   secret: string | null;
 }
@@ -138,14 +140,20 @@ function extractMentionedMemberIds(contents: string[], members: TeamMemberRow[])
   return targets;
 }
 
+interface ResolvedWebhook {
+  id: string | null;
+  url: string;
+  secret: string | null;
+}
+
 async function resolveWebhook(
   supabase: SupabaseClient,
   memo: MemoReplyDispatchMemo,
   member: TeamMemberRow,
-): Promise<WebhookConfigRow | { url: string; secret: null } | null> {
+): Promise<ResolvedWebhook | null> {
   const { data: projectConfig } = await supabase
     .from('webhook_configs')
-    .select('url, secret')
+    .select('id, url, secret')
     .eq('org_id', memo.org_id)
     .eq('member_id', member.id)
     .eq('project_id', memo.project_id)
@@ -157,7 +165,7 @@ async function resolveWebhook(
 
   const { data: defaultConfig } = await supabase
     .from('webhook_configs')
-    .select('url, secret')
+    .select('id, url, secret')
     .eq('org_id', memo.org_id)
     .eq('member_id', member.id)
     .is('project_id', null)
@@ -166,13 +174,15 @@ async function resolveWebhook(
     .maybeSingle();
 
   if (defaultConfig?.url) return defaultConfig as WebhookConfigRow;
-  if (member.webhook_url) return { url: member.webhook_url, secret: null };
+  if (member.webhook_url) return { id: null, url: member.webhook_url, secret: null };
   return null;
 }
 
 async function postWebhook(
+  supabase: SupabaseClient,
   fetchFn: typeof fetch,
-  webhook: WebhookConfigRow | { url: string; secret: null },
+  orgId: string,
+  webhook: ResolvedWebhook,
   title: string,
   description: string,
 ) {
@@ -191,14 +201,15 @@ async function postWebhook(
     ...buildWebhookSignatureHeaders(webhook.secret, body),
   };
 
-  const response = await fetchFn(webhook.url, {
-    method: 'POST',
+  return new WebhookDeliveryService(supabase).dispatch({
+    org_id: orgId,
+    webhook_config_id: webhook.id,
+    event_type: 'memo.reply',
+    url: webhook.url,
     headers,
     body,
-    signal: AbortSignal.timeout(10_000),
+    fetchFn,
   });
-
-  return response.ok;
 }
 
 export async function dispatchWorkflowMemoReplyWebhooks(
@@ -280,7 +291,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
     if (!webhook) continue;
 
     try {
-      const sent = await postWebhook(fetchFn, webhook, title, description);
+      const sent = await postWebhook(supabase, fetchFn, memo.org_id, webhook, title, description);
       if (sent) {
         sentCount += 1;
       } else {

--- a/apps/web/src/services/webhook-delivery.service.ts
+++ b/apps/web/src/services/webhook-delivery.service.ts
@@ -1,0 +1,99 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const BACKOFF_DELAYS_MS = [0, 1_000, 4_000] as const; // attempt 0,1,2 전 대기
+const MAX_ATTEMPTS = 3;
+
+export interface WebhookDispatchInput {
+  org_id: string;
+  webhook_config_id: string | null;
+  event_type: string;
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+  fetchFn?: typeof fetch;
+}
+
+export class WebhookDeliveryService {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async dispatch(input: WebhookDispatchInput): Promise<boolean> {
+    const { org_id, webhook_config_id, event_type, url, headers, body } = input;
+    const fetchFn = input.fetchFn ?? fetch;
+
+    const { data: delivery, error: insertError } = await this.supabase
+      .from('webhook_deliveries')
+      .insert({ org_id, webhook_config_id, event_type, payload: { url, body } })
+      .select('id')
+      .single();
+
+    if (insertError || !delivery) {
+      // delivery 기록 실패해도 발송은 시도
+      return this._sendWithRetry(fetchFn, url, headers, body, null, null);
+    }
+
+    return this._sendWithRetry(fetchFn, url, headers, body, delivery.id as string, org_id);
+  }
+
+  private async _sendWithRetry(
+    fetchFn: typeof fetch,
+    url: string,
+    headers: Record<string, string>,
+    body: string,
+    deliveryId: string | null,
+    orgId: string | null,
+  ): Promise<boolean> {
+    let lastError = '';
+
+    for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+      if (BACKOFF_DELAYS_MS[attempt] > 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, BACKOFF_DELAYS_MS[attempt]));
+      }
+
+      if (deliveryId) {
+        await this.supabase
+          .from('webhook_deliveries')
+          .update({ attempts: attempt + 1 })
+          .eq('id', deliveryId);
+      }
+
+      try {
+        const response = await fetchFn(url, {
+          method: 'POST',
+          headers,
+          body,
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (response.ok) {
+          if (deliveryId) {
+            await this.supabase
+              .from('webhook_deliveries')
+              .update({ status: 'success', delivered_at: new Date().toISOString() })
+              .eq('id', deliveryId);
+          }
+          return true;
+        }
+
+        lastError = `HTTP ${response.status}`;
+      } catch (err) {
+        lastError = err instanceof Error ? err.message : String(err);
+      }
+
+      if (deliveryId) {
+        await this.supabase
+          .from('webhook_deliveries')
+          .update({ last_error: lastError })
+          .eq('id', deliveryId);
+      }
+    }
+
+    if (deliveryId) {
+      await this.supabase
+        .from('webhook_deliveries')
+        .update({ status: 'failed', last_error: lastError })
+        .eq('id', deliveryId);
+    }
+
+    return false;
+  }
+}

--- a/packages/db/supabase/migrations/20260424190000_webhook_deliveries.sql
+++ b/packages/db/supabase/migrations/20260424190000_webhook_deliveries.sql
@@ -1,0 +1,27 @@
+-- webhook_deliveries: 아웃바운드 웹훅 발송 이력 + 재시도 추적
+CREATE TABLE IF NOT EXISTS public.webhook_deliveries (
+  id                uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id            uuid        NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  webhook_config_id uuid        REFERENCES public.webhook_configs(id) ON DELETE SET NULL,
+  event_type        text        NOT NULL,
+  payload           jsonb       NOT NULL DEFAULT '{}',
+  status            text        NOT NULL DEFAULT 'pending'
+                                CHECK (status IN ('pending', 'success', 'failed')),
+  attempts          integer     NOT NULL DEFAULT 0,
+  last_error        text,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  delivered_at      timestamptz
+);
+
+COMMENT ON TABLE public.webhook_deliveries IS '아웃바운드 웹훅 발송 이력';
+
+CREATE INDEX idx_webhook_deliveries_org_id        ON public.webhook_deliveries(org_id);
+CREATE INDEX idx_webhook_deliveries_config_id     ON public.webhook_deliveries(webhook_config_id) WHERE webhook_config_id IS NOT NULL;
+CREATE INDEX idx_webhook_deliveries_status        ON public.webhook_deliveries(status) WHERE status != 'success';
+
+-- RLS: 같은 org의 admin(owner/admin)만 조회 가능
+ALTER TABLE public.webhook_deliveries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "webhook_deliveries_select_admin"
+  ON public.webhook_deliveries FOR SELECT
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));


### PR DESCRIPTION
## Summary
- `webhook_deliveries` 테이블 신설 — `webhook_config_id / event_type / payload / status / attempts / last_error / delivered_at`
- `WebhookDeliveryService` 신설 — delivery 기록 → exponential backoff 3회(0s→1s→4s) 재시도 → 결과 업데이트
- 메모 배정(`memo-assignment-dispatch`) + 답신(`memo-reply-webhook-dispatch`) 발송 경로에 통합
- `webhook_configs` 쿼리에 `id` 컬럼 추가 — `webhook_config_id` 추적
- RLS: `get_user_admin_org_ids()` 기반, 같은 org admin만 조회 가능

## AC Checklist
- [x] AC1: `webhook_deliveries` 테이블 신설 (5 컬럼 + CHECK + 인덱스)
- [x] AC2: 발송 시 delivery 레코드 생성 → 발송 → 결과 업데이트 파이프라인
- [x] AC3: 실패 시 exponential backoff 재시도 (1초 → 4초, 최대 3회)
- [x] AC4: 3회 실패 시 `status='failed'`, `last_error` 기록
- [x] AC5: RLS — 같은 org admin만 deliveries 조회 가능

## Files Changed
- `packages/db/supabase/migrations/20260424190000_webhook_deliveries.sql` — 테이블 + RLS
- `apps/web/src/services/webhook-delivery.service.ts` — 신규
- `apps/web/src/services/memo-assignment-dispatch.ts` — WebhookDeliveryService 통합
- `apps/web/src/services/memo-reply-webhook-dispatch.ts` — WebhookDeliveryService 통합

🤖 Generated with [Claude Code](https://claude.com/claude-code)