### PR TITLE
feat(routes): land authenticated users on /inbox (A3)

### DIFF
--- a/apps/web/e2e/retro-corrected.spec.ts
+++ b/apps/web/e2e/retro-corrected.spec.ts
@@ -136,7 +136,7 @@ test.describe('Sprint Retro - Corrected E2E Tests', () => {
       
       // Check for columns
       const columns = ['Good', 'Bad', 'Improve'];
-      let found = [];
+      const found = [];
       
       for (const col of columns) {
         const elem = page.locator(`text=${col}`);

--- a/apps/web/e2e/retro-final.spec.ts
+++ b/apps/web/e2e/retro-final.spec.ts
@@ -101,7 +101,7 @@ test.describe('Sprint Retro - Final Comprehensive Tests', () => {
       
       // Check for phase stepper
       const phases = ['Collect', 'Group', 'Vote', 'Discuss', 'Action'];
-      let phasesFound = [];
+      const phasesFound = [];
       
       for (const phase of phases) {
         const element = page.locator(`text=${phase}`);
@@ -114,7 +114,7 @@ test.describe('Sprint Retro - Final Comprehensive Tests', () => {
       
       // Check for columns
       const columns = ['Good', 'Bad', 'Improve'];
-      let columnsFound = [];
+      const columnsFound = [];
       
       for (const col of columns) {
         const element = page.locator(`text=${col}`);

--- a/apps/web/src/app/auth/callback/fallback/page.tsx
+++ b/apps/web/src/app/auth/callback/fallback/page.tsx
@@ -119,7 +119,7 @@ function FallbackHandler() {
           writeSessionCookies(tokenData);
         }
 
-        const redirectTo = next && next.startsWith('/') ? next : '/dashboard';
+        const redirectTo = next && next.startsWith('/') ? next : '/inbox';
         window.location.replace(redirectTo);
       } catch {
         router.replace('/login?error=auth_failed');

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -44,10 +44,10 @@ export async function GET(request: Request) {
           .eq('user_id', user.id)
           .limit(1)
           .maybeSingle();
-        return NextResponse.redirect(`${origin}${membership ? '/dashboard' : '/onboarding'}`);
+        return NextResponse.redirect(`${origin}${membership ? '/inbox' : '/onboarding'}`);
       }
 
-      return NextResponse.redirect(`${origin}/dashboard`);
+      return NextResponse.redirect(`${origin}/inbox`);
     }
 
     // 서버 교환 실패 시 클라이언트 fallback으로

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export default async function RootPage() {
   if (isOssMode()) {
-    redirect('/dashboard');
+    redirect('/inbox');
   }
 
   const supabase = await createSupabaseServerClient();
@@ -12,5 +12,5 @@ export default async function RootPage() {
     data: { user },
   } = await supabase.auth.getUser();
 
-  redirect(user ? '/dashboard' : '/login');
+  redirect(user ? '/inbox' : '/login');
 }

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -26,27 +26,27 @@ describe('middleware', () => {
       process.env['OSS_MODE'] = 'true';
     });
 
-    it('redirects / to /dashboard (AC-4)', async () => {
+    it('redirects / to /inbox (AC-4)', async () => {
       const request = new NextRequest('https://app.example.com/');
       const response = await middleware(request);
       expect(response.status).toBe(307);
-      expect(response.headers.get('location')).toBe('https://app.example.com/dashboard');
+      expect(response.headers.get('location')).toBe('https://app.example.com/inbox');
       expect(createServerClient).not.toHaveBeenCalled();
     });
 
-    it('redirects /login to /dashboard (AC-5)', async () => {
+    it('redirects /login to /inbox (AC-5)', async () => {
       const request = new NextRequest('https://app.example.com/login');
       const response = await middleware(request);
       expect(response.status).toBe(307);
-      expect(response.headers.get('location')).toBe('https://app.example.com/dashboard');
+      expect(response.headers.get('location')).toBe('https://app.example.com/inbox');
       expect(createServerClient).not.toHaveBeenCalled();
     });
 
-    it('redirects /auth/callback to /dashboard (AC-5)', async () => {
+    it('redirects /auth/callback to /inbox (AC-5)', async () => {
       const request = new NextRequest('https://app.example.com/auth/callback?code=abc');
       const response = await middleware(request);
       expect(response.status).toBe(307);
-      expect(response.headers.get('location')).toBe('https://app.example.com/dashboard');
+      expect(response.headers.get('location')).toBe('https://app.example.com/inbox');
       expect(createServerClient).not.toHaveBeenCalled();
     });
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -25,17 +25,17 @@ export async function proxy(request: NextRequest) {
 
   // OSS_MODE: bypass Supabase auth entirely (AC-1, AC-4, AC-5)
   if (isOssMode()) {
-    // / → /dashboard (AC-4)
+    // / → /inbox (AC-4) — operator cockpit first screen (Phase A3)
     if (pathname === '/') {
       const url = request.nextUrl.clone();
-      url.pathname = '/dashboard';
+      url.pathname = '/inbox';
       return NextResponse.redirect(url);
     }
 
-    // /login, /auth/callback → /dashboard (AC-5)
+    // /login, /auth/callback → /inbox (AC-5)
     if (pathname === '/login' || pathname.startsWith('/auth/callback')) {
       const url = request.nextUrl.clone();
-      url.pathname = '/dashboard';
+      url.pathname = '/inbox';
       url.search = '';
       return NextResponse.redirect(url);
     }
@@ -102,7 +102,7 @@ export async function proxy(request: NextRequest) {
 
   if (request.nextUrl.pathname === '/login') {
     const url = request.nextUrl.clone();
-    url.pathname = '/dashboard';
+    url.pathname = '/inbox';
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
## Summary

Phase A3 — first-screen redirect.

Operator cockpit positioning makes decisions-waiting the workspace, not a project dashboard. After this PR, authenticated users land on `/inbox` from:

- Root `/` visit
- OAuth callback success (with org membership)
- PKCE fallback exchange (when no `next` param)
- Hitting `/login` while already signed in
- OSS_MODE bypass routes

What stays on `/dashboard`:
- Users without org membership go to `/onboarding` (unchanged)
- Permission denials inside protected pages still fall back to `/dashboard` (it remains a useful read-only surface)
- Direct `/dashboard` URL still works

## Files

- `apps/web/src/app/page.tsx` — root authenticated redirect
- `apps/web/src/app/auth/callback/route.ts` — server callback (2 paths)
- `apps/web/src/app/auth/callback/fallback/page.tsx` — client PKCE fallback default
- `apps/web/src/proxy.ts` — middleware redirects (3 places)
- `apps/web/src/proxy.test.ts` — assertions updated to `/inbox`

## Stack

- Targets `develop`.
- Independent of PR #244 (outbox worker) and PR #245 (A2-MIN UI). Lands cleanly on its own.
- Effect is most visible after PR #245 lands (decisions-waiting panel renders pending items on the new first screen).

## Test plan

- [x] `pnpm vitest run src/proxy.test.ts` — 8/8
- [x] Typecheck: no new errors (8 pre-existing on develop, unrelated)
- [x] Lint clean
- [ ] Staging dogfood: log in → URL ends at `/inbox` (not `/dashboard`)
- [ ] Visit `/` while signed in → redirects to `/inbox`
- [ ] Visit `/login` while signed in → redirects to `/inbox`
- [ ] Visit `/dashboard` directly → still works (no auto-redirect away)