### PR TITLE
feat(E-PLATFORM-SECURE-S7): BYOA agent_run tracking + webhook retry + scope

### DIFF
--- a/apps/web/src/app/api/agent-runs/route.ts
+++ b/apps/web/src/app/api/agent-runs/route.ts
@@ -6,6 +6,7 @@ import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { AgentRunService } from '@/services/agent-run';
+import { requireAgentScope } from '@/lib/auth-api-key';
 
 const createAgentRunSchema = z.object({
   agent_id: z.string().min(1),
@@ -29,6 +30,8 @@ export async function POST(request: Request) {
     const me = await getAuthContext(supabase, request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    if (!requireAgentScope(me, 'write')) return ApiErrors.insufficientScope('write');
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
 
@@ -84,10 +87,12 @@ export async function GET(request: Request) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     const limit = searchParams.get('limit');
+    const agentId = searchParams.get('agent_id') ?? undefined;
+    const cursor = searchParams.get('cursor') ?? undefined;
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new AgentRunService(dbClient);
-    const runs = await service.list(projectId, limit ? Number(limit) : undefined);
+    const runs = await service.list(projectId, limit ? Number(limit) : undefined, agentId, cursor);
     return apiSuccess(runs);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/lib/auth-api-key.ts
+++ b/apps/web/src/lib/auth-api-key.ts
@@ -111,6 +111,18 @@ export async function getTeamMemberFromApiKey(
  * @param adminClient - Service role client (RLS 우회용)
  * @param request - HTTP Request
  */
+/**
+ * Scope 검증 헬퍼 — agent API key의 scope가 required를 포함하는지 확인
+ * 사람(human) 인증에는 scope 제한 없음
+ */
+export function requireAgentScope(
+  me: { type?: string; scope?: string[] } | null | undefined,
+  required: string,
+): boolean {
+  if (!me || me.type !== 'agent') return true; // 사람 또는 미인증은 caller가 별도 처리
+  return (me.scope ?? ['read', 'write']).includes(required);
+}
+
 export async function getTeamMemberFromRequest(
   adminClient: SupabaseClient,
   request: Request

--- a/apps/web/src/services/agent-run.ts
+++ b/apps/web/src/services/agent-run.ts
@@ -14,6 +14,7 @@ export interface AgentRunRecord {
   project_id: string;
   agent_id: string;
   trigger: string;
+  metadata: Record<string, unknown>;
   model: string | null;
   story_id: string | null;
   memo_id: string | null;
@@ -37,6 +38,7 @@ export interface CreateAgentRunInput {
   project_id: string;
   agent_id: string;
   trigger: string;
+  metadata?: Record<string, unknown>;
   model?: string | null;
   story_id?: string | null;
   memo_id?: string | null;
@@ -80,6 +82,7 @@ export class AgentRunService {
         project_id: input.project_id,
         agent_id: input.agent_id,
         trigger: input.trigger,
+        metadata: input.metadata ?? {},
         model: input.model ?? null,
         story_id: input.story_id ?? null,
         memo_id: input.memo_id ?? null,
@@ -143,14 +146,18 @@ export class AgentRunService {
     return data as AgentRunRecord;
   }
 
-  async list(projectId: string, limit = 20): Promise<AgentRunRecord[]> {
-    const { data, error } = await this.supabase
+  async list(projectId: string, limit = 20, agentId?: string, cursor?: string): Promise<AgentRunRecord[]> {
+    let query = this.supabase
       .from('agent_runs')
       .select('*')
       .eq('project_id', projectId)
       .order('created_at', { ascending: false })
       .limit(limit);
 
+    if (agentId) query = query.eq('agent_id', agentId);
+    if (cursor) query = query.lt('created_at', cursor);
+
+    const { data, error } = await query;
     if (error) throw error;
     return (data ?? []) as AgentRunRecord[];
   }

--- a/apps/web/src/services/memo-event-dispatcher.ts
+++ b/apps/web/src/services/memo-event-dispatcher.ts
@@ -1,6 +1,7 @@
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
 import { AgentRoutingRuleService, RoutingPolicyError, type RoutingEvaluationResult, type RoutingRuleSummary } from './agent-routing-rule';
 import { buildWebhookSignatureHeaders } from '@/lib/webhook-signature';
+import { WebhookDeliveryService } from './webhook-delivery.service';
 
 type DispatchSource = 'realtime' | 'polling';
 
@@ -438,9 +439,7 @@ export class MemoEventDispatcher {
       return { status: 'skipped', reason: 'assignee_not_active_agent' };
     }
 
-    // BYOA: agent_runs 레코드 없이 webhook_url로 직접 발송
-    // createRun()은 agent_id가 type='agent'인 팀원이어야 하는 제약이 있어
-    // BYOA 멤버(human + webhook_url)는 insert 실패 후 dispatch가 abort됨.
+    // BYOA: webhook_url로 직접 발송 + agent_run 경량 추적 + webhook_deliveries 재시도 큐
     if (isByoa) {
       const webhook = await this.resolveWebhook(agent, memo.project_id);
       if (!webhook) {
@@ -449,6 +448,18 @@ export class MemoEventDispatcher {
         });
         return { status: 'skipped', reason: 'byoa_webhook_missing' };
       }
+
+      // agent_run 경량 기록 (fire-and-forget)
+      void this.options.supabase.from('agent_runs').insert({
+        org_id: memo.org_id,
+        project_id: memo.project_id,
+        agent_id: agent.id,
+        trigger: 'webhook',
+        memo_id: memo.id,
+        status: 'running',
+        metadata: { source, dispatch_key: dispatchKey },
+      });
+
       try {
         const outbound = this.buildWebhookPayload({
           webhookUrl: webhook.url,
@@ -461,29 +472,27 @@ export class MemoEventDispatcher {
           dispatchKey,
           routing,
         });
-        const response = await fetchWithTimeout(
-          this.fetchFn,
-          webhook.url,
-          {
-            method: 'POST',
-            redirect: 'manual',
-            headers: {
-              'Content-Type': 'application/json',
-              ...buildWebhookSignatureHeaders(webhook.secret, JSON.stringify(outbound.body)),
-            },
-            body: JSON.stringify(outbound.body),
+        const bodyStr = JSON.stringify(outbound.body);
+        // webhook_deliveries 재시도 큐 경유 발송
+        const deliveryService = new WebhookDeliveryService(this.options.supabase);
+        const success = await deliveryService.dispatch({
+          org_id: memo.org_id,
+          webhook_config_id: null,
+          event_type: 'memo.received',
+          url: webhook.url,
+          headers: {
+            'Content-Type': 'application/json',
+            ...buildWebhookSignatureHeaders(webhook.secret, bodyStr),
           },
-          this.webhookTimeoutMs,
-        );
-        if (!response.ok) {
-          const body = await response.text();
-          this.logger.warn('[MemoEventDispatcher] BYOA webhook dispatch failed', {
+          body: bodyStr,
+          fetchFn: this.fetchFn,
+        });
+        if (!success) {
+          this.logger.warn('[MemoEventDispatcher] BYOA webhook dispatch failed after retries', {
             agent_id: agent.id,
             memo_id: memo.id,
-            status: response.status,
-            body: body.slice(0, 200),
           });
-          return { status: 'failed', reason: `byoa_webhook_${response.status}` };
+          return { status: 'failed', reason: 'byoa_webhook_failed' };
         }
         return { status: 'dispatched' };
       } catch (error) {

--- a/packages/db/supabase/migrations/20260425120000_agent_runs.sql
+++ b/packages/db/supabase/migrations/20260425120000_agent_runs.sql
@@ -1,0 +1,6 @@
+-- E-PLATFORM-SECURE S7: agent_runs metadata 컬럼 추가
+-- trigger 컬럼이 trigger_type 역할 수행 ('webhook'|'manual'|'cron')
+-- AC1 요건: trigger_type은 기존 trigger 컬럼으로 충족, metadata 신규 추가
+
+ALTER TABLE public.agent_runs
+  ADD COLUMN IF NOT EXISTS metadata jsonb NOT NULL DEFAULT '{}';


### PR DESCRIPTION
## Summary

- Migration `20260425120000_agent_runs.sql`: `agent_runs.metadata jsonb DEFAULT '{}'` — `trigger` 컬럼이 `trigger_type` 역할 수행
- `AgentRunService`: `metadata` 필드 추가, `list()` — `agent_id` 필터 + `cursor` 페이지네이션
- `memo-event-dispatcher` BYOA 블록:
  - fire-and-forget `agent_runs` INSERT (`trigger='webhook'`, `status='running'`, `metadata`)
  - `WebhookDeliveryService.dispatch()` 경유 발송 (`webhook_deliveries` 재시도 큐 활용)
- `GET /api/agent-runs`: `?agent_id=` + `?cursor=` 지원 추가
- `requireAgentScope(me, required)` 헬퍼 in `auth-api-key.ts`
- `POST /api/agent-runs`: `requireAgentScope('write')` 적용

## Test plan

- [ ] migration: `metadata` 컬럼 추가 확인
- [ ] BYOA webhook 발송 시 `agent_runs` row 생성 확인 (fire-and-forget)
- [ ] BYOA webhook 실패 시 `webhook_deliveries` 재시도 동작 (3회)
- [ ] GET /api/agent-runs?agent_id=X — 에이전트별 필터 동작
- [ ] GET /api/agent-runs?cursor=ISO — 커서 페이지네이션 동작
- [ ] POST /api/agent-runs: scope=read only 에이전트 → 403 insufficientScope('write')
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)