### PR TITLE
fix: use dedicated supabase client in fallback to prevent _initialize() hang

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { createBrowserClient } from '@supabase/ssr';
 
 interface DiagInfo {
   cookieEnabled: boolean;
@@ -21,15 +21,13 @@ function collectDiag(serverCv: string, restoredFromSession: boolean): Omit<DiagI
   const cookieNames = allCookies.map(c => c.split('=')[0].trim());
   const hasSbCookie = cookieNames.some(n => n.startsWith('sb-'));
   const hasCodeVerifier = cookieNames.some(n => n.includes('code-verifier'));
-
   const localStorageSbKeys: string[] = [];
   try {
     for (let i = 0; i < localStorage.length; i++) {
       const k = localStorage.key(i);
       if (k && k.startsWith('sb-')) localStorageSbKeys.push(k);
     }
-  } catch { /* localStorage 접근 불가 */ }
-
+  } catch {}
   return { cookieEnabled, cookieNames, hasSbCookie, hasCodeVerifier, localStorageSbKeys, serverCv, restoredFromSession };
 }
 
@@ -45,44 +43,74 @@ function FallbackHandler() {
     const serverCv = searchParams.get('server_cv') ?? 'unknown';
     if (!code) { router.replace('/login?error=no_code'); return; }
 
-    const supabase = createSupabaseBrowserClient();
+    let restoredFromSession = false;
 
     (async () => {
-      // sessionStorage 백업에서 code_verifier 복원 (OAuth redirect chain 중 쿠키 유실 대비)
-      let restoredFromSession = false;
       try {
-        const backup = sessionStorage.getItem('sb-pkce-backup');
-        if (backup && !document.cookie.includes('code-verifier')) {
-          document.cookie = backup + '; Path=/; SameSite=Lax; Secure; Max-Age=600';
-          restoredFromSession = true;
+        // 1. sessionStorage 복원 (클라이언트 생성 전)
+        try {
+          const backup = sessionStorage.getItem('sb-pkce-backup');
+          if (backup && !document.cookie.includes('code-verifier')) {
+            document.cookie = backup + '; Path=/; SameSite=Lax; Secure; Max-Age=600';
+            restoredFromSession = true;
+          }
+          sessionStorage.removeItem('sb-pkce-backup');
+        } catch {}
+
+        const diagSnapshot = collectDiag(serverCv, restoredFromSession);
+
+        // 2. 전용 클라이언트 — detectSessionInUrl:false + isSingleton:false
+        // _initialize()가 세션 복원만 수행 (URL 파싱/자동 교환 안 함), 싱글톤 캐시와 격리
+        const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+        const supabase = createBrowserClient(
+          process.env['NEXT_PUBLIC_SUPABASE_URL']!,
+          process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
+          {
+            isSingleton: false,
+            cookieOptions: {
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+              sameSite: 'lax' as const,
+              secure: true,
+              path: '/',
+            },
+            auth: { detectSessionInUrl: false, flowType: 'pkce' },
+          },
+        );
+
+        // 3. exchange + 15초 timeout (hang 방지)
+        const { error } = await Promise.race([
+          supabase.auth.exchangeCodeForSession(code),
+          new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('Exchange timed out (15s)')), 15000)
+          ),
+        ]);
+
+        if (error) {
+          setDiag({ ...diagSnapshot, exchangeError: `${error.code ?? 'unknown'}: ${error.message}` });
+          setStatus('인증 실패. 아래 정보를 스크린샷으로 캡처해주세요.');
+          return;
         }
-        sessionStorage.removeItem('sb-pkce-backup');
-      } catch { /* sessionStorage 접근 불가 */ }
 
-      const diagSnapshot = collectDiag(serverCv, restoredFromSession);
+        const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
+          router.replace('/mfa'); return;
+        }
+        if (next && next.startsWith('/')) { router.replace(next); return; }
 
-      const { error } = await supabase.auth.exchangeCodeForSession(code);
-      if (error) {
-        setDiag({ ...diagSnapshot, exchangeError: `${error.code ?? 'unknown'}: ${error.message}` });
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          const { data: membership } = await supabase
+            .from('org_members').select('org_id')
+            .eq('user_id', user.id).limit(1).maybeSingle();
+          router.replace(membership ? '/dashboard' : '/onboarding');
+          return;
+        }
+        router.replace('/dashboard');
+      } catch (err) {
+        const diagSnapshot = collectDiag(serverCv, restoredFromSession);
+        setDiag({ ...diagSnapshot, exchangeError: `uncaught: ${String(err)}` });
         setStatus('인증 실패. 아래 정보를 스크린샷으로 캡처해주세요.');
-        return;
       }
-
-      const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
-      if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
-        router.replace('/mfa'); return;
-      }
-      if (next && next.startsWith('/')) { router.replace(next); return; }
-
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        const { data: membership } = await supabase
-          .from('org_members').select('org_id')
-          .eq('user_id', user.id).limit(1).maybeSingle();
-        router.replace(membership ? '/dashboard' : '/onboarding');
-        return;
-      }
-      router.replace('/dashboard');
     })();
   }, [router, searchParams]);
 


### PR DESCRIPTION
## 원인

`auth_code` 변경은 `_isPKCECallback` 자동 감지만 방지. `exchangeCodeForSession` 내부 `await this.initializePromise` → `_recoverAndRefresh()` hang은 방지 불가 → 무한 대기.

## 핵심 변경 3가지

1. **`createBrowserClient` 직접 import + `detectSessionInUrl: false` + `isSingleton: false`**
   - `_initialize()`가 세션 복원만 수행 (URL 파싱 / 자동 교환 없음)
   - 싱글톤 캐시와 격리

2. **전체 try-catch 감싸기** — throw 시에도 진단 박스 표시

3. **15초 timeout** — hang 시 자동 진단 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)