### PR TITLE
diag: add x-sp-debug-cookies/auth response headers to proxy.ts

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -106,6 +106,9 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(url);
   }
 
+  supabaseResponse.headers.set('x-sp-debug-cookies', String(request.cookies.getAll().filter(c => c.name.includes('auth-token')).length));
+  supabaseResponse.headers.set('x-sp-debug-auth', user ? user.id.slice(0, 8) : 'none');
+
   return supabaseResponse;
 }
 


### PR DESCRIPTION
## 변경 요약
세션 유지 문제 디버깅용 진단 헤더 2줄 추가.

`return supabaseResponse` 직전:
- `x-sp-debug-cookies`: auth-token 쿠키가 서버에 도달한 개수
- `x-sp-debug-auth`: getUser() 성공 시 user.id 앞 8자, 실패 시 'none'

메뉴 이동(RSC) 시 응답 헤더로 실측 데이터 확보 목적.

🤖 Generated with [Claude Code](https://claude.com/claude-code)