### PR TITLE
fix(epics): 에픽 상세 스토리 목록 클릭 내비게이션 수정

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1828,7 +1828,8 @@
     "backToList": "Back",
     "notAssigned": "Not assigned",
     "spExceeded": "SP Over",
-    "spExceededDetail": "{total}SP / target {target}SP exceeded"
+    "spExceededDetail": "{total}SP / target {target}SP exceeded",
+    "noStories": "No stories linked to this epic."
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1828,7 +1828,8 @@
     "backToList": "목록으로",
     "notAssigned": "미지정",
     "spExceeded": "SP 초과",
-    "spExceededDetail": "{total}SP / 목표 {target}SP 초과"
+    "spExceededDetail": "{total}SP / 목표 {target}SP 초과",
+    "noStories": "이 에픽에 연결된 스토리가 없습니다."
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { ChevronLeft, Plus, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -466,6 +467,7 @@ interface EpicDetailPanelProps {
 
 function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
   const t = useTranslations('epics');
+  const router = useRouter();
   const [isEditing, setIsEditing] = useState(false);
 
   const stories = epic.stories ?? [];
@@ -581,14 +583,16 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
             </div>
 
             {/* Story list */}
-            {stories.length > 0 ? (
-              <div className="space-y-2">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('stories')}</p>
+            <div className="space-y-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('stories')}</p>
+              {stories.length > 0 ? (
                 <div className="space-y-1.5">
                   {stories.map((story) => (
-                    <div
+                    <button
                       key={story.id}
-                      className="flex items-center justify-between rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] px-3 py-2"
+                      type="button"
+                      onClick={() => router.push(`/board?story=${story.id}`)}
+                      className="flex w-full items-center justify-between rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] px-3 py-2 text-left transition-colors hover:border-primary/30 hover:bg-primary/5"
                     >
                       <p className="text-sm text-[color:var(--operator-foreground)]">{story.title}</p>
                       <div className="flex shrink-0 items-center gap-2">
@@ -599,11 +603,13 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                           {story.status}
                         </Badge>
                       </div>
-                    </div>
+                    </button>
                   ))}
                 </div>
-              </div>
-            ) : null}
+              ) : (
+                <p className="text-sm italic text-[color:var(--operator-muted)]">{t('noStories')}</p>
+              )}
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
에픽 상세 페이지의 스토리 목록에서 클릭해도 스토리 상세로 이동이 안 되는 버그 수정.

- 스토리 항목이 클릭 불가능한 `<div>`였음 → `<button>` + `router.push('/board?story=id')`로 변경
- 뒤로가기 시 에픽 페이지로 복귀 (히스토리 스택)
- 빈 에픽: `noStories` 빈 상태 메시지 표시 추가

## Test plan
- [ ] 에픽 상세의 스토리 클릭 → `/board?story=id`로 이동 + 스토리 상세 패널 오픈
- [ ] 뒤로가기 → 에픽 상세로 복귀
- [ ] 스토리 없는 에픽 → "No stories linked to this epic." 메시지 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)