### PR TITLE
diag: sp-auth-path cookie in callback route + authPath in debug-session

### DIFF
--- a/apps/web/src/app/api/debug-session/route.ts
+++ b/apps/web/src/app/api/debug-session/route.ts
@@ -40,6 +40,7 @@ export async function GET(request: Request) {
     authError,
     sessionData,
     sessionError,
+    authPath: cookieStore.get('sp-auth-path')?.value ?? 'none',
     userAgent: request.headers.get('user-agent')?.slice(0, 80),
     timestamp: new Date().toISOString(),
   });

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -3,6 +3,9 @@ import { cookies } from 'next/headers';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { resolveAppUrl } from '@/services/app-url';
 
+const DIAG_COOKIE = 'sp-auth-path';
+const DIAG_MAX_AGE = 300;
+
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const code = searchParams.get('code');
@@ -18,9 +21,10 @@ export async function GET(request: Request) {
     fallbackParams.set('server_cv', hasCodeVerifier ? '1' : '0');
     const fallbackUrl = `${origin}/auth/callback/fallback?${fallbackParams.toString()}`;
 
-    // code_verifier 쿠키 없으면 서버 교환 skip → sessionStorage 백업에서 복원 시도
     if (!hasCodeVerifier) {
-      return NextResponse.redirect(fallbackUrl);
+      const res = NextResponse.redirect(fallbackUrl);
+      res.cookies.set(DIAG_COOKIE, 'fallback-no-cv', { path: '/', maxAge: DIAG_MAX_AGE });
+      return res;
     }
 
     const supabase = await createSupabaseServerClient();
@@ -29,29 +33,35 @@ export async function GET(request: Request) {
     if (!error) {
       const { data: aal } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
       if (aal?.nextLevel === 'aal2' && aal?.currentLevel !== 'aal2') {
-        return NextResponse.redirect(`${origin}/mfa`);
+        const res = NextResponse.redirect(`${origin}/mfa`);
+        res.cookies.set(DIAG_COOKIE, 'server-ok-mfa', { path: '/', maxAge: DIAG_MAX_AGE });
+        return res;
       }
 
+      let redirectTarget = `${origin}/dashboard`;
       if (next) {
-        return NextResponse.redirect(`${origin}${next}`);
+        redirectTarget = `${origin}${next}`;
+      } else {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          const { data: membership } = await supabase
+            .from('org_members')
+            .select('org_id')
+            .eq('user_id', user.id)
+            .limit(1)
+            .maybeSingle();
+          redirectTarget = `${origin}${membership ? '/dashboard' : '/onboarding'}`;
+        }
       }
 
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        const { data: membership } = await supabase
-          .from('org_members')
-          .select('org_id')
-          .eq('user_id', user.id)
-          .limit(1)
-          .maybeSingle();
-        return NextResponse.redirect(`${origin}${membership ? '/dashboard' : '/onboarding'}`);
-      }
-
-      return NextResponse.redirect(`${origin}/dashboard`);
+      const res = NextResponse.redirect(redirectTarget);
+      res.cookies.set(DIAG_COOKIE, 'server-ok', { path: '/', maxAge: DIAG_MAX_AGE });
+      return res;
     }
 
-    // 서버 교환 실패 시 클라이언트 fallback으로
-    return NextResponse.redirect(fallbackUrl);
+    const res = NextResponse.redirect(fallbackUrl);
+    res.cookies.set(DIAG_COOKIE, 'server-fail', { path: '/', maxAge: DIAG_MAX_AGE });
+    return res;
   }
 
   return NextResponse.redirect(`${origin}/login?error=auth_failed`);


### PR DESCRIPTION
## 변경 요약
모바일 OAuth callback이 어떤 경로를 타는지 확정용 진단 쿠키.

### route.ts
3개 분기에 `sp-auth-path` 쿠키 설정 (maxAge 300초):
- `fallback-no-cv`: code_verifier 쿠키 미도달 → fallback
- `server-ok`: 서버 exchange 성공
- `server-fail`: 서버 exchange 실패 → fallback

### debug-session/route.ts
`authPath` 필드 추가 (`sp-auth-path` 쿠키 값)

🤖 Generated with [Claude Code](https://claude.com/claude-code)