### PR TITLE
feat(auth): getClaims + 조건부 refreshSession 정석 구현

### DIFF
--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -21,10 +21,7 @@ export async function createSupabaseServerClient() {
               cookieStore.set(name, value, {
                 ...(options as Parameters<typeof cookieStore.set>[2]),
                 ...(cookieDomain ? { domain: cookieDomain } : {}),
-                sameSite: 'lax',
                 secure: true,
-                path: '/',
-                maxAge: (options['maxAge'] as number | undefined) ?? 3600,
               });
             }
           } catch {

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -91,20 +91,20 @@ export async function proxy(request: NextRequest) {
     },
   );
 
-  let user = null;
-  try {
-    const { data } = await supabase.auth.getUser();
-    user = data.user;
-  } catch {
+  // 로컬 JWT 파싱 — 네트워크 zero (JWKS 캐시 활용)
+  const { data: claimsData } = await supabase.auth.getClaims();
+
+  if (!claimsData?.claims) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     return NextResponse.redirect(url);
   }
 
-  if (!user) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/login';
-    return NextResponse.redirect(url);
+  // exp 만료 임박(5분 이내)일 때만 refreshSession() 호출
+  const exp = (claimsData.claims as { exp?: number }).exp;
+  const now = Math.floor(Date.now() / 1000);
+  if (exp !== undefined && exp - now < 300) {
+    await supabase.auth.refreshSession();
   }
 
   if (request.nextUrl.pathname === '/login') {


### PR DESCRIPTION
## Summary

PR #255의 단순 교체 실패를 교훈 삼아 정석 구현.

### proxy.ts
- `getClaims()` — 로컬 JWT 파싱 (JWKS 캐시 활용, 네트워크 zero)
- `exp` 만료 **5분 이내**일 때만 `refreshSession()` 조건부 호출 → 세션 자동 갱신 보장
- `claims == null` → `/login` redirect

### server.ts
- SDK 실제 `options` spread (`maxAge` 400일, `sameSite: lax`, `path: /`)
- `secure: true` 명시 추가 (SDK `DEFAULT_COOKIE_OPTIONS`에 없음, HTTPS 필수)
- `domain` 오버라이드만 유지

## AC Checklist

- [x] AC-1: `getClaims()` 로컬 JWT 파싱 (네트워크 zero)
- [x] AC-2: `exp` 만료 임박 시에만 `refreshSession()` 조건부 호출
- [x] AC-3: claims 유효 → 로컬 통과 (추가 네트워크 콜 없음)
- [x] AC-4: `server.ts` SDK 실제 옵션 위임 + `secure: true` 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)