### PR TITLE
feat(retro): 회고 상세 페이지 구현 (E-UI-POLISH S2)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -787,7 +787,22 @@
     "phaseVote": "🗳️ Vote",
     "phaseDiscuss": "💬 Discuss",
     "phaseAction": "🎯 Action",
-    "phaseClosed": "✅ Closed"
+    "phaseClosed": "✅ Closed",
+    "loading": "Loading...",
+    "backToList": "Back to list",
+    "sessionNotFound": "Session not found.",
+    "phaseNext": "Next phase",
+    "export": "Export",
+    "categoryGood": "Good",
+    "categoryBad": "Bad",
+    "categoryImprove": "Improve",
+    "addItem": "Add item",
+    "itemPlaceholder": "Enter your thoughts...",
+    "submit": "Add",
+    "actions": "Action items",
+    "noActions": "No action items yet.",
+    "addAction": "Add",
+    "actionPlaceholder": "Enter action item..."
   },
   "docs": {
     "title": "Documentation",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -787,7 +787,22 @@
     "phaseVote": "🗳️ 투표",
     "phaseDiscuss": "💬 토론",
     "phaseAction": "🎯 액션",
-    "phaseClosed": "✅ 완료"
+    "phaseClosed": "✅ 완료",
+    "loading": "불러오는 중...",
+    "backToList": "목록으로",
+    "sessionNotFound": "세션을 찾을 수 없습니다.",
+    "phaseNext": "다음 단계",
+    "export": "내보내기",
+    "categoryGood": "Good",
+    "categoryBad": "Bad",
+    "categoryImprove": "Improve",
+    "addItem": "항목 추가",
+    "itemPlaceholder": "의견을 입력하세요...",
+    "submit": "추가",
+    "actions": "액션 아이템",
+    "noActions": "아직 액션 아이템이 없습니다.",
+    "addAction": "추가",
+    "actionPlaceholder": "액션 아이템을 입력하세요..."
   },
   "docs": {
     "title": "문서",

--- a/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { ArrowLeft, Download, ChevronRight, Plus, ThumbsUp } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useDashboardContext } from '../../../dashboard/dashboard-shell';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RetroSession {
+  id: string;
+  title: string;
+  phase: string;
+}
+
+interface RetroItem {
+  id: string;
+  category: string;
+  text: string;
+  vote_count: number;
+}
+
+interface RetroAction {
+  id: string;
+  title: string;
+  status: string;
+}
+
+type Phase = 'collect' | 'group' | 'vote' | 'discuss' | 'action' | 'closed';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const PHASE_VARIANTS: Record<string, 'success' | 'info' | 'outline' | 'secondary'> = {
+  collect: 'info',
+  group: 'secondary',
+  vote: 'outline',
+  discuss: 'secondary',
+  action: 'success',
+  closed: 'outline',
+};
+
+const NEXT_PHASE: Record<string, Phase> = {
+  collect: 'group',
+  group: 'vote',
+  vote: 'discuss',
+  discuss: 'action',
+  action: 'closed',
+};
+
+const CATEGORIES: Array<'good' | 'bad' | 'improve'> = ['good', 'bad', 'improve'];
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default function RetroDetailPage() {
+  const t = useTranslations('retro');
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const { projectId } = useDashboardContext();
+
+  const [session, setSession] = useState<RetroSession | null>(null);
+  const [items, setItems] = useState<RetroItem[]>([]);
+  const [actions, setActions] = useState<RetroAction[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const [newItemCategory, setNewItemCategory] = useState<'good' | 'bad' | 'improve'>('good');
+  const [newItemText, setNewItemText] = useState('');
+  const [addingItem, setAddingItem] = useState(false);
+
+  const [newActionTitle, setNewActionTitle] = useState('');
+  const [addingAction, setAddingAction] = useState(false);
+
+  const [advancingPhase, setAdvancingPhase] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const [exportMd, setExportMd] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      const [sessRes, itemsRes, actionsRes] = await Promise.all([
+        fetch(`/api/retro-sessions/${id}?project_id=${projectId}`),
+        fetch(`/api/retro-sessions/${id}/items?project_id=${projectId}`),
+        fetch(`/api/retro-sessions/${id}/actions?project_id=${projectId}`),
+      ]);
+      if (sessRes.ok) {
+        const j = await sessRes.json();
+        setSession(j.data as RetroSession);
+      }
+      if (itemsRes.ok) {
+        const j = await itemsRes.json();
+        setItems((j.data ?? []) as RetroItem[]);
+      }
+      if (actionsRes.ok) {
+        const j = await actionsRes.json();
+        setActions((j.data ?? []) as RetroAction[]);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [id, projectId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const handleAddItem = async () => {
+    if (!newItemText.trim() || !projectId) return;
+    setAddingItem(true);
+    try {
+      const res = await fetch(`/api/retro-sessions/${id}/items?project_id=${projectId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category: newItemCategory, text: newItemText.trim() }),
+      });
+      if (res.ok) {
+        const j = await res.json();
+        setItems((prev) => [...prev, j.data as RetroItem]);
+        setNewItemText('');
+      }
+    } finally {
+      setAddingItem(false);
+    }
+  };
+
+  const handleVote = async (itemId: string) => {
+    if (!projectId) return;
+    await fetch(`/api/retro-sessions/${id}/items/${itemId}/vote?project_id=${projectId}`, { method: 'POST' });
+    setItems((prev) => prev.map((item) => item.id === itemId ? { ...item, vote_count: item.vote_count + 1 } : item));
+  };
+
+  const handleAddAction = async () => {
+    if (!newActionTitle.trim() || !projectId) return;
+    setAddingAction(true);
+    try {
+      const res = await fetch(`/api/retro-sessions/${id}/actions?project_id=${projectId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: newActionTitle.trim() }),
+      });
+      if (res.ok) {
+        const j = await res.json();
+        setActions((prev) => [...prev, j.data as RetroAction]);
+        setNewActionTitle('');
+      }
+    } finally {
+      setAddingAction(false);
+    }
+  };
+
+  const handleAdvancePhase = async () => {
+    if (!session || !projectId) return;
+    const next = NEXT_PHASE[session.phase];
+    if (!next) return;
+    setAdvancingPhase(true);
+    try {
+      const res = await fetch(`/api/retro-sessions/${id}?project_id=${projectId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phase: next }),
+      });
+      if (res.ok) {
+        const j = await res.json();
+        setSession(j.data as RetroSession);
+      }
+    } finally {
+      setAdvancingPhase(false);
+    }
+  };
+
+  const handleExport = async () => {
+    if (!projectId) return;
+    setExporting(true);
+    try {
+      const res = await fetch(`/api/retro-sessions/${id}/export?project_id=${projectId}`);
+      if (res.ok) {
+        const j = await res.json();
+        setExportMd((j.data as { markdown: string }).markdown);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  if (loading) {
+    return <p className="p-6 text-sm text-muted-foreground">{t('loading')}</p>;
+  }
+
+  if (!session) {
+    return (
+      <div className="p-6">
+        <button type="button" onClick={() => router.back()} className="mb-4 flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="size-4" /> {t('backToList')}
+        </button>
+        <p className="text-sm text-muted-foreground">{t('sessionNotFound')}</p>
+      </div>
+    );
+  }
+
+  const nextPhase = NEXT_PHASE[session.phase];
+
+  return (
+    <div className="space-y-6 p-6">
+      {/* Header */}
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center gap-3">
+          <button type="button" onClick={() => router.push('/retro')} className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground">
+            <ArrowLeft className="size-4" />
+            <span className="hidden lg:inline">{t('backToList')}</span>
+          </button>
+          <div>
+            <h1 className="text-lg font-semibold text-foreground">{session.title}</h1>
+            <Badge variant={PHASE_VARIANTS[session.phase] ?? 'outline'} className="mt-1">
+              {t(`phase${session.phase.charAt(0).toUpperCase()}${session.phase.slice(1)}` as 'phaseCollect')}
+            </Badge>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {nextPhase ? (
+            <Button size="sm" onClick={() => void handleAdvancePhase()} disabled={advancingPhase}>
+              <ChevronRight className="size-4" />
+              {advancingPhase ? '...' : t('phaseNext')}
+            </Button>
+          ) : null}
+          <Button size="sm" variant="outline" onClick={() => void handleExport()} disabled={exporting}>
+            <Download className="size-4" />
+            {exporting ? '...' : t('export')}
+          </Button>
+        </div>
+      </div>
+
+      {/* Export output */}
+      {exportMd ? (
+        <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <pre className="whitespace-pre-wrap text-xs text-foreground">{exportMd}</pre>
+        </div>
+      ) : null}
+
+      {/* Items by category */}
+      <div className="grid gap-4 lg:grid-cols-3">
+        {CATEGORIES.map((cat) => (
+          <div key={cat} className="rounded-lg border border-border bg-card p-4 space-y-3">
+            <h2 className="text-sm font-semibold text-foreground">
+              {cat === 'good' ? '👍' : cat === 'bad' ? '👎' : '💡'} {t(`category${cat.charAt(0).toUpperCase()}${cat.slice(1)}` as 'categoryGood')}
+            </h2>
+            <ul className="space-y-2">
+              {items.filter((item) => item.category === cat).map((item) => (
+                <li key={item.id} className="flex items-start justify-between gap-2 rounded-md border border-border px-3 py-2 text-sm">
+                  <span className="text-foreground">{item.text}</span>
+                  <button
+                    type="button"
+                    onClick={() => void handleVote(item.id)}
+                    className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground hover:text-primary"
+                  >
+                    <ThumbsUp className="size-3" />
+                    {item.vote_count}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      {/* Add item */}
+      {session.phase !== 'closed' ? (
+        <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+          <h2 className="text-sm font-semibold text-foreground">{t('addItem')}</h2>
+          <div className="flex flex-col gap-2 lg:flex-row">
+            <select
+              value={newItemCategory}
+              onChange={(e) => setNewItemCategory(e.target.value as 'good' | 'bad' | 'improve')}
+              className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            >
+              {CATEGORIES.map((cat) => (
+                <option key={cat} value={cat}>
+                  {cat === 'good' ? '👍' : cat === 'bad' ? '👎' : '💡'} {t(`category${cat.charAt(0).toUpperCase()}${cat.slice(1)}` as 'categoryGood')}
+                </option>
+              ))}
+            </select>
+            <input
+              type="text"
+              value={newItemText}
+              onChange={(e) => setNewItemText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleAddItem(); }}
+              placeholder={t('itemPlaceholder')}
+              className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <Button size="sm" onClick={() => void handleAddItem()} disabled={addingItem || !newItemText.trim()}>
+              <Plus className="size-4" />
+              {addingItem ? '...' : t('submit')}
+            </Button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* Action items */}
+      <div className="rounded-lg border border-border bg-card p-4 space-y-3">
+        <h2 className="text-sm font-semibold text-foreground">{t('actions')}</h2>
+        {actions.length === 0 ? (
+          <p className="text-xs italic text-muted-foreground">{t('noActions')}</p>
+        ) : (
+          <ul className="space-y-2">
+            {actions.map((action) => (
+              <li key={action.id} className="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+                <span className="text-foreground">{action.title}</span>
+                <Badge variant="outline">{action.status}</Badge>
+              </li>
+            ))}
+          </ul>
+        )}
+        {session.phase !== 'closed' ? (
+          <div className="flex gap-2 pt-1">
+            <input
+              type="text"
+              value={newActionTitle}
+              onChange={(e) => setNewActionTitle(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleAddAction(); }}
+              placeholder={t('actionPlaceholder')}
+              className="flex-1 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <Button size="sm" onClick={() => void handleAddAction()} disabled={addingAction || !newActionTitle.trim()}>
+              <Plus className="size-4" />
+              {addingAction ? '...' : t('addAction')}
+            </Button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -156,7 +157,7 @@ export default function RetroPage() {
           ) : (
             <div className="space-y-3">
               {sessions.map((session) => (
-                <div key={session.id} className="flex flex-col gap-3 rounded-md border border-border bg-card p-4 shadow-sm md:flex-row md:items-center md:justify-between">
+                <Link key={session.id} href={`/retro/${session.id}`} className="flex flex-col gap-3 rounded-md border border-border bg-card p-4 shadow-sm transition hover:bg-muted/40 md:flex-row md:items-center md:justify-between">
                   <div className="space-y-1">
                     <p className="text-sm font-semibold text-foreground">{session.title}</p>
                     <p className="text-xs text-muted-foreground">{new Date(session.created_at).toLocaleDateString()}</p>
@@ -164,7 +165,7 @@ export default function RetroPage() {
                   <Badge variant={PHASE_VARIANTS[session.phase] ?? 'outline'}>
                     {PHASE_KEYS[session.phase] ? t(PHASE_KEYS[session.phase] as 'phaseCollect') : session.phase}
                   </Badge>
-                </div>
+                </Link>
               ))}
             </div>
           )}

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -8,6 +8,28 @@ import { RetroSessionService } from '@/services/retro-session';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+// GET /api/retro-sessions/:id/actions?project_id=X
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new RetroSessionService(dbClient);
+    const data = await service.listActions(id, projectId);
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
 // POST /api/retro-sessions/:id/actions
 export async function POST(request: Request, { params }: RouteParams) {
   try {

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -9,6 +9,28 @@ import type { RetroItemCategory } from '@/services/retro-session';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+// GET /api/retro-sessions/:id/items?project_id=X
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new RetroSessionService(dbClient);
+    const data = await service.listItems(id, projectId);
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
 // POST /api/retro-sessions/:id/items
 export async function POST(request: Request, { params }: RouteParams) {
   try {
@@ -25,11 +47,11 @@ export async function POST(request: Request, { params }: RouteParams) {
     const body = await request.json() as { category?: RetroItemCategory; text?: string; author_id?: string };
     if (!body.category) return ApiErrors.badRequest('category required');
     if (!body.text) return ApiErrors.badRequest('text required');
-    if (!body.author_id) return ApiErrors.badRequest('author_id required');
+    const author_id = body.author_id ?? me.id;
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new RetroSessionService(dbClient);
-    const data = await service.addItem({ session_id: id, project_id: projectId, category: body.category, text: body.text, author_id: body.author_id });
+    const data = await service.addItem({ session_id: id, project_id: projectId, category: body.category, text: body.text, author_id });
     return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -9,6 +9,29 @@ import type { RetroSessionPhase } from '@/services/retro-session';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
+// GET /api/retro-sessions/:id?project_id=X
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new RetroSessionService(dbClient);
+    const data = await service.getSession(id, projectId);
+    if (!data) return ApiErrors.notFound('Session not found');
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
 // PATCH /api/retro-sessions/:id — change phase
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {

--- a/apps/web/src/services/retro-session.ts
+++ b/apps/web/src/services/retro-session.ts
@@ -44,6 +44,51 @@ const VALID_TRANSITIONS: Record<string, string[]> = {
 export class RetroSessionService {
   constructor(private readonly supabase: SupabaseClient) {}
 
+  async getSession(sessionId: string, projectId: string): Promise<RetroSessionRecord | null> {
+    const { data, error } = await this.supabase
+      .from('retro_sessions')
+      .select('*')
+      .eq('id', sessionId)
+      .eq('project_id', projectId)
+      .single();
+    if (error) return null;
+    return data as RetroSessionRecord;
+  }
+
+  async listItems(sessionId: string, projectId: string): Promise<RetroItemRecord[]> {
+    const { data: sess } = await this.supabase
+      .from('retro_sessions')
+      .select('id')
+      .eq('id', sessionId)
+      .eq('project_id', projectId)
+      .single();
+    if (!sess) throw new Error('Session not in project');
+    const { data, error } = await this.supabase
+      .from('retro_items')
+      .select('*')
+      .eq('session_id', sessionId)
+      .order('created_at');
+    if (error) throw error;
+    return (data ?? []) as RetroItemRecord[];
+  }
+
+  async listActions(sessionId: string, projectId: string): Promise<RetroActionRecord[]> {
+    const { data: sess } = await this.supabase
+      .from('retro_sessions')
+      .select('id')
+      .eq('id', sessionId)
+      .eq('project_id', projectId)
+      .single();
+    if (!sess) throw new Error('Session not in project');
+    const { data, error } = await this.supabase
+      .from('retro_actions')
+      .select('*')
+      .eq('session_id', sessionId)
+      .order('created_at');
+    if (error) throw error;
+    return (data ?? []) as RetroActionRecord[];
+  }
+
   async listSessions(projectId: string): Promise<RetroSessionRecord[]> {
     const { data, error } = await this.supabase
       .from('retro_sessions')


### PR DESCRIPTION
## Summary

회고 세션 상세 페이지 신규 구현.

- **retro/[id]/page.tsx** — 상세 페이지 신규 생성
- **retro/page.tsx** — 세션 클릭 시 `/retro/[id]` 링크 추가

### 백엔드 보완
- `RetroSessionService.getSession/listItems/listActions` 추가
- `GET /api/retro-sessions/[id]`, `/items`, `/actions` route 추가
- items POST — `author_id` 미전송 시 `me.id` 서버 fallback

## AC Checklist

- [x] AC-1: 회고 항목(Good/Bad/Improve) 카테고리별 3컬럼 목록
- [x] AC-2: 항목 추가 — 카테고리 선택 + 텍스트 입력 + Enter/버튼
- [x] AC-3: 항목 투표 — ThumbsUp 클릭으로 vote_count 증가
- [x] AC-4: 액션 아이템 목록 + 추가 폼
- [x] AC-5: Phase 전환 버튼 (collect→group→vote→discuss→action→closed)
- [x] AC-6: Export 버튼 → Markdown 인라인 표시
- [x] i18n ko/en 완비 (14키)
- [x] lg 기준 반응형 레이아웃

🤖 Generated with [Claude Code](https://claude.com/claude-code)