### PR TITLE
feat(E-PLATFORM-SECURE-S9): reward_balances MV + period leaderboard (에픽 마지막)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -893,7 +893,11 @@
     "unknown": "Unknown",
     "adminOnly": "Admin access required",
     "grantFailed": "Grant failed",
-    "adminOnlyHint": "Only org admin/owner can grant rewards"
+    "adminOnlyHint": "Only org admin/owner can grant rewards",
+    "periodAll": "All",
+    "periodDaily": "Daily",
+    "periodWeekly": "Weekly",
+    "periodMonthly": "Monthly"
   },
   "inbox": {
     "title": "Inbox",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -893,7 +893,11 @@
     "unknown": "알 수 없음",
     "adminOnly": "관리자 권한 필요",
     "grantFailed": "지급 실패",
-    "adminOnlyHint": "조직 관리자/소유자만 리워드 지급 가능"
+    "adminOnlyHint": "조직 관리자/소유자만 리워드 지급 가능",
+    "periodAll": "전체",
+    "periodDaily": "일간",
+    "periodWeekly": "주간",
+    "periodMonthly": "월간"
   },
   "inbox": {
     "title": "인박스",

--- a/apps/web/src/app/(authenticated)/rewards/page.tsx
+++ b/apps/web/src/app/(authenticated)/rewards/page.tsx
@@ -17,6 +17,7 @@ export default function RewardsPage() {
   const [ledger, setLedger] = useState<LedgerEntry[]>([]);
   const [members, setMembers] = useState<Member[]>([]);
   const [loading, setLoading] = useState(true);
+  const [period, setPeriod] = useState<'all' | 'daily' | 'weekly' | 'monthly'>('all');
   const [memberId, setMemberId] = useState('');
   const [amount, setAmount] = useState('');
   const [reason, setReason] = useState('');
@@ -42,20 +43,19 @@ export default function RewardsPage() {
       setLoading(true);
       try {
         const [lbRes, ledgerRes, membersRes] = await Promise.all([
-          fetch(`/api/rewards?project_id=${projectId}&type=leaderboard`),
+          fetch(`/api/rewards/leaderboard?project_id=${projectId}&period=${period}`),
           fetch(`/api/rewards?project_id=${projectId}`),
           fetch(`/api/team-members?project_id=${projectId}`),
         ]);
         if (lbRes.ok && !cancelled) { const j = await lbRes.json(); setLeaderboard(j.data); }
         if (ledgerRes.ok && !cancelled) { const j = await ledgerRes.json(); setLedger(j.data); }
         if (membersRes.ok && !cancelled) { const j = await membersRes.json(); setMembers(j.data); }
-        // 간단 admin 판별은 생략 — grant 실패 시 에러 표시로 대응
       } catch { /* silent */ }
       if (!cancelled) setLoading(false);
     }
     void load();
     return () => { cancelled = true; };
-  }, [projectId]);
+  }, [projectId, period]);
 
   const handleGrant = async () => {
     if (!memberId || !amount || !reason.trim()) return;
@@ -69,7 +69,7 @@ export default function RewardsPage() {
       if (res.ok) {
         setMemberId(''); setAmount(''); setReason('');
         const [lbRes, ledgerRes] = await Promise.all([
-          fetch(`/api/rewards?project_id=${projectId}&type=leaderboard`),
+          fetch(`/api/rewards/leaderboard?project_id=${projectId}&period=${period}`),
           fetch(`/api/rewards?project_id=${projectId}`),
         ]);
         if (lbRes.ok) { const j = await lbRes.json(); setLeaderboard(j.data); }
@@ -104,7 +104,20 @@ export default function RewardsPage() {
 
         {/* 리더보드 */}
         <div className="rounded-xl bg-white p-5 shadow-sm">
-          <h2 className="mb-3 text-sm font-semibold text-gray-700">🏆 {t('leaderboard')}</h2>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-sm font-semibold text-gray-700">🏆 {t('leaderboard')}</h2>
+            <div className="flex gap-1 rounded-lg bg-gray-100 p-1 text-xs">
+              {(['all', 'monthly', 'weekly', 'daily'] as const).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPeriod(p)}
+                  className={`rounded-md px-2 py-1 transition-colors ${period === p ? 'bg-white font-medium shadow-sm text-gray-900' : 'text-gray-500 hover:text-gray-700'}`}
+                >
+                  {p === 'all' ? t('periodAll') : p === 'monthly' ? t('periodMonthly') : p === 'weekly' ? t('periodWeekly') : t('periodDaily')}
+                </button>
+              ))}
+            </div>
+          </div>
           {loading ? (
             <div className="space-y-2">{[1,2,3].map(i => <div key={i} className="h-8 animate-pulse rounded bg-gray-100" />)}</div>
           ) : leaderboard.length === 0 ? (

--- a/apps/web/src/app/api/rewards/leaderboard/route.ts
+++ b/apps/web/src/app/api/rewards/leaderboard/route.ts
@@ -1,0 +1,33 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { RewardsService } from '@/services/rewards';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+
+/** GET /api/rewards/leaderboard?project_id=X&period=daily|weekly|monthly|all&limit=N&cursor=X */
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = me.type === 'agent' ? me.project_id : (searchParams.get('project_id') ?? me.project_id);
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+
+    const period = (searchParams.get('period') ?? 'all') as 'daily' | 'weekly' | 'monthly' | 'all';
+    if (!['daily', 'weekly', 'monthly', 'all'].includes(period)) {
+      return ApiErrors.badRequest('period must be one of: daily, weekly, monthly, all');
+    }
+
+    const limit = Math.min(Number(searchParams.get('limit') ?? '50'), 100);
+    const cursor = searchParams.get('cursor') ?? undefined;
+
+    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new RewardsService(dbClient);
+    const data = await service.getLeaderboardByPeriod(projectId, period, limit, cursor);
+    return apiSuccess(data);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/services/rewards.ts
+++ b/apps/web/src/services/rewards.ts
@@ -58,4 +58,50 @@ export class RewardsService {
       .map(([member_id, balance]) => ({ member_id, balance }))
       .sort((a, b) => b.balance - a.balance);
   }
+
+  async getLeaderboardByPeriod(
+    projectId: string,
+    period: 'daily' | 'weekly' | 'monthly' | 'all',
+    limit = 50,
+    cursor?: string,
+  ) {
+    const periodMs: Record<string, number> = {
+      daily: 86400_000,
+      weekly: 7 * 86400_000,
+      monthly: 30 * 86400_000,
+    };
+
+    if (period === 'all') {
+      // all-time: reward_balances materialized view 사용
+      let q = this.supabase
+        .from('reward_balances')
+        .select('member_id, balance')
+        .eq('project_id', projectId)
+        .order('balance', { ascending: false })
+        .limit(limit);
+      if (cursor) q = q.lt('balance', Number(cursor));
+      const { data, error } = await q;
+      if (error) throw error;
+      return (data ?? []) as { member_id: string; balance: number }[];
+    }
+
+    const since = new Date(Date.now() - periodMs[period]).toISOString();
+    let q = this.supabase
+      .from('reward_ledger')
+      .select('member_id, amount')
+      .eq('project_id', projectId)
+      .gte('created_at', since);
+    if (cursor) q = q.lt('created_at', cursor);
+    const { data, error } = await q;
+    if (error) throw error;
+
+    const totals: Record<string, number> = {};
+    for (const r of data ?? []) {
+      totals[r.member_id as string] = (totals[r.member_id as string] ?? 0) + Number(r.amount);
+    }
+    return Object.entries(totals)
+      .map(([member_id, balance]) => ({ member_id, balance }))
+      .sort((a, b) => b.balance - a.balance)
+      .slice(0, limit);
+  }
 }

--- a/packages/db/supabase/migrations/20260425140000_reward_balances_view.sql
+++ b/packages/db/supabase/migrations/20260425140000_reward_balances_view.sql
@@ -1,0 +1,36 @@
+-- E-PLATFORM-SECURE S9: reward_balances materialized view + auto-refresh trigger
+
+-- 1. materialized view
+CREATE MATERIALIZED VIEW IF NOT EXISTS public.reward_balances AS
+  SELECT
+    member_id,
+    project_id,
+    SUM(amount) AS balance
+  FROM public.reward_ledger
+  GROUP BY member_id, project_id;
+
+-- 2. UNIQUE index (CONCURRENTLY refresh에 필수)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_reward_balances_member_project
+  ON public.reward_balances(member_id, project_id);
+
+CREATE INDEX IF NOT EXISTS idx_reward_balances_project_balance
+  ON public.reward_balances(project_id, balance DESC);
+
+-- 3. auto-refresh trigger function
+CREATE OR REPLACE FUNCTION public.refresh_reward_balances()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY public.reward_balances;
+  RETURN NULL;
+END;
+$$;
+
+-- 4. trigger: reward_ledger INSERT/UPDATE/DELETE 시 자동 갱신
+DROP TRIGGER IF EXISTS trg_reward_balances_refresh ON public.reward_ledger;
+CREATE TRIGGER trg_reward_balances_refresh
+  AFTER INSERT OR UPDATE OR DELETE ON public.reward_ledger
+  FOR EACH STATEMENT
+  EXECUTE FUNCTION public.refresh_reward_balances();

--- a/packages/mcp-server/src/tools/rewards.ts
+++ b/packages/mcp-server/src/tools/rewards.ts
@@ -38,11 +38,16 @@ export function registerRewardsTools(server: McpServer) {
     }
   });
 
-  server.tool('get_leaderboard_v2', 'Get reward leaderboard for project', {
+  server.tool('get_leaderboard_v2', 'Get reward leaderboard for project with optional period filter', {
     project_id: z.string(),
-  }, async ({ project_id }) => {
+    period: z.enum(['all', 'daily', 'weekly', 'monthly']).optional().describe('Time period (default: all)'),
+    limit: z.number().int().min(1).max(100).optional().describe('Max results (default: 50)'),
+  }, async ({ project_id, period, limit }) => {
     try {
-      const data = await pmApi(`/api/rewards?project_id=${project_id}&type=leaderboard`);
+      const params = new URLSearchParams({ project_id });
+      if (period) params.set('period', period);
+      if (limit !== undefined) params.set('limit', String(limit));
+      const data = await pmApi(`/api/rewards/leaderboard?${params.toString()}`);
       return ok(data);
     } catch (e) {
       return err(e instanceof PmApiError ? e.message : String(e));


### PR DESCRIPTION
## Summary

E-PLATFORM-SECURE 에픽 마지막 스토리.

- **Migration** `20260425140000_reward_balances_view.sql`: `reward_balances` materialized view (member_id, project_id, balance) + UNIQUE index + INSERT/UPDATE/DELETE 트리거 CONCURRENTLY 자동 갱신
- **RewardsService**: `getLeaderboardByPeriod(projectId, period, limit, cursor)` — all → MV 활용, daily/weekly/monthly → reward_ledger 날짜 필터
- **GET /api/rewards/leaderboard**: `?period=daily|weekly|monthly|all` + `limit/cursor` 페이지네이션
- **Rewards UI**: 기간 탭 (전체/월간/주간/일간) — period 변경 시 API 재호출
- **MCP `get_leaderboard_v2`**: `period` + `limit` 파라미터 추가 → `/api/rewards/leaderboard` 경유

## Test plan

- [ ] migration: reward_balances MV + UNIQUE index + trigger 생성 확인
- [ ] trigger: reward_ledger INSERT 시 MV 자동 갱신 확인
- [ ] GET /api/rewards/leaderboard?period=all → MV 기반 결과
- [ ] GET /api/rewards/leaderboard?period=daily|weekly|monthly → 날짜 필터 결과
- [ ] UI: 기간 탭 전환 시 leaderboard 재조회
- [ ] MCP get_leaderboard_v2: period 파라미터 동작 확인
- [ ] type-check 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)