### PR TITLE
feat: 프로젝트 삭제 API + 레벨별 멤버 초대 (E-PM-ENHANCE S4)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -469,7 +469,16 @@
       }
     },
     "projectUpdated": "Project updated.",
-    "projectUpdateFailed": "Failed to update project."
+    "projectUpdateFailed": "Failed to update project.",
+    "deleteProject": "Delete",
+    "projectDeleted": "Project deleted.",
+    "projectDeleteFailed": "Failed to delete project.",
+    "projectDeleteConfirmTitle": "Delete this project?",
+    "projectDeleteConfirmDesc": "This action cannot be undone. The project and its data will be deactivated.",
+    "projectInviteTitle": "Invite to Project",
+    "projectInviteDescription": "Invite a team member directly to a specific project by email.",
+    "projectInviteSent": "Invitation link generated.",
+    "projectInviteFailed": "Failed to send project invitation."
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -469,7 +469,16 @@
       }
     },
     "projectUpdated": "프로젝트가 업데이트되었습니다.",
-    "projectUpdateFailed": "프로젝트 업데이트에 실패했습니다."
+    "projectUpdateFailed": "프로젝트 업데이트에 실패했습니다.",
+    "deleteProject": "삭제",
+    "projectDeleted": "프로젝트를 삭제했습니다.",
+    "projectDeleteFailed": "프로젝트 삭제에 실패했습니다.",
+    "projectDeleteConfirmTitle": "프로젝트를 삭제하시겠습니까?",
+    "projectDeleteConfirmDesc": "이 작업은 되돌릴 수 없습니다. 프로젝트와 관련 데이터가 비활성화됩니다.",
+    "projectInviteTitle": "프로젝트 초대",
+    "projectInviteDescription": "이메일로 특정 프로젝트에 바로 초대합니다.",
+    "projectInviteSent": "초대 링크가 생성되었습니다.",
+    "projectInviteFailed": "프로젝트 초대에 실패했습니다."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -97,6 +97,12 @@ export default function SettingsPage() {
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [adminChecked, setAdminChecked] = useState(false);
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
+  const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
+  const [projectInviteEmail, setProjectInviteEmail] = useState('');
+  const [projectInviteProjectId, setProjectInviteProjectId] = useState('');
+  const [projectInviting, setProjectInviting] = useState(false);
+  const [projectInviteResult, setProjectInviteResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const refreshProjects = async () => {
     const endpoint = orgId ? `/api/projects?org_id=${encodeURIComponent(orgId)}` : '/api/projects';
@@ -345,6 +351,47 @@ export default function SettingsPage() {
     setAddingMember(false);
   };
 
+  const handleDeleteProject = async (projectId: string) => {
+    setDeletingProjectId(projectId);
+    setProjectActionMessage(null);
+
+    const res = await fetch(`/api/projects/${projectId}`, { method: 'DELETE' });
+    if (res.ok) {
+      setProjects((prev) => prev.filter((p) => p.id !== projectId));
+      setProjectActionMessage({ type: 'success', text: t('projectDeleted') });
+      router.refresh();
+    } else {
+      const json = await res.json().catch(() => null);
+      setProjectActionMessage({ type: 'error', text: json?.error?.message ?? t('projectDeleteFailed') });
+    }
+
+    setDeletingProjectId(null);
+    setDeleteProjectConfirmId(null);
+  };
+
+  const handleProjectInvite = async () => {
+    if (!projectInviteEmail.trim() || !projectInviteProjectId) return;
+    setProjectInviting(true);
+    setProjectInviteResult(null);
+
+    const res = await fetch(`/api/projects/${projectInviteProjectId}/invitations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: projectInviteEmail.trim(), role: 'member' }),
+    });
+
+    if (res.ok) {
+      const json = await res.json();
+      setProjectInviteResult({ type: 'success', text: `${t('projectInviteSent')} ${json.data.invite_url}` });
+      setProjectInviteEmail('');
+    } else {
+      const json = await res.json().catch(() => null);
+      setProjectInviteResult({ type: 'error', text: json?.error?.message ?? t('projectInviteFailed') });
+    }
+
+    setProjectInviting(false);
+  };
+
   const handleRemoveProjectMember = async (memberId: string) => {
     setRemovingMemberId(memberId);
     setMemberActionMessage(null);
@@ -505,13 +552,24 @@ export default function SettingsPage() {
                       <div className="flex shrink-0 items-center gap-2">
                         {project.id === currentProjectId ? <Badge variant="info">{t('currentProjectBadge')}</Badge> : null}
                         {isAdmin ? (
-                          <Button variant="ghost" size="sm" onClick={() => {
-                            setEditingProjectId(project.id);
-                            setEditProjectName(project.name);
-                            setEditProjectDescription(project.description ?? '');
-                          }}>
-                            {tc('edit')}
-                          </Button>
+                          <>
+                            <Button variant="ghost" size="sm" onClick={() => {
+                              setEditingProjectId(project.id);
+                              setEditProjectName(project.name);
+                              setEditProjectDescription(project.description ?? '');
+                            }}>
+                              {tc('edit')}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                              onClick={() => setDeleteProjectConfirmId(project.id)}
+                              disabled={deletingProjectId === project.id}
+                            >
+                              {deletingProjectId === project.id ? '...' : t('deleteProject')}
+                            </Button>
+                          </>
                         ) : null}
                       </div>
                     </div>
@@ -635,6 +693,46 @@ export default function SettingsPage() {
             ) : null}
           </SectionCardBody>
         </SectionCard>
+        </section>
+      ) : null}
+
+      {isAdmin ? (
+        <section id="project-invitations">
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="space-y-1">
+                <h2 className="text-base font-semibold text-foreground">📨 {t('projectInviteTitle')}</h2>
+                <p className="text-sm text-muted-foreground">{t('projectInviteDescription')}</p>
+              </div>
+            </SectionCardHeader>
+            <SectionCardBody className="space-y-4">
+              <div className="flex flex-col gap-3 md:flex-row">
+                <OperatorInput
+                  type="email"
+                  value={projectInviteEmail}
+                  onChange={(e) => setProjectInviteEmail(e.target.value)}
+                  placeholder={t('emailPlaceholder')}
+                />
+                <OperatorSelect value={projectInviteProjectId} onChange={(e) => setProjectInviteProjectId(e.target.value)}>
+                  <option value="">{t('selectProject')}</option>
+                  {projects.map((project) => <option key={project.id} value={project.id}>{project.name}</option>)}
+                </OperatorSelect>
+                <Button
+                  variant="hero"
+                  size="lg"
+                  onClick={handleProjectInvite}
+                  disabled={projectInviting || !projectInviteEmail.trim() || !projectInviteProjectId}
+                >
+                  {projectInviting ? '...' : t('invite')}
+                </Button>
+              </div>
+              {projectInviteResult ? (
+                <div className={`rounded-md border p-3 text-xs break-all ${projectInviteResult.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
+                  {projectInviteResult.text}
+                </div>
+              ) : null}
+            </SectionCardBody>
+          </SectionCard>
         </section>
       ) : null}
 
@@ -794,6 +892,28 @@ export default function SettingsPage() {
                 disabled={deleting}
               >
                 {deleting ? '...' : t('confirmDelete')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {deleteProjectConfirmId ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <div className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-md">
+            <h3 className="text-lg font-semibold text-destructive">{t('projectDeleteConfirmTitle')}</h3>
+            <p className="mt-2 text-sm text-muted-foreground">{t('projectDeleteConfirmDesc')}</p>
+            <div className="mt-6 flex gap-3">
+              <Button variant="glass" className="flex-1" onClick={() => setDeleteProjectConfirmId(null)}>
+                {tc('cancel')}
+              </Button>
+              <Button
+                variant="destructive"
+                className="flex-1"
+                onClick={() => handleDeleteProject(deleteProjectConfirmId)}
+                disabled={deletingProjectId === deleteProjectConfirmId}
+              >
+                {deletingProjectId === deleteProjectConfirmId ? '...' : t('deleteProject')}
               </Button>
             </div>
           </div>

--- a/apps/web/src/app/api/projects/[id]/invitations/route.ts
+++ b/apps/web/src/app/api/projects/[id]/invitations/route.ts
@@ -1,0 +1,84 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { checkMemberLimit } from '@/lib/check-feature';
+import { parseBody, createInvitationSchema } from '@sprintable/shared';
+import { isOssMode } from '@/lib/storage/factory';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** POST /api/projects/:id/invitations — 프로젝트 레벨 초대 생성 */
+export async function POST(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Invitations are not supported in OSS mode.', 501);
+  try {
+    const { id: projectId } = await params;
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const parsed = await parseBody(request, createInvitationSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden('Team member not found');
+
+    // 프로젝트가 이 org에 속하는지 검증
+    const { data: project } = await supabase
+      .from('projects')
+      .select('id, org_id')
+      .eq('id', projectId)
+      .eq('org_id', me.org_id)
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    if (!project) return ApiErrors.notFound('Project not found');
+
+    const email = body.email;
+
+    const { data: existingOrgMember, error: existingOrgMemberError } = await supabase
+      .rpc('is_existing_org_member_email', { _org_id: me.org_id, _email: email });
+
+    if (existingOrgMemberError) throw existingOrgMemberError;
+
+    // 신규 org member 초대일 때만 멤버 제한 체크
+    if (!existingOrgMember) {
+      const memberCheck = await checkMemberLimit(supabase, me.org_id);
+      if (!memberCheck.allowed) {
+        return apiError('UPGRADE_REQUIRED', memberCheck.reason ?? 'Member limit reached', 403);
+      }
+    }
+
+    // 중복 초대 체크 (동일 org + email + project 조합)
+    const { data: existing } = await supabase
+      .from('invitations')
+      .select('id')
+      .eq('org_id', me.org_id)
+      .eq('email', email)
+      .eq('project_id', projectId)
+      .is('accepted_at', null)
+      .gt('expires_at', new Date().toISOString())
+      .maybeSingle();
+
+    if (existing) return apiError('DUPLICATE_INVITE', 'Invitation already pending', 400);
+
+    const { data, error } = await supabase
+      .from('invitations')
+      .insert({
+        org_id: me.org_id,
+        email,
+        role: body.role ?? 'member',
+        invited_by: me.id,
+        project_id: projectId,
+      })
+      .select('id, token, email, expires_at, project_id')
+      .single();
+
+    if (error) throw error;
+
+    const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? ''}/invite?token=${data.token}`;
+
+    return apiSuccess({ ...data, invite_url: inviteUrl }, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/projects/[id]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/route.ts
@@ -89,3 +89,37 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     return handleApiError(err);
   }
 }
+
+// DELETE /api/projects/:id — soft delete (owner/admin only)
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const { data: project } = await supabase
+      .from('projects')
+      .select('org_id')
+      .eq('id', id)
+      .is('deleted_at', null)
+      .maybeSingle();
+
+    if (!project) return ApiErrors.notFound('Project not found');
+
+    const role = await resolveOrgRole(supabase, project.org_id as string, user.id);
+    if (!role || !['owner', 'admin'].includes(role)) {
+      return ApiErrors.forbidden('Admin access required');
+    }
+
+    const { error } = await supabase
+      .from('projects')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', id);
+
+    if (error) throw error;
+    return apiSuccess({ id });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/projects/route.test.ts
+++ b/apps/web/src/app/api/projects/route.test.ts
@@ -26,13 +26,14 @@ interface ProjectRow {
   name: string;
   description?: string | null;
   created_at?: string;
+  deleted_at?: string | null;
 }
 
 function createSupabaseStub({
   user = { id: 'user-1', email: 'owner@sprintable.app', user_metadata: { name: 'Owner' } },
   orgMemberships = [{ org_id: 'org-1', role: 'admin' }],
   projects = [
-    { id: 'project-1', org_id: 'org-1', name: 'Alpha', description: 'First project', created_at: '2026-04-13T00:00:00.000Z' },
+    { id: 'project-1', org_id: 'org-1', name: 'Alpha', description: 'First project', created_at: '2026-04-13T00:00:00.000Z', deleted_at: null },
   ],
   createdProject,
   createProjectError = null,
@@ -70,8 +71,9 @@ function createSupabaseStub({
       if (column === 'org_id') orgIdFilter = value;
       return projectsListQuery;
     }),
+    is: vi.fn(() => projectsListQuery),
     order: vi.fn(() => Promise.resolve({
-      data: projects.filter((project) => (orgIdFilter ? project.org_id === orgIdFilter : true)),
+      data: projects.filter((project) => (orgIdFilter ? project.org_id === orgIdFilter : true) && project.deleted_at == null),
       error: null,
     })),
   };

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -68,14 +68,13 @@ export async function GET(request: Request) {
     let query = supabase
       .from('projects')
       .select('id, name, description, created_at, deleted_at')
-      .eq('org_id', orgAccess.orgId)
-      .order('created_at', { ascending: true });
+      .eq('org_id', orgAccess.orgId);
 
     if (!includeDeleted) {
       query = query.is('deleted_at', null);
     }
 
-    const { data, error } = await query;
+    const { data, error } = await query.order('created_at', { ascending: true });
 
     if (error) throw error;
     return apiSuccess(data ?? []);

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -63,11 +63,19 @@ export async function GET(request: Request) {
     if (orgAccess?.error) return orgAccess.error;
     if (!orgAccess) return ApiErrors.forbidden('Organization membership not found');
 
-    const { data, error } = await supabase
+    const includeDeleted = searchParams.get('include_deleted') === 'true';
+
+    let query = supabase
       .from('projects')
-      .select('id, name, description, created_at')
+      .select('id, name, description, created_at, deleted_at')
       .eq('org_id', orgAccess.orgId)
       .order('created_at', { ascending: true });
+
+    if (!includeDeleted) {
+      query = query.is('deleted_at', null);
+    }
+
+    const { data, error } = await query;
 
     if (error) throw error;
     return apiSuccess(data ?? []);


### PR DESCRIPTION
## Summary
- `DELETE /api/projects/[id]` soft delete (`deleted_at = now()`), owner/admin 검증
- `GET /api/projects` 기본 `deleted_at IS NULL` 필터 + `?include_deleted=true` 지원
- `POST /api/projects/[id]/invitations` 신규 — 프로젝트 레벨 초대 (기존 invitations 로직 재활용)
- 초대 수락 시 team_member 생성: 기존 `accept_invitation` RPC가 이미 처리
- Settings UI: 프로젝트 삭제 버튼(확인 모달) + 프로젝트 레벨 멤버 초대 폼

## AC Checklist
- [x] AC1: `DELETE /api/projects/[id]` soft delete, owner/admin 전용
- [x] AC2: 목록 기본 제외 + `?include_deleted=true` 조회 가능
- [x] AC3: `POST /api/projects/[id]/invitations` 신규
- [x] AC4: 수락 시 team_member 자동 생성 (기존 RPC 활용)
- [x] AC5: Settings UI 프로젝트별 멤버 초대/제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)