### PR TITLE
feat(E-PLATFORM-SECURE-S5): TOTP 2FA via Supabase MFA API

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -12,6 +12,7 @@ import { McpConnectionSettings } from '@/components/settings/mcp-connection-sett
 import { SlackIntegrationSettingsSection } from '@/components/settings/slack-integration-settings';
 import { ThemeSettings } from '@/components/settings/theme-settings';
 import { StandupDeadlineSection } from '@/components/settings/standup-deadline-section';
+import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput, OperatorSelect } from '@/components/ui/operator-control';
@@ -450,6 +451,10 @@ export default function SettingsPage() {
 
       <section id="theme">
         <ThemeSettings />
+      </section>
+
+      <section id="two-factor">
+        <TwoFactorSection />
       </section>
 
       <section id="notifications">

--- a/apps/web/src/app/api/auth/2fa/disable/route.ts
+++ b/apps/web/src/app/api/auth/2fa/disable/route.ts
@@ -1,0 +1,41 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+
+/** POST /api/auth/2fa/disable — OTP 검증 후 TOTP factor 비활성화 */
+export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', '2FA is not supported in OSS mode.', 501);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const { code } = await request.json() as { code: string };
+    if (!code) return apiError('BAD_REQUEST', 'code is required', 400);
+
+    // 등록된 TOTP factor 조회
+    const { data: factors, error: listError } = await supabase.auth.mfa.listFactors();
+    if (listError) return apiError('MFA_ERROR', listError.message, 400);
+
+    const totpFactor = factors?.totp?.[0];
+    if (!totpFactor) return apiError('NOT_FOUND', '2FA is not enabled', 404);
+
+    // OTP 검증
+    const { data: challenge, error: challengeError } = await supabase.auth.mfa.challenge({ factorId: totpFactor.id });
+    if (challengeError) return apiError('MFA_ERROR', challengeError.message, 400);
+
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId: totpFactor.id,
+      challengeId: challenge.id,
+      code,
+    });
+    if (verifyError) return apiError('INVALID_OTP', 'Invalid or expired OTP code', 400);
+
+    // Unenroll
+    const { error: unenrollError } = await supabase.auth.mfa.unenroll({ factorId: totpFactor.id });
+    if (unenrollError) return apiError('MFA_ERROR', unenrollError.message, 400);
+
+    return apiSuccess({ ok: true, enabled: false });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/auth/2fa/setup/route.ts
+++ b/apps/web/src/app/api/auth/2fa/setup/route.ts
@@ -1,0 +1,24 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+
+/** POST /api/auth/2fa/setup — TOTP factor 등록 시작, QR URI + secret 반환 */
+export async function POST() {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', '2FA is not supported in OSS mode.', 501);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const { data, error } = await supabase.auth.mfa.enroll({ factorType: 'totp' });
+    if (error) return apiError('MFA_ERROR', error.message, 400);
+
+    return apiSuccess({
+      factor_id: data.id,
+      qr_code: data.totp.qr_code,
+      secret: data.totp.secret,
+      uri: data.totp.uri,
+    });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/auth/2fa/verify/route.ts
+++ b/apps/web/src/app/api/auth/2fa/verify/route.ts
@@ -1,0 +1,29 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+
+/** POST /api/auth/2fa/verify — OTP 검증 → factor 활성화 (enabled=true) */
+export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', '2FA is not supported in OSS mode.', 501);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const { factor_id, code } = await request.json() as { factor_id: string; code: string };
+    if (!factor_id || !code) return apiError('BAD_REQUEST', 'factor_id and code are required', 400);
+
+    const { data: challenge, error: challengeError } = await supabase.auth.mfa.challenge({ factorId: factor_id });
+    if (challengeError) return apiError('MFA_ERROR', challengeError.message, 400);
+
+    const { error: verifyError } = await supabase.auth.mfa.verify({
+      factorId: factor_id,
+      challengeId: challenge.id,
+      code,
+    });
+    if (verifyError) return apiError('INVALID_OTP', 'Invalid or expired OTP code', 400);
+
+    return apiSuccess({ ok: true, enabled: true });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -12,6 +12,12 @@ export async function GET(request: Request) {
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
+      // MFA 검증 필요 여부 확인 (AAL1 → AAL2 required)
+      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
+        return NextResponse.redirect(`${origin}/mfa`);
+      }
+
       // next 파라미터가 있으면 (초대 플로우 등) 그대로 리다이렉트
       if (next) return NextResponse.redirect(`${origin}${next}`);
 

--- a/apps/web/src/app/mfa/page.tsx
+++ b/apps/web/src/app/mfa/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export default function MfaPage() {
+  const router = useRouter();
+  const supabase = createSupabaseBrowserClient();
+  const [code, setCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleVerify = async () => {
+    if (!code.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: factors, error: listError } = await supabase.auth.mfa.listFactors();
+      if (listError || !factors?.totp?.[0]) {
+        setError('No 2FA factor found. Please re-login.');
+        return;
+      }
+      const factor = factors.totp[0];
+      const { data: challenge, error: challengeError } = await supabase.auth.mfa.challenge({ factorId: factor.id });
+      if (challengeError) { setError(challengeError.message); return; }
+      const { error: verifyError } = await supabase.auth.mfa.verify({
+        factorId: factor.id,
+        challengeId: challenge.id,
+        code: code.trim(),
+      });
+      if (verifyError) { setError('Invalid verification code. Please try again.'); return; }
+      router.push('/dashboard');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo variant="stacked" className="text-gray-900" markClassName="h-14" wordmarkClassName="h-5" />
+          <h1 className="text-lg font-semibold text-gray-900">Two-Factor Authentication</h1>
+          <p className="text-sm text-gray-500">Enter the 6-digit code from your authenticator app.</p>
+        </div>
+        <div className="space-y-3">
+          <input
+            type="text"
+            inputMode="numeric"
+            maxLength={6}
+            placeholder="000000"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-center text-xl font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            onKeyDown={(e) => e.key === 'Enter' && handleVerify()}
+            autoFocus
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            onClick={handleVerify}
+            disabled={loading || code.length !== 6}
+            className="w-full rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Verifying...' : 'Verify'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/two-factor-section.tsx
+++ b/apps/web/src/components/settings/two-factor-section.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+
+type TwoFaState = 'loading' | 'disabled' | 'enrolling' | 'enabled';
+
+export function TwoFactorSection() {
+  const supabase = createSupabaseBrowserClient();
+  const [state, setState] = useState<TwoFaState>('loading');
+  const [factorId, setFactorId] = useState<string | null>(null);
+  const [qrCode, setQrCode] = useState<string | null>(null);
+  const [secret, setSecret] = useState<string | null>(null);
+  const [otpCode, setOtpCode] = useState('');
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.mfa.listFactors();
+      const enabled = (data?.totp?.length ?? 0) > 0 && data?.totp?.[0]?.status === 'verified';
+      setState(enabled ? 'enabled' : 'disabled');
+    })();
+  }, [supabase]);
+
+  const handleSetup = async () => {
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/auth/2fa/setup', { method: 'POST' });
+      const json = await res.json();
+      if (!res.ok) { setMessage({ type: 'error', text: json.error ?? 'Setup failed' }); return; }
+      setFactorId(json.data.factor_id);
+      setQrCode(json.data.qr_code);
+      setSecret(json.data.secret);
+      setState('enrolling');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleVerify = async () => {
+    if (!factorId || otpCode.length !== 6) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/auth/2fa/verify', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ factor_id: factorId, code: otpCode }),
+      });
+      const json = await res.json();
+      if (!res.ok) { setMessage({ type: 'error', text: json.error ?? 'Invalid code' }); return; }
+      setState('enabled');
+      setQrCode(null);
+      setSecret(null);
+      setOtpCode('');
+      setMessage({ type: 'success', text: '2FA enabled successfully.' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDisable = async () => {
+    if (otpCode.length !== 6) return;
+    setBusy(true);
+    setMessage(null);
+    try {
+      const res = await fetch('/api/auth/2fa/disable', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: otpCode }),
+      });
+      const json = await res.json();
+      if (!res.ok) { setMessage({ type: 'error', text: json.error ?? 'Invalid code' }); return; }
+      setState('disabled');
+      setOtpCode('');
+      setMessage({ type: 'success', text: '2FA disabled.' });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (state === 'loading') return null;
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">🔐 Two-Factor Authentication</h2>
+          <p className="text-sm text-muted-foreground">
+            {state === 'enabled' ? 'Two-factor authentication is active.' : 'Add an extra layer of security using a TOTP authenticator app.'}
+          </p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-4">
+        {message && (
+          <p className={`text-sm ${message.type === 'success' ? 'text-emerald-400' : 'text-rose-400'}`}>{message.text}</p>
+        )}
+
+        {state === 'disabled' && (
+          <button
+            onClick={handleSetup}
+            disabled={busy}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+          >
+            {busy ? '...' : 'Enable 2FA'}
+          </button>
+        )}
+
+        {state === 'enrolling' && qrCode && (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">Scan this QR code with your authenticator app, then enter the 6-digit code below.</p>
+            <div className="flex justify-center" dangerouslySetInnerHTML={{ __html: qrCode }} />
+            {secret && (
+              <p className="text-center text-xs text-muted-foreground">
+                Manual key: <span className="font-mono text-foreground">{secret}</span>
+              </p>
+            )}
+            <input
+              type="text"
+              inputMode="numeric"
+              maxLength={6}
+              placeholder="000000"
+              className="w-full rounded-lg border border-border bg-background px-4 py-2 text-center font-mono tracking-widest text-foreground focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={otpCode}
+              onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            />
+            <button
+              onClick={handleVerify}
+              disabled={busy || otpCode.length !== 6}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {busy ? '...' : 'Activate 2FA'}
+            </button>
+          </div>
+        )}
+
+        {state === 'enabled' && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">Enter your current authenticator code to disable 2FA.</p>
+            <input
+              type="text"
+              inputMode="numeric"
+              maxLength={6}
+              placeholder="000000"
+              className="w-full rounded-lg border border-border bg-background px-4 py-2 text-center font-mono tracking-widest text-foreground focus:outline-none focus:ring-2 focus:ring-rose-500"
+              value={otpCode}
+              onChange={(e) => setOtpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
+            />
+            <button
+              onClick={handleDisable}
+              disabled={busy || otpCode.length !== 6}
+              className="rounded-lg border border-rose-500/40 px-4 py-2 text-sm font-medium text-rose-400 hover:border-rose-400 hover:text-rose-300 disabled:opacity-50"
+            >
+              {busy ? '...' : 'Disable 2FA'}
+            </button>
+          </div>
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}


### PR DESCRIPTION
## Summary

Supabase 내장 MFA API(`supabase.auth.mfa.*`) 활용 — 커스텀 `user_2fa` 테이블 불필요.

- **No migration**: Supabase manages TOTP factors internally
- `POST /api/auth/2fa/setup`: `mfa.enroll({ factorType: 'totp' })` → QR code SVG + secret + factor_id
- `POST /api/auth/2fa/verify`: `mfa.challenge()` + `mfa.verify()` → factor activated (aal2)
- `POST /api/auth/2fa/disable`: verify OTP then `mfa.unenroll()` → factor removed
- `/mfa` page: AAL2 challenge page — lists enrolled factor, challenges, verifies, redirects to /dashboard
- `auth/callback`: `mfa.getAuthenticatorAssuranceLevel()` check → redirect to `/mfa` if `nextLevel = aal2`
- Settings `TwoFactorSection`: enable/enrolling (QR scan + OTP) / disable states

## Test plan

- [ ] Setup: POST /api/auth/2fa/setup → qr_code, secret, factor_id 반환
- [ ] Verify: 올바른 OTP → 200, 잘못된 OTP → 400 INVALID_OTP
- [ ] Disable: OTP 검증 후 unenroll 성공
- [ ] Auth callback: MFA 등록된 사용자 로그인 시 /mfa 리다이렉트
- [ ] /mfa page: OTP 입력 → verify → /dashboard 이동
- [ ] Settings 2FA 섹션: enable/qr/disable 플로우 UI
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)