### PR TITLE
diag: add /api/debug-session for mobile session inspection

### DIFF
--- a/apps/web/src/app/api/debug-session/route.ts
+++ b/apps/web/src/app/api/debug-session/route.ts
@@ -1,0 +1,30 @@
+import { cookies } from 'next/headers';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export async function GET(request: Request) {
+  const cookieStore = await cookies();
+  const allCookies = cookieStore.getAll();
+  const authCookies = allCookies.filter(c => c.name.includes('auth-token'));
+
+  let userId: string | null = null;
+  let authError: string | null = null;
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data, error } = await supabase.auth.getUser();
+    userId = data.user?.id?.slice(0, 8) ?? null;
+    if (error) authError = error.message;
+  } catch (e) {
+    authError = String(e);
+  }
+
+  return Response.json({
+    totalCookies: allCookies.length,
+    authCookieCount: authCookies.length,
+    authCookieNames: authCookies.map(c => c.name),
+    authCookieDomains: authCookies.map(c => ({ name: c.name, valueLength: c.value.length })),
+    userId,
+    authError,
+    userAgent: request.headers.get('user-agent')?.slice(0, 80),
+    timestamp: new Date().toISOString(),
+  });
+}


### PR DESCRIPTION
## 변경 요약
모바일 크롬에서 DevTools 없이 세션 진단용 API 엔드포인트 추가.

`/api/debug-session` 접속 시 JSON 반환:
- `totalCookies` / `authCookieCount` / `authCookieNames`
- `authCookieDomains`: 각 auth-token 쿠키의 value 길이
- `userId`: getUser() 성공 시 앞 8자
- `authError`: getUser() 실패 시 에러 메시지
- `userAgent` / `timestamp`

proxy.ts가 `/api/` 경로를 PUBLIC_PREFIX로 우회하므로 인증 없이 접근 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)