### PR TITLE
diag: extend debug-session with cookie format + getSession fields

### DIFF
--- a/apps/web/src/app/api/debug-session/route.ts
+++ b/apps/web/src/app/api/debug-session/route.ts
@@ -8,11 +8,24 @@ export async function GET(request: Request) {
 
   let userId: string | null = null;
   let authError: string | null = null;
+  let sessionData = null;
+  let sessionError: string | null = null;
+
   try {
     const supabase = await createSupabaseServerClient();
+
     const { data, error } = await supabase.auth.getUser();
     userId = data.user?.id?.slice(0, 8) ?? null;
     if (error) authError = error.message;
+
+    const { data: sd, error: se } = await supabase.auth.getSession();
+    sessionData = sd.session ? {
+      accessTokenExp: sd.session.expires_at,
+      accessTokenPrefix: sd.session.access_token?.slice(0, 20),
+      refreshTokenPrefix: sd.session.refresh_token?.slice(0, 10),
+      expiresIn: sd.session.expires_in,
+    } : null;
+    if (se) sessionError = se.message;
   } catch (e) {
     authError = String(e);
   }
@@ -22,8 +35,11 @@ export async function GET(request: Request) {
     authCookieCount: authCookies.length,
     authCookieNames: authCookies.map(c => c.name),
     authCookieDomains: authCookies.map(c => ({ name: c.name, valueLength: c.value.length })),
+    authCookieValuePrefixes: authCookies.map(c => ({ name: c.name, prefix: c.value.slice(0, 20) })),
     userId,
     authError,
+    sessionData,
+    sessionError,
     userAgent: request.headers.get('user-agent')?.slice(0, 80),
     timestamp: new Date().toISOString(),
   });


### PR DESCRIPTION
## 변경 요약
14차 수정 후에도 세션 유지 실패. 쿠키 형식 판별용 진단 필드 추가.

- `authCookieValuePrefixes`: 각 auth-token 쿠키 값 앞 20자 — `eyJ` = SDK 정상, `{"` = writeSessionCookies raw JSON
- `sessionData`: getSession() 결과 (accessTokenExp, tokenPrefix, expiresIn)
- `sessionError`: getSession() 에러

🤖 Generated with [Claude Code](https://claude.com/claude-code)