### PR TITLE
feat(workflow-contract): S1 원자 조건 타입 20종 + DB 스키마 3테이블

### DIFF
--- a/packages/db/supabase/migrations/20260427150000_workflow_contracts.sql
+++ b/packages/db/supabase/migrations/20260427150000_workflow_contracts.sql
@@ -1,0 +1,130 @@
+-- E-WORKFLOW-CONTRACT S1: workflow_contracts / workflow_instances / workflow_events
+
+-- ─── workflow_contracts ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS workflow_contracts (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id      UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  name        TEXT NOT NULL,
+  version     INTEGER NOT NULL DEFAULT 1,
+  mode        TEXT NOT NULL DEFAULT 'evaluate' CHECK (mode IN ('evaluate', 'enforce')),
+  definition  JSONB NOT NULL DEFAULT '{}',
+  entity_type TEXT NOT NULL,
+  is_active   BOOLEAN NOT NULL DEFAULT true,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (org_id, name, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_contracts_org_active
+  ON workflow_contracts (org_id, is_active, entity_type);
+
+-- ─── workflow_instances ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS workflow_instances (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  contract_id   UUID NOT NULL REFERENCES workflow_contracts(id) ON DELETE CASCADE,
+  entity_id     UUID NOT NULL,
+  current_state TEXT NOT NULL,
+  context       JSONB NOT NULL DEFAULT '{}',
+  status        TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'cancelled')),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_instances_contract
+  ON workflow_instances (contract_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_instances_entity
+  ON workflow_instances (entity_id, status);
+
+-- ─── workflow_events ──────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS workflow_events (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  instance_id UUID NOT NULL REFERENCES workflow_instances(id) ON DELETE CASCADE,
+  event_type  TEXT NOT NULL,
+  from_state  TEXT,
+  to_state    TEXT,
+  actor_id    UUID,
+  tool_name   TEXT,
+  details     JSONB NOT NULL DEFAULT '{}',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_workflow_events_instance
+  ON workflow_events (instance_id, created_at DESC);
+
+-- ─── updated_at triggers ──────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_workflow_contracts_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_workflow_contracts_updated_at
+      BEFORE UPDATE ON workflow_contracts
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  END IF;
+END $$;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_workflow_instances_updated_at'
+  ) THEN
+    CREATE TRIGGER trg_workflow_instances_updated_at
+      BEFORE UPDATE ON workflow_instances
+      FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+  END IF;
+END $$;
+
+-- ─── RLS ──────────────────────────────────────────────────────────────────────
+
+ALTER TABLE workflow_contracts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workflow_instances ENABLE ROW LEVEL SECURITY;
+ALTER TABLE workflow_events    ENABLE ROW LEVEL SECURITY;
+
+-- workflow_contracts: org_id 기준
+DROP POLICY IF EXISTS workflow_contracts_org ON workflow_contracts;
+CREATE POLICY workflow_contracts_org ON workflow_contracts
+  USING (
+    org_id IN (
+      SELECT org_id FROM organization_members
+      WHERE user_id = auth.uid() AND deleted_at IS NULL
+    )
+  );
+
+-- workflow_instances: contract의 org_id 기준
+DROP POLICY IF EXISTS workflow_instances_org ON workflow_instances;
+CREATE POLICY workflow_instances_org ON workflow_instances
+  USING (
+    contract_id IN (
+      SELECT id FROM workflow_contracts WHERE org_id IN (
+        SELECT org_id FROM organization_members
+        WHERE user_id = auth.uid() AND deleted_at IS NULL
+      )
+    )
+  );
+
+-- workflow_events: instance를 통해 org_id 기준
+DROP POLICY IF EXISTS workflow_events_org ON workflow_events;
+CREATE POLICY workflow_events_org ON workflow_events
+  USING (
+    instance_id IN (
+      SELECT wi.id FROM workflow_instances wi
+      JOIN workflow_contracts wc ON wc.id = wi.contract_id
+      WHERE wc.org_id IN (
+        SELECT org_id FROM organization_members
+        WHERE user_id = auth.uid() AND deleted_at IS NULL
+      )
+    )
+  );

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -285,3 +285,4 @@ export const updateBridgeUserSchema = z.object({
 });
 
 export * from './meetings';
+export * from './workflow-contract';

--- a/packages/shared/src/schemas/workflow-contract.ts
+++ b/packages/shared/src/schemas/workflow-contract.ts
@@ -1,0 +1,133 @@
+/**
+ * E-WORKFLOW-CONTRACT — 원자 조건 타입 세트
+ *
+ * 유한한 원자 조건 타입으로 무한한 계약을 표현한다.
+ * escape hatch(custom_fn) 없음. 모든 조건은 순수하다(부작용 없음).
+ *
+ * 조합: AllOf(AND) / AnyOf(OR) / NoneOf(NOT) 를 통해 복합 gate를 구성한다.
+ * definition(jsonb) 구조:
+ *   { states, initial_state, transitions: [{ from, to, on_tool, gate }] }
+ */
+
+// ─── Entity / Caller references ───────────────────────────────────────────────
+
+/** 상태 머신이 평가할 엔티티 종류 */
+export type WorkflowEntityType = 'story' | 'sprint' | 'epic' | 'task' | 'document' | 'retro_session';
+
+// ─── Atomic condition types (20종) ────────────────────────────────────────────
+
+/** field가 존재하는지(null/undefined가 아닌지) */
+export interface CondFieldExists    { type: 'field_exists';    entity: WorkflowEntityType; field: string }
+/** field가 비어있지 않은지 (string: length>0, array: length>0, number: defined) */
+export interface CondFieldNotEmpty  { type: 'field_not_empty'; entity: WorkflowEntityType; field: string }
+/** field 값이 특정 값과 같은지 */
+export interface CondFieldEquals    { type: 'field_equals';    entity: WorkflowEntityType; field: string; value: string | number | boolean }
+/** field 값이 특정 값과 다른지 */
+export interface CondFieldNotEquals { type: 'field_not_equals'; entity: WorkflowEntityType; field: string; value: string | number | boolean }
+/** field 값이 values 목록 안에 있는지 */
+export interface CondFieldIn        { type: 'field_in';        entity: WorkflowEntityType; field: string; values: Array<string | number> }
+/** array field의 원소 수가 n 이상인지 */
+export interface CondFieldMinCount  { type: 'field_min_count'; entity: WorkflowEntityType; field: string; n: number }
+/** array field의 원소 수가 n 이하인지 */
+export interface CondFieldMaxCount  { type: 'field_max_count'; entity: WorkflowEntityType; field: string; n: number }
+/** field 문자열이 정규식에 매칭되는지 */
+export interface CondFieldMatchesRegex { type: 'field_matches_regex'; entity: WorkflowEntityType; field: string; pattern: string }
+/** boolean field가 true인지 */
+export interface CondBoolIsTrue     { type: 'bool_is_true';    entity: WorkflowEntityType; field: string }
+/** boolean field가 false인지 */
+export interface CondBoolIsFalse    { type: 'bool_is_false';   entity: WorkflowEntityType; field: string }
+/** 엔티티의 status가 특정 값과 같은지 */
+export interface CondStatusEquals   { type: 'status_equals';   entity: WorkflowEntityType; status: string }
+/** 엔티티의 status가 statuses 목록 안에 있는지 */
+export interface CondStatusIn       { type: 'status_in';       entity: WorkflowEntityType; statuses: string[] }
+/** 호출자의 role이 특정 role인지 */
+export interface CondRoleIs         { type: 'role_is';         caller: 'actor' | 'assignee' | 'owner'; role: string }
+/** 호출자의 role이 roles 목록 안에 있는지 */
+export interface CondRoleIn         { type: 'role_in';         caller: 'actor' | 'assignee' | 'owner'; roles: string[] }
+/** since_event로부터 duration이 경과했는지 (ISO 8601 duration: "PT1H", "P7D") */
+export interface CondTimeElapsed    { type: 'time_elapsed';    since_event: string; duration: string }
+/** entity.field 날짜가 deadline(ISO datetime or duration) 이전인지 */
+export interface CondTimeBefore     { type: 'time_before';     entity: WorkflowEntityType; field: string; deadline: string }
+/** entity.field가 참조하는 외부 엔티티가 유효한지 (존재 + 삭제되지 않음) */
+export interface CondReferenceValid { type: 'reference_valid'; entity: WorkflowEntityType; field: string }
+/** entity를 filter 조건으로 조회했을 때 count >= n */
+export interface CondCountGte       { type: 'count_gte';       entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+/** entity를 filter 조건으로 조회했을 때 count <= n */
+export interface CondCountLte       { type: 'count_lte';       entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+/** entity를 filter 조건으로 조회했을 때 count === n */
+export interface CondCountEquals    { type: 'count_equals';    entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+
+/** 20종 원자 조건 Union */
+export type AtomicCondition =
+  | CondFieldExists | CondFieldNotEmpty | CondFieldEquals | CondFieldNotEquals | CondFieldIn
+  | CondFieldMinCount | CondFieldMaxCount | CondFieldMatchesRegex
+  | CondBoolIsTrue | CondBoolIsFalse
+  | CondStatusEquals | CondStatusIn
+  | CondRoleIs | CondRoleIn
+  | CondTimeElapsed | CondTimeBefore
+  | CondReferenceValid
+  | CondCountGte | CondCountLte | CondCountEquals;
+
+// ─── Composite gate (AND / OR / NOT) ──────────────────────────────────────────
+
+export type GateExpression =
+  | AtomicCondition
+  | { type: 'all_of'; conditions: GateExpression[] }   // AND
+  | { type: 'any_of'; conditions: GateExpression[] }   // OR
+  | { type: 'none_of'; conditions: GateExpression[] }; // NOT (none must be true)
+
+// ─── Contract definition (jsonb) ──────────────────────────────────────────────
+
+export interface WorkflowTransition {
+  from: string;
+  to: string;
+  on_tool: string;       // MCP 도구 이름
+  gate?: GateExpression; // 전환 허용 조건 (없으면 무조건 허용)
+}
+
+export interface WorkflowContractDefinition {
+  states: string[];
+  initial_state: string;
+  transitions: WorkflowTransition[];
+}
+
+// ─── DB record shapes ──────────────────────────────────────────────────────────
+
+export type WorkflowMode = 'evaluate' | 'enforce';
+export type WorkflowInstanceStatus = 'active' | 'completed' | 'cancelled';
+
+export interface WorkflowContractRecord {
+  id: string;
+  org_id: string;
+  name: string;
+  version: number;
+  mode: WorkflowMode;
+  definition: WorkflowContractDefinition;
+  entity_type: WorkflowEntityType;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowInstanceRecord {
+  id: string;
+  contract_id: string;
+  entity_id: string;
+  current_state: string;
+  context: Record<string, unknown>;
+  status: WorkflowInstanceStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowEventRecord {
+  id: string;
+  instance_id: string;
+  event_type: string;
+  from_state: string | null;
+  to_state: string | null;
+  actor_id: string | null;
+  tool_name: string | null;
+  details: Record<string, unknown>;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

E-WORKFLOW-CONTRACT S1 구현.

### 원자 조건 타입 20종 (`packages/shared/src/schemas/workflow-contract.ts`)

| 분류 | 타입 |
|------|------|
| field | `field_exists`, `field_not_empty`, `field_equals`, `field_not_equals`, `field_in`, `field_min_count`, `field_max_count`, `field_matches_regex` |
| bool | `bool_is_true`, `bool_is_false` |
| status | `status_equals`, `status_in` |
| role | `role_is`, `role_in` |
| time | `time_elapsed`, `time_before` |
| reference | `reference_valid` |
| count | `count_gte`, `count_lte`, `count_equals` |

조합: `all_of`(AND) / `any_of`(OR) / `none_of`(NOT)

### DB 마이그레이션 (`20260427150000_workflow_contracts.sql`)

- **workflow_contracts**: org_id, name, version, mode(evaluate/enforce), definition(jsonb), entity_type, is_active
- **workflow_instances**: contract_id FK, entity_id, current_state, context(jsonb), status(active/completed/cancelled)
- **workflow_events**: instance_id FK, event_type, from/to_state, actor_id, tool_name, details(jsonb)

## AC Checklist

- [x] AC-1: 원자 조건 타입 20종 TypeScript 정의 + 입력 스키마/출력 타입
- [x] AC-2: `workflow_contracts` 테이블
- [x] AC-3: `workflow_instances` 테이블 (contract_id FK)
- [x] AC-4: `workflow_events` 테이블 (instance_id FK)
- [x] AC-5: IF NOT EXISTS 멱등 마이그레이션
- [x] AC-6: RLS org_id 기준 (3테이블)

🤖 Generated with [Claude Code](https://claude.com/claude-code)