### PR TITLE
hotfix(P0): add flowType: 'pkce' to vanilla createClient in login page

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -19,6 +19,7 @@ export default function LoginPage() {
     const pkceClient = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { auth: { flowType: 'pkce' } },
     );
     await pkceClient.auth.signInWithOAuth({
       provider,


### PR DESCRIPTION
## Fix
`createClient` 기본값은 `implicit` flow — `flowType: 'pkce'` 미지정 시 Supabase가 `#access_token=...` hash 반환 → callback route `code` 파라미터 없음 → auth_failed.

1줄 추가: `{ auth: { flowType: 'pkce' } }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)