### PR TITLE
fix: rename code→auth_code in fallback URL to prevent PKCE race

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -40,7 +40,7 @@ function FallbackHandler() {
   const [diag, setDiag] = useState<DiagInfo | null>(null);
 
   useEffect(() => {
-    const code = searchParams.get('code');
+    const code = searchParams.get('auth_code');
     const next = searchParams.get('next');
     const serverCv = searchParams.get('server_cv') ?? 'unknown';
     if (!code) { router.replace('/login?error=no_code'); return; }

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: Request) {
     const cookieStore = await cookies();
     const hasCodeVerifier = cookieStore.getAll().some(c => c.name.includes('code-verifier'));
 
-    const fallbackParams = new URLSearchParams({ code });
+    const fallbackParams = new URLSearchParams({ auth_code: code });
     if (next) fallbackParams.set('next', next);
     fallbackParams.set('server_cv', hasCodeVerifier ? '1' : '0');
     const fallbackUrl = `${origin}/auth/callback/fallback?${fallbackParams.toString()}`;


### PR DESCRIPTION
## 문제
`createBrowserClient` (`detectSessionInUrl: true`) 가 fallback URL의 `?code=` 파라미터를 감지 → `_initialize()` 자동 PKCE exchange 시도 → 명시적 `exchangeCodeForSession` 호출과 lock 경합 → 페이지 hang.

## 수정 (4줄)
- `route.ts`: `{ code }` → `{ auth_code: code }` (fallback URL 파라미터명 변경)
- `fallback/page.tsx`: `get('code')` → `get('auth_code')`

`auth_code` 파라미터는 `_initialize()`가 PKCE callback으로 인식하지 않으므로 race condition 해소.

🤖 Generated with [Claude Code](https://claude.com/claude-code)