### PR TITLE
fix(dashboard): unwrap nested grid squashing cards

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -270,23 +270,22 @@ export default async function DashboardPage() {
           }
         />
 
-        <div className="grid gap-4 md:grid-cols-3">
-          <SectionCard className="col-span-full">
-            <SectionCardHeader>
-              <div className="flex items-center justify-between gap-3">
-                <div>
-                  <div className="text-sm font-semibold text-foreground">{t('commandCenter')}</div>
-                  <div className="text-sm text-muted-foreground">{t('commandCenterDescription')}</div>
-                </div>
-                <StatusBadge status="active" label={t('statusActive')} />
+        <SectionCard>
+          <SectionCardHeader>
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <div className="text-sm font-semibold text-foreground">{t('commandCenter')}</div>
+                <div className="text-sm text-muted-foreground">{t('commandCenterDescription')}</div>
               </div>
-            </SectionCardHeader>
-            <SectionCardBody className="grid gap-3 md:grid-cols-3">
-              <OperatorStatCard label={t('projects')} value={projectMemberships.length} hint={t('projectsHint')} />
-              <OperatorStatCard label={t('activeSprints')} value={activeSprints?.length ?? 0} hint={t('activeSprintsHint')} />
-              <OperatorStatCard label={t('openMemos')} value={recentMemos?.length ?? 0} hint={t('openMemosHint')} />
-            </SectionCardBody>
-          </SectionCard>
+              <StatusBadge status="active" label={t('statusActive')} />
+            </div>
+          </SectionCardHeader>
+          <SectionCardBody className="grid gap-3 md:grid-cols-3">
+            <OperatorStatCard label={t('projects')} value={projectMemberships.length} hint={t('projectsHint')} />
+            <OperatorStatCard label={t('activeSprints')} value={activeSprints?.length ?? 0} hint={t('activeSprintsHint')} />
+            <OperatorStatCard label={t('openMemos')} value={recentMemos?.length ?? 0} hint={t('openMemosHint')} />
+          </SectionCardBody>
+        </SectionCard>
 
         <div className="grid gap-4 xl:grid-cols-3">
           <SectionCard className="xl:col-span-2">
@@ -406,7 +405,6 @@ export default async function DashboardPage() {
           </SectionCard>
         </div>
       </div>
-    </div>
     </div>
   );
 }


### PR DESCRIPTION
## Bug
On the authenticated dashboard, the 5 detail cards (Pending work / Sprint health / Recent docs / Policy docs / Unread memos) were collapsing into ~100px-wide columns with text wrapping one character per line. See user-reported screenshot.

## Root cause
\`apps/web/src/app/dashboard/page.tsx\` wrapped the Command Center plus the 5-card grid inside an outer \`grid md:grid-cols-3\`. The inner \`grid xl:grid-cols-3\` was being placed in a single 1/3-wide cell of the outer grid, then internally divided into 3 more columns — so each card got roughly 1/9 of the available width.

The outer grid was leftover scaffolding; the Command Center already fills its own row via SectionCard, and the 5 detail cards have their own grid.

## Fix
Remove the outer \`grid md:grid-cols-3\` wrapper and the now-redundant \`col-span-full\` on the Command Center SectionCard. Layout becomes:

- Command Center (full width)
- 5 cards in \`grid xl:grid-cols-3\` (Pending work spans 2 cols)

OSS branch in the same file already used this pattern; the bug was only on the authenticated branch.

## Test plan
- [ ] \`/dashboard\` — Command Center renders full width with 3 stat cards
- [ ] Below it: Pending work (2/3) + Sprint health (1/3) on first row
- [ ] Recent docs / Policy docs / Unread memos on second row at \`xl\` breakpoint
- [ ] At \`md\` breakpoint, cards stack to single column gracefully
- [ ] No JSX/TS errors, eslint clean (only pre-existing warnings)