### PR TITLE
feat: 아웃바운드 HMAC X-Sprintable-* 헤더 + webhook_configs channel 컬럼 (E-NOTIFY-WEBHOOK S3)

### DIFF
--- a/apps/web/src/lib/webhook-signature.ts
+++ b/apps/web/src/lib/webhook-signature.ts
@@ -1,12 +1,19 @@
 import { createHmac } from 'crypto';
 
 /**
- * HMAC-SHA256 웹훅 서명 생성 (AC1~AC4)
+ * HMAC-SHA256 웹훅 서명 생성
  *
  * 서명 대상: `${timestamp}.${body}`
- * 헤더: X-Webhook-Signature: sha256={hex}, X-Webhook-Timestamp: {ts}
+ * 헤더: X-Sprintable-Signature: sha256={hex}, X-Sprintable-Timestamp: {ts}
  *
- * AC5: secret이 없으면 undefined 반환 → 헤더 미포함 (하위호환)
+ * secret이 없으면 빈 객체 반환 → 헤더 미포함 (하위호환)
+ *
+ * --- 수신측 검증 예시 (Node.js) ---
+ * const ts  = req.headers['x-sprintable-timestamp'];
+ * const sig = req.headers['x-sprintable-signature']; // "sha256=<hex>"
+ * const expected = 'sha256=' + createHmac('sha256', secret).update(`${ts}.${rawBody}`).digest('hex');
+ * const ok = timingSafeEqual(Buffer.from(sig), Buffer.from(expected));
+ * if (!ok || Math.abs(Date.now() - Number(ts)) > 300_000) throw new Error('invalid signature');
  */
 export function buildWebhookSignatureHeaders(
   secret: string | null | undefined,
@@ -18,7 +25,7 @@ export function buildWebhookSignatureHeaders(
     .update(`${timestamp}.${body}`)
     .digest('hex');
   return {
-    'X-Webhook-Signature': `sha256=${signature}`,
-    'X-Webhook-Timestamp': timestamp,
+    'X-Sprintable-Signature': `sha256=${signature}`,
+    'X-Sprintable-Timestamp': timestamp,
   };
 }

--- a/apps/web/src/services/memo-assignment-dispatch.test.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.test.ts
@@ -93,7 +93,7 @@ describe('dispatchMemoAssignmentImmediately', () => {
 
   it('prefers webhook_configs url over team_members.webhook_url', async () => {
     const supabase = makeSupabase({
-      webhook_configs: { data: { id: 'config-1', url: 'https://discord.com/api/webhooks/2/config', secret: null }, error: null },
+      webhook_configs: { data: { id: 'config-1', url: 'https://discord.com/api/webhooks/2/config', secret: null, channel: 'discord' }, error: null },
       team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/fallback' }, error: null },
     });
     createSupabaseAdminClient.mockReturnValue(supabase);

--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -63,7 +63,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     // webhook_configs: project_id 기준 우선
     const { data: projectConfig } = await supabase
       .from('webhook_configs')
-      .select('id, url, secret')
+      .select('id, url, secret, channel')
       .eq('org_id', memo.org_id)
       .eq('member_id', assigneeId)
       .eq('project_id', memo.project_id)
@@ -74,16 +74,18 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     let webhookUrl: string | null = null;
     let webhookSecret: string | null = null;
     let webhookConfigId: string | null = null;
+    let webhookChannel: string | null = null;
 
     if (projectConfig?.url) {
       webhookUrl = projectConfig.url as string;
       webhookSecret = (projectConfig.secret as string | null) ?? null;
       webhookConfigId = projectConfig.id as string;
+      webhookChannel = (projectConfig.channel as string | null) ?? null;
     } else {
       // webhook_configs: org 기본값
       const { data: defaultConfig } = await supabase
         .from('webhook_configs')
-        .select('id, url, secret')
+        .select('id, url, secret, channel')
         .eq('org_id', memo.org_id)
         .eq('member_id', assigneeId)
         .is('project_id', null)
@@ -95,6 +97,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
         webhookUrl = defaultConfig.url as string;
         webhookSecret = (defaultConfig.secret as string | null) ?? null;
         webhookConfigId = defaultConfig.id as string;
+        webhookChannel = (defaultConfig.channel as string | null) ?? null;
       } else {
         // fallback: team_members.webhook_url (config_id 없음)
         const { data: member } = await supabase
@@ -121,7 +124,7 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
     const memoLink = buildAbsoluteMemoLink(memo.id, process.env.NEXT_PUBLIC_APP_URL);
     const description = `${preview}\n\n${memoLink}`;
 
-    const isDiscord = webhookUrl.includes('discord.com') || webhookUrl.includes('discordapp.com');
+    const isDiscord = webhookChannel === 'discord' || (!webhookChannel && (webhookUrl.includes('discord.com') || webhookUrl.includes('discordapp.com')));
     const body = isDiscord
       ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}` })
       : JSON.stringify({ text: `*${title}*\n${description}` });

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -51,6 +51,7 @@ interface RoutingPayload {
 interface WebhookConfigRow {
   url: string;
   secret: string | null;
+  channel: OutboundWebhookFormat;
 }
 
 type OutboundWebhookFormat = 'discord' | 'google' | 'slack' | 'generic';
@@ -451,6 +452,7 @@ export class MemoEventDispatcher {
       try {
         const outbound = this.buildWebhookPayload({
           webhookUrl: webhook.url,
+          webhookChannel: webhook.channel,
           memo,
           agent,
           deploymentId: null,
@@ -562,6 +564,7 @@ export class MemoEventDispatcher {
     try {
       const outbound = this.buildWebhookPayload({
         webhookUrl: webhook.url,
+        webhookChannel: webhook.channel,
         memo,
         agent,
         deploymentId: deployment?.id ?? null,
@@ -631,6 +634,7 @@ export class MemoEventDispatcher {
 
   private buildWebhookPayload(input: {
     webhookUrl: string;
+    webhookChannel?: OutboundWebhookFormat | null;
     memo: MemoRow;
     agent: TeamMemberRow;
     deploymentId: string | null;
@@ -639,8 +643,8 @@ export class MemoEventDispatcher {
     dispatchKey: string;
     routing: RoutingEvaluationResult;
   }): { format: OutboundWebhookFormat; body: Record<string, unknown> } {
-    const { webhookUrl, memo, agent, deploymentId, runId, source, dispatchKey, routing } = input;
-    const format = detectWebhookFormat(webhookUrl);
+    const { webhookUrl, webhookChannel, memo, agent, deploymentId, runId, source, dispatchKey, routing } = input;
+    const format = webhookChannel ?? detectWebhookFormat(webhookUrl);
     const title = truncateText(memo.title, 256, 'New assigned memo');
     const description = truncateText(memo.content, 4000, '(no content)');
     const internalPayload = {
@@ -762,11 +766,11 @@ export class MemoEventDispatcher {
     return (data as AgentDeploymentRow | null) ?? null;
   }
 
-  private async resolveWebhook(agent: TeamMemberRow, projectId: string): Promise<WebhookConfigRow | { url: string; secret: null } | null> {
+  private async resolveWebhook(agent: TeamMemberRow, projectId: string): Promise<WebhookConfigRow | { url: string; secret: null; channel: null } | null> {
     const supabase = this.options.supabase;
     const { data: projectConfig } = await supabase
       .from('webhook_configs')
-      .select('url, secret')
+      .select('url, secret, channel')
       .eq('org_id', agent.org_id)
       .eq('member_id', agent.id)
       .eq('project_id', projectId)
@@ -778,7 +782,7 @@ export class MemoEventDispatcher {
 
     const { data: defaultConfig } = await supabase
       .from('webhook_configs')
-      .select('url, secret')
+      .select('url, secret, channel')
       .eq('org_id', agent.org_id)
       .eq('member_id', agent.id)
       .is('project_id', null)
@@ -787,7 +791,7 @@ export class MemoEventDispatcher {
       .maybeSingle();
 
     if (defaultConfig?.url) return defaultConfig as WebhookConfigRow;
-    if (agent.webhook_url) return { url: agent.webhook_url, secret: null };
+    if (agent.webhook_url) return { url: agent.webhook_url, secret: null, channel: null };
     return null;
   }
 

--- a/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
@@ -17,8 +17,8 @@ function createSupabaseStub(options?: {
     { id: 'member-3', name: '디디 은와추쿠', webhook_url: null, is_active: true },
   ];
   const webhookConfigs = options?.webhookConfigs ?? [
-    { id: 'config-1', org_id: 'org-1', member_id: 'member-1', project_id: 'project-1', is_active: true, url: 'https://discord.com/api/webhooks/member-1/project', secret: null },
-    { id: 'config-3', org_id: 'org-1', member_id: 'member-3', project_id: null, is_active: true, url: 'https://discord.com/api/webhooks/member-3/default', secret: null },
+    { id: 'config-1', org_id: 'org-1', member_id: 'member-1', project_id: 'project-1', is_active: true, url: 'https://discord.com/api/webhooks/member-1/project', secret: null, channel: 'discord' },
+    { id: 'config-3', org_id: 'org-1', member_id: 'member-3', project_id: null, is_active: true, url: 'https://discord.com/api/webhooks/member-3/default', secret: null, channel: 'discord' },
   ];
   const memoAssignees = options?.memoAssignees ?? [];
 

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -37,6 +37,7 @@ interface WebhookConfigRow {
   id: string;
   url: string;
   secret: string | null;
+  channel: 'discord' | 'slack' | 'google' | 'generic';
 }
 
 type Logger = Pick<Console, 'warn' | 'error'>;
@@ -144,6 +145,7 @@ interface ResolvedWebhook {
   id: string | null;
   url: string;
   secret: string | null;
+  channel: 'discord' | 'slack' | 'google' | 'generic' | null;
 }
 
 async function resolveWebhook(
@@ -153,7 +155,7 @@ async function resolveWebhook(
 ): Promise<ResolvedWebhook | null> {
   const { data: projectConfig } = await supabase
     .from('webhook_configs')
-    .select('id, url, secret')
+    .select('id, url, secret, channel')
     .eq('org_id', memo.org_id)
     .eq('member_id', member.id)
     .eq('project_id', memo.project_id)
@@ -165,7 +167,7 @@ async function resolveWebhook(
 
   const { data: defaultConfig } = await supabase
     .from('webhook_configs')
-    .select('id, url, secret')
+    .select('id, url, secret, channel')
     .eq('org_id', memo.org_id)
     .eq('member_id', member.id)
     .is('project_id', null)
@@ -174,7 +176,7 @@ async function resolveWebhook(
     .maybeSingle();
 
   if (defaultConfig?.url) return defaultConfig as WebhookConfigRow;
-  if (member.webhook_url) return { id: null, url: member.webhook_url, secret: null };
+  if (member.webhook_url) return { id: null, url: member.webhook_url, secret: null, channel: null };
   return null;
 }
 
@@ -186,7 +188,7 @@ async function postWebhook(
   title: string,
   description: string,
 ) {
-  const format = detectWebhookFormat(webhook.url);
+  const format = webhook.channel ?? detectWebhookFormat(webhook.url);
   const body = format === 'discord'
     ? JSON.stringify({
         content: `${title}\n${description.substring(0, 500)}`,

--- a/packages/db/supabase/migrations/20260424200000_webhook_configs_channel.sql
+++ b/packages/db/supabase/migrations/20260424200000_webhook_configs_channel.sql
@@ -1,0 +1,13 @@
+-- webhook_configs: channel 컬럼 추가 (URL heuristic 제거용)
+ALTER TABLE public.webhook_configs
+  ADD COLUMN IF NOT EXISTS channel text NOT NULL DEFAULT 'generic'
+    CHECK (channel IN ('discord', 'slack', 'google', 'generic'));
+
+-- 기존 레코드 channel 값 마이그레이션 (URL 패턴 기반)
+UPDATE public.webhook_configs
+  SET channel = CASE
+    WHEN url ILIKE '%discord.com%' OR url ILIKE '%discordapp.com%' THEN 'discord'
+    WHEN url ILIKE '%hooks.slack.com%'                             THEN 'slack'
+    WHEN url ILIKE '%chat.googleapis.com%'                         THEN 'google'
+    ELSE 'generic'
+  END;


### PR DESCRIPTION
## Summary
- `webhook_configs`에 `channel` 컬럼 추가 — `enum('discord','slack','google','generic')` + DB CHECK
- 기존 레코드 URL 패턴 기반 channel 값 마이그레이션
- `buildWebhookSignatureHeaders` 헤더명 `X-Webhook-*` → `X-Sprintable-*`
- 수신측 HMAC 검증 예시 코드 `webhook-signature.ts` 주석으로 문서화
- 발송 3경로 URL heuristic → channel 컬럼 기반으로 교체 (OSS fallback은 URL heuristic 유지)

## AC Checklist
- [x] AC1: 전 웹훅 발송 경로 `X-Sprintable-Timestamp` + `X-Sprintable-Signature` 헤더 적용
- [x] AC2: `webhook_configs.channel` 컬럼 추가 — enum 4종 + DB CHECK
- [x] AC3: URL 패턴 기반 채널 판별 → channel 컬럼 기반으로 교체 (3경로)
- [x] AC4: 기존 레코드 channel 값 마이그레이션 SQL
- [x] AC5: 수신측 검증 예시 코드 문서화 (`webhook-signature.ts`)

## Files Changed
- `packages/db/supabase/migrations/20260424200000_webhook_configs_channel.sql`
- `apps/web/src/lib/webhook-signature.ts` — 헤더명 변경 + 검증 예시
- `apps/web/src/services/memo-event-dispatcher.ts` — channel 컬럼 기반 format
- `apps/web/src/services/memo-assignment-dispatch.ts` — channel 컬럼 기반 format
- `apps/web/src/services/memo-reply-webhook-dispatch.ts` — channel 컬럼 기반 format
- 테스트 2건 stub channel 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)