### PR TITLE
fix(P0): Auth 400 refresh_token_already_used 재시도 루프 차단

### DIFF
--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -20,13 +20,26 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     return Promise.reject(new Error(`rate_limit_backoff:${remainingSec}`));
   }
 
-  return globalThis.fetch(input, init).then((response) => {
+  return globalThis.fetch(input, init).then(async (response) => {
     if (response.status === 429) {
       const retryAfterHeader = response.headers.get('Retry-After');
       const retrySeconds = parseInt(retryAfterHeader ?? '', 10);
       const backoffSec = !isNaN(retrySeconds) ? Math.max(retrySeconds, 60) : 60;
       rateLimitBlockedUntil.set(url, Date.now() + backoffSec * 1000);
     }
+
+    // refresh_token_already_used (HTTP 400) — SDK 재시도 루프 차단
+    // 같은 URL로의 10분 backoff를 설정해 자동 refresh 루프를 중단시킴.
+    if (response.status === 400 && url.includes('/token')) {
+      try {
+        const body = await response.clone().json() as { error?: string; error_description?: string };
+        const desc = (body.error_description ?? '').toLowerCase();
+        if (desc.includes('already used') || body.error === 'invalid_grant') {
+          rateLimitBlockedUntil.set(url, Date.now() + 600_000);
+        }
+      } catch { /* body parse 실패 무시 */ }
+    }
+
     return response;
   });
 }

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -35,7 +35,7 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
         const body = await response.clone().json() as Record<string, string>;
         const msg = (body.error_description ?? body.message ?? '').toLowerCase();
         const code = body.error ?? body.code ?? '';
-        if (msg.includes('already used') || code === 'invalid_grant' || code === 'refresh_token_already_used') {
+        if (msg.includes('already used') || msg.includes('already_used') || code === 'invalid_grant' || code === 'refresh_token_already_used') {
           rateLimitBlockedUntil.set(url, Date.now() + 600_000);
         }
       } catch { /* body parse 실패 무시 */ }

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -32,9 +32,10 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
     // 같은 URL로의 10분 backoff를 설정해 자동 refresh 루프를 중단시킴.
     if (response.status === 400 && url.includes('/token')) {
       try {
-        const body = await response.clone().json() as { error?: string; error_description?: string };
-        const desc = (body.error_description ?? '').toLowerCase();
-        if (desc.includes('already used') || body.error === 'invalid_grant') {
+        const body = await response.clone().json() as Record<string, string>;
+        const msg = (body.error_description ?? body.message ?? '').toLowerCase();
+        const code = body.error ?? body.code ?? '';
+        if (msg.includes('already used') || code === 'invalid_grant' || code === 'refresh_token_already_used') {
           rateLimitBlockedUntil.set(url, Date.now() + 600_000);
         }
       } catch { /* body parse 실패 무시 */ }


### PR DESCRIPTION
## Summary
PR #251(429 backoff)에 이어 400 `refresh_token_already_used` 케이스 추가.

`rateLimitedFetch`에서 `/token` 엔드포인트의 400 응답 + `already used` / `invalid_grant` 에러 감지 시 해당 URL에 10분 backoff 설정 → SDK 자동 refresh 루프 완전 차단.

## Test plan
- [ ] refresh_token_already_used 에러 발생 시 추가 재시도 없음 (10분 차단)
- [ ] 기존 로그인/429 backoff regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)