### PR TITLE
hotfix(P0): use localStorage-based vanilla client for PKCE OAuth flow

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,61 +1,43 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { createClient } from '@supabase/supabase-js';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [debugInfo, setDebugInfo] = useState<string[]>(['초기화 중...']);
 
   useEffect(() => {
-    const logs: string[] = [];
-    const log = (msg: string) => {
-      logs.push(`[${new Date().toISOString().slice(11,19)}] ${msg}`);
-      setDebugInfo([...logs]);
-    };
-
-    const code = searchParams.get('code');
     const next = searchParams.get('next');
-    log(`code: ${code ? code.slice(0, 8) + '...' : 'null'}`);
-    log(`next: ${next || 'null'}`);
 
-    // 1. document.cookie 중 sb-* 확인
-    const allCookies = document.cookie.split(';').map(c => c.trim());
-    const sbCookies = allCookies.filter(c => c.startsWith('sb-'));
-    log(`sb-* cookies (${sbCookies.length}): ${sbCookies.map(c => c.split('=')[0]).join(', ') || 'NONE'}`);
+    // vanilla client — localStorage 기반, signInWithOAuth가 저장한 code-verifier를 여기서 읽음
+    const pkceClient = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { auth: { flowType: 'pkce', detectSessionInUrl: true } },
+    );
 
-    const cvCookies = allCookies.filter(c => c.includes('code-verifier'));
-    log(`code-verifier cookies: ${cvCookies.length > 0 ? cvCookies.map(c => c.split('=')[0]).join(', ') : 'NONE'}`);
-
-    // 2. localStorage 중 sb-* 확인
-    const lsKeys = Object.keys(localStorage).filter(k => k.startsWith('sb-'));
-    log(`sb-* localStorage (${lsKeys.length}): ${lsKeys.join(', ') || 'NONE'}`);
-
-    const cvLS = lsKeys.filter(k => k.includes('code-verifier'));
-    log(`code-verifier localStorage: ${cvLS.length > 0 ? cvLS.map(k => `${k}=${localStorage.getItem(k)?.slice(0,20)}...`).join(', ') : 'NONE'}`);
-
-    // 3. Supabase client 생성 + onAuthStateChange
-    log('createSupabaseBrowserClient() 호출...');
-    const supabase = createSupabaseBrowserClient();
-    log('client 생성 완료');
-
-    const { data: { subscription } } = supabase.auth.onAuthStateChange(
+    const { data: { subscription } } = pkceClient.auth.onAuthStateChange(
       async (event, session) => {
-        log(`onAuthStateChange: event=${event}, session=${session ? 'YES' : 'null'}`);
+        if ((event === 'SIGNED_IN' || event === 'INITIAL_SESSION') && session) {
+          // SSR client(cookie)에 세션 bridge — 이후 서버 사이드 인증 유지
+          const ssrClient = createSupabaseBrowserClient();
+          await ssrClient.auth.setSession({
+            access_token: session.access_token,
+            refresh_token: session.refresh_token,
+          });
 
-        if (event === 'SIGNED_IN' && session) {
-          log('SIGNED_IN 수신 — redirect 진행');
-          const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+          const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
           if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
             router.replace('/mfa');
             return;
           }
           if (next) { router.replace(next); return; }
-          const { data: { user } } = await supabase.auth.getUser();
+          const { data: { user } } = await ssrClient.auth.getUser();
           if (user) {
-            const { data: membership } = await supabase
+            const { data: membership } = await ssrClient
               .from('org_members')
               .select('org_id')
               .eq('user_id', user.id)
@@ -65,39 +47,11 @@ function FallbackHandler() {
             return;
           }
           router.replace('/dashboard');
-        }
-
-        if (event === 'INITIAL_SESSION' && session) {
-          log('INITIAL_SESSION with session — 이미 로그인됨, redirect 진행');
-          if (next) { router.replace(next); return; }
-          const { data: { user } } = await supabase.auth.getUser();
-          if (user) {
-            const { data: membership } = await supabase
-              .from('org_members')
-              .select('org_id')
-              .eq('user_id', user.id)
-              .limit(1)
-              .maybeSingle();
-            router.replace(membership ? '/dashboard' : '/onboarding');
-            return;
-          }
-          router.replace('/dashboard');
-        }
-
-        if (event === 'INITIAL_SESSION' && !session) {
-          log('INITIAL_SESSION with NO session — auto-init 교환 실패 또는 code-verifier 없음');
         }
       }
     );
 
-    // 4. post-init 쿠키 재확인 (3초 후)
-    setTimeout(() => {
-      const postCookies = document.cookie.split(';').map(c => c.trim()).filter(c => c.startsWith('sb-'));
-      log(`[3초 후] sb-* cookies: ${postCookies.map(c => c.split('=')[0]).join(', ') || 'NONE'}`);
-    }, 3000);
-
     const timeout = setTimeout(() => {
-      log('15초 timeout — auth_failed redirect');
       router.replace('/login?error=auth_failed');
     }, 15000);
 
@@ -108,13 +62,8 @@ function FallbackHandler() {
   }, [router, searchParams]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 p-4">
-      <p className="text-sm text-gray-500 mb-4">로그인 처리 중...</p>
-      <div className="w-full max-w-lg bg-white border rounded p-3 text-xs font-mono text-gray-700 whitespace-pre-wrap">
-        {debugInfo.map((line, i) => (
-          <div key={i}>{line}</div>
-        ))}
-      </div>
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <p className="text-sm text-gray-500">로그인 처리 중...</p>
     </div>
   );
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from 'next/navigation';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { createClient } from '@supabase/supabase-js';
 
 export default function LoginPage() {
   const supabase = createSupabaseBrowserClient();
@@ -13,8 +14,13 @@ export default function LoginPage() {
     const callbackUrl = returnTo
       ? `${window.location.origin}/auth/callback?next=${encodeURIComponent(returnTo)}`
       : `${window.location.origin}/auth/callback`;
-    await supabase.auth.signOut(); // stale auth 쿠키 정리 (PKCE code verifier 충돌 방지)
-    await supabase.auth.signInWithOAuth({
+    await supabase.auth.signOut(); // stale auth 쿠키 정리
+    // vanilla client — code-verifier를 localStorage에 저장 (cookie 기반 SSR client는 redirect chain에서 소실)
+    const pkceClient = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    );
+    await pkceClient.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: callbackUrl,


### PR DESCRIPTION
## Root Cause (확정)
디버그 UI 결과: code-verifier가 cookie에도 localStorage에도 없음.
`@supabase/ssr` `createBrowserClient`는 cookie storage 사용 → 4홉 redirect chain에서 code-verifier 쿠키 소실.

## Fix
1. **`login/page.tsx`**: `signInWithOAuth` → vanilla `createClient` 사용 → code-verifier가 **localStorage**에 저장
2. **`fallback/page.tsx`**: vanilla `createClient` (`flowType: 'pkce'`, `detectSessionInUrl: true`) → localStorage에서 code-verifier 읽어 교환 → `ssrClient.auth.setSession()`으로 cookie에 세션 bridge. 디버깅 UI 제거.

🤖 Generated with [Claude Code](https://claude.com/claude-code)