### PR TITLE
fix(build): storage-sqlite static import → dynamic (SaaS 빌드 블로커 P0)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
   devIndicators: {
     position: 'bottom-right',
   },
+  serverExternalPackages: ['@sprintable/storage-sqlite'],
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/src/app/api/oss/seed/route.ts
+++ b/apps/web/src/app/api/oss/seed/route.ts
@@ -1,6 +1,5 @@
 import { isOssMode, createStoryRepository, createProjectRepository } from '@/lib/storage/factory';
 import { apiSuccess, apiError } from '@/lib/api-response';
-import { OSS_PROJECT_ID, OSS_ORG_ID } from '@sprintable/storage-sqlite';
 
 const SAMPLE_STORIES = [
   { title: 'SPR-1: GitHub Webhook 연동하기', status: 'backlog' as const, priority: 'high' as const },
@@ -14,6 +13,7 @@ export async function POST() {
   }
 
   try {
+    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
     const storyRepo = await createStoryRepository();
     const existing = await storyRepo.list({ project_id: OSS_PROJECT_ID, limit: 1 });
 

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!body.title) return ApiErrors.badRequest('title required');
 
     if (isOssMode()) {
-      const data = addOssRetroAction({ session_id: id, project_id: projectId, title: body.title, assignee_id: body.assignee_id ?? null });
+      const data = await addOssRetroAction({ session_id: id, project_id: projectId, title: body.title, assignee_id: body.assignee_id ?? null });
       return apiSuccess(data);
     }
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     const voterId = body.voter_id ?? me.id;
 
     if (isOssMode()) {
-      const data = voteOssRetroItem(item_id, voterId, projectId);
+      const data = await voteOssRetroItem(item_id, voterId, projectId);
       return apiSuccess(data);
     }
 

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -53,7 +53,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     const author_id = body.author_id ?? me.id;
 
     if (isOssMode()) {
-      const data = addOssRetroItem({ session_id: id, project_id: projectId, category: body.category as RetroCategory, text: body.text!, author_id: author_id });
+      const data = await addOssRetroItem({ session_id: id, project_id: projectId, category: body.category as RetroCategory, text: body.text!, author_id: author_id });
       return apiSuccess(data);
     }
 

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -26,10 +26,12 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
     if (isOssMode()) {
-      const session = getOssRetroSession(id, projectId);
+      const session = await getOssRetroSession(id, projectId);
       if (!session) return ApiErrors.notFound('Session not found');
-      const items = listOssRetroItems(id, projectId);
-      const actions = listOssRetroActions(id, projectId);
+      const [items, actions] = await Promise.all([
+        listOssRetroItems(id, projectId),
+        listOssRetroActions(id, projectId),
+      ]);
       return apiSuccess({ session, items, actions });
     }
 
@@ -64,7 +66,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (!body.phase) return ApiErrors.badRequest('phase required');
 
     if (isOssMode()) {
-      const data = advanceOssRetroPhase(id, projectId, body.phase as RetroPhase);
+      const data = await advanceOssRetroPhase(id, projectId, body.phase as RetroPhase);
       return apiSuccess(data);
     }
 

--- a/apps/web/src/app/api/retro/route.ts
+++ b/apps/web/src/app/api/retro/route.ts
@@ -18,7 +18,7 @@ export async function GET(request: Request) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     if (isOssMode()) {
-      return apiSuccess(listOssRetroSessions(projectId));
+      return apiSuccess(await listOssRetroSessions(projectId));
     }
     const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
     const service = new RetroService(dbClient);
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const parsed = await parseBody(request, createRetroSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     if (isOssMode()) {
-      const session = createOssRetroSession({
+      const session = await createOssRetroSession({
         org_id: me.org_id,
         project_id: body.project_id ?? me.project_id,
         title: body.title,

--- a/apps/web/src/app/api/standup/feedback/[id]/route.ts
+++ b/apps/web/src/app/api/standup/feedback/[id]/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     if (isOssMode()) {
-      return apiSuccess(listOssStandupFeedbackForEntry(entryId));
+      return apiSuccess(await listOssStandupFeedbackForEntry(entryId));
     }
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
@@ -56,7 +56,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const body = parsed.data;
 
     if (isOssMode()) {
-      return apiSuccess(updateOssStandupFeedback(id, body, me.id));
+      return apiSuccess(await updateOssStandupFeedback(id, body, me.id));
     }
 
     const service = new StandupFeedbackService(dbClient);
@@ -76,7 +76,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
     if (isOssMode()) {
-      deleteOssStandupFeedback(id, me.id);
+      await deleteOssStandupFeedback(id, me.id);
       return apiSuccess({ ok: true });
     }
 

--- a/apps/web/src/app/api/standup/feedback/route.ts
+++ b/apps/web/src/app/api/standup/feedback/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
     if (!projectId || !date) return ApiErrors.badRequest('project_id and date required');
 
     if (isOssMode()) {
-      return apiSuccess(listOssStandupFeedbackByDate(projectId, date));
+      return apiSuccess(await listOssStandupFeedbackByDate(projectId, date));
     }
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
     const body = parsed.data;
 
     if (ossMode) {
-      const feedback = createOssStandupFeedback({
+      const feedback = await createOssStandupFeedback({
         project_id: me.project_id,
         org_id: me.org_id,
         standup_entry_id: body.standup_entry_id,

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
     const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 50;
 
     if (isOssMode()) {
-      return apiSuccess(getOssStandupHistory(projectId, limit));
+      return apiSuccess(await getOssStandupHistory(projectId, limit));
     }
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
     if (!date) return ApiErrors.badRequest('date required');
 
     if (isOssMode()) {
-      return apiSuccess(getOssStandupMissing(projectId, date));
+      return apiSuccess(await getOssStandupMissing(projectId, date));
     }
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;

--- a/apps/web/src/app/api/standup/route.ts
+++ b/apps/web/src/app/api/standup/route.ts
@@ -25,9 +25,9 @@ export async function GET(request: Request) {
 
     if (isOssMode()) {
       if (memberId) {
-        return apiSuccess(getOssStandupEntryForUser(projectId, memberId, date));
+        return apiSuccess(await getOssStandupEntryForUser(projectId, memberId, date));
       }
-      return apiSuccess(listOssStandupEntries(projectId, date));
+      return apiSuccess(await listOssStandupEntries(projectId, date));
     }
 
     const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
@@ -70,7 +70,7 @@ export async function POST(request: Request) {
     const body = parsed.data;
 
     if (ossMode) {
-      const entry = saveOssStandupEntry({
+      const entry = await saveOssStandupEntry({
         project_id: me.project_id,
         org_id: me.org_id,
         author_id: authorId,
@@ -129,7 +129,7 @@ export async function PUT(request: Request) {
       }
       const body = parsed.data;
 
-      const entry = saveOssStandupEntry({
+      const entry = await saveOssStandupEntry({
         project_id: me.project_id,
         org_id: me.org_id,
         author_id: me.id,

--- a/apps/web/src/lib/oss-retro.ts
+++ b/apps/web/src/lib/oss-retro.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { getDb } from '@sprintable/storage-sqlite';
+
+let _sqlite: typeof import('@sprintable/storage-sqlite') | undefined;
+async function getSqlite() {
+  _sqlite ??= await import('@sprintable/storage-sqlite');
+  return _sqlite;
+}
 
 export type RetroPhase = 'collect' | 'group' | 'vote' | 'discuss' | 'action' | 'closed';
 export type RetroCategory = 'good' | 'bad' | 'improve';
@@ -47,25 +52,28 @@ function now() {
   return new Date().toISOString();
 }
 
-export function listOssRetroSessions(projectId: string): OssRetroSession[] {
+export async function listOssRetroSessions(projectId: string): Promise<OssRetroSession[]> {
+  const { getDb } = await getSqlite();
   return getDb()
     .prepare('SELECT * FROM retro_sessions WHERE project_id = ? ORDER BY created_at DESC')
-    .all(projectId) as unknown as unknown as OssRetroSession[];
+    .all(projectId) as unknown as OssRetroSession[];
 }
 
-export function getOssRetroSession(sessionId: string, projectId: string): OssRetroSession | null {
+export async function getOssRetroSession(sessionId: string, projectId: string): Promise<OssRetroSession | null> {
+  const { getDb } = await getSqlite();
   return (getDb()
     .prepare('SELECT * FROM retro_sessions WHERE id = ? AND project_id = ?')
     .get(sessionId, projectId) as unknown as OssRetroSession) ?? null;
 }
 
-export function createOssRetroSession(input: {
+export async function createOssRetroSession(input: {
   org_id: string;
   project_id: string;
   title: string;
   sprint_id?: string | null;
   created_by?: string | null;
-}): OssRetroSession {
+}): Promise<OssRetroSession> {
+  const { getDb } = await getSqlite();
   const id = randomUUID();
   const ts = now();
   getDb()
@@ -73,11 +81,12 @@ export function createOssRetroSession(input: {
       'INSERT INTO retro_sessions (id, org_id, project_id, sprint_id, title, phase, created_by, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
     )
     .run(id, input.org_id, input.project_id, input.sprint_id ?? null, input.title, 'collect', input.created_by ?? null, ts, ts);
-  return getOssRetroSession(id, input.project_id)!;
+  return (await getOssRetroSession(id, input.project_id))!;
 }
 
-export function advanceOssRetroPhase(sessionId: string, projectId: string, phase: RetroPhase): OssRetroSession {
-  const session = getOssRetroSession(sessionId, projectId);
+export async function advanceOssRetroPhase(sessionId: string, projectId: string, phase: RetroPhase): Promise<OssRetroSession> {
+  const { getDb } = await getSqlite();
+  const session = await getOssRetroSession(sessionId, projectId);
   if (!session) throw new Error('Session not found');
   if (!VALID_TRANSITIONS[session.phase]?.includes(phase)) {
     throw new Error(`Invalid transition: ${session.phase} → ${phase}`);
@@ -86,25 +95,27 @@ export function advanceOssRetroPhase(sessionId: string, projectId: string, phase
   getDb()
     .prepare('UPDATE retro_sessions SET phase = ?, updated_at = ? WHERE id = ?')
     .run(phase, ts, sessionId);
-  return getOssRetroSession(sessionId, projectId)!;
+  return (await getOssRetroSession(sessionId, projectId))!;
 }
 
-export function listOssRetroItems(sessionId: string, projectId: string): OssRetroItem[] {
-  const session = getOssRetroSession(sessionId, projectId);
+export async function listOssRetroItems(sessionId: string, projectId: string): Promise<OssRetroItem[]> {
+  const { getDb } = await getSqlite();
+  const session = await getOssRetroSession(sessionId, projectId);
   if (!session) return [];
   return getDb()
     .prepare('SELECT * FROM retro_items WHERE session_id = ? ORDER BY created_at ASC')
-    .all(sessionId) as unknown as unknown as OssRetroItem[];
+    .all(sessionId) as unknown as OssRetroItem[];
 }
 
-export function addOssRetroItem(input: {
+export async function addOssRetroItem(input: {
   session_id: string;
   project_id: string;
   category: RetroCategory;
   text: string;
   author_id: string;
-}): OssRetroItem {
-  const session = getOssRetroSession(input.session_id, input.project_id);
+}): Promise<OssRetroItem> {
+  const { getDb } = await getSqlite();
+  const session = await getOssRetroSession(input.session_id, input.project_id);
   if (!session) throw new Error('Session not in project');
   const id = randomUUID();
   const ts = now();
@@ -114,10 +125,11 @@ export function addOssRetroItem(input: {
   return getDb().prepare('SELECT * FROM retro_items WHERE id = ?').get(id) as unknown as OssRetroItem;
 }
 
-export function voteOssRetroItem(itemId: string, voterId: string, projectId: string): { voted: boolean } {
+export async function voteOssRetroItem(itemId: string, voterId: string, projectId: string): Promise<{ voted: boolean }> {
+  const { getDb } = await getSqlite();
   const item = getDb().prepare('SELECT session_id FROM retro_items WHERE id = ?').get(itemId) as { session_id: string } | null;
   if (!item) throw new Error('Item not found');
-  const session = getOssRetroSession(item.session_id, projectId);
+  const session = await getOssRetroSession(item.session_id, projectId);
   if (!session) throw new Error('Item not in project');
   try {
     getDb()
@@ -136,21 +148,23 @@ export function voteOssRetroItem(itemId: string, voterId: string, projectId: str
   }
 }
 
-export function listOssRetroActions(sessionId: string, projectId: string): OssRetroAction[] {
-  const session = getOssRetroSession(sessionId, projectId);
+export async function listOssRetroActions(sessionId: string, projectId: string): Promise<OssRetroAction[]> {
+  const { getDb } = await getSqlite();
+  const session = await getOssRetroSession(sessionId, projectId);
   if (!session) return [];
   return getDb()
     .prepare('SELECT * FROM retro_actions WHERE session_id = ? ORDER BY created_at ASC')
-    .all(sessionId) as unknown as unknown as OssRetroAction[];
+    .all(sessionId) as unknown as OssRetroAction[];
 }
 
-export function addOssRetroAction(input: {
+export async function addOssRetroAction(input: {
   session_id: string;
   project_id: string;
   title: string;
   assignee_id?: string | null;
-}): OssRetroAction {
-  const session = getOssRetroSession(input.session_id, input.project_id);
+}): Promise<OssRetroAction> {
+  const { getDb } = await getSqlite();
+  const session = await getOssRetroSession(input.session_id, input.project_id);
   if (!session) throw new Error('Session not in project');
   const id = randomUUID();
   const ts = now();

--- a/apps/web/src/lib/oss-standup.ts
+++ b/apps/web/src/lib/oss-standup.ts
@@ -1,5 +1,10 @@
 import { randomUUID } from 'node:crypto';
-import { getDb } from '@sprintable/storage-sqlite';
+
+let _sqlite: typeof import('@sprintable/storage-sqlite') | undefined;
+async function getSqlite() {
+  _sqlite ??= await import('@sprintable/storage-sqlite');
+  return _sqlite;
+}
 
 type StandupReviewType = 'comment' | 'approve' | 'request_changes';
 
@@ -73,7 +78,8 @@ function normalizeFeedback(row: Record<string, unknown>): StandupFeedbackRow {
   };
 }
 
-export function listOssStandupEntries(projectId: string, date: string): StandupEntryRow[] {
+export async function listOssStandupEntries(projectId: string, date: string): Promise<StandupEntryRow[]> {
+  const { getDb } = await getSqlite();
   const rows = getDb()
     .prepare(`
       SELECT *
@@ -86,7 +92,8 @@ export function listOssStandupEntries(projectId: string, date: string): StandupE
   return rows.map(normalizeEntry);
 }
 
-export function getOssStandupEntryForUser(projectId: string, authorId: string, date: string): StandupEntryRow | null {
+export async function getOssStandupEntryForUser(projectId: string, authorId: string, date: string): Promise<StandupEntryRow | null> {
+  const { getDb } = await getSqlite();
   const row = getDb()
     .prepare(`
       SELECT *
@@ -99,7 +106,7 @@ export function getOssStandupEntryForUser(projectId: string, authorId: string, d
   return row ? normalizeEntry(row) : null;
 }
 
-export function saveOssStandupEntry(input: {
+export async function saveOssStandupEntry(input: {
   project_id: string;
   org_id: string;
   sprint_id?: string | null;
@@ -109,12 +116,12 @@ export function saveOssStandupEntry(input: {
   plan: string | null;
   blockers: string | null;
   plan_story_ids?: string[];
-}): StandupEntryRow {
-  const db = getDb();
+}): Promise<StandupEntryRow> {
+  const { getDb } = await getSqlite();
   const now = new Date().toISOString();
   const id = randomUUID();
 
-  db.prepare(`
+  getDb().prepare(`
     INSERT INTO standup_entries (
       id, org_id, project_id, sprint_id, author_id, date, done, plan, blockers, plan_story_ids, created_at, updated_at
     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -140,10 +147,11 @@ export function saveOssStandupEntry(input: {
     now,
   );
 
-  return getOssStandupEntryForUser(input.project_id, input.author_id, input.date)!;
+  return (await getOssStandupEntryForUser(input.project_id, input.author_id, input.date))!;
 }
 
-export function getOssStandupMissing(projectId: string, date: string) {
+export async function getOssStandupMissing(projectId: string, date: string) {
+  const { getDb } = await getSqlite();
   const db = getDb();
   const members = db.prepare(`
     SELECT id, name
@@ -166,7 +174,8 @@ export function getOssStandupMissing(projectId: string, date: string) {
   };
 }
 
-export function getOssStandupHistory(projectId: string, limit = 50) {
+export async function getOssStandupHistory(projectId: string, limit = 50) {
+  const { getDb } = await getSqlite();
   return getDb().prepare(`
     SELECT author_id, date, done, plan, blockers
     FROM standup_entries
@@ -176,7 +185,8 @@ export function getOssStandupHistory(projectId: string, limit = 50) {
   `).all(projectId, limit) as Array<Record<string, unknown>>;
 }
 
-export function listOssStandupFeedbackByDate(projectId: string, date: string): StandupFeedbackRow[] {
+export async function listOssStandupFeedbackByDate(projectId: string, date: string): Promise<StandupFeedbackRow[]> {
+  const { getDb } = await getSqlite();
   const rows = getDb().prepare(`
     SELECT sf.*
     FROM standup_feedback sf
@@ -188,7 +198,8 @@ export function listOssStandupFeedbackByDate(projectId: string, date: string): S
   return rows.map(normalizeFeedback);
 }
 
-export function listOssStandupFeedbackForEntry(entryId: string): StandupFeedbackRow[] {
+export async function listOssStandupFeedbackForEntry(entryId: string): Promise<StandupFeedbackRow[]> {
+  const { getDb } = await getSqlite();
   const rows = getDb().prepare(`
     SELECT *
     FROM standup_feedback
@@ -199,14 +210,27 @@ export function listOssStandupFeedbackForEntry(entryId: string): StandupFeedback
   return rows.map(normalizeFeedback);
 }
 
-export function createOssStandupFeedback(input: {
+export async function getOssStandupFeedback(id: string): Promise<StandupFeedbackRow | null> {
+  const { getDb } = await getSqlite();
+  const row = getDb().prepare(`
+    SELECT *
+    FROM standup_feedback
+    WHERE id = ?
+    LIMIT 1
+  `).get(id) as Record<string, unknown> | undefined;
+
+  return row ? normalizeFeedback(row) : null;
+}
+
+export async function createOssStandupFeedback(input: {
   project_id: string;
   org_id: string;
   standup_entry_id: string;
   feedback_by_id: string;
   review_type?: StandupReviewType;
   feedback_text: string;
-}): StandupFeedbackRow {
+}): Promise<StandupFeedbackRow> {
+  const { getDb } = await getSqlite();
   const db = getDb();
   const entry = db.prepare(`
     SELECT sprint_id
@@ -238,26 +262,16 @@ export function createOssStandupFeedback(input: {
     now,
   );
 
-  return getOssStandupFeedback(id)!;
+  return (await getOssStandupFeedback(id))!;
 }
 
-export function getOssStandupFeedback(id: string): StandupFeedbackRow | null {
-  const row = getDb().prepare(`
-    SELECT *
-    FROM standup_feedback
-    WHERE id = ?
-    LIMIT 1
-  `).get(id) as Record<string, unknown> | undefined;
-
-  return row ? normalizeFeedback(row) : null;
-}
-
-export function updateOssStandupFeedback(
+export async function updateOssStandupFeedback(
   id: string,
   input: { review_type?: StandupReviewType; feedback_text?: string },
   actorId: string,
-): StandupFeedbackRow {
-  const current = getOssStandupFeedback(id);
+): Promise<StandupFeedbackRow> {
+  const { getDb } = await getSqlite();
+  const current = await getOssStandupFeedback(id);
   if (!current) throw new Error('Standup feedback not found');
   if (current.feedback_by_id !== actorId) throw new Error('Only the feedback author can update this entry');
 
@@ -270,11 +284,12 @@ export function updateOssStandupFeedback(
     WHERE id = ?
   `).run(nextReviewType, nextText, new Date().toISOString(), id);
 
-  return getOssStandupFeedback(id)!;
+  return (await getOssStandupFeedback(id))!;
 }
 
-export function deleteOssStandupFeedback(id: string, actorId: string): void {
-  const current = getOssStandupFeedback(id);
+export async function deleteOssStandupFeedback(id: string, actorId: string): Promise<void> {
+  const { getDb } = await getSqlite();
+  const current = await getOssStandupFeedback(id);
   if (!current) throw new Error('Standup feedback not found');
   if (current.feedback_by_id !== actorId) throw new Error('Only the feedback author can delete this entry');
 

--- a/apps/web/src/lib/storage/factory.ts
+++ b/apps/web/src/lib/storage/factory.ts
@@ -158,11 +158,17 @@ export async function createAgentRunBillingRepository(supabase?: unknown): Promi
 }
 
 export async function createAgentRunRepository(): Promise<IAgentRunRepository> {
-  const { SqliteAgentRunRepository, getDb } = await import('@sprintable/storage-sqlite');
-  return new SqliteAgentRunRepository(getDb());
+  if (isOssMode()) {
+    const { SqliteAgentRunRepository, getDb } = await import('@sprintable/storage-sqlite');
+    return new SqliteAgentRunRepository(getDb());
+  }
+  throw new Error('AgentRunRepository is only available in OSS mode');
 }
 
 export async function createAgentApiKeyRepository(): Promise<IAgentApiKeyRepository> {
-  const { SqliteAgentApiKeyRepository, getDb } = await import('@sprintable/storage-sqlite');
-  return new SqliteAgentApiKeyRepository(getDb());
+  if (isOssMode()) {
+    const { SqliteAgentApiKeyRepository, getDb } = await import('@sprintable/storage-sqlite');
+    return new SqliteAgentApiKeyRepository(getDb());
+  }
+  throw new Error('AgentApiKeyRepository is only available in OSS mode');
 }


### PR DESCRIPTION
## Summary

- **문제**: `oss-retro.ts`, `oss-standup.ts`, `oss/seed/route.ts`의 모듈 최상위 static import가 SaaS 빌드 트리에 `node:sqlite`를 포함시켜 CI FAILED 발생
- `oss-retro.ts`, `oss-standup.ts`: static `import { getDb }` 제거, lazy `getSqlite()` 캐시 헬퍼 도입, 모든 export 함수 async 전환
- `factory.ts`: `createAgentRunRepository`/`createAgentApiKeyRepository`에 `isOssMode()` 가드 추가 — SaaS에서 dynamic import 도달 자체를 차단
- `oss/seed/route.ts`: `OSS_PROJECT_ID`/`OSS_ORG_ID` static import → `isOssMode()` 통과 후 핸들러 내부 dynamic import로 이동
- `next.config.ts`: `serverExternalPackages: ['@sprintable/storage-sqlite']` 추가 — 빌드타임 번들링 완전 차단

## Test plan

- [ ] SaaS PR #218 CI 빌드 재실행 PASS 확인
- [ ] OSS 모드에서 standup, retro, seed API 정상 동작 확인 (기능 회귀 없음)
- [ ] static import 잔존 없음: `grep -rn "^import.*storage-sqlite" apps/web/src` → 결과 없음 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)