### PR TITLE
refactor(operator-cockpit-a1): 보일러플레이트 추출 + OSS 분기 통합 + 스키마 통합 + 로깅

### DIFF
--- a/apps/web/src/app/api/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/agent-runs/[id]/route.ts
@@ -7,6 +7,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { AgentRunService } from '@/services/agent-run';
 import { InboxItemService } from '@/services/inbox-item.service';
+import { originChainSchema, inboxOptionsSchema, INBOX_PRIORITIES } from '@sprintable/shared';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -19,21 +20,13 @@ const inboxOnCompletionSchema = z.object({
   title: z.string().min(1).max(200),
   context: z.string().max(2000).optional().nullable(),
   agent_summary: z.string().max(2000).optional().nullable(),
-  options: z.array(z.object({
-    id: z.string().uuid(),
-    label: z.string().min(1),
-    kind: z.enum(['approve', 'approve-alt', 'reassign', 'changes']),
-    consequence: z.string().min(1),
-  })).default([]),
+  options: inboxOptionsSchema.default([]),
   after_decision: z.string().max(500).optional().nullable(),
-  origin_chain: z.array(z.object({
-    type: z.enum(['memo', 'story', 'run', 'initiative']),
-    id: z.string().min(1),
-  })).optional(),
+  origin_chain: originChainSchema.optional(),
   story_id: z.string().optional().nullable(),
   memo_id: z.string().optional().nullable(),
-  priority: z.enum(['high', 'normal']).optional(),
-  kind: z.enum(['approval', 'decision', 'blocker']).optional().default('approval'),
+  priority: z.enum(INBOX_PRIORITIES).optional(),
+  kind: z.enum(['approval', 'decision', 'blocker'] as const).optional().default('approval'),
 });
 
 const updateAgentRunSchema = z.object({
@@ -105,9 +98,8 @@ export async function PATCH(request: Request, { params }: RouteParams) {
           source_type: 'agent_run',
           source_id: id,
         });
-      } catch {
-        // Inbox emit failure is logged at the service layer (future). Don't fail
-        // the run-update response; UNIQUE protects against double-emit on retry.
+      } catch (err: unknown) {
+        console.error('[agent-runs PATCH] inbox emit failed', err);
       }
     }
 

--- a/apps/web/src/app/api/inbox/[id]/dismiss/route.ts
+++ b/apps/web/src/app/api/inbox/[id]/dismiss/route.ts
@@ -1,12 +1,8 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { setupInboxRoute, mapInboxRepoError } from '@/lib/inbox-route-helpers';
+import { createInboxItemRepository } from '@/lib/storage/factory';
 import { parseBody, dismissInboxItemSchema } from '@sprintable/shared';
-import { NotFoundError } from '@sprintable/core-storage';
 
 /** POST /api/inbox/:id/dismiss — 항목 dismiss (사용자가 무시) */
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -14,15 +10,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const { id } = await params;
     if (!id) return ApiErrors.badRequest('id required');
 
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const ossMode = isOssMode();
-    const dbClient: SupabaseClient | undefined = ossMode
-      ? undefined
-      : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const setup = await setupInboxRoute(request);
+    if (!setup.ok) return setup.response;
+    const { me, dbClient } = setup;
 
     const parsed = await parseBody(request, dismissInboxItemSchema);
     if (!parsed.success) return parsed.response;
@@ -35,10 +25,7 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       });
       return apiSuccess(result);
     } catch (err: unknown) {
-      if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
-      const msg = err instanceof Error ? err.message : '';
-      if (msg.includes('already')) return apiError('CONFLICT', msg, 409);
-      throw err;
+      return mapInboxRepoError(err);
     }
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/inbox/[id]/resolve/route.ts
+++ b/apps/web/src/app/api/inbox/[id]/resolve/route.ts
@@ -1,12 +1,8 @@
-import type { SupabaseClient } from '@supabase/supabase-js';
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { setupInboxRoute, mapInboxRepoError } from '@/lib/inbox-route-helpers';
+import { createInboxItemRepository } from '@/lib/storage/factory';
 import { parseBody, resolveInboxItemSchema } from '@sprintable/shared';
-import { NotFoundError } from '@sprintable/core-storage';
 
 /** POST /api/inbox/:id/resolve — 의사결정 처리 */
 export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
@@ -14,15 +10,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
     const { id } = await params;
     if (!id) return ApiErrors.badRequest('id required');
 
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const ossMode = isOssMode();
-    const dbClient: SupabaseClient | undefined = ossMode
-      ? undefined
-      : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const setup = await setupInboxRoute(request);
+    if (!setup.ok) return setup.response;
+    const { me, dbClient } = setup;
 
     const parsed = await parseBody(request, resolveInboxItemSchema);
     if (!parsed.success) return parsed.response;
@@ -36,12 +26,9 @@ export async function POST(request: Request, { params }: { params: Promise<{ id:
       });
       return apiSuccess(result);
     } catch (err: unknown) {
-      if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
-      // 이미 resolved/dismissed 상태(SQLite throws Error, Postgres throws 23514)
       const msg = err instanceof Error ? err.message : '';
-      if (msg.includes('already')) return apiError('CONFLICT', msg, 409);
       if (msg.includes('Option id') || msg.includes('option_id')) return ApiErrors.badRequest(msg);
-      throw err;
+      return mapInboxRepoError(err);
     }
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/lib/inbox-route-helpers.ts
+++ b/apps/web/src/lib/inbox-route-helpers.ts
@@ -1,0 +1,33 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { NotFoundError } from '@sprintable/core-storage';
+
+export type InboxAuthContext = NonNullable<Awaited<ReturnType<typeof getAuthContext>>>;
+
+export type InboxRouteSetup =
+  | { ok: false; response: Response }
+  | { ok: true; me: InboxAuthContext; dbClient: SupabaseClient | undefined };
+
+export async function setupInboxRoute(request: Request): Promise<InboxRouteSetup> {
+  const supabase = await createSupabaseServerClient();
+  const me = await getAuthContext(supabase, request);
+  if (!me) return { ok: false, response: ApiErrors.unauthorized() };
+  if (me.rateLimitExceeded) return { ok: false, response: ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt) };
+
+  const dbClient: SupabaseClient | undefined = isOssMode()
+    ? undefined
+    : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+  return { ok: true, me, dbClient };
+}
+
+export function mapInboxRepoError(err: unknown): Response {
+  if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
+  const msg = err instanceof Error ? err.message : '';
+  if (msg.includes('already')) return apiError('CONFLICT', msg, 409);
+  throw err;
+}

--- a/apps/web/src/services/doc-comment-notifications.ts
+++ b/apps/web/src/services/doc-comment-notifications.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import { NotificationService } from './notification.service';
+import { InboxItemService } from './inbox-item.service';
 
 export interface MentionableProjectMember {
   id: string;
@@ -112,7 +113,6 @@ export async function notifyDocCommentMentions({
   // Inbox dual-write — Phase A.B에 inbox_items로 일원화 예정. v1엔 notifications + inbox 둘 다 emit.
   // 문서 댓글은 댓글 단위로 dedup해야 하므로 source_id에 commentId 포함 (doc_comment 별도 source key).
   // produceMentionFromMemo는 memo_id 단위 dedup이라 여기서는 service.create를 직접 호출.
-  const { InboxItemService } = await import('./inbox-item.service');
   const inboxService = new InboxItemService(adminSupabase);
   const inboxBody = buildDocCommentNotificationBody(doc.title, content);
   for (const member of mentionedMembers) {
@@ -131,8 +131,8 @@ export async function notifyDocCommentMentions({
         // 댓글 단위 dedup. memo_mention과 namespace 안 겹치게 prefix.
         source_id: `doc_comment:${commentId}:${member.id}`,
       });
-    } catch {
-      // dual-write tolerated to fail
+    } catch (err: unknown) {
+      console.error('[doc-comment-notifications] inbox dual-write failed', err);
     }
   }
 

--- a/apps/web/src/services/inbox-item.service.ts
+++ b/apps/web/src/services/inbox-item.service.ts
@@ -78,34 +78,26 @@ export class InboxItemService {
     });
   }
 
+  private async getRepo() {
+    return createInboxItemRepository(isOssMode() ? undefined : this.supabase);
+  }
+
   /**
    * resolve — assignee 본인 또는 admin이 호출. RLS가 권한 검증.
    * @throws NotFoundError, error with code 23514 if already resolved.
    */
   async resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem> {
-    if (isOssMode()) {
-      const repo = await createInboxItemRepository();
-      return repo.resolve(id, orgId, input);
-    }
-    const repo = await createInboxItemRepository(this.supabase);
+    const repo = await this.getRepo();
     return repo.resolve(id, orgId, input);
   }
 
   async dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem> {
-    if (isOssMode()) {
-      const repo = await createInboxItemRepository();
-      return repo.dismiss(id, orgId, input);
-    }
-    const repo = await createInboxItemRepository(this.supabase);
+    const repo = await this.getRepo();
     return repo.dismiss(id, orgId, input);
   }
 
   async reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem> {
-    if (isOssMode()) {
-      const repo = await createInboxItemRepository();
-      return repo.reassign(id, orgId, input);
-    }
-    const repo = await createInboxItemRepository(this.supabase);
+    const repo = await this.getRepo();
     return repo.reassign(id, orgId, input);
   }
 }

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -7,6 +7,7 @@ import { buildAbsoluteMemoLink } from './app-url';
 import { NotFoundError, ForbiddenError } from './sprint';
 import { NotificationService } from './notification.service';
 import { hasExactMemberMention } from './doc-comment-notifications';
+import { InboxItemService } from './inbox-item.service';
 
 export interface CreateMemoInput {
   project_id: string;
@@ -494,7 +495,6 @@ export class MemoService {
 
     // 멘션 알림 + inbox 듀얼 쓰기
     // notifications → 곧 inbox_items로 일원화 (Phase A.B). 그동안 둘 다 emit.
-    const { InboxItemService } = await import('./inbox-item.service');
     const inboxService = new InboxItemService(this.supabase);
 
     for (const userId of mentionedIds) {
@@ -520,8 +520,8 @@ export class MemoService {
           context: content.slice(0, 500),
           source_id: `${memoId}:${userId}`,
         });
-      } catch {
-        // dual-write tolerated to fail. notifications path stays authoritative for v1.
+      } catch (err: unknown) {
+        console.error('[MemoService._processMemoMentions] inbox dual-write failed', err);
       }
     }
   }


### PR DESCRIPTION
## Summary
- AC-1: `inbox-route-helpers.ts` 신설 — `setupInboxRoute` + `mapInboxRepoError` 헬퍼. resolve/dismiss 라우트 각 12라인 감소
- AC-2: `InboxItemService.getRepo()` private 메서드로 `isOssMode()` 분기 3중복 제거
- AC-3: `memo.ts`, `doc-comment-notifications.ts` dynamic import → top-level import
- AC-4: `inboxOnCompletionSchema` → `originChainSchema`/`inboxOptionsSchema`/`INBOX_PRIORITIES` shared 사용
- AC-5: 빈 catch 블록 3곳 `console.error` 로깅 추가

## Test plan
- [x] resolve/dismiss/inbox/agent-runs 관련 테스트 30건 전량 통과
- [x] team-members 2건 실패는 develop 기존 실패 확인 (내 변경과 무관)
- [x] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)