### PR TITLE
feat(memo): reply_memo에 assigned_to_ids 추가 — 웹훅 수신자 명시 지정

### DIFF
--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -36,7 +36,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     const repo = await createMemoRepository(dbClient);
     const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;
     const service = new MemoService(repo, dbClient as SupabaseClient | undefined, teamMemberRepo);
-    const reply = await service.addReply(id, body.content, me.id);
+    const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
+    const reply = await service.addReply(id, body.content, me.id, 'comment', resolvedIds);
     return apiSuccess(reply, undefined, 201);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.test.ts
@@ -268,4 +268,35 @@ describe('dispatchWorkflowMemoReplyWebhooks', () => {
     expect(calledUrls).toContain('https://discord.com/api/webhooks/member-1/project');
     expect(calledUrls).toContain('https://discord.com/api/webhooks/member-2/direct');
   });
+
+  it('delivers to additionalRecipientIds not otherwise in participant set', async () => {
+    const fetchFn = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 204 }));
+    const supabase = createSupabaseStub({ priorReplies: [], memoAssignees: [] });
+
+    const result = await dispatchWorkflowMemoReplyWebhooks({
+      supabase,
+      fetchFn: fetchFn as typeof fetch,
+      appUrl: 'https://app.example.com',
+      memo: {
+        id: 'memo-1',
+        org_id: 'org-1',
+        project_id: 'project-1',
+        title: 'QA 킥오프',
+        created_by: 'member-1',
+        assigned_to: null,
+        metadata: null,
+      },
+      reply: {
+        id: 'reply-4',
+        memo_id: 'memo-1',
+        content: 'QA 시작 바라는.',
+        created_by: 'member-1',
+      },
+      additionalRecipientIds: ['member-2'],
+    });
+
+    expect(result.status).toBe('sent');
+    const calledUrls = fetchFn.mock.calls.map((call) => call[0]);
+    expect(calledUrls).toContain('https://discord.com/api/webhooks/member-2/direct');
+  });
 });

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -46,6 +46,7 @@ export interface DispatchWorkflowMemoReplyWebhooksOptions {
   supabase?: SupabaseClient;
   memo: MemoReplyDispatchMemo;
   reply: MemoReplyDispatchReply;
+  additionalRecipientIds?: string[];
   logger?: Logger;
   fetchFn?: typeof fetch;
   appUrl?: string;
@@ -219,7 +220,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
 ): Promise<DispatchWorkflowMemoReplyWebhooksResult> {
   const logger = options.logger ?? console;
   const fetchFn = options.fetchFn ?? fetch;
-  const { memo, reply, supabase } = options;
+  const { memo, reply, supabase, additionalRecipientIds } = options;
 
   if (!supabase) return { status: 'skipped', reason: 'oss_mode' };
 
@@ -271,6 +272,9 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   );
   for (const memberId of mentionedIds) {
     participants.add(memberId);
+  }
+  for (const id of (additionalRecipientIds ?? [])) {
+    participants.add(id);
   }
 
   participants.delete(reply.created_by);

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -566,7 +566,7 @@ export class MemoService {
     return { ...enriched, supersedes_chain: chain };
   }
 
-  async addReply(memoId: string, content: string, createdBy: string, reviewType = 'comment') {
+  async addReply(memoId: string, content: string, createdBy: string, reviewType = 'comment', additionalRecipientIds?: string[]) {
     if (!content?.trim()) throw new Error('content is required');
 
     const memo = await this.repo.getById(memoId);
@@ -605,6 +605,7 @@ export class MemoService {
               content: data.content,
               created_by: data.created_by,
             },
+            additionalRecipientIds,
             appUrl: process.env.NEXT_PUBLIC_APP_URL,
           });
         } catch (dispatchError) {
@@ -615,7 +616,7 @@ export class MemoService {
         this._sendReplyNotifications(memo, data).catch(() => {});
       } else if (this.teamMemberRepo) {
         try {
-          await this.dispatchOssReplyWebhooks(memo, data);
+          await this.dispatchOssReplyWebhooks(memo, data, additionalRecipientIds);
         } catch (dispatchError) {
           console.warn('[MemoService.addReply] OSS reply webhook dispatch failed', dispatchError);
         }
@@ -666,7 +667,7 @@ export class MemoService {
     }
   }
 
-  private async dispatchOssReplyWebhooks(memo: Memo, reply: MemoReply) {
+  private async dispatchOssReplyWebhooks(memo: Memo, reply: MemoReply, additionalRecipientIds?: string[]) {
     if (!this.teamMemberRepo) return;
 
     const members = await this.teamMemberRepo.list({ org_id: memo.org_id, project_id: memo.project_id, is_active: true });
@@ -675,6 +676,7 @@ export class MemoService {
     const participants = new Set<string>([memo.created_by]);
     if (memo.assigned_to) participants.add(memo.assigned_to);
     for (const r of priorReplies) participants.add(r.created_by);
+    for (const id of (additionalRecipientIds ?? [])) participants.add(id);
 
     // Parse @mentions from current and prior replies — add to notification recipients
     const allContents = [reply.content, ...priorReplies.map((r) => r.content ?? '')];

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -87,11 +87,16 @@ export function registerMemosTools(server: McpServer) {
   server.tool('reply_memo', 'Reply to a memo', {
     memo_id: z.string(),
     content: z.string(),
-  }, async ({ memo_id, content }) => {
+    assigned_to: z.string().optional().describe('Single team member ID to explicitly notify via webhook (legacy, use assigned_to_ids for multiple)'),
+    assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to explicitly notify via webhook on this reply'),
+  }, async ({ memo_id, content, assigned_to, assigned_to_ids }) => {
     try {
+      const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
+      const payload: Record<string, unknown> = { content };
+      if (resolvedIds) payload.assigned_to_ids = resolvedIds;
       const data = await pmApi(`/api/memos/${encodeURIComponent(memo_id)}/replies`, {
         method: 'POST',
-        body: JSON.stringify({ content }),
+        body: JSON.stringify(payload),
       });
       return ok(data);
     } catch (e) { return handleError(e); }

--- a/packages/shared/src/schemas/__tests__/validation.test.ts
+++ b/packages/shared/src/schemas/__tests__/validation.test.ts
@@ -37,6 +37,12 @@ describe('Sprintable Zod Schemas', () => {
     it('빈 content 실패', () => {
       expect(createMemoReplySchema.safeParse({ content: '' }).success).toBe(false);
     });
+    it('assigned_to_ids 포함 reply 통과', () => {
+      expect(createMemoReplySchema.safeParse({ content: '답글', assigned_to_ids: ['uuid-1', 'uuid-2'] }).success).toBe(true);
+    });
+    it('assigned_to 단일 ID 통과', () => {
+      expect(createMemoReplySchema.safeParse({ content: '답글', assigned_to: 'uuid-1' }).success).toBe(true);
+    });
   });
 
   // ─── Core write APIs ───

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -83,6 +83,8 @@ export const updateNotificationSchema = z.object({
 
 export const createMemoReplySchema = z.object({
   content: z.string().min(1),
+  assigned_to: z.string().optional().describe('Single team member ID to notify via webhook (legacy, use assigned_to_ids for multiple)'),
+  assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to explicitly notify via webhook on this reply'),
 });
 
 export const createMemoLinkedDocSchema = z.object({


### PR DESCRIPTION
## Summary

- `reply_memo` MCP tool에 `assigned_to` / `assigned_to_ids` 파라미터 추가
- `createMemoReplySchema`에 해당 필드 추가 (optional, 하위 호환)
- `dispatchWorkflowMemoReplyWebhooks()`에 `additionalRecipientIds` 옵션 추가 → participants set에 합산
- OSS `dispatchOssReplyWebhooks()` 경로도 동일하게 처리
- `MemoService.addReply()` 시그니처에 `additionalRecipientIds` 추가

## Problem

`reply_memo`로 킥오프 thread에서 QA 요청 등 후속 위임을 보낼 때, 수신자를 지정할 방법이 없어서 해당 에이전트의 Discord 채널에 웹훅이 발송되지 않던 문제.
E-WORKFLOW-CONTRACT S6/S7/S8에서 3회 연속 실제 블로커로 작용함.

## AC Checklist

- [x] AC1: `reply_memo(assigned_to_ids=[<agent_id>])` 호출 시 해당 에이전트 채널에 웹훅 발송
- [x] AC2: 기존 `send_memo`의 `assigned_to` 동작 회귀 없음 (schema optional, 기존 participants 로직 유지)
- [x] AC3: 별도 `send_memo` 없이 reply_memo 한 번으로 QA 위임 가능

## Test Plan

- [x] `dispatchWorkflowMemoReplyWebhooks` 유닛 테스트: `additionalRecipientIds` 케이스 추가 (54 tests PASS)
- [x] `createMemoReplySchema` 유닛 테스트: assigned_to / assigned_to_ids 케이스 추가 (PASS)
- [ ] 통합 smoke: reply_memo에 assigned_to_ids 지정 후 해당 에이전트 Discord 채널 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)