### PR TITLE
hotfix(P0): fallback dual-tier PKCE exchange with localStorage backup (v14)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -1,69 +1,97 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+async function redirectAfterLogin(
+  client: ReturnType<typeof createSupabaseBrowserClient>,
+  router: ReturnType<typeof useRouter>,
+  next: string | null,
+) {
+  const { data: aal } = await client.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
+  if (next) { router.replace(next); return; }
+  const { data: { user } } = await client.auth.getUser();
+  if (user) {
+    const { data: membership } = await client.from('org_members').select('org_id').eq('user_id', user.id).limit(1).maybeSingle();
+    router.replace(membership ? '/dashboard' : '/onboarding');
+    return;
+  }
+  router.replace('/dashboard');
+}
 
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [debug, setDebug] = useState<string[]>([]);
 
   useEffect(() => {
-    const log = (msg: string) => setDebug(prev => [...prev, `[${new Date().toISOString().slice(11,19)}] ${msg}`]);
-
     const code = searchParams.get('code');
     const next = searchParams.get('next');
-
-    log(`URL code: ${code?.slice(0, 12) || 'MISSING'}`);
-    log(`URL next: ${next || 'null'}`);
-    log(`cookies: ${document.cookie || 'EMPTY'}`);
+    if (!code) { router.replace('/login?error=auth_failed'); return; }
 
     const ssrClient = createSupabaseBrowserClient();
 
-    if (code) {
-      ssrClient.auth.exchangeCodeForSession(code).then(({ data, error }) => {
-        if (error) {
-          log(`exchange FAIL: ${JSON.stringify(error)}`);
-        } else {
-          log(`exchange OK: ${data.session?.user?.email || 'no email'}`);
-        }
-      });
-    } else {
-      log('exchange SKIP: no code');
-    }
+    // 1차: @supabase/ssr 정상 교환 시도
+    ssrClient.auth.exchangeCodeForSession(code).then(async ({ data, error }) => {
+      if (!error && data.session) {
+        localStorage.removeItem('__pkce_cv_backup');
+        redirectAfterLogin(ssrClient, router, next);
+        return;
+      }
 
-    const { data: { subscription } } = ssrClient.auth.onAuthStateChange(async (event, session) => {
-      log(`auth event: ${event} session: ${session ? 'YES' : 'null'}`);
-      if (event === 'SIGNED_IN' && session) {
-        log('SIGNED_IN → redirecting...');
-        const { data: aal } = await ssrClient.auth.mfa.getAuthenticatorAssuranceLevel();
-        if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') { router.replace('/mfa'); return; }
-        if (next) { router.replace(next); return; }
-        const { data: { user } } = await ssrClient.auth.getUser();
-        if (user) {
-          const { data: membership } = await ssrClient.from('org_members').select('org_id').eq('user_id', user.id).limit(1).maybeSingle();
-          router.replace(membership ? '/dashboard' : '/onboarding');
-          return;
+      // 2차: localStorage 백업으로 REST API 직접 교환 (쿠키 리다이렉트 중 소실 대응)
+      if (error?.code === 'pkce_code_verifier_not_found') {
+        const backup = localStorage.getItem('__pkce_cv_backup');
+        if (!backup) { router.replace('/login?error=auth_failed'); return; }
+
+        // base64url 디코딩 (base64- prefix 제거)
+        let codeVerifier = backup;
+        if (codeVerifier.startsWith('base64-')) {
+          try {
+            const b64 = codeVerifier.substring(7);
+            codeVerifier = new TextDecoder().decode(
+              Uint8Array.from(atob(b64.replace(/-/g, '+').replace(/_/g, '/')), c => c.charCodeAt(0))
+            );
+          } catch { /* use raw value */ }
         }
-        router.replace('/dashboard');
+
+        try {
+          const res = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=pkce`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'apikey': SUPABASE_ANON_KEY,
+            },
+            body: JSON.stringify({ auth_code: code, code_verifier: codeVerifier }),
+          });
+          const tokenData = await res.json();
+          if (!res.ok) { router.replace('/login?error=auth_failed'); return; }
+
+          await ssrClient.auth.setSession({
+            access_token: tokenData.access_token,
+            refresh_token: tokenData.refresh_token,
+          });
+          localStorage.removeItem('__pkce_cv_backup');
+          redirectAfterLogin(ssrClient, router, next);
+        } catch {
+          router.replace('/login?error=auth_failed');
+        }
+      } else {
+        router.replace('/login?error=auth_failed');
       }
     });
 
-    const timeout = setTimeout(() => {
-      log('TIMEOUT 30s → auth_failed');
-      router.replace('/login?error=auth_failed');
-    }, 30000);
-
-    return () => { subscription.unsubscribe(); clearTimeout(timeout); };
+    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
+    return () => clearTimeout(timeout);
   }, [router, searchParams]);
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-start bg-gray-50 p-4 pt-16">
-      <p className="text-sm text-gray-500 mb-4">로그인 처리 중...</p>
-      <pre className="w-full max-w-lg bg-white border rounded p-2 text-[10px] text-gray-700 whitespace-pre-wrap break-all">
-        {debug.join('\n') || '...'}
-      </pre>
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <p className="text-sm text-gray-500">로그인 처리 중...</p>
     </div>
   );
 }


### PR DESCRIPTION
## Root Cause (확정)
login 페이지: `code-verifier in cookies: true` → fallback 페이지: `pkce_code_verifier_not_found`.
Amplify CloudFront/Lambda 리다이렉트 체인에서 `@supabase/ssr` code_verifier 쿠키 삭제됨.

## Fix (2-tier)
1. SSR `exchangeCodeForSession` 정상 시도
2. `pkce_code_verifier_not_found` 에러 시 `localStorage.__pkce_cv_backup` (login 페이지에서 저장) + REST API `POST /auth/v1/token?grant_type=pkce` 직접 호출
3. base64url 디코딩 처리 포함
4. 교환 성공 → `setSession()` + 리다이렉트

🤖 Generated with [Claude Code](https://claude.com/claude-code)