### PR TITLE
feat(perf): E-PERF-INFRA S8 — docs/epics/sprints 리스트 커서 페이징

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -87,6 +87,9 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [loading, setLoading] = useState(true);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
   const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [docsHasMore, setDocsHasMore] = useState(false);
+  const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
+  const [docsLoadingMore, setDocsLoadingMore] = useState(false);
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
 
   // Always-editable content states
@@ -132,22 +135,30 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     onSaved: handleDocSaved,
   });
 
-  const fetchTree = useCallback(async (tags?: string[]) => {
+  const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
 
     try {
-      const params = new URLSearchParams({ project_id: projectId });
+      const params = new URLSearchParams({ project_id: projectId, limit: '20' });
       if (tags?.length) params.set('tags', tags.join(','));
       else params.set('view', 'tree');
+      if (cursor) params.set('cursor', cursor);
       const res = await fetch(`/api/docs?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch tree');
 
-      const { data } = await res.json();
-      setTree(data || []);
+      const { data, meta } = await res.json() as { data: Doc[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
+      if (cursor) {
+        setTree((prev) => [...prev, ...(data || [])]);
+      } else {
+        setTree(data || []);
+      }
+      setDocsHasMore(meta?.hasMore ?? false);
+      setDocsNextCursor(meta?.nextCursor ?? null);
     } catch (error) {
       console.error('Failed to fetch docs tree:', error);
     } finally {
       setLoading(false);
+      setDocsLoadingMore(false);
     }
   }, [projectId]);
 
@@ -463,17 +474,36 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             }
           />
         ) : (
-          <DocTree
-            docs={tree}
-            selectedSlug={selectedDoc?.slug || null}
-            onSelect={(doc) => { handleSelectDoc(doc); }}
-            onReorder={handleReorder}
-            onMove={handleMove}
-            onMoveDenied={handleMoveDenied}
-            onRename={handleRename}
-            onDelete={handleDeleteDoc}
-            onAddChild={handleAddChild}
-          />
+          <>
+            <DocTree
+              docs={tree}
+              selectedSlug={selectedDoc?.slug || null}
+              onSelect={(doc) => { handleSelectDoc(doc); }}
+              onReorder={handleReorder}
+              onMove={handleMove}
+              onMoveDenied={handleMoveDenied}
+              onRename={handleRename}
+              onDelete={handleDeleteDoc}
+              onAddChild={handleAddChild}
+            />
+            {docsHasMore && (
+              <div className="px-2 py-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full text-xs text-muted-foreground"
+                  disabled={docsLoadingMore}
+                  onClick={() => {
+                    if (!docsNextCursor || docsLoadingMore) return;
+                    setDocsLoadingMore(true);
+                    void fetchTree(selectedTags.length ? selectedTags : undefined, docsNextCursor);
+                  }}
+                >
+                  {docsLoadingMore ? tc('loading') : tc('loadMore')}
+                </Button>
+              </div>
+            )}
+          </>
         )}
       </div>
     </>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -674,19 +674,37 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [loading, setLoading] = useState(true);
   const [showCreate, setShowCreate] = useState(false);
   const [mobileView, setMobileView] = useState<'list' | 'detail'>('list');
+  const [epicsHasMore, setEpicsHasMore] = useState(false);
+  const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
+  const [epicsLoadingMore, setEpicsLoadingMore] = useState(false);
 
-  const fetchEpics = useCallback(async () => {
+  const fetchEpics = useCallback(async (cursor?: string | null) => {
     try {
-      const res = await fetch(`/api/epics?project_id=${projectId}`);
+      const params = new URLSearchParams({ project_id: projectId, limit: '20' });
+      if (cursor) params.set('cursor', cursor);
+      const res = await fetch(`/api/epics?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch epics');
-      const { data } = await res.json() as { data: Epic[] };
-      setEpics(data ?? []);
+      const { data, meta } = await res.json() as { data: Epic[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
+      if (cursor) {
+        setEpics((prev) => [...prev, ...(data ?? [])]);
+      } else {
+        setEpics(data ?? []);
+      }
+      setEpicsHasMore(meta?.hasMore ?? false);
+      setEpicsNextCursor(meta?.nextCursor ?? null);
     } catch {
       // noop — show empty state
     } finally {
       setLoading(false);
+      setEpicsLoadingMore(false);
     }
   }, [projectId]);
+
+  const loadMoreEpics = useCallback(async () => {
+    if (!epicsHasMore || !epicsNextCursor || epicsLoadingMore) return;
+    setEpicsLoadingMore(true);
+    await fetchEpics(epicsNextCursor);
+  }, [epicsHasMore, epicsNextCursor, epicsLoadingMore, fetchEpics]);
 
   const fetchEpicDetail = useCallback(async (id: string) => {
     try {
@@ -758,6 +776,11 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
                 onClick={() => { void handleSelectEpic(epic); }}
               />
             ))}
+            {epicsHasMore && (
+              <Button variant="ghost" size="sm" className="w-full text-muted-foreground" onClick={() => void loadMoreEpics()} disabled={epicsLoadingMore}>
+                {epicsLoadingMore ? '로딩 중...' : '더 보기'}
+              </Button>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -150,6 +150,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
 
 export function SprintsClient({ projectId }: SprintsClientProps) {
   const t = useTranslations('sprints');
+  const tc = useTranslations('common');
 
   const [sprints, setSprints] = useState<Sprint[]>([]);
   const [loading, setLoading] = useState(true);
@@ -157,7 +158,13 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
   const [burndown, setBurndown] = useState<BurndownData | null>(null);
   const [loadingBurndown, setLoadingBurndown] = useState(false);
   const [sprintStories, setSprintStories] = useState<Story[]>([]);
+  const [sprintStoriesHasMore, setSprintStoriesHasMore] = useState(false);
+  const [sprintStoriesNextCursor, setSprintStoriesNextCursor] = useState<string | null>(null);
+  const [sprintStoriesLoadingMore, setSprintStoriesLoadingMore] = useState(false);
   const [backlogStories, setBacklogStories] = useState<Story[]>([]);
+  const [backlogHasMore, setBacklogHasMore] = useState(false);
+  const [backlogNextCursor, setBacklogNextCursor] = useState<string | null>(null);
+  const [backlogLoadingMore, setBacklogLoadingMore] = useState(false);
   const [loadingStories, setLoadingStories] = useState(false);
   const [showCreate, setShowCreate] = useState(false);
   const [activating, setActivating] = useState(false);
@@ -184,32 +191,72 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
     setLoadingStories(true);
     setBurndown(null);
     setSprintStories([]);
+    setSprintStoriesHasMore(false);
+    setSprintStoriesNextCursor(null);
     setBacklogStories([]);
+    setBacklogHasMore(false);
+    setBacklogNextCursor(null);
     setActionError(null);
 
     try {
       const [burndownRes, storiesRes, backlogRes] = await Promise.all([
         fetch(`/api/sprints/${sprint.id}/burndown`),
-        fetch(`/api/stories?project_id=${projectId}&sprint_id=${sprint.id}`),
-        fetch(`/api/stories/backlog?project_id=${projectId}`),
+        fetch(`/api/stories?project_id=${projectId}&sprint_id=${sprint.id}&limit=20`),
+        fetch(`/api/stories/backlog?project_id=${projectId}&limit=20`),
       ]);
       if (burndownRes.ok) {
         const json = await burndownRes.json();
         setBurndown(json.data);
       }
       if (storiesRes.ok) {
-        const json = await storiesRes.json();
+        const json = await storiesRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
         setSprintStories(json.data ?? []);
+        setSprintStoriesHasMore(json.meta?.hasMore ?? false);
+        setSprintStoriesNextCursor(json.meta?.nextCursor ?? null);
       }
       if (backlogRes.ok) {
-        const json = await backlogRes.json();
+        const json = await backlogRes.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
         setBacklogStories(json.data ?? []);
+        setBacklogHasMore(json.meta?.hasMore ?? false);
+        setBacklogNextCursor(json.meta?.nextCursor ?? null);
       }
     } finally {
       setLoadingBurndown(false);
       setLoadingStories(false);
     }
   }, [projectId]);
+
+  const loadMoreSprintStories = useCallback(async () => {
+    if (!selected || !sprintStoriesNextCursor || sprintStoriesLoadingMore) return;
+    setSprintStoriesLoadingMore(true);
+    try {
+      const res = await fetch(`/api/stories?project_id=${projectId}&sprint_id=${selected.id}&limit=20&cursor=${sprintStoriesNextCursor}`);
+      if (res.ok) {
+        const json = await res.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
+        setSprintStories((prev) => [...prev, ...(json.data ?? [])]);
+        setSprintStoriesHasMore(json.meta?.hasMore ?? false);
+        setSprintStoriesNextCursor(json.meta?.nextCursor ?? null);
+      }
+    } finally {
+      setSprintStoriesLoadingMore(false);
+    }
+  }, [selected, projectId, sprintStoriesNextCursor, sprintStoriesLoadingMore]);
+
+  const loadMoreBacklog = useCallback(async () => {
+    if (!backlogNextCursor || backlogLoadingMore) return;
+    setBacklogLoadingMore(true);
+    try {
+      const res = await fetch(`/api/stories/backlog?project_id=${projectId}&limit=20&cursor=${backlogNextCursor}`);
+      if (res.ok) {
+        const json = await res.json() as { data?: Story[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
+        setBacklogStories((prev) => [...prev, ...(json.data ?? [])]);
+        setBacklogHasMore(json.meta?.hasMore ?? false);
+        setBacklogNextCursor(json.meta?.nextCursor ?? null);
+      }
+    } finally {
+      setBacklogLoadingMore(false);
+    }
+  }, [projectId, backlogNextCursor, backlogLoadingMore]);
 
   const handleSelect = useCallback(async (sprint: Sprint) => {
     setSelected(sprint);
@@ -411,26 +458,39 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         ) : sprintStories.length === 0 ? (
           <p className="text-xs italic text-muted-foreground">{t('noSprintStories')}</p>
         ) : (
-          <ul className="space-y-1.5">
-            {sprintStories.map((story) => (
-              <li key={story.id} className="flex items-center justify-between rounded-lg border border-border px-3 py-2">
-                <span className="text-sm text-foreground truncate">{story.title}</span>
-                <div className="flex shrink-0 items-center gap-2">
-                  {story.story_points != null ? <span className="text-xs text-muted-foreground">{story.story_points}SP</span> : null}
-                  {selected.status !== 'closed' ? (
-                    <button
-                      type="button"
-                      onClick={() => void handleUnassignStory(story)}
-                      className="text-xs text-muted-foreground hover:text-destructive"
-                      title={t('unassign')}
-                    >
-                      <X className="size-3" />
-                    </button>
-                  ) : null}
-                </div>
-              </li>
-            ))}
-          </ul>
+          <>
+            <ul className="space-y-1.5">
+              {sprintStories.map((story) => (
+                <li key={story.id} className="flex items-center justify-between rounded-lg border border-border px-3 py-2">
+                  <span className="text-sm text-foreground truncate">{story.title}</span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {story.story_points != null ? <span className="text-xs text-muted-foreground">{story.story_points}SP</span> : null}
+                    {selected.status !== 'closed' ? (
+                      <button
+                        type="button"
+                        onClick={() => void handleUnassignStory(story)}
+                        className="text-xs text-muted-foreground hover:text-destructive"
+                        title={t('unassign')}
+                      >
+                        <X className="size-3" />
+                      </button>
+                    ) : null}
+                  </div>
+                </li>
+              ))}
+            </ul>
+            {sprintStoriesHasMore && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="mt-1 w-full text-xs text-muted-foreground"
+                disabled={sprintStoriesLoadingMore}
+                onClick={() => void loadMoreSprintStories()}
+              >
+                {sprintStoriesLoadingMore ? tc('loading') : tc('loadMore')}
+              </Button>
+            )}
+          </>
         )}
       </div>
 
@@ -452,6 +512,17 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
               </li>
             ))}
           </ul>
+          {backlogHasMore && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="w-full text-xs text-muted-foreground"
+              disabled={backlogLoadingMore}
+              onClick={() => void loadMoreBacklog()}
+            >
+              {backlogLoadingMore ? tc('loading') : tc('loadMore')}
+            </Button>
+          )}
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary

- **docs-shell-client**: `/api/docs` limit=20 + cursor 파라미터, 사이드바 트리 하단 더보기 버튼
- **epics-client**: `/api/epics` limit=20 + cursor 파라미터, 에픽 목록 하단 더보기 버튼
- **sprints-client**: `/api/stories` (sprint + backlog) limit=20 + cursor 파라미터, 각 목록 하단 더보기 버튼

## Test plan

- [ ] docs 사이드바: 21개+ docs 있는 프로젝트에서 더보기 버튼 노출 및 클릭 시 추가 로드 확인
- [ ] epics 목록: 21개+ epics 있는 프로젝트에서 더보기 버튼 노출 확인
- [ ] sprints 상세 패널: sprint stories/backlog 각각 21개+ 시 더보기 버튼 동작 확인
- [ ] 로딩 중 버튼 비활성화 및 로딩 텍스트 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)