### PR TITLE
fix(P0): restore setSession for SDK-compatible cookies, drop post-SDK calls

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']!;
 const SUPABASE_ANON_KEY = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!;
@@ -94,7 +95,20 @@ function FallbackHandler() {
 
         const tokenData = await res.json();
         removeCookie(CV_KEY);
-        writeSessionCookies(tokenData);
+
+        // setSession으로 SDK 표준 쿠키 기록 (서버 getUser 호환 필수)
+        try {
+          const supabase = createSupabaseBrowserClient();
+          await Promise.race([
+            supabase.auth.setSession({
+              access_token: tokenData.access_token,
+              refresh_token: tokenData.refresh_token,
+            }),
+            new Promise<never>((_, r) => setTimeout(() => r(new Error('timeout')), 10000)),
+          ]);
+        } catch {
+          writeSessionCookies(tokenData);
+        }
 
         const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
         window.location.replace(redirectTo);


### PR DESCRIPTION
## 변경 요약
8차 수정(`writeSessionCookies` 직접 기록)으로 대시보드 도달은 성공했지만, 메뉴 네비게이션 시 매번 `/login` redirect. 서버의 `createSupabaseServerClient().auth.getUser()`가 수동 쿠키 형식 불일치로 세션 인식 실패.

**수정:**
- `setSession()` 복원 + 10초 timeout
- timeout/실패 시 `writeSessionCookies(tokenData)` fallback 유지
- `getAuthenticatorAssuranceLevel()` / `getUser()` / `org_members` 쿼리 전부 없음 (7차 hang 원인)
- `window.location.replace()` hard redirect

SaaS는 서브모듈 범프만.

🤖 Generated with [Claude Code](https://claude.com/claude-code)