### PR TITLE
fix(kanban): prevent card compression and epic badge overflow

### DIFF
--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -237,7 +237,7 @@ export function KanbanColumn({
       ) : null}
 
       <SortableContextCompat items={stories.map((s) => s.id)} strategy={verticalListSortingStrategy}>
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-y-auto [&>*]:shrink-0">
           {stories.length === 0 && !composing ? (
             <div className="flex min-h-[100px] items-center justify-center px-4 text-center">
               <p className="text-xs text-muted-foreground/60">{t('noStories')}</p>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -144,8 +144,8 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
         <div className="absolute inset-0 pointer-events-none rounded-lg border border-transparent bg-gradient-to-r from-cyan-500/10 to-purple-500/10 opacity-50" />
       )}
       {epicName && story.epic_id ? (
-        <Badge variant={getEpicColor(story.epic_id)} className="mb-3 max-w-full truncate">
-          {epicName}
+        <Badge variant={getEpicColor(story.epic_id)} className="mb-3 max-w-full">
+          <span className="min-w-0 truncate leading-none">{epicName}</span>
         </Badge>
       ) : null}
       <p className="relative z-10 line-clamp-2 text-sm font-medium leading-5 text-foreground">{story.title}</p>


### PR DESCRIPTION
## Summary

칸반 보드의 두 가지 시각 버그 수정.

### 1. 컬럼에 카드가 많아지면 카드가 압착되는 문제 (`kanban-column.tsx`)
- **증상**: Done 컬럼에 카드 45개가 쌓이니 각 카드가 **24px**로 압착되어 제목·메타데이터가 거의 안 보임. 다른 컬럼 카드(106px)와 비교 시 1/5 수준.
- **원인**: `flex flex-col + overflow-y-auto` 컨테이너에서 자식의 기본 `flex-shrink: 1`이 컬럼 높이에 맞춰 카드 높이를 강제로 줄임. `overflow-y-auto`가 무력화됨.
- **수정**: 카드 컨테이너에 `[&>*]:shrink-0` 한 줄 추가. 카드는 자연 높이를 유지하고 초과분은 컬럼이 스크롤.

### 2. Epic badge가 카드 밖으로 삐져나오는 문제 (`story-card.tsx`)
- **증상**: 긴 Epic 이름(예: `E-UI-POLISH — UI 미구현/버그 4건 수정`)이 카드 폭(229px)을 초과할 때, 텍스트가 가운데 정렬된 채 양쪽이 잘리고 ellipsis도 표시되지 않음.
- **원인**: Badge가 `inline-flex justify-center whitespace-nowrap`이라 직접 텍스트노드에 `truncate`(text-overflow ellipsis)가 작동하지 않음.
- **수정**: 텍스트를 내부 `<span class="min-w-0 truncate leading-none">`으로 감쌈. Badge의 `items-center`는 그대로 두어 vertical center 유지하면서 ellipsis가 텍스트노드에 적용되도록.

## 측정 (before → after)

| 컬럼 | 카드 수 | before | after |
|---|---|---|---|
| Backlog | 4 | 122px | 122px (변화 없음) |
| Done | 45 | **24px** | **106px** |

| Epic Badge | before | after |
|---|---|---|
| 표시 | `-UI-POLISH — UI` (양쪽 잘림, ellipsis ✗) | `E-UI-POLISH — UI 미구현/...` (ellipsis ✓) |
| Vertical | OK | OK (items-center 유지) |

## 변경 라인 수

```
apps/web/src/components/kanban/kanban-column.tsx | 2 +-
apps/web/src/components/kanban/story-card.tsx    | 4 ++--
2 files changed, 3 insertions(+), 3 deletions(-)
```

## Test plan
- [ ] `/board`에서 Done 컬럼에 카드 30+개 있는 sprint 선택 → 카드가 정상 높이로 표시되고 컬럼이 스크롤되는지 확인
- [ ] 긴 epic 이름을 가진 카드에서 epic badge가 카드 폭 안에 들어오고 `…`로 잘리는지 확인
- [ ] Badge 텍스트가 vertical center 정렬되는지 확인
- [ ] `pnpm typecheck` / `pnpm lint` 통과