### PR TITLE
fix(P0): 프로젝트 전환 type='human' 필터 제거 + res.ok 체크

### DIFF
--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -24,7 +24,6 @@ export async function GET() {
         .from('team_members')
         .select('project_id, org_id, projects(name)')
         .eq('user_id', user.id)
-        .eq('type', 'human')
         .eq('is_active', true)
         .limit(1)
         .maybeSingle();
@@ -52,7 +51,6 @@ export async function GET() {
       .from('team_members')
       .select('id, project_id, org_id, projects(name)')
       .eq('user_id', user.id)
-      .eq('type', 'human')
       .eq('is_active', true)
       .eq('project_id', projectId)
       .maybeSingle();
@@ -91,7 +89,6 @@ export async function POST(request: Request) {
       .from('team_members')
       .select('id, project_id, projects(name)')
       .eq('user_id', user.id)
-      .eq('type', 'human')
       .eq('is_active', true)
       .eq('project_id', projectId)
       .maybeSingle();

--- a/apps/web/src/components/nav/project-switcher.tsx
+++ b/apps/web/src/components/nav/project-switcher.tsx
@@ -34,11 +34,15 @@ export function ProjectSwitcher({
 
         setPending(true);
         try {
-          await fetch('/api/current-project', {
+          const res = await fetch('/api/current-project', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ project_id: nextProjectId }),
           });
+          if (!res.ok) {
+            console.error('[ProjectSwitcher] project switch failed', res.status);
+            return;
+          }
           router.refresh();
         } finally {
           setPending(false);


### PR DESCRIPTION
## Summary
- **버그 1** (`current-project/route.ts`): GET/POST 모두 `.eq('type', 'human')` 제거 — owner 계정이 `type='agent'`일 경우 403으로 쿠키 SET 불가했던 근본 원인 수정
- **버그 2** (`project-switcher.tsx`): POST 응답 `res.ok` 체크 추가 — 실패 시 `router.refresh()` 호출 방지

## Test plan
- [ ] owner 계정으로 프로젝트 전환 → 쿠키 정상 SET + 페이지 갱신
- [ ] 미가입 프로젝트 전환 시도 → 403 반환, UI에서 refresh 없음
- [x] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)