### PR TITLE
fix(P0): JSON.parse SDK-serialized code_verifier from sessionStorage/cookie

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -92,21 +92,21 @@ function FallbackHandler() {
         let cvPrefix = 'N/A';
 
         try {
-          const ssVal = sessionStorage.getItem(CV_COOKIE);
-          if (ssVal) {
-            codeVerifier = ssVal;
+          const ssRaw = sessionStorage.getItem(CV_COOKIE);
+          if (ssRaw) {
+            try { codeVerifier = JSON.parse(ssRaw); } catch { codeVerifier = ssRaw; }
             cvSource = 'sessionStorage';
-            cvPrefix = ssVal.slice(0, 8);
+            cvPrefix = (codeVerifier ?? '').slice(0, 8);
             sessionStorage.removeItem(CV_COOKIE);
           }
         } catch {}
 
         if (!codeVerifier) {
-          const cookieVal = getCookieValue(CV_COOKIE);
-          if (cookieVal) {
-            codeVerifier = cookieVal;
+          const cookieRaw = getCookieValue(CV_COOKIE);
+          if (cookieRaw) {
+            try { codeVerifier = JSON.parse(cookieRaw); } catch { codeVerifier = cookieRaw; }
             cvSource = 'cookie';
-            cvPrefix = cookieVal.slice(0, 8);
+            cvPrefix = (codeVerifier ?? '').slice(0, 8);
           }
         }
 


### PR DESCRIPTION
## 변경 요약
6차 수정 진단 결과: `cvPrefix: "5237166` (쌍따옴표 포함) 확인.

SDK의 `setItemAsync`가 `JSON.stringify(codeVerifier)` 형태로 저장. `sessionStorage.getItem()` 직접 읽기는 `"5237166..."` (따옴표 포함) 반환 → REST API에 그대로 전송 → `bad_code_verifier`.

**수정:** sessionStorage + cookie 양쪽 모두 `JSON.parse()` 언래핑. 파싱 실패 시 raw 값 fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)