### PR TITLE
feat(perf): E-PERF-INFRA S7 — 보드 페이징 limit 20 + tasks story_ids 일괄 조회

### DIFF
--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -52,6 +52,8 @@ export async function GET(request: Request) {
 
     const { searchParams } = new URL(request.url);
     const storyId = searchParams.get('story_id') ?? undefined;
+    const storyIdsRaw = searchParams.get('story_ids');
+    const storyIds = storyIdsRaw ? storyIdsRaw.split(',').map((s) => s.trim()).filter(Boolean) : undefined;
     const projectId = searchParams.get('project_id') ?? undefined;
     const assigneeId = searchParams.get('assignee_id') ?? undefined;
     const status = searchParams.get('status') ?? undefined;
@@ -64,6 +66,25 @@ export async function GET(request: Request) {
 
     const repo = await createTaskRepository(dbClient);
     const service = new TaskService(repo);
+
+    // story_ids: 일괄 조회 (kanban board N+1 방지용)
+    if (storyIds && storyIds.length > 0) {
+      if (dbClient) {
+        let q = dbClient.from('tasks').select('*').in('story_id', storyIds).order('created_at', { ascending: true });
+        if (status) q = q.eq('status', status);
+        const { data, error } = await q;
+        if (error) throw error;
+        return apiSuccess(data ?? []);
+      }
+      // OSS: fallback to per-story serial fetch
+      const all: unknown[] = [];
+      for (const sid of storyIds) {
+        const items = await service.list({ story_id: sid, status });
+        all.push(...items);
+      }
+      return apiSuccess(all);
+    }
+
     const tasks = await service.list({
       story_id: storyId,
       project_id: projectId,

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -148,10 +148,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       const sprintParams = projectId ? `?project_id=${projectId}` : '';
       const epicParams = new URLSearchParams();
       if (projectId) epicParams.set('project_id', projectId);
-      epicParams.set('limit', '50');
+      epicParams.set('limit', '20');
       const memberParams = projectId ? `?project_id=${projectId}` : '';
 
-      params.set('limit', '50');
+      params.set('limit', '20');
       const [storiesRes, sprintsRes, epicsRes, membersRes] = await Promise.all([
         fetch(`/api/stories?${params}`),
         fetch(`/api/sprints${sprintParams}`),


### PR DESCRIPTION
## Summary

- `kanban-board.tsx`: epicParams + stories limit `50→20` (더보기 버튼은 기존 구현 활용)
- `/api/tasks`: `story_ids` 콤마 파라미터 지원 추가 — `.in('story_id', ids)` 일괄 조회, OSS per-story fallback

## AC Checklist

- [x] AC1: 보드 stories 초기 limit 50→20
- [x] AC2: 보드 epics 초기 limit 50→20
- [x] AC3: `/api/tasks?story_ids=a,b,c` 일괄 조회 동작
- [x] AC4: 기존 더보기 버튼(stories/epics) 정상 동작 유지
- [x] AC5: TypeScript 에러 없음 (기존 tsconfig 경로 에러 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)