### PR TITLE
feat(sprints): duration + burndown ideal line + auto report + sprints page (E-PM-ENHANCE S8)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -39,7 +39,8 @@
     "mockup": "Mockups",
     "meetings": "Meetings",
     "agents": "Agents",
-    "epics": "Epics"
+    "epics": "Epics",
+    "sprints": "Sprints"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -1815,5 +1816,18 @@
     "notAssigned": "Not assigned",
     "spExceeded": "SP Over",
     "spExceededDetail": "{total}SP / target {target}SP exceeded"
+  },
+  "sprints": {
+    "title": "Sprints",
+    "loading": "Loading...",
+    "noProject": "No project selected.",
+    "noSprints": "No sprints found.",
+    "days": "d",
+    "viewReport": "View Report",
+    "completionRate": "Completion",
+    "stories": "Stories",
+    "burndown": "Burndown",
+    "idealLine": "Ideal",
+    "actualLine": "Actual"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -39,7 +39,8 @@
     "mockup": "목업",
     "meetings": "회의록",
     "agents": "에이전트",
-    "epics": "에픽"
+    "epics": "에픽",
+    "sprints": "스프린트"
   },
   "dashboard": {
     "title": "대시보드",
@@ -1815,5 +1816,18 @@
     "notAssigned": "미지정",
     "spExceeded": "SP 초과",
     "spExceededDetail": "{total}SP / 목표 {target}SP 초과"
+  },
+  "sprints": {
+    "title": "스프린트",
+    "loading": "로딩 중...",
+    "noProject": "프로젝트가 선택되지 않았습니다.",
+    "noSprints": "스프린트가 없습니다.",
+    "days": "일",
+    "viewReport": "리포트 보기",
+    "completionRate": "완료율",
+    "stories": "스토리",
+    "burndown": "번다운",
+    "idealLine": "이상선",
+    "actualLine": "실제선"
   }
 }

--- a/apps/web/src/app/(authenticated)/sprints/page.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useDashboardContext } from '../../dashboard/dashboard-shell';
+import { SprintsClient } from './sprints-client';
+import { useTranslations } from 'next-intl';
+
+export default function SprintsPage() {
+  const { projectId, orgId } = useDashboardContext();
+  const t = useTranslations('sprints');
+
+  if (!projectId) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('noProject')}</p>
+      </div>
+    );
+  }
+
+  return <SprintsClient projectId={projectId} orgId={orgId ?? ''} />;
+}

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+interface Sprint {
+  id: string;
+  title: string;
+  status: string;
+  start_date: string;
+  end_date: string;
+  duration: number;
+  velocity: number | null;
+  report_doc_id: string | null;
+}
+
+interface BurndownData {
+  total_points: number;
+  done_points: number;
+  remaining_points: number;
+  completion_pct: number;
+  stories_count: number;
+  done_count: number;
+  ideal_line: Array<{ date: string; points: number }>;
+  actual_line: Array<{ date: string; points: number }>;
+}
+
+interface SprintsClientProps {
+  projectId: string;
+  orgId: string;
+}
+
+function statusVariant(status: string): 'default' | 'secondary' | 'outline' {
+  if (status === 'active') return 'default';
+  if (status === 'closed') return 'secondary';
+  return 'outline';
+}
+
+export function SprintsClient({ projectId }: SprintsClientProps) {
+  const t = useTranslations('sprints');
+  const [sprints, setSprints] = useState<Sprint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<Sprint | null>(null);
+  const [burndown, setBurndown] = useState<BurndownData | null>(null);
+  const [loadingBurndown, setLoadingBurndown] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/sprints?project_id=${projectId}`);
+        if (res.ok) {
+          const json = await res.json();
+          setSprints(json.data ?? []);
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    void load();
+  }, [projectId]);
+
+  const handleSelect = async (sprint: Sprint) => {
+    setSelected(sprint);
+    setBurndown(null);
+    setLoadingBurndown(true);
+    try {
+      const res = await fetch(`/api/sprints/${sprint.id}/burndown`);
+      if (res.ok) {
+        const json = await res.json();
+        setBurndown(json.data);
+      }
+    } finally {
+      setLoadingBurndown(false);
+    }
+  };
+
+  if (loading) {
+    return <p className="p-6 text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  return (
+    <div className="flex h-full">
+      {/* Sprint list */}
+      <div className="flex w-full flex-col gap-3 overflow-y-auto p-6 lg:w-1/2">
+        <h1 className="text-xl font-semibold text-foreground">{t('title')}</h1>
+        {sprints.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('noSprints')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {sprints.map((sprint) => (
+              <li
+                key={sprint.id}
+                onClick={() => void handleSelect(sprint)}
+                className={`cursor-pointer rounded-lg border p-4 transition hover:bg-muted/40 ${selected?.id === sprint.id ? 'border-primary bg-muted/40' : 'border-border'}`}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-foreground">{sprint.title}</span>
+                  <Badge variant={statusVariant(sprint.status)}>{sprint.status}</Badge>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {sprint.start_date} ~ {sprint.end_date} · {sprint.duration}{t('days')}
+                </p>
+                {sprint.report_doc_id ? (
+                  <a
+                    href={`/docs?id=${sprint.report_doc_id}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="mt-2 inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+                  >
+                    📄 {t('viewReport')}
+                  </a>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Burndown detail */}
+      {selected ? (
+        <div className="hidden w-1/2 overflow-y-auto border-l border-border p-6 lg:block">
+          <div className="flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-foreground">{selected.title}</h2>
+            <Button variant="ghost" size="sm" onClick={() => setSelected(null)}>✕</Button>
+          </div>
+
+          {loadingBurndown ? (
+            <p className="mt-4 text-sm text-muted-foreground">{t('loading')}</p>
+          ) : burndown ? (
+            <div className="mt-4 space-y-4">
+              <div className="grid grid-cols-3 gap-3">
+                <div className="rounded-md border border-border bg-muted/30 p-3 text-center">
+                  <p className="text-2xl font-bold text-foreground">{burndown.completion_pct}%</p>
+                  <p className="text-xs text-muted-foreground">{t('completionRate')}</p>
+                </div>
+                <div className="rounded-md border border-border bg-muted/30 p-3 text-center">
+                  <p className="text-2xl font-bold text-foreground">{burndown.done_points}<span className="text-sm text-muted-foreground">/{burndown.total_points}</span></p>
+                  <p className="text-xs text-muted-foreground">SP</p>
+                </div>
+                <div className="rounded-md border border-border bg-muted/30 p-3 text-center">
+                  <p className="text-2xl font-bold text-foreground">{burndown.done_count}<span className="text-sm text-muted-foreground">/{burndown.stories_count}</span></p>
+                  <p className="text-xs text-muted-foreground">{t('stories')}</p>
+                </div>
+              </div>
+
+              {/* Ideal vs Actual line summary */}
+              {burndown.ideal_line.length > 0 ? (
+                <div className="rounded-md border border-border p-3">
+                  <p className="mb-2 text-xs font-medium text-muted-foreground uppercase tracking-wide">{t('burndown')}</p>
+                  <div className="flex gap-4 text-xs text-muted-foreground">
+                    <span>📉 {t('idealLine')}: {burndown.ideal_line[0]?.points ?? 0} → 0</span>
+                    <span>📊 {t('actualLine')}: {burndown.actual_line[0]?.points ?? 0} → {burndown.actual_line[burndown.actual_line.length - 1]?.points ?? 0}</span>
+                  </div>
+                </div>
+              ) : null}
+
+              {selected.report_doc_id ? (
+                <a
+                  href={`/docs?id=${selected.report_doc_id}`}
+                  className="flex items-center gap-2 rounded-md border border-primary/30 bg-primary/5 p-3 text-sm font-medium text-primary hover:bg-primary/10 transition"
+                >
+                  📄 {t('viewReport')}
+                </a>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -5,8 +5,9 @@ import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { isOssMode, createSprintRepository, createDocRepository } from '@/lib/storage/factory';
 import { NotificationService } from '@/services/notification.service';
+import { DocsService } from '@/services/docs';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -26,23 +27,68 @@ export async function POST(request: Request, { params }: RouteParams) {
     const sprint = await service.close(id);
 
     if (!ossMode && dbClient) {
-      const notifService = new NotificationService(dbClient as SupabaseClient);
+      const db = dbClient as SupabaseClient;
+
+      // 알림 발송 (fire-and-forget)
+      const notifService = new NotificationService(db);
       (async () => {
-        const { data: members } = await (dbClient as SupabaseClient)
-          .from('team_members')
-          .select('id')
-          .eq('project_id', sprint.project_id)
-          .eq('is_active', true);
+        const { data: members } = await db.from('team_members').select('id').eq('project_id', sprint.project_id).eq('is_active', true);
         for (const member of (members ?? []) as Array<{ id: string }>) {
-          await notifService.create({
-            org_id: sprint.org_id,
-            user_id: member.id,
-            type: 'sprint_closed',
-            title: `${sprint.title ?? '스프린트'} 종료`,
-            reference_type: 'sprint',
-            reference_id: sprint.id,
-          });
+          await notifService.create({ org_id: sprint.org_id, user_id: member.id, type: 'sprint_closed', title: `${sprint.title ?? '스프린트'} 종료`, reference_type: 'sprint', reference_id: sprint.id });
         }
+      })().catch(() => {});
+
+      // 자동 sprint report 생성 (fire-and-forget)
+      (async () => {
+        const { data: stories } = await db.from('stories').select('id, title, status, story_points, assignee_id').eq('sprint_id', id);
+        const allStories = (stories ?? []) as Array<{ id: string; title: string; status: string; story_points: number | null; assignee_id: string | null }>;
+        const doneStories = allStories.filter((s) => s.status === 'done');
+        const carriedOver = allStories.filter((s) => s.status !== 'done');
+        const totalSp = allStories.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+        const doneSp = doneStories.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+        const completionPct = totalSp > 0 ? Math.round((doneSp / totalSp) * 100) : 0;
+        const duration = (sprint.duration as number | undefined) ?? 14;
+        const velocityPerDay = duration > 0 ? Math.round((doneSp / duration) * 10) / 10 : 0;
+
+        const reportContent = [
+          `# Sprint Report: ${sprint.title ?? id}`,
+          ``,
+          `**기간:** ${sprint.start_date ?? ''} ~ ${sprint.end_date ?? ''}  `,
+          `**Duration:** ${duration}일`,
+          ``,
+          `## 결과 요약`,
+          `| 항목 | 수치 |`,
+          `|---|---|`,
+          `| 완료율 | ${completionPct}% |`,
+          `| 완료 SP | ${doneSp} / ${totalSp} |`,
+          `| 속도 | ${velocityPerDay} SP/일 |`,
+          `| 완료 스토리 | ${doneStories.length} / ${allStories.length} |`,
+          ``,
+          `## 완료 스토리`,
+          ...doneStories.map((s) => `- [x] ${s.title} (${s.story_points ?? 0} SP)`),
+          ``,
+          `## 이월 스토리`,
+          carriedOver.length === 0 ? '_없음_' : '',
+          ...carriedOver.map((s) => `- [ ] ${s.title} (${s.story_points ?? 0} SP)`),
+        ].join('\n');
+
+        const slug = `sprint-report-${id.slice(0, 8)}-${Date.now()}`;
+        const docRepo = await createDocRepository(db);
+        const docsService = new DocsService(docRepo, db);
+        const doc = await docsService.createDoc({
+          org_id: sprint.org_id as string,
+          project_id: sprint.project_id as string,
+          title: `Sprint Report: ${sprint.title ?? id}`,
+          slug,
+          content: reportContent,
+          content_format: 'markdown',
+          doc_type: 'sprint_report',
+          created_by: me.id,
+        });
+
+        // sprint에 report_doc_id 기록
+        const sprintRepo = await createSprintRepository(db);
+        await sprintRepo.update(id, { report_doc_id: doc.id });
       })().catch(() => {});
     }
 

--- a/apps/web/src/components/nav/operator-shell.tsx
+++ b/apps/web/src/components/nav/operator-shell.tsx
@@ -18,6 +18,7 @@ import {
   PenTool,
   Search,
   Settings,
+  Timer,
   Users,
 } from 'lucide-react';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
@@ -44,6 +45,7 @@ const NAV_ITEMS: NavItem[] = [
     children: [
       { key: 'board', href: '/board', icon: FolderKanban },
       { key: 'epics', href: '/epics', icon: Layers },
+      { key: 'sprints', href: '/sprints', icon: Timer },
       { key: 'standup', href: '/standup', icon: Users },
       { key: 'retro', href: '/retro', icon: Gauge },
     ],

--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -97,20 +97,41 @@ export class SprintService {
   async getBurndown(id: string) {
     const sprint = await this.getById(id);
     if (!this.supabase) {
-      return { sprint, total_points: 0, done_points: 0, remaining_points: 0, completion_pct: 0, stories_count: 0, done_count: 0 };
+      return { sprint, total_points: 0, done_points: 0, remaining_points: 0, completion_pct: 0, stories_count: 0, done_count: 0, ideal_line: [], actual_line: [] };
     }
     const { data: stories, error } = await this.supabase.from('stories').select('story_points, status, updated_at').eq('sprint_id', id);
     if (error) throw error;
     const totalPoints = (stories ?? []).reduce((sum, s) => sum + ((s.story_points as number) ?? 0), 0);
     const donePoints = (stories ?? []).filter((s) => s.status === 'done').reduce((sum, s) => sum + ((s.story_points as number) ?? 0), 0);
+    const remaining = totalPoints - donePoints;
+
+    // 이상선: duration 기준 선형 감소 (day 0 → total, day duration → 0)
+    const duration = (sprint.duration as number | undefined) ?? 14;
+    const startDate = sprint.start_date ? new Date(sprint.start_date as string) : null;
+    const idealLine: Array<{ date: string; points: number }> = [];
+    for (let day = 0; day <= duration; day++) {
+      const date = startDate ? new Date(startDate.getTime() + day * 86_400_000).toISOString().slice(0, 10) : String(day);
+      idealLine.push({ date, points: Math.round(totalPoints * (1 - day / duration)) });
+    }
+
+    // 실제선: 시작일=total, 오늘=remaining (단순 2포인트)
+    const today = new Date().toISOString().slice(0, 10);
+    const startDateStr = startDate ? startDate.toISOString().slice(0, 10) : today;
+    const actualLine: Array<{ date: string; points: number }> = [
+      { date: startDateStr, points: totalPoints },
+      { date: today, points: remaining },
+    ];
+
     return {
       sprint,
       total_points: totalPoints,
       done_points: donePoints,
-      remaining_points: totalPoints - donePoints,
+      remaining_points: remaining,
       completion_pct: totalPoints > 0 ? Math.round((donePoints / totalPoints) * 100) : 0,
       stories_count: stories?.length ?? 0,
       done_count: (stories ?? []).filter((s) => s.status === 'done').length,
+      ideal_line: idealLine,
+      actual_line: actualLine,
     };
   }
 

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -14,6 +14,7 @@ export interface Doc {
   tags: string[] | null;
   sort_order: number;
   is_folder: boolean;
+  doc_type: string;
   created_by: string;
   created_at: string;
   updated_at: string;
@@ -42,6 +43,7 @@ export interface CreateDocInput {
   parent_id?: string | null;
   is_folder?: boolean;
   sort_order?: number;
+  doc_type?: string;
   created_by: string;
 }
 

--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -11,6 +11,8 @@ export interface Sprint {
   end_date: string;
   team_size: number | null;
   velocity: number | null;
+  duration: number;
+  report_doc_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -31,6 +33,8 @@ export interface UpdateSprintInput {
   team_size?: number;
   status?: string;
   velocity?: number | null;
+  duration?: number;
+  report_doc_id?: string | null;
 }
 
 export interface SprintListFilters extends PaginationOptions {

--- a/packages/db/supabase/migrations/20260425010000_sprint_duration_doc_type.sql
+++ b/packages/db/supabase/migrations/20260425010000_sprint_duration_doc_type.sql
@@ -1,0 +1,13 @@
+-- E-PM-ENHANCE S8: sprints.duration + sprints.report_doc_id + docs.doc_type
+
+-- 1. sprints.duration — 스프린트 기간 (일 단위, 기본 14)
+ALTER TABLE public.sprints
+  ADD COLUMN IF NOT EXISTS duration integer NOT NULL DEFAULT 14;
+
+-- 2. sprints.report_doc_id — 종료 시 자동 생성 report doc 참조
+ALTER TABLE public.sprints
+  ADD COLUMN IF NOT EXISTS report_doc_id uuid REFERENCES public.docs(id) ON DELETE SET NULL;
+
+-- 3. docs.doc_type — 문서 유형 식별 (page, sprint_report 등)
+ALTER TABLE public.docs
+  ADD COLUMN IF NOT EXISTS doc_type text NOT NULL DEFAULT 'page';

--- a/packages/storage-supabase/src/SupabaseDocRepository.ts
+++ b/packages/storage-supabase/src/SupabaseDocRepository.ts
@@ -75,6 +75,7 @@ export class SupabaseDocRepository implements IDocRepository {
         tags: input.tags ?? [],
         sort_order: input.sort_order ?? 0,
         is_folder: input.is_folder ?? false,
+        doc_type: input.doc_type ?? 'page',
         created_by: input.created_by,
       })
       .select()

--- a/packages/storage-supabase/src/SupabaseSprintRepository.ts
+++ b/packages/storage-supabase/src/SupabaseSprintRepository.ts
@@ -59,7 +59,7 @@ export class SupabaseSprintRepository implements ISprintRepository {
   }
 
   async update(id: string, input: UpdateSprintInput): Promise<Sprint> {
-    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status', 'velocity'];
+    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status', 'velocity', 'duration', 'report_doc_id'];
     const patch: Record<string, unknown> = {};
     for (const key of ALLOWED) {
       if (key in input) patch[key] = input[key];


### PR DESCRIPTION
## Summary
- `sprints.duration` 컬럼 추가 (기본 14일) + `sprints.report_doc_id` FK
- `docs.doc_type` 컬럼 추가 ('page' 기본값, 'sprint_report' 자동 생성)
- `SprintService.getBurndown()`: `ideal_line` (선형 감소) + `actual_line` (시작점 vs 오늘)
- close 시 sprint report 자동 생성 → docs 테이블 저장 + sprint.report_doc_id 기록
- `/sprints` 페이지 신설: 목록 + 상세 패널(번다운 요약 + report 링크)
- nav: Sprints 메뉴 항목 (Timer 아이콘)

## AC 검증
1. ✅ `sprints.duration` 컬럼 (DEFAULT 14)
2. ✅ `getBurndown()` ideal_line (선형) + actual_line (2포인트)
3. ✅ close 시 완료율/속도(SP/일)/이월 스토리 markdown report 자동 생성
4. ✅ docs `doc_type='sprint_report'`로 저장
5. ✅ `/sprints` 페이지에서 closed sprint report 링크 표시

## DB 마이그레이션
`20260425010000_sprint_duration_doc_type.sql` — sprints.duration + report_doc_id + docs.doc_type

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)