### PR TITLE
hotfix(P0): screen debug UI in fallback page for mobile diagnosis (v13, TEMP)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,19 +1,42 @@
 'use client';
 
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [debug, setDebug] = useState<string[]>([]);
 
   useEffect(() => {
+    const log = (msg: string) => setDebug(prev => [...prev, `[${new Date().toISOString().slice(11,19)}] ${msg}`]);
+
+    const code = searchParams.get('code');
     const next = searchParams.get('next');
+
+    log(`URL code: ${code?.slice(0, 12) || 'MISSING'}`);
+    log(`URL next: ${next || 'null'}`);
+    log(`cookies: ${document.cookie || 'EMPTY'}`);
+
     const ssrClient = createSupabaseBrowserClient();
 
+    if (code) {
+      ssrClient.auth.exchangeCodeForSession(code).then(({ data, error }) => {
+        if (error) {
+          log(`exchange FAIL: ${JSON.stringify(error)}`);
+        } else {
+          log(`exchange OK: ${data.session?.user?.email || 'no email'}`);
+        }
+      });
+    } else {
+      log('exchange SKIP: no code');
+    }
+
     const { data: { subscription } } = ssrClient.auth.onAuthStateChange(async (event, session) => {
+      log(`auth event: ${event} session: ${session ? 'YES' : 'null'}`);
       if (event === 'SIGNED_IN' && session) {
+        log('SIGNED_IN → redirecting...');
         const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
         if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
         if (next) { router.replace(next); return; }
@@ -27,13 +50,20 @@ function FallbackHandler() {
       }
     });
 
-    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
+    const timeout = setTimeout(() => {
+      log('TIMEOUT 30s → auth_failed');
+      router.replace('/login?error=auth_failed');
+    }, 30000);
+
     return () => { subscription.unsubscribe(); clearTimeout(timeout); };
   }, [router, searchParams]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
-      <p className="text-sm text-gray-500">로그인 처리 중...</p>
+    <div className="flex min-h-screen flex-col items-center justify-start bg-gray-50 p-4 pt-16">
+      <p className="text-sm text-gray-500 mb-4">로그인 처리 중...</p>
+      <pre className="w-full max-w-lg bg-white border rounded p-2 text-[10px] text-gray-700 whitespace-pre-wrap break-all">
+        {debug.join('\n') || '...'}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
## 목적
v12도 실패 — 선생님 모바일에서 추가 정보 없이 추측 불가. 화면에 직접 표시.

## 화면에 표시되는 항목
- `document.cookie` 전체 (code_verifier 쿠키 확인)
- URL `code`, `next` 파라미터
- `exchangeCodeForSession(code)` 결과 (OK 또는 에러 메시지)
- `onAuthStateChange` 이벤트 로그

## 변경
- timeout 15s → 30s (디버그 읽을 시간 확보)
- `createSupabaseBrowserClient()` SSR client 유지
- `onAuthStateChange` SIGNED_IN 정상 리다이렉트 유지

⚠️ TEMP — 원인 확인 후 제거 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)