### PR TITLE
feat(docs): tag GIN index + tag filter API + tag chip UI (E-COLLAB-TOOLS S4)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -869,7 +869,8 @@
     "codeCopy": "Copy code",
     "codeCopied": "Copied",
     "moveCircularError": "Cannot move a document into its own subtree",
-    "movePermissionError": "You do not have permission to move documents here"
+    "movePermissionError": "You do not have permission to move documents here",
+    "clearFilter": "Clear filter"
   },
   "rewards": {
     "title": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -869,7 +869,8 @@
     "codeCopy": "코드 복사",
     "codeCopied": "복사됨",
     "moveCircularError": "문서를 자신의 하위로 이동할 수 없습니다",
-    "movePermissionError": "이 위치로 문서를 이동할 권한이 없습니다"
+    "movePermissionError": "이 위치로 문서를 이동할 권한이 없습니다",
+    "clearFilter": "필터 초기화"
   },
   "rewards": {
     "title": "리워드",

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -84,6 +84,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
 
   // Always-editable content states
   const [title, setTitle] = useState('');
@@ -126,11 +127,14 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     onSaved: handleDocSaved,
   });
 
-  const fetchTree = useCallback(async () => {
+  const fetchTree = useCallback(async (tags?: string[]) => {
     if (!projectId) return;
 
     try {
-      const res = await fetch(`/api/docs?project_id=${projectId}&view=tree`);
+      const params = new URLSearchParams({ project_id: projectId });
+      if (tags?.length) params.set('tags', tags.join(','));
+      else params.set('view', 'tree');
+      const res = await fetch(`/api/docs?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch tree');
 
       const { data } = await res.json();
@@ -363,8 +367,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   }, [selectedDoc, projectId, router, t]);
 
   useEffect(() => {
-    fetchTree();
-  }, [fetchTree]);
+    void fetchTree(selectedTags.length ? selectedTags : undefined);
+  }, [fetchTree, selectedTags]);
 
   useEffect(() => {
     const slug = searchParams.get('slug');
@@ -399,6 +403,30 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
           </Button>
         </div>
       </div>
+      {/* Tag filter chips */}
+      {(() => {
+        const allTags = [...new Set(tree.flatMap((d) => (d as unknown as { tags?: string[] | null }).tags ?? []))];
+        if (allTags.length === 0) return null;
+        return (
+          <div className="flex flex-wrap gap-1.5 border-b border-white/10 px-4 py-2">
+            {allTags.map((tag) => (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag])}
+                className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}
+              >
+                #{tag}
+              </button>
+            ))}
+            {selectedTags.length > 0 && (
+              <button type="button" onClick={() => setSelectedTags([])} className="text-[11px] text-muted-foreground hover:text-foreground underline">
+                {t('clearFilter')}
+              </button>
+            )}
+          </div>
+        );
+      })()}
       <div className="flex-1 overflow-y-auto p-2">
         {tree.length === 0 ? (
           <EmptyState

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -38,9 +38,11 @@ export async function GET(request: Request) {
       cursor: searchParams.get('cursor'),
     }, { defaultLimit: 40, maxLimit: 100 });
     const query = searchParams.get('q');
+    const tagsParam = searchParams.get('tags');
+    const tags = tagsParam ? tagsParam.split(',').map((t) => t.trim()).filter(Boolean) : undefined;
     const rows = query
-      ? await service.search(projectId, query, pageInput)
-      : await service.list(projectId, pageInput);
+      ? await service.search(projectId, query, { ...pageInput, tags })
+      : await service.list(projectId, { ...pageInput, tags });
     const { page, meta } = buildCursorPageMeta(rows, pageInput.limit, 'updated_at');
     return apiSuccess(page, meta);
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -15,8 +15,8 @@ export class DocsService {
     return new DocsService(new SupabaseDocRepository(supabase), supabase);
   }
 
-  async list(projectId: string, input?: { limit?: number; cursor?: string | null }) {
-    return this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined });
+  async list(projectId: string, input?: { limit?: number; cursor?: string | null; tags?: string[] }) {
+    return this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined, tags: input?.tags });
   }
 
   async getTree(projectId: string) {
@@ -154,7 +154,7 @@ export class DocsService {
     }
   }
 
-  async search(projectId: string, query: string, input?: { limit?: number; cursor?: string | null }) {
+  async search(projectId: string, query: string, input?: { limit?: number; cursor?: string | null; tags?: string[] }) {
     if (this.supabase) {
       let builder = this.supabase
         .from('docs')
@@ -162,6 +162,7 @@ export class DocsService {
         .eq('project_id', projectId)
         .or(`title.ilike.%${query}%,content.ilike.%${query}%`)
         .order('updated_at', { ascending: false });
+      if (input?.tags?.length) builder = (builder as unknown as { contains: (col: string, val: string[]) => typeof builder }).contains('tags', input.tags);
       if (input?.cursor) builder = builder.lt('updated_at', input.cursor);
       if (input?.limit) builder = builder.limit(input.limit + 1);
       const { data, error } = await builder;

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -26,6 +26,7 @@ export interface DocSummary {
   title: string;
   slug: string;
   icon: string | null;
+  tags: string[] | null;
   sort_order: number;
   is_folder: boolean;
   updated_at: string;
@@ -59,6 +60,7 @@ export interface UpdateDocInput {
 
 export interface DocListFilters extends PaginationOptions {
   project_id: string;
+  tags?: string[];
 }
 
 export interface IDocRepository {

--- a/packages/db/supabase/migrations/20260425050000_docs_tags_gin.sql
+++ b/packages/db/supabase/migrations/20260425050000_docs_tags_gin.sql
@@ -1,0 +1,5 @@
+-- E-COLLAB-TOOLS S4: docs.tags GIN 인덱스 추가
+-- tags 컬럼은 text[] 타입으로 이미 존재 — @> 연산자 검색 최적화
+
+CREATE INDEX IF NOT EXISTS idx_docs_tags_gin
+  ON public.docs USING gin(tags);

--- a/packages/mcp-server/src/tools/docs.ts
+++ b/packages/mcp-server/src/tools/docs.ts
@@ -7,11 +7,15 @@ function ok(data: unknown) { return { content: [{ type: 'text' as const, text: J
 function handleError(e: unknown) { return err(e instanceof PmApiError ? e.message : String(e)); }
 
 export function registerDocsTools(server: McpServer) {
-  server.tool('list_docs', 'List docs tree for project', {
+  server.tool('list_docs', 'List docs for project (tree or flat with optional tag filter)', {
     project_id: z.string().describe('Project ID'),
-  }, async ({ project_id }) => {
+    tags: z.array(z.string()).optional().describe('Filter by tags — AND match (all tags must be present)'),
+  }, async ({ project_id, tags }) => {
     try {
-      const data = await pmApi(`/api/docs?project_id=${encodeURIComponent(project_id)}&view=tree`);
+      const params = new URLSearchParams({ project_id });
+      if (tags?.length) params.set('tags', tags.join(','));
+      else params.set('view', 'tree');
+      const data = await pmApi(`/api/docs?${params.toString()}`);
       return ok(data);
     } catch (e) { return handleError(e); }
   });
@@ -71,12 +75,15 @@ export function registerDocsTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  server.tool('search_docs', 'Search docs by title/content', {
+  server.tool('search_docs', 'Search docs by title/content with optional tag filter', {
     project_id: z.string().describe('Project ID'),
     query: z.string(),
-  }, async ({ project_id, query }) => {
+    tags: z.array(z.string()).optional().describe('Filter by tags — AND match'),
+  }, async ({ project_id, query, tags }) => {
     try {
-      const data = await pmApi(`/api/docs?project_id=${encodeURIComponent(project_id)}&q=${encodeURIComponent(query)}`);
+      const params = new URLSearchParams({ project_id, q: query });
+      if (tags?.length) params.set('tags', tags.join(','));
+      const data = await pmApi(`/api/docs?${params.toString()}`);
       return ok(data);
     } catch (e) { return handleError(e); }
   });

--- a/packages/storage-supabase/src/SupabaseDocRepository.ts
+++ b/packages/storage-supabase/src/SupabaseDocRepository.ts
@@ -17,10 +17,11 @@ export class SupabaseDocRepository implements IDocRepository {
   async list(filters: DocListFilters): Promise<DocSummary[]> {
     let query = this.supabase
       .from('docs')
-      .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
+      .select('id, parent_id, title, slug, icon, tags, sort_order, is_folder, updated_at')
       .eq('project_id', filters.project_id)
       .is('deleted_at', null)
       .order('updated_at', { ascending: false });
+    if (filters.tags?.length) query = (query as unknown as { contains: (col: string, val: string[]) => typeof query }).contains('tags', filters.tags);
     if (filters.cursor) query = query.lt('updated_at', filters.cursor);
     if (filters.limit) query = query.limit(filters.limit + 1);
     const { data, error } = await query;
@@ -31,7 +32,7 @@ export class SupabaseDocRepository implements IDocRepository {
   async getTree(projectId: string): Promise<DocSummary[]> {
     const { data, error } = await this.supabase
       .from('docs')
-      .select('id, parent_id, title, slug, icon, sort_order, is_folder, updated_at')
+      .select('id, parent_id, title, slug, icon, tags, sort_order, is_folder, updated_at')
       .eq('project_id', projectId)
       .is('deleted_at', null)
       .order('sort_order');


### PR DESCRIPTION
## Summary
- `docs.tags` GIN 인덱스 (`@>` 연산자 검색 최적화)
- `DocListFilters.tags: string[]` — AND match (`.contains()`)
- `DocSummary`에 `tags` 필드 포함 (list/getTree select 업데이트)
- `GET /api/docs?tags=a,b` — `?q=` 와 조합 가능
- `DocsService.list/search`: tags 파라미터 전달
- MCP `list_docs`/`search_docs`: tags 배열 파라미터 추가
- docs-shell-client: tree에서 태그 추출 → 필터 칩 (선택/해제 토글 + clear)

## AC 검증
1. ✅ `idx_docs_tags_gin` GIN 인덱스
2. ✅ `@>` 연산자 기반 AND 검색 (`.contains()`)
3. ✅ `GET /api/docs?tags=` — list + search 양쪽
4. ✅ MCP `list_docs` + `search_docs` tags 파라미터
5. ✅ docs 사이드바 태그 필터 칩 (선택 시 primary 색상, clear 버튼)

## DB 마이그레이션
`20260425050000_docs_tags_gin.sql`

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)