### PR TITLE
hotfix(P0): bypass Supabase client, use REST API for PKCE exchange (v11)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,54 +1,58 @@
 'use client';
-import { Suspense, useEffect } from 'react';
+
+import { Suspense, useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createClient } from '@supabase/supabase-js';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [debug, setDebug] = useState('starting...');
 
   useEffect(() => {
     const code = new URLSearchParams(window.location.search).get('code');
     const next = searchParams.get('next');
 
-    if (!code) {
-      router.replace('/login?error=auth_failed');
+    // Step 1: Supabase 클라이언트 생성 전 localStorage 직접 읽기 — _initialize() 우회
+    const cvKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
+    const cvRaw = cvKey ? localStorage.getItem(cvKey) : null;
+    const codeVerifier = cvRaw?.split('/')[0] ?? null; // "verifier/redirectType" 형식
+
+    setDebug(`code=${code?.slice(0,8)||'MISSING'} cv=${codeVerifier?.slice(0,8)||'MISSING'}`);
+
+    if (!code || !codeVerifier) {
+      setDebug(`FAIL: code=${!!code} cv=${!!codeVerifier}`);
+      setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
       return;
     }
 
-    // 디버그
-    const cvKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
-    console.error('[v10] code_verifier present:', !!cvKey, 'value:', cvKey ? localStorage.getItem(cvKey)?.slice(0, 8) : 'MISSING');
+    // Step 2: REST API 직접 호출 — Supabase 클라이언트 _initialize() 완전 우회
+    fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/token?grant_type=pkce`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      },
+      body: JSON.stringify({ auth_code: code, code_verifier: codeVerifier }),
+    }).then(async (res) => {
+      const data = await res.json();
+      setDebug(`exchange ${res.ok ? 'OK' : 'FAIL'}: ${res.ok ? 'got session' : JSON.stringify(data).slice(0, 80)}`);
 
-    // 구 세션 제거 — _initialize()의 _recoverAndRefresh가 _saveSession을 호출해서 code-verifier를 삭제하는 것을 방지
-    const supabaseRef = (process.env.NEXT_PUBLIC_SUPABASE_URL || '').split('//')[1]?.split('.')[0] || '';
-    if (supabaseRef) {
-      localStorage.removeItem(`sb-${supabaseRef}-auth-token`);
-    }
-
-    const pkceClient = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      { auth: { flowType: 'pkce', detectSessionInUrl: false } },
-    );
-
-    pkceClient.auth.exchangeCodeForSession(code).then(async ({ data, error }) => {
-      if (error || !data.session) {
-        console.error('[v10] exchange failed:', error?.message);
-        router.replace('/login?error=auth_failed');
+      if (!res.ok || !data.access_token) {
+        setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
         return;
       }
 
-      const session = data.session;
+      // Step 3: SSR cookie client에 세션 bridge
       const ssrClient = createSupabaseBrowserClient();
-      const { error: setError } = await ssrClient.auth.setSession({
-        access_token: session.access_token,
-        refresh_token: session.refresh_token,
+      const { error: setErr } = await ssrClient.auth.setSession({
+        access_token: data.access_token,
+        refresh_token: data.refresh_token,
       });
-      if (setError) {
-        console.error('[v10] setSession failed:', setError.message);
-        router.replace('/login?error=auth_failed');
+      setDebug(`setSession ${setErr ? `FAIL: ${setErr.message}` : 'OK'}`);
+
+      if (setErr) {
+        setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
         return;
       }
 
@@ -62,22 +66,31 @@ function FallbackHandler() {
         return;
       }
       router.replace('/dashboard');
+    }).catch(e => {
+      setDebug(`fetch error: ${e.message}`);
+      setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
     });
 
-    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
+    const timeout = setTimeout(() => {
+      setDebug('TIMEOUT 15s');
+      router.replace('/login?error=auth_failed');
+    }, 15000);
     return () => clearTimeout(timeout);
   }, [router, searchParams]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <p className="text-sm text-gray-500">로그인 처리 중...</p>
+      <div className="text-center space-y-2">
+        <p className="text-sm text-gray-500">로그인 처리 중...</p>
+        <p className="text-xs text-red-500 font-mono max-w-xs break-all px-4">{debug}</p>
+      </div>
     </div>
   );
 }
 
 export default function AuthCallbackFallbackPage() {
   return (
-    <Suspense fallback={<div className="flex min-h-screen items-center justify-center bg-gray-50"><p className="text-sm text-gray-500">로그인 처리 중...</p></div>}>
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><p className="text-sm text-gray-500">로그인 처리 중...</p></div>}>
       <FallbackHandler />
     </Suspense>
   );


### PR DESCRIPTION
## Root Cause
`createClient()` → `_initialize()` → `_recoverAndRefresh()` → `_saveSession()` 경로에서 code-verifier 삭제. `exchangeCodeForSession`도 내부 storage 읽기 경로에서 동일 race 발생.

## Fix
- `createClient()` 호출 완전 제거 → `_initialize()` 실행 없음
- localStorage에서 code-verifier 직접 읽기 (Supabase 클라이언트 개입 없음)
- `POST ${SUPABASE_URL}/auth/v1/token?grant_type=pkce` REST API 직접 호출
- 교환 성공 → `ssrClient.auth.setSession()` bridge
- 화면에 각 단계 디버그 상태 표시 (모바일 콘솔 없는 환경 대응)

🤖 Generated with [Claude Code](https://claude.com/claude-code)