### PR TITLE
feat(retro): carry over open retro actions on sprint close (E-COLLAB-TOOLS S7)

### DIFF
--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -90,6 +90,52 @@ export async function POST(request: Request, { params }: RouteParams) {
         const sprintRepo = await createSprintRepository(db);
         await sprintRepo.update(id, { report_doc_id: doc.id });
       })().catch(() => {});
+
+      // 미완료 회고 액션 이월 (fire-and-forget)
+      (async () => {
+        // 1. 현재 스프린트 retro session 조회
+        const { data: closedSession } = await db
+          .from('retro_sessions')
+          .select('id')
+          .eq('sprint_id', id)
+          .maybeSingle();
+        if (!closedSession) return;
+
+        // 2. 미완료 액션 조회
+        const { data: openActions } = await db
+          .from('retro_actions')
+          .select('title, assignee_id')
+          .eq('session_id', closedSession.id)
+          .neq('status', 'done');
+        if (!openActions?.length) return;
+
+        // 3. 다음 active 스프린트 조회
+        const { data: nextSprint } = await db
+          .from('sprints')
+          .select('id')
+          .eq('project_id', sprint.project_id)
+          .eq('status', 'active')
+          .maybeSingle();
+        if (!nextSprint) return;
+
+        // 4. 다음 스프린트 retro session 조회
+        const { data: nextSession } = await db
+          .from('retro_sessions')
+          .select('id')
+          .eq('sprint_id', nextSprint.id)
+          .maybeSingle();
+        if (!nextSession) return;
+
+        // 5. 이월 INSERT
+        await db.from('retro_actions').insert(
+          openActions.map((a) => ({
+            session_id: nextSession.id,
+            title: `[이월] ${a.title}`,
+            assignee_id: a.assignee_id,
+            status: 'open',
+          })),
+        );
+      })().catch(() => {});
     }
 
     return apiSuccess(sprint);


### PR DESCRIPTION
## Summary
스프린트 close 시 미완료 회고 액션을 다음 active 스프린트 회고 세션에 이월한다.

- `POST /api/sprints/:id/close`: 기존 알림 + report 생성 블록 뒤에 fire-and-forget 이월 블록 추가
- 이월 조건: closed sprint → retro_session → actions status != 'done' → next active sprint → retro_session
- 이월 액션 title에 `[이월] ` prefix 추가
- 어느 단계든 데이터 없으면 skip — close 성공에 영향 없음

## AC 검증
1. ✅ close route에 미완료 액션 이월 로직
2. ✅ `retro_actions.status != 'done'` 필터 (`.neq('status', 'done')`)
3. ✅ 다음 active 스프린트 retro_session 조회 → 없으면 skip
4. ✅ `[이월] ` prefix
5. ✅ fire-and-forget `.catch(() => {})`

## Test
- pnpm type-check: 신규 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)