### PR TITLE
fix(P0): Auth 429 무한 재시도 루프 수정

### DIFF
--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -16,7 +16,6 @@ export async function GET(request: Request) {
   }
 
   const supabase = await createSupabaseServerClient();
-  await supabase.auth.signOut();
 
   const redirectTo = returnTo && returnTo.startsWith('/')
     ? `${origin}/auth/callback?next=${encodeURIComponent(returnTo)}`

--- a/apps/web/src/hooks/use-realtime-memos.ts
+++ b/apps/web/src/hooks/use-realtime-memos.ts
@@ -29,10 +29,13 @@ interface UseRealtimeMemosOptions {
   onMemoUpdated?: (memo: RealtimeMemo) => void;
 }
 
+const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000]; // 5s → 30s → 60s → 5min
+
 export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, onMemoUpdated }: UseRealtimeMemosOptions) {
   const channelRef = useRef<RealtimeChannel | null>(null);
   const [connected, setConnected] = useState(false);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
   const onNewMemoRef = useRef(onNewMemo);
   const onNewReplyRef = useRef(onNewReply);
   const onMemoUpdatedRef = useRef(onMemoUpdated);
@@ -74,13 +77,17 @@ return;
         .subscribe((status) => {
           if (status === 'SUBSCRIBED') {
             setConnected(true);
+            reconnectAttemptsRef.current = 0;
           } else if (status === 'CLOSED' || status === 'CHANNEL_ERROR') {
             setConnected(false);
             if (!reconnectTimerRef.current) {
+              const attempts = reconnectAttemptsRef.current;
+              const delay = RECONNECT_DELAYS_MS[Math.min(attempts, RECONNECT_DELAYS_MS.length - 1)];
+              reconnectAttemptsRef.current += 1;
               reconnectTimerRef.current = setTimeout(() => {
                 reconnectTimerRef.current = null;
                 subscribe();
-              }, 5000);
+              }, delay);
             }
           }
         });

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -2,6 +2,34 @@
 
 import { createBrowserClient } from '@supabase/ssr';
 
+// URL별 rate-limit backoff 만료 시각 (ms). 모듈 스코프로 탭 전체 공유.
+const rateLimitBlockedUntil = new Map<string, number>();
+
+function getUrlKey(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const url = getUrlKey(input);
+  const now = Date.now();
+  const blockedUntil = rateLimitBlockedUntil.get(url);
+  if (blockedUntil && now < blockedUntil) {
+    const remainingSec = Math.ceil((blockedUntil - now) / 1000);
+    return Promise.reject(new Error(`rate_limit_backoff:${remainingSec}`));
+  }
+
+  return globalThis.fetch(input, init).then((response) => {
+    if (response.status === 429) {
+      const retryAfterHeader = response.headers.get('Retry-After');
+      const backoffSec = retryAfterHeader ? Math.max(parseInt(retryAfterHeader, 10), 60) : 60;
+      rateLimitBlockedUntil.set(url, Date.now() + backoffSec * 1000);
+    }
+    return response;
+  });
+}
+
 export function createSupabaseBrowserClient() {
   const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
   return createBrowserClient(
@@ -13,6 +41,9 @@ export function createSupabaseBrowserClient() {
         sameSite: 'lax',
         secure: true,
         path: '/',
+      },
+      global: {
+        fetch: rateLimitedFetch,
       },
     },
   );

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -23,7 +23,8 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
   return globalThis.fetch(input, init).then((response) => {
     if (response.status === 429) {
       const retryAfterHeader = response.headers.get('Retry-After');
-      const backoffSec = retryAfterHeader ? Math.max(parseInt(retryAfterHeader, 10), 60) : 60;
+      const retrySeconds = parseInt(retryAfterHeader ?? '', 10);
+      const backoffSec = !isNaN(retrySeconds) ? Math.max(retrySeconds, 60) : 60;
       rateLimitBlockedUntil.set(url, Date.now() + backoffSec * 1000);
     }
     return response;


### PR DESCRIPTION
## Summary
로그인 실패 → 429 에러 후 초당 1회씩 무한 재시도하는 루프 수정.

**3건 수정:**

1. **`client.ts`** — 429 감지 fetch wrapper 주입
   - Retry-After 헤더 존중, 없으면 60초 backoff
   - backoff 중 동일 URL 요청 즉시 reject

2. **`use-realtime-memos.ts`** — 고정 5초 → exponential backoff
   - 5s → 30s → 60s → 5min (성공 시 reset)

3. **`login/route.ts`** — OAuth 전 불필요한 `signOut()` 제거
   - GoTrue rate limit 소비 방지

## Test plan
- [ ] 로그인 실패 후 429 → 60초 이상 재시도 없음
- [ ] Realtime 연결 실패 → exponential backoff 확인
- [ ] 기존 로그인 플로우 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)