### PR TITLE
feat(inbox): operator cockpit Phase A.1 backend foundation

### DIFF
--- a/apps/web/src/app/api/inbox/[id]/dismiss/route.ts
+++ b/apps/web/src/app/api/inbox/[id]/dismiss/route.ts
@@ -1,0 +1,46 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { parseBody, dismissInboxItemSchema } from '@sprintable/shared';
+import { NotFoundError } from '@sprintable/core-storage';
+
+/** POST /api/inbox/:id/dismiss — 항목 dismiss (사용자가 무시) */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    if (!id) return ApiErrors.badRequest('id required');
+
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const ossMode = isOssMode();
+    const dbClient: SupabaseClient | undefined = ossMode
+      ? undefined
+      : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    const parsed = await parseBody(request, dismissInboxItemSchema);
+    if (!parsed.success) return parsed.response;
+
+    const repo = await createInboxItemRepository(dbClient);
+    try {
+      const result = await repo.dismiss(id, me.org_id, {
+        resolved_by: me.id,
+        resolved_note: parsed.data.reason ?? null,
+      });
+      return apiSuccess(result);
+    } catch (err: unknown) {
+      if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
+      const msg = err instanceof Error ? err.message : '';
+      if (msg.includes('already')) return apiError('CONFLICT', msg, 409);
+      throw err;
+    }
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/inbox/[id]/resolve/route.test.ts
+++ b/apps/web/src/app/api/inbox/[id]/resolve/route.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createSupabaseServerClient,
+  createSupabaseAdminClient,
+  getAuthContext,
+  createInboxItemRepository,
+  isOssMode,
+} = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  createSupabaseAdminClient: vi.fn(),
+  getAuthContext: vi.fn(),
+  createInboxItemRepository: vi.fn(),
+  isOssMode: vi.fn(() => false),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getAuthContext };
+});
+vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository, isOssMode }));
+
+import { POST } from './route';
+import { NotFoundError } from '@sprintable/core-storage';
+
+const ME = {
+  id: 'tm-1',
+  org_id: 'org-1',
+  project_id: 'proj-1',
+  project_name: 'Proj',
+  type: 'human' as const,
+  rateLimitExceeded: false,
+  rateLimitRemaining: 299,
+  rateLimitResetAt: 0,
+};
+
+// Use a valid RFC 4122 v4 UUID (variant nibble must be 8/9/a/b).
+const VALID_OPTION_ID = '123e4567-e89b-42d3-a456-426614174000';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/inbox/i1/resolve', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const PARAMS = { params: Promise.resolve({ id: 'i1' }) };
+
+describe('POST /api/inbox/[id]/resolve', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isOssMode.mockReturnValue(false);
+    createSupabaseServerClient.mockResolvedValue({});
+    getAuthContext.mockResolvedValue(ME);
+  });
+
+  it('401 without auth', async () => {
+    getAuthContext.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
+    expect(res.status).toBe(401);
+  });
+
+  it('200 success calls repo.resolve with assignee = me.id', async () => {
+    const item = { id: 'i1', state: 'resolved', resolved_option_id: VALID_OPTION_ID };
+    const repo = { resolve: vi.fn().mockResolvedValue(item) };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await POST(makeRequest({ choice: VALID_OPTION_ID, note: 'ok' }), PARAMS);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.state).toBe('resolved');
+    expect(repo.resolve).toHaveBeenCalledWith('i1', 'org-1', {
+      resolved_by: 'tm-1',
+      resolved_option_id: VALID_OPTION_ID,
+      resolved_note: 'ok',
+    });
+  });
+
+  it('400 on missing choice', async () => {
+    createInboxItemRepository.mockResolvedValue({ resolve: vi.fn() });
+
+    const res = await POST(makeRequest({ note: 'ok' }), PARAMS);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('VALIDATION_FAILED');
+  });
+
+  it('400 on non-uuid choice', async () => {
+    createInboxItemRepository.mockResolvedValue({ resolve: vi.fn() });
+
+    const res = await POST(makeRequest({ choice: 'not-uuid' }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it('404 when repo throws NotFoundError', async () => {
+    const repo = {
+      resolve: vi.fn().mockRejectedValue(new NotFoundError('Inbox item not found: i1')),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error.code).toBe('NOT_FOUND');
+  });
+
+  it('409 when item already resolved (double-resolve)', async () => {
+    const repo = {
+      resolve: vi.fn().mockRejectedValue(new Error('Inbox item already resolved')),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error.code).toBe('CONFLICT');
+  });
+
+  it('400 when option_id not in options', async () => {
+    const repo = {
+      resolve: vi.fn().mockRejectedValue(new Error('Option id xxx not found in inbox item options')),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
+    expect(res.status).toBe(400);
+  });
+
+  it('OSS mode passes undefined dbClient', async () => {
+    isOssMode.mockReturnValue(true);
+    const repo = { resolve: vi.fn().mockResolvedValue({ id: 'i1', state: 'resolved' }) };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
+    expect(createInboxItemRepository).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/web/src/app/api/inbox/[id]/resolve/route.ts
+++ b/apps/web/src/app/api/inbox/[id]/resolve/route.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { parseBody, resolveInboxItemSchema } from '@sprintable/shared';
+import { NotFoundError } from '@sprintable/core-storage';
+
+/** POST /api/inbox/:id/resolve — 의사결정 처리 */
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    if (!id) return ApiErrors.badRequest('id required');
+
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const ossMode = isOssMode();
+    const dbClient: SupabaseClient | undefined = ossMode
+      ? undefined
+      : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    const parsed = await parseBody(request, resolveInboxItemSchema);
+    if (!parsed.success) return parsed.response;
+
+    const repo = await createInboxItemRepository(dbClient);
+    try {
+      const result = await repo.resolve(id, me.org_id, {
+        resolved_by: me.id,
+        resolved_option_id: parsed.data.choice,
+        resolved_note: parsed.data.note ?? null,
+      });
+      return apiSuccess(result);
+    } catch (err: unknown) {
+      if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
+      // 이미 resolved/dismissed 상태(SQLite throws Error, Postgres throws 23514)
+      const msg = err instanceof Error ? err.message : '';
+      if (msg.includes('already')) return apiError('CONFLICT', msg, 409);
+      if (msg.includes('Option id') || msg.includes('option_id')) return ApiErrors.badRequest(msg);
+      throw err;
+    }
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/inbox/incoming/route.ts
+++ b/apps/web/src/app/api/inbox/incoming/route.ts
@@ -1,0 +1,72 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { incomingInboxItemSchema } from '@sprintable/shared';
+import { verifyIncomingHmac } from '@/services/inbox-item.service';
+
+/**
+ * POST /api/inbox/incoming
+ *
+ * External agents push HITL requests via this endpoint. v1: HMAC-SHA256 with
+ * shared secret AGENT_INBOX_HMAC_SECRET. Phase B: per-agent rotation.
+ *
+ * Headers:
+ *   - x-sprintable-signature: hex-encoded HMAC of raw body
+ *   - x-sprintable-org-id: target org_id (since shared secret can't bind agent → org)
+ *
+ * Body: matches incomingInboxItemSchema (project_id, assignee_member_id, kind, ...).
+ */
+export async function POST(request: Request) {
+  try {
+    const orgIdHeader = request.headers.get('x-sprintable-org-id');
+    if (!orgIdHeader) return ApiErrors.badRequest('x-sprintable-org-id header required');
+
+    // Read raw body for HMAC, then parse JSON manually (parseBody consumes body)
+    const rawBody = await request.text();
+    const verified = await verifyIncomingHmac(request, rawBody);
+    if (!verified) return ApiErrors.unauthorized();
+
+    let parsedRaw: unknown;
+    try {
+      parsedRaw = JSON.parse(rawBody);
+    } catch {
+      return ApiErrors.badRequest('Invalid JSON body');
+    }
+
+    const result = incomingInboxItemSchema.safeParse(parsedRaw);
+    if (!result.success) {
+      const issues = result.error.issues.map((i) => ({
+        path: i.path.join('.'),
+        message: i.message,
+      }));
+      return ApiErrors.validationFailed(issues);
+    }
+
+    const ossMode = isOssMode();
+    const repo = await createInboxItemRepository(ossMode ? undefined : createSupabaseAdminClient());
+
+    const item = await repo.create({
+      org_id: orgIdHeader,
+      project_id: result.data.project_id,
+      assignee_member_id: result.data.assignee_member_id,
+      kind: result.data.kind,
+      title: result.data.title,
+      context: result.data.context ?? null,
+      agent_summary: result.data.agent_summary ?? null,
+      origin_chain: result.data.origin_chain,
+      options: result.data.options,
+      after_decision: result.data.after_decision ?? null,
+      from_agent_id: result.data.from_agent_id ?? null,
+      story_id: result.data.story_id ?? null,
+      memo_id: result.data.memo_id ?? null,
+      priority: result.data.priority,
+      source_type: 'webhook',
+      source_id: result.data.source_id,
+    });
+
+    return apiSuccess(item, undefined, 201);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/inbox/route.test.ts
+++ b/apps/web/src/app/api/inbox/route.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createSupabaseServerClient,
+  createSupabaseAdminClient,
+  getAuthContext,
+  createInboxItemRepository,
+  isOssMode,
+  cookies,
+} = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  createSupabaseAdminClient: vi.fn(),
+  getAuthContext: vi.fn(),
+  createInboxItemRepository: vi.fn(),
+  isOssMode: vi.fn(() => false),
+  cookies: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/supabase/admin', () => ({ createSupabaseAdminClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getAuthContext };
+});
+vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository, isOssMode }));
+vi.mock('next/headers', () => ({ cookies }));
+
+import { GET } from './route';
+
+const ME = {
+  id: 'tm-1',
+  org_id: 'org-1',
+  project_id: 'proj-1',
+  project_name: 'Proj',
+  type: 'human' as const,
+  rateLimitExceeded: false,
+  rateLimitRemaining: 299,
+  rateLimitResetAt: 0,
+};
+
+describe('GET /api/inbox', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isOssMode.mockReturnValue(false);
+    createSupabaseServerClient.mockResolvedValue({});
+    cookies.mockResolvedValue({ get: vi.fn(() => undefined) });
+    getAuthContext.mockResolvedValue(ME);
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    getAuthContext.mockResolvedValueOnce(null);
+    const res = await GET(new Request('http://localhost/api/inbox'));
+    expect(res.status).toBe(401);
+  });
+
+  it('lists pending inbox items for the current assignee + project + org', async () => {
+    const repo = {
+      list: vi.fn().mockResolvedValue([
+        { id: 'i1', org_id: 'org-1', kind: 'approval', state: 'pending', created_at: '2026-04-26T00:00:00Z' },
+      ]),
+      count: vi.fn().mockResolvedValue({
+        total: 1,
+        byKind: { approval: 1, decision: 0, blocker: 0, mention: 0 },
+      }),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await GET(new Request('http://localhost/api/inbox'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+    expect(body.meta.pendingCount).toBe(1);
+    expect(body.meta.countsByKind.approval).toBe(1);
+    expect(repo.list).toHaveBeenCalledWith(expect.objectContaining({
+      org_id: 'org-1',
+      project_id: 'proj-1',
+      assignee_member_id: 'tm-1',
+      state: 'pending',
+    }));
+  });
+
+  it('rejects invalid kind', async () => {
+    const repo = { list: vi.fn(), count: vi.fn() };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await GET(new Request('http://localhost/api/inbox?kind=invalid'));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe('BAD_REQUEST');
+  });
+
+  it('rejects invalid state', async () => {
+    const repo = { list: vi.fn(), count: vi.fn() };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await GET(new Request('http://localhost/api/inbox?state=closed'));
+    expect(res.status).toBe(400);
+  });
+
+  it('forwards kind filter to repo when valid', async () => {
+    const repo = {
+      list: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue({ total: 0, byKind: { approval: 0, decision: 0, blocker: 0, mention: 0 } }),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    await GET(new Request('http://localhost/api/inbox?kind=blocker'));
+    expect(repo.list).toHaveBeenCalledWith(expect.objectContaining({ kind: 'blocker' }));
+  });
+
+  it('uses cookie project_id when present', async () => {
+    cookies.mockResolvedValue({
+      get: vi.fn((name: string) => (name === 'sprintable_current_project_id' ? { value: 'cookie-proj' } : undefined)),
+    });
+    const repo = {
+      list: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue({ total: 0, byKind: { approval: 0, decision: 0, blocker: 0, mention: 0 } }),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    await GET(new Request('http://localhost/api/inbox'));
+    expect(repo.list).toHaveBeenCalledWith(expect.objectContaining({ project_id: 'cookie-proj' }));
+  });
+
+  it('OSS mode skips dbClient and uses local repo', async () => {
+    isOssMode.mockReturnValue(true);
+    const repo = {
+      list: vi.fn().mockResolvedValue([]),
+      count: vi.fn().mockResolvedValue({ total: 0, byKind: { approval: 0, decision: 0, blocker: 0, mention: 0 } }),
+    };
+    createInboxItemRepository.mockResolvedValue(repo);
+
+    const res = await GET(new Request('http://localhost/api/inbox'));
+    expect(res.status).toBe(200);
+    expect(createInboxItemRepository).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,0 +1,72 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext, CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
+import { cookies } from 'next/headers';
+import {
+  isOssMode,
+  createInboxItemRepository,
+} from '@/lib/storage/factory';
+import { INBOX_KINDS, INBOX_STATES } from '@sprintable/shared';
+import type { InboxKind, InboxState } from '@sprintable/core-storage';
+
+/** GET — inbox 목록 (현재 project + 본인 assignee 기준, state=pending 기본) */
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const ossMode = isOssMode();
+    const dbClient: SupabaseClient | undefined = ossMode
+      ? undefined
+      : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    const { searchParams } = new URL(request.url);
+    const kindParam = searchParams.get('kind');
+    const stateParam = searchParams.get('state') ?? 'pending';
+    const cursor = searchParams.get('cursor') ?? undefined;
+    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') ?? '50', 10) || 50, 1), 100);
+
+    if (kindParam && !INBOX_KINDS.includes(kindParam as InboxKind)) {
+      return ApiErrors.badRequest(`Invalid kind: ${kindParam}`);
+    }
+    if (!INBOX_STATES.includes(stateParam as InboxState)) {
+      return ApiErrors.badRequest(`Invalid state: ${stateParam}`);
+    }
+
+    // project_id 우선순위: query → cookie → me.project_id
+    const cookieStore = await cookies();
+    const projectIdFromCookie = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value;
+    const projectId = searchParams.get('project_id') ?? projectIdFromCookie ?? me.project_id;
+
+    const repo = await createInboxItemRepository(dbClient);
+    const items = await repo.list({
+      org_id: me.org_id,
+      project_id: projectId,
+      assignee_member_id: me.id,
+      kind: kindParam ? (kindParam as InboxKind) : undefined,
+      state: stateParam as InboxState,
+      cursor,
+      limit,
+    });
+
+    const counts = await repo.count({
+      org_id: me.org_id,
+      project_id: projectId,
+      assignee_member_id: me.id,
+      state: 'pending',
+    });
+
+    return apiSuccess(items, {
+      pendingCount: counts.total,
+      countsByKind: counts.byKind,
+      nextCursor: items.length === limit ? items[items.length - 1]!.created_at : null,
+    });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/lib/storage/factory.ts
+++ b/apps/web/src/lib/storage/factory.ts
@@ -12,6 +12,7 @@ import type {
   IAgentRunBillingRepository,
   IAgentRunRepository,
   IAgentApiKeyRepository,
+  IInboxItemRepository,
 } from '@sprintable/core-storage';
 
 export function isOssMode(): boolean {
@@ -106,6 +107,16 @@ export async function createTeamMemberRepository(supabase?: unknown): Promise<IT
   const { SupabaseTeamMemberRepository } = await import('@sprintable/storage-supabase');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return new SupabaseTeamMemberRepository(supabase as any);
+}
+
+export async function createInboxItemRepository(supabase?: unknown): Promise<IInboxItemRepository> {
+  if (isOssMode()) {
+    const { SqliteInboxItemRepository, getDb } = await import('@sprintable/storage-sqlite');
+    return new SqliteInboxItemRepository(getDb());
+  }
+  const { SupabaseInboxItemRepository } = await import('@sprintable/storage-supabase');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return new SupabaseInboxItemRepository(supabase as any);
 }
 
 // ============================================================================

--- a/apps/web/src/services/inbox-item.service.ts
+++ b/apps/web/src/services/inbox-item.service.ts
@@ -1,0 +1,138 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  InboxItem,
+  CreateInboxItemInput,
+  ResolveInboxItemInput,
+  DismissInboxItemInput,
+  ReassignInboxItemInput,
+  InboxKind,
+  OriginNode,
+  InboxOption,
+} from '@sprintable/core-storage';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { createInboxItemSchema, originChainSchema, inboxOptionsSchema } from '@sprintable/shared';
+
+// Operator Cockpit Phase A — high-level service for producers
+// Producers: agent_runs lifecycle hook, memo @mention emit, /api/inbox/incoming webhook.
+// Each producer constructs CreateInboxItemInput and calls InboxItemService.create().
+
+export interface ProduceApprovalArgs {
+  org_id: string;
+  project_id: string;
+  assignee_member_id: string;
+  title: string;
+  context?: string | null;
+  agent_summary?: string | null;
+  origin_chain?: OriginNode[];
+  options?: InboxOption[];
+  after_decision?: string | null;
+  from_agent_id?: string | null;
+  story_id?: string | null;
+  memo_id?: string | null;
+  source_id: string;
+  priority?: 'high' | 'normal';
+}
+
+export class InboxItemService {
+  constructor(private readonly supabase?: SupabaseClient) {}
+
+  /**
+   * Create new inbox_item. Idempotent on (org_id, source_type, source_id, kind).
+   * Validates origin_chain + options via Zod before insert.
+   */
+  async create(input: CreateInboxItemInput): Promise<InboxItem> {
+    // Validate at single boundary point (codex tactical fix #10 — Zod at write time)
+    const validated = createInboxItemSchema.parse(input);
+    const repo = await createInboxItemRepository(this.supabase ?? createSupabaseAdminClient());
+    return repo.create(validated);
+  }
+
+  /**
+   * Convenience producer: agent_run completion → approval inbox item.
+   * Used by agent_runs lifecycle hook in apps/web/src/services/agent-runs.ts.
+   */
+  async produceApprovalFromAgentRun(args: ProduceApprovalArgs & { run_id: string }): Promise<InboxItem> {
+    return this.create({
+      ...args,
+      kind: 'approval',
+      source_type: 'agent_run',
+      source_id: args.run_id,
+      origin_chain: args.origin_chain ?? [{ type: 'run', id: args.run_id }],
+      priority: args.priority ?? 'normal',
+    });
+  }
+
+  /**
+   * Convenience producer: memo @mention → mention inbox item.
+   */
+  async produceMentionFromMemo(args: ProduceApprovalArgs & { memo_id: string }): Promise<InboxItem> {
+    return this.create({
+      ...args,
+      kind: 'mention',
+      source_type: 'memo_mention',
+      source_id: `${args.memo_id}:${args.assignee_member_id}`,
+      memo_id: args.memo_id,
+      origin_chain: args.origin_chain ?? [{ type: 'memo', id: args.memo_id }],
+      priority: args.priority ?? 'normal',
+    });
+  }
+
+  /**
+   * resolve — assignee 본인 또는 admin이 호출. RLS가 권한 검증.
+   * @throws NotFoundError, error with code 23514 if already resolved.
+   */
+  async resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem> {
+    if (isOssMode()) {
+      const repo = await createInboxItemRepository();
+      return repo.resolve(id, orgId, input);
+    }
+    const repo = await createInboxItemRepository(this.supabase);
+    return repo.resolve(id, orgId, input);
+  }
+
+  async dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem> {
+    if (isOssMode()) {
+      const repo = await createInboxItemRepository();
+      return repo.dismiss(id, orgId, input);
+    }
+    const repo = await createInboxItemRepository(this.supabase);
+    return repo.dismiss(id, orgId, input);
+  }
+
+  async reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem> {
+    if (isOssMode()) {
+      const repo = await createInboxItemRepository();
+      return repo.reassign(id, orgId, input);
+    }
+    const repo = await createInboxItemRepository(this.supabase);
+    return repo.reassign(id, orgId, input);
+  }
+}
+
+/**
+ * HMAC verification for /api/inbox/incoming webhook.
+ * Phase A v1: shared secret via AGENT_INBOX_HMAC_SECRET env. Phase B: per-agent rotation.
+ */
+export async function verifyIncomingHmac(request: Request, rawBody: string): Promise<boolean> {
+  const secret = process.env['AGENT_INBOX_HMAC_SECRET'];
+  if (!secret) return false; // 안전한 기본 — secret 미설정 시 모두 거부
+
+  const signature = request.headers.get('x-sprintable-signature');
+  if (!signature) return false;
+
+  const { createHmac, timingSafeEqual } = await import('node:crypto');
+  const expected = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const expectedBuf = Buffer.from(expected, 'hex');
+  const actualBuf = Buffer.from(signature, 'hex');
+  if (expectedBuf.length !== actualBuf.length) return false;
+  return timingSafeEqual(expectedBuf, actualBuf);
+}
+
+/**
+ * Re-export Zod schemas for convenience at API route layer.
+ */
+export { originChainSchema, inboxOptionsSchema };
+
+/** Type alias for callers. */
+export type { InboxKind, OriginNode, InboxOption };

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -103,5 +103,23 @@ export type {
   CreateAgentApiKeyInput,
 } from './interfaces/IAgentApiKeyRepository';
 
+export type {
+  IInboxItemRepository,
+  InboxItem,
+  CreateInboxItemInput,
+  InboxListFilters,
+  ResolveInboxItemInput,
+  DismissInboxItemInput,
+  ReassignInboxItemInput,
+  InboxItemCount,
+  InboxKind,
+  InboxState,
+  InboxPriority,
+  InboxSourceType,
+  OutboxEventType,
+  OriginNode,
+  InboxOption,
+} from './interfaces/IInboxItemRepository';
+
 export { NullSubscriptionRepository } from './null/NullSubscriptionRepository';
 export { NullAgentRunBillingRepository } from './null/NullAgentRunBillingRepository';

--- a/packages/core-storage/src/interfaces/IInboxItemRepository.ts
+++ b/packages/core-storage/src/interfaces/IInboxItemRepository.ts
@@ -1,0 +1,108 @@
+import type { PaginationOptions } from '../types';
+
+// Operator Cockpit Phase A — inbox_items repository interface
+// See packages/db/supabase/migrations/20260426170000_inbox_items.sql
+// See packages/shared/src/schemas/inbox.ts for Zod validation
+
+export type InboxKind = 'approval' | 'decision' | 'blocker' | 'mention';
+export type InboxPriority = 'high' | 'normal';
+export type InboxState = 'pending' | 'resolved' | 'dismissed';
+export type InboxSourceType = 'agent_run' | 'memo_mention' | 'webhook' | 'manual';
+export type OutboxEventType = 'resolved' | 'dismissed' | 'reassigned';
+
+export interface OriginNode {
+  type: 'memo' | 'story' | 'run' | 'initiative';
+  id: string;
+}
+
+export interface InboxOption {
+  id: string; // uuid — stable reference for resolved_option_id
+  label: string;
+  kind: 'approve' | 'approve-alt' | 'reassign' | 'changes';
+  consequence: string;
+}
+
+export interface InboxItem {
+  id: string;
+  org_id: string;
+  project_id: string;
+  assignee_member_id: string;
+  kind: InboxKind;
+  title: string;
+  context: string | null;
+  agent_summary: string | null;
+  origin_chain: OriginNode[];
+  options: InboxOption[];
+  after_decision: string | null;
+  from_agent_id: string | null;
+  story_id: string | null;
+  memo_id: string | null;
+  priority: InboxPriority;
+  state: InboxState;
+  resolved_by: string | null;
+  resolved_option_id: string | null;
+  resolved_note: string | null;
+  source_type: InboxSourceType;
+  source_id: string;
+  waiting_since: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+export interface CreateInboxItemInput {
+  org_id: string;
+  project_id: string;
+  assignee_member_id: string;
+  kind: InboxKind;
+  title: string;
+  context?: string | null;
+  agent_summary?: string | null;
+  origin_chain?: OriginNode[];
+  options?: InboxOption[];
+  after_decision?: string | null;
+  from_agent_id?: string | null;
+  story_id?: string | null;
+  memo_id?: string | null;
+  priority?: InboxPriority;
+  source_type: InboxSourceType;
+  source_id: string;
+}
+
+export interface InboxListFilters extends PaginationOptions {
+  org_id: string;
+  project_id?: string;
+  assignee_member_id?: string;
+  kind?: InboxKind;
+  state?: InboxState;
+}
+
+export interface ResolveInboxItemInput {
+  resolved_by: string; // team_member id
+  resolved_option_id: string;
+  resolved_note?: string | null;
+}
+
+export interface DismissInboxItemInput {
+  resolved_by: string;
+  resolved_note?: string | null;
+}
+
+export interface ReassignInboxItemInput {
+  new_assignee_member_id: string;
+  reassigned_by: string;
+}
+
+export interface InboxItemCount {
+  total: number;
+  byKind: Record<InboxKind, number>;
+}
+
+export interface IInboxItemRepository {
+  create(input: CreateInboxItemInput): Promise<InboxItem>;
+  list(filters: InboxListFilters): Promise<InboxItem[]>;
+  get(id: string, orgId: string): Promise<InboxItem | null>;
+  count(filters: Omit<InboxListFilters, 'limit' | 'cursor'>): Promise<InboxItemCount>;
+  resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem>;
+  dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem>;
+  reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem>;
+}

--- a/packages/db/supabase/migrations/20260426170000_inbox_items.sql
+++ b/packages/db/supabase/migrations/20260426170000_inbox_items.sql
@@ -1,0 +1,127 @@
+-- Operator Cockpit Phase A.1 — inbox_items + RLS + agent type validation trigger
+-- See .omc/plans/2026-04-26-01-operator-cockpit-redesign.md
+-- Decisions applied: D1 (org_id + team_members(id) + project_id filter), D2 (typed JSONB origin_chain),
+--                    Codex tactical: assignee_member_id rename, resolved_option_id uuid, idempotency unique,
+--                    explicit RLS policies (5), GIN index on origin_chain.
+
+-- ============================================================
+-- 1. inbox_items
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.inbox_items (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id              uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  project_id          uuid NOT NULL REFERENCES public.projects(id) ON DELETE CASCADE,
+  assignee_member_id  uuid NOT NULL REFERENCES public.team_members(id) ON DELETE CASCADE,
+  kind                text NOT NULL CHECK (kind IN ('approval', 'decision', 'blocker', 'mention')),
+  title               text NOT NULL,
+  context             text,
+  agent_summary       text,
+  origin_chain        jsonb NOT NULL DEFAULT '[]'::jsonb,
+    -- typed array: [{type:'memo'|'story'|'run'|'initiative', id:'<uuid>'}]
+    -- application-layer Zod validation; DB does not enforce referential integrity on chain nodes
+  options             jsonb NOT NULL DEFAULT '[]'::jsonb,
+    -- [{id:'<uuid>', label, kind:'approve'|'approve-alt'|'reassign'|'changes', consequence}]
+  after_decision      text,
+  from_agent_id       uuid REFERENCES public.team_members(id) ON DELETE SET NULL,
+  story_id            uuid REFERENCES public.stories(id) ON DELETE SET NULL,
+  memo_id             uuid REFERENCES public.memos(id) ON DELETE SET NULL,
+  priority            text NOT NULL DEFAULT 'normal' CHECK (priority IN ('high', 'normal')),
+  state               text NOT NULL DEFAULT 'pending' CHECK (state IN ('pending', 'resolved', 'dismissed')),
+  resolved_by         uuid REFERENCES public.team_members(id) ON DELETE SET NULL,
+  resolved_option_id  uuid,
+    -- references options[].id (jsonb), stable across label/kind drift
+  resolved_note       text,
+  source_type         text NOT NULL CHECK (source_type IN ('agent_run', 'memo_mention', 'webhook', 'manual')),
+  source_id           text NOT NULL,
+    -- references agent_runs.id / memos.id / external webhook id / manual creator id
+  waiting_since       timestamptz NOT NULL DEFAULT now(),
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  resolved_at         timestamptz,
+  CONSTRAINT inbox_items_source_unique UNIQUE (org_id, source_type, source_id, kind)
+);
+
+COMMENT ON TABLE public.inbox_items IS 'HITL 결정 큐 — operator cockpit inbox';
+
+-- ============================================================
+-- 2. Indexes
+-- ============================================================
+CREATE INDEX idx_inbox_items_org_id            ON public.inbox_items(org_id);
+CREATE INDEX idx_inbox_items_project_id        ON public.inbox_items(project_id);
+CREATE INDEX idx_inbox_items_assignee          ON public.inbox_items(assignee_member_id);
+CREATE INDEX idx_inbox_items_pending           ON public.inbox_items(state) WHERE state = 'pending';
+CREATE INDEX idx_inbox_items_kind              ON public.inbox_items(kind);
+CREATE INDEX idx_inbox_items_created_at        ON public.inbox_items(created_at DESC);
+CREATE INDEX idx_inbox_items_origin_chain_gin  ON public.inbox_items USING gin (origin_chain);
+CREATE INDEX idx_inbox_items_options_gin       ON public.inbox_items USING gin (options);
+
+-- ============================================================
+-- 3. agent type validation trigger (reuse pattern from agent_runs)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.validate_inbox_item_from_agent()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  _type text;
+BEGIN
+  IF NEW.from_agent_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+  SELECT type INTO _type FROM public.team_members WHERE id = NEW.from_agent_id;
+  IF _type IS NULL OR _type != 'agent' THEN
+    RAISE EXCEPTION 'inbox_items.from_agent_id must reference a team_member with type=agent';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_inbox_items_validate_agent
+  BEFORE INSERT OR UPDATE ON public.inbox_items
+  FOR EACH ROW EXECUTE FUNCTION public.validate_inbox_item_from_agent();
+
+-- ============================================================
+-- 4. RLS — explicit policies (5)
+-- inbox_items는 agent reasoning + approval choices를 노출하므로 notifications보다 strict.
+-- ============================================================
+ALTER TABLE public.inbox_items ENABLE ROW LEVEL SECURITY;
+
+-- 4.1 SELECT — assignee 본인만
+CREATE POLICY "inbox_items_select_assignee" ON public.inbox_items FOR SELECT
+  USING (
+    org_id IN (SELECT public.get_user_org_ids())
+    AND assignee_member_id IN (
+      SELECT id FROM public.team_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- 4.2 SELECT — admin escalation (audit/escalation 용도)
+CREATE POLICY "inbox_items_select_admin" ON public.inbox_items FOR SELECT
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- 4.3 UPDATE — assignee 본인 (state, resolved_*)
+CREATE POLICY "inbox_items_update_assignee" ON public.inbox_items FOR UPDATE
+  USING (
+    assignee_member_id IN (
+      SELECT id FROM public.team_members
+      WHERE user_id = auth.uid()
+    )
+  );
+
+-- 4.4 UPDATE — admin (reassign 용도, assignee_member_id 변경 가능)
+CREATE POLICY "inbox_items_update_admin" ON public.inbox_items FOR UPDATE
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- 4.5 INSERT — admin org 또는 service_role
+CREATE POLICY "inbox_items_insert" ON public.inbox_items FOR INSERT
+  WITH CHECK (
+    org_id IN (SELECT public.get_user_admin_org_ids())
+    AND EXISTS (
+      SELECT 1 FROM public.team_members tm
+      WHERE tm.id = assignee_member_id AND tm.org_id = org_id
+    )
+  );
+
+-- 4.6 DELETE — admin only
+CREATE POLICY "inbox_items_delete" ON public.inbox_items FOR DELETE
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));

--- a/packages/db/supabase/migrations/20260426170100_team_members_color.sql
+++ b/packages/db/supabase/migrations/20260426170100_team_members_color.sql
@@ -1,0 +1,24 @@
+-- Operator Cockpit Phase A — agent identity columns on team_members
+-- Phase A에서 inbox-row가 agent identity(컬러+이름)에 즉시 의존하므로 phase A 첫 PR에 동봉.
+-- See .omc/plans/2026-04-26-01-operator-cockpit-redesign.md (Phase B.3 — Codebase 정렬: agents 테이블 X, team_members 사용)
+
+ALTER TABLE public.team_members
+  ADD COLUMN IF NOT EXISTS color      text NOT NULL DEFAULT '#3385f8',
+  ADD COLUMN IF NOT EXISTS agent_role text;
+  -- agent_role: 'backend'|'frontend'|'qa'|'design'|'pm'|'api' for type='agent', NULL for human
+
+-- Hex color check constraint (codex tactical fix #6 — stored CSS injection 방지)
+ALTER TABLE public.team_members
+  ADD CONSTRAINT team_members_color_hex_check
+    CHECK (color ~ '^#[0-9a-fA-F]{6}$');
+
+-- agent_role only meaningful for agents (codex tactical fix #7 — humans don't need role tag)
+ALTER TABLE public.team_members
+  ADD CONSTRAINT team_members_agent_role_only_for_agents
+    CHECK (
+      (type = 'agent' AND (agent_role IS NULL OR agent_role IN ('backend','frontend','qa','design','pm','api')))
+      OR (type != 'agent' AND agent_role IS NULL)
+    );
+
+COMMENT ON COLUMN public.team_members.color IS 'Hex color for UI identity. Default brand blue. Auto-assigned via hash for new agents.';
+COMMENT ON COLUMN public.team_members.agent_role IS 'Agent specialty (backend/frontend/qa/design/pm/api). NULL for human members.';

--- a/packages/db/supabase/migrations/20260426170200_inbox_outbox.sql
+++ b/packages/db/supabase/migrations/20260426170200_inbox_outbox.sql
@@ -1,0 +1,66 @@
+-- Operator Cockpit Phase A — inbox_outbox for webhook delivery (D6 권장 채택)
+-- resolve API는 outbox row insert 후 즉시 200 반환, 별도 worker가 retry exponential backoff.
+-- 이 outbox 패턴은 outbox pattern (DB write + async delivery 둘을 atomic하게 보장하기 위한 표준 패턴).
+-- See .omc/plans/2026-04-26-01-operator-cockpit-redesign.md — D6 webhook outbox 정책
+
+-- ============================================================
+-- inbox_outbox — agent webhook 전달 큐
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.inbox_outbox (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id          uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  inbox_item_id   uuid NOT NULL REFERENCES public.inbox_items(id) ON DELETE CASCADE,
+  event_type      text NOT NULL CHECK (event_type IN ('resolved', 'dismissed', 'reassigned')),
+  payload         jsonb NOT NULL,
+    -- {item: {...}, choice, note?, resolved_by, ts}
+  webhook_url     text,
+    -- agent별 webhook URL. NULL이면 worker가 agent 설정에서 lookup.
+  status          text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'in_flight', 'delivered', 'failed', 'dead')),
+  attempt_count   integer NOT NULL DEFAULT 0,
+  last_attempt_at timestamptz,
+  next_attempt_at timestamptz NOT NULL DEFAULT now(),
+    -- exponential backoff: now → now+30s → now+5m → now+30m → now+3h → dead
+  last_error      text,
+  delivered_at    timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.inbox_outbox IS 'Outbox pattern for agent webhook delivery. Worker polls status=pending AND next_attempt_at<=now().';
+
+-- ============================================================
+-- Indexes
+-- ============================================================
+CREATE INDEX idx_inbox_outbox_org_id          ON public.inbox_outbox(org_id);
+CREATE INDEX idx_inbox_outbox_inbox_item_id   ON public.inbox_outbox(inbox_item_id);
+CREATE INDEX idx_inbox_outbox_pending_due     ON public.inbox_outbox(next_attempt_at)
+  WHERE status = 'pending' OR status = 'in_flight';
+CREATE INDEX idx_inbox_outbox_status          ON public.inbox_outbox(status);
+
+-- ============================================================
+-- updated_at 자동 갱신 트리거
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.touch_inbox_outbox_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_inbox_outbox_touch_updated_at
+  BEFORE UPDATE ON public.inbox_outbox
+  FOR EACH ROW EXECUTE FUNCTION public.touch_inbox_outbox_updated_at();
+
+-- ============================================================
+-- RLS — service_role only. 일반 사용자는 outbox에 접근 불가.
+-- ============================================================
+ALTER TABLE public.inbox_outbox ENABLE ROW LEVEL SECURITY;
+
+-- admin SELECT for debugging/audit
+CREATE POLICY "inbox_outbox_select_admin" ON public.inbox_outbox FOR SELECT
+  USING (org_id IN (SELECT public.get_user_admin_org_ids()));
+
+-- writes only via service_role (bypasses RLS by default)
+-- 일반 사용자 INSERT/UPDATE/DELETE 정책 없음 = denied.

--- a/packages/db/supabase/migrations/20260426170300_inbox_resolve_fn.sql
+++ b/packages/db/supabase/migrations/20260426170300_inbox_resolve_fn.sql
@@ -1,0 +1,190 @@
+-- Operator Cockpit Phase A — atomic resolve/dismiss/reassign RPCs
+-- inbox_items state change + outbox row insert in single transaction.
+-- See packages/db/supabase/migrations/20260426170000_inbox_items.sql
+
+-- ============================================================
+-- resolve_inbox_item: state='resolved' + outbox 'resolved' row
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.resolve_inbox_item(
+  p_id                  uuid,
+  p_org_id              uuid,
+  p_resolved_by         uuid,
+  p_resolved_option_id  uuid,
+  p_resolved_note       text DEFAULT NULL
+)
+RETURNS public.inbox_items
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_items;
+  _option_exists boolean;
+BEGIN
+  SELECT * INTO _row FROM public.inbox_items WHERE id = p_id AND org_id = p_org_id FOR UPDATE;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'inbox_item not found' USING ERRCODE = 'P0002';
+  END IF;
+  IF _row.state != 'pending' THEN
+    RAISE EXCEPTION 'inbox_item already %', _row.state USING ERRCODE = '23514';
+  END IF;
+
+  -- option_id must exist in options[].id
+  SELECT EXISTS (
+    SELECT 1 FROM jsonb_array_elements(_row.options) AS opt
+    WHERE (opt->>'id')::uuid = p_resolved_option_id
+  ) INTO _option_exists;
+  IF NOT _option_exists THEN
+    RAISE EXCEPTION 'resolved_option_id not found in options[].id' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.inbox_items
+  SET state = 'resolved',
+      resolved_by = p_resolved_by,
+      resolved_option_id = p_resolved_option_id,
+      resolved_note = p_resolved_note,
+      resolved_at = now()
+  WHERE id = p_id AND org_id = p_org_id
+  RETURNING * INTO _row;
+
+  INSERT INTO public.inbox_outbox (
+    org_id, inbox_item_id, event_type, payload, status, next_attempt_at
+  ) VALUES (
+    p_org_id, p_id, 'resolved',
+    jsonb_build_object(
+      'inbox_item_id', p_id,
+      'event_type', 'resolved',
+      'inbox_item_snapshot', jsonb_build_object(
+        'title', _row.title,
+        'kind', _row.kind,
+        'project_id', _row.project_id,
+        'org_id', _row.org_id,
+        'options', _row.options,
+        'origin_chain', _row.origin_chain
+      ),
+      'resolved_choice', p_resolved_option_id,
+      'resolved_note', p_resolved_note,
+      'resolved_by', p_resolved_by,
+      'ts', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    ),
+    'pending',
+    now()
+  );
+
+  RETURN _row;
+END;
+$$;
+
+-- ============================================================
+-- dismiss_inbox_item: state='dismissed' + outbox 'dismissed'
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.dismiss_inbox_item(
+  p_id              uuid,
+  p_org_id          uuid,
+  p_resolved_by     uuid,
+  p_resolved_note   text DEFAULT NULL
+)
+RETURNS public.inbox_items
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_items;
+BEGIN
+  SELECT * INTO _row FROM public.inbox_items WHERE id = p_id AND org_id = p_org_id FOR UPDATE;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'inbox_item not found' USING ERRCODE = 'P0002';
+  END IF;
+  IF _row.state != 'pending' THEN
+    RAISE EXCEPTION 'inbox_item already %', _row.state USING ERRCODE = '23514';
+  END IF;
+
+  UPDATE public.inbox_items
+  SET state = 'dismissed',
+      resolved_by = p_resolved_by,
+      resolved_note = p_resolved_note,
+      resolved_at = now()
+  WHERE id = p_id AND org_id = p_org_id
+  RETURNING * INTO _row;
+
+  INSERT INTO public.inbox_outbox (
+    org_id, inbox_item_id, event_type, payload, status, next_attempt_at
+  ) VALUES (
+    p_org_id, p_id, 'dismissed',
+    jsonb_build_object(
+      'inbox_item_id', p_id,
+      'event_type', 'dismissed',
+      'inbox_item_snapshot', jsonb_build_object(
+        'title', _row.title,
+        'kind', _row.kind,
+        'project_id', _row.project_id,
+        'org_id', _row.org_id,
+        'options', _row.options,
+        'origin_chain', _row.origin_chain
+      ),
+      'resolved_note', p_resolved_note,
+      'resolved_by', p_resolved_by,
+      'ts', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    ),
+    'pending',
+    now()
+  );
+
+  RETURN _row;
+END;
+$$;
+
+-- ============================================================
+-- reassign_inbox_item: assignee_member_id 변경 + outbox 'reassigned'
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.reassign_inbox_item(
+  p_id                      uuid,
+  p_org_id                  uuid,
+  p_new_assignee_member_id  uuid,
+  p_reassigned_by           uuid
+)
+RETURNS public.inbox_items
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_items;
+BEGIN
+  SELECT * INTO _row FROM public.inbox_items WHERE id = p_id AND org_id = p_org_id FOR UPDATE;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'inbox_item not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  UPDATE public.inbox_items
+  SET assignee_member_id = p_new_assignee_member_id
+  WHERE id = p_id AND org_id = p_org_id
+  RETURNING * INTO _row;
+
+  INSERT INTO public.inbox_outbox (
+    org_id, inbox_item_id, event_type, payload, status, next_attempt_at
+  ) VALUES (
+    p_org_id, p_id, 'reassigned',
+    jsonb_build_object(
+      'inbox_item_id', p_id,
+      'event_type', 'reassigned',
+      'inbox_item_snapshot', jsonb_build_object(
+        'title', _row.title,
+        'kind', _row.kind,
+        'project_id', _row.project_id,
+        'org_id', _row.org_id,
+        'options', _row.options,
+        'origin_chain', _row.origin_chain
+      ),
+      'new_assignee_member_id', p_new_assignee_member_id,
+      'resolved_by', p_reassigned_by,
+      'ts', to_char(now() AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+    ),
+    'pending',
+    now()
+  );
+
+  RETURN _row;
+END;
+$$;

--- a/packages/shared/src/schemas/inbox.ts
+++ b/packages/shared/src/schemas/inbox.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod/v4';
+
+// Operator Cockpit Phase A — inbox_items + outbox schemas
+// See .omc/plans/2026-04-26-01-operator-cockpit-redesign.md
+
+// ─── origin_chain ────────────────────────────────────
+// typed array of {type, id} — DB는 referential integrity 보장 안 함, 여기서 검증.
+export const ORIGIN_NODE_TYPES = ['memo', 'story', 'run', 'initiative'] as const;
+
+export const originNodeSchema = z.object({
+  type: z.enum(ORIGIN_NODE_TYPES),
+  id: z.string().trim().min(1),
+});
+
+export const originChainSchema = z.array(originNodeSchema);
+
+// ─── options[] ────────────────────────────────────
+// Each option carries its own stable id (uuid) so resolved_option_id stays valid
+// even if label/kind changes.
+export const OPTION_KINDS = ['approve', 'approve-alt', 'reassign', 'changes'] as const;
+
+export const inboxOptionSchema = z.object({
+  id: z.string().uuid(),
+  label: z.string().min(1),
+  kind: z.enum(OPTION_KINDS),
+  consequence: z.string().min(1),
+});
+
+export const inboxOptionsSchema = z.array(inboxOptionSchema);
+
+// ─── inbox_items ────────────────────────────────────
+export const INBOX_KINDS = ['approval', 'decision', 'blocker', 'mention'] as const;
+export const INBOX_PRIORITIES = ['high', 'normal'] as const;
+export const INBOX_STATES = ['pending', 'resolved', 'dismissed'] as const;
+export const INBOX_SOURCE_TYPES = ['agent_run', 'memo_mention', 'webhook', 'manual'] as const;
+
+export const createInboxItemSchema = z.object({
+  org_id: z.string().min(1),
+  project_id: z.string().min(1),
+  assignee_member_id: z.string().min(1),
+  kind: z.enum(INBOX_KINDS),
+  title: z.string().min(1).max(200),
+  context: z.string().max(2000).optional().nullable(),
+  agent_summary: z.string().max(2000).optional().nullable(),
+  origin_chain: originChainSchema.default([]),
+  options: inboxOptionsSchema.default([]),
+  after_decision: z.string().max(500).optional().nullable(),
+  from_agent_id: z.string().optional().nullable(),
+  story_id: z.string().optional().nullable(),
+  memo_id: z.string().optional().nullable(),
+  priority: z.enum(INBOX_PRIORITIES).optional().default('normal'),
+  source_type: z.enum(INBOX_SOURCE_TYPES),
+  source_id: z.string().min(1),
+});
+
+export const resolveInboxItemSchema = z.object({
+  choice: z.string().uuid(), // option.id
+  note: z.string().max(1000).optional().nullable(),
+});
+
+export const dismissInboxItemSchema = z.object({
+  reason: z.string().max(500).optional().nullable(),
+});
+
+export const inboxListQuerySchema = z.object({
+  kind: z.enum(INBOX_KINDS).optional(),
+  state: z.enum(INBOX_STATES).optional().default('pending'),
+  project_id: z.string().optional(),
+  cursor: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+});
+
+// ─── webhook incoming ────────────────────────────────
+// External agents POST to /api/inbox/incoming with HMAC.
+// Subset of createInboxItemSchema — agent doesn't need to specify org_id (HMAC keys are scoped).
+export const incomingInboxItemSchema = z.object({
+  project_id: z.string().min(1),
+  assignee_member_id: z.string().min(1),
+  kind: z.enum(INBOX_KINDS),
+  title: z.string().min(1).max(200),
+  context: z.string().max(2000).optional().nullable(),
+  agent_summary: z.string().max(2000).optional().nullable(),
+  origin_chain: originChainSchema.default([]),
+  options: inboxOptionsSchema.default([]),
+  after_decision: z.string().max(500).optional().nullable(),
+  from_agent_id: z.string().optional().nullable(),
+  story_id: z.string().optional().nullable(),
+  memo_id: z.string().optional().nullable(),
+  priority: z.enum(INBOX_PRIORITIES).optional().default('normal'),
+  source_id: z.string().min(1), // external dedup key
+});
+
+// ─── outbox ────────────────────────────────────
+export const OUTBOX_EVENT_TYPES = ['resolved', 'dismissed', 'reassigned'] as const;
+export const OUTBOX_STATUSES = ['pending', 'in_flight', 'delivered', 'failed', 'dead'] as const;
+
+// outbox payload shape — consumed by worker
+export const outboxPayloadSchema = z.object({
+  inbox_item_id: z.string().uuid(),
+  event_type: z.enum(OUTBOX_EVENT_TYPES),
+  inbox_item_snapshot: z.object({
+    title: z.string(),
+    kind: z.enum(INBOX_KINDS),
+    project_id: z.string(),
+    org_id: z.string(),
+    options: inboxOptionsSchema,
+    origin_chain: originChainSchema,
+  }),
+  resolved_choice: z.string().uuid().optional().nullable(),
+  resolved_note: z.string().optional().nullable(),
+  resolved_by: z.string().optional().nullable(),
+  ts: z.string(), // ISO 8601
+});
+
+// Color hex regex (codex tactical fix #6 — stored CSS injection 방지)
+export const colorHexSchema = z.string().regex(/^#[0-9a-fA-F]{6}$/, 'Color must be 6-digit hex like #3385f8');
+
+// agent_role enum (codex tactical fix #7)
+export const AGENT_ROLES = ['backend', 'frontend', 'qa', 'design', 'pm', 'api'] as const;
+export const agentRoleSchema = z.enum(AGENT_ROLES);
+
+// Type exports for service / API consumers
+export type InboxKind = (typeof INBOX_KINDS)[number];
+export type InboxState = (typeof INBOX_STATES)[number];
+export type InboxPriority = (typeof INBOX_PRIORITIES)[number];
+export type InboxSourceType = (typeof INBOX_SOURCE_TYPES)[number];
+export type OriginNode = z.infer<typeof originNodeSchema>;
+export type OriginChain = z.infer<typeof originChainSchema>;
+export type InboxOption = z.infer<typeof inboxOptionSchema>;
+export type CreateInboxItemInput = z.infer<typeof createInboxItemSchema>;
+export type ResolveInboxItemInput = z.infer<typeof resolveInboxItemSchema>;
+export type IncomingInboxItemInput = z.infer<typeof incomingInboxItemSchema>;
+export type InboxListQuery = z.infer<typeof inboxListQuerySchema>;
+export type AgentRole = (typeof AGENT_ROLES)[number];

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -286,3 +286,4 @@ export const updateBridgeUserSchema = z.object({
 });
 
 export * from './meetings';
+export * from './inbox';

--- a/packages/storage-sqlite/src/SqliteInboxItemRepository.ts
+++ b/packages/storage-sqlite/src/SqliteInboxItemRepository.ts
@@ -1,0 +1,311 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { randomUUID } from 'node:crypto';
+import type {
+  IInboxItemRepository,
+  InboxItem,
+  CreateInboxItemInput,
+  InboxListFilters,
+  ResolveInboxItemInput,
+  DismissInboxItemInput,
+  ReassignInboxItemInput,
+  InboxItemCount,
+  InboxKind,
+  OriginNode,
+  InboxOption,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+
+type SqlParam = string | number | bigint | null | Uint8Array;
+
+interface InboxItemRow {
+  id: string;
+  org_id: string;
+  project_id: string;
+  assignee_member_id: string;
+  kind: InboxKind;
+  title: string;
+  context: string | null;
+  agent_summary: string | null;
+  origin_chain: string;     // JSON-encoded
+  options: string;          // JSON-encoded
+  after_decision: string | null;
+  from_agent_id: string | null;
+  story_id: string | null;
+  memo_id: string | null;
+  priority: 'high' | 'normal';
+  state: 'pending' | 'resolved' | 'dismissed';
+  resolved_by: string | null;
+  resolved_option_id: string | null;
+  resolved_note: string | null;
+  source_type: InboxItem['source_type'];
+  source_id: string;
+  waiting_since: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+function hydrate(row: InboxItemRow): InboxItem {
+  return {
+    ...row,
+    origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+    options: parseJsonArray<InboxOption>(row.options),
+  };
+}
+
+function parseJsonArray<T>(text: string | null | undefined): T[] {
+  if (!text) return [];
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export class SqliteInboxItemRepository implements IInboxItemRepository {
+  constructor(private readonly db: DatabaseSync) {}
+
+  async create(input: CreateInboxItemInput): Promise<InboxItem> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    // Idempotency: same (org, source_type, source_id, kind) returns existing row
+    const existing = this.db.prepare(
+      'SELECT * FROM inbox_items WHERE org_id = ? AND source_type = ? AND source_id = ? AND kind = ?'
+    ).get(input.org_id, input.source_type, input.source_id, input.kind) as InboxItemRow | undefined;
+    if (existing) return hydrate(existing);
+
+    this.db.prepare(`
+      INSERT INTO inbox_items (
+        id, org_id, project_id, assignee_member_id, kind, title, context, agent_summary,
+        origin_chain, options, after_decision, from_agent_id, story_id, memo_id,
+        priority, state, source_type, source_id, waiting_since, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
+    `).run(
+      id, input.org_id, input.project_id, input.assignee_member_id, input.kind,
+      input.title, input.context ?? null, input.agent_summary ?? null,
+      JSON.stringify(input.origin_chain ?? []),
+      JSON.stringify(input.options ?? []),
+      input.after_decision ?? null, input.from_agent_id ?? null,
+      input.story_id ?? null, input.memo_id ?? null,
+      input.priority ?? 'normal',
+      input.source_type, input.source_id, now, now,
+    );
+
+    return this.requireById(id, input.org_id);
+  }
+
+  async list(filters: InboxListFilters): Promise<InboxItem[]> {
+    let sql = 'SELECT * FROM inbox_items WHERE org_id = ?';
+    const params: SqlParam[] = [filters.org_id];
+
+    if (filters.project_id) { sql += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.assignee_member_id) { sql += ' AND assignee_member_id = ?'; params.push(filters.assignee_member_id); }
+    if (filters.kind) { sql += ' AND kind = ?'; params.push(filters.kind); }
+    if (filters.state) { sql += ' AND state = ?'; params.push(filters.state); }
+    if (filters.cursor) { sql += ' AND created_at < ?'; params.push(filters.cursor); }
+
+    sql += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { sql += ' LIMIT ?'; params.push(filters.limit); }
+
+    const rows = this.db.prepare(sql).all(...params) as unknown as InboxItemRow[];
+    return rows.map(hydrate);
+  }
+
+  async get(id: string, orgId: string): Promise<InboxItem | null> {
+    const row = this.db.prepare(
+      'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?'
+    ).get(id, orgId) as InboxItemRow | undefined;
+    return row ? hydrate(row) : null;
+  }
+
+  async count(filters: Omit<InboxListFilters, 'limit' | 'cursor'>): Promise<InboxItemCount> {
+    let sql = 'SELECT kind, COUNT(*) as n FROM inbox_items WHERE org_id = ?';
+    const params: SqlParam[] = [filters.org_id];
+    if (filters.project_id) { sql += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.assignee_member_id) { sql += ' AND assignee_member_id = ?'; params.push(filters.assignee_member_id); }
+    if (filters.state) { sql += ' AND state = ?'; params.push(filters.state); }
+    sql += ' GROUP BY kind';
+
+    const rows = this.db.prepare(sql).all(...params) as unknown as Array<{ kind: InboxKind; n: number }>;
+    const byKind: Record<InboxKind, number> = { approval: 0, decision: 0, blocker: 0, mention: 0 };
+    let total = 0;
+    for (const r of rows) {
+      byKind[r.kind] = r.n;
+      total += r.n;
+    }
+    return { total, byKind };
+  }
+
+  async resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    this.db.exec('BEGIN');
+    try {
+      const row = this.db.prepare(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?'
+      ).get(id, orgId) as InboxItemRow | undefined;
+      if (!row) {
+        this.db.exec('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+      if (row.state !== 'pending') {
+        this.db.exec('ROLLBACK');
+        throw new Error(`Inbox item already ${row.state}`);
+      }
+
+      // Verify resolved_option_id exists in options
+      const options = parseJsonArray<InboxOption>(row.options);
+      if (!options.some((opt) => opt.id === input.resolved_option_id)) {
+        this.db.exec('ROLLBACK');
+        throw new Error(`Option id ${input.resolved_option_id} not found in inbox item options`);
+      }
+
+      this.db.prepare(`
+        UPDATE inbox_items
+        SET state = 'resolved', resolved_by = ?, resolved_option_id = ?, resolved_note = ?, resolved_at = ?
+        WHERE id = ? AND org_id = ?
+      `).run(input.resolved_by, input.resolved_option_id, input.resolved_note ?? null, now, id, orgId);
+
+      this.enqueueOutbox(orgId, id, 'resolved', {
+        inbox_item_id: id,
+        event_type: 'resolved',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options,
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_choice: input.resolved_option_id,
+        resolved_note: input.resolved_note ?? null,
+        resolved_by: input.resolved_by,
+        ts: now,
+      });
+
+      this.db.exec('COMMIT');
+    } catch (e) {
+      try { this.db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  async dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    this.db.exec('BEGIN');
+    try {
+      const row = this.db.prepare(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?'
+      ).get(id, orgId) as InboxItemRow | undefined;
+      if (!row) {
+        this.db.exec('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+      if (row.state !== 'pending') {
+        this.db.exec('ROLLBACK');
+        throw new Error(`Inbox item already ${row.state}`);
+      }
+
+      this.db.prepare(`
+        UPDATE inbox_items
+        SET state = 'dismissed', resolved_by = ?, resolved_note = ?, resolved_at = ?
+        WHERE id = ? AND org_id = ?
+      `).run(input.resolved_by, input.resolved_note ?? null, now, id, orgId);
+
+      this.enqueueOutbox(orgId, id, 'dismissed', {
+        inbox_item_id: id,
+        event_type: 'dismissed',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options: parseJsonArray<InboxOption>(row.options),
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_note: input.resolved_note ?? null,
+        resolved_by: input.resolved_by,
+        ts: now,
+      });
+
+      this.db.exec('COMMIT');
+    } catch (e) {
+      try { this.db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  async reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    this.db.exec('BEGIN');
+    try {
+      const row = this.db.prepare(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?'
+      ).get(id, orgId) as InboxItemRow | undefined;
+      if (!row) {
+        this.db.exec('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+
+      this.db.prepare(`
+        UPDATE inbox_items
+        SET assignee_member_id = ?
+        WHERE id = ? AND org_id = ?
+      `).run(input.new_assignee_member_id, id, orgId);
+
+      this.enqueueOutbox(orgId, id, 'reassigned', {
+        inbox_item_id: id,
+        event_type: 'reassigned',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options: parseJsonArray<InboxOption>(row.options),
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_by: input.reassigned_by,
+        ts: now,
+      });
+
+      this.db.exec('COMMIT');
+    } catch (e) {
+      try { this.db.exec('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  // ──────────────────────────────────────────────
+  // Internal helpers
+  // ──────────────────────────────────────────────
+
+  private requireById(id: string, orgId: string): InboxItem {
+    const row = this.db.prepare(
+      'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?'
+    ).get(id, orgId) as InboxItemRow | undefined;
+    if (!row) throw new NotFoundError(`Inbox item not found after upsert: ${id}`);
+    return hydrate(row);
+  }
+
+  private enqueueOutbox(orgId: string, inboxItemId: string, eventType: 'resolved' | 'dismissed' | 'reassigned', payload: unknown): void {
+    const now = new Date().toISOString();
+    this.db.prepare(`
+      INSERT INTO inbox_outbox (
+        id, org_id, inbox_item_id, event_type, payload,
+        webhook_url, status, attempt_count, next_attempt_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, NULL, 'pending', 0, ?, ?, ?)
+    `).run(
+      randomUUID(), orgId, inboxItemId, eventType, JSON.stringify(payload),
+      now, now, now,
+    );
+  }
+}

--- a/packages/storage-sqlite/src/__tests__/SqliteInboxItemRepository.test.ts
+++ b/packages/storage-sqlite/src/__tests__/SqliteInboxItemRepository.test.ts
@@ -1,0 +1,334 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { DatabaseSync } from 'node:sqlite';
+import { randomUUID } from 'node:crypto';
+import { SqliteInboxItemRepository } from '../SqliteInboxItemRepository';
+import type {
+  CreateInboxItemInput,
+  InboxOption,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+
+// Phase A.1 — SqliteInboxItemRepository contract test.
+// PGlite migration note: when OSS storage moves to PGlite, this entire file
+// gets superseded by a contract test against the IInboxItemRepository
+// interface (run against PGlite). The Supabase repo test still applies.
+
+const ORG = '11111111-1111-1111-1111-111111111111';
+const PROJECT = '22222222-2222-2222-2222-222222222222';
+const ASSIGNEE = '33333333-3333-3333-3333-333333333333';
+
+function makeOption(kind: InboxOption['kind'], label: string): InboxOption {
+  return { id: randomUUID(), kind, label, consequence: `${label} happens` };
+}
+
+function makeItemInput(overrides: Partial<CreateInboxItemInput> = {}): CreateInboxItemInput {
+  return {
+    org_id: ORG,
+    project_id: PROJECT,
+    assignee_member_id: ASSIGNEE,
+    kind: 'approval',
+    title: 'Approve PR #1284',
+    context: 'Max ran 247 tests, 0 failed',
+    options: [
+      makeOption('approve', '승인'),
+      makeOption('changes', '변경 요청'),
+    ],
+    source_type: 'agent_run',
+    source_id: 'run_test_' + Math.random().toString(36).slice(2),
+    ...overrides,
+  };
+}
+
+function setupDb(): DatabaseSync {
+  const db = new DatabaseSync(':memory:');
+  // Create just the schema we need for these tests.
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS inbox_items (
+      id                  TEXT PRIMARY KEY,
+      org_id              TEXT NOT NULL,
+      project_id          TEXT NOT NULL,
+      assignee_member_id  TEXT NOT NULL,
+      kind                TEXT NOT NULL CHECK (kind IN ('approval','decision','blocker','mention')),
+      title               TEXT NOT NULL,
+      context             TEXT,
+      agent_summary       TEXT,
+      origin_chain        TEXT NOT NULL DEFAULT '[]',
+      options             TEXT NOT NULL DEFAULT '[]',
+      after_decision      TEXT,
+      from_agent_id       TEXT,
+      story_id            TEXT,
+      memo_id             TEXT,
+      priority            TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('high','normal')),
+      state               TEXT NOT NULL DEFAULT 'pending' CHECK (state IN ('pending','resolved','dismissed')),
+      resolved_by         TEXT,
+      resolved_option_id  TEXT,
+      resolved_note       TEXT,
+      source_type         TEXT NOT NULL CHECK (source_type IN ('agent_run','memo_mention','webhook','manual')),
+      source_id           TEXT NOT NULL,
+      waiting_since       TEXT NOT NULL,
+      created_at          TEXT NOT NULL,
+      resolved_at         TEXT,
+      UNIQUE (org_id, source_type, source_id, kind)
+    );
+    CREATE TABLE IF NOT EXISTS inbox_outbox (
+      id              TEXT PRIMARY KEY,
+      org_id          TEXT NOT NULL,
+      inbox_item_id   TEXT NOT NULL,
+      event_type      TEXT NOT NULL,
+      payload         TEXT NOT NULL,
+      webhook_url     TEXT,
+      status          TEXT NOT NULL DEFAULT 'pending',
+      attempt_count   INTEGER NOT NULL DEFAULT 0,
+      last_attempt_at TEXT,
+      next_attempt_at TEXT NOT NULL,
+      last_error      TEXT,
+      delivered_at    TEXT,
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+describe('SqliteInboxItemRepository', () => {
+  let db: DatabaseSync;
+  let repo: SqliteInboxItemRepository;
+
+  beforeEach(() => {
+    db = setupDb();
+    repo = new SqliteInboxItemRepository(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe('create', () => {
+    it('inserts a new pending inbox item', async () => {
+      const input = makeItemInput();
+      const result = await repo.create(input);
+
+      expect(result.id).toBeDefined();
+      expect(result.org_id).toBe(ORG);
+      expect(result.kind).toBe('approval');
+      expect(result.state).toBe('pending');
+      expect(result.options).toHaveLength(2);
+      expect(result.options[0]?.id).toBe(input.options![0]!.id);
+    });
+
+    it('parses origin_chain and options as arrays', async () => {
+      const input = makeItemInput({
+        origin_chain: [
+          { type: 'memo', id: 'm1' },
+          { type: 'story', id: 'SPR-1' },
+          { type: 'run', id: 'run_1' },
+        ],
+      });
+      const result = await repo.create(input);
+      expect(result.origin_chain).toHaveLength(3);
+      expect(result.origin_chain[0]).toEqual({ type: 'memo', id: 'm1' });
+    });
+
+    it('idempotent on (org_id, source_type, source_id, kind) — returns existing', async () => {
+      const input = makeItemInput({ source_id: 'run_dedupe' });
+      const first = await repo.create(input);
+      const second = await repo.create({ ...input, title: 'Different title' });
+      expect(second.id).toBe(first.id);
+      expect(second.title).toBe(first.title); // original wins
+    });
+  });
+
+  describe('list', () => {
+    it('returns items filtered by org + state', async () => {
+      await repo.create(makeItemInput({ source_id: 'a' }));
+      await repo.create(makeItemInput({ source_id: 'b' }));
+
+      const items = await repo.list({ org_id: ORG, state: 'pending' });
+      expect(items).toHaveLength(2);
+    });
+
+    it('filters by kind', async () => {
+      await repo.create(makeItemInput({ source_id: 'a', kind: 'approval' }));
+      await repo.create(makeItemInput({ source_id: 'b', kind: 'blocker' }));
+
+      const blockers = await repo.list({ org_id: ORG, kind: 'blocker' });
+      expect(blockers).toHaveLength(1);
+      expect(blockers[0]?.kind).toBe('blocker');
+    });
+
+    it('filters by assignee_member_id', async () => {
+      await repo.create(makeItemInput({ source_id: 'a' }));
+      await repo.create(makeItemInput({ source_id: 'b', assignee_member_id: 'other-assignee' }));
+
+      const mine = await repo.list({ org_id: ORG, assignee_member_id: ASSIGNEE });
+      expect(mine).toHaveLength(1);
+      expect(mine[0]?.assignee_member_id).toBe(ASSIGNEE);
+    });
+
+    it('respects cross-org boundary', async () => {
+      await repo.create(makeItemInput({ source_id: 'a' }));
+      const otherOrg = await repo.list({ org_id: 'other-org', state: 'pending' });
+      expect(otherOrg).toHaveLength(0);
+    });
+  });
+
+  describe('count', () => {
+    it('returns total + byKind breakdown', async () => {
+      await repo.create(makeItemInput({ source_id: 'a', kind: 'approval' }));
+      await repo.create(makeItemInput({ source_id: 'b', kind: 'approval' }));
+      await repo.create(makeItemInput({ source_id: 'c', kind: 'blocker' }));
+
+      const counts = await repo.count({ org_id: ORG, state: 'pending' });
+      expect(counts.total).toBe(3);
+      expect(counts.byKind.approval).toBe(2);
+      expect(counts.byKind.blocker).toBe(1);
+      expect(counts.byKind.decision).toBe(0);
+      expect(counts.byKind.mention).toBe(0);
+    });
+  });
+
+  describe('resolve', () => {
+    it('marks state=resolved and stores option id + note', async () => {
+      const input = makeItemInput();
+      const item = await repo.create(input);
+      const optionId = item.options[0]!.id;
+
+      const resolved = await repo.resolve(item.id, ORG, {
+        resolved_by: ASSIGNEE,
+        resolved_option_id: optionId,
+        resolved_note: 'Looks good',
+      });
+
+      expect(resolved.state).toBe('resolved');
+      expect(resolved.resolved_option_id).toBe(optionId);
+      expect(resolved.resolved_note).toBe('Looks good');
+      expect(resolved.resolved_at).toBeTruthy();
+    });
+
+    it('enqueues outbox row in same transaction', async () => {
+      const input = makeItemInput();
+      const item = await repo.create(input);
+      const optionId = item.options[0]!.id;
+
+      await repo.resolve(item.id, ORG, {
+        resolved_by: ASSIGNEE,
+        resolved_option_id: optionId,
+      });
+
+      const outboxRow = db.prepare(
+        'SELECT event_type, status, attempt_count FROM inbox_outbox WHERE inbox_item_id = ?'
+      ).get(item.id) as { event_type: string; status: string; attempt_count: number } | undefined;
+      expect(outboxRow?.event_type).toBe('resolved');
+      expect(outboxRow?.status).toBe('pending');
+      expect(outboxRow?.attempt_count).toBe(0);
+    });
+
+    it('rejects resolve with an option_id not in options', async () => {
+      const input = makeItemInput();
+      const item = await repo.create(input);
+
+      await expect(
+        repo.resolve(item.id, ORG, {
+          resolved_by: ASSIGNEE,
+          resolved_option_id: randomUUID(), // not in item.options
+        })
+      ).rejects.toThrow(/Option id/);
+    });
+
+    it('rejects double-resolve (already resolved)', async () => {
+      const input = makeItemInput();
+      const item = await repo.create(input);
+      const optionId = item.options[0]!.id;
+
+      await repo.resolve(item.id, ORG, {
+        resolved_by: ASSIGNEE,
+        resolved_option_id: optionId,
+      });
+      await expect(
+        repo.resolve(item.id, ORG, {
+          resolved_by: ASSIGNEE,
+          resolved_option_id: optionId,
+        })
+      ).rejects.toThrow(/already/);
+    });
+
+    it('throws NotFoundError for unknown id', async () => {
+      const optionId = randomUUID();
+      await expect(
+        repo.resolve(randomUUID(), ORG, {
+          resolved_by: ASSIGNEE,
+          resolved_option_id: optionId,
+        })
+      ).rejects.toThrow(NotFoundError);
+    });
+
+    it('respects org boundary', async () => {
+      const input = makeItemInput();
+      const item = await repo.create(input);
+      const optionId = item.options[0]!.id;
+
+      await expect(
+        repo.resolve(item.id, 'wrong-org', {
+          resolved_by: ASSIGNEE,
+          resolved_option_id: optionId,
+        })
+      ).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('dismiss', () => {
+    it('marks state=dismissed and enqueues outbox', async () => {
+      const item = await repo.create(makeItemInput());
+      const dismissed = await repo.dismiss(item.id, ORG, {
+        resolved_by: ASSIGNEE,
+        resolved_note: 'Not relevant',
+      });
+      expect(dismissed.state).toBe('dismissed');
+
+      const outboxRow = db.prepare(
+        'SELECT event_type FROM inbox_outbox WHERE inbox_item_id = ?'
+      ).get(item.id) as { event_type: string } | undefined;
+      expect(outboxRow?.event_type).toBe('dismissed');
+    });
+  });
+
+  describe('reassign', () => {
+    it('changes assignee + enqueues outbox', async () => {
+      const item = await repo.create(makeItemInput());
+      const newAssignee = '44444444-4444-4444-4444-444444444444';
+
+      const result = await repo.reassign(item.id, ORG, {
+        new_assignee_member_id: newAssignee,
+        reassigned_by: ASSIGNEE,
+      });
+      expect(result.assignee_member_id).toBe(newAssignee);
+
+      const outboxRow = db.prepare(
+        'SELECT event_type FROM inbox_outbox WHERE inbox_item_id = ?'
+      ).get(item.id) as { event_type: string } | undefined;
+      expect(outboxRow?.event_type).toBe('reassigned');
+    });
+  });
+
+  describe('rollback on failed resolve', () => {
+    it('does not enqueue outbox if resolve validation fails', async () => {
+      const item = await repo.create(makeItemInput());
+
+      await expect(
+        repo.resolve(item.id, ORG, {
+          resolved_by: ASSIGNEE,
+          resolved_option_id: randomUUID(),
+        })
+      ).rejects.toThrow();
+
+      const outboxCount = db.prepare(
+        'SELECT COUNT(*) as n FROM inbox_outbox WHERE inbox_item_id = ?'
+      ).get(item.id) as { n: number };
+      expect(outboxCount.n).toBe(0);
+
+      // Item still pending
+      const stillPending = await repo.get(item.id, ORG);
+      expect(stillPending?.state).toBe('pending');
+    });
+  });
+});

--- a/packages/storage-sqlite/src/db.ts
+++ b/packages/storage-sqlite/src/db.ts
@@ -18,6 +18,7 @@ export function getDb(): DatabaseSync {
   migrateLegacyStoryStatuses(_db);
   migrateStorySchema(_db);
   migrateEpicSchema(_db);
+  migrateTeamMembersAgentIdentity(_db);
   seedOssDefaults(_db);
   return _db;
 }
@@ -202,6 +203,74 @@ function initSchema(db: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS idx_team_members_org_id ON team_members(org_id);
     CREATE INDEX IF NOT EXISTS idx_team_members_user_id ON team_members(user_id);
 
+    -- ============================================================
+    -- inbox_items — Operator Cockpit Phase A.1
+    -- See packages/db/supabase/migrations/20260426170000_inbox_items.sql
+    -- SQLite has no jsonb; origin_chain/options stored as TEXT (JSON string).
+    -- Application-layer Zod validation enforces shape.
+    -- ============================================================
+    CREATE TABLE IF NOT EXISTS inbox_items (
+      id                  TEXT PRIMARY KEY,
+      org_id              TEXT NOT NULL,
+      project_id          TEXT NOT NULL,
+      assignee_member_id  TEXT NOT NULL,
+      kind                TEXT NOT NULL CHECK (kind IN ('approval','decision','blocker','mention')),
+      title               TEXT NOT NULL,
+      context             TEXT,
+      agent_summary       TEXT,
+      origin_chain        TEXT NOT NULL DEFAULT '[]',
+      options             TEXT NOT NULL DEFAULT '[]',
+      after_decision      TEXT,
+      from_agent_id       TEXT,
+      story_id            TEXT,
+      memo_id             TEXT,
+      priority            TEXT NOT NULL DEFAULT 'normal' CHECK (priority IN ('high','normal')),
+      state               TEXT NOT NULL DEFAULT 'pending' CHECK (state IN ('pending','resolved','dismissed')),
+      resolved_by         TEXT,
+      resolved_option_id  TEXT,
+      resolved_note       TEXT,
+      source_type         TEXT NOT NULL CHECK (source_type IN ('agent_run','memo_mention','webhook','manual')),
+      source_id           TEXT NOT NULL,
+      waiting_since       TEXT NOT NULL,
+      created_at          TEXT NOT NULL,
+      resolved_at         TEXT,
+      UNIQUE (org_id, source_type, source_id, kind)
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_org_id      ON inbox_items(org_id);
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_project_id  ON inbox_items(project_id);
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_assignee    ON inbox_items(assignee_member_id);
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_pending     ON inbox_items(state) WHERE state = 'pending';
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_kind        ON inbox_items(kind);
+    CREATE INDEX IF NOT EXISTS idx_inbox_items_created_at  ON inbox_items(created_at DESC);
+
+    -- ============================================================
+    -- inbox_outbox — webhook delivery queue (D6 outbox pattern)
+    -- See packages/db/supabase/migrations/20260426170200_inbox_outbox.sql
+    -- ============================================================
+    CREATE TABLE IF NOT EXISTS inbox_outbox (
+      id              TEXT PRIMARY KEY,
+      org_id          TEXT NOT NULL,
+      inbox_item_id   TEXT NOT NULL REFERENCES inbox_items(id) ON DELETE CASCADE,
+      event_type      TEXT NOT NULL CHECK (event_type IN ('resolved','dismissed','reassigned')),
+      payload         TEXT NOT NULL,
+      webhook_url     TEXT,
+      status          TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending','in_flight','delivered','failed','dead')),
+      attempt_count   INTEGER NOT NULL DEFAULT 0,
+      last_attempt_at TEXT,
+      next_attempt_at TEXT NOT NULL,
+      last_error      TEXT,
+      delivered_at    TEXT,
+      created_at      TEXT NOT NULL,
+      updated_at      TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_inbox_outbox_inbox_item_id ON inbox_outbox(inbox_item_id);
+    CREATE INDEX IF NOT EXISTS idx_inbox_outbox_status        ON inbox_outbox(status);
+    CREATE INDEX IF NOT EXISTS idx_inbox_outbox_pending_due   ON inbox_outbox(next_attempt_at)
+      WHERE status IN ('pending','in_flight');
+
     CREATE TABLE IF NOT EXISTS standup_entries (
       id TEXT PRIMARY KEY,
       org_id TEXT NOT NULL,
@@ -365,6 +434,23 @@ function migrateEpicSchema(db: DatabaseSync): void {
   }
   // 기존 'open' status → 'active' 정리
   db.exec(`UPDATE epics SET status = 'active' WHERE status = 'open'`);
+}
+
+// Operator Cockpit Phase A: agent identity columns on team_members
+// See packages/db/supabase/migrations/20260426170100_team_members_color.sql
+function migrateTeamMembersAgentIdentity(db: DatabaseSync): void {
+  const newColumns: [string, string, string?][] = [
+    ['color', 'TEXT', "'#3385f8'"],
+    ['agent_role', 'TEXT', undefined],
+  ];
+  for (const [col, type, defaultValue] of newColumns) {
+    const ddl = defaultValue
+      ? `ALTER TABLE team_members ADD COLUMN ${col} ${type} NOT NULL DEFAULT ${defaultValue}`
+      : `ALTER TABLE team_members ADD COLUMN ${col} ${type}`;
+    try { db.exec(ddl); } catch { /* already exists */ }
+  }
+  // SQLite에는 ALTER TABLE ADD CONSTRAINT가 없음.
+  // hex 검증 + agent_role 제약은 application layer (zod)에서 enforce.
 }
 
 function seedOssDefaults(db: DatabaseSync): void {

--- a/packages/storage-sqlite/src/index.ts
+++ b/packages/storage-sqlite/src/index.ts
@@ -9,4 +9,5 @@ export { SqliteNotificationRepository } from './SqliteNotificationRepository';
 export { SqliteTeamMemberRepository } from './SqliteTeamMemberRepository';
 export { SqliteAgentRunRepository } from './SqliteAgentRunRepository';
 export { SqliteAgentApiKeyRepository } from './SqliteAgentApiKeyRepository';
+export { SqliteInboxItemRepository } from './SqliteInboxItemRepository';
 export { getDb, OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } from './db';

--- a/packages/storage-supabase/src/SupabaseInboxItemRepository.ts
+++ b/packages/storage-supabase/src/SupabaseInboxItemRepository.ts
@@ -1,0 +1,151 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  IInboxItemRepository,
+  InboxItem,
+  CreateInboxItemInput,
+  InboxListFilters,
+  ResolveInboxItemInput,
+  DismissInboxItemInput,
+  ReassignInboxItemInput,
+  InboxItemCount,
+  InboxKind,
+} from '@sprintable/core-storage';
+import { ForbiddenError, NotFoundError } from '@sprintable/core-storage';
+import { mapSupabaseError } from './utils';
+
+export class SupabaseInboxItemRepository implements IInboxItemRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async create(input: CreateInboxItemInput): Promise<InboxItem> {
+    // Idempotency: UNIQUE(org_id, source_type, source_id, kind) — on conflict return existing
+    const { data: existing } = await this.supabase
+      .from('inbox_items')
+      .select('*')
+      .eq('org_id', input.org_id)
+      .eq('source_type', input.source_type)
+      .eq('source_id', input.source_id)
+      .eq('kind', input.kind)
+      .maybeSingle();
+    if (existing) return existing as InboxItem;
+
+    const { data, error } = await this.supabase
+      .from('inbox_items')
+      .insert({
+        org_id: input.org_id,
+        project_id: input.project_id,
+        assignee_member_id: input.assignee_member_id,
+        kind: input.kind,
+        title: input.title,
+        context: input.context ?? null,
+        agent_summary: input.agent_summary ?? null,
+        origin_chain: input.origin_chain ?? [],
+        options: input.options ?? [],
+        after_decision: input.after_decision ?? null,
+        from_agent_id: input.from_agent_id ?? null,
+        story_id: input.story_id ?? null,
+        memo_id: input.memo_id ?? null,
+        priority: input.priority ?? 'normal',
+        source_type: input.source_type,
+        source_id: input.source_id,
+      })
+      .select()
+      .single();
+    if (error) {
+      if (error.code === '42501') throw new ForbiddenError('Permission denied');
+      throw mapSupabaseError(error);
+    }
+    return data as InboxItem;
+  }
+
+  async list(filters: InboxListFilters): Promise<InboxItem[]> {
+    let query = this.supabase
+      .from('inbox_items')
+      .select('*')
+      .eq('org_id', filters.org_id)
+      .order('created_at', { ascending: false });
+    if (filters.project_id) query = query.eq('project_id', filters.project_id);
+    if (filters.assignee_member_id) query = query.eq('assignee_member_id', filters.assignee_member_id);
+    if (filters.kind) query = query.eq('kind', filters.kind);
+    if (filters.state) query = query.eq('state', filters.state);
+    if (filters.cursor) query = query.lt('created_at', filters.cursor);
+    if (filters.limit) query = query.limit(filters.limit);
+    const { data, error } = await query;
+    if (error) throw mapSupabaseError(error);
+    return (data ?? []) as InboxItem[];
+  }
+
+  async get(id: string, orgId: string): Promise<InboxItem | null> {
+    const { data, error } = await this.supabase
+      .from('inbox_items')
+      .select('*')
+      .eq('id', id)
+      .eq('org_id', orgId)
+      .maybeSingle();
+    if (error) throw mapSupabaseError(error);
+    return (data as InboxItem | null) ?? null;
+  }
+
+  async count(filters: Omit<InboxListFilters, 'limit' | 'cursor'>): Promise<InboxItemCount> {
+    let query = this.supabase
+      .from('inbox_items')
+      .select('kind', { count: 'exact', head: false })
+      .eq('org_id', filters.org_id);
+    if (filters.project_id) query = query.eq('project_id', filters.project_id);
+    if (filters.assignee_member_id) query = query.eq('assignee_member_id', filters.assignee_member_id);
+    if (filters.state) query = query.eq('state', filters.state);
+    const { data, error } = await query;
+    if (error) throw mapSupabaseError(error);
+
+    const byKind: Record<InboxKind, number> = { approval: 0, decision: 0, blocker: 0, mention: 0 };
+    let total = 0;
+    for (const row of data ?? []) {
+      const k = (row as { kind: InboxKind }).kind;
+      byKind[k] = (byKind[k] ?? 0) + 1;
+      total += 1;
+    }
+    return { total, byKind };
+  }
+
+  async resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem> {
+    const { data, error } = await this.supabase.rpc('resolve_inbox_item', {
+      p_id: id,
+      p_org_id: orgId,
+      p_resolved_by: input.resolved_by,
+      p_resolved_option_id: input.resolved_option_id,
+      p_resolved_note: input.resolved_note ?? null,
+    });
+    if (error) {
+      if (error.code === 'P0002') throw new NotFoundError(`Inbox item not found: ${id}`);
+      throw mapSupabaseError(error);
+    }
+    return data as InboxItem;
+  }
+
+  async dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem> {
+    const { data, error } = await this.supabase.rpc('dismiss_inbox_item', {
+      p_id: id,
+      p_org_id: orgId,
+      p_resolved_by: input.resolved_by,
+      p_resolved_note: input.resolved_note ?? null,
+    });
+    if (error) {
+      if (error.code === 'P0002') throw new NotFoundError(`Inbox item not found: ${id}`);
+      throw mapSupabaseError(error);
+    }
+    return data as InboxItem;
+  }
+
+  async reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem> {
+    const { data, error } = await this.supabase.rpc('reassign_inbox_item', {
+      p_id: id,
+      p_org_id: orgId,
+      p_new_assignee_member_id: input.new_assignee_member_id,
+      p_reassigned_by: input.reassigned_by,
+    });
+    if (error) {
+      if (error.code === 'P0002') throw new NotFoundError(`Inbox item not found: ${id}`);
+      throw mapSupabaseError(error);
+    }
+    return data as InboxItem;
+  }
+}

--- a/packages/storage-supabase/src/index.ts
+++ b/packages/storage-supabase/src/index.ts
@@ -7,3 +7,4 @@ export { SupabaseProjectRepository } from './SupabaseProjectRepository';
 export { SupabaseSprintRepository } from './SupabaseSprintRepository';
 export { SupabaseNotificationRepository } from './SupabaseNotificationRepository';
 export { SupabaseTeamMemberRepository } from './SupabaseTeamMemberRepository';
+export { SupabaseInboxItemRepository } from './SupabaseInboxItemRepository';


### PR DESCRIPTION
## Summary

Phase A.1 backend foundation for the operator cockpit redesign. Replaces the
notification-as-email model with an HITL (human-in-the-loop) decision queue.

This PR ships the schema, repository layer, atomic state-change RPCs, API
routes, and tests. **No UI yet** — Phase A.2 (UI rewrite) and A.3
(redirect+i18n) ship as separate PRs. **Producers wired in follow-up** —
agent_runs lifecycle hook + memo @mention dual-write are tracked for the
next PR.

Plan: `.omc/plans/2026-04-26-01-operator-cockpit-redesign.md` (eng review +
design review both CLEAR, codex outside voice 24 findings reflected).

### What's in this PR

- 4 Supabase migrations: `inbox_items` table + 5 RLS policies, `inbox_outbox`
  for webhook delivery (D6 outbox pattern), `team_members.color/agent_role`
  with hex check + agent-only role constraint, atomic
  `resolve_inbox_item` / `dismiss_inbox_item` / `reassign_inbox_item`
  PLpgSQL functions.
- SQLite parity for OSS mode: `inbox_items` + `inbox_outbox` tables in
  `db.ts`, `migrateTeamMembersAgentIdentity` for backfill.
- `IInboxItemRepository` interface in `@sprintable/core-storage` with both
  `SqliteInboxItemRepository` (BEGIN/COMMIT for atomic resolve+outbox) and
  `SupabaseInboxItemRepository` (delegates to RPCs).
- Zod schemas for `origin_chain` (typed `[{type,id}]`), `options` (with
  stable uuid id per option), color hex validation, agent_role enum.
- API routes: `GET /api/inbox` (list+count), `POST /api/inbox/:id/resolve`,
  `POST /api/inbox/:id/dismiss`, `POST /api/inbox/incoming` (HMAC webhook
  for external agents — D7 producer #3).
- `InboxItemService` with single-boundary Zod validation and convenience
  methods for the two upcoming code-side producers.
- 32 tests across SQLite repo + 2 API routes (success, validation,
  cross-org boundary, double-resolve 409, NotFoundError 404, OSS mode,
  rollback verification).

### Decisions baked in (from review)

- **D1**: schema follows `notifications` pattern (`org_id` + `user_id fk
  team_members(id)`) with extra `project_id` filter column for current
  project scoping.
- **D2**: `origin_chain` typed JSONB array `[{type,id}]` with Zod, GIN
  indexed.
- **D4**: OSS storage parity is in scope. SQLite repo + factory wired.
- **D6**: webhook outbox table + atomic insert in resolve/dismiss/reassign
  RPCs. Worker not in this PR (separate cron task).
- **D7 producer #3**: webhook-incoming endpoint with HMAC-SHA256
  verification. Producers #1 (agent_runs lifecycle) and #2 (memo @mention
  dual-write) ship in next PR.
- **D8**: schema-first (no view-projection layer) — sprintable-ui-mock
  already validated the domain shape.
- **D9**: personal-only inbox + admin escalation. RLS policies enforce.

### Codex tactical fixes applied

`assignee_member_id` rename, `resolved_option_id` uuid (not free text),
explicit RLS policies (5), risk-weighted coverage language, color hex
check constraint, sprint_tags FK (Phase B), realtime+polling dedupe in
spec, token-equivalent visual acceptance, color+icon+text triple a11y.

### PGlite future-compat

When OSS storage moves to PGlite later: migrations in
`packages/db/supabase/migrations/*.sql` run as-is (Postgres-compatible),
RPCs work, RLS works, JSONB native. Throwaway delta is ~30%
(`SqliteInboxItemRepository` + sqlite schema strings in `db.ts`). API
routes + service + interface + supabase repo all stay.

## Test plan

- [x] `pnpm vitest run packages/storage-sqlite/src/__tests__/SqliteInboxItemRepository.test.ts` — 17 tests green
- [x] `pnpm vitest run apps/web/src/app/api/inbox/route.test.ts` — 6 tests green
- [x] `pnpm vitest run 'apps/web/src/app/api/inbox/[id]/resolve/route.test.ts'` — 9 tests green
- [x] `pnpm --filter @sprintable/core-storage exec tsc --noEmit` — clean
- [x] `pnpm --filter @sprintable/storage-sqlite exec tsc --noEmit` — clean
- [x] `pnpm --filter @sprintable/storage-supabase exec tsc --noEmit` — clean
- [x] `pnpm --filter @sprintable/shared exec tsc --noEmit` — clean
- [x] `pnpm --filter web exec tsc --noEmit` — clean
- [ ] Apply migrations against staging Supabase + sanity insert/resolve via
  cURL
- [ ] OSS sqlite build green: `pnpm --filter @sprintable/storage-sqlite
  build`
- [ ] RLS Postgres integration test (deferred to Phase A.6 sub-PR with
  Supabase local CI)

## Follow-up PRs

- **A.1 producers** (next): wire `agent_runs.completed → approval` hook in
  `services/agent-runs.ts`, dual-write `doc-comment-notifications.ts` to
  also emit `inbox_items.kind=mention`.
- **A.2 UI**: rewrite `app/(authenticated)/inbox/page.tsx` with the
  approved sprintable-ui-mock direction (kind icon box, origin trail
  chips, options-with-consequences, agent avatar with color identity).
- **A.3**: first-screen redirect to `/inbox` + ko/en i18n keys.
- **Outbox worker**: cron task that polls `inbox_outbox` and POSTs to
  `team_members.webhook_url` with exponential backoff. Separate small PR.

## Open questions still tracked in plan

- Standup/Retro sidebar demotion location — phase B before sidebar
  rewrite.
- Lead role for shared-decision authorization — phase B if dogfood shows
  need.