### PR TITLE
fix(P0): isSingleton:false setSession + non-chunked base cookie cleanup

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { createBrowserClient } from '@supabase/ssr';
 
 const SUPABASE_URL = process.env['NEXT_PUBLIC_SUPABASE_URL']!;
 const SUPABASE_ANON_KEY = process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!;
@@ -29,7 +29,7 @@ function writeSessionCookies(session: Record<string, unknown>) {
   const COOKIE_BASE = `sb-${getProjectRef()}-auth-token`;
   document.cookie.split(';').forEach(c => {
     const name = c.trim().split('=')[0];
-    if (name.startsWith(COOKIE_BASE + '.')) {
+    if (name === COOKIE_BASE || name.startsWith(COOKIE_BASE + '.')) {
       document.cookie = `${name}=; Path=/; Max-Age=0${domainAttr}`;
     }
   });
@@ -96,9 +96,18 @@ function FallbackHandler() {
         const tokenData = await res.json();
         removeCookie(CV_KEY);
 
-        // setSession으로 SDK 표준 쿠키 기록 (서버 getUser 호환 필수)
+        // isSingleton:false 전용 클라이언트로 setSession — 싱글톤 lock 경합 없음
         try {
-          const supabase = createSupabaseBrowserClient();
+          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+          const supabase = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+            isSingleton: false,
+            cookieOptions: {
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+              sameSite: 'lax' as const,
+              secure: true,
+              path: '/',
+            },
+          });
           await Promise.race([
             supabase.auth.setSession({
               access_token: tokenData.access_token,


### PR DESCRIPTION
## 변경 요약
9차 수정에서 대시보드 도달은 성공했지만 메뉴 네비게이션 시 매번 /login redirect.
원인: `createSupabaseBrowserClient()` (싱글톤)의 `setSession`이 stale 쿠키로 `_initialize()` hang → timeout → `writeSessionCookies` fallback이 raw JSON 형식으로 기록 → 서버 SDK `getUser()` 호환 안 됨.

**수정:**
1. `isSingleton: false` 전용 `createBrowserClient`로 `setSession` 호출 — 싱글톤 lock 경합 없음
2. `writeSessionCookies` fallback에서 non-chunked base cookie(`COOKIE_BASE` 자체)도 삭제 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)