### PR TITLE
feat(perf): E-PERF-INFRA S6 — 메모 목록 cursor 기반 페이징

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
@@ -36,6 +36,9 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
   const [searchQuery, setSearchQuery] = useState('');
   const [debouncedQuery, setDebouncedQuery] = useState('');
+  const [hasMore, setHasMore] = useState(false);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [loadingMore, setLoadingMore] = useState(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleSearchChange = (value: string) => {
@@ -49,26 +52,40 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
     [members],
   );
 
-  const fetchMemos = useCallback(async (q?: string) => {
+  const fetchMemos = useCallback(async (q?: string, cursor?: string | null) => {
     if (!projectId) return;
 
     try {
       const params = new URLSearchParams();
       params.append('project_id', projectId);
-      params.append('limit', '50');
+      params.append('limit', '10');
       if (q?.trim()) params.append('q', q.trim());
+      if (cursor) params.append('cursor', cursor);
 
       const res = await fetch(`/api/memos?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch memos');
 
-      const { data } = await res.json();
-      setMemos(data || []);
+      const { data, meta } = await res.json();
+      if (cursor) {
+        setMemos((prev) => [...prev, ...(data ?? [])]);
+      } else {
+        setMemos(data ?? []);
+      }
+      setHasMore(meta?.hasMore ?? false);
+      setNextCursor(meta?.nextCursor ?? null);
     } catch (error) {
       console.error('Failed to fetch memos:', error);
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
   }, [projectId]);
+
+  const loadMore = useCallback(async () => {
+    if (!hasMore || !nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    await fetchMemos(debouncedQuery || undefined, nextCursor);
+  }, [fetchMemos, debouncedQuery, hasMore, loadingMore, nextCursor]);
 
   const fetchMembers = useCallback(async () => {
     if (!projectId) return;
@@ -207,6 +224,8 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
   }, [fetchMemos, fetchMembers]);
 
   useEffect(() => {
+    setNextCursor(null);
+    setHasMore(false);
     void fetchMemos(debouncedQuery);
   }, [debouncedQuery, fetchMemos]);
 
@@ -310,6 +329,13 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
             memberMap={memberMap}
             onNewMemo={handleNewMemo}
           />
+          {hasMore && (
+            <div className="px-3 py-2">
+              <Button variant="ghost" size="sm" className="w-full text-muted-foreground" onClick={() => void loadMore()} disabled={loadingMore}>
+                {loadingMore ? t('loading') : t('loadMore')}
+              </Button>
+            </div>
+          )}
         </div>
       </div>
 
@@ -330,6 +356,13 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
               memberMap={memberMap}
               onNewMemo={handleNewMemo}
             />
+            {hasMore && (
+              <div className="px-3 py-2">
+                <Button variant="ghost" size="sm" className="w-full text-muted-foreground" onClick={() => void loadMore()} disabled={loadingMore}>
+                  {loadingMore ? t('loading') : t('loadMore')}
+                </Button>
+              </div>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- `limit` 50 → 10 (초기 로드 부담 감소)
- `fetchMemos`에 `cursor` 파라미터 추가
- `hasMore` / `nextCursor` / `loadingMore` 상태 추가
- 더보기 버튼 — desktop 패널 + mobile 리스트 양쪽
- 검색(debouncedQuery) 변경 시 cursor 리셋
- API `buildCursorPageMeta` 기존 구현 그대로 활용

## AC Checklist

- [x] AC1: 초기 로드 10건만 표시
- [x] AC2: 더보기 클릭 시 10건 추가 append
- [x] AC3: 전체 10건 이하 시 더보기 버튼 미표시 (hasMore=false)
- [x] AC4: 검색 시 페이징 정상 동작 (cursor 리셋 후 새 결과)
- [x] AC5: TypeScript 에러 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)