### PR TITLE
feat(memos): full-text search with tsvector + search bar UI (E-COLLAB-TOOLS S1)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -235,7 +235,8 @@
     "sidebarSubtitle": "Open memos, reply, and create new ones from anywhere",
     "closeSidebar": "Close memo sidebar",
     "expandReplies": "Show {count} earlier replies",
-    "collapseReplies": "Hide earlier replies"
+    "collapseReplies": "Hide earlier replies",
+    "searchPlaceholder": "Search memos..."
   },
   "login": {
     "title": "Sprintable",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -235,7 +235,8 @@
     "sidebarSubtitle": "모든 페이지에서 메모를 바로 확인하고 답글할 수 있습니다",
     "closeSidebar": "메모 사이드바 닫기",
     "expandReplies": "이전 답글 {count}건 보기",
-    "collapseReplies": "답글 접기"
+    "collapseReplies": "답글 접기",
+    "searchPlaceholder": "메모 검색..."
   },
   "login": {
     "title": "Sprintable",

--- a/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { ChevronLeft, Plus, X } from 'lucide-react';
+import { ChevronLeft, Plus, Search, X } from 'lucide-react';
 import { MemoFeed } from '@/components/memos/memo-feed';
 import { MemoThread } from '@/components/memos/memo-thread';
 import { MemoCreateForm } from '@/components/memos/memo-create-form';
@@ -33,19 +33,29 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [debouncedQuery, setDebouncedQuery] = useState('');
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = (value: string) => {
+    setSearchQuery(value);
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(() => setDebouncedQuery(value), 300);
+  };
 
   const memberMap = useMemo(
     () => Object.fromEntries(members.map((m) => [m.id, m.name])),
     [members],
   );
 
-  const fetchMemos = useCallback(async () => {
+  const fetchMemos = useCallback(async (q?: string) => {
     if (!projectId) return;
 
     try {
       const params = new URLSearchParams();
       params.append('project_id', projectId);
       params.append('limit', '50');
+      if (q?.trim()) params.append('q', q.trim());
 
       const res = await fetch(`/api/memos?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch memos');
@@ -195,6 +205,10 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
     void Promise.all([fetchMemos(), fetchMembers()]);
   }, [fetchMemos, fetchMembers]);
 
+  useEffect(() => {
+    void fetchMemos(debouncedQuery);
+  }, [debouncedQuery, fetchMemos]);
+
   if (loading) {
     return (
       <div className="flex h-64 items-center justify-center">
@@ -213,6 +227,25 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
         <Button size="sm" onClick={handleNewMemo}>
           <Plus className="h-4 w-4" />
         </Button>
+      </div>
+      <div className="relative mt-3">
+        <Search className="absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => handleSearchChange(e.target.value)}
+          placeholder={t('searchPlaceholder')}
+          className="w-full rounded-md border border-border bg-muted/30 py-1.5 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        />
+        {searchQuery ? (
+          <button
+            type="button"
+            onClick={() => handleSearchChange('')}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        ) : null}
       </div>
     </div>
   );

--- a/packages/db/supabase/migrations/20260425020000_memos_fts.sql
+++ b/packages/db/supabase/migrations/20260425020000_memos_fts.sql
@@ -1,0 +1,38 @@
+-- E-COLLAB-TOOLS S1: memos full-text search
+-- tsvector 컬럼 + GIN 인덱스 + 자동 갱신 트리거
+
+-- 1. search_vector 컬럼 추가
+ALTER TABLE public.memos
+  ADD COLUMN IF NOT EXISTS search_vector tsvector;
+
+-- 2. 기존 데이터 초기화
+UPDATE public.memos
+SET search_vector = to_tsvector('simple',
+  coalesce(title, '') || ' ' || coalesce(content, '')
+)
+WHERE deleted_at IS NULL;
+
+-- 3. GIN 인덱스
+CREATE INDEX IF NOT EXISTS idx_memos_search_vector
+  ON public.memos USING gin(search_vector);
+
+-- 4. 자동 갱신 함수
+CREATE OR REPLACE FUNCTION public.memos_search_vector_update()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.search_vector := to_tsvector('simple',
+    coalesce(NEW.title, '') || ' ' || coalesce(NEW.content, '')
+  );
+  RETURN NEW;
+END;
+$$;
+
+-- 5. INSERT/UPDATE 트리거
+DROP TRIGGER IF EXISTS trg_memos_search_vector ON public.memos;
+CREATE TRIGGER trg_memos_search_vector
+  BEFORE INSERT OR UPDATE OF title, content
+  ON public.memos
+  FOR EACH ROW
+  EXECUTE FUNCTION public.memos_search_vector_update();

--- a/packages/storage-supabase/src/SupabaseMemoRepository.ts
+++ b/packages/storage-supabase/src/SupabaseMemoRepository.ts
@@ -48,7 +48,7 @@ export class SupabaseMemoRepository implements IMemoRepository {
     if (filters.assigned_to) query = query.eq('assigned_to', filters.assigned_to);
     if (filters.created_by) query = query.eq('created_by', filters.created_by);
     if (filters.status) query = query.eq('status', filters.status);
-    if (filters.q?.trim()) query = query.or(`title.ilike.%${filters.q.trim()}%,content.ilike.%${filters.q.trim()}%`);
+    if (filters.q?.trim()) query = query.textSearch('search_vector', filters.q.trim(), { type: 'websearch', config: 'simple' });
     if (filters.cursor) query = query.lt('created_at', filters.cursor);
     if (filters.limit) query = query.limit(filters.limit + 1);
     const { data, error } = await query;


### PR DESCRIPTION
## Summary
- `memos.search_vector tsvector` 컬럼 + GIN 인덱스 신설
- INSERT/UPDATE 트리거로 `simple` config tsvector 자동 갱신
- `SupabaseMemoRepository.list()`: ILIKE → `textSearch('search_vector', q, websearch/simple)`
- memos-feed-client: 검색바 UI + 300ms debounce + clear 버튼

## AC 검증
1. ✅ `memos.search_vector` tsvector + GIN + `to_tsvector('simple', title || content)`
2. ✅ `trg_memos_search_vector` INSERT/UPDATE 트리거
3. ✅ GET `/api/memos?q=` — textSearch 기반 (기존 ILIKE 대체)
4. ✅ MCP `list_memos q` — API 호출 경로 동일, 변경 없음
5. ✅ 메모 목록 UI 검색바 — debounce 300ms 후 API 재호출

## DB 마이그레이션
`20260425020000_memos_fts.sql` — tsvector 컬럼 + GIN + 트리거 + 기존 데이터 초기화

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)