### PR TITLE
hotfix(P0): fix INITIAL_SESSION race with stale localStorage session

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -21,7 +21,7 @@ function FallbackHandler() {
 
     const { data: { subscription } } = pkceClient.auth.onAuthStateChange(
       async (event, session) => {
-        if ((event === 'SIGNED_IN' || event === 'INITIAL_SESSION') && session) {
+        if (event === 'SIGNED_IN' && session) {
           // SSR client(cookie)에 세션 bridge — 이후 서버 사이드 인증 유지
           const ssrClient = createSupabaseBrowserClient();
           await ssrClient.auth.setSession({

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -21,6 +21,7 @@ export default function LoginPage() {
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       { auth: { flowType: 'pkce' } },
     );
+    await pkceClient.auth.signOut(); // localStorage 잔류 세션 정리
     await pkceClient.auth.signInWithOAuth({
       provider,
       options: {


### PR DESCRIPTION
## Root Cause
`INITIAL_SESSION` 이벤트가 localStorage의 구 세션으로 발화 → 만료 토큰으로 `setSession` cookie bridge → 미들웨어 인증 실패 → `/login` 무음 복귀.

## Fix
1. **`fallback/page.tsx`**: `INITIAL_SESSION || SIGNED_IN` → `SIGNED_IN`만. 새 PKCE 교환 완료 후 발화하는 이벤트만 처리.
2. **`login/page.tsx`**: `pkceClient.auth.signOut()` 추가 → localStorage 잔류 세션 정리 후 OAuth 시작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)