### PR TITLE
feat(E-PLATFORM-SECURE-S3): invitation revoke + resend

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -489,7 +489,10 @@
     "projectInviteFailed": "Failed to send project invitation.",
     "standupSettings": "Standup Settings",
     "standupSettingsDesc": "Set the daily standup deadline time.",
-    "standupDeadline": "Deadline"
+    "standupDeadline": "Deadline",
+    "revoked": "Revoked",
+    "revoke": "Revoke",
+    "resend": "Resend"
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -489,7 +489,10 @@
     "projectInviteFailed": "프로젝트 초대에 실패했습니다.",
     "standupSettings": "스탠드업 설정",
     "standupSettingsDesc": "일일 스탠드업 마감 시간을 설정합니다.",
-    "standupDeadline": "마감 시간"
+    "standupDeadline": "마감 시간",
+    "revoked": "취소됨",
+    "revoke": "취소",
+    "resend": "재발송"
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -40,6 +40,7 @@ interface ProjectOption {
 interface InvitationItem {
   id: string;
   email: string;
+  status: 'pending' | 'accepted' | 'revoked';
   accepted_at: string | null;
   expires_at: string;
   project_id: string | null;
@@ -104,6 +105,9 @@ export default function SettingsPage() {
   const [projectInviteProjectId, setProjectInviteProjectId] = useState('');
   const [projectInviting, setProjectInviting] = useState(false);
   const [projectInviteResult, setProjectInviteResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [revokingInviteId, setRevokingInviteId] = useState<string | null>(null);
+  const [resendingInviteId, setResendingInviteId] = useState<string | null>(null);
+  const [resendResult, setResendResult] = useState<{ id: string; url: string } | null>(null);
 
   const refreshProjects = async () => {
     const endpoint = orgId ? `/api/projects?org_id=${encodeURIComponent(orgId)}` : '/api/projects';
@@ -131,6 +135,31 @@ export default function SettingsPage() {
     if (res.status === 403) {
       setIsAdmin(false);
       setAdminChecked(true);
+    }
+  };
+
+  const handleRevokeInvite = async (inviteId: string) => {
+    setRevokingInviteId(inviteId);
+    try {
+      const res = await fetch(`/api/invitations/${inviteId}`, { method: 'DELETE' });
+      if (res.ok) await refreshInvitations();
+    } finally {
+      setRevokingInviteId(null);
+    }
+  };
+
+  const handleResendInvite = async (inviteId: string) => {
+    setResendingInviteId(inviteId);
+    setResendResult(null);
+    try {
+      const res = await fetch(`/api/invitations/${inviteId}/resend`, { method: 'POST' });
+      if (res.ok) {
+        const json = await res.json();
+        setResendResult({ id: inviteId, url: json.data?.invite_url ?? '' });
+        await refreshInvitations();
+      }
+    } finally {
+      setResendingInviteId(null);
     }
   };
 
@@ -680,14 +709,39 @@ export default function SettingsPage() {
             {invitations.length > 0 ? (
               <div className="space-y-2">
                 {invitations.map((invitation) => (
-                  <div key={invitation.id} className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
-                    <span className="text-foreground">{invitation.email}</span>
-                    <span className="shrink-0 text-muted-foreground">
-                      {invitation.projects?.name ?? t('orgWide')}
-                    </span>
-                    <span className={`shrink-0 ${invitation.accepted_at ? 'text-emerald-300' : new Date(invitation.expires_at) < new Date() ? 'text-rose-300' : 'text-amber-200'}`}>
-                      {invitation.accepted_at ? t('accepted') : new Date(invitation.expires_at) < new Date() ? t('expired') : t('pending')}
-                    </span>
+                  <div key={invitation.id}>
+                    <div className="flex items-center justify-between gap-2 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
+                      <span className="text-foreground">{invitation.email}</span>
+                      <span className="shrink-0 text-muted-foreground">
+                        {invitation.projects?.name ?? t('orgWide')}
+                      </span>
+                      <span className={`shrink-0 ${invitation.status === 'accepted' ? 'text-emerald-300' : invitation.status === 'revoked' ? 'text-muted-foreground line-through' : new Date(invitation.expires_at) < new Date() ? 'text-rose-300' : 'text-amber-200'}`}>
+                        {invitation.status === 'accepted' ? t('accepted') : invitation.status === 'revoked' ? t('revoked') : new Date(invitation.expires_at) < new Date() ? t('expired') : t('pending')}
+                      </span>
+                      {invitation.status === 'pending' && (
+                        <div className="flex shrink-0 gap-1">
+                          <button
+                            type="button"
+                            className="rounded px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground border border-border hover:border-foreground/30 transition-colors disabled:opacity-50"
+                            disabled={resendingInviteId === invitation.id}
+                            onClick={() => handleResendInvite(invitation.id)}
+                          >
+                            {resendingInviteId === invitation.id ? '...' : t('resend')}
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded px-2 py-0.5 text-xs text-rose-400 hover:text-rose-300 border border-rose-400/30 hover:border-rose-300/50 transition-colors disabled:opacity-50"
+                            disabled={revokingInviteId === invitation.id}
+                            onClick={() => handleRevokeInvite(invitation.id)}
+                          >
+                            {revokingInviteId === invitation.id ? '...' : t('revoke')}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                    {resendResult?.id === invitation.id && (
+                      <p className="mt-1 break-all px-1 text-xs text-amber-200">{t('inviteLinkCopied')}: {resendResult.url}</p>
+                    )}
                   </div>
                 ))}
               </div>

--- a/apps/web/src/app/api/invitations/[id]/resend/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/resend/route.ts
@@ -1,0 +1,55 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** POST /api/invitations/[id]/resend — 토큰 갱신 + expires_at 연장 */
+export async function POST(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Invitations are not supported in OSS mode.', 501);
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    if (me.type !== 'agent') {
+      const denied = await requireRole(supabase, me.org_id, ADMIN_ROLES, 'Admin access required to resend invitations');
+      if (denied) return denied;
+    }
+
+    const { data: invitation, error: fetchError } = await supabase
+      .from('invitations')
+      .select('id, org_id, status, email')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (fetchError) throw fetchError;
+    if (!invitation) return ApiErrors.notFound('Invitation not found');
+    if (invitation.org_id !== me.org_id) return ApiErrors.forbidden('Forbidden');
+    if ((invitation.status as string) !== 'pending') {
+      return apiError('BAD_REQUEST', `Cannot resend invitation with status: ${invitation.status}`, 400);
+    }
+
+    const arr = new Uint8Array(32);
+    globalThis.crypto.getRandomValues(arr);
+    const newToken = Array.from(arr).map((b) => b.toString(16).padStart(2, '0')).join('');
+    const newExpiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    const { data: updated, error: updateError } = await supabase
+      .from('invitations')
+      .update({ token: newToken, expires_at: newExpiresAt })
+      .eq('id', id)
+      .select('id, token, email, expires_at, project_id')
+      .single();
+
+    if (updateError) throw updateError;
+
+    const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? ''}/invite?token=${updated.token}`;
+    return apiSuccess({ ...updated, invite_url: inviteUrl });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/invitations/[id]/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/route.ts
@@ -1,0 +1,46 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** DELETE /api/invitations/[id] — pending 초대를 revoked 상태로 전환 */
+export async function DELETE(request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Invitations are not supported in OSS mode.', 501);
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    if (me.type !== 'agent') {
+      const denied = await requireRole(supabase, me.org_id, ADMIN_ROLES, 'Admin access required to revoke invitations');
+      if (denied) return denied;
+    }
+
+    const { data: invitation, error: fetchError } = await supabase
+      .from('invitations')
+      .select('id, org_id, status')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (fetchError) throw fetchError;
+    if (!invitation) return ApiErrors.notFound('Invitation not found');
+    if (invitation.org_id !== me.org_id) return ApiErrors.forbidden('Forbidden');
+    if ((invitation.status as string) !== 'pending') {
+      return apiError('BAD_REQUEST', `Cannot revoke invitation with status: ${invitation.status}`, 400);
+    }
+
+    const { error: updateError } = await supabase
+      .from('invitations')
+      .update({ status: 'revoked' })
+      .eq('id', id);
+
+    if (updateError) throw updateError;
+    return apiSuccess({ ok: true, id });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/invitations/accept/route.ts
+++ b/apps/web/src/app/api/invitations/accept/route.ts
@@ -21,6 +21,7 @@ export async function POST(request: Request) {
     const { data, error } = await supabase.rpc('accept_invitation', { _token: token });
 
     if (error) {
+      if (error.message.includes('revoked')) return apiError('INVITATION_REVOKED', error.message, 400);
       if (error.message.includes('expired')) return apiError('INVITATION_EXPIRED', error.message, 400);
       if (error.message.includes('mismatch')) return apiError('EMAIL_MISMATCH', error.message, 403);
       if (error.message.includes('not found')) return ApiErrors.notFound(error.message);

--- a/apps/web/src/app/api/invitations/route.ts
+++ b/apps/web/src/app/api/invitations/route.ts
@@ -84,6 +84,7 @@ export async function POST(request: Request) {
       .select('id')
       .eq('org_id', me.org_id)
       .eq('email', email)
+      .eq('status', 'pending')
       .is('accepted_at', null)
       .gt('expires_at', new Date().toISOString());
 

--- a/packages/db/supabase/migrations/20260425080000_invitation_status.sql
+++ b/packages/db/supabase/migrations/20260425080000_invitation_status.sql
@@ -1,0 +1,87 @@
+-- E-PLATFORM-SECURE S3: invitations.status 컬럼 추가 (revoke 지원)
+
+ALTER TABLE public.invitations
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'pending'
+  CHECK (status IN ('pending', 'accepted', 'revoked'));
+
+-- 기존 수락된 초대 백필
+UPDATE public.invitations SET status = 'accepted' WHERE accepted_at IS NOT NULL;
+
+-- accept_invitation RPC 업데이트: revoked 초대 거부
+CREATE OR REPLACE FUNCTION public.accept_invitation(_token text)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  _uid uuid;
+  _invite record;
+  _user_email text;
+  _project record;
+  _name text;
+BEGIN
+  _uid := auth.uid();
+  IF _uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- 초대 조회 (FOR UPDATE로 race condition 방지)
+  SELECT * INTO _invite FROM public.invitations
+  WHERE token = _token AND accepted_at IS NULL
+  FOR UPDATE;
+
+  IF _invite IS NULL THEN
+    RAISE EXCEPTION 'Invitation not found or already accepted';
+  END IF;
+
+  IF _invite.status = 'revoked' THEN
+    RAISE EXCEPTION 'Invitation revoked';
+  END IF;
+
+  IF _invite.expires_at < now() THEN
+    RAISE EXCEPTION 'Invitation expired';
+  END IF;
+
+  -- 이메일 검증
+  SELECT email INTO _user_email FROM auth.users WHERE id = _uid;
+  IF _user_email != _invite.email THEN
+    RAISE EXCEPTION 'Email mismatch: invitation was sent to a different email';
+  END IF;
+
+  -- org_member 생성 (이미 존재하면 무시)
+  INSERT INTO public.org_members (org_id, user_id, role)
+  VALUES (_invite.org_id, _uid, COALESCE(_invite.role, 'member'))
+  ON CONFLICT DO NOTHING;
+
+  -- team_member 생성: project_id가 지정되었으면 해당 프로젝트, 아니면 첫 프로젝트
+  IF _invite.project_id IS NOT NULL THEN
+    SELECT id INTO _project FROM public.projects WHERE id = _invite.project_id;
+  ELSE
+    SELECT id INTO _project FROM public.projects
+    WHERE org_id = _invite.org_id LIMIT 1;
+  END IF;
+
+  IF _project IS NOT NULL THEN
+    _name := COALESCE(
+      (SELECT raw_user_meta_data->>'name' FROM auth.users WHERE id = _uid),
+      (SELECT raw_user_meta_data->>'full_name' FROM auth.users WHERE id = _uid),
+      _user_email,
+      'Unknown'
+    );
+    INSERT INTO public.team_members (org_id, project_id, type, user_id, name, role)
+    VALUES (_invite.org_id, _project.id, 'human', _uid, _name, 'member')
+    ON CONFLICT (project_id, user_id) WHERE type = 'human' AND user_id IS NOT NULL
+    DO NOTHING;
+  END IF;
+
+  -- 초대 수락 표시
+  UPDATE public.invitations SET accepted_at = now(), status = 'accepted' WHERE id = _invite.id;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'org_id', _invite.org_id,
+    'project_id', _invite.project_id
+  );
+END;
+$$;


### PR DESCRIPTION
## Summary

- New `invitations.status` column: `pending` | `accepted` | `revoked` (migration + backfill + RPC update)
- `DELETE /api/invitations/[id]`: pending → revoked, admin/owner only
- `POST /api/invitations/[id]/resend`: new token (crypto) + 7-day expiry, admin/owner only
- `accept_invitation` RPC: reject revoked invitations with `INVITATION_REVOKED` error
- Invitations POST duplicate check: `.eq('status', 'pending')` to exclude revoked from dup detection
- Settings UI: status badge updated (revoked = strikethrough), revoke/resend buttons for pending invitations
- i18n: `revoked` / `revoke` / `resend` keys (ko + en)

## Test plan

- [ ] migration: `status` column + CHECK constraint + backfill + updated RPC
- [ ] DELETE /api/invitations/[id]: pending → revoked, non-pending returns 400, member returns 403
- [ ] POST /api/invitations/[id]/resend: new token + extended expiry, non-pending returns 400
- [ ] accept with revoked token → 400 INVITATION_REVOKED
- [ ] revoked invitation does NOT block re-invite (dup check skips revoked)
- [ ] Settings UI: pending 초대에 취소/재발송 버튼 노출, accepted/revoked에는 미노출
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)