### PR TITLE
fix(P0): try SDK exchangeCodeForSession first in fallback

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -70,6 +70,31 @@ function FallbackHandler() {
           }
         }
 
+        const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
+
+        // 1단계: SDK exchange 우선 시도 (브라우저 쿠키에서 code_verifier 직접 읽음)
+        try {
+          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+          const supabaseForExchange = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+            isSingleton: false,
+            cookieOptions: {
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+              sameSite: 'lax' as const,
+              secure: true,
+              path: '/',
+            },
+          });
+          const { error: exchangeError } = await supabaseForExchange.auth.exchangeCodeForSession(code);
+          if (!exchangeError) {
+            supabaseForExchange.auth.stopAutoRefresh();
+            window.location.replace(redirectTo);
+            return;
+          }
+          console.warn('[fallback] SDK exchange failed, falling back to REST:', exchangeError.message);
+        } catch (e) {
+          console.warn('[fallback] SDK exchange exception, falling back to REST:', e);
+        }
+
         if (!codeVerifier) {
           router.replace('/login?error=auth_failed');
           return;
@@ -120,7 +145,6 @@ function FallbackHandler() {
           writeSessionCookies(tokenData);
         }
 
-        const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
         window.location.replace(redirectTo);
       } catch {
         router.replace('/login?error=auth_failed');


### PR DESCRIPTION
## 변경 요약
진단 결과 `authPath: "fallback-no-cv"` 확정 — 모바일에서 code_verifier 쿠키가 CloudFront/Lambda에 미도달.

SDK `exchangeCodeForSession`은 브라우저에서 실행되어 브라우저 쿠키에서 code_verifier를 직접 읽으므로 서버 전달 문제를 우회.

### 흐름
1. `createBrowserClient(isSingleton:false)` → `exchangeCodeForSession(code)` 시도
2. 성공 → `stopAutoRefresh()` + `window.location.replace(redirectTo)` (early return)
3. 실패 → `console.warn` + 기존 REST fetch + setSession 폴백 (하위 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)