### PR TITLE
fix(P0): proxy.ts PUBLIC_PREFIX에 /signup, /forgot-password 추가

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -11,6 +11,8 @@ const PUBLIC_EXACT = [
 const PUBLIC_PREFIX = [
   '/api/',
   '/login',
+  '/signup',
+  '/forgot-password',
   '/auth/callback',
   '/auth/login',
   '/invite',


### PR DESCRIPTION
## Summary
미로그인 사용자가 `/signup`, `/forgot-password` 접근 시 proxy.ts 인증 검사에 걸려 `/login`으로 리다이렉트되는 P0 버그 수정.

PUBLIC_PREFIX 배열에 2개 항목 추가.

## Test plan
- [ ] 미로그인 상태에서 `/signup` 접근 → 리다이렉트 없이 페이지 표시
- [ ] 미로그인 상태에서 `/forgot-password` 접근 → 리다이렉트 없이 페이지 표시
- [ ] 기존 인증 보호 경로 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)