### PR TITLE
[P0] fix: code-verifier preflight 체크 복원 — exchangeCodeForSession removeItem 쿠키 소거 방지

### DIFF
--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { resolveAppUrl } from '@/services/app-url';
 
@@ -9,6 +10,20 @@ export async function GET(request: Request) {
   const origin = resolveAppUrl(null);
 
   if (code) {
+    const fallbackParams = new URLSearchParams({ code });
+    if (next) fallbackParams.set('next', next);
+    const fallbackUrl = `${origin}/auth/callback/fallback?${fallbackParams.toString()}`;
+
+    // code_verifier 쿠키 없으면 서버 교환 skip.
+    // exchangeCodeForSession 내부가 code_verifier 유무와 무관하게 removeItem을 호출하여
+    // 삭제 Set-Cookie 헤더를 반환하고, 이로 인해 브라우저의 code_verifier 쿠키가 소거됨.
+    // 서버에 쿠키가 없으면 바로 fallback으로 이동 → 브라우저 쿠키 보존 → fallback 교환 성공.
+    const cookieStore = await cookies();
+    const hasCodeVerifier = cookieStore.getAll().some(c => c.name.includes('code-verifier'));
+    if (!hasCodeVerifier) {
+      return NextResponse.redirect(fallbackUrl);
+    }
+
     const supabase = await createSupabaseServerClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
 
@@ -36,10 +51,8 @@ export async function GET(request: Request) {
       return NextResponse.redirect(`${origin}/dashboard`);
     }
 
-    // 서버 교환 실패 시 클라이언트 fallback으로 (CloudFront 쿠키 미전달 등 환경 이슈 대비)
-    const params = new URLSearchParams({ code });
-    if (next) params.set('next', next);
-    return NextResponse.redirect(`${origin}/auth/callback/fallback?${params.toString()}`);
+    // 서버 교환 실패 시 클라이언트 fallback으로
+    return NextResponse.redirect(fallbackUrl);
   }
 
   return NextResponse.redirect(`${origin}/login?error=auth_failed`);


### PR DESCRIPTION
## 근본 원인 확정

`exchangeCodeForSession` 내부가 code_verifier 존재 여부와 무관하게 `removeItem`을 호출 → 삭제 Set-Cookie 헤더 반환 → 브라우저가 redirect 처리 시 code_verifier 쿠키 삭제 → fallback에서 쿠키 없음 → 교환 실패.

## 수정

서버에 code_verifier 쿠키가 없으면 `exchangeCodeForSession` 호출 자체를 skip하고 바로 fallback으로 redirect:
- 서버에 쿠키 있음 → 서버 교환 시도 (정상 경로, 데스크톱)
- 서버에 쿠키 없음 → SDK removeItem 미호출 → 브라우저 쿠키 보존 → fallback 클라이언트 교환 성공 (모바일)

진단 UI(`fallback/page.tsx`)는 유지 — 이번에도 실패 시 추가 데이터 수집 가능.

## 맥락

PR #212에서 추가 → PR #213(AC5)에서 제거 → 이번에 복원. 이번엔 제거 이유(코드 소비)와 반대 이유(removeItem 쿠키 소거)가 충돌하는데, removeItem 소거가 실제 원인으로 확정됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)