### PR TITLE
feat: 에픽 target_sp 초과 경고 표시 (E-PM-ENHANCE S3)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1797,6 +1797,8 @@
     "doneStories": "Done Stories",
     "totalStories": "Total Stories",
     "backToList": "Back",
-    "notAssigned": "Not assigned"
+    "notAssigned": "Not assigned",
+    "spExceeded": "SP Over",
+    "spExceededDetail": "{total}SP / target {target}SP exceeded"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1797,6 +1797,8 @@
     "doneStories": "완료 스토리",
     "totalStories": "전체 스토리",
     "backToList": "목록으로",
-    "notAssigned": "미지정"
+    "notAssigned": "미지정",
+    "spExceeded": "SP 초과",
+    "spExceededDetail": "{total}SP / 목표 {target}SP 초과"
   }
 }

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -395,6 +395,8 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
   const stories = epic.stories ?? [];
   const { done, total } = calcStoryProgress(stories);
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const spProgress = calcSpProgress(stories);
+  const spExceeded = typeof epic.target_sp === 'number' && epic.target_sp > 0 && spProgress.total > epic.target_sp;
 
   const statusLabel: Record<EpicStatus, string> = {
     draft: t('statusDraft'),
@@ -434,6 +436,11 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
             <span>{t('targetDate')}: {formatDate(epic.target_date)}</span>
           ) : null}
           <span>{done}/{total} {t('stories')}</span>
+          {spExceeded ? (
+            <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
+              {t('spExceeded')}
+            </span>
+          ) : null}
         </div>
 
         {total > 0 ? (
@@ -464,6 +471,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
   const stories = epic.stories ?? [];
   const storyProgress = calcStoryProgress(stories);
   const spProgress = calcSpProgress(stories);
+  const spExceeded = typeof epic.target_sp === 'number' && epic.target_sp > 0 && spProgress.total > epic.target_sp;
 
   const statusLabel: Record<EpicStatus, string> = {
     draft: t('statusDraft'),
@@ -536,7 +544,12 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
               </div>
               <div className="rounded-xl bg-[color:var(--operator-surface-soft,hsl(var(--muted)))] px-3 py-2.5">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('targetSp')}</p>
-                <p className="mt-1 text-sm font-medium text-[color:var(--operator-foreground)]">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
+                <div className="mt-1 flex items-center gap-1.5">
+                  <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
+                  {spExceeded ? (
+                    <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">{t('spExceeded')}</span>
+                  ) : null}
+                </div>
               </div>
             </div>
 
@@ -554,7 +567,14 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
               <ProgressBar done={storyProgress.done} total={storyProgress.total} label={`${t('doneStories')} / ${t('totalStories')}`} />
               {spProgress.total > 0 ? (
                 <>
-                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('spProgress')}</p>
+                  <div className="flex items-center gap-2">
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('spProgress')}</p>
+                    {spExceeded ? (
+                      <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
+                        {t('spExceededDetail', { total: spProgress.total, target: epic.target_sp ?? 0 })}
+                      </span>
+                    ) : null}
+                  </div>
                   <ProgressBar done={spProgress.done} total={spProgress.total} label={`${t('doneSp')} / ${t('totalSp')}`} />
                 </>
               ) : null}


### PR DESCRIPTION
## Summary
- `EpicRow` + `EpicDetailPanel` 모두 `spExceeded` 조건 추가
- `spProgress.total > epic.target_sp` 시 붉은 경고 배지("SP 초과") 표시
- 상세 패널 SP 섹션: 초과 시 `{total}SP / 목표 {target}SP 초과` 텍스트 추가
- `target_sp` 미설정 에픽은 경고 미표시 (AC4)
- 실시간 반영: `fetchEpicDetail`이 stories를 epics state에 업데이트 → 카드 re-render (AC3)

## AC Checklist
- [x] AC1: 상세 뷰 SP 합계 > target_sp 시 경고 배지 표시
- [x] AC2: 목록 카드에서도 초과 에픽 경고 배지 표시
- [x] AC3: 상세 패널 클릭 시 stories 로드 → 목록 카드 자동 반영
- [x] AC4: target_sp 미설정 에픽 경고 미표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)