### PR TITLE
feat(inbox): A2-MIN decisions-waiting panel

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -994,7 +994,11 @@
     "hoursAgo": "h ago",
     "selectToView": "Select a notification to view details",
     "detailEmptyTitle": "No notification selected",
-    "receivedAt": "Received"
+    "receivedAt": "Received",
+    "decisionsWaiting": "Decisions waiting",
+    "decisionsErrorRetry": "Action failed. Please retry shortly.",
+    "priorityHigh": "Urgent",
+    "dismiss": "Dismiss"
   },
   "invite": {
     "title": "Organization Invitation",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -994,7 +994,11 @@
     "hoursAgo": "시간 전",
     "selectToView": "알림을 선택하면 상세 내용을 볼 수 있습니다",
     "detailEmptyTitle": "선택된 알림이 없습니다",
-    "receivedAt": "수신 시각"
+    "receivedAt": "수신 시각",
+    "decisionsWaiting": "결정 대기",
+    "decisionsErrorRetry": "처리에 실패했습니다. 잠시 후 다시 시도해 주세요.",
+    "priorityHigh": "긴급",
+    "dismiss": "보류"
   },
   "invite": {
     "title": "조직 초대",

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -8,6 +8,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
+import { DecisionsWaiting } from '@/components/inbox/decisions-waiting';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { useToast, ToastContainer } from '@/components/ui/toast';
 import {
@@ -207,7 +208,10 @@ export default function InboxPage() {
         }
       />
 
-      <div className="flex min-h-0 flex-1 overflow-hidden">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <DecisionsWaiting onChange={() => void refreshNotifications()} />
+
+        <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left: notification list */}
         <div className="flex w-full max-w-[420px] min-w-[320px] flex-col border-r border-border/80">
           <div className="flex-1 overflow-y-auto px-3 py-3">
@@ -317,6 +321,7 @@ export default function InboxPage() {
               <p className="text-sm font-medium text-[color:var(--operator-muted)]">{t('selectToView')}</p>
             </div>
           )}
+        </div>
         </div>
       </div>
 

--- a/apps/web/src/components/inbox/decisions-waiting.test.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { NextIntlClientProvider } from 'next-intl';
+import koMessages from '../../../messages/ko.json';
+import { DecisionsWaiting } from './decisions-waiting';
+
+function wrap(node: React.ReactNode) {
+  return (
+    <NextIntlClientProvider locale="ko" messages={koMessages} timeZone="Asia/Seoul">
+      {node}
+    </NextIntlClientProvider>
+  );
+}
+
+describe('DecisionsWaiting (SSR snapshot)', () => {
+  beforeEach(() => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing on first paint while items load (avoids layout shift)', () => {
+    const markup = renderToStaticMarkup(wrap(<DecisionsWaiting />));
+    // SSR runs the initial render before useEffect — items=[] and loading=true → returns null
+    expect(markup).toBe('');
+  });
+});

--- a/apps/web/src/components/inbox/decisions-waiting.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { CheckCircle2, X, Sparkles } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+
+// Operator Cockpit Phase A2-MIN — pending decisions panel.
+// Reads from /api/inbox (inbox_items) and lets the operator resolve or dismiss
+// each item. Notifications panel stays untouched below for transition period.
+
+interface OriginNode {
+  type: 'memo' | 'story' | 'run' | 'initiative';
+  id: string;
+}
+
+interface InboxOption {
+  id: string;
+  label: string;
+  kind: 'approve' | 'approve-alt' | 'reassign' | 'changes';
+  consequence: string;
+}
+
+interface InboxItem {
+  id: string;
+  org_id: string;
+  project_id: string;
+  kind: 'approval' | 'decision' | 'blocker' | 'mention';
+  title: string;
+  agent_summary?: string | null;
+  origin_chain: OriginNode[];
+  options: InboxOption[];
+  priority: 'high' | 'normal';
+  state: 'pending' | 'resolved' | 'dismissed';
+  created_at: string;
+}
+
+interface InboxListResponse {
+  data: InboxItem[];
+  meta?: {
+    pendingCount?: number;
+    countsByKind?: Record<string, number>;
+  };
+}
+
+const ORIGIN_LABEL: Record<OriginNode['type'], string> = {
+  memo: 'Memo',
+  story: 'Story',
+  run: 'Run',
+  initiative: 'Initiative',
+};
+
+interface DecisionsWaitingProps {
+  onChange?: () => void;
+}
+
+export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
+  const t = useTranslations('inbox');
+  const [items, setItems] = useState<InboxItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [pending, setPending] = useState<Record<string, boolean>>({});
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchItems = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch('/api/inbox?state=pending');
+      if (!res.ok) {
+        if (res.status === 401) return;
+        setError('fetch_failed');
+        return;
+      }
+      const json = (await res.json()) as InboxListResponse;
+      setItems(json.data ?? []);
+    } catch {
+      setError('fetch_failed');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchItems();
+  }, [fetchItems]);
+
+  const removeLocally = (id: string) => {
+    setItems((prev) => prev.filter((it) => it.id !== id));
+    onChange?.();
+  };
+
+  const resolve = async (item: InboxItem, optionId: string) => {
+    setPending((p) => ({ ...p, [item.id]: true }));
+    try {
+      const res = await fetch(`/api/inbox/${item.id}/resolve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ choice: optionId }),
+      });
+      if (res.ok || res.status === 409) {
+        // 409 means someone else already resolved it — drop from local view
+        removeLocally(item.id);
+      } else {
+        setError('resolve_failed');
+      }
+    } catch {
+      setError('resolve_failed');
+    } finally {
+      setPending((p) => ({ ...p, [item.id]: false }));
+    }
+  };
+
+  const dismiss = async (item: InboxItem) => {
+    setPending((p) => ({ ...p, [item.id]: true }));
+    try {
+      const res = await fetch(`/api/inbox/${item.id}/dismiss`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+      if (res.ok || res.status === 409) {
+        removeLocally(item.id);
+      } else {
+        setError('dismiss_failed');
+      }
+    } catch {
+      setError('dismiss_failed');
+    } finally {
+      setPending((p) => ({ ...p, [item.id]: false }));
+    }
+  };
+
+  if (loading) return null;
+  if (items.length === 0) return null;
+
+  return (
+    <section
+      data-testid="decisions-waiting"
+      className="border-b border-white/8 bg-[color:var(--operator-surface-soft)]/40 px-4 py-3"
+    >
+      <header className="mb-2 flex items-center gap-2">
+        <Sparkles className="size-4 text-[color:var(--operator-primary)]" />
+        <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">
+          {t('decisionsWaiting')}
+        </h2>
+        <Badge variant="outline" className="tabular-nums">
+          {items.length}
+        </Badge>
+      </header>
+
+      {error ? (
+        <p className="mb-2 text-xs text-red-400" role="alert">
+          {t('decisionsErrorRetry')}
+        </p>
+      ) : null}
+
+      <ul className="space-y-2">
+        {items.map((item) => {
+          const isBusy = !!pending[item.id];
+          return (
+            <li
+              key={item.id}
+              data-testid={`decision-item-${item.id}`}
+              className="rounded-xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                      {item.kind}
+                    </Badge>
+                    {item.priority === 'high' ? (
+                      <Badge className="bg-red-500/15 text-red-300 text-[10px] uppercase">
+                        {t('priorityHigh')}
+                      </Badge>
+                    ) : null}
+                    {item.origin_chain.length > 0 ? (
+                      <span className="text-[11px] text-[color:var(--operator-muted)]">
+                        {item.origin_chain
+                          .map((n) => `${ORIGIN_LABEL[n.type]} · ${n.id.slice(0, 8)}`)
+                          .join(' → ')}
+                      </span>
+                    ) : null}
+                  </div>
+                  <p className="text-sm font-medium text-[color:var(--operator-foreground)]">
+                    {item.title}
+                  </p>
+                  {item.agent_summary ? (
+                    <p className="line-clamp-2 text-xs text-[color:var(--operator-muted)]">
+                      {item.agent_summary}
+                    </p>
+                  ) : null}
+                </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  aria-label={t('dismiss')}
+                  disabled={isBusy}
+                  onClick={() => void dismiss(item)}
+                >
+                  <X className="size-4" />
+                </Button>
+              </div>
+
+              {item.options.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {item.options.map((opt) => (
+                    <Button
+                      key={opt.id}
+                      variant="outline"
+                      size="sm"
+                      disabled={isBusy}
+                      onClick={() => void resolve(item, opt.id)}
+                      title={opt.consequence}
+                    >
+                      <CheckCircle2 className="mr-1 size-3" />
+                      {opt.label}
+                    </Button>
+                  ))}
+                </div>
+              ) : null}
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Phase A2-MIN — smallest viable operator cockpit UI on `/inbox`.

- New `DecisionsWaiting` panel above the existing notifications list.
- Reads from `/api/inbox?state=pending` (the inbox_items model wired in PR #227 / #228 / #240).
- Each row: kind + priority + origin chain summary, title, agent_summary, and option buttons sourced from `inbox_items.options[]`. Resolve POSTs the chosen option's `id` (uuid). Dismiss is a one-click action.
- 409 (already resolved) is treated like success — drop from local state.
- Renders nothing while loading or when nothing is pending. No empty state to scroll past, no layout shift.

The legacy notifications list and selection detail pane are untouched — dual-display lets dogfood compare both surfaces. Phase A2 (full) will demote notifications and introduce `DecisionContext` / `OriginTrail` / `AgentAvatar` after the backend is validated on staging.

## Why MIN before FULL

The most direct way to validate the inbox_items backend (PR #244) is to actually click resolve on a real row. A2-MIN gives that capability for ~275 LoC. A2-FULL (~600–800 LoC, custom components, keyboard shortcuts, count bar, notifications demotion) becomes a follow-up shaped by what dogfood reveals.

## Stack

- Targets `develop` (not main).
- Builds on backend in PR #227 / #228 / #240, which are already on develop.
- Will benefit from PR #244 (outbox worker) once that lands.

## Test plan

- [x] SSR snapshot confirms loading state returns null
- [x] Typecheck (no new errors; pre-existing `verify-sdk-e2e.ts` errors exist on develop)
- [x] Lint (0 warnings on new files)
- [ ] Staging dogfood: trigger a memo @mention or doc comment @mention with `state=pending` for self → row appears in `Decisions waiting`
- [ ] Click an option button → row disappears, `inbox_items.state='resolved'`, `inbox_outbox` row queued
- [ ] Click dismiss → row disappears, `inbox_items.state='dismissed'`
- [ ] i18n: ko/en strings render correctly

## i18n keys added

- `inbox.decisionsWaiting` — "Decisions waiting" / "결정 대기"
- `inbox.decisionsErrorRetry` — error toast retry message
- `inbox.priorityHigh` — "Urgent" / "긴급"
- `inbox.dismiss` — "Dismiss" / "보류"