### PR TITLE
[P0-DEBUG] fallback: cookie/localStorage 진단 UI 추가

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -4,10 +4,38 @@ import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
+interface DiagInfo {
+  cookieEnabled: boolean;
+  cookieNames: string[];
+  hasSbCookie: boolean;
+  hasCodeVerifier: boolean;
+  localStorageSbKeys: string[];
+  exchangeError?: string;
+}
+
+function collectDiag(): Omit<DiagInfo, 'exchangeError'> {
+  const cookieEnabled = navigator.cookieEnabled;
+  const allCookies = document.cookie ? document.cookie.split(';').map(c => c.trim()) : [];
+  const cookieNames = allCookies.map(c => c.split('=')[0].trim());
+  const hasSbCookie = cookieNames.some(n => n.startsWith('sb-'));
+  const hasCodeVerifier = cookieNames.some(n => n.includes('code-verifier'));
+
+  const localStorageSbKeys: string[] = [];
+  try {
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k && k.startsWith('sb-')) localStorageSbKeys.push(k);
+    }
+  } catch { /* localStorage 접근 불가 */ }
+
+  return { cookieEnabled, cookieNames, hasSbCookie, hasCodeVerifier, localStorageSbKeys };
+}
+
 function FallbackHandler() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [status, setStatus] = useState('로그인 처리 중...');
+  const [diag, setDiag] = useState<DiagInfo | null>(null);
 
   useEffect(() => {
     const code = searchParams.get('code');
@@ -17,13 +45,12 @@ function FallbackHandler() {
     const supabase = createSupabaseBrowserClient();
 
     (async () => {
+      const diagSnapshot = collectDiag();
+
       const { error } = await supabase.auth.exchangeCodeForSession(code);
       if (error) {
-        setStatus('인증 실패. 다시 시도해주세요.');
-        const params = new URLSearchParams({ error: 'auth_failed' });
-        if (error.code) params.set('error_code', error.code);
-        if (error.message) params.set('error_message', error.message);
-        setTimeout(() => router.replace(`/login?${params.toString()}`), 2000);
+        setDiag({ ...diagSnapshot, exchangeError: `${error.code ?? 'unknown'}: ${error.message}` });
+        setStatus('인증 실패. 아래 정보를 스크린샷으로 캡처해주세요.');
         return;
       }
 
@@ -46,8 +73,19 @@ function FallbackHandler() {
   }, [router, searchParams]);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 p-6">
       <p className="text-sm text-gray-500">{status}</p>
+      {diag && (
+        <div className="w-full max-w-lg rounded-lg border border-red-200 bg-red-50 p-4 text-xs font-mono text-red-900 space-y-1">
+          <p className="font-bold text-red-700">🔍 Auth Debug Info</p>
+          <p>cookieEnabled: {String(diag.cookieEnabled)}</p>
+          <p>hasSbCookie: {String(diag.hasSbCookie)}</p>
+          <p>hasCodeVerifier: {String(diag.hasCodeVerifier)}</p>
+          <p>cookieNames: [{diag.cookieNames.join(', ') || '(empty)'}]</p>
+          <p>localStorageSbKeys: [{diag.localStorageSbKeys.join(', ') || '(empty)'}]</p>
+          {diag.exchangeError && <p>exchangeError: {diag.exchangeError}</p>}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 목적
쿠키 속성 수정 후에도 모바일 크롬 `pkce_code_verifier_not_found` 재현. 실제 쿠키 상태를 파악하기 위한 진단 UI.

## 추가 내용
`exchangeCodeForSession` 실패 시 화면에 표시:
- `navigator.cookieEnabled`
- 모든 쿠키 이름 (값 마스킹)
- `sb-*` 쿠키 존재 여부
- `code-verifier` 쿠키 존재 여부
- `localStorage`의 `sb-*` 키 목록
- 교환 에러 코드 + 메시지

→ 선생님이 스크린샷으로 캡처 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)