### PR TITLE
hotfix(P0): unify to SSR cookie client, remove vanilla localStorage client (v12)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,96 +1,46 @@
 'use client';
 
-import { Suspense, useState, useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [debug, setDebug] = useState('starting...');
 
   useEffect(() => {
-    const code = new URLSearchParams(window.location.search).get('code');
     const next = searchParams.get('next');
+    const ssrClient = createSupabaseBrowserClient();
 
-    // Step 1: Supabase 클라이언트 생성 전 localStorage 직접 읽기 — _initialize() 우회
-    const cvKey = Object.keys(localStorage).find(k => k.includes('code-verifier'));
-    const cvRaw = cvKey ? localStorage.getItem(cvKey) : null;
-    const codeVerifier = cvRaw?.split('/')[0] ?? null; // "verifier/redirectType" 형식
-
-    setDebug(`code=${code?.slice(0,8)||'MISSING'} cv=${codeVerifier?.slice(0,8)||'MISSING'}`);
-
-    if (!code || !codeVerifier) {
-      setDebug(`FAIL: code=${!!code} cv=${!!codeVerifier}`);
-      setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
-      return;
-    }
-
-    // Step 2: REST API 직접 호출 — Supabase 클라이언트 _initialize() 완전 우회
-    fetch(`${process.env.NEXT_PUBLIC_SUPABASE_URL}/auth/v1/token?grant_type=pkce`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'apikey': process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      },
-      body: JSON.stringify({ auth_code: code, code_verifier: codeVerifier }),
-    }).then(async (res) => {
-      const data = await res.json();
-      setDebug(`exchange ${res.ok ? 'OK' : 'FAIL'}: ${res.ok ? 'got session' : JSON.stringify(data).slice(0, 80)}`);
-
-      if (!res.ok || !data.access_token) {
-        setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
-        return;
+    const { data: { subscription } } = ssrClient.auth.onAuthStateChange(async (event, session) => {
+      if (event === 'SIGNED_IN' && session) {
+        const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
+        if (next) { router.replace(next); return; }
+        const { data: { user } } = await ssrClient.auth.getUser();
+        if (user) {
+          const { data: membership } = await ssrClient.from('org_members').select('org_id').eq('user_id', user.id).limit(1).maybeSingle();
+          router.replace(membership ? '/dashboard' : '/onboarding');
+          return;
+        }
+        router.replace('/dashboard');
       }
-
-      // Step 3: SSR cookie client에 세션 bridge
-      const ssrClient = createSupabaseBrowserClient();
-      const { error: setErr } = await ssrClient.auth.setSession({
-        access_token: data.access_token,
-        refresh_token: data.refresh_token,
-      });
-      setDebug(`setSession ${setErr ? `FAIL: ${setErr.message}` : 'OK'}`);
-
-      if (setErr) {
-        setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
-        return;
-      }
-
-      const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
-      if (next) { router.replace(next); return; }
-      const { data: { user } } = await ssrClient.auth.getUser();
-      if (user) {
-        const { data: membership } = await ssrClient.from('org_members').select('org_id').eq('user_id', user.id).limit(1).maybeSingle();
-        router.replace(membership ? '/dashboard' : '/onboarding');
-        return;
-      }
-      router.replace('/dashboard');
-    }).catch(e => {
-      setDebug(`fetch error: ${e.message}`);
-      setTimeout(() => router.replace('/login?error=auth_failed'), 3000);
     });
 
-    const timeout = setTimeout(() => {
-      setDebug('TIMEOUT 15s');
-      router.replace('/login?error=auth_failed');
-    }, 15000);
-    return () => clearTimeout(timeout);
+    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
+    return () => { subscription.unsubscribe(); clearTimeout(timeout); };
   }, [router, searchParams]);
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <div className="text-center space-y-2">
-        <p className="text-sm text-gray-500">로그인 처리 중...</p>
-        <p className="text-xs text-red-500 font-mono max-w-xs break-all px-4">{debug}</p>
-      </div>
+      <p className="text-sm text-gray-500">로그인 처리 중...</p>
     </div>
   );
 }
 
 export default function AuthCallbackFallbackPage() {
   return (
-    <Suspense fallback={<div className="flex min-h-screen items-center justify-center"><p className="text-sm text-gray-500">로그인 처리 중...</p></div>}>
+    <Suspense fallback={<div className="flex min-h-screen items-center justify-center bg-gray-50"><p className="text-sm text-gray-500">로그인 처리 중...</p></div>}>
       <FallbackHandler />
     </Suspense>
   );

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -3,7 +3,6 @@
 import { useSearchParams } from 'next/navigation';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
-import { createClient } from '@supabase/supabase-js';
 
 export default function LoginPage() {
   const supabase = createSupabaseBrowserClient();
@@ -14,14 +13,8 @@ export default function LoginPage() {
     const callbackUrl = returnTo
       ? `${window.location.origin}/auth/callback?next=${encodeURIComponent(returnTo)}`
       : `${window.location.origin}/auth/callback`;
-    await supabase.auth.signOut(); // stale auth 쿠키 정리
-    // vanilla client — code-verifier를 localStorage에 저장 (cookie 기반 SSR client는 redirect chain에서 소실)
-    const pkceClient = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-      { auth: { flowType: 'pkce' } },
-    );
-    await pkceClient.auth.signInWithOAuth({
+    await supabase.auth.signOut(); // 구 쿠키 code_verifier 포함 전체 정리
+    await supabase.auth.signInWithOAuth({
       provider,
       options: {
         redirectTo: callbackUrl,


### PR DESCRIPTION
## Root Cause (최종 진단)
모바일 브라우저가 이전 OAuth callback URL 캐시 재사용 → CODE_1 + code_verifier_2 불일치 → `bad_code_verifier`. localStorage stale verifier 잔류가 구조적 문제.

## Fix
- `login/page.tsx`: `createClient` import 제거, vanilla pkceClient 제거. `supabase`(SSR cookie client) 직접 `signInWithOAuth` 사용.
- `fallback/page.tsx`: `createSupabaseBrowserClient()` (SSR cookie), `onAuthStateChange` `SIGNED_IN`만 처리. `createClient`/`useState`/debug 제거.

SSR cookie client로 단일화 → stale localStorage verifier 문제 원천 차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)