### PR TITLE
hotfix(P0): remove server-side exchangeCodeForSession, always use client fallback

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,7 +1,5 @@
-import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { resolveAppUrl } from '@/services/app-url';
-import { cookies } from 'next/headers';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -10,48 +8,9 @@ export async function GET(request: Request) {
   const origin = resolveAppUrl(null);
 
   if (code) {
-    const cookieStore = await cookies();
-    const hasCodeVerifier = cookieStore.getAll().some(c => c.name.includes('code-verifier'));
-    if (!hasCodeVerifier) {
-      const params = new URLSearchParams({ code });
-      if (next) params.set('next', next);
-      return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
-    }
-
-    const supabase = await createSupabaseServerClient();
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (error) {
-      console.error('[auth/callback] exchangeCodeForSession failed:', error.message, error.status);
-      // Mobile PKCE fallback: server couldn't read code_verifier cookie — retry in browser
-      const params = new URLSearchParams({ code });
-      if (next) params.set('next', next);
-      return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
-    }
-    if (!error) {
-      // MFA 검증 필요 여부 확인 (AAL1 → AAL2 required)
-      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
-        return NextResponse.redirect(`${origin}/mfa`);
-      }
-
-      // next 파라미터가 있으면 (초대 플로우 등) 그대로 리다이렉트
-      if (next) return NextResponse.redirect(`${origin}${next}`);
-
-      // next 없으면 (직접 가입) org 소속 여부로 온보딩/대시보드 분기
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        const { data: membership } = await supabase
-          .from('org_members')
-          .select('org_id')
-          .eq('user_id', user.id)
-          .limit(1)
-          .maybeSingle();
-
-        return NextResponse.redirect(membership ? `${origin}/dashboard` : `${origin}/onboarding`);
-      }
-
-      return NextResponse.redirect(`${origin}/dashboard`);
-    }
+    const params = new URLSearchParams({ code });
+    if (next) params.set('next', next);
+    return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
   }
 
   return NextResponse.redirect(`${origin}/login?error=auth_failed`);


### PR DESCRIPTION
## Root Cause (v3 이후 재분석)
일반 탭의 stale code-verifier 쿠키로 인해 v3의 `hasCodeVerifier` 가드가 "있음"으로 판단 → `exchangeCodeForSession` 호출 → wrong verifier → one-time auth code 소비 → fallback에서 재사용 불가 → 실패.

시크릿 탭: 쿠키 없음 → v3 가드로 fallback → 성공. 일반 탭: stale 쿠키 → v3 가드 통과 → 실패.

## Fix
서버 사이드 `exchangeCodeForSession` 완전 제거. `code` 있으면 항상 `/auth/callback/fallback` 으로 redirect. 클라이언트 localStorage의 code-verifier로 교환 (PR #196에서 구현 완료).

44줄 제거, 3줄 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)