### PR TITLE
revert: Revert PR #236 SDK exchangeCodeForSession (로그인 전면 실패)

### DIFF
--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -70,31 +70,6 @@ function FallbackHandler() {
           }
         }
 
-        const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
-
-        // 1단계: SDK exchange 우선 시도 (브라우저 쿠키에서 code_verifier 직접 읽음)
-        try {
-          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
-          const supabaseForExchange = createBrowserClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-            isSingleton: false,
-            cookieOptions: {
-              ...(cookieDomain ? { domain: cookieDomain } : {}),
-              sameSite: 'lax' as const,
-              secure: true,
-              path: '/',
-            },
-          });
-          const { error: exchangeError } = await supabaseForExchange.auth.exchangeCodeForSession(code);
-          if (!exchangeError) {
-            supabaseForExchange.auth.stopAutoRefresh();
-            window.location.replace(redirectTo);
-            return;
-          }
-          console.warn('[fallback] SDK exchange failed, falling back to REST:', exchangeError.message);
-        } catch (e) {
-          console.warn('[fallback] SDK exchange exception, falling back to REST:', e);
-        }
-
         if (!codeVerifier) {
           router.replace('/login?error=auth_failed');
           return;
@@ -145,6 +120,7 @@ function FallbackHandler() {
           writeSessionCookies(tokenData);
         }
 
+        const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
         window.location.replace(redirectTo);
       } catch {
         router.replace('/login?error=auth_failed');


### PR DESCRIPTION
## 긴급 롤백

PR #236 배포 후 모바일 로그인 전면 실패.

**원인:** SDK `exchangeCodeForSession(code)`이 authorization code를 소비(무효화) → 이후 REST fallback에서 같은 code 재사용 불가 → 로그인 전체 실패.

`aba0f33` revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)