### PR TITLE
fix(P0): read cv from SDK sessionStorage key, cookie fallback

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -85,24 +85,29 @@ function FallbackHandler() {
 
     (async () => {
       try {
-        // 1. code_verifier: 쿠키 우선, 없으면 sb-pkce-verifier sessionStorage
+        // 1. code_verifier: SDK sessionStorage 우선, 없으면 쿠키 fallback
         const projectRef = getProjectRef();
         const CV_COOKIE = `sb-${projectRef}-auth-token-code-verifier`;
-        let codeVerifier = getCookieValue(CV_COOKIE);
-        let cvPrefix = CV_COOKIE;
+        let codeVerifier: string | null | undefined;
+        let cvPrefix = 'N/A';
 
-        if (codeVerifier) {
-          cvSource = 'cookie';
-        } else {
-          try {
-            const ssVal = sessionStorage.getItem('sb-pkce-verifier');
-            if (ssVal) {
-              codeVerifier = ssVal;
-              cvSource = 'sessionStorage';
-              cvPrefix = 'sb-pkce-verifier';
-              sessionStorage.removeItem('sb-pkce-verifier');
-            }
-          } catch {}
+        try {
+          const ssVal = sessionStorage.getItem(CV_COOKIE);
+          if (ssVal) {
+            codeVerifier = ssVal;
+            cvSource = 'sessionStorage';
+            cvPrefix = ssVal.slice(0, 8);
+            sessionStorage.removeItem(CV_COOKIE);
+          }
+        } catch {}
+
+        if (!codeVerifier) {
+          const cookieVal = getCookieValue(CV_COOKIE);
+          if (cookieVal) {
+            codeVerifier = cookieVal;
+            cvSource = 'cookie';
+            cvPrefix = cookieVal.slice(0, 8);
+          }
         }
 
         const diagSnapshot = collectDiag(serverCv, cvSource, cvPrefix);


### PR DESCRIPTION
## 변경 요약
5차 수정. `login/page.tsx`가 SDK의 sessionStorage adapter를 통해 code_verifier를 sessionStorage에 직접 기록 → fallback이 SDK 네이티브 키로 읽기.

### fallback/page.tsx
- `sb-pkce-verifier` 수동 키 제거 (v4)
- SDK 네이티브 키 `sb-{ref}-auth-token-code-verifier`로 sessionStorage 먼저 조회
- 없으면 쿠키 fallback
- `cvPrefix` = 실제 code_verifier 앞 8자 (진단)

### 대응 SaaS PR
- SaaS PR #169: `login/page.tsx`에 `createClient` + sessionStorage adapter 주입

## 근본 원인
쿠키 full string을 직접 파싱하면 value 인코딩이 SDK 내부 원본과 불일치할 수 있음.
SDK 자체 storage adapter로 sessionStorage를 주입하면 SDK가 원본 그대로 기록/읽기.

🤖 Generated with [Claude Code](https://claude.com/claude-code)