### PR TITLE
fix(P0): proxy.ts setAll cookieDomain + fallback stopAutoRefresh

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -115,6 +115,7 @@ function FallbackHandler() {
             }),
             new Promise<never>((_, r) => setTimeout(() => r(new Error('timeout')), 10000)),
           ]);
+          supabase.auth.stopAutoRefresh();
         } catch {
           writeSessionCookies(tokenData);
         }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -72,12 +72,16 @@ export async function proxy(request: NextRequest) {
           return request.cookies.getAll();
         },
         setAll(cookiesToSet: Array<{ name: string; value: string; options: Record<string, unknown> }>) {
+          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
           for (const { name, value } of cookiesToSet) {
             request.cookies.set(name, value);
           }
           supabaseResponse = NextResponse.next({ request });
           for (const { name, value, options } of cookiesToSet) {
-            supabaseResponse.cookies.set(name, value, options as Parameters<typeof supabaseResponse.cookies.set>[2]);
+            supabaseResponse.cookies.set(name, value, {
+              ...(options as Parameters<typeof supabaseResponse.cookies.set>[2]),
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+            });
           }
         },
       },


### PR DESCRIPTION
## 변경 요약
진단 결과: `authCookieCount: 2` (쿠키 정상 도달) / `authError: "Invalid Refresh Token: Refresh Token Not Found"` (리프레시 토큰 stale).

근본 원인: proxy.ts setAll에서 `cookieDomain` 미설정 → 토큰 로테이션 시 도메인 불일치로 stale 쿠키 잔존.

### proxy.ts
`setAll` 응답 쿠키에 `NEXT_PUBLIC_COOKIE_DOMAIN` 적용

### fallback/page.tsx
`setSession` 성공 직후 `stopAutoRefresh()` 호출 — 단명 클라이언트의 백그라운드 토큰 갱신 방지

🤖 Generated with [Claude Code](https://claude.com/claude-code)