### PR TITLE
feat(E-PLATFORM-SECURE-S4): org soft delete + subscription guard + RLS

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/route.ts
@@ -1,0 +1,54 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** DELETE /api/organizations/[id] — soft delete (owner only) */
+export async function DELETE(_request: Request, { params }: RouteParams) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Organization management is not supported in OSS mode.', 501);
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    // Owner-only check via org_members
+    const { data: orgMember, error: memberError } = await supabase
+      .from('org_members')
+      .select('role')
+      .eq('org_id', id)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (memberError) throw memberError;
+    if (!orgMember || orgMember.role !== 'owner') {
+      return ApiErrors.forbidden('Owner access required to delete organization');
+    }
+
+    // Active subscription check → 409
+    const { data: subscription } = await supabase
+      .from('org_subscriptions')
+      .select('id')
+      .eq('org_id', id)
+      .eq('status', 'active')
+      .maybeSingle();
+
+    if (subscription) {
+      return apiError('CONFLICT', 'Cannot delete organization with an active subscription. Cancel your subscription first.', 409);
+    }
+
+    // Soft delete via admin client to bypass RLS UPDATE restriction
+    const admin = createSupabaseAdminClient();
+    const { error } = await admin
+      .from('organizations')
+      .update({ deleted_at: new Date().toISOString() })
+      .eq('id', id)
+      .is('deleted_at', null);
+
+    if (error) throw error;
+    return apiSuccess({ ok: true, id });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/packages/db/supabase/migrations/20260425090000_org_soft_delete.sql
+++ b/packages/db/supabase/migrations/20260425090000_org_soft_delete.sql
@@ -1,0 +1,12 @@
+-- E-PLATFORM-SECURE S4: organizations soft delete + RLS 업데이트
+
+-- 1. deleted_at 컬럼 추가
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS deleted_at timestamptz;
+
+-- 2. org_select_own RLS 정책에 deleted_at IS NULL 조건 추가
+DROP POLICY IF EXISTS "org_select_own" ON public.organizations;
+
+CREATE POLICY "org_select_own"
+  ON public.organizations FOR SELECT
+  USING (id IN (SELECT public.get_user_org_ids()) AND deleted_at IS NULL);


### PR DESCRIPTION
## Summary

- Migration `20260425090000_org_soft_delete.sql`: `organizations.deleted_at timestamptz` + `org_select_own` RLS policy updated to filter `deleted_at IS NULL`
- `DELETE /api/organizations/[id]`: owner-only (org_members check), active subscription → 409, soft delete via admin client
- **AC1 confirmed**: `invitations.expires_at DEFAULT (now() + interval '7 days')` already in migration `20260401023000_invitations.sql`
- **AC2 confirmed**: `accept_invitation` RPC already has `IF _invite.expires_at < now() THEN RAISE EXCEPTION 'Invitation expired'`

## Test plan

- [ ] migration: `deleted_at` 컬럼 추가 + RLS 재생성 (deleted_at IS NULL)
- [ ] DELETE /api/organizations/[id]: owner → soft delete 성공
- [ ] DELETE: admin/member → 403
- [ ] DELETE: active subscription 존재 시 → 409
- [ ] DELETE 후 GET → org 조회 불가 (RLS deleted_at IS NULL 적용)
- [ ] AC1: invitations POST 시 expires_at = now + 7d 자동 설정
- [ ] AC2: 만료된 초대 token accept → 400 INVITATION_EXPIRED
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)