### PR TITLE
[P0-HOTFIX] fix: OAuth fallback 이중 PKCE 교환 방지

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -34,19 +34,34 @@ function FallbackHandler() {
     if (!code) { router.replace('/login?error=auth_failed'); return; }
 
     const ssrClient = createSupabaseBrowserClient();
+    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
 
-    // 1차: @supabase/ssr 정상 교환 시도
-    ssrClient.auth.exchangeCodeForSession(code).then(async ({ data, error }) => {
-      if (!error && data.session) {
+    (async () => {
+      // createBrowserClient._initialize() may have already auto-exchanged the code
+      // via detectSessionInUrl. getSession() awaits initializePromise, so if the
+      // auto-exchange already succeeded we skip the explicit call entirely.
+      const { data: { session: existingSession } } = await ssrClient.auth.getSession();
+      if (existingSession) {
+        clearTimeout(timeout);
         localStorage.removeItem('__pkce_cv_backup');
-        redirectAfterLogin(ssrClient, router, next);
+        await redirectAfterLogin(ssrClient, router, next);
         return;
       }
 
-      // 2차: localStorage 백업으로 REST API 직접 교환 (쿠키 리다이렉트 중 소실 대응)
+      // No session yet (auto-exchange failed, e.g. incognito with no PKCE cookie) →
+      // try explicit exchange using the code from URL.
+      const { data, error } = await ssrClient.auth.exchangeCodeForSession(code);
+      if (!error && data.session) {
+        clearTimeout(timeout);
+        localStorage.removeItem('__pkce_cv_backup');
+        await redirectAfterLogin(ssrClient, router, next);
+        return;
+      }
+
+      // 2차: PKCE 쿠키 유실 → localStorage 백업으로 REST API 직접 교환
       if (error?.code === 'pkce_code_verifier_not_found') {
         const backup = localStorage.getItem('__pkce_cv_backup');
-        if (!backup) { router.replace('/login?error=auth_failed'); return; }
+        if (!backup) { clearTimeout(timeout); router.replace('/login?error=auth_failed'); return; }
 
         // base64url 디코딩 (base64- prefix 제거)
         let codeVerifier = backup;
@@ -69,23 +84,25 @@ function FallbackHandler() {
             body: JSON.stringify({ auth_code: code, code_verifier: codeVerifier }),
           });
           const tokenData = await res.json();
-          if (!res.ok) { router.replace('/login?error=auth_failed'); return; }
+          if (!res.ok) { clearTimeout(timeout); router.replace('/login?error=auth_failed'); return; }
 
           await ssrClient.auth.setSession({
             access_token: tokenData.access_token,
             refresh_token: tokenData.refresh_token,
           });
+          clearTimeout(timeout);
           localStorage.removeItem('__pkce_cv_backup');
-          redirectAfterLogin(ssrClient, router, next);
+          await redirectAfterLogin(ssrClient, router, next);
         } catch {
+          clearTimeout(timeout);
           router.replace('/login?error=auth_failed');
         }
       } else {
+        clearTimeout(timeout);
         router.replace('/login?error=auth_failed');
       }
-    });
+    })();
 
-    const timeout = setTimeout(() => router.replace('/login?error=auth_failed'), 15000);
     return () => clearTimeout(timeout);
   }, [router, searchParams]);
 


### PR DESCRIPTION
## 문제
일반 브라우저(쿠키 있는 상태)에서 Google/GitHub OAuth 로그인 실패. 시크릿탭에서만 성공하는 역설적 상황.

## 근본 원인
`fallback/page.tsx`에서 이중 토큰 교환 발생:
1. `createBrowserClient()` 생성 시 내부 `_initialize()`가 URL `?code=`를 자동 감지 → **EXCHANGE #1**
2. 이후 명시적 `exchangeCodeForSession(code)` 호출 → 이미 소진된 code 재사용 → **EXCHANGE #2 실패**

시크릿탭에서 되는 이유: PKCE 쿠키 없어서 `_initialize()` 자동 교환 실패 → 명시적 호출만 작동.

## 수정 내용
`getSession()`은 내부 `initializePromise`를 await하므로, `_initialize()` 완료 후 세션 존재 여부를 확인:
- **세션 존재**: `_initialize()` 자동 교환 성공 → 바로 리다이렉트 (명시적 교환 스킵)
- **세션 없음**: 자동 교환 실패 (incognito 등) → 명시적 교환 → localStorage 백업 REST API 순서로 시도

## AC 검증
- [ ] AC1: 일반 브라우저(쿠키 있음)에서 Google OAuth 로그인 성공
- [ ] AC2: 시크릿탭에서도 로그인 성공 (회귀 없음)
- [ ] AC3: 로그인 후 올바른 페이지 리다이렉트 (/dashboard 또는 /onboarding)
- [ ] AC4: MFA 플로우 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)