### PR TITLE
feat(inbox): outbox worker for webhook delivery

### DIFF
--- a/apps/web/src/app/api/cron/inbox-outbox/route.test.ts
+++ b/apps/web/src/app/api/cron/inbox-outbox/route.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createClient, scan } = vi.hoisted(() => {
+  process.env.CRON_SECRET = 'cron-secret';
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  return {
+    createClient: vi.fn(),
+    scan: vi.fn(),
+  };
+});
+
+vi.mock('@supabase/supabase-js', () => ({ createClient }));
+vi.mock('@/services/inbox-outbox.service', () => ({
+  InboxOutboxService: class InboxOutboxService {
+    scan = scan;
+  },
+}));
+
+import { GET } from './route';
+
+describe('GET /api/cron/inbox-outbox', () => {
+  beforeEach(() => {
+    createClient.mockReset();
+    scan.mockReset();
+  });
+
+  it('rejects unauthorized cron calls', async () => {
+    const response = await GET(new Request('http://localhost/api/cron/inbox-outbox'));
+    expect(response.status).toBe(401);
+  });
+
+  it('returns scanner results for authorized cron calls', async () => {
+    createClient.mockReturnValue({});
+    scan.mockResolvedValue({
+      scanned: 3,
+      delivered: 2,
+      retried: 1,
+      dead: 0,
+      skipped: 0,
+    });
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/inbox-outbox', {
+        headers: { authorization: 'Bearer cron-secret' },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      data: { scanned: 3, delivered: 2, retried: 1, dead: 0, skipped: 0 },
+    });
+  });
+
+  it('returns 500 when service throws', async () => {
+    createClient.mockReturnValue({});
+    scan.mockRejectedValue(new Error('rpc_failed'));
+
+    const response = await GET(
+      new Request('http://localhost/api/cron/inbox-outbox', {
+        headers: { authorization: 'Bearer cron-secret' },
+      }),
+    );
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/apps/web/src/app/api/cron/inbox-outbox/route.ts
+++ b/apps/web/src/app/api/cron/inbox-outbox/route.ts
@@ -1,0 +1,32 @@
+import { createClient } from '@supabase/supabase-js';
+import { apiError, apiSuccess } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+import { InboxOutboxService } from '@/services/inbox-outbox.service';
+
+const CRON_SECRET = process.env.CRON_SECRET;
+
+export async function GET(request: Request) {
+  if (isOssMode()) return apiSuccess({ ok: true, skipped: true });
+
+  const authHeader = request.headers.get('authorization');
+  if (CRON_SECRET && authHeader !== `Bearer ${CRON_SECRET}`) {
+    return apiError('UNAUTHORIZED', 'Unauthorized', 401);
+  }
+
+  try {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const service = new InboxOutboxService(supabase, { logger: console });
+    const result = await service.scan();
+    return apiSuccess(result);
+  } catch (error) {
+    return apiError(
+      'INTERNAL_ERROR',
+      error instanceof Error ? error.message : 'Internal error',
+      500,
+    );
+  }
+}

--- a/apps/web/src/services/inbox-outbox.service.test.ts
+++ b/apps/web/src/services/inbox-outbox.service.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { InboxOutboxService } from './inbox-outbox.service';
+
+function makeRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: '11111111-1111-4111-8111-111111111111',
+    org_id: 'org-1',
+    inbox_item_id: 'item-1',
+    event_type: 'resolved',
+    payload: { hello: 'world' },
+    webhook_url: 'https://agent.example.com/hook',
+    status: 'in_flight',
+    attempt_count: 1,
+    ...overrides,
+  };
+}
+
+describe('InboxOutboxService.scan', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns zero counts when no rows are claimed', async () => {
+    const supabase = {
+      rpc: vi.fn().mockResolvedValue({ data: [], error: null }),
+    };
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 0, delivered: 0, retried: 0, dead: 0, skipped: 0 });
+    expect(supabase.rpc).toHaveBeenCalledWith('claim_pending_outbox', expect.any(Object));
+  });
+
+  it('delivers rows with 2xx response and marks delivered', async () => {
+    const row = makeRow();
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+
+    const rpcCalls: Array<{ name: string; args: Record<string, unknown> }> = [];
+    const supabase = {
+      rpc: vi.fn(async (name: string, args: Record<string, unknown>) => {
+        rpcCalls.push({ name, args });
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        if (name === 'mark_outbox_delivered') return { data: { ...row, status: 'delivered' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 1, delivered: 1, retried: 0, dead: 0, skipped: 0 });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchImpl.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-sprintable-org-id']).toBe('org-1');
+    expect(headers['x-sprintable-event-type']).toBe('resolved');
+    expect(headers['x-sprintable-outbox-id']).toBe(row.id);
+    expect(headers['x-sprintable-signature']).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(rpcCalls.map(c => c.name)).toEqual(['claim_pending_outbox', 'mark_outbox_delivered']);
+  });
+
+  it('retries on 5xx response (status returned by mark_outbox_failed remains pending)', async () => {
+    const row = makeRow({ attempt_count: 1 });
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 502 }));
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        if (name === 'mark_outbox_failed') return { data: { ...row, status: 'pending' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 1, delivered: 0, retried: 1, dead: 0, skipped: 0 });
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'mark_outbox_failed',
+      expect.objectContaining({ p_id: row.id, p_error: 'http_502' }),
+    );
+  });
+
+  it('marks dead when mark_outbox_failed returns status=dead', async () => {
+    const row = makeRow({ attempt_count: 5 });
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 500 }));
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        if (name === 'mark_outbox_failed') return { data: { ...row, status: 'dead' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 1, delivered: 0, retried: 0, dead: 1, skipped: 0 });
+  });
+
+  it('skips and marks dead when webhook_url is null', async () => {
+    const row = makeRow({ webhook_url: null });
+    const fetchImpl = vi.fn();
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        if (name === 'mark_outbox_dead') return { data: { ...row, status: 'dead' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 1, delivered: 0, retried: 0, dead: 0, skipped: 1 });
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'mark_outbox_dead',
+      expect.objectContaining({ p_error: 'no_webhook_url' }),
+    );
+  });
+
+  it('treats fetch rejection as retryable failure', async () => {
+    const row = makeRow();
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        if (name === 'mark_outbox_failed') return { data: { ...row, status: 'pending' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 1, delivered: 0, retried: 1, dead: 0, skipped: 0 });
+    expect(supabase.rpc).toHaveBeenCalledWith(
+      'mark_outbox_failed',
+      expect.objectContaining({ p_error: 'network down' }),
+    );
+  });
+
+  it('processes multiple rows independently', async () => {
+    const ok = makeRow({
+      id: 'aaaaaaaa-1111-4111-8111-111111111111',
+      webhook_url: 'https://ok.example.com/hook',
+    });
+    const fail = makeRow({
+      id: 'bbbbbbbb-2222-4222-8222-222222222222',
+      webhook_url: 'https://fail.example.com/hook',
+    });
+    const skip = makeRow({
+      id: 'cccccccc-3333-4333-8333-333333333333',
+      webhook_url: null,
+    });
+
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url === ok.webhook_url) return new Response(null, { status: 204 });
+      return new Response(null, { status: 503 });
+    });
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [ok, fail, skip], error: null };
+        if (name === 'mark_outbox_delivered') return { data: { ...ok, status: 'delivered' }, error: null };
+        if (name === 'mark_outbox_failed') return { data: { ...fail, status: 'pending' }, error: null };
+        if (name === 'mark_outbox_dead') return { data: { ...skip, status: 'dead' }, error: null };
+        return { data: null, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    const result = await service.scan();
+
+    expect(result).toEqual({ scanned: 3, delivered: 1, retried: 1, dead: 0, skipped: 1 });
+  });
+
+  it('throws when claim_pending_outbox RPC errors', async () => {
+    const supabase = {
+      rpc: vi.fn().mockResolvedValue({ data: null, error: { message: 'pg_down' } }),
+    };
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: 'secret',
+      logger: { error: () => {} },
+    });
+
+    await expect(service.scan()).rejects.toBeDefined();
+  });
+
+  it('omits HMAC header when no secret is configured', async () => {
+    const row = makeRow();
+    const fetchImpl = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
+
+    const supabase = {
+      rpc: vi.fn(async (name: string) => {
+        if (name === 'claim_pending_outbox') return { data: [row], error: null };
+        return { data: { ...row, status: 'delivered' }, error: null };
+      }),
+    };
+
+    const service = new InboxOutboxService(supabase as never, {
+      hmacSecret: '',
+      fetchImpl,
+      logger: { error: () => {} },
+    });
+
+    await service.scan();
+
+    const [, init] = fetchImpl.mock.calls[0];
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-sprintable-signature']).toBeUndefined();
+  });
+});

--- a/apps/web/src/services/inbox-outbox.service.ts
+++ b/apps/web/src/services/inbox-outbox.service.ts
@@ -1,0 +1,181 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createHmac } from 'node:crypto';
+
+// Operator Cockpit Phase A — outbox worker
+// Polls inbox_outbox via claim_pending_outbox RPC, POSTs to webhook_url with HMAC,
+// then marks delivered / retries with exponential backoff / marks dead.
+// Triggered from /api/cron/inbox-outbox by external scheduler.
+
+const DEFAULT_BATCH_SIZE = 50;
+const DEFAULT_DELIVERY_TIMEOUT_MS = 10_000;
+
+type OutboxEventType = 'resolved' | 'dismissed' | 'reassigned';
+type OutboxStatus = 'pending' | 'in_flight' | 'delivered' | 'failed' | 'dead';
+
+interface OutboxRow {
+  id: string;
+  org_id: string;
+  inbox_item_id: string;
+  event_type: OutboxEventType;
+  payload: Record<string, unknown>;
+  webhook_url: string | null;
+  status: OutboxStatus;
+  attempt_count: number;
+}
+
+export interface OutboxScanResult {
+  scanned: number;
+  delivered: number;
+  retried: number;
+  dead: number;
+  skipped: number;
+}
+
+export interface OutboxWorkerLogger {
+  error: (message: string, ...args: unknown[]) => void;
+  info?: (message: string, ...args: unknown[]) => void;
+}
+
+export interface InboxOutboxServiceOptions {
+  logger?: OutboxWorkerLogger;
+  hmacSecret?: string;
+  batchSize?: number;
+  deliveryTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export class InboxOutboxService {
+  private readonly logger: OutboxWorkerLogger;
+  private readonly hmacSecret: string | undefined;
+  private readonly batchSize: number;
+  private readonly deliveryTimeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(
+    private readonly supabase: SupabaseClient,
+    options: InboxOutboxServiceOptions = {},
+  ) {
+    this.logger = options.logger ?? console;
+    this.hmacSecret = options.hmacSecret ?? process.env['AGENT_INBOX_HMAC_SECRET'];
+    this.batchSize = options.batchSize ?? DEFAULT_BATCH_SIZE;
+    this.deliveryTimeoutMs = options.deliveryTimeoutMs ?? DEFAULT_DELIVERY_TIMEOUT_MS;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  async scan(): Promise<OutboxScanResult> {
+    const result: OutboxScanResult = {
+      scanned: 0,
+      delivered: 0,
+      retried: 0,
+      dead: 0,
+      skipped: 0,
+    };
+
+    const { data: rows, error } = await this.supabase.rpc('claim_pending_outbox', {
+      p_batch_size: this.batchSize,
+    });
+
+    if (error) {
+      this.logger.error('inbox_outbox_claim_failed', error);
+      throw error;
+    }
+
+    const claimed = (rows ?? []) as OutboxRow[];
+    result.scanned = claimed.length;
+    if (claimed.length === 0) return result;
+
+    for (const row of claimed) {
+      if (!row.webhook_url) {
+        await this.markDead(row.id, 'no_webhook_url');
+        result.skipped++;
+        continue;
+      }
+
+      try {
+        await this.deliver(row);
+        await this.markDelivered(row.id);
+        result.delivered++;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'unknown_error';
+        const becameDead = await this.markFailed(row.id, message);
+        if (becameDead) result.dead++;
+        else result.retried++;
+      }
+    }
+
+    return result;
+  }
+
+  private async deliver(row: OutboxRow): Promise<void> {
+    if (!row.webhook_url) throw new Error('no_webhook_url');
+
+    const body = JSON.stringify(row.payload);
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+      'x-sprintable-org-id': row.org_id,
+      'x-sprintable-event-type': row.event_type,
+      'x-sprintable-outbox-id': row.id,
+    };
+    if (this.hmacSecret) {
+      headers['x-sprintable-signature'] = createHmac('sha256', this.hmacSecret)
+        .update(body)
+        .digest('hex');
+    }
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.deliveryTimeoutMs);
+    let response: Response;
+    try {
+      response = await this.fetchImpl(row.webhook_url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error('delivery_timeout');
+      }
+      throw err;
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      throw new Error(`http_${response.status}`);
+    }
+  }
+
+  private async markDelivered(id: string): Promise<void> {
+    const { error } = await this.supabase.rpc('mark_outbox_delivered', { p_id: id });
+    if (error) {
+      this.logger.error('mark_outbox_delivered_failed', { id, error });
+      throw error;
+    }
+  }
+
+  /** Returns true if the row transitioned to 'dead'. */
+  private async markFailed(id: string, errorMsg: string): Promise<boolean> {
+    const { data, error } = await this.supabase.rpc('mark_outbox_failed', {
+      p_id: id,
+      p_error: errorMsg,
+    });
+    if (error) {
+      this.logger.error('mark_outbox_failed_failed', { id, error });
+      throw error;
+    }
+    const status = (data as OutboxRow | null)?.status;
+    return status === 'dead';
+  }
+
+  private async markDead(id: string, errorMsg: string): Promise<void> {
+    const { error } = await this.supabase.rpc('mark_outbox_dead', {
+      p_id: id,
+      p_error: errorMsg,
+    });
+    if (error) {
+      this.logger.error('mark_outbox_dead_failed', { id, error });
+      throw error;
+    }
+  }
+}

--- a/packages/db/supabase/migrations/20260427100000_inbox_outbox_claim_fn.sql
+++ b/packages/db/supabase/migrations/20260427100000_inbox_outbox_claim_fn.sql
@@ -1,0 +1,135 @@
+-- Operator Cockpit Phase A — outbox worker RPCs
+-- claim → POST → mark_delivered / mark_failed / mark_dead lifecycle.
+-- See packages/db/supabase/migrations/20260426170200_inbox_outbox.sql
+
+-- ============================================================
+-- claim_pending_outbox — atomic batch claim with FOR UPDATE SKIP LOCKED
+-- worker가 한 번에 N개 행을 status='in_flight'로 전환하며 잠금. attempt_count++.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.claim_pending_outbox(p_batch_size int DEFAULT 50)
+RETURNS SETOF public.inbox_outbox
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT id
+    FROM public.inbox_outbox
+    WHERE status = 'pending' AND next_attempt_at <= now()
+    ORDER BY next_attempt_at
+    LIMIT GREATEST(p_batch_size, 1)
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.inbox_outbox o
+  SET status = 'in_flight',
+      last_attempt_at = now(),
+      attempt_count = o.attempt_count + 1
+  FROM claimed
+  WHERE o.id = claimed.id
+  RETURNING o.*;
+END;
+$$;
+
+COMMENT ON FUNCTION public.claim_pending_outbox(int) IS
+  'Worker가 호출. status=pending AND next_attempt_at <= now() 행 N개를 in_flight로 잠그고 반환.';
+
+-- ============================================================
+-- mark_outbox_delivered — 2xx 응답 시 호출
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.mark_outbox_delivered(p_id uuid)
+RETURNS public.inbox_outbox
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_outbox;
+BEGIN
+  UPDATE public.inbox_outbox
+  SET status = 'delivered',
+      delivered_at = now(),
+      last_error = NULL
+  WHERE id = p_id
+  RETURNING * INTO _row;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'outbox row not found' USING ERRCODE = 'P0002';
+  END IF;
+  RETURN _row;
+END;
+$$;
+
+-- ============================================================
+-- mark_outbox_failed — 일시적 실패. 지수 백오프 재시도 또는 max 도달 시 dead.
+-- backoff: attempt_count 1→30s, 2→5m, 3→30m, 4→3h, 5+→dead
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.mark_outbox_failed(
+  p_id uuid,
+  p_error text
+)
+RETURNS public.inbox_outbox
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_outbox;
+  _next_delay interval;
+  _max_attempts int := 5;
+BEGIN
+  SELECT * INTO _row FROM public.inbox_outbox WHERE id = p_id FOR UPDATE;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'outbox row not found' USING ERRCODE = 'P0002';
+  END IF;
+
+  IF _row.attempt_count >= _max_attempts THEN
+    UPDATE public.inbox_outbox
+    SET status = 'dead', last_error = p_error
+    WHERE id = p_id
+    RETURNING * INTO _row;
+  ELSE
+    _next_delay := CASE _row.attempt_count
+      WHEN 1 THEN interval '30 seconds'
+      WHEN 2 THEN interval '5 minutes'
+      WHEN 3 THEN interval '30 minutes'
+      WHEN 4 THEN interval '3 hours'
+      ELSE interval '12 hours'
+    END;
+    UPDATE public.inbox_outbox
+    SET status = 'pending',
+        next_attempt_at = now() + _next_delay,
+        last_error = p_error
+    WHERE id = p_id
+    RETURNING * INTO _row;
+  END IF;
+
+  RETURN _row;
+END;
+$$;
+
+-- ============================================================
+-- mark_outbox_dead — 영구 실패 (재시도 안 함). webhook_url 미설정 등에 사용.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.mark_outbox_dead(
+  p_id uuid,
+  p_error text
+)
+RETURNS public.inbox_outbox
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+DECLARE
+  _row public.inbox_outbox;
+BEGIN
+  UPDATE public.inbox_outbox
+  SET status = 'dead', last_error = p_error
+  WHERE id = p_id
+  RETURNING * INTO _row;
+  IF _row.id IS NULL THEN
+    RAISE EXCEPTION 'outbox row not found' USING ERRCODE = 'P0002';
+  END IF;
+  RETURN _row;
+END;
+$$;


### PR DESCRIPTION
## Summary

- Implements the worker side of the D6 outbox pattern for inbox webhook delivery.
- Adds 3 new RPCs (`claim_pending_outbox`, `mark_outbox_delivered`, `mark_outbox_failed`, `mark_outbox_dead`).
- Adds `InboxOutboxService.scan()` — claims a batch, POSTs with HMAC-SHA256 + 10s timeout, applies exponential backoff.
- Adds `/api/cron/inbox-outbox` — Bearer `CRON_SECRET` auth, OSS short-circuit, mirrors the existing `hitl-timeouts` cron route shape.

## Behavior

| Outcome | Action |
|---|---|
| 2xx response | `status='delivered'`, `delivered_at=now()` |
| Non-2xx / network / timeout (attempts < 5) | retry with backoff (30s → 5m → 30m → 3h) |
| Attempt 5 fails | `status='dead'` |
| `webhook_url IS NULL` | immediate `dead` with `last_error='no_webhook_url'` |

The `claim_pending_outbox` RPC uses `FOR UPDATE SKIP LOCKED` so multiple workers (or accidental overlap) cannot claim the same row.

## Operations

External scheduler must hit `GET /api/cron/inbox-outbox` with `Authorization: Bearer $CRON_SECRET`. Suggested cadence: every 1 minute (matches the 30s shortest backoff window).

Required env on staging/prod:
- `CRON_SECRET`
- `AGENT_INBOX_HMAC_SECRET` (shared with `/api/inbox/incoming` for symmetry)
- `NEXT_PUBLIC_SUPABASE_URL`
- `SUPABASE_SERVICE_ROLE_KEY`

## Test plan

- [x] Service unit tests (9) — happy path, 5xx retry, max-attempt → dead, null webhook → skipped, fetch reject, multi-row mix, RPC error, no-HMAC mode
- [x] Route tests (3) — 401, 200 with payload, 500 on service throw
- [x] Full inbox suite still green (15/15)
- [x] Lint clean (0 warnings on new files)
- [x] Typecheck clean
- [ ] Apply migration to staging supabase (via `migrate.yml` workflow on merge)
- [ ] Configure scheduled invocation on Amplify / EventBridge after deploy
- [ ] Dogfood — resolve a real inbox item, observe webhook delivered to test URL