### PR TITLE
feat(tasks): deprecate story_points from task API and schema (E-PM-ENHANCE S9)

### DIFF
--- a/packages/core-storage/src/interfaces/ITaskRepository.ts
+++ b/packages/core-storage/src/interfaces/ITaskRepository.ts
@@ -19,14 +19,12 @@ export interface CreateTaskInput {
   title: string;
   assignee_id?: string | null;
   status?: string;
-  story_points?: number | null;
 }
 
 export interface UpdateTaskInput {
   title?: string;
   status?: string;
   assignee_id?: string | null;
-  story_points?: number | null;
 }
 
 export interface TaskListFilters extends PaginationOptions {

--- a/packages/shared/src/schemas/tasks.ts
+++ b/packages/shared/src/schemas/tasks.ts
@@ -5,12 +5,10 @@ export const createTaskSchema = z.object({
   title: z.string().min(1),
   assignee_id: z.string().optional().nullable(),
   status: z.string().optional(),
-  story_points: z.number().optional().nullable(),
 });
 
 export const updateTaskSchema = z.object({
   title: z.string().min(1).optional(),
   status: z.string().optional(),
   assignee_id: z.string().optional().nullable(),
-  story_points: z.number().optional().nullable(),
 });

--- a/packages/storage-sqlite/src/SqliteTaskRepository.ts
+++ b/packages/storage-sqlite/src/SqliteTaskRepository.ts
@@ -14,9 +14,9 @@ export class SqliteTaskRepository implements ITaskRepository {
     const id = randomUUID();
     const now = new Date().toISOString();
     this.db.prepare(`
-      INSERT INTO tasks (id, org_id, story_id, title, status, assignee_id, story_points, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, story.org_id, input.story_id, input.title.trim(), input.status ?? 'todo', input.assignee_id ?? null, input.story_points ?? null, now, now);
+      INSERT INTO tasks (id, org_id, story_id, title, status, assignee_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, story.org_id, input.story_id, input.title.trim(), input.status ?? 'todo', input.assignee_id ?? null, now, now);
     return this.getById(id);
   }
 
@@ -60,7 +60,7 @@ export class SqliteTaskRepository implements ITaskRepository {
   }
 
   async update(id: string, input: UpdateTaskInput): Promise<Task> {
-    const ALLOWED: (keyof UpdateTaskInput)[] = ['title', 'status', 'assignee_id', 'story_points'];
+    const ALLOWED: (keyof UpdateTaskInput)[] = ['title', 'status', 'assignee_id'];
     const sets: string[] = [];
     const params: SqlParam[] = [];
     for (const key of ALLOWED) {

--- a/packages/storage-supabase/src/SupabaseTaskRepository.ts
+++ b/packages/storage-supabase/src/SupabaseTaskRepository.ts
@@ -27,7 +27,6 @@ export class SupabaseTaskRepository implements ITaskRepository {
         title: input.title.trim(),
         assignee_id: input.assignee_id ?? null,
         status: input.status ?? 'todo',
-        story_points: input.story_points ?? null,
       })
       .select()
       .single();
@@ -89,7 +88,7 @@ export class SupabaseTaskRepository implements ITaskRepository {
   }
 
   async update(id: string, input: UpdateTaskInput): Promise<Task> {
-    const ALLOWED: (keyof UpdateTaskInput)[] = ['title', 'status', 'assignee_id', 'story_points'];
+    const ALLOWED: (keyof UpdateTaskInput)[] = ['title', 'status', 'assignee_id'];
     const patch: Record<string, unknown> = {};
     for (const key of ALLOWED) {
       if (key in input) patch[key] = input[key];


### PR DESCRIPTION
## Summary
태스크 `story_points` 필드를 API/스키마 레벨에서 deprecated 처리.

- `createTaskSchema` / `updateTaskSchema` (Zod) — `story_points` 제거
- `CreateTaskInput` / `UpdateTaskInput` 인터페이스 — `story_points` 제거
- `SupabaseTaskRepository` insert + ALLOWED — `story_points` 제거
- `SqliteTaskRepository` insert + ALLOWED — `story_points` 제거

## AC 검증
1. ✅ 태스크 생성/수정 UI — 기존부터 story_points 입력 필드 없음 (추가 변경 불필요)
2. ✅ API에서 story_points 파라미터 무시 — Zod 스키마에서 제거하여 파싱 단계에서 strip
3. ✅ DB 컬럼 유지 — 마이그레이션 없음, `Task` 인터페이스의 `story_points` 필드 유지
4. ✅ 태스크 목록/상세 UI — 기존부터 story_points 표시 없음
5. ✅ 번다운 계산 — `SprintService.getBurndown()` 은 stories 테이블만 쿼리 (변경 없음)

## Test
- task route 테스트 2/2 PASS
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)