### PR TITLE
feat: 에픽 스키마 보강 — priority CHECK + target_date 활성화 (E-PM-ENHANCE S1)

### DIFF
--- a/packages/db/supabase/migrations/20260424210000_epics_priority_check.sql
+++ b/packages/db/supabase/migrations/20260424210000_epics_priority_check.sql
@@ -1,0 +1,12 @@
+-- E-PM-ENHANCE S1: epics priority DB CHECK 제약 + null 마이그레이션
+-- target_date는 20260424100000에서 이미 추가됨
+
+-- 1. priority null 또는 유효하지 않은 값 → 'medium' 정규화
+UPDATE public.epics
+  SET priority = 'medium'
+  WHERE priority IS NULL OR priority NOT IN ('critical', 'high', 'medium', 'low');
+
+-- 2. priority CHECK 제약 추가
+ALTER TABLE public.epics
+  ADD CONSTRAINT epics_priority_check
+    CHECK (priority IN ('critical', 'high', 'medium', 'low'));

--- a/packages/storage-supabase/src/SupabaseEpicRepository.ts
+++ b/packages/storage-supabase/src/SupabaseEpicRepository.ts
@@ -63,7 +63,7 @@ export class SupabaseEpicRepository implements IEpicRepository {
   }
 
   async update(id: string, input: UpdateEpicInput): Promise<Epic> {
-    const ALLOWED: (keyof UpdateEpicInput)[] = ['title', 'status', 'priority', 'description'];
+    const ALLOWED: (keyof UpdateEpicInput)[] = ['title', 'status', 'priority', 'description', 'target_date', 'objective', 'success_criteria', 'target_sp'];
     const patch: Record<string, unknown> = {};
     for (const key of ALLOWED) {
       if (key in input) patch[key] = input[key];


### PR DESCRIPTION
## Summary
- `epics.priority` DB CHECK 제약 추가 — enum(critical/high/medium/low)
- 기존 priority null/무효값 → 'medium' 정규화 마이그레이션
- `SupabaseEpicRepository.update()` ALLOWED 리스트에 `target_date`, `objective`, `success_criteria`, `target_sp` 추가
- `target_date`는 `20260424100000` 마이그레이션으로 이미 DB에 존재, 이번에 update 경로 활성화

## AC Checklist
- [x] AC1: `epics.priority` DB CHECK 제약 추가 (critical/high/medium/low)
- [x] AC2: `target_date` 에픽 수정 API에서 정상 동작 (ALLOWED 추가)
- [x] AC3: 에픽 목록/상세 API 응답에 target_date, priority 포함 (`select('*')`)
- [x] AC4: 무효 priority INSERT 시 DB CHECK 에러 발생
- [x] AC5: 기존 priority null → 'medium' 마이그레이션

## Files Changed
- `packages/db/supabase/migrations/20260424210000_epics_priority_check.sql`
- `packages/storage-supabase/src/SupabaseEpicRepository.ts` — ALLOWED 확장

🤖 Generated with [Claude Code](https://claude.com/claude-code)