### PR TITLE
fix(auth): refresh_token_already_used 시 sb-* 쿠키 자동 클리어 + /login 리다이렉트

### DIFF
--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -28,15 +28,21 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
       rateLimitBlockedUntil.set(url, Date.now() + backoffSec * 1000);
     }
 
-    // refresh_token_already_used (HTTP 400) — SDK 재시도 루프 차단
-    // 같은 URL로의 10분 backoff를 설정해 자동 refresh 루프를 중단시킴.
+    // refresh_token_already_used (HTTP 400) — sb-* 쿠키 클리어 후 /login 리다이렉트
     if (response.status === 400 && url.includes('/token')) {
       try {
         const body = await response.clone().json() as Record<string, string>;
         const msg = (body.error_description ?? body.message ?? '').toLowerCase();
         const code = body.error ?? body.code ?? '';
         if (msg.includes('already used') || msg.includes('already_used') || code === 'invalid_grant' || code === 'refresh_token_already_used') {
-          rateLimitBlockedUntil.set(url, Date.now() + 600_000);
+          // sb-* auth 쿠키 전량 삭제 후 /login 리다이렉트
+          document.cookie.split(';').forEach((c) => {
+            const name = c.trim().split('=')[0];
+            if (name?.startsWith('sb-')) {
+              document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+            }
+          });
+          window.location.href = '/login';
         }
       } catch { /* body parse 실패 무시 */ }
     }

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -36,10 +36,11 @@ function rateLimitedFetch(input: RequestInfo | URL, init?: RequestInit): Promise
         const code = body.error ?? body.code ?? '';
         if (msg.includes('already used') || msg.includes('already_used') || code === 'invalid_grant' || code === 'refresh_token_already_used') {
           // sb-* auth 쿠키 전량 삭제 후 /login 리다이렉트
+          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
           document.cookie.split(';').forEach((c) => {
             const name = c.trim().split('=')[0];
             if (name?.startsWith('sb-')) {
-              document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+              document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/${cookieDomain ? `; domain=${cookieDomain}` : ''}`;
             }
           });
           window.location.href = '/login';


### PR DESCRIPTION
## Summary

선생님 발견 UX 버그 수정 — 수동 쿠키 삭제 강요 제거.

`rateLimitedFetch` 400 핸들러에서 `refresh_token_already_used` 감지 시:
1. `sb-*` prefix 쿠키 전량 삭제 (`expires=Thu, 01 Jan 1970` 설정)
2. `window.location.href = '/login'` 즉시 리다이렉트

기존 10분 backoff 제거. 429 rate limit backoff는 그대로 유지.

## AC Checklist

- [x] AC-1: 400 refresh_token_already_used 감지 → sb-* 쿠키 클리어 + /login redirect
- [x] AC-2: 정상 세션 플로우 변화 없음 (429 backoff 유지)
- [x] AC-3: 리다이렉트로 재로그인 가능, 토스트 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)