### PR TITLE
hotfix(P0): remove pkceClient.signOut + debug logs in fallback

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -10,6 +10,11 @@ function FallbackHandler() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
+    const rawKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
+    console.error('[FALLBACK DEBUG] code-verifier key:', rawKey);
+    console.error('[FALLBACK DEBUG] code-verifier value:', rawKey ? localStorage.getItem(rawKey) : 'MISSING');
+    console.error('[FALLBACK DEBUG] URL code:', new URLSearchParams(window.location.search).get('code')?.slice(0, 8));
+
     const next = searchParams.get('next');
 
     // vanilla client — localStorage 기반, signInWithOAuth가 저장한 code-verifier를 여기서 읽음

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -21,7 +21,6 @@ export default function LoginPage() {
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
       { auth: { flowType: 'pkce' } },
     );
-    await pkceClient.auth.signOut(); // localStorage 잔류 세션 정리
     await pkceClient.auth.signInWithOAuth({
       provider,
       options: {


### PR DESCRIPTION
## Root Cause (v8 실패 원인)
`pkceClient.auth.signOut()`이 localStorage의 code-verifier를 포함한 모든 auth 데이터를 삭제 → PKCE 교환 실패.

## Fix
1. **`login/page.tsx`**: `pkceClient.auth.signOut()` 제거. SSR client `signOut()`만 유지.
2. **`fallback/page.tsx`**: debug `console.error` 3줄 추가 (code-verifier key/value/URL code 상태 확인용, 임시).

🤖 Generated with [Claude Code](https://claude.com/claude-code)