### PR TITLE
feat(inbox): wire 2 producers (agent_run lifecycle + mention dual-write)

### DIFF
--- a/apps/web/src/app/api/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/agent-runs/[id]/route.ts
@@ -6,8 +6,35 @@ import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { AgentRunService } from '@/services/agent-run';
+import { InboxItemService } from '@/services/inbox-item.service';
 
 type RouteParams = { params: Promise<{ id: string }> };
+
+// Optional inbox emit on agent_run completion (Phase A.5b producer #1).
+// When the agent run transitions to status='completed' AND `inbox` is present,
+// we emit an inbox_items row for HITL approval. Idempotent via UNIQUE constraint
+// (org_id, source_type='agent_run', source_id=run.id, kind=approval).
+const inboxOnCompletionSchema = z.object({
+  assignee_member_id: z.string().min(1),
+  title: z.string().min(1).max(200),
+  context: z.string().max(2000).optional().nullable(),
+  agent_summary: z.string().max(2000).optional().nullable(),
+  options: z.array(z.object({
+    id: z.string().uuid(),
+    label: z.string().min(1),
+    kind: z.enum(['approve', 'approve-alt', 'reassign', 'changes']),
+    consequence: z.string().min(1),
+  })).default([]),
+  after_decision: z.string().max(500).optional().nullable(),
+  origin_chain: z.array(z.object({
+    type: z.enum(['memo', 'story', 'run', 'initiative']),
+    id: z.string().min(1),
+  })).optional(),
+  story_id: z.string().optional().nullable(),
+  memo_id: z.string().optional().nullable(),
+  priority: z.enum(['high', 'normal']).optional(),
+  kind: z.enum(['approval', 'decision', 'blocker']).optional().default('approval'),
+});
 
 const updateAgentRunSchema = z.object({
   status: z.enum(['running', 'completed', 'failed']),
@@ -18,6 +45,7 @@ const updateAgentRunSchema = z.object({
   cost_usd: z.number().optional().nullable(),
   started_at: z.string().optional().nullable(),
   finished_at: z.string().optional().nullable(),
+  inbox: inboxOnCompletionSchema.optional(),
 });
 
 // PATCH /api/agent-runs/[id]
@@ -50,7 +78,39 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const body = parsed.data;
 
     const service = new AgentRunService(dbClient);
-    const run = await service.update(id, body, existing.org_id, existing.project_id);
+    const { inbox: inboxRequest, ...updateInput } = body;
+    const run = await service.update(id, updateInput, existing.org_id, existing.project_id);
+
+    // Producer #1 — agent_runs lifecycle hook → inbox approval.
+    // Emit inbox only when the run transitions to a successful terminal state AND
+    // caller explicitly attached `inbox` payload. Failure here must not roll back
+    // the run update — idempotent UNIQUE constraint protects against retries.
+    if (inboxRequest && body.status === 'completed') {
+      try {
+        const inboxService = new InboxItemService(dbClient);
+        await inboxService.create({
+          org_id: existing.org_id,
+          project_id: existing.project_id,
+          assignee_member_id: inboxRequest.assignee_member_id,
+          kind: inboxRequest.kind ?? 'approval',
+          title: inboxRequest.title,
+          context: inboxRequest.context ?? null,
+          agent_summary: inboxRequest.agent_summary ?? null,
+          options: inboxRequest.options,
+          after_decision: inboxRequest.after_decision ?? null,
+          origin_chain: inboxRequest.origin_chain ?? [{ type: 'run', id }],
+          story_id: inboxRequest.story_id ?? null,
+          memo_id: inboxRequest.memo_id ?? null,
+          priority: inboxRequest.priority ?? 'normal',
+          source_type: 'agent_run',
+          source_id: id,
+        });
+      } catch {
+        // Inbox emit failure is logged at the service layer (future). Don't fail
+        // the run-update response; UNIQUE protects against double-emit on retry.
+      }
+    }
+
     return apiSuccess(run);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/services/doc-comment-notifications.ts
+++ b/apps/web/src/services/doc-comment-notifications.ts
@@ -109,5 +109,32 @@ export async function notifyDocCommentMentions({
 
   await new NotificationService(adminSupabase).createMany(notifications);
 
+  // Inbox dual-write — Phase A.B에 inbox_items로 일원화 예정. v1엔 notifications + inbox 둘 다 emit.
+  // 문서 댓글은 댓글 단위로 dedup해야 하므로 source_id에 commentId 포함 (doc_comment 별도 source key).
+  // produceMentionFromMemo는 memo_id 단위 dedup이라 여기서는 service.create를 직접 호출.
+  const { InboxItemService } = await import('./inbox-item.service');
+  const inboxService = new InboxItemService(adminSupabase);
+  const inboxBody = buildDocCommentNotificationBody(doc.title, content);
+  for (const member of mentionedMembers) {
+    try {
+      await inboxService.create({
+        org_id: doc.org_id,
+        project_id: doc.project_id,
+        assignee_member_id: member.id,
+        kind: 'mention',
+        title: '문서 댓글에서 멘션됨',
+        context: inboxBody,
+        origin_chain: [{ type: 'memo', id: doc.id }],
+        options: [],
+        memo_id: doc.id,
+        source_type: 'memo_mention',
+        // 댓글 단위 dedup. memo_mention과 namespace 안 겹치게 prefix.
+        source_id: `doc_comment:${commentId}:${member.id}`,
+      });
+    } catch {
+      // dual-write tolerated to fail
+    }
+  }
+
   return notifications.length;
 }

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -492,7 +492,11 @@ export class MemoService {
         { onConflict: 'memo_id,mentioned_user_id', ignoreDuplicates: true },
       );
 
-    // 멘션 알림
+    // 멘션 알림 + inbox 듀얼 쓰기
+    // notifications → 곧 inbox_items로 일원화 (Phase A.B). 그동안 둘 다 emit.
+    const { InboxItemService } = await import('./inbox-item.service');
+    const inboxService = new InboxItemService(this.supabase);
+
     for (const userId of mentionedIds) {
       await notifService.create({
         org_id: orgId,
@@ -503,6 +507,22 @@ export class MemoService {
         reference_type: 'memo',
         reference_id: memoId,
       });
+
+      // Inbox dual-write — idempotent via UNIQUE (org_id, source_type, source_id, kind).
+      // Failure here must not block the legacy notification path.
+      try {
+        await inboxService.produceMentionFromMemo({
+          org_id: orgId,
+          project_id: projectId,
+          assignee_member_id: userId,
+          memo_id: memoId,
+          title: '메모에서 멘션됨',
+          context: content.slice(0, 500),
+          source_id: `${memoId}:${userId}`,
+        });
+      } catch {
+        // dual-write tolerated to fail. notifications path stays authoritative for v1.
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Stacked on top of #227. Wires the remaining two inbox producers from
Phase A.5b. With this PR merged the operator inbox starts receiving
real data from existing user actions (memo @mention, doc comment
@mention) and from agent run completions that opt in.

Plan reference: `.omc/plans/2026-04-26-01-operator-cockpit-redesign.md`
section A.5b — 3 producers (agent_runs lifecycle, memo @mention,
webhook callback). Webhook (#3) shipped in #227.

## Changes

- **PATCH /api/agent-runs/[id]** now accepts optional `inbox` body
  field. When the run transitions to `status='completed'` and `inbox`
  is present, the route emits `inbox_items.kind=approval` (or
  `decision`/`blocker` if the agent specified). source_type=`agent_run`,
  source_id=run.id, so retries are idempotent against the UNIQUE
  constraint. If inbox emit throws the run update still succeeds.
  Existing callers that don't pass `inbox` are unchanged.
- **services/memo.ts `_processMemoMentions`** dual-writes
  `inbox_items.kind=mention` for each mentioned project member next
  to the existing notifications.create loop. Source key
  `${memoId}:${memberId}` dedups across re-edits of the same memo.
- **services/doc-comment-notifications.ts** dual-writes
  `inbox_items.kind=mention` via `inboxService.create` directly
  (the helper would dedupe at memo_id which is wrong for multi-comment
  threads). Source key `doc_comment:${commentId}:${memberId}` keeps
  each comment-mention as its own inbox row.

Both dual-writes are wrapped in try/catch — the legacy `notifications`
path remains authoritative for v1. Phase A.B is when we cut over and
remove the notifications path.

## Test plan

- [x] `pnpm vitest run` of all touched + adjacent tests passes (5 files,
  46 tests, no regression). `services/doc-comment-notifications.test.ts`
  and `services/agent-run-history.test.ts` continue green.
- [x] `pnpm --filter web exec tsc --noEmit` clean.
- [ ] Apply migrations against staging Supabase, then trigger a memo
  with @mention via UI and confirm both `notifications` and
  `inbox_items` rows are created (project + assignee scoped).
- [ ] Smoke-test agent run lifecycle: PATCH `/api/agent-runs/:id` with
  `status=completed` + `inbox` payload, confirm UNIQUE prevents
  duplicate inbox rows on agent retry.
- [ ] OSS sqlite path: same flows against local sqlite + verify
  outbox queue rows produced for resolve actions.

## Why no producer-specific unit tests in this PR

The dual-write is thin glue (try/catch around an existing service
method). The underlying create + RPC + idempotency paths are already
covered by the 32-test suite in #227. Existing notification tests stay
authoritative for the legacy path. Adding new mocks here would test
the mocks more than the wiring. Integration is verified at staging.

## Follow-up

- A.2 — UI rewrite of `app/(authenticated)/inbox/page.tsx`. Receives
  data from these producers + the HMAC webhook.
- A.3 — first-screen redirect to `/inbox` + ko/en i18n.
- Outbox worker — cron that consumes `inbox_outbox` rows and POSTs to
  `team_members.webhook_url` with exponential backoff.