### PR TITLE
hotfix(P0): client-side PKCE fallback for mobile OAuth (SameSite=Lax)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Suspense, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+function FallbackHandler() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+    const next = searchParams.get('next');
+
+    if (!code) {
+      router.replace('/login?error=auth_failed');
+      return;
+    }
+
+    const supabase = createSupabaseBrowserClient();
+
+    supabase.auth.exchangeCodeForSession(code).then(async ({ error }) => {
+      if (error) {
+        console.error('[auth/callback/fallback] exchangeCodeForSession failed:', error.message);
+        router.replace('/login?error=auth_failed');
+        return;
+      }
+
+      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
+        router.replace('/mfa');
+        return;
+      }
+
+      if (next) {
+        router.replace(next);
+        return;
+      }
+
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user) {
+        const { data: membership } = await supabase
+          .from('org_members')
+          .select('org_id')
+          .eq('user_id', user.id)
+          .limit(1)
+          .maybeSingle();
+        router.replace(membership ? '/dashboard' : '/onboarding');
+        return;
+      }
+
+      router.replace('/dashboard');
+    });
+  }, [router, searchParams]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <p className="text-sm text-gray-500">로그인 처리 중...</p>
+    </div>
+  );
+}
+
+export default function AuthCallbackFallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <p className="text-sm text-gray-500">로그인 처리 중...</p>
+      </div>
+    }>
+      <FallbackHandler />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -13,6 +13,10 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (error) {
       console.error('[auth/callback] exchangeCodeForSession failed:', error.message, error.status);
+      // Mobile PKCE fallback: server couldn't read code_verifier cookie — retry in browser
+      const params = new URLSearchParams({ code });
+      if (next) params.set('next', next);
+      return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
     }
     if (!error) {
       // MFA 검증 필요 여부 확인 (AAL1 → AAL2 required)


### PR DESCRIPTION
## Summary
- Mobile Chrome의 Google OAuth `auth_failed` 무한 루프 수정 (P0)
- 4홉 cross-origin 리다이렉트에서 `SameSite=Lax` 쿠키 drop → 서버가 `code_verifier` 읽기 실패

## 변경 내용
### `apps/web/src/app/auth/callback/route.ts`
- `exchangeCodeForSession` 실패 시 `/login?error=auth_failed` 대신 `/auth/callback/fallback?code=...` 로 리다이렉트

### `apps/web/src/app/auth/callback/fallback/page.tsx` (신규)
- Client Component에서 `createSupabaseBrowserClient().auth.exchangeCodeForSession(code)` 재시도
- 브라우저는 localStorage의 `code_verifier`에 접근 가능 → 교환 성공
- 성공 시 MFA 체크 → `next` 파라미터 → org membership → dashboard/onboarding 분기
- 실패 시 `/login?error=auth_failed` 리다이렉트

## AC 검증
1. 모바일 크롬 Google OAuth 성공 (fallback 경로 통해)
2. 데스크톱: 서버 교환 성공 → fallback 미진입
3. `exchangeCodeForSession` 에러 로깅 확인
4. fallback 성공 시 dashboard/onboarding 정상 분기

🤖 Generated with [Claude Code](https://claude.com/claude-code)