### PR TITLE
chore(nav): remove Mockups menu item from sidebar

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -14,7 +14,6 @@ import {
   Inbox,
   LayoutDashboard,
   MessageSquareMore,
-  PenTool,
   Search,
   Settings,
   Users,
@@ -245,16 +244,6 @@ export function AppSidebar({
                 >
                   <CalendarDays />
                   <span>{t('meetings')}</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  render={<Link href="/mockups" />}
-                  isActive={isActive('/mockups')}
-                  tooltip={t('mockup')}
-                >
-                  <PenTool />
-                  <span>{t('mockup')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>


### PR DESCRIPTION
## Summary
Drop the Mockups entry (icon + label + link) from the Workspace group of the sidebar, and remove the now-unused PenTool icon import. The /mockups route itself is left in place — only the navigation surface is hidden.

## Test plan
- [ ] Sidebar Workspace group shows: Docs / Meetings / Agents (no Mockups)
- [ ] Other groups (Inbox/Dashboard/Memos top, Sprint, Configure) unchanged
- [ ] No lint warnings about unused PenTool