### PR TITLE
feat(perf): E-PERF-INFRA S9 — 폴링 최적화 4종

### DIFF
--- a/apps/web/src/app/api/docs/[id]/updated-at/route.ts
+++ b/apps/web/src/app/api/docs/[id]/updated-at/route.ts
@@ -1,0 +1,38 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET — updated_at 타임스탬프만 반환 (충돌 감지 경량 폴링용) */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    if (isOssMode()) {
+      const repo = await createDocRepository();
+      const doc = await repo.getById(id);
+      return apiSuccess({ updated_at: doc.updated_at });
+    }
+
+    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const { data, error } = await dbClient
+      .from('docs')
+      .select('updated_at')
+      .eq('id', id)
+      .eq('project_id', me.project_id)
+      .single();
+
+    if (error || !data) return ApiErrors.notFound();
+    return apiSuccess({ updated_at: (data as { updated_at: string }).updated_at });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/app/api/notifications/count/route.ts
+++ b/apps/web/src/app/api/notifications/count/route.ts
@@ -1,0 +1,47 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode, createNotificationRepository } from '@/lib/storage/factory';
+
+/** GET — 안읽음 뱃지용 COUNT만 반환 (full list 조회 없음) */
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    if (isOssMode()) {
+      const repo = await createNotificationRepository();
+      const all = await repo.list({ user_id: me.id, is_read: false, limit: 200 });
+      const memoUnreadCount = all.filter((n) => n.type?.startsWith('memo')).length;
+      const inboxUnreadCount = all.length;
+      return apiSuccess({ memoUnreadCount, inboxUnreadCount });
+    }
+
+    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+
+    const [memoResult, totalResult] = await Promise.all([
+      dbClient
+        .from('notifications')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', me.id)
+        .eq('is_read', false)
+        .like('type', 'memo%'),
+      dbClient
+        .from('notifications')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', me.id)
+        .eq('is_read', false),
+    ]);
+
+    return apiSuccess({
+      memoUnreadCount: memoResult.count ?? 0,
+      inboxUnreadCount: totalResult.count ?? 0,
+    });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ArrowLeft, Bot, Clock3, RefreshCw, TriangleAlert, User } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -72,12 +72,22 @@ export function AgentHitlRequestsList() {
     }
   }, []);
 
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
   useEffect(() => {
+    const start = () => {
+      if (intervalRef.current) return;
+      intervalRef.current = setInterval(() => { void fetchRequests(true); }, AUTO_REFRESH_INTERVAL);
+    };
+    const stop = () => {
+      if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
+    };
+    const handleVisibility = () => { if (document.hidden) { stop(); } else { void fetchRequests(true); start(); } };
+
     void fetchRequests();
-    const interval = setInterval(() => {
-      void fetchRequests(true);
-    }, AUTO_REFRESH_INTERVAL);
-    return () => clearInterval(interval);
+    start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => { stop(); document.removeEventListener('visibilitychange', handleVisibility); };
   }, [fetchRequests]);
 
   return (

--- a/apps/web/src/components/docs/use-doc-sync.ts
+++ b/apps/web/src/components/docs/use-doc-sync.ts
@@ -48,7 +48,7 @@ export function useDocSync<TDoc = { updated_at: string }>({
   editing,
   autosave = true,
   autosaveDelay = 1500,
-  pollInterval = 10_000,
+  pollInterval = 30_000,
   onSaved,
   onRemoteChange,
 }: UseDocSyncOptions<TDoc>) {
@@ -188,27 +188,36 @@ export function useDocSync<TDoc = { updated_at: string }>({
   useEffect(() => {
     if (!docId || !editing || !baselineUpdatedAt || remoteChangedRef.current || conflictRef.current) return;
 
-    const interval = window.setInterval(async () => {
-      if (savingRef.current) return;
+    let intervalId: ReturnType<typeof window.setInterval> | null = null;
 
+    const poll = async () => {
+      if (savingRef.current || remoteChangedRef.current || conflictRef.current) return;
       try {
-        const res = await fetch(`/api/docs/${docId}`);
+        const res = await fetch(`/api/docs/${docId}/updated-at`);
         if (!res.ok) return;
-
-        const json = await res.json();
-        const remoteUpdatedAt = json.data?.updated_at as string | undefined;
-
+        const json = await res.json() as { data?: { updated_at?: string } };
+        const remoteUpdatedAt = json.data?.updated_at;
         if (!remoteUpdatedAt || remoteUpdatedAt === baselineUpdatedAt) return;
-
         remoteChangedRef.current = true;
         setStatus('remote-changed');
         onRemoteChange?.(remoteUpdatedAt);
       } catch {
         // polling failures are intentionally silent
       }
-    }, pollInterval);
+    };
 
-    return () => window.clearInterval(interval);
+    const start = () => {
+      if (intervalId) return;
+      intervalId = window.setInterval(() => { void poll(); }, pollInterval);
+    };
+    const stop = () => {
+      if (intervalId) { window.clearInterval(intervalId); intervalId = null; }
+    };
+    const handleVisibility = () => { if (document.hidden) { stop(); } else { start(); } };
+
+    start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => { stop(); document.removeEventListener('visibilitychange', handleVisibility); };
   }, [baselineUpdatedAt, docId, editing, onRemoteChange, pollInterval]);
 
   return {

--- a/apps/web/src/components/docs/use-doc-sync.ts
+++ b/apps/web/src/components/docs/use-doc-sync.ts
@@ -188,7 +188,7 @@ export function useDocSync<TDoc = { updated_at: string }>({
   useEffect(() => {
     if (!docId || !editing || !baselineUpdatedAt || remoteChangedRef.current || conflictRef.current) return;
 
-    let intervalId: ReturnType<typeof window.setInterval> | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
 
     const poll = async () => {
       if (savingRef.current || remoteChangedRef.current || conflictRef.current) return;
@@ -208,10 +208,10 @@ export function useDocSync<TDoc = { updated_at: string }>({
 
     const start = () => {
       if (intervalId) return;
-      intervalId = window.setInterval(() => { void poll(); }, pollInterval);
+      intervalId = setInterval(() => { void poll(); }, pollInterval);
     };
     const stop = () => {
-      if (intervalId) { window.clearInterval(intervalId); intervalId = null; }
+      if (intervalId) { clearInterval(intervalId); intervalId = null; }
     };
     const handleVisibility = () => { if (document.hidden) { stop(); } else { start(); } };
 

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -78,29 +78,35 @@ export function AppSidebar({
     return () => window.removeEventListener('keydown', onKeyDown);
   }, []);
 
-  useEffect(() => {
-    async function fetchUnread() {
-      try {
-        const [memoRes, inboxRes] = await Promise.all([
-          fetch('/api/notifications?unread=true&type=memo'),
-          fetch('/api/notifications?unread=true'),
-        ]);
-        if (memoRes.ok) {
-          const json = await memoRes.json() as { meta?: { unreadCount?: number } };
-          setMemoUnreadCount(json.meta?.unreadCount ?? 0);
-        }
-        if (inboxRes.ok) {
-          const json = await inboxRes.json() as { meta?: { unreadCount?: number } };
-          setInboxUnreadCount(json.meta?.unreadCount ?? 0);
-        }
-      } catch {
-        // noop
-      }
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchUnread = useCallback(async () => {
+    try {
+      const res = await fetch('/api/notifications/count');
+      if (!res.ok) return;
+      const json = await res.json() as { data?: { memoUnreadCount?: number; inboxUnreadCount?: number } };
+      setMemoUnreadCount(json.data?.memoUnreadCount ?? 0);
+      setInboxUnreadCount(json.data?.inboxUnreadCount ?? 0);
+    } catch {
+      // noop
     }
-    void fetchUnread();
-    const interval = setInterval(fetchUnread, 30000);
-    return () => clearInterval(interval);
   }, []);
+
+  useEffect(() => {
+    const start = () => {
+      if (intervalRef.current) return;
+      intervalRef.current = setInterval(() => { void fetchUnread(); }, 30000);
+    };
+    const stop = () => {
+      if (intervalRef.current) { clearInterval(intervalRef.current); intervalRef.current = null; }
+    };
+    const handleVisibility = () => { if (document.hidden) { stop(); } else { void fetchUnread(); start(); } };
+
+    void fetchUnread();
+    start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => { stop(); document.removeEventListener('visibilitychange', handleVisibility); };
+  }, [fetchUnread]);
 
   function isActive(href: string) {
     return pathname === href || (href !== '/' && pathname.startsWith(href));


### PR DESCRIPTION
## Summary

- **`/api/notifications/count`** 신설: memo+inbox unread count를 단일 COUNT 쿼리로 반환
- **`app-sidebar`**: full list fetch 2건 → count EP 1건 교체 + Visibility API (탭 비활성 시 폴링 중단)
- **`/api/docs/[id]/updated-at`** 신설: `updated_at` 타임스탬프만 반환 (충돌 감지 경량화)
- **`use-doc-sync`**: full GET → updated-at EP, 폴링 간격 10초 → 30초, Visibility API 적용
- **`agent-hitl-requests-list`**: Visibility API 적용

## Before / After

| 컴포넌트 | 이전 | 이후 |
|---|---|---|
| app-sidebar | 14-16 쿼리/틱 | 2 쿼리/틱 |
| doc sync | 7-8 쿼리/틱 | 1 쿼리/틱 |
| 비활성 탭 | 계속 폴링 | 즉시 중단 |

## AC Checklist

- [x] AC1: app-sidebar 폴링 쿼리 14-16 → 2/틱
- [x] AC2: doc sync 폴링 쿼리 7-8 → 1/틱  
- [x] AC3: 브라우저 탭 비활성 시 모든 폴링 중단 (visibilitychange)
- [x] AC4: Realtime — 기존 Supabase Realtime 경로 유지 (inbox page 패턴 존재, app-sidebar는 count EP로 대체)
- [x] AC5: 기존 뱃지/충돌감지 기능 정상 동작
- [x] AC6: TypeScript 에러 없음 (기존 tsconfig 경로 에러 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)