### PR TITLE
feat: 칸반 WIP Limit + 카드 검색 + position DnD (E-PM-ENHANCE S6)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -108,7 +108,13 @@
     "changeStatus": "Change Status",
     "assignMember": "Assign Member",
     "deleteStory": "Delete Story",
-    "validDrop": "Drop here"
+    "validDrop": "Drop here",
+    "searchPlaceholder": "Search by title or assignee...",
+    "wipLimitLabel": "WIP Limit",
+    "wipLimitSet": "Set WIP Limit",
+    "wipLimitExceeded": "WIP limit exceeded",
+    "wipLimitSave": "Save",
+    "wipLimitRemove": "Remove limit"
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -108,7 +108,13 @@
     "changeStatus": "상태 변경",
     "assignMember": "담당자 변경",
     "deleteStory": "스토리 삭제",
-    "validDrop": "이동 가능"
+    "validDrop": "이동 가능",
+    "searchPlaceholder": "제목 또는 담당자 검색...",
+    "wipLimitLabel": "WIP 한도",
+    "wipLimitSet": "WIP 한도 설정",
+    "wipLimitExceeded": "WIP 한도 초과",
+    "wipLimitSave": "저장",
+    "wipLimitRemove": "한도 제거"
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { KanbanColumn } from './kanban-column';
 import { KanbanFilters } from './kanban-filters';
 import { KanbanListView } from './kanban-list-view';
@@ -37,6 +38,28 @@ interface KanbanBoardProps {
   projectId?: string;
 }
 
+// WIP limit localStorage 키
+function wipLimitKey(projectId: string | undefined, status: string): string {
+  return `wip_limit_${projectId ?? 'default'}_${status}`;
+}
+
+function loadWipLimit(projectId: string | undefined, status: string): number | null {
+  if (typeof window === 'undefined') return null;
+  const raw = localStorage.getItem(wipLimitKey(projectId, status));
+  if (raw === null) return null;
+  const n = parseInt(raw, 10);
+  return isNaN(n) ? null : n;
+}
+
+function saveWipLimit(projectId: string | undefined, status: string, limit: number | null): void {
+  if (typeof window === 'undefined') return;
+  if (limit === null) {
+    localStorage.removeItem(wipLimitKey(projectId, status));
+  } else {
+    localStorage.setItem(wipLimitKey(projectId, status), String(limit));
+  }
+}
+
 export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -57,6 +80,30 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [selectedSprintId, setSelectedSprintId] = useState(() => searchParams.get('sprint_id') ?? '');
   const [selectedEpicId, setSelectedEpicId] = useState(() => searchParams.get('epic_id') ?? '');
   const [selectedAssigneeId, setSelectedAssigneeId] = useState('');
+
+  // AC2: 검색 쿼리
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // AC1/AC5: WIP limit 상태 — 컬럼별 { limit: number|null, editing: boolean, draft: string }
+  const [wipLimits, setWipLimits] = useState<Record<string, { limit: number | null; editing: boolean; draft: string }>>(() => {
+    const initial: Record<string, { limit: number | null; editing: boolean; draft: string }> = {};
+    for (const col of COLUMNS) {
+      initial[col.id] = { limit: null, editing: false, draft: '' };
+    }
+    return initial;
+  });
+
+  // 클라이언트 마운트 후 localStorage에서 WIP limit 로드
+  useEffect(() => {
+    setWipLimits((prev) => {
+      const next = { ...prev };
+      for (const col of COLUMNS) {
+        const stored = loadWipLimit(projectId, col.id);
+        next[col.id] = { limit: stored, editing: false, draft: stored !== null ? String(stored) : '' };
+      }
+      return next;
+    });
+  }, [projectId]);
 
   // Sync epic_id to URL
   useEffect(() => {
@@ -149,9 +196,6 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [searchParams, router]);
 
   // URL에서 스토리 ID 읽어서 자동으로 패널 열기
-  // selectedStory를 deps에서 제외: setSelectedStory(null) 호출 시 effect가 재발화하면
-  // searchParams에 ?story= 가 아직 남아있어 패널이 즉시 재오픈되는 race condition ���생.
-  // selectedStoryRef(항상 최신값)로 비교해 중복 오픈만 방지한다.
   useEffect(() => {
     const storyId = searchParams.get('story');
     if (storyId && stories.length > 0) {
@@ -162,14 +206,29 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     }
   }, [searchParams, stories, handleStoryClick]);
 
+  // AC2: 검색 + 기존 필터 조합
   const filteredStories = stories.filter((s) => {
     if (selectedEpicId && s.epic_id !== selectedEpicId) return false;
     if (selectedAssigneeId && s.assignee_id !== selectedAssigneeId) return false;
+    if (searchQuery) {
+      const q = searchQuery.toLowerCase();
+      const titleMatch = s.title?.toLowerCase().includes(q);
+      const assigneeName = s.assignee_id ? memberMap[s.assignee_id]?.name?.toLowerCase() : '';
+      const assigneeMatch = assigneeName?.includes(q);
+      if (!titleMatch && !assigneeMatch) return false;
+    }
     return true;
   });
 
-  const storiesByColumn = (columnId: string) =>
-    filteredStories.filter((s) => s.status === columnId);
+  // position 기준으로 정렬
+  const storiesByColumn = (columnId: string): KanbanStory[] => {
+    const col = filteredStories.filter((s) => s.status === columnId);
+    return [...col].sort((a, b) => {
+      const pa = a.position ?? 0;
+      const pb = b.position ?? 0;
+      return pa - pb;
+    });
+  };
 
   const handleDragStart = (event: { active: { id: string | number } }) => {
     setActiveId(String(event.active.id));
@@ -187,33 +246,83 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     return null;
   };
 
+  // AC4: 드래그 완료 후 position gap 계산
+  const computeNewPosition = (
+    columnStories: KanbanStory[],
+    storyId: string,
+    overId: string,
+    newStatus: ColumnId,
+  ): number => {
+    // 같은 컬럼 내 재정렬: over.id가 story id인 경우
+    const overStory = columnStories.find((s) => s.id === overId);
+    if (!overStory) {
+      // 빈 컬럼이거나 컬럼 자체에 드롭 — 마지막에 추가
+      const sorted = [...columnStories].sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+      const last = sorted[sorted.length - 1];
+      return last ? (last.position ?? 0) + 1000 : 1000;
+    }
+
+    const sorted = [...columnStories.filter((s) => s.id !== storyId && s.status === newStatus)]
+      .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
+
+    const overIdx = sorted.findIndex((s) => s.id === overId);
+    if (overIdx === -1) {
+      const last = sorted[sorted.length - 1];
+      return last ? (last.position ?? 0) + 1000 : 1000;
+    }
+
+    const prev = sorted[overIdx - 1];
+    const next = sorted[overIdx];
+    const prevPos = prev?.position ?? (next.position ?? 0) - 2000;
+    const nextPos = next?.position ?? prevPos + 2000;
+    return Math.round((prevPos + nextPos) / 2);
+  };
+
   const handleDragEnd = async (event: DragEndEvent) => {
     setActiveId(null);
     const { active, over } = event;
     if (!over) return;
 
     const storyId = String(active.id);
-    const newStatus = resolveColumnId(String(over.id));
+    const overId = String(over.id);
+    const newStatus = resolveColumnId(overId);
     if (!newStatus) return;
 
-    // 같은 컬럼이면 무시
     const story = stories.find((s) => s.id === storyId);
-    if (!story || story.status === newStatus) return;
+    if (!story) return;
 
-    // 유효하지 않은 전이 사전 차단 — API 호출 없이 즉시 피드백
-    const validNext = VALID_TRANSITIONS[story.status] ?? [];
-    if (!validNext.includes(newStatus)) {
-      setTransitionError(t('invalidTransition'));
-      setTimeout(() => setTransitionError(null), 4000);
-      return;
+    const isSameColumn = story.status === newStatus;
+
+    // 다른 컬럼으로 이동 시 유효성 검사
+    if (!isSameColumn) {
+      const validNext = VALID_TRANSITIONS[story.status] ?? [];
+      if (!validNext.includes(newStatus)) {
+        setTransitionError(t('invalidTransition'));
+        setTimeout(() => setTransitionError(null), 4000);
+        return;
+      }
     }
+
+    // AC4: 새 position 계산
+    const targetColumnStories = stories.filter((s) => s.status === newStatus);
+    const newPosition = computeNewPosition(targetColumnStories, storyId, overId, newStatus);
 
     // 낙관적 업데이트
     setStories((prev) =>
-      prev.map((s) => (s.id === storyId ? { ...s, status: newStatus } : s)),
+      prev.map((s) => (s.id === storyId ? { ...s, status: newStatus, position: newPosition } : s)),
     );
 
-    // API 호출
+    if (isSameColumn) {
+      // 같은 컬럼 내 재정렬 — position만 PATCH (fire-and-forget)
+      void fetch(`/api/stories/${storyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ position: newPosition }),
+      });
+      return;
+    }
+
+    // 다른 컬럼으로 이동 — status + position PATCH
     try {
       const res = await fetch('/api/stories/bulk', {
         method: 'PATCH',
@@ -223,9 +332,8 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       if (!res.ok) {
         // 롤백
         setStories((prev) =>
-          prev.map((s) => (s.id === storyId ? { ...s, status: story.status } : s)),
+          prev.map((s) => (s.id === storyId ? { ...s, status: story.status, position: story.position } : s)),
         );
-        // 에러 토스트 (i18n)
         const errJson = await res.json().catch(() => null);
         const code = errJson?.error?.code;
         if (code === 'INVALID_TRANSITION') {
@@ -235,11 +343,18 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           setTransitionError(t('transitionDenied'));
           setTimeout(() => setTransitionError(null), 4000);
         }
+        return;
       }
+      // status 성공 후 position fire-and-forget
+      void fetch(`/api/stories/${storyId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ position: newPosition }),
+      });
     } catch {
       // 롤백
       setStories((prev) =>
-        prev.map((s) => (s.id === storyId ? { ...s, status: story.status } : s)),
+        prev.map((s) => (s.id === storyId ? { ...s, status: story.status, position: story.position } : s)),
       );
     }
   };
@@ -318,6 +433,46 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     }
   }, [fetchData]);
 
+  // AC1/AC5: WIP limit 핸들러
+  const handleWipLimitEdit = useCallback((columnId: string) => {
+    setWipLimits((prev) => ({
+      ...prev,
+      [columnId]: {
+        ...prev[columnId],
+        editing: true,
+        draft: prev[columnId]?.limit !== null ? String(prev[columnId]?.limit) : '',
+      },
+    }));
+  }, []);
+
+  const handleWipLimitSave = useCallback((columnId: string) => {
+    setWipLimits((prev) => {
+      const draft = prev[columnId]?.draft ?? '';
+      const n = parseInt(draft, 10);
+      const limit = !isNaN(n) && n > 0 ? n : null;
+      saveWipLimit(projectId, columnId, limit);
+      return {
+        ...prev,
+        [columnId]: { limit, editing: false, draft: limit !== null ? String(limit) : '' },
+      };
+    });
+  }, [projectId]);
+
+  const handleWipLimitRemove = useCallback((columnId: string) => {
+    saveWipLimit(projectId, columnId, null);
+    setWipLimits((prev) => ({
+      ...prev,
+      [columnId]: { limit: null, editing: false, draft: '' },
+    }));
+  }, [projectId]);
+
+  const handleWipLimitDraftChange = useCallback((columnId: string, value: string) => {
+    setWipLimits((prev) => ({
+      ...prev,
+      [columnId]: { ...prev[columnId], draft: value },
+    }));
+  }, []);
+
   const activeStory = activeId ? stories.find((s) => s.id === activeId) : null;
   const dragStatus = activeStory?.status ?? null;
 
@@ -342,6 +497,16 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           onEpicChange={setSelectedEpicId}
           onAssigneeChange={setSelectedAssigneeId}
         />
+        {/* AC2: 검색 input */}
+        <div className="mt-2">
+          <Input
+            type="search"
+            placeholder={t('searchPlaceholder')}
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="h-8 text-sm"
+          />
+        </div>
       </div>
 
       {/* Mobile list view (hidden on md+) */}
@@ -360,22 +525,35 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
           <div className="rounded-2xl border border-border/70 bg-card p-4 shadow-sm">
             <div className="flex flex-row gap-5 overflow-x-auto pb-1">
-            {COLUMNS.map((col) => (
-              <KanbanColumn
-                key={col.id}
-                id={col.id}
-                label={t(col.i18nKey)}
-                stories={storiesByColumn(col.id)}
-                epicMap={epicMap}
-                memberMap={memberMap}
-                dragStatus={dragStatus}
-                onStoryClick={handleStoryClick}
-                onEditStory={handleEditStory}
-                onChangeStatus={handleChangeStatus}
-                onAssignStory={handleAssignStory}
-                onDeleteStory={handleDeleteStory}
-              />
-            ))}
+            {COLUMNS.map((col) => {
+              const colStories = storiesByColumn(col.id);
+              const wipState = wipLimits[col.id] ?? { limit: null, editing: false, draft: '' };
+              const isExceeded = wipState.limit !== null && colStories.length > wipState.limit;
+              return (
+                <KanbanColumn
+                  key={col.id}
+                  id={col.id}
+                  label={t(col.i18nKey)}
+                  stories={colStories}
+                  epicMap={epicMap}
+                  memberMap={memberMap}
+                  dragStatus={dragStatus}
+                  onStoryClick={handleStoryClick}
+                  onEditStory={handleEditStory}
+                  onChangeStatus={handleChangeStatus}
+                  onAssignStory={handleAssignStory}
+                  onDeleteStory={handleDeleteStory}
+                  wipLimit={wipState.limit}
+                  wipExceeded={isExceeded}
+                  wipEditing={wipState.editing}
+                  wipDraft={wipState.draft}
+                  onWipLimitEdit={() => handleWipLimitEdit(col.id)}
+                  onWipLimitSave={() => handleWipLimitSave(col.id)}
+                  onWipLimitRemove={() => handleWipLimitRemove(col.id)}
+                  onWipDraftChange={(v) => handleWipLimitDraftChange(col.id, v)}
+                />
+              );
+            })}
             </div>
           </div>
           <DragOverlayCompat adjustScale={false} className="cursor-grabbing">

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ComponentType } from 'react';
+import { useRef } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { useTranslations } from 'next-intl';
@@ -8,6 +9,8 @@ import { StoryCard } from './story-card';
 import type { KanbanStory, KanbanMember } from './types';
 import { VALID_TRANSITIONS } from './types';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 
 
 type SortableContextCompatProps = {
@@ -30,38 +33,119 @@ interface KanbanColumnProps {
   onChangeStatus?: (storyId: string, newStatus: string) => void;
   onAssignStory?: (storyId: string) => void;
   onDeleteStory?: (storyId: string) => void;
+  // AC1/AC5: WIP limit
+  wipLimit?: number | null;
+  wipExceeded?: boolean;
+  wipEditing?: boolean;
+  wipDraft?: string;
+  onWipLimitEdit?: () => void;
+  onWipLimitSave?: () => void;
+  onWipLimitRemove?: () => void;
+  onWipDraftChange?: (value: string) => void;
 }
 
-export function KanbanColumn({ id, label, stories, epicMap, memberMap, dragStatus, onStoryClick, onEditStory, onChangeStatus, onAssignStory, onDeleteStory }: KanbanColumnProps) {
+export function KanbanColumn({
+  id, label, stories, epicMap, memberMap, dragStatus, onStoryClick,
+  onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
+  wipLimit, wipExceeded, wipEditing, wipDraft,
+  onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
+}: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const isDragging = dragStatus != null;
   const isValidTarget = isDragging && (VALID_TRANSITIONS[dragStatus] ?? []).includes(id);
   const isInvalidTarget = isDragging && !isValidTarget && dragStatus !== id;
 
+  // AC1: WIP 초과 시 빨간 테두리
+  const borderClass = wipExceeded
+    ? 'border-destructive/70 shadow-[0_0_0_1px_rgba(var(--destructive),0.25)]'
+    : isOver && isValidTarget
+      ? 'border-primary/40 bg-primary/5 shadow-[0_0_0_1px_rgba(var(--primary),0.2)]'
+      : isValidTarget
+        ? 'border-emerald-400/25 bg-emerald-400/5'
+        : isInvalidTarget
+          ? 'border-border/50 bg-muted/30 opacity-45'
+          : 'border-border/80 bg-card shadow-sm';
+
   return (
     <div
       ref={setNodeRef}
-      className={`flex min-h-[360px] w-full flex-col rounded-2xl border p-4 transition md:w-[340px] md:min-w-[300px] ${
-        isOver && isValidTarget
-          ? 'border-primary/40 bg-primary/5 shadow-[0_0_0_1px_rgba(var(--primary),0.2)]'
-          : isValidTarget
-          ? 'border-emerald-400/25 bg-emerald-400/5'
-          : isInvalidTarget
-          ? 'border-border/50 bg-muted/30 opacity-45'
-          : 'border-border/80 bg-card shadow-sm'
-      }`}
+      className={`flex min-h-[360px] w-full flex-col rounded-2xl border p-4 transition md:w-[340px] md:min-w-[300px] ${borderClass}`}
     >
       {isDragging && isValidTarget && (
         <div className="mb-3 rounded-xl border border-emerald-400/20 bg-emerald-400/8 px-2 py-1 text-center text-[10px] font-medium uppercase tracking-widest text-emerald-400/70">
           {t('validDrop')}
         </div>
       )}
-      <div className="mb-4 flex items-center justify-between gap-3 border-b border-border/70 pb-3">
-        <h3 className="text-sm font-semibold tracking-tight text-foreground">{label}</h3>
-        <Badge variant="secondary" className="rounded-full px-2.5 font-mono text-[11px] shadow-sm">{stories.length}</Badge>
+
+      {/* 컬럼 헤더 */}
+      <div className="mb-4 flex flex-col gap-2 border-b border-border/70 pb-3">
+        <div className="flex items-center justify-between gap-3">
+          <h3 className="text-sm font-semibold tracking-tight text-foreground">{label}</h3>
+          <div className="flex items-center gap-1.5">
+            {/* AC1: WIP 초과 배지 */}
+            {wipExceeded && (
+              <Badge variant="destructive" className="rounded-full px-2 font-mono text-[10px]">
+                {t('wipLimitExceeded')}
+              </Badge>
+            )}
+            {/* AC1: WIP limit 배지 (설정된 경우) */}
+            {wipLimit !== null && wipLimit !== undefined && !wipExceeded && (
+              <Badge variant="secondary" className="rounded-full px-2 font-mono text-[10px] text-muted-foreground">
+                {t('wipLimitLabel')}: {wipLimit}
+              </Badge>
+            )}
+            {/* 카드 수 배지 */}
+            <Badge
+              variant="secondary"
+              className={`rounded-full px-2.5 font-mono text-[11px] shadow-sm ${wipExceeded ? 'bg-destructive/15 text-destructive' : ''}`}
+            >
+              {stories.length}
+            </Badge>
+            {/* AC5: WIP limit 편집 버튼 */}
+            <button
+              type="button"
+              aria-label={t('wipLimitSet')}
+              title={t('wipLimitSet')}
+              onClick={onWipLimitEdit}
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 transition hover:text-foreground"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <path d="M11.013 1.427a1.75 1.75 0 012.474 2.474L4.92 12.47l-3.265.905.905-3.265 8.453-8.683z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        {/* AC5: WIP limit 편집 UI */}
+        {wipEditing && (
+          <div className="flex items-center gap-2">
+            <Input
+              ref={inputRef}
+              type="number"
+              min={1}
+              value={wipDraft ?? ''}
+              onChange={(e) => onWipDraftChange?.(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') onWipLimitSave?.();
+                if (e.key === 'Escape') onWipLimitRemove?.();
+              }}
+              placeholder={t('wipLimitLabel')}
+              className="h-7 w-20 text-xs"
+              autoFocus
+            />
+            <Button size="sm" variant="default" className="h-7 px-2 text-xs" onClick={onWipLimitSave}>
+              {t('wipLimitSave')}
+            </Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2 text-xs text-muted-foreground" onClick={onWipLimitRemove}>
+              {t('wipLimitRemove')}
+            </Button>
+          </div>
+        )}
       </div>
+
       <SortableContextCompat items={stories.map((s) => s.id)} strategy={verticalListSortingStrategy}>
         <div className="flex min-w-0 flex-1 flex-col gap-3">
           {stories.length === 0 ? (

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -8,6 +8,7 @@ export interface KanbanStory {
   epic_id: string | null;
   sprint_id: string | null;
   description: string | null;
+  position: number | null;
 }
 
 export interface KanbanEpic {

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -90,7 +90,7 @@ export class StoryService {
   async update(id: string, input: UpdateStoryInput) {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
-      'epic_id', 'sprint_id', 'assignee_id',
+      'epic_id', 'sprint_id', 'assignee_id', 'position',
     ];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) {

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -14,6 +14,7 @@ export interface Story {
   story_points: number | null;
   description: string | null;
   acceptance_criteria: string | null;
+  position: number | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -44,6 +45,7 @@ export interface UpdateStoryInput {
   epic_id?: string | null;
   sprint_id?: string | null;
   assignee_id?: string | null;
+  position?: number | null;
 }
 
 export interface BulkUpdateItem {

--- a/packages/db/supabase/migrations/20260424230000_stories_position.sql
+++ b/packages/db/supabase/migrations/20260424230000_stories_position.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.stories ADD COLUMN IF NOT EXISTS position INTEGER;
+UPDATE public.stories SET position = EXTRACT(EPOCH FROM created_at)::INTEGER * 1000 WHERE position IS NULL;

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -48,6 +48,7 @@ export const updateStorySchema = z.object({
   epic_id: z.string().optional().nullable(),
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),
+  position: z.number().int().optional().nullable(),
 });
 
 const bulkUpdateItemSchema = z.object({

--- a/packages/storage-sqlite/src/SqliteStoryRepository.ts
+++ b/packages/storage-sqlite/src/SqliteStoryRepository.ts
@@ -56,7 +56,7 @@ export class SqliteStoryRepository implements IStoryRepository {
   }
 
   async update(id: string, input: UpdateStoryInput): Promise<Story> {
-    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria', 'epic_id', 'sprint_id', 'assignee_id'];
+    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria', 'epic_id', 'sprint_id', 'assignee_id', 'position'];
     const sets: string[] = [];
     const params: SqlParam[] = [];
     for (const key of ALLOWED) {

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -292,6 +292,9 @@ function migrateLegacyStoryStatuses(db: DatabaseSync): void {
 
 function migrateStorySchema(db: DatabaseSync): void {
   try { db.exec(`ALTER TABLE stories ADD COLUMN acceptance_criteria TEXT`); } catch { /* already exists */ }
+  try { db.exec(`ALTER TABLE stories ADD COLUMN position INTEGER`); } catch { /* already exists */ }
+  // position 초기값: created_at epoch * 1000
+  db.exec(`UPDATE stories SET position = CAST(strftime('%s', created_at) AS INTEGER) * 1000 WHERE position IS NULL`);
   // 비표준 priority → 'medium'
   db.exec(`UPDATE stories SET priority = 'medium' WHERE priority NOT IN ('critical','high','medium','low')`);
   // 비표준 story_points → 가장 가까운 피보나치

--- a/packages/storage-supabase/src/SupabaseStoryRepository.ts
+++ b/packages/storage-supabase/src/SupabaseStoryRepository.ts
@@ -82,7 +82,7 @@ export class SupabaseStoryRepository implements IStoryRepository {
   }
 
   async update(id: string, input: UpdateStoryInput): Promise<Story> {
-    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'epic_id', 'sprint_id', 'assignee_id'];
+    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'epic_id', 'sprint_id', 'assignee_id', 'position'];
     const patch: Record<string, unknown> = {};
     for (const key of ALLOWED) {
       if (key in input) patch[key] = input[key];


### PR DESCRIPTION
## Summary
- `stories.position` 컬럼 추가 (SQL + SQLite 마이그레이션)
- 드래그 완료 시 `computeNewPosition()` gap 방식(1000 단위) → `PATCH /api/stories/{id}` fire-and-forget
- 컬럼별 WIP Limit — localStorage 저장, 초과 시 빨간 테두리 + 배지
- 컬럼 헤더 연필 아이콘 → 인라인 number input으로 WIP Limit 설정
- 보드 상단 검색 input — 제목/담당자 클라이언트사이드 필터링

## AC Checklist
- [x] AC1: WIP Limit 초과 시 컬럼 빨간 테두리 + 배지 경고
- [x] AC2: 카드 검색 UI (제목/담당자 필터링)
- [x] AC3: `stories.position` 필드 추가 + PATCH 지원
- [x] AC4: 드래그 앤 드롭 시 position gap 재계산
- [x] AC5: WIP Limit 설정 UI (컬럼 헤더 인라인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)