### PR TITLE
hotfix(P0): skip exchangeCodeForSession when code-verifier cookie absent

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { resolveAppUrl } from '@/services/app-url';
+import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -9,6 +10,14 @@ export async function GET(request: Request) {
   const origin = resolveAppUrl(null);
 
   if (code) {
+    const cookieStore = await cookies();
+    const hasCodeVerifier = cookieStore.getAll().some(c => c.name.includes('code-verifier'));
+    if (!hasCodeVerifier) {
+      const params = new URLSearchParams({ code });
+      if (next) params.set('next', next);
+      return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
+    }
+
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (error) {


### PR DESCRIPTION
## Root Cause
`exchangeCodeForSession()` 실패 시 Supabase 내부 `removeItemAsync`가 `Set-Cookie: sb-xxx-code-verifier=; Expires=past` 헤더를 응답에 포함 → 리다이렉트 시 브라우저의 code-verifier 쿠키 파괴 → v2 fallback 클라이언트 교환도 실패.

## Fix
`createSupabaseServerClient()` 호출 전, `cookies()` API로 code-verifier 쿠키 존재 여부 확인.
없으면 Supabase 미터치 → 즉시 `/auth/callback/fallback` 리다이렉트.

## AC
1. 모바일 크롬: code-verifier 쿠키 없음 → exchangeCodeForSession 미호출 → fallback → 클라이언트 교환 성공
2. 데스크톱: code-verifier 쿠키 있음 → 기존 서버 교환 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)