### PR TITLE
feat(ui-polish): S5 Docs 태그 필터 접기/펼치기 + 공간 축소 + 활성 뱃지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -967,7 +967,9 @@
     "codeCopy": "Copy code",
     "codeCopied": "Copied",
     "moveCircularError": "Cannot move a document into its own subtree",
-    "movePermissionError": "You do not have permission to move documents here"
+    "movePermissionError": "You do not have permission to move documents here",
+    "tagFilter": "Tags",
+    "clearFilter": "Clear filters"
   },
   "rewards": {
     "title": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -967,7 +967,9 @@
     "codeCopy": "코드 복사",
     "codeCopied": "복사됨",
     "moveCircularError": "문서를 자신의 하위로 이동할 수 없습니다",
-    "movePermissionError": "이 위치로 문서를 이동할 권한이 없습니다"
+    "movePermissionError": "이 위치로 문서를 이동할 권한이 없습니다",
+    "tagFilter": "태그",
+    "clearFilter": "필터 지우기"
   },
   "rewards": {
     "title": "리워드",

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { ChevronLeft, Plus, X, Trash2, Copy, Check } from 'lucide-react';
+import { ChevronLeft, ChevronDown, ChevronRight, Plus, X, Trash2, Copy, Check } from 'lucide-react';
 import { DocsShell } from '@/components/docs/docs-shell';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 
@@ -87,6 +87,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [loading, setLoading] = useState(true);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [tagsCollapsed, setTagsCollapsed] = useState(true);
 
   // Always-editable content states
   const [title, setTitle] = useState('');
@@ -401,26 +402,49 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   const sidebarContent = (
     <>
-      {/* Tag filter chips */}
+      {/* Tag filter — AC1 접기/펼치기 */}
       {(() => {
         const allTags = [...new Set(tree.flatMap((d) => (d as unknown as { tags?: string[] | null }).tags ?? []))];
         if (allTags.length === 0) return null;
         return (
-          <div className="flex flex-wrap gap-1.5 border-b border-white/10 px-4 py-2">
-            {allTags.map((tag) => (
-              <button
-                key={tag}
-                type="button"
-                onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag])}
-                className={`rounded-full px-2.5 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}
-              >
-                #{tag}
-              </button>
-            ))}
-            {selectedTags.length > 0 && (
-              <button type="button" onClick={() => setSelectedTags([])} className="text-[11px] text-muted-foreground hover:text-foreground underline">
-                {t('clearFilter')}
-              </button>
+          <div className="border-b border-white/10">
+            {/* AC1: 토글 헤더 + AC3: 활성 태그 뱃지 */}
+            <button
+              type="button"
+              onClick={() => setTagsCollapsed((v) => !v)}
+              className="flex w-full items-center justify-between px-4 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+            >
+              <span className="flex items-center gap-1.5">
+                {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
+                {t('tagFilter')}
+                {/* AC3: 접힌 상태에서 활성 태그 수 뱃지 */}
+                {tagsCollapsed && selectedTags.length > 0 && (
+                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">
+                    {selectedTags.length}
+                  </span>
+                )}
+              </span>
+            </button>
+
+            {/* AC1: 펼친 상태에서만 태그 칩 표시 + AC2: 공간 축소 */}
+            {!tagsCollapsed && (
+              <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
+                {allTags.map((tag) => (
+                  <button
+                    key={tag}
+                    type="button"
+                    onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag])}
+                    className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}
+                  >
+                    #{tag}
+                  </button>
+                ))}
+                {selectedTags.length > 0 && (
+                  <button type="button" onClick={() => setSelectedTags([])} className="text-[11px] text-muted-foreground underline hover:text-foreground">
+                    {t('clearFilter')}
+                  </button>
+                )}
+              </div>
             )}
           </div>
         );


### PR DESCRIPTION
## Summary
문서 트리 가시성 확보를 위한 태그 필터 영역 개선

## AC 체크리스트
1. ✅ 접기/펼치기 — 기본 collapsed, ChevronRight/Down 아이콘 토글
2. ✅ 공간 축소 — 펼친 상태 py-1, gap-1, max-h-[120px] + overflow-y-auto 스크롤
3. ✅ 활성 필터 뱃지 — 접힌 상태에서 활성 태그 수 primary 뱃지 표시

## 변경 파일
- `docs/docs-shell-client.tsx` — 태그 영역 collapsible 처리 (+20/-12)
- `messages/ko.json` — docs.tagFilter/clearFilter 추가
- `messages/en.json` — docs.tagFilter/clearFilter 추가

## 스토리
E-UI-POLISH S5 (54a40b5c, 2SP, high)

🤖 Generated with [Claude Code](https://claude.com/claude-code)