### PR TITLE
hotfix(P0): replace detectSessionInUrl with manual exchangeCodeForSession in fallback

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-
 import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createClient } from '@supabase/supabase-js';
@@ -10,60 +9,63 @@ function FallbackHandler() {
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    const rawKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
-    console.error('[FALLBACK DEBUG] code-verifier key:', rawKey);
-    console.error('[FALLBACK DEBUG] code-verifier value:', rawKey ? localStorage.getItem(rawKey) : 'MISSING');
-    console.error('[FALLBACK DEBUG] URL code:', new URLSearchParams(window.location.search).get('code')?.slice(0, 8));
-
+    const code = new URLSearchParams(window.location.search).get('code');
     const next = searchParams.get('next');
 
-    // vanilla client — localStorage 기반, signInWithOAuth가 저장한 code-verifier를 여기서 읽음
+    if (!code) {
+      router.replace('/login?error=auth_failed');
+      return;
+    }
+
+    // 디버그
+    const cvKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
+    console.error('[v10] code_verifier present:', !!cvKey, 'value:', cvKey ? localStorage.getItem(cvKey)?.slice(0, 8) : 'MISSING');
+
+    // 구 세션 제거 — _initialize()의 _recoverAndRefresh가 _saveSession을 호출해서 code-verifier를 삭제하는 것을 방지
+    const supabaseRef = (process.env.NEXT_PUBLIC_SUPABASE_URL || '').split('//')[1]?.split('.')[0] || '';
+    if (supabaseRef) {
+      localStorage.removeItem(`sb-${supabaseRef}-auth-token`);
+    }
+
     const pkceClient = createClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
       process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      { auth: { flowType: 'pkce', detectSessionInUrl: true } },
+      { auth: { flowType: 'pkce', detectSessionInUrl: false } },
     );
 
-    const { data: { subscription } } = pkceClient.auth.onAuthStateChange(
-      async (event, session) => {
-        if (event === 'SIGNED_IN' && session) {
-          // SSR client(cookie)에 세션 bridge — 이후 서버 사이드 인증 유지
-          const ssrClient = createSupabaseBrowserClient();
-          await ssrClient.auth.setSession({
-            access_token: session.access_token,
-            refresh_token: session.refresh_token,
-          });
-
-          const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
-          if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
-            router.replace('/mfa');
-            return;
-          }
-          if (next) { router.replace(next); return; }
-          const { data: { user } } = await ssrClient.auth.getUser();
-          if (user) {
-            const { data: membership } = await ssrClient
-              .from('org_members')
-              .select('org_id')
-              .eq('user_id', user.id)
-              .limit(1)
-              .maybeSingle();
-            router.replace(membership ? '/dashboard' : '/onboarding');
-            return;
-          }
-          router.replace('/dashboard');
-        }
+    pkceClient.auth.exchangeCodeForSession(code).then(async ({ data, error }) => {
+      if (error || !data.session) {
+        console.error('[v10] exchange failed:', error?.message);
+        router.replace('/login?error=auth_failed');
+        return;
       }
-    );
 
-    const timeout = setTimeout(() => {
-      router.replace('/login?error=auth_failed');
-    }, 15000);
+      const session = data.session;
+      const ssrClient = createSupabaseBrowserClient();
+      const { error: setError } = await ssrClient.auth.setSession({
+        access_token: session.access_token,
+        refresh_token: session.refresh_token,
+      });
+      if (setError) {
+        console.error('[v10] setSession failed:', setError.message);
+        router.replace('/login?error=auth_failed');
+        return;
+      }
 
-    return () => {
-      subscription.unsubscribe();
-      clearTimeout(timeout);
-    };
+      const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
+      if (next) { router.replace(next); return; }
+      const { data: { user } } = await ssrClient.auth.getUser();
+      if (user) {
+        const { data: membership } = await ssrClient.from('org_members').select('org_id').eq('user_id', user.id).limit(1).maybeSingle();
+        router.replace(membership ? '/dashboard' : '/onboarding');
+        return;
+      }
+      router.replace('/dashboard');
+    });
+
+    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
+    return () => clearTimeout(timeout);
   }, [router, searchParams]);
 
   return (
@@ -75,11 +77,7 @@ function FallbackHandler() {
 
 export default function AuthCallbackFallbackPage() {
   return (
-    <Suspense fallback={
-      <div className="flex min-h-screen items-center justify-center bg-gray-50">
-        <p className="text-sm text-gray-500">로그인 처리 중...</p>
-      </div>
-    }>
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center bg-gray-50"><p className="text-sm text-gray-500">로그인 처리 중...</p></div>}>
       <FallbackHandler />
     </Suspense>
   );


### PR DESCRIPTION
## Root Cause
`detectSessionInUrl: true` 자체가 레이스 원인 — `_initialize()`의 `_recoverAndRefresh`가 code-verifier를 삭제.

## Fix
- `detectSessionInUrl: false` 설정
- 수동 `exchangeCodeForSession(code)` 호출
- 교환 전 localStorage 구 세션(`sb-*-auth-token`) 제거
- 교환 성공 → `ssrClient.setSession()` bridge
- 디버그 로그 유지 (임시)

`login/page.tsx` 변경 없음 (v9 상태 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)