### PR TITLE
hotfix: clear stale auth cookie before OAuth login

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -11,6 +11,9 @@ export async function GET(request: Request) {
   if (code) {
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) {
+      console.error('[auth/callback] exchangeCodeForSession failed:', error.message, error.status);
+    }
     if (!error) {
       // MFA 검증 필요 여부 확인 (AAL1 → AAL2 required)
       const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -13,6 +13,7 @@ export default function LoginPage() {
     const callbackUrl = returnTo
       ? `${window.location.origin}/auth/callback?next=${encodeURIComponent(returnTo)}`
       : `${window.location.origin}/auth/callback`;
+    await supabase.auth.signOut(); // stale auth 쿠키 정리 (PKCE code verifier 충돌 방지)
     await supabase.auth.signInWithOAuth({
       provider,
       options: {


### PR DESCRIPTION
## 증상
Google OAuth 로그인 → `/login?error=auth_failed` 무한 반복

## 원인
stale auth 쿠키가 PKCE code verifier 교환을 방해. `exchangeCodeForSession(code)` 실패.

## 수정 내용
- `login/page.tsx`: `signInWithOAuth` 전에 `signOut()` 추가 → stale 쿠키 정리
- `callback/route.ts`: `exchangeCodeForSession` 실패 시 에러 로깅 추가

## Test plan
- [ ] Google OAuth 로그인 시 `/login?error=auth_failed` 무한루프 재현 안됨 확인
- [ ] 정상 로그인 → /dashboard 또는 /onboarding 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)