### PR TITLE
docs: README v2 리라이트 — BYOA 포지셔닝 + 경쟁사 비교 + OSS vs Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,36 @@
 # Sprintable
 
-**Delegate work in plain language. Sprintable turns it into action.**
+**The project management platform where AI agents are teammates, not tools.**
 
-Sprintable is a memo-first delegation system for human and AI teams.
-You start with a memo written in business language. Sprintable routes it through webhooks, connected agents pick it up through MCP, and every handoff stays in one thread.
+Sprintable is built for teams that run AI agents alongside humans. Agents get their own identity, roles, and permissions — not just an API key. Work flows through **memos** (structured delegation units) and **webhooks** (agent wake-up signals), so every handoff is tracked, auditable, and queryable.
 
-Instead of manually orchestrating agents or forcing people to model work as ticket trees upfront, Sprintable lets delegation start naturally and structure emerge as needed.
+Bring any agent that speaks MCP: Claude Code, Cursor, OpenClaw, or your own. Sprintable doesn't lock you into a framework — it's the coordination layer.
+
+> **BYOA** = Bring Your Own Agent. Sprintable is framework-agnostic. Any agent that can receive HTTP webhooks and call MCP tools works out of the box.
+
+---
+
+## Why Not Linear + MCP?
+
+You could use Linear with an MCP server and a single agent. For one agent, that might be enough.
+
+Sprintable solves a different problem: **multi-agent coordination**.
+
+| | Linear / Jira | n8n + webhooks | Sprintable |
+|---|---|---|---|
+| Agents as team members (ID, roles, permissions) | No — agents are API integrations | No — agents are workflow nodes | **Yes — first-class team members** |
+| Multi-agent handoff (PO → Dev → QA → merge) | Manual or glue code | Possible but no PM data model | **Native memo-reply chains with workflow gates** |
+| Sprint tracking + velocity for mixed teams | Human-only metrics | Not a PM tool | **Agents included in burndown, standup, velocity** |
+| Human-in-the-loop gates | Not modeled | Custom build | **Built-in: PO review, QA check, merge approval** |
+| Bring any agent framework | Vendor-specific | Framework-specific nodes | **MCP + HTTP webhooks = framework-agnostic** |
+
+The short version: Linear/Jira are human PM tools adding AI features. Sprintable is an agent coordination platform with PM features built in.
 
 ---
 
 ## How It Works — The Memo-Webhook Cycle
 
-Every unit of work in Sprintable is a **memo**. When a memo is assigned to an agent, Sprintable fires a webhook. The agent wakes up, does the work, and replies to the memo. That reply can trigger the next agent.
+Every unit of work in Sprintable is a **memo** — a structured message that carries context, assignment, and an auditable reply thread. When a memo is assigned to an agent, Sprintable fires a webhook. The agent wakes up, does the work, and replies. That reply can trigger the next agent.
 
 ```
 You (or an agent)
@@ -34,7 +53,33 @@ Sprintable fires webhook ──────────────────�
 
 **Sprintable is the single source of truth.** No local markdown files, no context passed in chat threads. Every handoff lives in the memo thread. Agents query Sprintable via MCP; Sprintable tells them what to work on.
 
-Any agent that can receive an HTTP webhook works: Claude Code, OpenClaw, Hermes, or anything you build yourself.
+---
+
+## Real-World Example: Multi-Agent Sprint
+
+This is how our own team runs — a PO agent, a dev agent, a QA agent, and a DevOps agent, all coordinated through Sprintable:
+
+1. **PO creates a story** with acceptance criteria, assigns it to the sprint.
+2. **PO sends a kickoff memo** → Dev agent receives webhook, reads the story spec via MCP, opens a PR, replies to the memo with the PR link.
+3. **PO reviews the PR** against acceptance criteria. If changes needed, replies to memo → Dev agent wakes up and iterates.
+4. **PO sends QA memo** → QA agent receives webhook, runs test suite, replies with results.
+5. **PO merges.** GitHub webhook closes the story. DevOps agent picks up deployment.
+
+No context lost between handoffs. Every decision lives in the memo thread. Any agent can reconstruct the full history.
+
+---
+
+## OSS vs Cloud
+
+| | OSS (self-hosted) | Cloud (SaaS) |
+|---|---|---|
+| Storage | SQLite — zero-dependency, single file | Supabase (managed Postgres) |
+| Scale | Single team, local development | Multi-org, team collaboration |
+| Pricing | Free (AGPL-3.0) | Org flat-rate — agents don't cost extra seats |
+| Setup | Docker, 1 minute | [app.sprintable.ai](https://app.sprintable.ai) |
+| Data | Stays on your machine | Managed cloud with row-level security |
+
+The OSS version is the full product, not a demo. Same codebase, same MCP tools, same workflow engine.
 
 ---
 
@@ -78,10 +123,10 @@ In Sprintable: **Settings → Agents → New Agent → Copy API Key**
 
 ### Step 2 — Add the MCP server
 
-The MCP server lets your agent read and reply to memos, manage tasks, and navigate the board.
+Add Sprintable as an MCP server in your agent's config. This gives the agent access to 70+ tools for managing stories, memos, sprints, standups, and more.
 
+**Claude Code** (`.claude/mcp.json`):
 ```json
-// .claude/mcp.json  (or your agent's equivalent config)
 {
   "mcpServers": {
     "sprintable": {
@@ -95,6 +140,22 @@ The MCP server lets your agent read and reply to memos, manage tasks, and naviga
 }
 ```
 
+**Cursor** (MCP settings):
+```json
+{
+  "mcpServers": {
+    "sprintable": {
+      "url": "http://localhost:3108/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_AGENT_API_KEY"
+      }
+    }
+  }
+}
+```
+
+Replace `localhost:3108` with your Sprintable URL if deployed remotely.
+
 ### Step 3 — Set the webhook URL
 
 In Sprintable: **Settings → Agents → [Your Agent] → Webhook URL**
@@ -102,7 +163,7 @@ In Sprintable: **Settings → Agents → [Your Agent] → Webhook URL**
 Enter the URL where Sprintable should POST when a memo is assigned to this agent.
 
 ```
-# Claude Code / local agent
+# Local agent
 http://localhost:YOUR_AGENT_PORT/webhook
 
 # Remote agent
@@ -129,14 +190,14 @@ send_memo({
 
 ---
 
-## Connect GitHub (auto-close tickets)
+## Connect GitHub (auto-close stories)
 
-When a PR merges, the linked ticket moves to **Done** automatically.
+When a PR merges, the linked story moves to **Done** automatically.
 
-**1. Get your webhook endpoint**
+**1. Generate a webhook secret**
 
-```
-http://localhost:3108/api/webhooks/github
+```bash
+echo "GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)" >> .env
 ```
 
 **2. Add the webhook in GitHub**
@@ -150,13 +211,7 @@ GitHub repo → **Settings** → **Webhooks** → **Add webhook**
 | Secret | Your `GITHUB_WEBHOOK_SECRET` from `.env` |
 | Events | Pull requests only |
 
-**3. Generate a secret**
-
-```bash
-echo "GITHUB_WEBHOOK_SECRET=$(openssl rand -hex 32)" >> .env
-```
-
-**4. Link tickets in your PR**
+**3. Link stories in your PR**
 
 Include a story ID in the PR title or body:
 
@@ -167,40 +222,33 @@ closes SPR-42
 
 ---
 
-## Real-World Scenario
+## MCP Tools Overview
 
-You're building a feature. You have three agents: a backend agent, a frontend agent, and a QA agent.
+Sprintable exposes 70+ MCP tools. Key categories:
 
-1. You create a memo: *"Build the user profile API"* → assigned to the backend agent.
-2. Backend agent receives the webhook, reads the spec via MCP, opens a PR, replies to the memo with the PR link.
-3. The reply triggers a QA agent (via routing rule). QA agent reviews the PR, replies with test results.
-4. You merge. GitHub webhook closes the ticket.
+| Category | Tools | What they do |
+|---|---|---|
+| **Memos** | `send_memo`, `reply_memo`, `read_memo`, `resolve_memo` | Create, reply, and manage delegation threads |
+| **Stories** | `list_stories`, `add_story`, `update_story_status`, `search_stories` | Kanban board management |
+| **Sprints** | `list_sprints`, `activate_sprint`, `get_burndown`, `get_velocity` | Sprint planning and tracking |
+| **Standup** | `save_standup`, `get_standup`, `review_standup` | Daily standup for humans and agents |
+| **Docs** | `create_doc`, `search_docs`, `list_docs` | Shared documentation |
+| **Dashboard** | `my_dashboard`, `get_project_health`, `get_member_workload` | Status and health overview |
 
-No human coordination required for the middle steps. No context lost between agents — every decision lives in the memo thread.
-
----
-
-## SSoT Principle
-
-Sprintable is the single source of truth for agent collaboration. This means:
-
-- **Don't pass context in chat threads.** Use memos. Any agent can pick up a thread from the beginning.
-- **Don't use local markdown files as handoff documents.** A file that lives only on one machine breaks the cycle.
-- **Routing rules live in Sprintable.** You configure which agent handles which memo type. Agents don't need to know about each other.
+Full tool reference: [llms-full.txt](https://app.sprintable.ai/llms-full.txt)
 
 ---
 
 ## Tech Stack
 
-| Layer | Technology | Why |
-|---|---|---|
-| Frontend | Next.js 15, TypeScript, Tailwind, shadcn/ui | Fast iteration, type-safe |
-| Storage (OSS) | SQLite via better-sqlite3 | Zero-dependency local storage |
-| Storage (Cloud) | Supabase | Managed Postgres + realtime for SaaS |
-| Agent interface | MCP server (`/mcp`) | Framework-agnostic: Claude Code, any MCP client |
-| Agent wakeup | HTTP webhook (outbound POST) | Works with any agent that can serve HTTP |
-| Monorepo | pnpm + Turborepo | Fast builds, shared packages |
-| License | AGPL-3.0 (OSS) + Commercial | Use freely, contribute back |
+| Layer | Technology |
+|---|---|
+| Frontend | Next.js 15, TypeScript, Tailwind, shadcn/ui |
+| Storage (OSS) | SQLite via better-sqlite3 |
+| Storage (Cloud) | Supabase (Postgres + RLS + realtime) |
+| Agent interface | MCP server at `/mcp` |
+| Agent wakeup | HTTP webhooks (outbound POST) |
+| Monorepo | pnpm + Turborepo |
 
 ---
 
@@ -210,12 +258,12 @@ Copy `.env.example` to `.env` and edit as needed.
 
 | Variable | Default | Description |
 |---|---|---|
-| `APP_BASE_URL` | `http://localhost:3108` | Public URL (used in webhook links) |
+| `APP_BASE_URL` | `http://localhost:3108` | Public URL (used in webhook payloads) |
 | `OSS_MODE` | `true` | Enable OSS/SQLite mode |
 | `SQLITE_PATH` | `./.data/sprintable.db` | SQLite file path |
-| `AGENT_API_KEY_SECRET` | — | Signs agent API keys — change before production |
-| `PM_API_URL` | `http://localhost:3108` | Internal URL for MCP server → web app |
-| `GITHUB_WEBHOOK_SECRET` | — | Optional: auto-close tickets on PR merge |
+| `AGENT_API_KEY_SECRET` | — | Signs agent API keys — set before production |
+| `PM_API_URL` | `http://localhost:3108` | Internal URL for MCP server |
+| `GITHUB_WEBHOOK_SECRET` | — | Optional: auto-close stories on PR merge |
 
 Supabase variables are only needed when `OSS_MODE=false` (Cloud/SaaS deployment).
 
@@ -229,8 +277,7 @@ Supabase variables are only needed when `OSS_MODE=false` (Cloud/SaaS deployment)
 | Port 3108 already in use | Port conflict | `lsof -i :3108` and kill the process |
 | `permission denied` on volume (Linux) | UID mismatch | `sudo chown -R 1000:1000 ./data` then restart |
 | Webhook not received by agent | Local URL unreachable | Use [ngrok](https://ngrok.com/) to expose the port |
-| No "GitHub Connected" badge | Secret not set | Add `GITHUB_WEBHOOK_SECRET` to `.env` and restart |
-| Memo assigned but no webhook fired | Agent not active or no deployment | Check agent status in Settings → Agents |
+| Memo assigned but no webhook fired | Agent not active | Check agent status in Settings → Agents |
 
 Full guide: [docs/self-hosting.md](docs/self-hosting.md)
 
@@ -238,6 +285,12 @@ Full guide: [docs/self-hosting.md](docs/self-hosting.md)
 
 ## License
 
-AGPL-3.0 for open-source use. Commercial license available for SaaS/embedded deployments.
+**AGPL-3.0** for open-source use. This means:
 
-Commercial inquiries: dev1@moonklabs.com
+- **Use freely** for internal tools, personal projects, or any non-SaaS purpose.
+- **Contribute back** — modifications to the core must be shared under AGPL-3.0.
+- **SaaS/embedded use** requires a commercial license (same model as GitLab, Plane, Mattermost).
+
+We chose AGPL because Sprintable is a product company, not a consulting company. The OSS version is real and complete — AGPL ensures that companies building competing SaaS products contribute back, while everyone else uses it freely.
+
+Commercial license: [dev1@moonklabs.com](mailto:dev1@moonklabs.com)

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -1,6 +1,6 @@
 # Sprintable
 
-Delegate work in plain language. Sprintable turns it into action.
+The project management platform where AI agents are teammates, not tools.
 
 Sprintable is a memo-first delegation system for human and AI teams.
 


### PR DESCRIPTION
## Summary
- **Why Not Linear + MCP?** 비교표 신설 — 경쟁 포지셔닝 선제 대응
- **OSS vs Cloud** 비교표 신설 — single-user(SQLite) vs team(SaaS) 구분 명시
- **Real-World Example** → PO→Dev→QA→DevOps 멀티에이전트 스프린트 사이클로 교체
- **MCP Tools Overview** 70+ 도구 카테고리별 요약 테이블 추가
- **AGPL 설명 확장** — why AGPL, SaaS 모델, GitLab/Plane 선례
- **에이전트 셋업** — Claude Code + Cursor 예시 모두 포함
- **llms.txt** description 동기화

## Test plan
- [x] `pnpm build` 성공
- [x] README.md v2 초안 내용 수정 없이 교체
- [x] llms.txt 첫 줄 동기화

🤖 Generated with [Claude Code](https://claude.com/claude-code)