### PR TITLE
feat(nav): sidebar reorder + command palette (⌘K)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -44,7 +44,22 @@
     "workspace": "Workspace",
     "configure": "Configure",
     "sprints": "Sprints",
+    "search": "Search…",
     "help": "Help"
+  },
+  "commandPalette": {
+    "title": "Command palette",
+    "placeholder": "Type a command, memo ID, or agent name…",
+    "navigate": "Navigate",
+    "actions": "Actions",
+    "noResults": "No results",
+    "close": "Close",
+    "goInbox": "Go to Inbox",
+    "goDashboard": "Go to Dashboard",
+    "goBoard": "Go to Board",
+    "goMemos": "Go to Memos",
+    "goAgents": "Go to Agents",
+    "goDocs": "Go to Docs"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -44,7 +44,22 @@
     "workspace": "워크스페이스",
     "configure": "환경설정",
     "sprints": "스프린트",
+    "search": "검색…",
     "help": "도움말"
+  },
+  "commandPalette": {
+    "title": "커맨드 팔레트",
+    "placeholder": "명령, 메모 ID, 에이전트 이름 입력…",
+    "navigate": "이동",
+    "actions": "작업",
+    "noResults": "결과 없음",
+    "close": "닫기",
+    "goInbox": "인박스로 이동",
+    "goDashboard": "대시보드로 이동",
+    "goBoard": "보드로 이동",
+    "goMemos": "메모로 이동",
+    "goAgents": "에이전트로 이동",
+    "goDocs": "문서로 이동"
   },
   "dashboard": {
     "title": "대시보드",

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useMemo, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import {
+  BookOpen,
+  Bot,
+  FolderKanban,
+  Inbox,
+  LayoutDashboard,
+  MessageSquareMore,
+  Search,
+  type LucideIcon,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface CommandItem {
+  id: string;
+  group: 'navigate';
+  icon: LucideIcon;
+  labelKey: string;
+  href: string;
+  shortcut?: string[];
+}
+
+const ITEMS: CommandItem[] = [
+  { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
+  { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
+  { id: 'go-board', group: 'navigate', icon: FolderKanban, labelKey: 'goBoard', href: '/board', shortcut: ['G', 'B'] },
+  { id: 'go-memos', group: 'navigate', icon: MessageSquareMore, labelKey: 'goMemos', href: '/memos', shortcut: ['G', 'M'] },
+  { id: 'go-agents', group: 'navigate', icon: Bot, labelKey: 'goAgents', href: '/agents', shortcut: ['G', 'A'] },
+  { id: 'go-docs', group: 'navigate', icon: BookOpen, labelKey: 'goDocs', href: '/docs', shortcut: ['G', 'S'] },
+];
+
+export interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+  const router = useRouter();
+  const t = useTranslations('commandPalette');
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return ITEMS;
+    return ITEMS.filter((item) => t(item.labelKey).toLowerCase().includes(q));
+  }, [query, t]);
+
+  // Clamp active index to filtered range during render (avoid cascading effects).
+  const clampedActiveIndex =
+    filtered.length === 0 ? 0 : Math.min(Math.max(activeIndex, 0), filtered.length - 1);
+
+  function handleOpenChange(next: boolean) {
+    if (!next) {
+      setQuery('');
+      setActiveIndex(0);
+    }
+    onOpenChange(next);
+  }
+
+  function handleSelect(item: CommandItem) {
+    router.push(item.href);
+    handleOpenChange(false);
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex(Math.min(filtered.length - 1, clampedActiveIndex + 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex(Math.max(0, clampedActiveIndex - 1));
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const item = filtered[clampedActiveIndex];
+      if (item) handleSelect(item);
+    }
+  }
+
+  const navigateItems = filtered.filter((item) => item.group === 'navigate');
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop
+          className="fixed inset-0 z-50 bg-black/20 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0"
+        />
+        <DialogPrimitive.Popup
+          className={cn(
+            'fixed top-[20%] left-1/2 z-50 w-full max-w-[calc(100%-2rem)] -translate-x-1/2',
+            'overflow-hidden rounded-xl bg-popover text-popover-foreground shadow-lg ring-1 ring-foreground/10',
+            'sm:max-w-xl outline-none',
+            'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95',
+            'data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          )}
+        >
+          <DialogPrimitive.Title className="sr-only">{t('title')}</DialogPrimitive.Title>
+
+          <div className="flex items-center gap-2 border-b border-border/60 px-3 py-2.5">
+            <Search className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder={t('placeholder')}
+              className="flex-1 bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              aria-label={t('placeholder')}
+            />
+            <DialogPrimitive.Close
+              className="rounded border border-border/60 bg-muted/50 px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label={t('close')}
+            >
+              ESC
+            </DialogPrimitive.Close>
+          </div>
+
+          <div ref={listRef} className="max-h-80 overflow-y-auto p-2">
+            {filtered.length === 0 ? (
+              <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                {t('noResults')}
+              </div>
+            ) : (
+              navigateItems.length > 0 && (
+                <CommandGroup
+                  label={t('navigate')}
+                  items={navigateItems}
+                  activeIndex={clampedActiveIndex}
+                  filteredItems={filtered}
+                  onSelect={handleSelect}
+                  t={t}
+                />
+              )
+            )}
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+interface CommandGroupProps {
+  label: string;
+  items: CommandItem[];
+  filteredItems: CommandItem[];
+  activeIndex: number;
+  onSelect: (item: CommandItem) => void;
+  t: (key: string) => string;
+}
+
+function CommandGroup({ label, items, filteredItems, activeIndex, onSelect, t }: CommandGroupProps) {
+  return (
+    <div className="flex flex-col">
+      <div className="px-2 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <ul className="flex flex-col">
+        {items.map((item) => {
+          const idx = filteredItems.indexOf(item);
+          const active = idx === activeIndex;
+          const Icon = item.icon;
+          return (
+            <li key={item.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(item)}
+                onMouseEnter={() => {
+                  /* hover does not change activeIndex to avoid mouse/keyboard fight */
+                }}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors',
+                  active ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent/60',
+                )}
+                data-active={active || undefined}
+              >
+                <Icon className="size-4 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{t(item.labelKey)}</span>
+                {item.shortcut ? (
+                  <span className="ml-auto flex items-center gap-1">
+                    {item.shortcut.map((key) => (
+                      <kbd
+                        key={key}
+                        className="rounded border border-border/60 bg-muted/40 px-1.5 py-0.5 font-mono text-[10px] font-medium text-muted-foreground"
+                      >
+                        {key}
+                      </kbd>
+                    ))}
+                  </span>
+                ) : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -15,10 +15,12 @@ import {
   LayoutDashboard,
   MessageSquareMore,
   PenTool,
+  Search,
   Settings,
   Users,
 } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
+import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProjectSwitcher } from '@/components/nav/project-switcher';
 import {
   Sidebar,
@@ -59,6 +61,22 @@ export function AppSidebar({
   const t = useTranslations('nav');
   const [memoUnreadCount, setMemoUnreadCount] = useState(0);
   const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const isMod = event.metaKey || event.ctrlKey;
+      if (!isMod || event.key.toLowerCase() !== 'k') return;
+      const target = event.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      event.preventDefault();
+      setPaletteOpen((prev) => !prev);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
 
   useEffect(() => {
     async function fetchUnread() {
@@ -102,6 +120,18 @@ export function AppSidebar({
             {projectName ?? 'Sprintable'}
           </div>
         )}
+        <button
+          type="button"
+          onClick={openPalette}
+          className="mt-2 flex w-full items-center gap-2 rounded-md border border-sidebar-border/60 bg-sidebar-accent/30 px-2.5 py-1.5 text-left text-sm text-sidebar-foreground/60 transition hover:border-sidebar-border hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+          aria-label={t('search')}
+        >
+          <Search className="size-4" />
+          <span className="flex-1 truncate">{t('search')}</span>
+          <kbd className="hidden rounded border border-sidebar-border/60 bg-sidebar-accent/40 px-1.5 py-0 font-mono text-[10px] font-medium text-sidebar-foreground/60 sm:inline-flex">
+            ⌘K
+          </kbd>
+        </button>
       </SidebarHeader>
 
       <SidebarContent>
@@ -275,6 +305,7 @@ export function AppSidebar({
       </SidebarFooter>
 
       <SidebarRail />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
     </Sidebar>
   );
 }

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -12,6 +12,7 @@ import {
   FolderKanban,
   Gauge,
   Inbox,
+  LayoutDashboard,
   MessageSquareMore,
   PenTool,
   Settings,
@@ -105,6 +106,53 @@ export function AppSidebar({
 
       <SidebarContent>
         <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/inbox" />}
+                  isActive={isActive('/inbox')}
+                  tooltip={t('inbox')}
+                >
+                  <Inbox />
+                  <span>{t('inbox')}</span>
+                  {inboxUnreadCount > 0 ? (
+                    <SidebarMenuBadge>
+                      {inboxUnreadCount > 9 ? '9+' : inboxUnreadCount}
+                    </SidebarMenuBadge>
+                  ) : null}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/dashboard" />}
+                  isActive={isActive('/dashboard')}
+                  tooltip={t('dashboard')}
+                >
+                  <LayoutDashboard />
+                  <span>{t('dashboard')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/memos" />}
+                  isActive={isActive('/memos')}
+                  tooltip={t('memos')}
+                >
+                  <MessageSquareMore />
+                  <span>{t('memos')}</span>
+                  {memoUnreadCount > 0 ? (
+                    <SidebarMenuBadge>
+                      {memoUnreadCount > 9 ? '9+' : memoUnreadCount}
+                    </SidebarMenuBadge>
+                  ) : null}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
           <SidebarGroupLabel>{t('sprint')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
@@ -149,36 +197,6 @@ export function AppSidebar({
           <SidebarGroupLabel>{t('workspace')}</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/inbox" />}
-                  isActive={isActive('/inbox')}
-                  tooltip={t('inbox')}
-                >
-                  <Inbox />
-                  <span>{t('inbox')}</span>
-                  {inboxUnreadCount > 0 ? (
-                    <SidebarMenuBadge>
-                      {inboxUnreadCount > 9 ? '9+' : inboxUnreadCount}
-                    </SidebarMenuBadge>
-                  ) : null}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/memos" />}
-                  isActive={isActive('/memos')}
-                  tooltip={t('memos')}
-                >
-                  <MessageSquareMore />
-                  <span>{t('memos')}</span>
-                  {memoUnreadCount > 0 ? (
-                    <SidebarMenuBadge>
-                      {memoUnreadCount > 9 ? '9+' : memoUnreadCount}
-                    </SidebarMenuBadge>
-                  ) : null}
-                </SidebarMenuButton>
-              </SidebarMenuItem>
               <SidebarMenuItem>
                 <SidebarMenuButton
                   render={<Link href="/docs" />}


### PR DESCRIPTION
## Summary
Two stacked improvements to the left sidebar:

### 1. Reorder
- Pull **Inbox**, **Dashboard**, **Memos** out of the *Workspace* group
- Place them as a header-less section at the top, above the *Sprint* group
- Workspace group now keeps Docs / Meetings / Mockups / Agents
- Adds a Dashboard menu entry (uses `nav.dashboard` + `LayoutDashboard` icon)

### 2. Command palette (⌘K)
- Search pill below the project switcher (`Search… ⌘K`)
- Global ⌘K / Ctrl+K listener opens the palette anywhere in the dashboard shell
- Centered modal with input + filtered results
- **Navigate** section: Go to Inbox / Dashboard / Board / Memos / Agents / Docs
- Arrow up/down + Enter to select; Esc / overlay click to close
- i18n: `commandPalette.*` keys for both en and ko

## Final IA
```
[Project switcher]
[Search…              ⌘K]   ← new

[no header]
  Inbox      (badge)
  Dashboard
  Memos      (badge)

Sprint
  Board / Standup / Retro

Workspace
  Docs / Meetings / Mockups / Agents

Configure
  Settings
```

## Out of scope (follow-up)
- Actions section (New memo, Wake agent, Approve top inbox item, Create branch from story)
- `G + X` two-key chord shortcuts (Linear-style)
- Dynamic memo ID / agent name lookup

## Test plan
- [ ] Sidebar pill 클릭 → 팔레트 모달 오픈
- [ ] ⌘K (mac) / Ctrl+K (win) 어디서나 팔레트 토글
- [ ] 입력란 타이핑 시 라벨 부분일치 필터링
- [ ] 화살표 ↑↓ + Enter 로 선택 가능
- [ ] Esc / 외부 클릭 / ESC 칩으로 닫기 — 닫힐 때 query / activeIndex 리셋
- [ ] `/inbox`, `/dashboard`, `/memos` 사이드바 active 표시 정상
- [ ] inbox/memo unread 뱃지 정상 노출
- [ ] 한국어/영어 라벨 + placeholder 모두 정상
- [ ] 라이트/다크 모드 시각 회귀 없음