### PR TITLE
feat(S10): agent-builtin-tools — update_story_status gate check 훅 추가

### DIFF
--- a/apps/web/src/services/agent-builtin-tools.ts
+++ b/apps/web/src/services/agent-builtin-tools.ts
@@ -12,6 +12,21 @@ type AuditSeverity = 'debug' | 'info' | 'warn' | 'error' | 'security';
 
 type AuditLogger = (eventType: string, severity: AuditSeverity, payload: Record<string, unknown>) => Promise<void>;
 
+export type StatusUpdateGateResult = {
+  pass: boolean;
+  nextStatus: string;
+  mode?: string;
+  violations?: Array<{ condition?: string; field?: string; message: string }>;
+};
+
+export type StatusUpdateGateFn = (
+  storyId: string,
+  targetStatus: string,
+  orgId: string,
+  projectId: string,
+  actorId: string,
+) => Promise<StatusUpdateGateResult | null>;
+
 interface MemoScope {
   id: string;
   org_id: string;
@@ -243,6 +258,7 @@ export class AgentBuiltinToolService {
   private _epicServicePromise: Promise<EpicService> | null = null;
   private readonly auditLogger?: AuditLogger;
   private readonly fetchFn: typeof fetch;
+  private readonly statusUpdateGateFn?: StatusUpdateGateFn;
 
   constructor(
     private readonly supabase: SupabaseClient,
@@ -252,6 +268,7 @@ export class AgentBuiltinToolService {
       epicService?: EpicService;
       auditLogger?: AuditLogger;
       fetchFn?: typeof fetch;
+      statusUpdateGateFn?: StatusUpdateGateFn;
     } = {},
   ) {
     this.memoService = options.memoService ?? MemoService.fromSupabase(supabase);
@@ -259,6 +276,7 @@ export class AgentBuiltinToolService {
     this._epicService = options.epicService ?? null;
     this.auditLogger = options.auditLogger;
     this.fetchFn = options.fetchFn ?? fetch;
+    this.statusUpdateGateFn = options.statusUpdateGateFn;
   }
 
   private async getEpicService(): Promise<EpicService> {
@@ -406,6 +424,24 @@ export class AgentBuiltinToolService {
       case 'update_story_status': {
         const args = updateStoryStatusSchema.parse(rawArgs);
         const story = await this.ensureStoryInScope(args.story_id, ctx);
+
+        if (this.statusUpdateGateFn) {
+          const gateResult = await this.statusUpdateGateFn(
+            story.id, args.status, ctx.memo.org_id, ctx.memo.project_id, ctx.agent.id
+          );
+          if (gateResult && !gateResult.pass) {
+            return {
+              gate_failed: true,
+              mode: gateResult.mode,
+              violations: gateResult.violations,
+              hint: gateResult.violations?.map((v) => v.message).join('; ') ?? 'Gate check failed',
+            };
+          }
+          const nextStatus = gateResult?.nextStatus ?? args.status;
+          const updated = await this.storyService.update(story.id, { status: nextStatus });
+          return { story: this.presentStory(updated as StoryRecord), gate: gateResult };
+        }
+
         const updated = await this.storyService.update(story.id, { status: args.status });
         return { story: this.presentStory(updated as StoryRecord) };
       }


### PR DESCRIPTION
## Summary

- `AgentBuiltinToolService` 옵션에 `statusUpdateGateFn?: StatusUpdateGateFn` 추가
- `update_story_status` 케이스: 훅이 주입된 경우 gate check 실행, 결과에 따라 전이 또는 차단
- enforce 모드 gate 실패: `gate_failed: true` + `violations` + `hint` 반환 → 에이전트가 사유 인지
- OSS 모드: 훅 미주입 → 기존 직접 업데이트 동작 유지 (하위 호환)

## Test plan

- [ ] SaaS에서 update_story_status 호출 시 gate check 통과 여부 확인
- [ ] enforce 모드에서 조건 미충족 시 에이전트에게 violation 메시지 반환 확인
- [ ] evaluate 모드에서 gate 실패해도 전이 허용 확인
- [ ] OSS 모드에서 기존 동작 (직접 업데이트) 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)