### PR TITLE
feat(E-PLATFORM-SECURE-S8): billing cleanup + grace_period + Settings notice

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -492,7 +492,8 @@
     "standupDeadline": "Deadline",
     "revoked": "Revoked",
     "revoke": "Revoke",
-    "resend": "Resend"
+    "resend": "Resend",
+    "gracePeriodNotice": "Your current plan will remain active until {date}."
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -492,7 +492,8 @@
     "standupDeadline": "마감 시간",
     "revoked": "취소됨",
     "revoke": "취소",
-    "resend": "재발송"
+    "resend": "재발송",
+    "gracePeriodNotice": "{date}까지 현재 플랜이 유지됩니다."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -109,6 +109,7 @@ export default function SettingsPage() {
   const [revokingInviteId, setRevokingInviteId] = useState<string | null>(null);
   const [resendingInviteId, setResendingInviteId] = useState<string | null>(null);
   const [resendResult, setResendResult] = useState<{ id: string; url: string } | null>(null);
+  const [graceUntil, setGraceUntil] = useState<string | null>(null);
 
   const refreshProjects = async () => {
     const endpoint = orgId ? `/api/projects?org_id=${encodeURIComponent(orgId)}` : '/api/projects';
@@ -130,6 +131,12 @@ export default function SettingsPage() {
       setIsAdmin(true);
       setAdminChecked(true);
       setInvitations(json.data ?? []);
+      // grace period 정보 조회
+      const statusRes = await fetch('/api/subscription/status');
+      if (statusRes.ok) {
+        const statusJson = await statusRes.json() as { data?: { grace_until?: string | null } };
+        setGraceUntil(statusJson.data?.grace_until ?? null);
+      }
       return;
     }
 
@@ -883,7 +890,12 @@ export default function SettingsPage() {
               <p className="text-sm text-muted-foreground">{t('subscriptionDescription')}</p>
             </div>
           </SectionCardHeader>
-          <SectionCardBody>
+          <SectionCardBody className="space-y-3">
+            {graceUntil && new Date(graceUntil) > new Date() && (
+              <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
+                {t('gracePeriodNotice', { date: new Date(graceUntil).toLocaleDateString('ko-KR') })}
+              </p>
+            )}
             <Button
               variant="glass"
               size="lg"

--- a/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
@@ -53,41 +53,10 @@ export async function POST(request: Request, { params }: RouteParams) {
       (usageRows ?? []).reduce((sum: number, r: { duration_sec: number }) => sum + r.duration_sec, 0) / 60,
     );
 
-    // AC9: STT minute quota—checkFeatureLimit로 free tier 폴백 포함 조회
+    // AC9: STT minute quota — checkFeatureLimit 경유 (SaaS overlay에서 org_subscriptions 기반 검증)
     const quotaCheck = await checkFeatureLimit(dbClient, me.org_id, 'max_stt_minutes');
     if (!quotaCheck.allowed) {
       return apiUpgradeRequired(`Monthly STT limit reached (${monthlyMinutes} min)`, 'stt_minutes');
-    }
-    const { data: sub } = await dbClient
-      .from('subscriptions')
-      .select('tier_id')
-      .eq('org_id', me.org_id)
-      .eq('status', 'active')
-      .maybeSingle();
-
-    let tierId = sub?.tier_id ?? null;
-    if (!tierId) {
-      const { data: freeTier } = await dbClient
-        .from('plan_tiers')
-        .select('id')
-        .eq('name', 'free')
-        .single();
-      tierId = freeTier?.id ?? null;
-    }
-
-    if (tierId) {
-      const { data: feature } = await dbClient
-        .from('plan_features')
-        .select('limit_value')
-        .eq('tier_id', tierId)
-        .eq('feature_key', 'max_stt_minutes')
-        .single();
-      if (feature?.limit_value != null && monthlyMinutes >= feature.limit_value) {
-        return apiUpgradeRequired(
-          `Monthly STT limit reached (${monthlyMinutes}/${feature.limit_value} min)`,
-          'stt_minutes',
-        );
-      }
     }
 
     const formData = await request.formData();

--- a/apps/web/src/app/api/subscription/status/route.ts
+++ b/apps/web/src/app/api/subscription/status/route.ts
@@ -1,0 +1,23 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+
+/** GET /api/subscription/status — grace_until + status 조회 */
+export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess({ status: 'active', grace_until: null });
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+
+    const { data } = await supabase
+      .from('org_subscriptions')
+      .select('status, tier, grace_until')
+      .eq('org_id', me.org_id)
+      .maybeSingle();
+
+    return apiSuccess(data ?? { status: 'active', tier: 'free', grace_until: null });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/packages/db/supabase/migrations/20260425130000_billing_cleanup.sql
+++ b/packages/db/supabase/migrations/20260425130000_billing_cleanup.sql
@@ -1,0 +1,16 @@
+-- E-PLATFORM-SECURE S8: 레거시 과금 테이블 정리 + grace_period 추가
+
+-- 1. 미사용 레거시 과금 테이블 DROP
+--    price_tier_map: Paddle/Toss PG price 매핑 (Polar로 전환됨, OSS 미참조)
+--    plan_offering_snapshots: grandfathering 스냅샷 (OSS 미참조)
+DROP TABLE IF EXISTS public.price_tier_map CASCADE;
+DROP TABLE IF EXISTS public.plan_offering_snapshots CASCADE;
+
+-- NOTE: subscriptions, plan_tiers, plan_features 테이블은
+--       SaaS overlay에서 관리 중(checkFeatureLimit 구현체 경유)이므로 유지.
+--       OSS 직접 참조는 meetings/transcribe route에서 제거됨 (AC2).
+
+-- 2. org_subscriptions에 grace_until 컬럼 추가
+--    Polar 취소 webhook 수신 시 grace_until = now() + interval '30 days' 설정
+ALTER TABLE public.org_subscriptions
+  ADD COLUMN IF NOT EXISTS grace_until timestamptz;


### PR DESCRIPTION
## Summary

- **AC1 (레거시 테이블 DROP)**: `price_tier_map`, `plan_offering_snapshots` DROP (OSS 미참조 확인). `subscriptions`/`plan_tiers`는 SaaS overlay 관리 중이라 유지.
- **AC2 (OSS billing 감사)**: `meetings/[id]/transcribe/route.ts`에서 직접 `subscriptions`/`plan_tiers`/`plan_features` 쿼리 제거 → `checkFeatureLimit()` 단일 인터페이스로 통합. `billing-limit-enforcer.ts`, `agent-run-billing.ts`는 이미 OSS stub (주석으로 명시됨).
- **AC3 (grace_until)**: `org_subscriptions.grace_until timestamptz` 컬럼 추가. Polar 취소 webhook 수신 시 `now() + 30d` 설정 (SaaS webhook handler가 처리).
- **AC4 (grace 중 기능 유지)**: `check-feature.ts` OSS stub이 `allowed: true` 반환 — grace period 자동 포함. SaaS overlay에서 `grace_until > now()` 조건으로 플랜 유지.
- **AC5 (Settings UI)**: `GET /api/subscription/status` 신설 → `grace_until` 반환. 구독 섹션에 amber 배너로 `{date}까지 현재 플랜 유지` 안내.

## Test plan

- [ ] migration: price_tier_map + plan_offering_snapshots DROP 확인
- [ ] org_subscriptions.grace_until 컬럼 추가 확인
- [ ] meetings/transcribe: subscriptions/plan_tiers 직접 쿼리 제거 확인
- [ ] GET /api/subscription/status → grace_until 반환
- [ ] Settings 구독 섹션: grace_until 미래이면 amber 배너 표시
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)