### PR TITLE
feat(memos): mention parsing + memo_mentions table + creation-time notifications (E-COLLAB-TOOLS S2)

### DIFF
--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -456,7 +456,54 @@ export class MemoService {
       } as DispatchableMemo);
     }
 
+    // @멘션 파싱 + DB 저장 + 알림 (fire-and-forget)
+    if (this.supabase) {
+      this._processMemoMentions(data.id, input.content.trim(), input.org_id, input.project_id, input.created_by).catch(() => {});
+    }
+
     return data;
+  }
+
+  private async _processMemoMentions(memoId: string, content: string, orgId: string, projectId: string, authorId: string): Promise<void> {
+    if (!this.supabase) return;
+    const notifService = new NotificationService(this.supabase);
+
+    const { data: members } = await this.supabase
+      .from('team_members')
+      .select('id, name')
+      .eq('org_id', orgId)
+      .eq('project_id', projectId)
+      .eq('is_active', true);
+
+    const mentionedIds: string[] = [];
+    for (const member of (members ?? []) as Array<{ id: string; name: string | null }>) {
+      if (!member.name?.trim() || member.id === authorId) continue;
+      if (!hasExactMemberMention(content, member.name.trim())) continue;
+      mentionedIds.push(member.id);
+    }
+
+    if (mentionedIds.length === 0) return;
+
+    // memo_mentions DB 저장 (ON CONFLICT DO NOTHING)
+    await this.supabase
+      .from('memo_mentions')
+      .upsert(
+        mentionedIds.map((uid) => ({ memo_id: memoId, mentioned_user_id: uid })),
+        { onConflict: 'memo_id,mentioned_user_id', ignoreDuplicates: true },
+      );
+
+    // 멘션 알림
+    for (const userId of mentionedIds) {
+      await notifService.create({
+        org_id: orgId,
+        user_id: userId,
+        type: 'memo_mention',
+        title: '메모에서 멘션되었습니다',
+        body: content.slice(0, 100),
+        reference_type: 'memo',
+        reference_id: memoId,
+      });
+    }
   }
 
   async list(filters: { org_id?: string; project_id?: string; assigned_to?: string; created_by?: string; status?: string; limit?: number; cursor?: string | null; q?: string }) {

--- a/packages/db/supabase/migrations/20260425030000_memo_mentions.sql
+++ b/packages/db/supabase/migrations/20260425030000_memo_mentions.sql
@@ -1,0 +1,35 @@
+-- E-COLLAB-TOOLS S2: memo_mentions 테이블 신설
+
+CREATE TABLE IF NOT EXISTS public.memo_mentions (
+  id                uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  memo_id           uuid        NOT NULL REFERENCES public.memos(id) ON DELETE CASCADE,
+  mentioned_user_id uuid        NOT NULL,
+  created_at        timestamptz DEFAULT now() NOT NULL,
+  UNIQUE (memo_id, mentioned_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_memo_mentions_memo_id
+  ON public.memo_mentions(memo_id);
+
+CREATE INDEX IF NOT EXISTS idx_memo_mentions_user_id
+  ON public.memo_mentions(mentioned_user_id);
+
+ALTER TABLE public.memo_mentions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "memo_mentions_select" ON public.memo_mentions FOR SELECT
+  USING (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+        AND deleted_at IS NULL
+    )
+  );
+
+CREATE POLICY "memo_mentions_insert" ON public.memo_mentions FOR INSERT
+  WITH CHECK (
+    memo_id IN (
+      SELECT id FROM public.memos
+      WHERE org_id IN (SELECT public.get_user_org_ids())
+        AND deleted_at IS NULL
+    )
+  );


### PR DESCRIPTION
## Summary
- `memo_mentions` 테이블 신설 (memo_id FK + mentioned_user_id + UNIQUE + RLS)
- `MemoService._processMemoMentions()` — 메모 생성 시 @name 파싱 → upsert → 알림 (fire-and-forget)
- 답장 시 memo_reply/memo_mention 알림은 `_sendReplyNotifications()` 기존 구현으로 AC4 충족

## AC 검증
1. ✅ 메모 생성 시 content 에서 `hasExactMemberMention()` 기반 @멘션 파싱
2. ✅ `memo_mentions` 테이블 — memo_id FK + mentioned_user_id + UNIQUE(memo_id, mentioned_user_id)
3. ✅ 멘션 대상자에게 `memo_mention` 알림 (자기 자신 제외)
4. ✅ 메모 답장 시 원저자 `memo_reply` 알림 — 기존 `_sendReplyNotifications()` 유지
5. ✅ fire-and-forget (`.catch(() => {})`)

## DB 마이그레이션
`20260425030000_memo_mentions.sql` — 테이블 + 인덱스 + RLS

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)