### PR TITLE
fix: 마이그레이션 BIGINT/DROP POLICY 수정 + type='human' 필터 복구

### DIFF
--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -24,6 +24,7 @@ export async function GET() {
         .from('team_members')
         .select('project_id, org_id, projects(name)')
         .eq('user_id', user.id)
+        .eq('type', 'human')
         .eq('is_active', true)
         .limit(1)
         .maybeSingle();
@@ -51,6 +52,7 @@ export async function GET() {
       .from('team_members')
       .select('id, project_id, org_id, projects(name)')
       .eq('user_id', user.id)
+      .eq('type', 'human')
       .eq('is_active', true)
       .eq('project_id', projectId)
       .maybeSingle();
@@ -89,6 +91,7 @@ export async function POST(request: Request) {
       .from('team_members')
       .select('id, project_id, projects(name)')
       .eq('user_id', user.id)
+      .eq('type', 'human')
       .eq('is_active', true)
       .eq('project_id', projectId)
       .maybeSingle();

--- a/packages/db/supabase/migrations/20260424230000_stories_position.sql
+++ b/packages/db/supabase/migrations/20260424230000_stories_position.sql
@@ -1,2 +1,2 @@
-ALTER TABLE public.stories ADD COLUMN IF NOT EXISTS position INTEGER;
-UPDATE public.stories SET position = EXTRACT(EPOCH FROM created_at)::INTEGER * 1000 WHERE position IS NULL;
+ALTER TABLE public.stories ADD COLUMN IF NOT EXISTS position BIGINT;
+UPDATE public.stories SET position = EXTRACT(EPOCH FROM created_at)::BIGINT * 1000 WHERE position IS NULL;

--- a/packages/db/supabase/migrations/20260425000000_story_activities.sql
+++ b/packages/db/supabase/migrations/20260425000000_story_activities.sql
@@ -17,8 +17,10 @@ CREATE INDEX IF NOT EXISTS idx_story_activities_story_id
 
 ALTER TABLE public.story_activities ENABLE ROW LEVEL SECURITY;
 
+DROP POLICY IF EXISTS "story_activities_select" ON public.story_activities;
 CREATE POLICY "story_activities_select" ON public.story_activities FOR SELECT
   USING (org_id IN (SELECT public.get_user_org_ids()));
 
+DROP POLICY IF EXISTS "story_activities_insert" ON public.story_activities;
 CREATE POLICY "story_activities_insert" ON public.story_activities FOR INSERT
   WITH CHECK (org_id IN (SELECT public.get_user_org_ids()));


### PR DESCRIPTION
## Summary
- **마이그레이션 1** (`20260424230000_stories_position.sql`): `INTEGER` → `BIGINT` 변경 — 2026년 epoch*1000이 INTEGER 범위 초과
- **마이그레이션 2** (`20260425000000_story_activities.sql`): `CREATE POLICY` 전 `DROP POLICY IF EXISTS` 추가 — 프로덕션 기존 policy 충돌 방지
- **route 복구** (`current-project/route.ts`): `.eq('type', 'human')` 3곳 복구 — 웹 UI 인간 사용자 전용 보안 필터 (PR #241에서 잘못 제거됨, 진짜 원인은 마이그레이션 미적용)

## Test plan
- [x] `pnpm build` 성공
- [ ] 마이그레이션 적용 후 stories.position 저장 정상
- [ ] human 사용자 프로젝트 전환 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)