### PR TITLE
feat(sidebar): add theme toggle to GNB footer (E-UI-POLISH S7)

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -19,6 +19,7 @@ import {
   Users,
 } from 'lucide-react';
 import { LocaleSwitcher } from '@/components/locale-switcher';
+import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
 import { ProjectSwitcher } from '@/components/nav/project-switcher';
 import {
@@ -281,7 +282,10 @@ export function AppSidebar({
 
       <SidebarFooter className="p-2">
         <div className="flex items-center justify-between gap-2">
-          <LocaleSwitcher />
+          <div className="flex items-center gap-2">
+            <LocaleSwitcher />
+            <ThemeToggle />
+          </div>
           <Link
             href="/docs"
             aria-label={t('help')}

--- a/apps/web/src/components/nav/theme-toggle.tsx
+++ b/apps/web/src/components/nav/theme-toggle.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+
+const THEMES = [
+  { value: 'light', Icon: Sun },
+  { value: 'dark', Icon: Moon },
+  { value: 'system', Icon: Monitor },
+] as const;
+
+export function ThemeToggle({ className = '' }: { className?: string }) {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className={`flex items-center gap-1 ${className}`.trim()}>
+      {THEMES.map(({ value, Icon }) => {
+        const isActive = theme === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            onClick={() => setTheme(value)}
+            aria-pressed={isActive}
+            aria-label={value}
+            className={`rounded-xl p-1.5 transition ${
+              isActive
+                ? 'bg-primary text-primary-foreground shadow-sm'
+                : 'text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)] hover:text-[color:var(--operator-foreground)]'
+            }`}
+          >
+            <Icon className="size-4" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- AC1: `ThemeToggle` 신규 컴포넌트 — Sun/Moon/Monitor 3버튼, LocaleSwitcher 동일 스타일
- AC2: `SidebarFooter`에 LocaleSwitcher 옆 배치 (flex gap-2 그룹)
- AC3: `useTheme().setTheme` 즉시 반영 — 새로고침 불필요

## Test plan
- [ ] 라이트/다크/시스템 버튼 클릭 시 즉시 테마 전환 확인
- [ ] 활성 버튼 하이라이트 (bg-primary) 확인
- [ ] LocaleSwitcher 옆 레이아웃 정상 배치 확인

Story: `61b90ee7-c8da-4073-a989-70cc2dd26672` | Epic: E-UI-POLISH

🤖 Generated with [Claude Code](https://claude.com/claude-code)