### PR TITLE
feat: 인앱 알림 확장 — 메모 답장/멘션 (E-NOTIFY-WEBHOOK S4)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -885,6 +885,8 @@
     "filter_info": "Info",
     "filter_warning": "Warning",
     "filter_system": "System",
+    "filter_memo_reply": "Memo Reply",
+    "filter_memo_mention": "Mention",
     "noNotifications": "No notifications",
     "justNow": "Just now",
     "minutesAgo": "m ago",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -885,6 +885,8 @@
     "filter_info": "안내",
     "filter_warning": "경고",
     "filter_system": "시스템",
+    "filter_memo_reply": "메모 답장",
+    "filter_memo_mention": "멘션",
     "noNotifications": "알림이 없습니다",
     "justNow": "방금",
     "minutesAgo": "분 전",

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -5,6 +5,8 @@ import { dispatchMemoAssignmentImmediately, type DispatchableMemo } from './memo
 import { dispatchWorkflowMemoReplyWebhooks } from './memo-reply-webhook-dispatch';
 import { buildAbsoluteMemoLink } from './app-url';
 import { NotFoundError, ForbiddenError } from './sprint';
+import { NotificationService } from './notification.service';
+import { hasExactMemberMention } from './doc-comment-notifications';
 
 export interface CreateMemoInput {
   project_id: string;
@@ -540,6 +542,9 @@ export class MemoService {
         } catch (dispatchError) {
           console.warn('[MemoService.addReply] workflow reply webhook dispatch failed', dispatchError);
         }
+
+        // In-app notifications: memo_reply + memo_mention
+        this._sendReplyNotifications(memo, data).catch(() => {});
       } else if (this.teamMemberRepo) {
         try {
           await this.dispatchOssReplyWebhooks(memo, data);
@@ -550,6 +555,47 @@ export class MemoService {
     }
 
     return data;
+  }
+
+  private async _sendReplyNotifications(memo: Memo, reply: MemoReply) {
+    if (!this.supabase) return;
+    const notifService = new NotificationService(this.supabase);
+    const replyAuthor = reply.created_by;
+
+    // memo_reply: 원 메모 작성자에게 (자기 자신 제외)
+    if (memo.created_by !== replyAuthor) {
+      await notifService.create({
+        org_id: memo.org_id,
+        user_id: memo.created_by,
+        type: 'memo_reply',
+        title: '메모에 답장이 달렸습니다',
+        body: reply.content.slice(0, 100),
+        reference_type: 'memo',
+        reference_id: memo.id,
+      });
+    }
+
+    // memo_mention: @멘션 대상자 (자기 자신 제외)
+    const { data: members } = await this.supabase
+      .from('team_members')
+      .select('id, name')
+      .eq('org_id', memo.org_id)
+      .eq('project_id', memo.project_id)
+      .eq('is_active', true);
+
+    for (const member of (members ?? []) as Array<{ id: string; name: string | null }>) {
+      if (!member.name?.trim() || member.id === replyAuthor) continue;
+      if (!hasExactMemberMention(reply.content, member.name.trim())) continue;
+      await notifService.create({
+        org_id: memo.org_id,
+        user_id: member.id,
+        type: 'memo_mention',
+        title: '메모에서 멘션되었습니다',
+        body: reply.content.slice(0, 100),
+        reference_type: 'memo',
+        reference_id: memo.id,
+      });
+    }
   }
 
   private async dispatchOssReplyWebhooks(memo: Memo, reply: MemoReply) {

--- a/apps/web/src/services/notification-display.ts
+++ b/apps/web/src/services/notification-display.ts
@@ -8,6 +8,8 @@ export const NOTIFICATION_TYPE_ICONS: Record<string, string> = {
   info: 'ℹ️',
   warning: '⚠️',
   system: '🔧',
+  memo_reply: '💬',
+  memo_mention: '@',
 };
 
 export const INBOX_FILTER_TYPES = ['', ...NOTIFICATION_TYPES] as const;
@@ -31,6 +33,10 @@ export function getInboxNotificationLabel(
       return t('filter_warning');
     case 'system':
       return t('filter_system');
+    case 'memo_reply':
+      return t('filter_memo_reply');
+    case 'memo_mention':
+      return t('filter_memo_mention');
     default:
       return type;
   }


### PR DESCRIPTION
## Summary
- `MemoService.addReply()` SaaS 경로에 `NotificationService` 연동 — `memo_reply` + `memo_mention` 인앱 알림 발송
- `_sendReplyNotifications()` — 원 메모 작성자(memo_reply) + @멘션 대상자(memo_mention), 자기 자신 제외
- `NotificationInbox` 아이콘/라벨 추가 (`💬` memo_reply, `@` memo_mention)
- i18n: `filter_memo_reply`, `filter_memo_mention` 키 추가 (ko/en)
- 딥링크: `reference_type:'memo', reference_id` — 기존 `notification-navigation.ts`가 이미 `/memos?id=` 처리

## AC Checklist
- [x] AC1: 답장 생성 시 원 메모 작성자에게 `memo_reply` 알림
- [x] AC2: 답장 내 @멘션 파싱 → 대상자에게 `memo_mention` 알림 (`hasExactMemberMention`)
- [x] AC3: 자기 자신(작성자 == 수신자) 알림 제외
- [x] AC4: 딥링크 포함 — `reference_type:'memo', reference_id:memoId`
- [x] AC5: `NotificationInbox` `memo_reply`/`memo_mention` 타입 필터 동작

## Files Changed
- `apps/web/src/services/memo.ts` — `_sendReplyNotifications()` 추가
- `apps/web/src/services/notification-display.ts` — 아이콘/라벨 추가
- `apps/web/messages/ko.json` — i18n 키 추가
- `apps/web/messages/en.json` — i18n 키 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)