### PR TITLE
feat(P0): add Supabase middleware.ts for session refresh

### DIFF
--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -28,7 +28,7 @@ export async function createSupabaseServerClient() {
               });
             }
           } catch {
-            // Server Component에서는 set 불가 — 무시
+            // Server Component에서는 set 불가 — middleware refreshing user sessions에서는 무시
           }
         },
       },

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,52 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+
+  const supabase = createServerClient(
+    process.env['NEXT_PUBLIC_SUPABASE_URL']!,
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value));
+          supabaseResponse = NextResponse.next({ request });
+          cookiesToSet.forEach(({ name, value, options }) =>
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+            })
+          );
+        },
+      },
+    }
+  );
+
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (
+    !user &&
+    !request.nextUrl.pathname.startsWith('/login') &&
+    !request.nextUrl.pathname.startsWith('/auth') &&
+    !request.nextUrl.pathname.startsWith('/invite') &&
+    !request.nextUrl.pathname.startsWith('/signup') &&
+    !request.nextUrl.pathname.startsWith('/forgot-password') &&
+    request.nextUrl.pathname !== '/'
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: ['/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
+};


### PR DESCRIPTION
## 변경 요약
근본 원인 2번 수정: `middleware.ts` 부재로 세션 쿠키 갱신이 안 되어 메뉴 네비게이션 시 /login redirect.

### middleware.ts (신규)
- `createServerClient` + `getAll`/`setAll` 쿠키 핸들러
- `getUser()` (JWT 서버 검증) — `getSession()` 미사용
- 미인증 사용자 → `/login` redirect (공개 경로 제외)
- `NEXT_PUBLIC_COOKIE_DOMAIN` setAll 지원

### server.ts
- catch 주석 명확화: "middleware refreshing user sessions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)