### PR TITLE
chore(dev): auto-kill leftover dev server before pnpm dev

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --webpack --port ${PORT:-3108}",
+    "dev": "bash scripts/kill-port.sh ${PORT:-3108} && next dev --webpack --port ${PORT:-3108}",
     "build": "next build",
-    "start": "next start --port ${PORT:-3108}",
+    "start": "bash scripts/kill-port.sh ${PORT:-3108} && next start --port ${PORT:-3108}",
     "lint": "eslint",
     "type-check": "tsc --noEmit",
     "runtime:worker": "tsx scripts/background-runtime-worker.ts",

--- a/apps/web/scripts/kill-port.sh
+++ b/apps/web/scripts/kill-port.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Kill any process listening on the given TCP port. Safe no-op when nothing
+# is bound. Used by `pnpm dev` to recover from a leftover Next.js dev server
+# that survived a previous session and is still holding the port.
+set -e
+
+PORT="${1:-3108}"
+# Only target the LISTENing socket — without this filter we'd also kill any
+# client process that happens to have an open connection to the port (e.g. an
+# attached browser tab), which has bitten us before.
+PIDS=$(lsof -ti tcp:"$PORT" -sTCP:LISTEN 2>/dev/null || true)
+
+if [ -n "$PIDS" ]; then
+  echo "[kill-port] freeing port $PORT — killing PID(s): $PIDS"
+  kill -9 $PIDS 2>/dev/null || true
+  # Give the kernel a beat to release the socket before the next bind.
+  sleep 0.3
+fi


### PR DESCRIPTION
## Summary
\`pnpm dev\` would fail with \`EADDRINUSE\` when a previous Next.js dev server was still bound to port 3108 — typically after a session crashed or the parent shell was killed. This adds a tiny preflight that frees the port first.

## Changes
- New \`apps/web/scripts/kill-port.sh\` — finds the LISTENing PID on a given port (default 3108) and kills it. No-op when nothing is bound.
- \`apps/web/package.json\` — \`dev\` and \`start\` scripts now run \`bash scripts/kill-port.sh \${PORT:-3108} && next ...\`.

## Why \`-sTCP:LISTEN\`
\`lsof -ti tcp:PORT\` alone returns every PID with **any** TCP connection involving that port, including client processes (e.g. an attached browser tab). The \`-sTCP:LISTEN\` filter restricts the kill to just the listener — discovered the hard way after the first version of this script also took down a Chrome instance that had \`localhost:3108\` open.

## Test plan
- [ ] \`pnpm dev\` on a free port → kills nothing, server starts
- [ ] \`pnpm dev\` while another dev server is bound → \`[kill-port] freeing port 3108 — killing PID(s): N\`, then new server starts cleanly
- [ ] Other tabs / clients connected to the port survive (only the listener PID is killed)
- [ ] \`PORT=3500 pnpm dev\` honors the override