### PR TITLE
feat(stories): assignee change notifications + activity log (E-PM-ENHANCE S7)

### DIFF
--- a/apps/web/src/app/api/stories/[id]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/route.ts
@@ -7,6 +7,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { NotificationService } from '@/services/notification.service';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -48,7 +49,36 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const parsed = await parseBody(request, updateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createStoryRepository(dbClient);
     const service = new StoryService(repo, dbClient as SupabaseClient | undefined, { isAdminContext: me.type === 'agent' });
+
+    const before = await service.getById(id);
     const story = await service.update(id, body);
+
+    if (!ossMode && dbClient) {
+      const notifService = new NotificationService(dbClient as SupabaseClient);
+      const actorId = me.id;
+      const orgId = me.org_id;
+
+      // 담당자 변경 알림 + activity log (AC1, AC5)
+      if ('assignee_id' in body && body.assignee_id !== before.assignee_id) {
+        const newAssigneeId = body.assignee_id as string | null;
+        const oldAssigneeId = before.assignee_id as string | null;
+
+        if (newAssigneeId && newAssigneeId !== actorId) {
+          notifService.create({ org_id: orgId, user_id: newAssigneeId, type: 'story_assigned', title: '스토리가 배정되었습니다', body: before.title ?? '', reference_type: 'story', reference_id: id }).catch(() => {});
+        }
+        if (oldAssigneeId && oldAssigneeId !== actorId && oldAssigneeId !== newAssigneeId) {
+          notifService.create({ org_id: orgId, user_id: oldAssigneeId, type: 'story_assigned', title: '스토리 담당자가 변경되었습니다', body: before.title ?? '', reference_type: 'story', reference_id: id }).catch(() => {});
+        }
+
+        service.logActivity({ story_id: id, org_id: orgId, actor_id: actorId, action_type: 'assignee_changed', old_value: oldAssigneeId, new_value: newAssigneeId }).catch(() => {});
+      }
+
+      // 상태 변경 activity log (AC4)
+      if (body.status && body.status !== before.status) {
+        service.logActivity({ story_id: id, org_id: orgId, actor_id: actorId, action_type: 'status_changed', old_value: before.status as string, new_value: body.status }).catch(() => {});
+      }
+    }
+
     return apiSuccess(story);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -197,4 +197,8 @@ export class StoryService {
   async getActivities(storyId: string, options?: { limit?: number; cursor?: string }) {
     return this.repo.getActivities(storyId, options);
   }
+
+  async logActivity(input: { story_id: string; org_id: string; actor_id: string; action_type: string; old_value?: string | null; new_value?: string | null }): Promise<void> {
+    await this.repo.addActivity(input);
+  }
 }

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -85,4 +85,5 @@ export interface IStoryRepository {
   addComment(input: { story_id: string; content: string; created_by: string }): Promise<StoryComment>;
   getComments(storyId: string, options?: PaginationOptions): Promise<StoryComment[]>;
   getActivities(storyId: string, options?: PaginationOptions): Promise<unknown[]>;
+  addActivity(input: { story_id: string; org_id: string; actor_id: string; action_type: string; old_value?: string | null; new_value?: string | null }): Promise<void>;
 }

--- a/packages/db/supabase/migrations/20260425000000_story_activities.sql
+++ b/packages/db/supabase/migrations/20260425000000_story_activities.sql
@@ -1,0 +1,24 @@
+-- E-PM-ENHANCE S7: story_activities 테이블 신설
+-- 스토리 상태 변경 / 담당자 변경 이력 추적
+
+CREATE TABLE IF NOT EXISTS public.story_activities (
+  id          uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  story_id    uuid        NOT NULL REFERENCES public.stories(id) ON DELETE CASCADE,
+  org_id      uuid        NOT NULL,
+  actor_id    uuid        NOT NULL,
+  action_type text        NOT NULL CHECK (action_type IN ('status_changed', 'assignee_changed', 'comment_added')),
+  old_value   text,
+  new_value   text,
+  created_at  timestamptz DEFAULT now() NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_story_activities_story_id
+  ON public.story_activities(story_id, created_at DESC);
+
+ALTER TABLE public.story_activities ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "story_activities_select" ON public.story_activities FOR SELECT
+  USING (org_id IN (SELECT public.get_user_org_ids()));
+
+CREATE POLICY "story_activities_insert" ON public.story_activities FOR INSERT
+  WITH CHECK (org_id IN (SELECT public.get_user_org_ids()));

--- a/packages/storage-sqlite/src/SqliteStoryRepository.ts
+++ b/packages/storage-sqlite/src/SqliteStoryRepository.ts
@@ -102,4 +102,8 @@ export class SqliteStoryRepository implements IStoryRepository {
     if (options?.limit) { sql += ` LIMIT ${options.limit}`; }
     return this.db.prepare(sql).all(...params);
   }
+
+  async addActivity(_input: { story_id: string; org_id: string; actor_id: string; action_type: string; old_value?: string | null; new_value?: string | null }): Promise<void> {
+    // OSS SQLite mode: activity logs not persisted
+  }
 }

--- a/packages/storage-supabase/src/SupabaseStoryRepository.ts
+++ b/packages/storage-supabase/src/SupabaseStoryRepository.ts
@@ -136,4 +136,9 @@ export class SupabaseStoryRepository implements IStoryRepository {
     if (error) throw error;
     return data ?? [];
   }
+
+  async addActivity(input: { story_id: string; org_id: string; actor_id: string; action_type: string; old_value?: string | null; new_value?: string | null }): Promise<void> {
+    const { error } = await this.supabase.from('story_activities').insert(input);
+    if (error) throw mapSupabaseError(error);
+  }
 }


### PR DESCRIPTION
## Summary
- `story_activities` 테이블 신설 — status_changed / assignee_changed 이력 추적
- PATCH `/api/stories/[id]`: 담당자 변경 시 신/구 담당자 `story_assigned` 알림 (self 제외)
- 상태 변경 시 activity log 자동 기록 (fire-and-forget)
- `StoryService.logActivity()` → `IStoryRepository.addActivity()` 인터페이스 체계 신설
- OSS SQLite: `addActivity()` no-op 구현

## AC 검증
1. ✅ 담당자 변경 시 신/구 담당자 `story_assigned` 알림 (self 제외)
2. ✅ story-detail-panel Activity 탭 — `/api/stories/[id]/activities` 기존 구현과 연동
3. ✅ `story_activities` 테이블 (action_type CHECK + RLS)
4. ✅ PATCH route에서 status 변경 시 `status_changed` activity log 기록
5. ✅ actor === assignee 시 알림 미발송

## DB 마이그레이션
`20260425000000_story_activities.sql` — story_activities 테이블 + RLS 정책

## Test
- 기존 route.test.ts 7/7 PASS
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)