### PR TITLE
feat(E-PLATFORM-SECURE-S2): permission audit log for role/member changes

### DIFF
--- a/apps/web/src/app/api/audit-logs/route.ts
+++ b/apps/web/src/app/api/audit-logs/route.ts
@@ -1,0 +1,30 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
+import { AuditLogService } from '@/services/audit-log.service';
+
+// GET /api/audit-logs?limit=50&cursor=<iso_timestamp>
+export async function GET(request: Request) {
+  if (isOssMode()) return ApiErrors.notFound('Not supported in OSS mode');
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const denied = await requireRole(supabase, me.org_id, ADMIN_ROLES, 'Admin access required to view audit logs');
+    if (denied) return denied;
+
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Number(searchParams.get('limit') ?? '50'), 100);
+    const cursor = searchParams.get('cursor') ?? undefined;
+
+    const service = new AuditLogService(createSupabaseAdminClient());
+    const data = await service.list(me.org_id, limit, cursor);
+    return apiSuccess(data);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,8 +1,11 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getMyTeamMember, getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
+import { AuditLogService } from '@/services/audit-log.service';
 
 export async function DELETE(
   request: Request,
@@ -27,7 +30,7 @@ export async function DELETE(
 
     const { data: target, error: targetError } = await supabase
       .from('team_members')
-      .select('id, org_id, user_id, type, is_active')
+      .select('id, org_id, user_id, type, is_active, role')
       .eq('id', id)
       .maybeSingle();
 
@@ -58,7 +61,80 @@ export async function DELETE(
 
     if (updateError) throw updateError;
 
+    new AuditLogService(createSupabaseAdminClient()).log({
+      org_id: me.org_id as string,
+      actor_id: user.id,
+      action: 'member_removed',
+      target_user_id: (target.user_id as string | null) ?? null,
+      old_role: (target.role as string | null) ?? null,
+    }).catch(() => {});
+
     return apiSuccess({ ok: true, id });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function PATCH(
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Member management is not supported in OSS mode.', 501);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const meScope = await getAuthContext(supabase, request);
+    if (meScope?.type === 'agent' && !meScope.scope?.includes('admin')) {
+      return ApiErrors.insufficientScope('admin');
+    }
+
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden('Team member not found');
+
+    const { id } = await context.params;
+
+    const { data: target, error: targetError } = await supabase
+      .from('team_members')
+      .select('id, org_id, user_id, role, is_active')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (targetError) throw targetError;
+    if (!target) return ApiErrors.notFound('Team member not found');
+    if (target.org_id !== me.org_id) return ApiErrors.forbidden('Forbidden');
+    if (!target.is_active) return apiError('BAD_REQUEST', 'Cannot update inactive member', 400);
+
+    const denied = await requireRole(supabase, me.org_id as string, ADMIN_ROLES, 'Admin access required to change member roles');
+    if (denied) return denied;
+
+    let body: unknown;
+    try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON', 400); }
+    const { role: newRole } = body as { role?: string };
+    if (!newRole) return apiError('BAD_REQUEST', 'role required', 400);
+
+    const oldRole = target.role as string;
+
+    const { data: updated, error: updateError } = await supabase
+      .from('team_members')
+      .update({ role: newRole })
+      .eq('id', id)
+      .select('id, name, type, role, user_id, project_id, is_active')
+      .single();
+
+    if (updateError) throw updateError;
+
+    new AuditLogService(createSupabaseAdminClient()).log({
+      org_id: me.org_id as string,
+      actor_id: user.id,
+      action: 'role_changed',
+      target_user_id: (target.user_id as string | null) ?? null,
+      old_role: oldRole,
+      new_role: newRole,
+    }).catch(() => {});
+
+    return apiSuccess(updated);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -1,4 +1,5 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getMyTeamMember } from '@/lib/auth-helpers';
@@ -6,6 +7,7 @@ import { checkMemberLimit } from '@/lib/check-feature';
 import { parseBody, createTeamMemberSchema } from '@sprintable/shared';
 import { managedAgentRegistrationConfigSchema } from '@/lib/managed-agent-contract';
 import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { AuditLogService } from '@/services/audit-log.service';
 
 export async function GET(request: Request) {
   if (isOssMode()) {
@@ -152,6 +154,13 @@ export async function POST(request: Request) {
           .single();
 
         if (reactivateError) throw reactivateError;
+        new AuditLogService(createSupabaseAdminClient()).log({
+          org_id: me.org_id as string,
+          actor_id: user.id,
+          action: 'member_added',
+          target_user_id: body.user_id ?? null,
+          new_role: body.role ?? 'member',
+        }).catch(() => {});
         return apiSuccess(reactivated, undefined, 201);
       }
 
@@ -183,6 +192,13 @@ export async function POST(request: Request) {
         .single();
 
       if (error) throw error;
+      new AuditLogService(createSupabaseAdminClient()).log({
+        org_id: me.org_id as string,
+        actor_id: user.id,
+        action: 'member_added',
+        target_user_id: body.user_id ?? null,
+        new_role: body.role ?? 'member',
+      }).catch(() => {});
       return apiSuccess(data, undefined, 201);
     }
 
@@ -211,6 +227,13 @@ export async function POST(request: Request) {
       .single();
 
     if (error) throw error;
+    new AuditLogService(createSupabaseAdminClient()).log({
+      org_id: me.org_id as string,
+      actor_id: user.id,
+      action: 'member_added',
+      target_user_id: body.user_id ?? null,
+      new_role: body.role ?? 'member',
+    }).catch(() => {});
     return apiSuccess(data, undefined, 201);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/services/audit-log.service.ts
+++ b/apps/web/src/services/audit-log.service.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type AuditAction = 'member_added' | 'member_removed' | 'role_changed';
+
+export interface AuditLogInput {
+  org_id: string;
+  actor_id: string;
+  action: AuditAction;
+  target_user_id?: string | null;
+  old_role?: string | null;
+  new_role?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+export class AuditLogService {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async log(input: AuditLogInput): Promise<void> {
+    await this.supabase.from('permission_audit_logs').insert({
+      org_id: input.org_id,
+      actor_id: input.actor_id,
+      action: input.action,
+      target_user_id: input.target_user_id ?? null,
+      old_role: input.old_role ?? null,
+      new_role: input.new_role ?? null,
+      metadata: input.metadata ?? {},
+    });
+  }
+
+  async list(orgId: string, limit = 50, cursor?: string) {
+    let query = this.supabase
+      .from('permission_audit_logs')
+      .select('id, org_id, actor_id, action, target_user_id, old_role, new_role, metadata, created_at')
+      .eq('org_id', orgId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (cursor) query = query.lt('created_at', cursor);
+    const { data, error } = await query;
+    if (error) throw error;
+    return data ?? [];
+  }
+}

--- a/packages/db/supabase/migrations/20260425070000_permission_audit_logs.sql
+++ b/packages/db/supabase/migrations/20260425070000_permission_audit_logs.sql
@@ -1,0 +1,25 @@
+-- E-PLATFORM-SECURE S2: permission_audit_logs 테이블 신설
+
+CREATE TABLE IF NOT EXISTS public.permission_audit_logs (
+  id              uuid        DEFAULT gen_random_uuid() PRIMARY KEY,
+  org_id          uuid        NOT NULL,
+  actor_id        uuid        NOT NULL,
+  action          text        NOT NULL CHECK (action IN ('member_added', 'member_removed', 'role_changed')),
+  target_user_id  uuid,
+  old_role        text,
+  new_role        text,
+  metadata        jsonb       NOT NULL DEFAULT '{}',
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_permission_audit_logs_org_id
+  ON public.permission_audit_logs(org_id, created_at DESC);
+
+ALTER TABLE public.permission_audit_logs ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "permission_audit_logs_select" ON public.permission_audit_logs FOR SELECT
+  USING (org_id IN (
+    SELECT DISTINCT org_id FROM public.team_members
+    WHERE user_id = auth.uid() AND is_active = true
+      AND role IN ('owner', 'admin')
+  ));

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -26,6 +26,7 @@ import { registerNotificationsTools } from './tools/notifications.js';
 import { registerStandupsTools } from './tools/standups.js';
 import { registerAgentRunsTools } from './tools/agent-runs.js';
 import { registerWorkflowTools } from './tools/workflow.js';
+import { registerAuditTools } from './tools/audit.js';
 
 const PM_API_URL = process.env['PM_API_URL'] ?? '';
 const AGENT_API_KEY = process.env['AGENT_API_KEY'] ?? '';
@@ -62,6 +63,7 @@ registerNotificationsTools(server);
 registerStandupsTools(server);
 registerAgentRunsTools(server);
 registerWorkflowTools(server);
+registerAuditTools(server);
 
 async function main() {
   if (MODE === 'sse') {

--- a/packages/mcp-server/src/tools/audit.ts
+++ b/packages/mcp-server/src/tools/audit.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { pmApi, PmApiError } from '../pm-api.js';
+
+function ok(data: unknown) {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(data) }] };
+}
+
+function err(message: string) {
+  return { content: [{ type: 'text' as const, text: `Error: ${message}` }] };
+}
+
+export function registerAuditTools(server: McpServer) {
+  server.tool(
+    'list_audit_logs',
+    'List permission audit logs (member_added, member_removed, role_changed). Admin/owner only.',
+    {
+      limit: z.number().int().min(1).max(100).optional().describe('Max records to return (default 50)'),
+      cursor: z.string().optional().describe('Pagination cursor — created_at of last record (ISO timestamp)'),
+    },
+    async ({ limit, cursor }) => {
+      try {
+        const params = new URLSearchParams();
+        if (limit !== undefined) params.set('limit', String(limit));
+        if (cursor !== undefined) params.set('cursor', cursor);
+        const qs = params.size > 0 ? `?${params.toString()}` : '';
+        const data = await pmApi(`/api/audit-logs${qs}`);
+        return ok(data);
+      } catch (e) {
+        return err(e instanceof PmApiError ? e.message : String(e));
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- New `permission_audit_logs` table: `member_added` / `member_removed` / `role_changed` actions, RLS admin/owner SELECT only
- New `AuditLogService`: `log()` (admin client, fire-and-forget) + `list()` with cursor pagination
- `team-members POST`: audit log on insert, reactivation, and agent creation
- `team-members/[id] DELETE`: audit log on member removal
- `team-members/[id] PATCH` (new endpoint): role change with `ADMIN_ROLES` guard + audit log
- `GET /api/audit-logs`: admin/owner only, limit/cursor pagination, uses admin client for read
- MCP `list_audit_logs` tool with limit + cursor params

## Test plan

- [ ] migration SQL: CREATE TABLE + INDEX + RLS SELECT policy (admin/owner only)
- [ ] member POST (human insert / reactivate / agent): permission_audit_logs row 생성 확인
- [ ] member DELETE: member_removed 로그 기록 확인
- [ ] member PATCH role 변경: role_changed 로그 + old_role/new_role 기록 확인
- [ ] GET /api/audit-logs: admin 접근 허용, member 접근 403
- [ ] MCP list_audit_logs: admin API key로 호출 성공
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)