### PR TITLE
hotfix(P0): replace manual exchangeCodeForSession with onAuthStateChange in fallback

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -9,48 +9,48 @@ function FallbackHandler() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    const code = searchParams.get('code');
+    const supabase = createSupabaseBrowserClient();
     const next = searchParams.get('next');
 
-    if (!code) {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+      async (event, session) => {
+        if (event === 'SIGNED_IN' && session) {
+          const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+          if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
+            router.replace('/mfa');
+            return;
+          }
+
+          if (next) {
+            router.replace(next);
+            return;
+          }
+
+          const { data: { user } } = await supabase.auth.getUser();
+          if (user) {
+            const { data: membership } = await supabase
+              .from('org_members')
+              .select('org_id')
+              .eq('user_id', user.id)
+              .limit(1)
+              .maybeSingle();
+            router.replace(membership ? '/dashboard' : '/onboarding');
+            return;
+          }
+
+          router.replace('/dashboard');
+        }
+      }
+    );
+
+    const timeout = setTimeout(() => {
       router.replace('/login?error=auth_failed');
-      return;
-    }
+    }, 15000);
 
-    const supabase = createSupabaseBrowserClient();
-
-    supabase.auth.exchangeCodeForSession(code).then(async ({ error }) => {
-      if (error) {
-        console.error('[auth/callback/fallback] exchangeCodeForSession failed:', error.message);
-        router.replace('/login?error=auth_failed');
-        return;
-      }
-
-      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
-        router.replace('/mfa');
-        return;
-      }
-
-      if (next) {
-        router.replace(next);
-        return;
-      }
-
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        const { data: membership } = await supabase
-          .from('org_members')
-          .select('org_id')
-          .eq('user_id', user.id)
-          .limit(1)
-          .maybeSingle();
-        router.replace(membership ? '/dashboard' : '/onboarding');
-        return;
-      }
-
-      router.replace('/dashboard');
-    });
+    return () => {
+      subscription.unsubscribe();
+      clearTimeout(timeout);
+    };
   }, [router, searchParams]);
 
   return (


### PR DESCRIPTION
## Root Cause
`createBrowserClient` `detectSessionInUrl: true` 기본값으로 `_initialize()` 시 자동으로 `_exchangeCodeForSession` 호출 → one-time code 소비.
useEffect에서 수동으로도 `exchangeCodeForSession(code)` 재호출 → 이미 소비된 code → 실패 → auth_failed redirect.

## Fix
- 수동 `exchangeCodeForSession` 완전 제거
- `createBrowserClient` auto-init이 code 교환 처리
- `onAuthStateChange` `SIGNED_IN` 이벤트 수신 시 MFA/next/membership 분기
- 15초 timeout: 교환 실패 시 `/login?error=auth_failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)