### PR TITLE
feat(E-PLATFORM-SECURE-S1): role-based access guard for critical endpoints

### DIFF
--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -7,22 +7,7 @@ import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { isOssMode, createDocRepository } from '@/lib/storage/factory';
-
-const EDIT_ROLES = ['owner', 'admin', 'po'] as const;
-const ADMIN_ROLES = ['owner', 'admin'] as const;
-
-async function getCallerRole(supabase: SupabaseClient, orgId: string): Promise<string | null> {
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) return null;
-  const { data } = await supabase
-    .from('team_members')
-    .select('role')
-    .eq('org_id', orgId)
-    .eq('user_id', user.id)
-    .limit(1)
-    .maybeSingle();
-  return (data?.role as string) ?? null;
-}
+import { requireRole, EDIT_ROLES, ADMIN_ROLES } from '@/lib/role-guard';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -44,8 +29,8 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
       if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents are read-only', 403);
       if (docType === 'policy') {
-        const role = await getCallerRole(dbClient as SupabaseClient, existing.org_id);
-        if (!role || !(EDIT_ROLES as readonly string[]).includes(role)) return ApiErrors.forbidden('Admin or PO access required to edit policy documents');
+        const denied = await requireRole(dbClient as SupabaseClient, existing.org_id, EDIT_ROLES, 'Admin or PO access required to edit policy documents');
+        if (denied) return denied;
       }
     }
 
@@ -97,8 +82,8 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
       if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents cannot be deleted', 403);
       if (docType === 'policy') {
-        const role = await getCallerRole(dbClient as SupabaseClient, existing.org_id);
-        if (!role || !(ADMIN_ROLES as readonly string[]).includes(role)) return ApiErrors.forbidden('Admin access required to delete policy documents');
+        const denied = await requireRole(dbClient as SupabaseClient, existing.org_id, ADMIN_ROLES, 'Admin access required to delete policy documents');
+        if (denied) return denied;
       }
     }
 

--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -6,7 +6,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { createEpicRepository, isOssMode } from '@/lib/storage/factory';
-import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -59,12 +59,9 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    // 권한 체크: admin/owner만 에픽 삭제 가능
     if (!isOssMode() && me.type !== 'agent') {
-      const role = await getEpicActorRole(supabase, me.id);
-      if (!role || !hasEpicRole(role, 'admin')) {
-        return apiError('FORBIDDEN', 'Epic deletion requires admin or owner role', 403);
-      }
+      const denied = await requireRole(supabase, me.org_id, ADMIN_ROLES, 'Epic deletion requires admin or owner role');
+      if (denied) return denied;
     }
 
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;

--- a/apps/web/src/app/api/project-settings/route.ts
+++ b/apps/web/src/app/api/project-settings/route.ts
@@ -5,6 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, EDIT_ROLES } from '@/lib/role-guard';
 
 // GET /api/project-settings?project_id=
 export async function GET(request: Request) {
@@ -32,6 +33,11 @@ export async function PATCH(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     if (isOssMode()) return ApiErrors.notFound('Not supported in OSS mode');
+
+    if (me.type !== 'agent') {
+      const denied = await requireRole(supabase, me.org_id, EDIT_ROLES, 'Admin or PO access required to update project settings');
+      if (denied) return denied;
+    }
 
     const body = await request.json() as { project_id?: string; standup_deadline?: string };
     const projectId = body.project_id ?? me.project_id;

--- a/apps/web/src/app/api/projects/[id]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/route.ts
@@ -2,6 +2,8 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
 import { z } from 'zod/v4';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -10,16 +12,6 @@ const updateProjectSchema = z.object({
   name: z.string().trim().min(1).optional(),
   description: z.string().optional().nullable(),
 });
-
-async function resolveOrgRole(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, orgId: string, userId: string) {
-  const { data } = await supabase
-    .from('org_members')
-    .select('role')
-    .eq('org_id', orgId)
-    .eq('user_id', userId)
-    .maybeSingle();
-  return data?.role as string | undefined;
-}
 
 // GET /api/projects/:id
 export async function GET(request: Request, { params }: RouteParams) {
@@ -50,8 +42,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     const { data: project } = await supabase
       .from('projects')
@@ -61,9 +54,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 
     if (!project) return ApiErrors.notFound('Project not found');
 
-    const role = await resolveOrgRole(supabase, project.org_id as string, user.id);
-    if (!role || !['owner', 'admin'].includes(role)) {
-      return ApiErrors.forbidden('Admin access required');
+    if (!isOssMode() && me.type !== 'agent') {
+      const denied = await requireRole(supabase, project.org_id as string, ADMIN_ROLES, 'Admin access required');
+      if (denied) return denied;
     }
 
     let body: unknown;
@@ -91,12 +84,13 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 }
 
 // DELETE /api/projects/:id — soft delete (owner/admin only)
-export async function DELETE(_request: Request, { params }: RouteParams) {
+export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const supabase = await createSupabaseServerClient();
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     const { data: project } = await supabase
       .from('projects')
@@ -107,9 +101,9 @@ export async function DELETE(_request: Request, { params }: RouteParams) {
 
     if (!project) return ApiErrors.notFound('Project not found');
 
-    const role = await resolveOrgRole(supabase, project.org_id as string, user.id);
-    if (!role || !['owner', 'admin'].includes(role)) {
-      return ApiErrors.forbidden('Admin access required');
+    if (!isOssMode() && me.type !== 'agent') {
+      const denied = await requireRole(supabase, project.org_id as string, ADMIN_ROLES, 'Admin access required');
+      if (denied) return denied;
     }
 
     const { error } = await supabase

--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -8,6 +8,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createSprintRepository, createDocRepository } from '@/lib/storage/factory';
 import { NotificationService } from '@/services/notification.service';
 import { DocsService } from '@/services/docs';
+import { requireRole, EDIT_ROLES } from '@/lib/role-guard';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -21,6 +22,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
     const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    if (!ossMode && dbClient && me.type !== 'agent') {
+      const denied = await requireRole(supabase, me.org_id, EDIT_ROLES, 'Admin or PO access required to close sprint');
+      if (denied) return denied;
+    }
 
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as SupabaseClient | undefined);

--- a/apps/web/src/lib/role-guard.ts
+++ b/apps/web/src/lib/role-guard.ts
@@ -1,0 +1,38 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { ApiErrors } from '@/lib/api-response';
+
+export const ADMIN_ROLES = ['owner', 'admin'] as const;
+export const EDIT_ROLES = ['owner', 'admin', 'po'] as const;
+export type RoleGuardRole = typeof ADMIN_ROLES[number] | typeof EDIT_ROLES[number];
+
+/** Fetch the caller's role in the org. Returns null if unauthenticated or not a member. */
+export async function getCallerRole(supabase: SupabaseClient, orgId: string): Promise<string | null> {
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return null;
+  const { data } = await supabase
+    .from('team_members')
+    .select('role')
+    .eq('org_id', orgId)
+    .eq('user_id', user.id)
+    .limit(1)
+    .maybeSingle();
+  return (data?.role as string) ?? null;
+}
+
+/**
+ * Assert that the caller has one of the required roles.
+ * Returns an ApiErrors.forbidden() Response if not, null if allowed.
+ * OSS mode always passes (isOssMode check must be done by caller before invoking).
+ */
+export async function requireRole(
+  supabase: SupabaseClient,
+  orgId: string,
+  roles: readonly string[],
+  message?: string,
+): Promise<Response | null> {
+  const role = await getCallerRole(supabase, orgId);
+  if (!role || !roles.includes(role)) {
+    return ApiErrors.forbidden(message ?? `Required role: ${roles.join(' | ')}`);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- New `apps/web/src/lib/role-guard.ts`: shared `requireRole()` / `getCallerRole()` helper with `ADMIN_ROLES` and `EDIT_ROLES` constants
- Applied to 5 endpoints: `docs/[id]` (PATCH/DELETE), `projects/[id]` (PATCH/DELETE), `epics/[id]` (DELETE), `sprints/[id]/close` (POST), `project-settings` (PATCH)
- Replaced inline role checks (`resolveOrgRole`, `getEpicActorRole`/`hasEpicRole`) with the centralized helper
- All guards follow `!isOssMode() && me.type !== 'agent'` bypass pattern — agents and OSS mode unaffected

## Test plan

- [ ] policy 문서 PATCH: owner/admin/po 만 허용, member 는 403
- [ ] policy 문서 DELETE: owner/admin 만 허용, po 는 403
- [ ] projects PATCH/DELETE: owner/admin 만 허용
- [ ] epics DELETE: owner/admin 만 허용
- [ ] sprint close: owner/admin/po 만 허용
- [ ] project-settings PATCH: owner/admin/po 만 허용
- [ ] 에이전트 API 키로 요청 시 role 체크 bypass 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)