### PR TITLE
feat(retro): remove v1 MCP tools/API routes, rename v2 retro tools (E-COLLAB-TOOLS S6)

### DIFF
--- a/apps/web/src/app/api/retro/[sprint_id]/actions/route.ts
+++ b/apps/web/src/app/api/retro/[sprint_id]/actions/route.ts
@@ -1,35 +1,6 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
-import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroService } from '@/services/retro';
+const GONE = Response.json({ error: { code: 'GONE', message: 'v1 retro API is removed. Use /api/retro-sessions/:id instead.' } }, { status: 410 });
 
-type RouteParams = { params: Promise<{ sprint_id: string }> };
-
-// POST /api/retro/:sprint_id/actions
-export async function POST(request: Request, { params }: RouteParams) {
-  try {
-    const { sprint_id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const body = await request.json() as { title?: string; assignee_id?: string };
-    if (!body.title) return ApiErrors.badRequest('title required');
-    if (!body.assignee_id) return ApiErrors.badRequest('assignee_id required');
-
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new RetroService(dbClient);
-    const data = await service.addActionBySprintId(projectId, sprint_id, body.title, body.assignee_id);
-    return apiSuccess(data);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
-}
+export async function GET() { return GONE; }
+export async function POST() { return GONE; }
+export async function PATCH() { return GONE; }
+export async function DELETE() { return GONE; }

--- a/apps/web/src/app/api/retro/[sprint_id]/export/route.ts
+++ b/apps/web/src/app/api/retro/[sprint_id]/export/route.ts
@@ -1,31 +1,6 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
-import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroService } from '@/services/retro';
+const GONE = Response.json({ error: { code: 'GONE', message: 'v1 retro API is removed. Use /api/retro-sessions/:id instead.' } }, { status: 410 });
 
-type RouteParams = { params: Promise<{ sprint_id: string }> };
-
-// GET /api/retro/:sprint_id/export?project_id=X
-export async function GET(request: Request, { params }: RouteParams) {
-  try {
-    const { sprint_id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new RetroService(dbClient);
-    const data = await service.exportBySprintId(projectId, sprint_id);
-    return apiSuccess(data);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
-}
+export async function GET() { return GONE; }
+export async function POST() { return GONE; }
+export async function PATCH() { return GONE; }
+export async function DELETE() { return GONE; }

--- a/apps/web/src/app/api/retro/[sprint_id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro/[sprint_id]/items/[item_id]/vote/route.ts
@@ -1,29 +1,6 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
-import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroService } from '@/services/retro';
+const GONE = Response.json({ error: { code: 'GONE', message: 'v1 retro API is removed. Use /api/retro-sessions/:id instead.' } }, { status: 410 });
 
-type RouteParams = { params: Promise<{ sprint_id: string; item_id: string }> };
-
-// POST /api/retro/:sprint_id/items/:item_id/vote
-export async function POST(request: Request, { params }: RouteParams) {
-  try {
-    const { item_id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new RetroService(dbClient);
-    const data = await service.vote(item_id, me.id);
-    return apiSuccess(data);
-  } catch (err: unknown) {
-    const e = err as Error & { code?: string };
-    if (e.code === 'CONFLICT') return apiError('CONFLICT', e.message, 409);
-    return handleApiError(err);
-  }
-}
+export async function GET() { return GONE; }
+export async function POST() { return GONE; }
+export async function PATCH() { return GONE; }
+export async function DELETE() { return GONE; }

--- a/apps/web/src/app/api/retro/[sprint_id]/items/route.ts
+++ b/apps/web/src/app/api/retro/[sprint_id]/items/route.ts
@@ -1,37 +1,6 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
-import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroService } from '@/services/retro';
-import type { RetroCategory } from '@/services/retro';
+const GONE = Response.json({ error: { code: 'GONE', message: 'v1 retro API is removed. Use /api/retro-sessions/:id instead.' } }, { status: 410 });
 
-type RouteParams = { params: Promise<{ sprint_id: string }> };
-
-// POST /api/retro/:sprint_id/items
-export async function POST(request: Request, { params }: RouteParams) {
-  try {
-    const { sprint_id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const body = await request.json() as { category?: RetroCategory; text?: string; author_id?: string };
-    if (!body.category) return ApiErrors.badRequest('category required');
-    if (!body.text) return ApiErrors.badRequest('text required');
-    if (!body.author_id) return ApiErrors.badRequest('author_id required');
-
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new RetroService(dbClient);
-    const data = await service.addItemBySprintId(projectId, sprint_id, body.category, body.text, body.author_id);
-    return apiSuccess(data);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
-}
+export async function GET() { return GONE; }
+export async function POST() { return GONE; }
+export async function PATCH() { return GONE; }
+export async function DELETE() { return GONE; }

--- a/apps/web/src/app/api/retro/[sprint_id]/route.ts
+++ b/apps/web/src/app/api/retro/[sprint_id]/route.ts
@@ -40,26 +40,7 @@ export async function GET(request: Request, { params }: RouteParams) {
 }
 
 // PATCH /api/retro/:sprint_id — change phase
-export async function PATCH(request: Request, { params }: RouteParams) {
-  try {
-    const { sprint_id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const body = await request.json() as { phase?: RetroPhase };
-    if (!body.phase) return ApiErrors.badRequest('phase required');
-
-    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const service = new RetroService(dbClient);
-    const data = await service.changePhaseBySprintId(projectId, sprint_id, body.phase);
-    return apiSuccess(data);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+// PATCH /api/retro/:sprint_id — deprecated (use PATCH /api/retro-sessions/:id/phase)
+export async function PATCH(_request: Request, _params: RouteParams) {
+  return Response.json({ error: { code: 'GONE', message: 'v1 retro API is removed. Use /api/retro-sessions/:id instead.' } }, { status: 410 });
 }

--- a/packages/mcp-server/src/tools/retro.ts
+++ b/packages/mcp-server/src/tools/retro.ts
@@ -23,74 +23,6 @@ export function registerRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('change_retro_phase', 'Change retro session phase', {
-    project_id: z.string(),
-    sprint_id: z.string(),
-    phase: z.enum(['collect', 'vote', 'discuss', 'action', 'closed']),
-  }, async ({ project_id, sprint_id, phase }) => {
-    try {
-      const data = await pmApi(`/api/retro/${sprint_id}?project_id=${project_id}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ phase }),
-      });
-      return ok(data);
-    } catch (e) {
-      return err(e instanceof PmApiError ? e.message : String(e));
-    }
-  });
-
-  server.tool('add_retro_item', 'Add item to retro session', {
-    project_id: z.string(),
-    sprint_id: z.string(),
-    category: z.enum(['good', 'bad', 'improve']),
-    text: z.string(),
-    author_id: z.string(),
-  }, async ({ project_id, sprint_id, category, text, author_id }) => {
-    try {
-      const data = await pmApi(`/api/retro/${sprint_id}/items?project_id=${project_id}`, {
-        method: 'POST',
-        body: JSON.stringify({ category, text, author_id }),
-      });
-      return ok(data);
-    } catch (e) {
-      return err(e instanceof PmApiError ? e.message : String(e));
-    }
-  });
-
-  server.tool('vote_retro_item', 'Vote on retro item via retro-sessions endpoint (retro_votes, duplicate-protected). voter_id defaults to caller identity.', {
-    session_id: z.string().describe('Retro session ID (use get_retro_session to obtain)'),
-    item_id: z.string(),
-    project_id: z.string(),
-    voter_id: z.string().optional().describe('Explicit voter ID; omit to use caller identity'),
-  }, async ({ session_id, item_id, project_id, voter_id }) => {
-    try {
-      const data = await pmApi(`/api/retro-sessions/${session_id}/items/${item_id}/vote?project_id=${encodeURIComponent(project_id)}`, {
-        method: 'POST',
-        body: JSON.stringify(voter_id ? { voter_id } : {}),
-      });
-      return ok(data);
-    } catch (e) {
-      return err(e instanceof PmApiError ? e.message : String(e));
-    }
-  });
-
-  server.tool('add_retro_action', 'Add action item to retro session', {
-    project_id: z.string(),
-    sprint_id: z.string(),
-    title: z.string(),
-    assignee_id: z.string(),
-  }, async ({ project_id, sprint_id, title, assignee_id }) => {
-    try {
-      const data = await pmApi(`/api/retro/${sprint_id}/actions?project_id=${project_id}`, {
-        method: 'POST',
-        body: JSON.stringify({ title, assignee_id }),
-      });
-      return ok(data);
-    } catch (e) {
-      return err(e instanceof PmApiError ? e.message : String(e));
-    }
-  });
-
   server.tool('update_retro_action_status', 'Update retro action status', {
     action_id: z.string(),
     status: z.enum(['open', 'done']),
@@ -100,18 +32,6 @@ export function registerRetroTools(server: McpServer) {
         method: 'PATCH',
         body: JSON.stringify({ status }),
       });
-      return ok(data);
-    } catch (e) {
-      return err(e instanceof PmApiError ? e.message : String(e));
-    }
-  });
-
-  server.tool('export_retro', 'Export retro as markdown', {
-    project_id: z.string(),
-    sprint_id: z.string(),
-  }, async ({ project_id, sprint_id }) => {
-    try {
-      const data = await pmApi(`/api/retro/${sprint_id}/export?project_id=${project_id}`);
       return ok(data);
     } catch (e) {
       return err(e instanceof PmApiError ? e.message : String(e));

--- a/packages/mcp-server/src/tools/standup-retro.ts
+++ b/packages/mcp-server/src/tools/standup-retro.ts
@@ -117,7 +117,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('change_retro_phase_v2', 'Change retro session phase', {
+  server.tool('change_retro_phase', 'Change retro session phase', {
     project_id: z.string(),
     session_id: z.string(),
     phase: z.enum(['collect', 'group', 'vote', 'discuss', 'action', 'closed']),
@@ -133,7 +133,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('add_retro_item_v2', 'Add retro item', {
+  server.tool('add_retro_item', 'Add retro item', {
     project_id: z.string(),
     session_id: z.string(),
     category: z.enum(['good', 'bad', 'improve']),
@@ -151,7 +151,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('vote_retro_item_v2', 'Vote on retro item', {
+  server.tool('vote_retro_item', 'Vote on retro item', {
     project_id: z.string(),
     session_id: z.string(),
     item_id: z.string(),
@@ -168,7 +168,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('add_retro_action_v2', 'Add retro action item', {
+  server.tool('add_retro_action', 'Add retro action item', {
     project_id: z.string(),
     session_id: z.string(),
     title: z.string(),
@@ -187,7 +187,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('export_retro_v2', 'Export retro as markdown', {
+  server.tool('export_retro', 'Export retro as markdown', {
     project_id: z.string(),
     session_id: z.string(),
   }, async ({ project_id, session_id }) => {


### PR DESCRIPTION
## Summary
- MCP `retro.ts`: v1 도구 5개 제거 (add_retro_item, vote_retro_item, change_retro_phase, export_retro, add_retro_action)
- MCP `standup-retro.ts`: v2 retro 도구 5개 `_v2` 접미사 제거 (change_retro_phase, add_retro_item, vote_retro_item, add_retro_action, export_retro)
- v1 API 라우트 → 410 Gone: PATCH /api/retro/:sprint_id, items, vote, export, actions
- GET /api/retro/:sprint_id 유지 (get_retro_session 호환)
- DB 데이터 유지 — 마이그레이션 없음

## AC 검증
1. ✅ v1 MCP 도구 제거 (add_retro_item, vote_retro_item, change_retro_phase, export_retro)
2. ✅ v2 MCP 도구 5개만 유지 (접미사 제거)
3. ✅ v1 API POST/PATCH → 410 Gone
4. ✅ `_v2` 접미사 제거
5. ✅ DB 데이터 유지 (마이그레이션 없음)

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)