### PR TITLE
feat(arch): E-ARCH-MONOREPO S2 — SaaS 전용 코드 ee/ 이동

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -28,7 +28,11 @@
       "@sprintable/storage-sqlite/*": ["../../packages/storage-sqlite/src/*"],
       "@sprintable/storage-supabase": ["../../packages/storage-supabase/src/index.ts"],
       "@sprintable/storage-supabase/*": ["../../packages/storage-supabase/src/*"],
-      "@ee/*": ["../../ee/packages/*"]
+      "@ee/*": ["../../ee/packages/*"],
+      "@moonklabs/storage-saas": ["../../ee/packages/storage-saas/src/index.ts"],
+      "@moonklabs/storage-saas/*": ["../../ee/packages/storage-saas/src/*"],
+      "@moonklabs/mcp-server-saas": ["../../ee/packages/mcp-server-saas/src/index.ts"],
+      "@moonklabs/mcp-server-saas/*": ["../../ee/packages/mcp-server-saas/src/*"]
     }
   },
   "include": [

--- a/ee/apps/web/src/instrumentation.ts
+++ b/ee/apps/web/src/instrumentation.ts
@@ -1,0 +1,31 @@
+/**
+ * Next.js 16 instrumentation hook (SaaS overlay).
+ *
+ * Two responsibilities:
+ *   1. Bootstrap SaaS-only Repository registry overrides before any
+ *      route handler runs (OSS core never imports @moonklabs/storage-saas).
+ *   2. Load .env.production from the process cwd for the Node.js SSR
+ *      Lambda runtime — Next.js 16 `standalone` server.js does NOT
+ *      auto-load .env.production, so env values dumped by amplify.yml
+ *      preBuild would otherwise be invisible to process.env.
+ *
+ * OSS builds do not include this file (overlay only).
+ */
+import { registerSaasRepositories } from '@/lib/storage/saas-bootstrap';
+
+export async function register(): Promise<void> {
+  // dotenv side-effect must run in Node runtime only — Edge has no process.cwd
+  if (process.env['NEXT_RUNTIME'] === 'nodejs') {
+    const [{ default: path }, dotenv] = await Promise.all([
+      import('node:path'),
+      import('dotenv'),
+    ]);
+    // override:false so Lambda/container-injected env wins over file values
+    dotenv.config({
+      path: path.join(process.cwd(), '.next', '.env.production'),
+      override: false,
+    });
+  }
+
+  registerSaasRepositories();
+}

--- a/ee/apps/web/src/lib/storage/saas-bootstrap.ts
+++ b/ee/apps/web/src/lib/storage/saas-bootstrap.ts
@@ -1,0 +1,35 @@
+/**
+ * SaaS Repository bootstrap.
+ *
+ * Call `registerSaasRepositories()` once at app startup (Next.js
+ * instrumentation hook or root layout import side-effect) to override
+ * the OSS-default Null stubs with real Supabase-backed implementations.
+ *
+ * OSS code (sprintable-core) never imports @moonklabs/storage-saas
+ * directly — this file (which lives in the SaaS overlay) is the only
+ * link between the public factory registry and the private SaaS impls.
+ */
+import {
+  registerSubscriptionRepository,
+  registerAgentRunBillingRepository,
+} from '@/lib/storage/factory';
+import {
+  SupabaseSubscriptionRepository,
+  SupabaseAgentRunBillingRepository,
+} from '@moonklabs/storage-saas';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+let _bootstrapped = false;
+
+export function registerSaasRepositories(): void {
+  if (_bootstrapped) return;
+  _bootstrapped = true;
+
+  registerSubscriptionRepository(async (supabase?: unknown) => {
+    return new SupabaseSubscriptionRepository(supabase as SupabaseClient);
+  });
+
+  registerAgentRunBillingRepository(async (supabase?: unknown) => {
+    return new SupabaseAgentRunBillingRepository(supabase as SupabaseClient);
+  });
+}

--- a/ee/packages/mcp-server-saas/package.json
+++ b/ee/packages/mcp-server-saas/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@moonklabs/mcp-server-saas",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/ee/packages/mcp-server-saas/src/contract-generate-tools.ts
+++ b/ee/packages/mcp-server-saas/src/contract-generate-tools.ts
@@ -1,0 +1,68 @@
+/**
+ * S5 — generate_contract_from_nl MCP 도구
+ *
+ * 자연어 → LLM structured output → 계약 JSON preview.
+ * 반환된 register_payload를 register_contract에 전달해 등록한다. (AC4)
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+let _pmApiUrl = '';
+let _agentApiKey = '';
+
+export function configureSaasContractGenerateApi(pmApiUrl: string, agentApiKey: string) {
+  _pmApiUrl = pmApiUrl.replace(/\/$/, '');
+  _agentApiKey = agentApiKey;
+}
+
+async function pmApi(path: string, init: RequestInit = {}): Promise<unknown> {
+  const res = await fetch(`${_pmApiUrl}${path}`, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${_agentApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers as Record<string, string> ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`PM API ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function ok(data: unknown) { return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }; }
+function err(msg: string) { return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }; }
+
+export function registerContractGenerateTools(server: McpServer) {
+  server.tool(
+    'generate_contract_from_nl',
+    [
+      'Convert natural language workflow rules into a contract JSON preview (SaaS only).',
+      'Returns preview + register_payload. Pass register_payload to register_contract to finalize.',
+      'validate.valid=false means the LLM output failed schema checks — retry or adjust the description.',
+    ].join(' '),
+    {
+      natural_language: z.string().min(10).describe('Natural language description of the workflow rules'),
+      entity_type: z.enum(['story', 'sprint', 'epic', 'task', 'document', 'retro_session'])
+        .describe('Entity type the workflow governs'),
+      org_id: z.string().describe('Organization ID'),
+      project_id: z.string().describe('Project ID (used to resolve LLM config)'),
+      suggested_name: z.string().optional().describe('Optional contract name hint'),
+    },
+    async ({ natural_language, entity_type, org_id, project_id, suggested_name }) => {
+      try {
+        const params = new URLSearchParams({ org_id, project_id });
+        const body: Record<string, string> = { natural_language, entity_type };
+        if (suggested_name) body['suggested_name'] = suggested_name;
+
+        const data = await pmApi(`/api/workflow-contracts/generate?${params.toString()}`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+        });
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+}

--- a/ee/packages/mcp-server-saas/src/gate-check-tools.ts
+++ b/ee/packages/mcp-server-saas/src/gate-check-tools.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+let _pmApiUrl = '';
+let _agentApiKey = '';
+
+export function configureSaasGateMcpApi(pmApiUrl: string, agentApiKey: string) {
+  _pmApiUrl = pmApiUrl.replace(/\/$/, '');
+  _agentApiKey = agentApiKey;
+}
+
+async function pmApi(path: string, init: RequestInit = {}): Promise<unknown> {
+  const res = await fetch(`${_pmApiUrl}${path}`, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${_agentApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers as Record<string, string> ?? {}),
+    },
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(JSON.stringify(json));
+  return json;
+}
+
+function ok(data: unknown) { return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }; }
+function err(msg: string) { return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }; }
+
+export function registerGateCheckTools(server: McpServer) {
+  server.tool(
+    'check_workflow_gate',
+    'Check workflow gate before executing a tool on an entity. Evaluates atomic conditions against the active workflow instance. Returns pass/fail with violations list. In enforce mode, a failed gate blocks the tool call.',
+    {
+      entity_type: z.string().describe('Entity type: story | sprint | epic | task | document | retro_session'),
+      entity_id: z.string().describe('UUID of the entity to check'),
+      tool_name: z.string().describe('Name of the MCP tool being gated'),
+      org_id: z.string().describe('Organization ID'),
+      project_id: z.string().describe('Project ID'),
+      actor_role: z.string().optional().describe('Caller role (default: member)'),
+    },
+    async (args) => {
+      try {
+        const data = await pmApi('/api/gate-check', {
+          method: 'POST',
+          body: JSON.stringify(args),
+        });
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  server.tool(
+    'create_workflow_instance',
+    'Create a workflow instance for an entity under a specific contract (SaaS only).',
+    {
+      contract_id: z.string().describe('Workflow contract UUID'),
+      entity_id: z.string().describe('Entity UUID'),
+      initial_state: z.string().describe('Starting state (must match contract definition)'),
+    },
+    async (args) => {
+      try {
+        const data = await pmApi('/api/workflow-instances', {
+          method: 'POST',
+          body: JSON.stringify(args),
+        });
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+}

--- a/ee/packages/mcp-server-saas/src/index.ts
+++ b/ee/packages/mcp-server-saas/src/index.ts
@@ -1,0 +1,12 @@
+/**
+ * @moonklabs/mcp-server-saas
+ *
+ * SaaS 전용 MCP 도구 확장 패키지.
+ * core MCP 서버에 workflow contract 도구 3종을 추가한다.
+ */
+
+export { registerWorkflowContractTools } from './workflow-contract-tools.js';
+export { registerGateCheckTools, configureSaasGateMcpApi } from './gate-check-tools.js';
+export { registerStoryWorkflowTools } from './story-workflow-tools.js';
+export { registerContractGenerateTools, configureSaasContractGenerateApi } from './contract-generate-tools.js';
+export { registerWorkflowStateTools, configureSaasWorkflowStateApi } from './workflow-state-tools.js';

--- a/ee/packages/mcp-server-saas/src/story-workflow-tools.ts
+++ b/ee/packages/mcp-server-saas/src/story-workflow-tools.ts
@@ -1,0 +1,82 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+let _pmApiUrl = '';
+let _agentApiKey = '';
+
+export function configureSaasStoryMcpApi(pmApiUrl: string, agentApiKey: string) {
+  _pmApiUrl = pmApiUrl.replace(/\/$/, '');
+  _agentApiKey = agentApiKey;
+}
+
+async function pmApi(path: string, init: RequestInit = {}): Promise<unknown> {
+  const res = await fetch(`${_pmApiUrl}${path}`, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${_agentApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers as Record<string, string> ?? {}),
+    },
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(JSON.stringify(json));
+  return json;
+}
+
+function ok(data: unknown) { return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }; }
+function err(msg: string) { return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }; }
+
+export function registerStoryWorkflowTools(server: McpServer) {
+  server.tool(
+    'update_story_status_gated',
+    'Update story status through the workflow gate check (SaaS only). In enforce mode, gate violations block the status change. In evaluate mode, violations are logged but the update proceeds.',
+    {
+      story_id: z.string().describe('Story UUID'),
+      status: z.string().describe('Target status: backlog | ready-for-dev | in-progress | in-review | done'),
+      org_id: z.string().describe('Organization ID'),
+      project_id: z.string().describe('Project ID'),
+    },
+    async ({ story_id, status, org_id, project_id }) => {
+      try {
+        const data = await pmApi(
+          `/api/stories/${encodeURIComponent(story_id)}/status?org_id=${encodeURIComponent(org_id)}&project_id=${encodeURIComponent(project_id)}`,
+          { method: 'PATCH', body: JSON.stringify({ status }) },
+        );
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  server.tool(
+    'get_default_story_contract',
+    'Get or auto-create the default story workflow contract for an organization (SaaS only).',
+    {
+      org_id: z.string().describe('Organization ID'),
+    },
+    async ({ org_id }) => {
+      try {
+        const data = await pmApi(`/api/workflow-contracts/default?org_id=${encodeURIComponent(org_id)}&entity_type=story`);
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  server.tool(
+    'set_contract_mode',
+    'Switch a workflow contract between evaluate (advisory) and enforce (blocking) mode (SaaS only, AC4).',
+    {
+      contract_id: z.string().describe('Contract UUID'),
+      org_id: z.string().describe('Organization ID'),
+      mode: z.enum(['evaluate', 'enforce']).describe('evaluate: log only | enforce: block on gate fail'),
+    },
+    async ({ contract_id, org_id, mode }) => {
+      try {
+        const data = await pmApi(
+          `/api/workflow-contracts/${encodeURIComponent(contract_id)}/mode?org_id=${encodeURIComponent(org_id)}`,
+          { method: 'PATCH', body: JSON.stringify({ mode }) },
+        );
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+}

--- a/ee/packages/mcp-server-saas/src/workflow-contract-tools.ts
+++ b/ee/packages/mcp-server-saas/src/workflow-contract-tools.ts
@@ -1,0 +1,94 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+let _pmApiUrl = '';
+let _agentApiKey = '';
+
+export function configureSaasMcpApi(pmApiUrl: string, agentApiKey: string) {
+  _pmApiUrl = pmApiUrl.replace(/\/$/, '');
+  _agentApiKey = agentApiKey;
+}
+
+async function pmApi(path: string, init: RequestInit = {}): Promise<unknown> {
+  const res = await fetch(`${_pmApiUrl}${path}`, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${_agentApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers as Record<string, string> ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`PM API ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function ok(data: unknown) { return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }; }
+function err(msg: string) { return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }; }
+
+export function registerWorkflowContractTools(server: McpServer) {
+  server.tool(
+    'register_contract',
+    'Register a new workflow contract (SaaS only). Validates atomic condition types and runs static graph analysis (deadlock/unreachable detection).',
+    {
+      org_id: z.string().describe('Organization ID'),
+      name: z.string().describe('Contract name (unique per org+version)'),
+      entity_type: z.string().describe('Entity type: story | sprint | epic | task | document | retro_session'),
+      definition: z.object({
+        states: z.array(z.string()).describe('All state names'),
+        initial_state: z.string().describe('Starting state'),
+        transitions: z.array(z.object({
+          from: z.string(),
+          to: z.string(),
+          on_tool: z.string().describe('MCP tool name triggering this transition'),
+          gate: z.record(z.unknown()).optional().describe('Gate expression (atomic conditions with all_of/any_of/none_of)'),
+        })),
+      }),
+      mode: z.enum(['evaluate', 'enforce']).optional().describe('evaluate: advisory only | enforce: blocks tool execution'),
+      version: z.number().int().positive().optional().describe('Contract version (default: 1)'),
+    },
+    async (args) => {
+      try {
+        const data = await pmApi('/api/workflow-contracts', {
+          method: 'POST',
+          body: JSON.stringify(args),
+        });
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  server.tool(
+    'get_contract',
+    'Retrieve a workflow contract by ID (SaaS only).',
+    {
+      contract_id: z.string().describe('Contract UUID'),
+      org_id: z.string().describe('Organization ID'),
+    },
+    async ({ contract_id, org_id }) => {
+      try {
+        const data = await pmApi(`/api/workflow-contracts/${encodeURIComponent(contract_id)}?org_id=${encodeURIComponent(org_id)}`);
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  server.tool(
+    'list_contracts',
+    'List active workflow contracts for an organization (SaaS only).',
+    {
+      org_id: z.string().describe('Organization ID'),
+      entity_type: z.string().optional().describe('Filter by entity type'),
+    },
+    async ({ org_id, entity_type }) => {
+      try {
+        const params = new URLSearchParams({ org_id });
+        if (entity_type) params.set('entity_type', entity_type);
+        const data = await pmApi(`/api/workflow-contracts?${params.toString()}`);
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+}

--- a/ee/packages/mcp-server-saas/src/workflow-state-tools.ts
+++ b/ee/packages/mcp-server-saas/src/workflow-state-tools.ts
@@ -1,0 +1,104 @@
+/**
+ * S6 — 워크플로우 상태 조회 MCP 도구
+ *
+ * AC1: get_workflow_state — 현재 상태 + 가능한 전이 + gate 충족 여부
+ * AC2: 도구 description에 계약 정보(enforce/evaluate 모드) soft guidance 포함
+ * AC3: get_my_workflow_saas — 기존 get_my_workflow + active_contracts + current_instance
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+let _pmApiUrl = '';
+let _agentApiKey = '';
+
+export function configureSaasWorkflowStateApi(pmApiUrl: string, agentApiKey: string) {
+  _pmApiUrl = pmApiUrl.replace(/\/$/, '');
+  _agentApiKey = agentApiKey;
+}
+
+async function pmApi(path: string, init: RequestInit = {}): Promise<unknown> {
+  const res = await fetch(`${_pmApiUrl}${path}`, {
+    ...init,
+    headers: {
+      'Authorization': `Bearer ${_agentApiKey}`,
+      'Content-Type': 'application/json',
+      ...(init.headers as Record<string, string> ?? {}),
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(`PM API ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+function ok(data: unknown) { return { content: [{ type: 'text' as const, text: JSON.stringify(data, null, 2) }] }; }
+function err(msg: string) { return { content: [{ type: 'text' as const, text: `Error: ${msg}` }] }; }
+
+export function registerWorkflowStateTools(server: McpServer) {
+  // ── AC1 + AC2 ──────────────────────────────────────────────────────────────
+  server.tool(
+    'get_workflow_state',
+    [
+      'Get the current workflow state and available transitions for an entity (SaaS only).',
+      'Returns: current_state, contract_id, contract_mode (evaluate=advisory/enforce=blocking),',
+      'and transitions_available with gate_satisfied flag for each.',
+      'Use this before calling update_story_status_gated or any gated tool',
+      'to check which transitions are ready and what conditions must be met.',
+      'In enforce mode, unsatisfied gates will block the transition with a 422 error.',
+    ].join(' '),
+    {
+      entity_type: z.enum(['story', 'sprint', 'epic', 'task', 'document', 'retro_session'])
+        .describe('Entity type'),
+      entity_id: z.string().describe('Entity UUID'),
+      org_id: z.string().describe('Organization ID'),
+      project_id: z.string().describe('Project ID'),
+    },
+    async ({ entity_type, entity_id, org_id, project_id }) => {
+      try {
+        const params = new URLSearchParams({ entity_type, entity_id, org_id, project_id });
+        const data = await pmApi(`/api/workflow-state?${params.toString()}`);
+        return ok(data);
+      } catch (e) { return err(String(e)); }
+    },
+  );
+
+  // ── AC3: get_my_workflow SaaS 확장 버전 ───────────────────────────────────
+  server.tool(
+    'get_my_workflow_saas',
+    [
+      'SaaS extension of get_my_workflow.',
+      'Returns the same routing/gate data as get_my_workflow,',
+      'plus active_contracts (workflow contracts active for the org)',
+      'and current_workflow_mode summary.',
+      'Use this instead of get_my_workflow in SaaS deployments.',
+    ].join(' '),
+    {
+      org_id: z.string().describe('Organization ID'),
+      project_id: z.string().describe('Project ID'),
+    },
+    async ({ org_id, project_id }) => {
+      try {
+        // 기존 get_my_workflow 데이터 + SaaS 계약 데이터를 병합
+        const [myWorkflow, contracts] = await Promise.all([
+          pmApi('/api/me').then(async (me) => {
+            const myId = (me as { id: string }).id;
+            const [rules, versions] = await Promise.all([
+              pmApi('/api/v1/agent-routing-rules').catch(() => []),
+              pmApi('/api/v1/workflow-versions').catch(() => []),
+            ]);
+            return { me, myId, rules, versions };
+          }).catch(() => null),
+          pmApi(`/api/workflow-contracts?org_id=${encodeURIComponent(org_id)}&project_id=${encodeURIComponent(project_id)}`).catch(() => ({ data: [] })),
+        ]);
+
+        return ok({
+          workflow: myWorkflow,
+          active_contracts: contracts,
+          hint: 'Use get_workflow_state to check transition readiness for a specific entity.',
+        });
+      } catch (e) { return err(String(e)); }
+    },
+  );
+}

--- a/ee/packages/mcp-server-saas/tsconfig.json
+++ b/ee/packages/mcp-server-saas/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "noEmit": false,
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/ee/packages/storage-saas/package.json
+++ b/ee/packages/storage-saas/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@moonklabs/storage-saas",
+  "version": "0.1.0",
+  "private": true,
+  "description": "SaaS-only Repository implementations (Subscription, AgentRunBilling)",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@sprintable/core-storage": "workspace:*",
+    "@supabase/supabase-js": "^2.101.1"
+  },
+  "devDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/ee/packages/storage-saas/src/SupabaseAgentRunBillingRepository.ts
+++ b/ee/packages/storage-saas/src/SupabaseAgentRunBillingRepository.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  IAgentRunBillingRepository,
+  AgentRunBilling,
+  RecordAgentRunBillingInput,
+  AgentRunBillingSummary,
+} from '@sprintable/core-storage';
+
+/**
+ * SaaS-only. Persists per-run token usage + cost to `agent_run_billing` table.
+ * OSS mode uses NullAgentRunBillingRepository (no-op record, zero summary).
+ */
+export class SupabaseAgentRunBillingRepository implements IAgentRunBillingRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async record(input: RecordAgentRunBillingInput): Promise<AgentRunBilling> {
+    const { data, error } = await this.supabase
+      .from('agent_run_billing')
+      .insert({
+        org_id: input.org_id,
+        agent_run_id: input.agent_run_id,
+        input_tokens: input.token_input,
+        output_tokens: input.token_output,
+        cost_usd: input.cost_usd,
+      })
+      .select()
+      .single();
+    if (error) throw error;
+    const row = data as Record<string, unknown>;
+    return {
+      id: (row['id'] as string) ?? '',
+      org_id: (row['org_id'] as string) ?? input.org_id,
+      agent_run_id: (row['agent_run_id'] as string) ?? input.agent_run_id,
+      token_input: Number(row['input_tokens'] ?? input.token_input),
+      token_output: Number(row['output_tokens'] ?? input.token_output),
+      cost_usd: Number(row['cost_usd'] ?? input.cost_usd),
+      created_at: (row['created_at'] as string) ?? new Date().toISOString(),
+    };
+  }
+
+  async getSummaryForOrg(orgId: string, since?: string): Promise<AgentRunBillingSummary> {
+    let query = this.supabase
+      .from('agent_run_billing')
+      .select('input_tokens, output_tokens, cost_usd')
+      .eq('org_id', orgId);
+    if (since) query = query.gte('created_at', since);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    const rows = (data ?? []) as Array<{ input_tokens: number | null; output_tokens: number | null; cost_usd: number | null }>;
+    return {
+      total_runs: rows.length,
+      total_token_input: rows.reduce((sum, r) => sum + (r.input_tokens ?? 0), 0),
+      total_token_output: rows.reduce((sum, r) => sum + (r.output_tokens ?? 0), 0),
+      total_cost_usd: rows.reduce((sum, r) => sum + (Number(r.cost_usd) || 0), 0),
+    };
+  }
+}

--- a/ee/packages/storage-saas/src/SupabaseMemberRepository.ts
+++ b/ee/packages/storage-saas/src/SupabaseMemberRepository.ts
@@ -1,0 +1,153 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface Member {
+  id: string;
+  org_id: string;
+  user_id: string | null;
+  name: string;
+  type: 'human' | 'agent';
+  avatar_url?: string | null;
+  agent_config?: Record<string, unknown> | null;
+  webhook_url?: string | null;
+  is_active: boolean;
+  deleted_at?: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpsertMemberInput {
+  org_id: string;
+  user_id?: string | null;
+  name: string;
+  type: 'human' | 'agent';
+  avatar_url?: string | null;
+  agent_config?: Record<string, unknown> | null;
+  webhook_url?: string | null;
+  is_active?: boolean;
+}
+
+export interface UpdateMemberInput {
+  name?: string;
+  avatar_url?: string | null;
+  webhook_url?: string | null;
+  is_active?: boolean;
+}
+
+export class SupabaseMemberRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async list(filters: { org_id: string; type?: 'human' | 'agent'; is_active?: boolean }): Promise<Member[]> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let query = (this.supabase as any)
+      .from('members')
+      .select('*')
+      .eq('org_id', filters.org_id)
+      .order('created_at', { ascending: true });
+
+    if (filters.type !== undefined) query = query.eq('type', filters.type);
+    if (filters.is_active !== undefined) query = query.eq('is_active', filters.is_active);
+
+    const { data, error } = await query;
+    if (error || !data) return [];
+    return data as Member[];
+  }
+
+  async getById(id: string): Promise<Member | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (this.supabase as any)
+      .from('members')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    return (data as Member | null) ?? null;
+  }
+
+  async getByUserId(userId: string, orgId: string, type?: string): Promise<Member | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let query = (this.supabase as any)
+      .from('members')
+      .select('*')
+      .eq('user_id', userId)
+      .eq('org_id', orgId);
+    if (type) query = query.eq('type', type);
+    const { data } = await query.maybeSingle();
+    return (data as Member | null) ?? null;
+  }
+
+  async upsertHuman(input: UpsertMemberInput & { user_id: string }): Promise<Member | null> {
+    // Partial unique index (WHERE type = 'human') cannot be used as ON CONFLICT target via JS client.
+    // Use explicit select → update/insert pattern with type='human' filter to prevent multi-row
+    // error when the same (user_id, org_id) exists as both human and agent records.
+    const existing = await this.getByUserId(input.user_id, input.org_id, 'human');
+
+    if (existing) {
+      return this.update(existing.id, {
+        name: input.name,
+        avatar_url: input.avatar_url,
+        is_active: input.is_active ?? true,
+      });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (this.supabase as any)
+      .from('members')
+      .insert({
+        org_id: input.org_id,
+        user_id: input.user_id,
+        name: input.name,
+        type: 'human',
+        avatar_url: input.avatar_url ?? null,
+        is_active: input.is_active ?? true,
+        updated_at: new Date().toISOString(),
+      })
+      .select('*')
+      .single();
+    if (error) return null;
+    return data as Member;
+  }
+
+  async insertAgent(input: UpsertMemberInput): Promise<Member | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (this.supabase as any)
+      .from('members')
+      .insert({
+        org_id: input.org_id,
+        user_id: input.user_id ?? null,
+        name: input.name,
+        type: 'agent',
+        agent_config: input.agent_config ?? null,
+        webhook_url: input.webhook_url ?? null,
+        is_active: input.is_active ?? true,
+        updated_at: new Date().toISOString(),
+      })
+      .select('*')
+      .single();
+    if (error) return null;
+    return data as Member;
+  }
+
+  async update(id: string, input: UpdateMemberInput): Promise<Member | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (this.supabase as any)
+      .from('members')
+      .update({ ...input, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error) return null;
+    return data as Member;
+  }
+
+  async softDelete(id: string): Promise<boolean> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (this.supabase as any)
+      .from('members')
+      .update({
+        is_active: false,
+        deleted_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', id);
+    return !error;
+  }
+}

--- a/ee/packages/storage-saas/src/SupabaseProjectPermissionsRepository.ts
+++ b/ee/packages/storage-saas/src/SupabaseProjectPermissionsRepository.ts
@@ -1,0 +1,80 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface ProjectPermission {
+  id: string;
+  member_id: string;
+  project_id: string;
+  role: 'owner' | 'admin' | 'member' | 'viewer';
+  permissions: { read: boolean; write: boolean; manage: boolean };
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpsertProjectPermissionInput {
+  member_id: string;
+  project_id: string;
+  role?: 'owner' | 'admin' | 'member' | 'viewer';
+  permissions?: Partial<{ read: boolean; write: boolean; manage: boolean }>;
+}
+
+export class SupabaseProjectPermissionsRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async upsert(input: UpsertProjectPermissionInput): Promise<ProjectPermission | null> {
+    const role = input.role ?? 'member';
+    const defaultManage = role === 'owner' || role === 'admin';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data, error } = await (this.supabase as any)
+      .from('project_permissions')
+      .upsert(
+        {
+          member_id: input.member_id,
+          project_id: input.project_id,
+          role,
+          permissions: {
+            read: true,
+            write: true,
+            manage: defaultManage,
+            ...input.permissions,
+          },
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'member_id,project_id', ignoreDuplicates: false },
+      )
+      .select('*')
+      .single();
+    if (error) return null;
+    return data as ProjectPermission;
+  }
+
+  async get(memberId: string, projectId: string): Promise<ProjectPermission | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data } = await (this.supabase as any)
+      .from('project_permissions')
+      .select('*')
+      .eq('member_id', memberId)
+      .eq('project_id', projectId)
+      .maybeSingle();
+    return (data as ProjectPermission | null) ?? null;
+  }
+
+  async hasPermission(
+    memberId: string,
+    projectId: string,
+    permission: 'read' | 'write' | 'manage',
+  ): Promise<boolean> {
+    const pp = await this.get(memberId, projectId);
+    if (!pp) return false;
+    return pp.permissions[permission] === true;
+  }
+
+  async delete(memberId: string, projectId: string): Promise<boolean> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { error } = await (this.supabase as any)
+      .from('project_permissions')
+      .delete()
+      .eq('member_id', memberId)
+      .eq('project_id', projectId);
+    return !error;
+  }
+}

--- a/ee/packages/storage-saas/src/SupabaseSubscriptionRepository.ts
+++ b/ee/packages/storage-saas/src/SupabaseSubscriptionRepository.ts
@@ -1,0 +1,59 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  ISubscriptionRepository,
+  Subscription,
+  UpdateSubscriptionInput,
+} from '@sprintable/core-storage';
+
+/**
+ * SaaS-only. Backed by `subscriptions` table in the multi-tenant Supabase project.
+ * OSS mode uses NullSubscriptionRepository (returns plan:'oss') — this impl
+ * is only reachable via factory when OSS_MODE != 'true' and sprintable-saas
+ * is composed into the build (submodule/overlay).
+ */
+export class SupabaseSubscriptionRepository implements ISubscriptionRepository {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async getForOrg(orgId: string): Promise<Subscription | null> {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .select('*')
+      .eq('org_id', orgId)
+      .maybeSingle();
+    if (error) throw error;
+    if (!data) return null;
+    const row = data as Record<string, unknown>;
+    return {
+      id: (row['id'] as string) ?? `sub-${orgId}`,
+      org_id: orgId,
+      plan: (row['tier_id'] as string) ?? 'free',
+      status: (row['status'] as string) ?? 'active',
+      current_period_start: (row['current_period_start'] as string | null) ?? null,
+      current_period_end: (row['current_period_end'] as string | null) ?? null,
+      cancel_at_period_end: Boolean(row['cancel_at_period_end'] ?? row['canceled_at']),
+      metadata: (row['metadata'] as Record<string, unknown> | null) ?? null,
+      created_at: (row['created_at'] as string) ?? '1970-01-01T00:00:00.000Z',
+      updated_at: (row['updated_at'] as string) ?? '1970-01-01T00:00:00.000Z',
+    };
+  }
+
+  async update(orgId: string, input: UpdateSubscriptionInput): Promise<Subscription> {
+    const patch: Record<string, unknown> = {};
+    if (input.plan !== undefined) patch['tier_id'] = input.plan;
+    if (input.status !== undefined) patch['status'] = input.status;
+    if (input.current_period_start !== undefined) patch['current_period_start'] = input.current_period_start;
+    if (input.current_period_end !== undefined) patch['current_period_end'] = input.current_period_end;
+    if (input.cancel_at_period_end !== undefined) patch['canceled_at'] = input.cancel_at_period_end ? new Date().toISOString() : null;
+    if (input.metadata !== undefined) patch['metadata'] = input.metadata;
+
+    const { error } = await this.supabase
+      .from('subscriptions')
+      .update(patch)
+      .eq('org_id', orgId);
+    if (error) throw error;
+
+    const refreshed = await this.getForOrg(orgId);
+    if (!refreshed) throw new Error(`Subscription not found after update: ${orgId}`);
+    return refreshed;
+  }
+}

--- a/ee/packages/storage-saas/src/index.ts
+++ b/ee/packages/storage-saas/src/index.ts
@@ -1,0 +1,7 @@
+export { SupabaseSubscriptionRepository } from './SupabaseSubscriptionRepository';
+export { SupabaseAgentRunBillingRepository } from './SupabaseAgentRunBillingRepository';
+export { SupabaseMemberRepository } from './SupabaseMemberRepository';
+export type { Member, UpsertMemberInput, UpdateMemberInput } from './SupabaseMemberRepository';
+export { SupabaseProjectPermissionsRepository } from './SupabaseProjectPermissionsRepository';
+export type { ProjectPermission, UpsertProjectPermissionInput } from './SupabaseProjectPermissionsRepository';
+export type * from './workflow-contract';

--- a/ee/packages/storage-saas/src/workflow-contract.ts
+++ b/ee/packages/storage-saas/src/workflow-contract.ts
@@ -1,0 +1,140 @@
+/**
+ * E-WORKFLOW-CONTRACT — 원자 조건 타입 세트
+ *
+ * 유한한 원자 조건 타입으로 무한한 계약을 표현한다.
+ * escape hatch(custom_fn) 없음. 모든 조건은 순수하다(부작용 없음).
+ *
+ * 조합: AllOf(AND) / AnyOf(OR) / NoneOf(NOT) 를 통해 복합 gate를 구성한다.
+ * definition(jsonb) 구조:
+ *   { states, initial_state, transitions: [{ from, to, on_tool, gate }] }
+ */
+
+// ─── Entity / Caller references ───────────────────────────────────────────────
+
+/** 내장 PM 엔티티 종류 */
+export type KnownEntityType = 'story' | 'sprint' | 'epic' | 'task' | 'document' | 'retro_session';
+
+/**
+ * 상태 머신이 평가할 엔티티 종류.
+ * KnownEntityType 외에 커스텀 도메인(order, article, candidate 등)을 string으로 허용한다. (AC1, AC2)
+ */
+export type WorkflowEntityType = KnownEntityType | (string & {});
+
+// ─── Atomic condition types (20종) ────────────────────────────────────────────
+
+/** field가 존재하는지(null/undefined가 아닌지) */
+export interface CondFieldExists    { type: 'field_exists';    entity: WorkflowEntityType; field: string }
+/** field가 비어있지 않은지 (string: length>0, array: length>0, number: defined) */
+export interface CondFieldNotEmpty  { type: 'field_not_empty'; entity: WorkflowEntityType; field: string }
+/** field 값이 특정 값과 같은지 */
+export interface CondFieldEquals    { type: 'field_equals';    entity: WorkflowEntityType; field: string; value: string | number | boolean }
+/** field 값이 특정 값과 다른지 */
+export interface CondFieldNotEquals { type: 'field_not_equals'; entity: WorkflowEntityType; field: string; value: string | number | boolean }
+/** field 값이 values 목록 안에 있는지 */
+export interface CondFieldIn        { type: 'field_in';        entity: WorkflowEntityType; field: string; values: Array<string | number> }
+/** array field의 원소 수가 n 이상인지 */
+export interface CondFieldMinCount  { type: 'field_min_count'; entity: WorkflowEntityType; field: string; n: number }
+/** array field의 원소 수가 n 이하인지 */
+export interface CondFieldMaxCount  { type: 'field_max_count'; entity: WorkflowEntityType; field: string; n: number }
+/** field 문자열이 정규식에 매칭되는지 */
+export interface CondFieldMatchesRegex { type: 'field_matches_regex'; entity: WorkflowEntityType; field: string; pattern: string }
+/** boolean field가 true인지 */
+export interface CondBoolIsTrue     { type: 'bool_is_true';    entity: WorkflowEntityType; field: string }
+/** boolean field가 false인지 */
+export interface CondBoolIsFalse    { type: 'bool_is_false';   entity: WorkflowEntityType; field: string }
+/** 엔티티의 status가 특정 값과 같은지 */
+export interface CondStatusEquals   { type: 'status_equals';   entity: WorkflowEntityType; status: string }
+/** 엔티티의 status가 statuses 목록 안에 있는지 */
+export interface CondStatusIn       { type: 'status_in';       entity: WorkflowEntityType; statuses: string[] }
+/** 호출자의 role이 특정 role인지 */
+export interface CondRoleIs         { type: 'role_is';         caller: 'actor' | 'assignee' | 'owner'; role: string }
+/** 호출자의 role이 roles 목록 안에 있는지 */
+export interface CondRoleIn         { type: 'role_in';         caller: 'actor' | 'assignee' | 'owner'; roles: string[] }
+/** since_event로부터 duration이 경과했는지 (ISO 8601 duration: "PT1H", "P7D") */
+export interface CondTimeElapsed    { type: 'time_elapsed';    since_event: string; duration: string }
+/** entity.field 날짜가 deadline(ISO datetime or duration) 이전인지 */
+export interface CondTimeBefore     { type: 'time_before';     entity: WorkflowEntityType; field: string; deadline: string }
+/** entity.field가 참조하는 외부 엔티티가 유효한지 (존재 + 삭제되지 않음) */
+export interface CondReferenceValid { type: 'reference_valid'; entity: WorkflowEntityType; field: string }
+/** entity를 filter 조건으로 조회했을 때 count >= n */
+export interface CondCountGte       { type: 'count_gte';       entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+/** entity를 filter 조건으로 조회했을 때 count <= n */
+export interface CondCountLte       { type: 'count_lte';       entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+/** entity를 filter 조건으로 조회했을 때 count === n */
+export interface CondCountEquals    { type: 'count_equals';    entity: WorkflowEntityType; filter: Record<string, unknown>; n: number }
+
+/** 20종 원자 조건 Union */
+export type AtomicCondition =
+  | CondFieldExists | CondFieldNotEmpty | CondFieldEquals | CondFieldNotEquals | CondFieldIn
+  | CondFieldMinCount | CondFieldMaxCount | CondFieldMatchesRegex
+  | CondBoolIsTrue | CondBoolIsFalse
+  | CondStatusEquals | CondStatusIn
+  | CondRoleIs | CondRoleIn
+  | CondTimeElapsed | CondTimeBefore
+  | CondReferenceValid
+  | CondCountGte | CondCountLte | CondCountEquals;
+
+// ─── Composite gate (AND / OR / NOT) ──────────────────────────────────────────
+
+export type GateExpression =
+  | AtomicCondition
+  | { type: 'all_of'; conditions: GateExpression[] }   // AND
+  | { type: 'any_of'; conditions: GateExpression[] }   // OR
+  | { type: 'none_of'; conditions: GateExpression[] }; // NOT (none must be true)
+
+// ─── Contract definition (jsonb) ──────────────────────────────────────────────
+
+export interface WorkflowTransition {
+  from: string;
+  to: string;
+  on_tool: string;       // MCP 도구 이름
+  gate?: GateExpression; // 전환 허용 조건 (없으면 무조건 허용)
+}
+
+export interface WorkflowContractDefinition {
+  states: string[];
+  initial_state: string;
+  transitions: WorkflowTransition[];
+  terminal_states?: string[];  // 명시적 종료 상태. 없으면 전환 없는 상태가 deadlock으로 감지됨
+}
+
+// ─── DB record shapes ──────────────────────────────────────────────────────────
+
+export type WorkflowMode = 'evaluate' | 'enforce';
+export type WorkflowInstanceStatus = 'active' | 'completed' | 'cancelled';
+
+export interface WorkflowContractRecord {
+  id: string;
+  org_id: string;
+  name: string;
+  version: number;
+  mode: WorkflowMode;
+  definition: WorkflowContractDefinition;
+  entity_type: WorkflowEntityType;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowInstanceRecord {
+  id: string;
+  contract_id: string;
+  entity_id: string;
+  current_state: string;
+  context: Record<string, unknown>;
+  status: WorkflowInstanceStatus;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkflowEventRecord {
+  id: string;
+  instance_id: string;
+  event_type: string;
+  from_state: string | null;
+  to_state: string | null;
+  actor_id: string | null;
+  tool_name: string | null;
+  details: Record<string, unknown>;
+  created_at: string;
+}

--- a/ee/packages/storage-saas/tsconfig.json
+++ b/ee/packages/storage-saas/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- `ee/apps/web/src/instrumentation.ts` — SaaS 버전 (dotenv 로드 + `registerSaasRepositories`)
- `ee/apps/web/src/lib/storage/saas-bootstrap.ts` — Supabase Repository 등록 bootstrap
- `ee/packages/storage-saas/` — `@moonklabs/storage-saas` (8파일, `@sprintable/core-storage` 의존)
- `ee/packages/mcp-server-saas/` — `@moonklabs/mcp-server-saas` (8파일)
- `apps/web/tsconfig.json` — `@moonklabs/storage-saas`, `@moonklabs/mcp-server-saas` 경로 alias 추가

## 아키텍처 노트

- `pnpm-workspace.yaml`의 `ee/packages/*` 등록(S1)으로 workspace 해석 완료
- OSS 빌드는 `ee/` 패키지를 import하지 않으므로 영향 0건
- `amplify.yml` preBuild overlay 제거는 S2 범위 외 (GCP 전환 시점)

## Test plan

- [ ] TypeScript 에러 없음 (기존 react-email 제외)
- [ ] `ee/packages/storage-saas/` 및 `ee/packages/mcp-server-saas/` 파일 확인
- [ ] `ee/apps/web/src/` 2파일 (`instrumentation.ts`, `lib/storage/saas-bootstrap.ts`) 확인
- [ ] `@moonklabs/storage-saas` / `@moonklabs/mcp-server-saas` tsconfig paths 정상 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)