### PR TITLE
feat(docs): doc_type permission gating — policy/sprint_report (E-COLLAB-TOOLS S5)

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -34,6 +34,8 @@ interface DocDetail {
   parent_id?: string | null;
   icon?: string | null;
   is_folder?: boolean;
+  doc_type?: string;
+  org_id?: string;
 }
 
 interface DocsShellClientProps {
@@ -542,9 +544,11 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                   <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
                     {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
                   </Button>
-                  <Button variant="ghost" size="sm" onClick={handleDelete}>
-                    <Trash2 className="h-4 w-4" />
-                  </Button>
+                  {selectedDoc.doc_type !== 'sprint_report' && (
+                    <Button variant="ghost" size="sm" onClick={handleDelete}>
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
                 </div>
               </div>
             </div>
@@ -554,7 +558,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
               <DocEditor
                 value={content}
                 contentFormat={contentFormat}
-                editable={true} // TODO: pass per-doc permission when RBAC is introduced (e.g. canEdit ?? true)
+                editable={selectedDoc.doc_type !== 'sprint_report'}
                 currentDocId={selectedDoc.id}
                 onNavigate={handleSelectDoc}
                 onChange={setContent}

--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -8,6 +8,22 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
+const EDIT_ROLES = ['owner', 'admin', 'po'] as const;
+const ADMIN_ROLES = ['owner', 'admin'] as const;
+
+async function getCallerRole(supabase: SupabaseClient, orgId: string): Promise<string | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('org_id', orgId)
+    .eq('user_id', user.id)
+    .limit(1)
+    .maybeSingle();
+  return (data?.role as string) ?? null;
+}
+
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function PATCH(request: Request, { params }: RouteParams) {
@@ -22,6 +38,17 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const parsed = await parseBody(request, updateDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createDocRepository(dbClient);
     const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+
+    if (!ossMode && dbClient) {
+      const existing = await repo.getById(id);
+      const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
+      if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents are read-only', 403);
+      if (docType === 'policy') {
+        const role = await getCallerRole(dbClient as SupabaseClient, existing.org_id);
+        if (!role || !(EDIT_ROLES as readonly string[]).includes(role)) return ApiErrors.forbidden('Admin or PO access required to edit policy documents');
+      }
+    }
+
     const doc = await service.updateDoc(id, {
       ...body,
       created_by: me.id,
@@ -64,6 +91,17 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const ossMode = isOssMode();
     const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
     const repo = await createDocRepository(dbClient);
+
+    if (!ossMode && dbClient) {
+      const existing = await repo.getById(id);
+      const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
+      if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents cannot be deleted', 403);
+      if (docType === 'policy') {
+        const role = await getCallerRole(dbClient as SupabaseClient, existing.org_id);
+        if (!role || !(ADMIN_ROLES as readonly string[]).includes(role)) return ApiErrors.forbidden('Admin access required to delete policy documents');
+      }
+    }
+
     const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
     await service.deleteDoc(id);
     return apiSuccess({ ok: true });


### PR DESCRIPTION
## Summary
- `PATCH /api/docs/:id`: `sprint_report` → 403, `policy` → owner/admin/po 필요
- `DELETE /api/docs/:id`: `sprint_report` → 403, `policy` → owner/admin 필요
- `getCallerRole()`: `team_members.role` 조회 헬퍼 (supabase auth user 기준)
- docs-shell-client: `sprint_report` → `editable=false` + 삭제 버튼 숨김
- `DocDetail` 인터페이스: `doc_type`, `org_id` 필드 추가

## AC 검증
1. ✅ `sprint_report` → PATCH/DELETE 403
2. ✅ `policy` PATCH → owner/admin/po만 허용
3. ✅ `policy` DELETE → owner/admin만 허용
4. ✅ `page` → 기존 동작 유지
5. ✅ UI: `sprint_report` 삭제 버튼 숨김 + editable=false

## 역할 체계
- `EDIT_ROLES`: owner, admin, po
- `ADMIN_ROLES`: owner, admin
- OSS 모드: 권한 체크 없음 (단일 유저)

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)