### PR TITLE
fix(auth): getUser→getClaims + maxAge/cookie-opts SDK 위임

### DIFF
--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -21,10 +21,6 @@ export async function createSupabaseServerClient() {
               cookieStore.set(name, value, {
                 ...(options as Parameters<typeof cookieStore.set>[2]),
                 ...(cookieDomain ? { domain: cookieDomain } : {}),
-                sameSite: 'lax',
-                secure: true,
-                path: '/',
-                maxAge: (options['maxAge'] as number | undefined) ?? 3600,
               });
             }
           } catch {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -91,17 +91,8 @@ export async function proxy(request: NextRequest) {
     },
   );
 
-  let user = null;
-  try {
-    const { data } = await supabase.auth.getUser();
-    user = data.user;
-  } catch {
-    const url = request.nextUrl.clone();
-    url.pathname = '/login';
-    return NextResponse.redirect(url);
-  }
-
-  if (!user) {
+  const { data: claimsData } = await supabase.auth.getClaims();
+  if (!claimsData?.claims) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary

주말 인증 장애 근본 원인 보완 — Auth 코드 감사 결과 적용

- **proxy.ts**: `getUser()` (네트워크 round-trip) → `getClaims()` (로컬 JWT 검증, JWKS 캐시 활용)
- **server.ts**: `maxAge: 3600` 하드코딩 제거 → SDK 계산값 위임
- **server.ts**: `sameSite/secure/path` 오버라이드 제거 → SDK 기본값 위임 (domain만 유지)

## AC Checklist

- [x] AC-1: `proxy.ts` — `getUser()` → `getClaims()` 교체 (`!claimsData?.claims` 로 미인증 처리)
- [x] AC-2: `server.ts` — `maxAge: 3600` 하드코딩 제거
- [x] AC-3: `server.ts` — `sameSite/secure/path` 하드코딩 제거, SDK 기본값 위임
- [x] AC-4: type-check PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)