### PR TITLE
revert: PR #255 getClaims + maxAge SDK 위임 — 세션 유지 regression

### DIFF
--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -21,6 +21,10 @@ export async function createSupabaseServerClient() {
               cookieStore.set(name, value, {
                 ...(options as Parameters<typeof cookieStore.set>[2]),
                 ...(cookieDomain ? { domain: cookieDomain } : {}),
+                sameSite: 'lax',
+                secure: true,
+                path: '/',
+                maxAge: (options['maxAge'] as number | undefined) ?? 3600,
               });
             }
           } catch {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -91,8 +91,17 @@ export async function proxy(request: NextRequest) {
     },
   );
 
-  const { data: claimsData } = await supabase.auth.getClaims();
-  if (!claimsData?.claims) {
+  let user = null;
+  try {
+    const { data } = await supabase.auth.getUser();
+    user = data.user;
+  } catch {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  if (!user) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Revert 이유

PR #255 배포 후 프로덕션에서 세션 유지 실패 regression 발생.

**증상:** 로그인 성공 후 다른 메뉴 이동 시 `/login` redirect, 반복 호출

**원인:**
1. `getClaims()` — 토큰 만료 시 자동 갱신을 트리거하지 않아 `claims null` → `/login` redirect
2. `server.ts` `maxAge/sameSite/secure/path` 제거 → SDK 기본값 누락 가능성

## 변경 내용

`git revert d2792e8` — PR #255 완전 롤백:
- `proxy.ts`: `getClaims()` → `getUser()` 복원
- `server.ts`: `maxAge: 3600`, `sameSite/secure/path` 하드코딩 복원

🤖 Generated with [Claude Code](https://claude.com/claude-code)