### PR TITLE
feat(arch): E-ARCH-MONOREPO S3 — Billing/Subscription 코드 ee/ 분리

### DIFF
--- a/ee/apps/web/src/app/(authenticated)/settings/billing/page.tsx
+++ b/ee/apps/web/src/app/(authenticated)/settings/billing/page.tsx
@@ -1,0 +1,52 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { TIER_QUOTAS } from '@/lib/entitlement';
+import { BillingSection } from '@/components/settings/billing-section';
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export default async function BillingPage() {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login');
+
+  const me = await getMyTeamMember(supabase, user);
+  if (!me) redirect('/login');
+
+  const [{ data: sub }, { data: usageRow }] = await Promise.all([
+    supabase
+      .from('org_subscriptions')
+      .select('tier, status')
+      .eq('org_id', me.org_id)
+      .maybeSingle(),
+    supabase
+      .from('org_usage')
+      .select('stories, memos, api_calls')
+      .eq('org_id', me.org_id)
+      .eq('period', currentPeriod())
+      .maybeSingle(),
+  ]);
+
+  const tier = (!sub || sub.status === 'expired' || sub.status === 'past_due') ? 'free' : (sub.tier ?? 'free');
+  const quotas = TIER_QUOTAS[tier] ?? TIER_QUOTAS['free']!;
+  const usage: Record<string, number> = {
+    stories: usageRow?.stories ?? 0,
+    memos: usageRow?.memos ?? 0,
+    api_calls: usageRow?.api_calls ?? 0,
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6">
+      <h1 className="mb-6 text-xl font-semibold">Billing</h1>
+      <BillingSection
+        tier={tier}
+        usage={usage}
+        quotas={quotas as unknown as Record<string, number>}
+      />
+    </div>
+  );
+}

--- a/ee/apps/web/src/app/api/billing/cancel/route.test.ts
+++ b/ee/apps/web/src/app/api/billing/cancel/route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createSupabaseServerClient, getMyTeamMember, requireOrgAdmin } = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+
+import { POST } from './route';
+
+function createSupabaseStub() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+  };
+}
+
+describe('POST /api/billing/cancel', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+  });
+
+  it('returns validation errors for malformed payloads', async () => {
+    createSupabaseServerClient.mockResolvedValue(createSupabaseStub());
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+
+    const response = await POST(new Request('http://localhost/api/billing/cancel', {
+      method: 'POST',
+      body: JSON.stringify({ immediately: 'yes' }),
+      headers: { 'Content-Type': 'application/json' },
+    }));
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error.code).toBe('VALIDATION_FAILED');
+  });
+});

--- a/ee/apps/web/src/app/api/billing/cancel/route.ts
+++ b/ee/apps/web/src/app/api/billing/cancel/route.ts
@@ -1,0 +1,55 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { getPaymentAdapter } from '@/lib/payment/factory';
+import { SubscriptionService } from '@/services/subscription';
+import { z } from 'zod';
+import { parseBody } from '@sprintable/shared';
+
+const cancelSchema = z.object({
+  immediately: z.boolean().optional().default(false),
+});
+
+/**
+ * POST /api/billing/cancel
+ * AC5: 구독 취소 (즉시 vs 기간 만료 후)
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const parsed = await parseBody(request, cancelSchema);
+    if (!parsed.success) return parsed.response;
+
+    const { data: sub } = await supabase
+      .from('subscriptions')
+      .select('provider_subscription_id, payment_provider, status')
+      .eq('org_id', me.org_id)
+      .single();
+
+    if (!sub?.provider_subscription_id) return ApiErrors.badRequest('No active subscription');
+
+    // PG 취소 요청 (AC5: 즉시 vs 기간만료 분기)
+    const adapter = getPaymentAdapter(sub.payment_provider as 'paddle' | 'toss');
+    await adapter.cancelSubscription(sub.provider_subscription_id, parsed.data.immediately);
+
+    // DB 업데이트
+    const service = new SubscriptionService(supabase);
+    const result = await service.cancelSubscription(me.org_id);
+
+    // 즉시 취소 시 grace period 없이 바로 Free로
+    if (parsed.data.immediately) {
+      await service.downgradeToFree(me.org_id);
+    }
+
+    return apiSuccess(result);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/billing/portal/route.ts
+++ b/ee/apps/web/src/app/api/billing/portal/route.ts
@@ -1,0 +1,46 @@
+import { Polar } from '@polar-sh/sdk';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+
+// POST /api/billing/portal — create a Polar Customer Portal session URL
+export async function POST() {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    const { data: sub } = await supabase
+      .from('org_subscriptions')
+      .select('polar_customer_id')
+      .eq('org_id', me.org_id)
+      .maybeSingle();
+
+    if (!sub?.polar_customer_id) {
+      return ApiErrors.badRequest('No active Polar subscription found');
+    }
+
+    const isSandbox = (process.env['POLAR_SERVER_URL'] ?? '').includes('sandbox');
+    const polar = new Polar({
+      accessToken: process.env['POLAR_ACCESS_TOKEN'],
+      server: isSandbox ? 'sandbox' : 'production',
+    });
+
+    const session = await polar.customerSessions.create({
+      customerId: sub.polar_customer_id,
+    });
+
+    const portalBase = isSandbox
+      ? 'https://sandbox.polar.sh'
+      : 'https://polar.sh';
+    const url = `${portalBase}/login?customer_session_token=${session.token}`;
+
+    return apiSuccess({ url });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/billing/route.ts
+++ b/ee/apps/web/src/app/api/billing/route.ts
@@ -1,0 +1,118 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { getPaymentAdapter } from '@/lib/payment/factory';
+
+/** admin 여부 확인 (soft — 에러 안 던짐) */
+async function isOrgAdmin(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, orgId: string): Promise<boolean> {
+  const { data } = await supabase
+    .from('org_members')
+    .select('role')
+    .eq('org_id', orgId)
+    .eq('user_id', (await supabase.auth.getUser()).data.user?.id ?? '')
+    .single();
+  return data?.role === 'admin' || data?.role === 'owner';
+}
+
+interface PaddleTransaction {
+  id: string;
+  status: string;
+  created_at: string;
+  billed_at: string | null;
+  details: {
+    totals: { grand_total: string; currency_code: string };
+  };
+  invoice_url?: string;
+}
+
+async function fetchPaddleInvoices(providerSubId: string, apiKey: string, sandbox: boolean): Promise<PaddleTransaction[]> {
+  const base = sandbox ? 'https://sandbox-api.paddle.com' : 'https://api.paddle.com';
+  const res = await fetch(`${base}/transactions?subscription_id=${providerSubId}&per_page=20`, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) return [];
+  const json = await res.json() as { data: PaddleTransaction[] };
+  return json.data ?? [];
+}
+
+/**
+ * GET /api/billing
+ * AC1: 현재 플랜, 다음 결제일, 결제 수단
+ * AC2: 인보이스 목록
+ * AC7: Grandfathering 표시
+ */
+export async function GET() {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    // 구독 조회
+    const { data: sub } = await supabase
+      .from('subscriptions')
+      .select('tier_id, status, current_period_end, payment_provider, provider_subscription_id, offering_snapshot_id')
+      .eq('org_id', me.org_id)
+      .maybeSingle();
+
+    // 현재 tier
+    const { data: tier } = sub?.tier_id
+      ? await supabase.from('plan_tiers').select('id, name, price_monthly, price_yearly').eq('id', sub.tier_id).single()
+      : { data: null };
+
+    // AC7: grandfathering 여부
+    let grandfathered = false;
+    let snapshotFeatures: Record<string, unknown> | null = null;
+    if (sub?.offering_snapshot_id) {
+      const { data: snap } = await supabase
+        .from('plan_offering_snapshots')
+        .select('features, version')
+        .eq('id', sub.offering_snapshot_id)
+        .single();
+      if (snap) {
+        grandfathered = true;
+        snapshotFeatures = snap.features as Record<string, unknown>;
+      }
+    }
+
+    // AC2: 인보이스 목록 (Paddle API)
+    let invoices: PaddleTransaction[] = [];
+    if (sub?.provider_subscription_id && sub.payment_provider === 'paddle') {
+      const apiKey = process.env.PADDLE_API_KEY;
+      if (apiKey) {
+        const sandbox = process.env.PAYMENT_SANDBOX === 'true';
+        invoices = await fetchPaddleInvoices(sub.provider_subscription_id, apiKey, sandbox);
+      }
+    }
+
+    // AC4: 결제 수단 변경 URL (admin only — non-admin 우회 방지)
+    let paymentMethodUrl: string | null = null;
+    const admin = await isOrgAdmin(supabase, me.org_id);
+    if (admin && sub?.provider_subscription_id && sub.payment_provider === 'paddle') {
+      try {
+        const adapter = getPaymentAdapter('paddle');
+        const portal = await adapter.getPortalUrl(sub.provider_subscription_id);
+        paymentMethodUrl = portal.portalUrl;
+      } catch { /* ignore */ }
+    }
+
+    return apiSuccess({
+      subscription: sub,
+      tier,
+      grandfathered,
+      snapshotFeatures,
+      invoices: invoices.map(tx => ({
+        id: tx.id,
+        status: tx.status,
+        billedAt: tx.billed_at ?? tx.created_at,
+        amount: tx.details.totals.grand_total,
+        currency: tx.details.totals.currency_code,
+        invoiceUrl: tx.invoice_url ?? null,
+      })),
+      paymentMethodUrl,
+    });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/checkout/polar/route.ts
+++ b/ee/apps/web/src/app/api/checkout/polar/route.ts
@@ -1,0 +1,45 @@
+import { Polar } from '@polar-sh/sdk';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { z } from 'zod';
+
+const bodySchema = z.object({
+  product_id: z.string().min(1),
+});
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const body = await request.json().catch(() => null);
+    const parsed = bodySchema.safeParse(body);
+    if (!parsed.success) return ApiErrors.badRequest('Invalid product_id');
+
+    const { data: orgMember } = await supabase
+      .from('org_members')
+      .select('org_id')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    const polar = new Polar({
+      accessToken: process.env['POLAR_ACCESS_TOKEN'] ?? '',
+      serverURL: process.env['POLAR_SERVER_URL'] ?? 'https://api.polar.sh',
+    });
+
+    const appUrl = process.env['NEXT_PUBLIC_APP_URL'] ?? '';
+    const checkout = await polar.checkouts.create({
+      products: [parsed.data.product_id],
+      successUrl: `${appUrl}/upgrade/success`,
+      embedOrigin: appUrl,
+      customerEmail: user.email ?? undefined,
+      metadata: orgMember?.org_id ? { org_id: orgMember.org_id } : undefined,
+    });
+
+    return apiSuccess({ url: checkout.url });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/checkout/route.ts
+++ b/ee/apps/web/src/app/api/checkout/route.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { getPaymentAdapter } from '@/lib/payment/factory';
+import { SubscriptionService } from '@/services/subscription';
+import { parseBody } from '@sprintable/shared';
+
+const checkoutSchema = z.object({
+  priceId: z.string().min(1),
+  successUrl: z.string().url(),
+  cancelUrl: z.string().url(),
+});
+
+/**
+ * POST /api/checkout
+ * AC5: 체크아웃 URL 생성
+ * AC8: Zod 검증
+ * AC9: 환경변수 기반 PG 선택
+ * AC10: sandbox 지원 (PAYMENT_SANDBOX env)
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const parsed = await parseBody(request, checkoutSchema);
+    if (!parsed.success) return parsed.response;
+
+    // AC5: priceId ↔ tierId 서버 사이드 검증 (권한 상승 방지)
+    // price_tier_map에서 priceId로 매핑된 tierId 조회 → 클라이언트 tierId 무시
+    const adapter = getPaymentAdapter();
+    const { data: mapping } = await supabase
+      .from('price_tier_map')
+      .select('tier_id')
+      .eq('provider', adapter.provider)
+      .eq('price_id', parsed.data.priceId)
+      .single();
+
+    if (!mapping) {
+      return ApiErrors.badRequest('Unknown priceId — not mapped to any tier');
+    }
+
+    const serverTierId = mapping.tier_id as string;
+
+    const result = await adapter.createCheckout({
+      orgId: me.org_id,
+      tierId: serverTierId,  // 서버에서 매핑된 tier 사용 (클라이언트 tierId 무시)
+      priceId: parsed.data.priceId,
+      customerEmail: user.email ?? '',
+      successUrl: parsed.data.successUrl,
+      cancelUrl: parsed.data.cancelUrl,
+    });
+
+    const subscriptionService = new SubscriptionService(supabase);
+    await subscriptionService.recordCheckoutSession({
+      orgId: me.org_id,
+      tierId: serverTierId,
+      provider: adapter.provider,
+      priceId: parsed.data.priceId,
+      providerTransactionId: result.providerTransactionId,
+      checkoutUrl: result.checkoutUrl,
+    });
+
+    return apiSuccess(result);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/subscription/portal/route.ts
+++ b/ee/apps/web/src/app/api/subscription/portal/route.ts
@@ -1,0 +1,33 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { getPaymentAdapter } from '@/lib/payment/factory';
+
+/** POST /api/subscription/portal — AC7: Paddle customer portal URL */
+export async function POST() {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const { data: sub } = await supabase
+      .from('subscriptions')
+      .select('provider_subscription_id, payment_provider')
+      .eq('org_id', me.org_id)
+      .single();
+
+    if (!sub?.provider_subscription_id) {
+      return ApiErrors.badRequest('No active paid subscription');
+    }
+
+    const adapter = getPaymentAdapter(sub.payment_provider as 'paddle' | 'toss');
+    const result = await adapter.getPortalUrl(sub.provider_subscription_id);
+    return apiSuccess(result);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/alerts/route.test.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/alerts/route.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createSupabaseServerClient,
+  getMyTeamMember,
+  requireOrgAdmin,
+  getResolvedSettings,
+  getMonthlyUsageSnapshot,
+  listMonthlyBillingLimitAlerts,
+} = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  getResolvedSettings: vi.fn(),
+  getMonthlyUsageSnapshot: vi.fn(),
+  listMonthlyBillingLimitAlerts: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+vi.mock('@/services/billing-limit-enforcer', () => ({
+  BillingLimitEnforcer: class {
+    getResolvedSettings = getResolvedSettings;
+    getMonthlyUsageSnapshot = getMonthlyUsageSnapshot;
+  },
+}));
+vi.mock('@/services/monthly-agent-usage-dashboard', () => ({
+  listMonthlyBillingLimitAlerts,
+}));
+
+import { GET } from './route';
+
+function createSupabaseStub() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+  };
+}
+
+describe('GET /api/v1/billing/agent-usage/alerts', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-12T08:00:00Z'));
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+    getResolvedSettings.mockReset();
+    getMonthlyUsageSnapshot.mockReset();
+    listMonthlyBillingLimitAlerts.mockReset();
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+  });
+
+  it('returns alert summary and recent alert records', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    getResolvedSettings.mockResolvedValue({
+      monthlyCapCents: 10000,
+      dailyCapCents: null,
+      alertThresholdPct: 80,
+      source: 'explicit',
+      tierName: 'pro',
+    });
+    getMonthlyUsageSnapshot.mockResolvedValue({
+      usageMonth: '2026-04-01',
+      monthToDateCostCents: 8100,
+    });
+    listMonthlyBillingLimitAlerts.mockResolvedValue([
+      {
+        alert_type: 'threshold_80',
+        threshold_pct: 80,
+        usage_month: '2026-04-01',
+        created_at: '2026-04-12T07:00:00.000Z',
+      },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/alerts?month=2026-04'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      org_id: 'org-1',
+      usage_month: '2026-04-01',
+      scope_type: 'org',
+      scope_label: 'Organization-wide budget alerts',
+      project_filter_applies: false,
+      month_to_date_cost_cents: 8100,
+      monthly_cap_cents: 10000,
+      threshold_amount_cents: 8000,
+      threshold_reached: true,
+      monthly_cap_exceeded: false,
+    });
+    expect(body.data.alerts).toEqual([
+      expect.objectContaining({
+        alert_type: 'threshold_80',
+        kind: 'threshold',
+        label: '80% threshold reached',
+      }),
+    ]);
+    expect(getMonthlyUsageSnapshot).toHaveBeenCalledWith('org-1', '2026-04');
+    expect(listMonthlyBillingLimitAlerts).toHaveBeenCalledWith(supabase, {
+      orgId: 'org-1',
+      usageMonth: '2026-04-01',
+    });
+  });
+
+  it('keeps the alert month basis aligned with the billing ledger snapshot', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    getResolvedSettings.mockResolvedValue({
+      monthlyCapCents: 10000,
+      dailyCapCents: null,
+      alertThresholdPct: 80,
+      source: 'explicit',
+      tierName: 'pro',
+    });
+    getMonthlyUsageSnapshot.mockResolvedValue({
+      usageMonth: '2026-04-01',
+      monthToDateCostCents: 0,
+    });
+    listMonthlyBillingLimitAlerts.mockResolvedValue([]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/alerts?month=2026-04'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      usage_month: '2026-04-01',
+      month_to_date_cost_cents: 0,
+      threshold_reached: false,
+      monthly_cap_exceeded: false,
+    });
+  });
+
+  it('rejects invalid month formats', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/alerts?month=2026/04'));
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/alerts/route.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/alerts/route.ts
@@ -1,0 +1,81 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { BillingLimitEnforcer } from '@/services/billing-limit-enforcer';
+import { validateUsageMonth } from '@/services/monthly-agent-usage';
+import { listMonthlyBillingLimitAlerts } from '@/services/monthly-agent-usage-dashboard';
+
+function presentAlertLabel(alertType: string, thresholdPct: number | null) {
+  if (alertType.startsWith('threshold_')) {
+    return {
+      kind: 'threshold',
+      label: `${thresholdPct ?? 0}% threshold reached`,
+    };
+  }
+
+  if (alertType === 'monthly_cap_exceeded') {
+    return {
+      kind: 'cap_exceeded',
+      label: 'Monthly cap exceeded',
+    };
+  }
+
+  return {
+    kind: 'other',
+    label: alertType,
+  };
+}
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const url = new URL(request.url);
+    const monthParam = url.searchParams.get('month');
+    const monthValidation = monthParam ? validateUsageMonth(monthParam) : null;
+    if (monthValidation && !monthValidation.ok) return ApiErrors.badRequest(monthValidation.message);
+
+    const enforcer = new BillingLimitEnforcer(supabase as never);
+    const settings = await enforcer.getResolvedSettings(me.org_id);
+    const selectedMonth = monthValidation?.month ?? new Date().toISOString().slice(0, 7);
+    const usage = await enforcer.getMonthlyUsageSnapshot(me.org_id, selectedMonth);
+    const alerts = await listMonthlyBillingLimitAlerts(supabase as never, {
+      orgId: me.org_id,
+      usageMonth: usage.usageMonth,
+    });
+
+    const thresholdAmount = settings.monthlyCapCents == null
+      ? null
+      : Math.ceil((settings.monthlyCapCents * settings.alertThresholdPct) / 100);
+
+    return apiSuccess({
+      org_id: me.org_id,
+      usage_month: usage.usageMonth,
+      scope_type: 'org',
+      scope_label: 'Organization-wide budget alerts',
+      project_filter_applies: false,
+      month_to_date_cost_cents: usage.monthToDateCostCents,
+      monthly_cap_cents: settings.monthlyCapCents,
+      monthly_cap_unlimited: settings.monthlyCapCents == null,
+      alert_threshold_pct: settings.alertThresholdPct,
+      threshold_amount_cents: thresholdAmount,
+      threshold_reached: thresholdAmount == null ? false : usage.monthToDateCostCents >= thresholdAmount,
+      monthly_cap_exceeded: settings.monthlyCapCents == null ? false : usage.monthToDateCostCents > settings.monthlyCapCents,
+      alerts: alerts.map((alert) => ({
+        ...alert,
+        ...presentAlertLabel(alert.alert_type, alert.threshold_pct),
+      })),
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/breakdown/route.test.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/breakdown/route.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createSupabaseServerClient, getMyTeamMember, requireOrgAdmin, loadMonthlyAgentUsageRows, loadMonthlyUsageLookupMaps, ensureUsageProjectInOrg } = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  loadMonthlyAgentUsageRows: vi.fn(),
+  loadMonthlyUsageLookupMaps: vi.fn(),
+  ensureUsageProjectInOrg: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+vi.mock('@/services/monthly-agent-usage-dashboard', () => ({
+  loadMonthlyAgentUsageRows,
+  loadMonthlyUsageLookupMaps,
+  ensureUsageProjectInOrg,
+}));
+
+import { GET } from './route';
+
+function createSupabaseStub() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+  };
+}
+
+describe('GET /api/v1/billing/agent-usage/breakdown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-07T10:00:00Z'));
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+    loadMonthlyAgentUsageRows.mockReset();
+    loadMonthlyUsageLookupMaps.mockReset();
+    ensureUsageProjectInOrg.mockReset();
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1', project_id: 'project-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+    ensureUsageProjectInOrg.mockResolvedValue(null);
+    loadMonthlyUsageLookupMaps.mockResolvedValue({
+      projectNameById: { 'project-1': 'Apollo' },
+      agentNameById: { 'agent-1': 'Sentinel' },
+    });
+  });
+
+  it('returns agent-level breakdown rows', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 37800000, input_tokens: 10000, output_tokens: 5000, computed_cost_cents: 2300 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/breakdown?org_id=org-1&month=2026-04&group_by=agent'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.rows).toEqual([
+      expect.objectContaining({ key: 'agent-1', label: 'Sentinel', total_hours: 10.5, total_tokens: 15000, total_cost_cents: 2300, run_count: 1 }),
+    ]);
+  });
+
+  it('returns model-level breakdown rows', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 29520000, input_tokens: 7000, output_tokens: 2000, computed_cost_cents: 1200 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/breakdown?org_id=org-1&month=2026-04&group_by=model'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.rows[0]).toMatchObject({ key: 'gpt-4o-mini', label: 'gpt-4o-mini' });
+  });
+
+  it('returns project-level breakdown rows when all projects are selected', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 3600000, input_tokens: 100, output_tokens: 20, computed_cost_cents: 300 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/breakdown?org_id=org-1&month=2026-04&group_by=project'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.rows[0]).toMatchObject({ key: 'project-1', label: 'Apollo', total_cost_cents: 300 });
+  });
+
+  it('rejects invalid breakdown group values', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/breakdown?org_id=org-1&month=2026-04&group_by=team'));
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects cross-org breakdown lookups', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/breakdown?org_id=org-2&month=2026-04&group_by=agent'));
+    expect(response.status).toBe(403);
+    expect(loadMonthlyAgentUsageRows).not.toHaveBeenCalled();
+  });
+});

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/breakdown/route.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/breakdown/route.ts
@@ -1,0 +1,65 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { buildMonthlyUsageBreakdownRows, type MonthlyAgentUsageBreakdownGroup, validateUsageMonth } from '@/services/monthly-agent-usage';
+import { ensureUsageProjectInOrg, loadMonthlyAgentUsageRows, loadMonthlyUsageLookupMaps } from '@/services/monthly-agent-usage-dashboard';
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    const url = new URL(request.url);
+    const orgId = url.searchParams.get('org_id');
+    if (!orgId) return ApiErrors.badRequest('org_id is required');
+    if (orgId !== me.org_id) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const monthValidation = validateUsageMonth(url.searchParams.get('month'));
+    if (!monthValidation.ok) return ApiErrors.badRequest(monthValidation.message);
+
+    const groupBy = url.searchParams.get('group_by');
+    if (groupBy !== 'project' && groupBy !== 'agent' && groupBy !== 'model') {
+      return ApiErrors.badRequest('group_by must be project, agent, or model');
+    }
+
+    const projectId = url.searchParams.get('project_id');
+    const project = projectId
+      ? await ensureUsageProjectInOrg(supabase as never, orgId, projectId).catch((error: unknown) => {
+        if (error instanceof Error && error.message === 'project_id must belong to the same organization') {
+          return '__INVALID_PROJECT__' as const;
+        }
+        throw error;
+      })
+      : null;
+
+    if (project === '__INVALID_PROJECT__') {
+      return ApiErrors.badRequest('project_id must belong to the same organization');
+    }
+
+    const rows = await loadMonthlyAgentUsageRows(supabase as never, {
+      orgId,
+      month: monthValidation.month,
+      projectId,
+    });
+    const lookup = await loadMonthlyUsageLookupMaps(supabase as never, rows);
+
+    return apiSuccess({
+      org_id: orgId,
+      month: monthValidation.month,
+      project_id: projectId,
+      project_name: project?.name ?? null,
+      group_by: groupBy,
+      rows: buildMonthlyUsageBreakdownRows(rows, groupBy as MonthlyAgentUsageBreakdownGroup, lookup),
+    });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/export/route.test.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/export/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createSupabaseServerClient,
+  getMyTeamMember,
+  requireOrgAdmin,
+  loadMonthlyAgentUsageRows,
+  loadMonthlyUsageLookupMaps,
+  ensureUsageProjectInOrg,
+} = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  loadMonthlyAgentUsageRows: vi.fn(),
+  loadMonthlyUsageLookupMaps: vi.fn(),
+  ensureUsageProjectInOrg: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+vi.mock('@/services/monthly-agent-usage-dashboard', () => ({
+  loadMonthlyAgentUsageRows,
+  loadMonthlyUsageLookupMaps,
+  ensureUsageProjectInOrg,
+}));
+
+import { GET } from './route';
+
+function createSupabaseStub() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+  };
+}
+
+describe('GET /api/v1/billing/agent-usage/export', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-12T08:00:00Z'));
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+    loadMonthlyAgentUsageRows.mockReset();
+    loadMonthlyUsageLookupMaps.mockReset();
+    ensureUsageProjectInOrg.mockReset();
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+    ensureUsageProjectInOrg.mockResolvedValue(null);
+    loadMonthlyUsageLookupMaps.mockResolvedValue({
+      projectNameById: { 'project-1': 'Apollo' },
+      agentNameById: { 'agent-1': 'Sentinel' },
+    });
+  });
+
+  it('exports the selected breakdown as csv', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 3600000, input_tokens: 100, output_tokens: 20, computed_cost_cents: 300 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/export?month=2026-04&group_by=project'));
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toContain('text/csv');
+    expect(response.headers.get('Content-Disposition')).toContain('agent-usage-2026-04-project.csv');
+    const csv = await response.text();
+    expect(csv).toContain('month,2026-04');
+    expect(csv).toContain('project,All projects');
+    expect(csv).toContain('project-1,Apollo,1,120,300,1');
+  });
+
+  it('supports project-scoped exports', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    ensureUsageProjectInOrg.mockResolvedValue({ id: 'project-1', name: 'Apollo' });
+    loadMonthlyAgentUsageRows.mockResolvedValue([]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/export?month=2026-04&group_by=agent&project_id=project-1'));
+
+    expect(response.status).toBe(200);
+    const csv = await response.text();
+    expect(csv).toContain('project,Apollo');
+  });
+
+  it('rejects invalid breakdown group values', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage/export?month=2026-04&group_by=team'));
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/export/route.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/export/route.ts
@@ -1,0 +1,71 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import {
+  buildMonthlyUsageBreakdownRows,
+  serializeMonthlyUsageBreakdownCsv,
+  type MonthlyAgentUsageBreakdownGroup,
+  validateUsageMonth,
+} from '@/services/monthly-agent-usage';
+import { ensureUsageProjectInOrg, loadMonthlyAgentUsageRows, loadMonthlyUsageLookupMaps } from '@/services/monthly-agent-usage-dashboard';
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const url = new URL(request.url);
+    const monthValidation = validateUsageMonth(url.searchParams.get('month'));
+    if (!monthValidation.ok) return ApiErrors.badRequest(monthValidation.message);
+
+    const groupBy = url.searchParams.get('group_by');
+    if (groupBy !== 'project' && groupBy !== 'agent' && groupBy !== 'model') {
+      return ApiErrors.badRequest('group_by must be project, agent, or model');
+    }
+
+    const projectId = url.searchParams.get('project_id');
+    const project = projectId
+      ? await ensureUsageProjectInOrg(supabase as never, me.org_id, projectId).catch((error: unknown) => {
+        if (error instanceof Error && error.message === 'project_id must belong to the same organization') {
+          return '__INVALID_PROJECT__' as const;
+        }
+        throw error;
+      })
+      : null;
+
+    if (project === '__INVALID_PROJECT__') {
+      return ApiErrors.badRequest('project_id must belong to the same organization');
+    }
+
+    const rows = await loadMonthlyAgentUsageRows(supabase as never, {
+      orgId: me.org_id,
+      month: monthValidation.month,
+      projectId,
+    });
+    const lookup = await loadMonthlyUsageLookupMaps(supabase as never, rows);
+    const csv = serializeMonthlyUsageBreakdownCsv({
+      month: monthValidation.month,
+      groupBy: groupBy as MonthlyAgentUsageBreakdownGroup,
+      projectLabel: project?.name ?? 'All projects',
+      rows: buildMonthlyUsageBreakdownRows(rows, groupBy as MonthlyAgentUsageBreakdownGroup, lookup),
+    });
+
+    return new Response(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="agent-usage-${monthValidation.month}-${groupBy}.csv"`,
+      },
+    });
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/route.test.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/route.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createSupabaseServerClient, getMyTeamMember, requireOrgAdmin, loadMonthlyAgentUsageRows, ensureUsageProjectInOrg } = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  loadMonthlyAgentUsageRows: vi.fn(),
+  ensureUsageProjectInOrg: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+vi.mock('@/services/monthly-agent-usage-dashboard', () => ({
+  loadMonthlyAgentUsageRows,
+  ensureUsageProjectInOrg,
+}));
+
+import { GET } from './route';
+
+function createSupabaseStub() {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+    },
+  };
+}
+
+describe('GET /api/v1/billing/agent-usage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-07T10:00:00Z'));
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+    loadMonthlyAgentUsageRows.mockReset();
+    ensureUsageProjectInOrg.mockReset();
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1', project_id: 'project-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+    ensureUsageProjectInOrg.mockResolvedValue(null);
+  });
+
+  it('returns monthly usage totals for the requested org and month', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 3600000, input_tokens: 10000, output_tokens: 1000, computed_cost_cents: 3456 },
+      { project_id: 'project-1', agent_id: 'agent-2', model: 'gpt-4o', duration_ms: 9000000, input_tokens: 1200, output_tokens: 145, computed_cost_cents: 3333 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-1&month=2026-04'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      org_id: 'org-1',
+      month: '2026-04',
+      project_id: null,
+      project_name: null,
+      active_agents: 2,
+      total_hours: 3.5,
+      total_tokens: 12345,
+      total_cost_cents: 6789,
+    });
+    expect(loadMonthlyAgentUsageRows).toHaveBeenCalledWith(supabase, {
+      orgId: 'org-1',
+      month: '2026-04',
+      projectId: null,
+    });
+  });
+
+  it('returns zero values instead of 404 when the month has no runs', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    loadMonthlyAgentUsageRows.mockResolvedValue([]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-1&month=2026-04'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      active_agents: 0,
+      total_hours: 0,
+      total_tokens: 0,
+      total_cost_cents: 0,
+    });
+  });
+
+  it('supports project-scoped summaries', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+    ensureUsageProjectInOrg.mockResolvedValue({ id: 'project-1', name: 'Apollo' });
+    loadMonthlyAgentUsageRows.mockResolvedValue([
+      { project_id: 'project-1', agent_id: 'agent-1', model: 'gpt-4o-mini', duration_ms: 1800000, input_tokens: 100, output_tokens: 20, computed_cost_cents: 300 },
+    ]);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-1&month=2026-04&project_id=project-1'));
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      project_id: 'project-1',
+      project_name: 'Apollo',
+      total_cost_cents: 300,
+    });
+  });
+
+  it('rejects cross-org usage lookups', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-2&month=2026-04'));
+    expect(response.status).toBe(403);
+    expect(loadMonthlyAgentUsageRows).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid month formats', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-1&month=2026/04'));
+    expect(response.status).toBe(400);
+  });
+
+  it('rejects future months', async () => {
+    const supabase = createSupabaseStub();
+    createSupabaseServerClient.mockResolvedValue(supabase);
+
+    const response = await GET(new Request('http://localhost/api/v1/billing/agent-usage?org_id=org-1&month=2026-05'));
+    expect(response.status).toBe(400);
+  });
+});

--- a/ee/apps/web/src/app/api/v1/billing/agent-usage/route.ts
+++ b/ee/apps/web/src/app/api/v1/billing/agent-usage/route.ts
@@ -1,0 +1,58 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { summarizeMonthlyUsageRows, validateUsageMonth } from '@/services/monthly-agent-usage';
+import { ensureUsageProjectInOrg, loadMonthlyAgentUsageRows } from '@/services/monthly-agent-usage-dashboard';
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    const url = new URL(request.url);
+    const orgId = url.searchParams.get('org_id');
+    if (!orgId) return ApiErrors.badRequest('org_id is required');
+    if (orgId !== me.org_id) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const monthValidation = validateUsageMonth(url.searchParams.get('month'));
+    if (!monthValidation.ok) return ApiErrors.badRequest(monthValidation.message);
+
+    const projectId = url.searchParams.get('project_id');
+    const project = projectId
+      ? await ensureUsageProjectInOrg(supabase as never, orgId, projectId).catch((error: unknown) => {
+        if (error instanceof Error && error.message === 'project_id must belong to the same organization') {
+          return '__INVALID_PROJECT__' as const;
+        }
+        throw error;
+      })
+      : null;
+
+    if (project === '__INVALID_PROJECT__') {
+      return ApiErrors.badRequest('project_id must belong to the same organization');
+    }
+
+    const rows = await loadMonthlyAgentUsageRows(supabase as never, {
+      orgId,
+      month: monthValidation.month,
+      projectId,
+    });
+
+    return apiSuccess({
+      org_id: orgId,
+      month: monthValidation.month,
+      project_id: projectId,
+      project_name: project?.name ?? null,
+      ...summarizeMonthlyUsageRows(rows),
+    });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/v1/billing/limits/route.test.ts
+++ b/ee/apps/web/src/app/api/v1/billing/limits/route.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createSupabaseServerClient, getMyTeamMember, requireOrgAdmin, getResolvedSettings, getUsageSnapshot, saveSettings } = vi.hoisted(() => ({
+  createSupabaseServerClient: vi.fn(),
+  getMyTeamMember: vi.fn(),
+  requireOrgAdmin: vi.fn(),
+  getResolvedSettings: vi.fn(),
+  getUsageSnapshot: vi.fn(),
+  saveSettings: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({ createSupabaseServerClient }));
+vi.mock('@/lib/auth-helpers', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
+  return { ...actual, getMyTeamMember };
+});
+vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
+vi.mock('@/services/billing-limit-enforcer', () => ({
+  BillingLimitEnforcer: class {
+    getResolvedSettings = getResolvedSettings;
+    getUsageSnapshot = getUsageSnapshot;
+    saveSettings = saveSettings;
+  },
+}));
+
+import { GET, PUT } from './route';
+
+describe('billing limits route', () => {
+  beforeEach(() => {
+    createSupabaseServerClient.mockReset();
+    getMyTeamMember.mockReset();
+    requireOrgAdmin.mockReset();
+    getResolvedSettings.mockReset();
+    getUsageSnapshot.mockReset();
+    saveSettings.mockReset();
+
+    createSupabaseServerClient.mockResolvedValue({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
+      },
+    });
+    getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1', project_id: 'project-1' });
+    requireOrgAdmin.mockResolvedValue(undefined);
+  });
+
+  it('returns resolved billing limits for the current org', async () => {
+    getResolvedSettings.mockResolvedValue({
+      monthlyCapCents: 1000,
+      dailyCapCents: null,
+      alertThresholdPct: 80,
+      source: 'plan_default',
+      tierName: 'free',
+    });
+    getUsageSnapshot.mockResolvedValue({
+      usageMonth: '2026-04-01',
+      usageDate: '2026-04-07',
+      monthToDateCostCents: 420,
+      dayToDateCostCents: 42,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toMatchObject({
+      org_id: 'org-1',
+      monthly_cap_cents: 1000,
+      monthly_cap_unlimited: false,
+      source: 'plan_default',
+      tier_name: 'free',
+      month_to_date_cost_cents: 420,
+      day_to_date_cost_cents: 42,
+    });
+  });
+
+  it('rejects negative limits with 400 validation failure', async () => {
+    const response = await PUT(new Request('http://localhost/api/v1/billing/limits', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ monthly_cap_cents: -1, daily_cap_cents: 50, alert_threshold_pct: 80 }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(saveSettings).not.toHaveBeenCalled();
+  });
+});

--- a/ee/apps/web/src/app/api/v1/billing/limits/route.ts
+++ b/ee/apps/web/src/app/api/v1/billing/limits/route.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { ApiErrors, apiSuccess } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+import { BillingLimitEnforcer } from '@/services/billing-limit-enforcer';
+
+const payloadSchema = z.object({
+  monthly_cap_cents: z.number().int().min(0).nullable().optional(),
+  daily_cap_cents: z.number().int().min(0).nullable().optional(),
+  alert_threshold_pct: z.number().int().min(1).max(100).optional(),
+});
+
+function presentSettings(orgId: string, settings: Awaited<ReturnType<BillingLimitEnforcer['getResolvedSettings']>>, usage: Awaited<ReturnType<BillingLimitEnforcer['getUsageSnapshot']>>) {
+  return {
+    org_id: orgId,
+    monthly_cap_cents: settings.monthlyCapCents,
+    monthly_cap_unlimited: settings.monthlyCapCents == null,
+    daily_cap_cents: settings.dailyCapCents,
+    daily_cap_unlimited: settings.dailyCapCents == null,
+    alert_threshold_pct: settings.alertThresholdPct,
+    source: settings.source,
+    tier_name: settings.tierName,
+    usage_month: usage.usageMonth,
+    usage_date: usage.usageDate,
+    month_to_date_cost_cents: usage.monthToDateCostCents,
+    day_to_date_cost_cents: usage.dayToDateCostCents,
+  };
+}
+
+export async function GET() {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const enforcer = new BillingLimitEnforcer(supabase as never);
+    const [settings, usage] = await Promise.all([
+      enforcer.getResolvedSettings(me.org_id),
+      enforcer.getUsageSnapshot(me.org_id),
+    ]);
+
+    return apiSuccess(presentSettings(me.org_id, settings, usage));
+  } catch (error) {
+    return handleApiError(error);
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    await requireOrgAdmin(supabase, me.org_id);
+
+    const parsed = payloadSchema.safeParse(await request.json());
+    if (!parsed.success) {
+      return ApiErrors.validationFailed(parsed.error.issues.map((issue) => ({
+        path: issue.path.join('.'),
+        message: issue.message,
+      })));
+    }
+
+    const enforcer = new BillingLimitEnforcer(supabase as never);
+    const settings = await enforcer.saveSettings(me.org_id, {
+      monthlyCapCents: parsed.data.monthly_cap_cents,
+      dailyCapCents: parsed.data.daily_cap_cents,
+      alertThresholdPct: parsed.data.alert_threshold_pct,
+    });
+    const usage = await enforcer.getUsageSnapshot(me.org_id);
+
+    return apiSuccess(presentSettings(me.org_id, settings, usage));
+  } catch (error) {
+    return handleApiError(error);
+  }
+}

--- a/ee/apps/web/src/app/api/webhooks/payment/route.ts
+++ b/ee/apps/web/src/app/api/webhooks/payment/route.ts
@@ -1,0 +1,34 @@
+import { createClient } from '@supabase/supabase-js';
+import { apiSuccess, apiError } from '@/lib/api-response';
+import { getPaymentAdapter } from '@/lib/payment/factory';
+import { SubscriptionService } from '@/services/subscription';
+
+/**
+ * POST /api/webhooks/payment
+ * AC5+AC6: PG 웹훅 수신 → subscriptions 업데이트
+ * AC8: Zod 검증 (어댑터 내부에서 서명 검증)
+ */
+export async function POST(request: Request) {
+  try {
+    // service_role — 웹훅은 인증 없이 PG에서 직접 호출
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.SUPABASE_SERVICE_ROLE_KEY!,
+    );
+
+    const adapter = getPaymentAdapter();
+
+    // 어댑터가 서명 검증 + 이벤트 파싱
+    const event = await adapter.webhookHandler(request);
+
+    // 구독 서비스로 이벤트 처리
+    const service = new SubscriptionService(supabase);
+    const result = await service.processWebhookEvent(event, adapter.provider);
+
+    return apiSuccess(result);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Webhook processing failed';
+    console.error('[payment-webhook]', msg);
+    return apiError('WEBHOOK_ERROR', msg, 400);
+  }
+}

--- a/ee/apps/web/src/app/api/webhooks/polar/route.ts
+++ b/ee/apps/web/src/app/api/webhooks/polar/route.ts
@@ -1,0 +1,104 @@
+import { validateEvent, WebhookVerificationError } from '@polar-sh/sdk/webhooks';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { NextResponse } from 'next/server';
+import { POLAR_PRODUCT_TIER, POLAR_PRODUCT_BILLING_CYCLE } from '@/lib/polar-products';
+
+export async function POST(request: Request) {
+  const rawBody = await request.text();
+  const headers: Record<string, string> = {};
+  request.headers.forEach((v, k) => { headers[k] = v; });
+
+  const secret = process.env['POLAR_WEBHOOK_SECRET'];
+  if (!secret) {
+    console.error('POLAR_WEBHOOK_SECRET not set');
+    return NextResponse.json({ ok: false }, { status: 500 });
+  }
+
+  let event;
+  try {
+    event = validateEvent(rawBody, headers, secret);
+  } catch (err) {
+    if (err instanceof WebhookVerificationError) {
+      return NextResponse.json({ ok: false, error: 'Invalid signature' }, { status: 403 });
+    }
+    throw err;
+  }
+
+  const supabase = createSupabaseAdminClient();
+
+  switch (event.type) {
+    case 'checkout.updated': {
+      if (event.data.status !== 'succeeded') break;
+      const checkout = event.data;
+      const orgId = checkout.metadata?.['org_id'] as string | undefined;
+      if (!orgId || !checkout.customerId) break;
+
+      const productId = checkout.productId ?? '';
+      const tier = POLAR_PRODUCT_TIER[productId] ?? 'free';
+      const billingCycle = POLAR_PRODUCT_BILLING_CYCLE[productId] ?? null;
+
+      await supabase.from('org_subscriptions').upsert({
+        org_id: orgId,
+        polar_customer_id: checkout.customerId,
+        polar_subscription_id: checkout.subscriptionId ?? null,
+        tier,
+        billing_cycle: billingCycle,
+        status: 'active',
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'org_id' });
+      break;
+    }
+
+    case 'subscription.active': {
+      const sub = event.data;
+      await supabase.from('org_subscriptions')
+        .update({
+          status: 'active',
+          polar_subscription_id: sub.id,
+          current_period_start: sub.currentPeriodStart.toISOString(),
+          current_period_end: sub.currentPeriodEnd.toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('polar_customer_id', sub.customerId);
+      break;
+    }
+
+    case 'subscription.canceled': {
+      await supabase.from('org_subscriptions')
+        .update({ status: 'canceled', updated_at: new Date().toISOString() })
+        .eq('polar_subscription_id', event.data.id);
+      break;
+    }
+
+    case 'subscription.past_due': {
+      await supabase.from('org_subscriptions')
+        .update({ status: 'past_due', updated_at: new Date().toISOString() })
+        .eq('polar_subscription_id', event.data.id);
+      break;
+    }
+
+    case 'subscription.revoked': {
+      await supabase.from('org_subscriptions')
+        .update({ status: 'expired', tier: 'free', updated_at: new Date().toISOString() })
+        .eq('polar_subscription_id', event.data.id);
+      break;
+    }
+
+    case 'order.created': {
+      const order = event.data;
+      if (!order.subscription) break;
+      await supabase.from('org_subscriptions')
+        .update({
+          current_period_start: order.createdAt.toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('polar_subscription_id', order.subscription.id);
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/ee/apps/web/src/components/settings/billing-section.tsx
+++ b/ee/apps/web/src/components/settings/billing-section.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+const UNLIMITED = 999_999_999;
+
+const TIER_LABELS: Record<string, string> = {
+  free: 'Free',
+  team: 'Team',
+  pro: 'Pro',
+};
+
+const RESOURCE_LABELS: Record<string, string> = {
+  stories: 'Stories',
+  memos: 'Memos',
+  api_calls: 'API Calls',
+};
+
+interface UsageBarProps {
+  label: string;
+  current: number;
+  limit: number;
+}
+
+function UsageBar({ label, current, limit }: UsageBarProps) {
+  if (limit >= UNLIMITED) {
+    return (
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-medium">{current.toLocaleString()} / Unlimited</span>
+      </div>
+    );
+  }
+  const pct = limit > 0 ? Math.min(Math.round((current / limit) * 100), 100) : 0;
+  const barColor = pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-primary';
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">{label}</span>
+        <span className="font-medium">
+          {current.toLocaleString()} / {limit.toLocaleString()} ({pct}%)
+        </span>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-muted">
+        <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+interface BillingSectionProps {
+  tier: string;
+  usage: Record<string, number>;
+  quotas: Record<string, number>;
+}
+
+export function BillingSection({ tier, usage, quotas }: BillingSectionProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isFree = tier === 'free';
+
+  async function handleManage() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/billing/portal', { method: 'POST' });
+      const data = await res.json();
+      if (!res.ok || !data.data?.url) {
+        setError('Failed to open billing portal. Please try again.');
+        return;
+      }
+      window.open(data.data.url, '_blank', 'noopener,noreferrer');
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Current Plan */}
+      <div className="rounded-lg border bg-card p-5">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Current Plan</p>
+            <p className="mt-1 text-2xl font-bold">{TIER_LABELS[tier] ?? tier}</p>
+          </div>
+          {isFree ? (
+            <Link
+              href="/upgrade"
+              className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+            >
+              Upgrade
+            </Link>
+          ) : (
+            <button
+              onClick={handleManage}
+              disabled={loading}
+              className="rounded-lg border px-4 py-2 text-sm font-medium hover:bg-muted disabled:opacity-50"
+            >
+              {loading ? 'Opening…' : 'Manage Subscription'}
+            </button>
+          )}
+        </div>
+        {error && <p className="mt-3 text-xs text-destructive">{error}</p>}
+      </div>
+
+      {/* Usage */}
+      <div className="rounded-lg border bg-card p-5">
+        <p className="mb-4 text-sm font-semibold">This Month's Usage</p>
+        <div className="space-y-4">
+          {(['stories', 'memos', 'api_calls'] as const).map((r) => (
+            <UsageBar
+              key={r}
+              label={RESOURCE_LABELS[r] ?? r}
+              current={usage[r] ?? 0}
+              limit={quotas[r] ?? 0}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Upgrade CTA for free tier */}
+      {isFree && (
+        <div className="rounded-lg border-2 border-primary/20 bg-primary/5 p-5 text-center">
+          <p className="mb-1 text-sm font-semibold">Need more capacity?</p>
+          <p className="mb-4 text-xs text-muted-foreground">
+            Upgrade to Team for 10× higher limits, or Pro for unlimited usage.
+          </p>
+          <Link
+            href="/upgrade"
+            className="inline-block rounded-lg bg-primary px-6 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+          >
+            View Plans
+          </Link>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ee/apps/web/src/lib/billing-policy.test.ts
+++ b/ee/apps/web/src/lib/billing-policy.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BILLING_ENTITLEMENT_SOURCE_PRIORITY,
+  BILLING_PLAN_ORDER,
+  getEntitlementBearingSubscription,
+  ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES,
+  TRIAL_DURATION_DAYS,
+  TRIAL_LIMIT_PER_ORG,
+  TRIAL_PLAN_NAME,
+  isEntitlementActiveSubscriptionStatus,
+} from './billing-policy';
+
+describe('billing-policy', () => {
+  it('pins the commercial plan order and trial baseline', () => {
+    expect(BILLING_PLAN_ORDER).toEqual(['free', 'team', 'pro']);
+    expect(TRIAL_PLAN_NAME).toBe('team');
+    expect(TRIAL_DURATION_DAYS).toBe(14);
+    expect(TRIAL_LIMIT_PER_ORG).toBe(1);
+  });
+
+  it('treats trialing subscriptions as entitlement-bearing', () => {
+    expect(ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES).toEqual(['active', 'trialing']);
+    expect(isEntitlementActiveSubscriptionStatus('active')).toBe(true);
+    expect(isEntitlementActiveSubscriptionStatus('trialing')).toBe(true);
+    expect(isEntitlementActiveSubscriptionStatus('canceled')).toBe(false);
+    expect(isEntitlementActiveSubscriptionStatus('past_due')).toBe(false);
+  });
+
+
+  it('filters non-entitled subscription rows through the shared resolver', async () => {
+    const makeSupabase = (status: string | null) => ({
+      from() {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: async () => ({ data: status ? { status, tier_id: 'tier-1' } : null, error: null }),
+        };
+      },
+    });
+
+    await expect(getEntitlementBearingSubscription(makeSupabase('trialing') as never, 'org-1', 'status, tier_id')).resolves.toEqual({ status: 'trialing', tier_id: 'tier-1' });
+    await expect(getEntitlementBearingSubscription(makeSupabase('canceled') as never, 'org-1', 'status, tier_id')).resolves.toBeNull();
+  });
+
+  it('documents the entitlement resolution priority', () => {
+    expect(BILLING_ENTITLEMENT_SOURCE_PRIORITY).toEqual([
+      'subscriptions.offering_snapshot_id -> plan_offering_snapshots.features',
+      'legacy subscriptions without snapshot -> plan_features',
+      'no entitled subscription -> current free snapshot',
+    ]);
+  });
+});

--- a/ee/apps/web/src/lib/billing-policy.ts
+++ b/ee/apps/web/src/lib/billing-policy.ts
@@ -1,0 +1,51 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const BILLING_PLAN_ORDER = ['free', 'team', 'pro'] as const;
+
+export type BillingPlanName = (typeof BILLING_PLAN_ORDER)[number];
+
+export const TRIAL_PLAN_NAME: BillingPlanName = 'team';
+export const TRIAL_DURATION_DAYS = 14;
+export const TRIAL_LIMIT_PER_ORG = 1;
+
+export const ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES = ['active', 'trialing'] as const;
+
+export type EntitlementActiveSubscriptionStatus = (typeof ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES)[number];
+
+export function isEntitlementActiveSubscriptionStatus(
+  status: string | null | undefined,
+): status is EntitlementActiveSubscriptionStatus {
+  return ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES.includes(
+    status as EntitlementActiveSubscriptionStatus,
+  );
+}
+
+export const BILLING_ENTITLEMENT_SOURCE_PRIORITY = [
+  'subscriptions.offering_snapshot_id -> plan_offering_snapshots.features',
+  'legacy subscriptions without snapshot -> plan_features',
+  'no entitled subscription -> current free snapshot',
+] as const;
+
+export const BILLING_POLICY_NOTES = {
+  commercialTiersOnly: BILLING_PLAN_ORDER,
+  trialUsesPaidSnapshotOf: TRIAL_PLAN_NAME,
+  entitlementStatuses: ENTITLEMENT_ACTIVE_SUBSCRIPTION_STATUSES,
+} as const;
+
+export async function getEntitlementBearingSubscription<T extends { status?: string | null }>(
+  supabase: SupabaseClient,
+  orgId: string,
+  _columns?: string, // kept for interface compatibility; org_subscriptions always returns tier + status
+): Promise<T | null> {
+  const { data } = await supabase
+    .from('org_subscriptions')
+    .select('tier, status')
+    .eq('org_id', orgId)
+    .maybeSingle();
+
+  if (!data || !isEntitlementActiveSubscriptionStatus((data as { status?: string | null }).status)) {
+    return null;
+  }
+
+  return data as unknown as T;
+}

--- a/ee/apps/web/src/lib/check-feature.test.ts
+++ b/ee/apps/web/src/lib/check-feature.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkFeatureLimit, checkResourceLimit } from './check-feature';
+
+type Row = Record<string, unknown>;
+
+function createSupabaseStub(state: {
+  subscriptions?: Row[];
+  planOfferingSnapshots?: Row[];
+  planTiers?: Row[];
+  planFeatures?: Row[];
+  docs?: Row[];
+}) {
+  function applyFilters(rows: Row[], filters: Array<{ kind: 'eq' | 'in' | 'is'; column: string; value: unknown }>) {
+    return rows.filter((row) => filters.every((filter) => {
+      const value = row[filter.column];
+      if (filter.kind === 'eq') return value === filter.value;
+      if (filter.kind === 'is') return filter.value === null ? value == null : value === filter.value;
+      if (filter.kind === 'in') return Array.isArray(filter.value) && filter.value.includes(value);
+      return true;
+    }));
+  }
+
+  function createSelectBuilder(rowsFactory: () => Row[]) {
+    const filters: Array<{ kind: 'eq' | 'in' | 'is'; column: string; value: unknown }> = [];
+    let orderBy: { column: string; ascending: boolean } | null = null;
+    let rowLimit: number | null = null;
+
+    const resolveRows = () => {
+      let rows = applyFilters(rowsFactory(), filters);
+      if (orderBy) {
+        const currentOrder = orderBy;
+        rows = [...rows].sort((a, b) => {
+          const left = a[currentOrder.column];
+          const right = b[currentOrder.column];
+          if (left === right) return 0;
+          if (left == null) return currentOrder.ascending ? -1 : 1;
+          if (right == null) return currentOrder.ascending ? 1 : -1;
+          return left < right ? (currentOrder.ascending ? -1 : 1) : (currentOrder.ascending ? 1 : -1);
+        });
+      }
+      if (rowLimit != null) rows = rows.slice(0, rowLimit);
+      return rows;
+    };
+
+    const builder = {
+      select() { return builder; },
+      eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+      in(column: string, value: unknown[]) { filters.push({ kind: 'in', column, value }); return builder; },
+      is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+      order(column: string, options?: { ascending?: boolean }) {
+        orderBy = { column, ascending: options?.ascending ?? true };
+        return builder;
+      },
+      limit(value: number) {
+        rowLimit = value;
+        return builder;
+      },
+      single: async () => ({ data: resolveRows()[0] ?? null, error: null }),
+      maybeSingle: async () => ({ data: resolveRows()[0] ?? null, error: null }),
+      then(resolve: (value: { data: Row[]; count: number; error: null }) => unknown) {
+        const rows = resolveRows();
+        return Promise.resolve({ data: rows, count: rows.length, error: null }).then(resolve);
+      },
+    };
+
+    return builder;
+  }
+
+  return {
+    from(table: string) {
+      if (table === 'subscriptions') return createSelectBuilder(() => state.subscriptions ?? []);
+      if (table === 'plan_offering_snapshots') return createSelectBuilder(() => state.planOfferingSnapshots ?? []);
+      if (table === 'plan_tiers') return createSelectBuilder(() => state.planTiers ?? []);
+      if (table === 'plan_features') return createSelectBuilder(() => state.planFeatures ?? []);
+      if (table === 'docs') return createSelectBuilder(() => state.docs ?? []);
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+describe('check-feature', () => {
+  it('uses trialing subscription snapshots as the entitlement source', async () => {
+    const supabase = createSupabaseStub({
+      subscriptions: [{ org_id: 'org-1', status: 'trialing', tier_id: 'tier-team', offering_snapshot_id: 'snap-team' }],
+      planOfferingSnapshots: [{ id: 'snap-team', tier_id: 'tier-team', version: 1, features: { agent_orchestration: true } }],
+    });
+
+    const result = await checkFeatureLimit(supabase as never, 'org-1', 'agent_orchestration');
+
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('falls back to the current free snapshot when there is no entitled subscription', async () => {
+    const supabase = createSupabaseStub({
+      planOfferingSnapshots: [{
+        id: 'snap-free',
+        tier_id: '00000000-0000-0000-0000-000000000a01',
+        version: 2,
+        effective_until: null,
+        features: { agent_orchestration: false },
+      }],
+    });
+
+    const result = await checkFeatureLimit(supabase as never, 'org-1', 'agent_orchestration');
+
+    expect(result.allowed).toBe(false);
+    expect(result.upgradeRequired).toBe(true);
+  });
+
+  it('falls back to legacy plan_features when a subscription has no snapshot yet', async () => {
+    const supabase = createSupabaseStub({
+      subscriptions: [{ org_id: 'org-1', status: 'active', tier_id: 'tier-free', offering_snapshot_id: null }],
+      planFeatures: [{ tier_id: 'tier-free', feature_key: 'max_docs', enabled: true, limit_value: 10 }],
+      docs: Array.from({ length: 10 }, (_, index) => ({ id: `doc-${index + 1}`, org_id: 'org-1' })),
+    });
+
+    const result = await checkResourceLimit(supabase as never, 'org-1', 'max_docs', 'docs');
+
+    expect(result.allowed).toBe(false);
+    expect(result.upgradeRequired).toBe(true);
+    expect(result.reason).toContain('max_docs limit reached (10)');
+  });
+});

--- a/ee/apps/web/src/lib/check-feature.ts
+++ b/ee/apps/web/src/lib/check-feature.ts
@@ -1,0 +1,253 @@
+// @deprecated E-DATA-INTEGRITY S9: 2계층(plan_tiers/plan_features) 기반 체크 함수.
+// 모든 호출 지점은 entitlement.ts의 checkEntitlement()로 전환됨.
+// Phase 4에서 이 파일 및 관련 DB 테이블(plan_tiers, plan_features) 완전 제거 예정.
+import { cache } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { getEntitlementBearingSubscription } from './billing-policy';
+
+type OrgSubscriptionRow = {
+  status?: string | null;
+  tier?: string | null; // org_subscriptions.tier ('free'|'team'|'pro')
+};
+
+// 요청 내 캐싱: org_subscriptions 테이블을 한 번만 조회
+const _getOrgSubscription = cache(
+  (supabase: SupabaseClient, orgId: string) =>
+    getEntitlementBearingSubscription<OrgSubscriptionRow>(supabase, orgId),
+);
+
+export interface FeatureCheckResult {
+  allowed: boolean;
+  reason?: string;
+  upgradeRequired?: boolean;
+}
+
+interface OfferingFeatures {
+  max_members?: number | null;
+  max_projects?: number | null;
+  max_stories?: number | null;
+  max_docs?: number | null;
+  max_mockups?: number | null;
+  byoa_agents?: number | null;
+  [key: string]: unknown;
+}
+
+/**
+ * 조직의 구독에서 offering features 조회 (grandfathering 지원)
+ * 1. subscriptions.offering_snapshot_id → plan_offering_snapshots.features (jsonb) — 구독 시점 고정
+ * 2. offering_snapshot_id null (레거시 구독) → plan_features 직접 참조 폴백
+ * 3. entitlement-bearing subscription이 없으면 → free tier 현행 스냅샷
+ *
+ * trialing 상태는 active와 동일하게 entitlement-bearing으로 취급한다.
+ */
+async function getOrgOfferingFeatures(supabase: SupabaseClient, orgId: string): Promise<OfferingFeatures | null> {
+  const sub = await _getOrgSubscription(supabase, orgId);
+
+  // org_subscriptions에 offering_snapshot_id 없음 → 항상 plan_features 폴백
+  // sub 있으면: plan_features 직접 참조 (null 반환 → 호출자가 plan_features 코드로 감)
+  // sub 없으면: free tier로 처리 (null 반환 → 호출자가 plan_features 코드로 감)
+  void sub; // used for cache warming only
+  return null;
+}
+
+/**
+ * 조직의 요금제 티어 ID 조회 (구독 없으면 free) — 폴백용
+ */
+async function getOrgTierId(supabase: SupabaseClient, orgId: string): Promise<string | null> {
+  const sub = await _getOrgSubscription(supabase, orgId);
+  const tierName = sub?.tier ?? 'free';
+
+  const { data: tier } = await supabase
+    .from('plan_tiers')
+    .select('id')
+    .eq('name', tierName)
+    .single();
+
+  return tier?.id ?? null;
+}
+
+/**
+ * 조직의 요금제에서 특정 기능이 허용되는지 확인 (boolean)
+ * offering.features → plan_features 폴백
+ */
+export async function checkFeatureLimit(
+  supabase: SupabaseClient,
+  orgId: string,
+  featureKey: string,
+): Promise<FeatureCheckResult> {
+  // 1. offering features에서 확인
+  const features = await getOrgOfferingFeatures(supabase, orgId);
+  if (features && featureKey in features) {
+    const val = features[featureKey];
+    if (val === false) {
+      return { allowed: false, reason: `Feature "${featureKey}" is not available on your current plan. Upgrade to Team.`, upgradeRequired: true };
+    }
+    return { allowed: true };
+  }
+
+  // 2. plan_features 폴백
+  const tierId = await getOrgTierId(supabase, orgId);
+  if (!tierId) return { allowed: false, reason: 'No plan configured', upgradeRequired: true };
+
+  const { data: feature } = await supabase
+    .from('plan_features')
+    .select('enabled, limit_value')
+    .eq('tier_id', tierId)
+    .eq('feature_key', featureKey)
+    .single();
+
+  if (!feature) return { allowed: true }; // 미설정이면 허용
+  if (!feature.enabled) {
+    return { allowed: false, reason: `Feature "${featureKey}" is not available on your current plan. Upgrade to Team.`, upgradeRequired: true };
+  }
+  return { allowed: true };
+}
+
+/**
+ * 조직의 멤버 수 제한 확인
+ */
+export async function checkMemberLimit(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<FeatureCheckResult> {
+  // offering features에서 max_members 확인
+  const features = await getOrgOfferingFeatures(supabase, orgId);
+  const maxMembers = features?.max_members;
+
+  if (maxMembers == null) {
+    // offering에 없으면 plan_tiers 폴백
+    const tierId = await getOrgTierId(supabase, orgId);
+    if (!tierId) return { allowed: true };
+
+    const { data: tier } = await supabase
+      .from('plan_tiers')
+      .select('max_members')
+      .eq('id', tierId)
+      .single();
+
+    if (!tier || tier.max_members == null) return { allowed: true };
+
+    const { count } = await supabase
+      .from('org_members')
+      .select('id', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+
+    if ((count ?? 0) >= (tier.max_members as number)) {
+      return { allowed: false, reason: `Member limit reached (${tier.max_members}). Upgrade to Team.`, upgradeRequired: true };
+    }
+    return { allowed: true };
+  }
+
+  // offering features에서 확인
+  const { count } = await supabase
+    .from('org_members')
+    .select('id', { count: 'exact', head: true })
+    .eq('org_id', orgId);
+
+  if ((count ?? 0) >= maxMembers) {
+    return { allowed: false, reason: `Member limit reached (${maxMembers}). Upgrade to Team.`, upgradeRequired: true };
+  }
+  return { allowed: true };
+}
+
+/**
+ * 조직의 프로젝트 수 제한 확인
+ */
+export async function checkProjectLimit(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<FeatureCheckResult> {
+  const features = await getOrgOfferingFeatures(supabase, orgId);
+  const maxProjects = features?.max_projects;
+
+  if (maxProjects == null) {
+    // offering에 없으면 plan_tiers 폴백
+    const tierId = await getOrgTierId(supabase, orgId);
+    if (!tierId) return { allowed: true };
+
+    const { data: tier } = await supabase
+      .from('plan_tiers')
+      .select('max_projects')
+      .eq('id', tierId)
+      .single();
+
+    if (!tier || tier.max_projects == null) return { allowed: true };
+
+    const { count } = await supabase
+      .from('projects')
+      .select('id', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+
+    if ((count ?? 0) >= (tier.max_projects as number)) {
+      return { allowed: false, reason: `Project limit reached (${tier.max_projects}). Upgrade to Team.`, upgradeRequired: true };
+    }
+    return { allowed: true };
+  }
+
+  const { count } = await supabase
+    .from('projects')
+    .select('id', { count: 'exact', head: true })
+    .eq('org_id', orgId);
+
+  if ((count ?? 0) >= maxProjects) {
+    return { allowed: false, reason: `Project limit reached (${maxProjects}). Upgrade to Team.`, upgradeRequired: true };
+  }
+  return { allowed: true };
+}
+
+/**
+ * 제네릭 리소스 count 제한 확인 (stories, docs 등)
+ * offering.features → plan_features 폴백
+ */
+export async function checkResourceLimit(
+  supabase: SupabaseClient,
+  orgId: string,
+  featureKey: string,
+  table: string,
+  orgColumn = 'org_id',
+): Promise<FeatureCheckResult> {
+  // 1. offering features에서 확인
+  const features = await getOrgOfferingFeatures(supabase, orgId);
+  if (features && featureKey in features) {
+    const limit = features[featureKey] as number | null;
+    if (limit == null) return { allowed: true }; // null = 무제한
+
+    const { count } = await supabase
+      .from(table)
+      .select('id', { count: 'exact', head: true })
+      .eq(orgColumn, orgId);
+
+    if ((count ?? 0) >= limit) {
+      return { allowed: false, reason: `${featureKey} limit reached (${limit}). Upgrade to Team.`, upgradeRequired: true };
+    }
+    return { allowed: true };
+  }
+
+  // 2. plan_features 폴백
+  const tierId = await getOrgTierId(supabase, orgId);
+  if (!tierId) return { allowed: true };
+
+  const { data: feature } = await supabase
+    .from('plan_features')
+    .select('enabled, limit_value')
+    .eq('tier_id', tierId)
+    .eq('feature_key', featureKey)
+    .single();
+
+  if (!feature) return { allowed: true };
+  if (!feature.enabled) {
+    return { allowed: false, reason: `Feature "${featureKey}" is not available on your current plan. Upgrade to Team.`, upgradeRequired: true };
+  }
+  if (feature.limit_value == null) return { allowed: true };
+
+  const { count } = await supabase
+    .from(table)
+    .select('id', { count: 'exact', head: true })
+    .eq(orgColumn, orgId);
+
+  if ((count ?? 0) >= feature.limit_value) {
+    return { allowed: false, reason: `${featureKey} limit reached (${feature.limit_value}). Upgrade to Team.`, upgradeRequired: true };
+  }
+  return { allowed: true };
+}

--- a/ee/apps/web/src/lib/entitlement.ts
+++ b/ee/apps/web/src/lib/entitlement.ts
@@ -1,0 +1,94 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export type EntitlementResource = 'stories' | 'memos' | 'docs' | 'members' | 'projects' | 'api_calls';
+
+interface TierQuota {
+  stories: number;
+  memos: number;
+  docs: number;
+  members: number;
+  projects: number;
+  api_calls: number;
+}
+
+const UNLIMITED = 999_999_999;
+
+export const TIER_QUOTAS: Record<string, TierQuota> = {
+  free: { members: 5, projects: 1, stories: 100, memos: 500, docs: 50, api_calls: 10_000 },
+  team: { members: 20, projects: 5, stories: 1_000, memos: 5_000, docs: 500, api_calls: 100_000 },
+  pro: { members: UNLIMITED, projects: UNLIMITED, stories: UNLIMITED, memos: UNLIMITED, docs: UNLIMITED, api_calls: UNLIMITED },
+};
+
+export interface EntitlementResult {
+  allowed: boolean;
+  current: number;
+  limit: number;
+  upgradeUrl: string;
+}
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+async function getOrgTier(supabase: SupabaseClient, orgId: string): Promise<string> {
+  const { data } = await supabase
+    .from('org_subscriptions')
+    .select('tier, status')
+    .eq('org_id', orgId)
+    .maybeSingle();
+  if (!data || data.status === 'expired' || data.status === 'past_due') return 'free';
+  return data.tier ?? 'free';
+}
+
+export async function checkEntitlement(
+  supabase: SupabaseClient,
+  orgId: string,
+  resource: EntitlementResource,
+): Promise<EntitlementResult> {
+  const tier = await getOrgTier(supabase, orgId);
+  const quota = TIER_QUOTAS[tier] ?? TIER_QUOTAS['free']!;
+  const limit = quota[resource];
+  const upgradeUrl = '/upgrade';
+
+  if (limit === UNLIMITED) return { allowed: true, current: 0, limit, upgradeUrl };
+
+  let current = 0;
+
+  if (resource === 'members') {
+    const { count } = await supabase
+      .from('org_members')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else if (resource === 'projects') {
+    const { count } = await supabase
+      .from('projects')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else if (resource === 'docs') {
+    const { count } = await supabase
+      .from('docs')
+      .select('*', { count: 'exact', head: true })
+      .eq('org_id', orgId);
+    current = count ?? 0;
+  } else {
+    const { data: usage } = await supabase
+      .from('org_usage')
+      .select(resource)
+      .eq('org_id', orgId)
+      .eq('period', currentPeriod())
+      .maybeSingle();
+    current = (usage as Record<string, number> | null)?.[resource] ?? 0;
+  }
+
+  return { allowed: current < limit, current, limit, upgradeUrl };
+}
+
+export async function checkMemberEntitlement(
+  supabase: SupabaseClient,
+  orgId: string,
+): Promise<EntitlementResult> {
+  return checkEntitlement(supabase, orgId, 'members');
+}

--- a/ee/apps/web/src/lib/polar-products.ts
+++ b/ee/apps/web/src/lib/polar-products.ts
@@ -1,0 +1,34 @@
+export interface PolarProduct {
+  teamMonthly: string;
+  teamYearly: string;
+  proMonthly: string;
+  proYearly: string;
+}
+
+const SANDBOX: PolarProduct = {
+  teamMonthly: '200c2c3c-1235-41e1-a259-1440200b4a93',
+  teamYearly: 'e79b7587-6261-4384-abdb-f3fd13612f06',
+  proMonthly: '9e3c0067-7d28-4314-abe8-c59929eedf30',
+  proYearly: '39462386-91b7-4864-9cc2-eecc8cfc2307',
+};
+
+export const POLAR_PRODUCTS: PolarProduct = {
+  teamMonthly: process.env['NEXT_PUBLIC_POLAR_PRODUCT_TEAM_MONTHLY'] ?? SANDBOX.teamMonthly,
+  teamYearly: process.env['NEXT_PUBLIC_POLAR_PRODUCT_TEAM_YEARLY'] ?? SANDBOX.teamYearly,
+  proMonthly: process.env['NEXT_PUBLIC_POLAR_PRODUCT_PRO_MONTHLY'] ?? SANDBOX.proMonthly,
+  proYearly: process.env['NEXT_PUBLIC_POLAR_PRODUCT_PRO_YEARLY'] ?? SANDBOX.proYearly,
+};
+
+export const POLAR_PRODUCT_TIER: Record<string, string> = {
+  [POLAR_PRODUCTS.teamMonthly]: 'team',
+  [POLAR_PRODUCTS.teamYearly]: 'team',
+  [POLAR_PRODUCTS.proMonthly]: 'pro',
+  [POLAR_PRODUCTS.proYearly]: 'pro',
+};
+
+export const POLAR_PRODUCT_BILLING_CYCLE: Record<string, string> = {
+  [POLAR_PRODUCTS.teamMonthly]: 'monthly',
+  [POLAR_PRODUCTS.teamYearly]: 'yearly',
+  [POLAR_PRODUCTS.proMonthly]: 'monthly',
+  [POLAR_PRODUCTS.proYearly]: 'yearly',
+};

--- a/ee/apps/web/src/services/agent-run-billing.test.ts
+++ b/ee/apps/web/src/services/agent-run-billing.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { calculateRunBilling, type ManagedPricingRow } from './agent-run-billing';
+import type { LLMProvider } from '@/lib/llm';
+
+function pricing(provider: LLMProvider, model: string, inputRate: number, outputRate: number): ManagedPricingRow {
+  return {
+    provider,
+    model,
+    input_cost_per_million_tokens_usd: inputRate,
+    output_cost_per_million_tokens_usd: outputRate,
+  };
+}
+
+describe('calculateRunBilling', () => {
+  it('returns zero cost for byom runs', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'byom', provider: 'openai', model: 'gpt-4o-mini', perRunCapCents: undefined },
+      inputTokens: 1000,
+      outputTokens: 500,
+      pricingRow: pricing('openai', 'gpt-4o-mini', 0.15, 0.6),
+    });
+
+    expect(result.llmProvider).toBe('byom');
+    expect(result.llmProviderKey).toBe('openai');
+    expect(result.model).toBe('gpt-4o-mini');
+    expect(result.computedCostCents).toBe(0);
+    expect(result.billingNotes).toContain('byom_no_charge');
+  });
+
+  it('applies managed pricing with 30 percent margin for openai', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'openai', model: 'gpt-4o', perRunCapCents: undefined },
+      inputTokens: 1_000_000,
+      outputTokens: 500_000,
+      pricingRow: pricing('openai', 'gpt-4o', 2.5, 10),
+    });
+
+    expect(result.llmProvider).toBe('managed');
+    expect(result.llmProviderKey).toBe('openai');
+    expect(result.model).toBe('gpt-4o');
+    expect(result.computedCostCents).toBe(975);
+    expect(result.costUsd).toBe(9.75);
+  });
+
+  it('applies managed pricing for anthropic', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'anthropic', model: 'claude-sonnet-4', perRunCapCents: undefined },
+      inputTokens: 500_000,
+      outputTokens: 250_000,
+      pricingRow: pricing('anthropic', 'claude-sonnet-4', 3, 15),
+    });
+
+    expect(result.computedCostCents).toBe(683);
+  });
+
+  it('applies managed pricing for google', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'google', model: 'gemini-2.5-flash', perRunCapCents: undefined },
+      inputTokens: 2_000_000,
+      outputTokens: 1_000_000,
+      pricingRow: pricing('google', 'gemini-2.5-flash', 0.3, 2.5),
+    });
+
+    expect(result.computedCostCents).toBe(403);
+  });
+
+  it('applies managed pricing for groq', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'groq', model: 'llama-3.1-8b-instant', perRunCapCents: undefined },
+      inputTokens: 4_000_000,
+      outputTokens: 1_000_000,
+      pricingRow: pricing('groq', 'llama-3.1-8b-instant', 0.05, 0.08),
+    });
+
+    expect(result.computedCostCents).toBe(37);
+  });
+
+  it('adds a fallback billing note when token usage is unavailable', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'openai', model: 'gpt-4o-mini', perRunCapCents: undefined },
+      inputTokens: null,
+      outputTokens: null,
+      pricingRow: pricing('openai', 'gpt-4o-mini', 0.15, 0.6),
+    });
+
+    expect(result.computedCostCents).toBe(0);
+    expect(result.billingNotes).toContain('token_count_unavailable');
+  });
+
+  it('falls back to default managed pricing when the model is not seeded', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'openai', model: 'unseeded-model', perRunCapCents: undefined },
+      inputTokens: 1_000_000,
+      outputTokens: 1_000_000,
+      pricingRow: null,
+    });
+
+    expect(result.computedCostCents).toBe(2600);
+    expect(result.costUsd).toBe(26);
+    expect(result.billingNotes).toContain('managed_pricing_missing');
+    expect(result.billingNotes).toContain('managed_pricing_fallback');
+  });
+
+  it('flags cap exceedance when computed cost is above perRunCapCents', () => {
+    const result = calculateRunBilling({
+      llmConfig: { billingMode: 'managed', provider: 'openai', model: 'gpt-4o-mini', perRunCapCents: 100 },
+      inputTokens: 100_000,
+      outputTokens: 50_000,
+      pricingRow: pricing('openai', 'gpt-4o-mini', 10, 30),
+    });
+
+    expect(result.capExceeded).toBe(true);
+    expect(result.billingNotes).toContain('per_run_cap_exceeded');
+  });
+});

--- a/ee/apps/web/src/services/agent-run-billing.ts
+++ b/ee/apps/web/src/services/agent-run-billing.ts
@@ -1,0 +1,121 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { LLMConfig, LLMProvider } from '@/lib/llm';
+
+export interface ManagedPricingRow {
+  provider: LLMProvider;
+  model: string;
+  input_cost_per_million_tokens_usd: number;
+  output_cost_per_million_tokens_usd: number;
+}
+
+export interface RunBillingSummary {
+  llmProvider: 'managed' | 'byom' | null;
+  llmProviderKey: LLMProvider | null;
+  model: string | null;
+  computedCostCents: number;
+  costUsd: number;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  billingNotes: string[];
+  perRunCapCents: number | null;
+  capExceeded: boolean;
+}
+
+const BILLING_MARGIN_MULTIPLIER = 1.3;
+const DEFAULT_FALLBACK_INPUT_COST_PER_MILLION_USD = 5;
+const DEFAULT_FALLBACK_OUTPUT_COST_PER_MILLION_USD = 15;
+
+export async function getManagedPricingRow(
+  supabase: SupabaseClient,
+  provider: LLMProvider,
+  model: string,
+): Promise<ManagedPricingRow | null> {
+  const { data, error } = await supabase
+    .from('llm_pricing_config')
+    .select('provider, model, input_cost_per_million_tokens_usd, output_cost_per_million_tokens_usd')
+    .eq('provider', provider)
+    .eq('model', model)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data ?? null) as ManagedPricingRow | null;
+}
+
+export function calculateRunBilling(input: {
+  llmConfig: Pick<LLMConfig, 'billingMode' | 'provider' | 'model' | 'perRunCapCents'>;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  pricingRow?: ManagedPricingRow | null;
+}): RunBillingSummary {
+  const notes: string[] = [];
+  const perRunCapCents = input.llmConfig.perRunCapCents ?? null;
+
+  if (input.llmConfig.billingMode === 'byom') {
+    notes.push('byom_no_charge');
+    return {
+      llmProvider: 'byom',
+      llmProviderKey: input.llmConfig.provider,
+      model: String(input.llmConfig.model),
+      computedCostCents: 0,
+      costUsd: 0,
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      billingNotes: notes,
+      perRunCapCents,
+      capExceeded: false,
+    };
+  }
+
+  if (input.inputTokens == null || input.outputTokens == null) {
+    notes.push('token_count_unavailable');
+    return {
+      llmProvider: 'managed',
+      llmProviderKey: input.llmConfig.provider,
+      model: String(input.llmConfig.model),
+      computedCostCents: 0,
+      costUsd: 0,
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      billingNotes: notes,
+      perRunCapCents,
+      capExceeded: false,
+    };
+  }
+
+  const pricingRow = input.pricingRow ?? {
+    provider: input.llmConfig.provider,
+    model: String(input.llmConfig.model),
+    input_cost_per_million_tokens_usd: DEFAULT_FALLBACK_INPUT_COST_PER_MILLION_USD,
+    output_cost_per_million_tokens_usd: DEFAULT_FALLBACK_OUTPUT_COST_PER_MILLION_USD,
+  } satisfies ManagedPricingRow;
+
+  if (!input.pricingRow) {
+    notes.push('managed_pricing_missing', 'managed_pricing_fallback');
+  }
+
+  const rawCostUsd = (
+    (input.inputTokens * pricingRow.input_cost_per_million_tokens_usd)
+    + (input.outputTokens * pricingRow.output_cost_per_million_tokens_usd)
+  ) / 1_000_000;
+  const managedCostUsd = rawCostUsd * BILLING_MARGIN_MULTIPLIER;
+  const computedCostCents = Math.ceil(managedCostUsd * 100);
+  const capExceeded = perRunCapCents != null && computedCostCents > perRunCapCents;
+
+  if (capExceeded) {
+    notes.push('per_run_cap_exceeded');
+  }
+
+  return {
+    llmProvider: 'managed',
+    llmProviderKey: input.llmConfig.provider,
+    model: String(input.llmConfig.model),
+    computedCostCents,
+    costUsd: Number((computedCostCents / 100).toFixed(2)),
+    inputTokens: input.inputTokens,
+    outputTokens: input.outputTokens,
+    billingNotes: notes,
+    perRunCapCents,
+    capExceeded,
+  };
+}

--- a/ee/apps/web/src/services/billing-limit-enforcer.test.ts
+++ b/ee/apps/web/src/services/billing-limit-enforcer.test.ts
@@ -1,0 +1,417 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { BillingLimitEnforcer } from './billing-limit-enforcer';
+
+interface RunRow {
+  id: string;
+  org_id: string;
+  deployment_id: string | null;
+  status: string;
+  created_at: string;
+  computed_cost_cents: number;
+  result_summary?: string | null;
+}
+
+interface DeploymentRow {
+  id: string;
+  org_id: string;
+  status: string;
+  deleted_at: string | null;
+}
+
+function createSupabaseStub(options?: {
+  billingLimits?: { monthly_cap_cents: number | null; daily_cap_cents: number | null; alert_threshold_pct: number | null } | null;
+  subscriptions?: Array<{ org_id: string; status: string; tier_id: string }>;
+  planTiers?: Array<{ id: string; name: string }>;
+  runs?: RunRow[];
+  deployments?: DeploymentRow[];
+  orgMembers?: Array<{ org_id: string; user_id: string; role: string }>;
+  teamMembers?: Array<{ id: string; org_id: string; user_id: string | null; type: string; is_active: boolean }>;
+  slackAuth?: { access_token_ref: string; expires_at: string | null } | null;
+  slackChannels?: Array<{ org_id: string; channel_id: string; platform: string; is_active: boolean }>;
+}) {
+  const state = {
+    billingLimits: options?.billingLimits ? { org_id: 'org-1', ...options.billingLimits } : null,
+    subscriptions: options?.subscriptions ?? [],
+    planTiers: options?.planTiers ?? [{ id: 'tier-free', name: 'free' }],
+    runs: options?.runs ?? [],
+    deployments: options?.deployments ?? [],
+    orgMembers: options?.orgMembers ?? [{ org_id: 'org-1', user_id: 'user-admin', role: 'owner' }],
+    teamMembers: options?.teamMembers ?? [{ id: 'tm-admin', org_id: 'org-1', user_id: 'user-admin', type: 'human', is_active: true }],
+    alerts: [] as Array<{ org_id: string; usage_month: string; alert_type: string; threshold_pct: number | null }>,
+    notifications: [] as Array<Record<string, unknown>>,
+    memoReplies: [] as Array<Record<string, unknown>>,
+    slackAuth: options?.slackAuth ? { org_id: 'org-1', platform: 'slack', ...options.slackAuth } : null,
+    slackChannels: options?.slackChannels ?? [],
+  };
+
+  function applyFilters<T extends Record<string, unknown>>(rows: T[], filters: Array<{ kind: 'eq' | 'in' | 'gte' | 'lt' | 'is'; column: string; value: unknown }>) {
+    return rows.filter((row) => filters.every((filter) => {
+      const value = row[filter.column];
+      if (filter.kind === 'eq') return value === filter.value;
+      if (filter.kind === 'is') return filter.value === null ? value == null : value === filter.value;
+      if (filter.kind === 'in') return Array.isArray(filter.value) && filter.value.includes(value);
+      if (filter.kind === 'gte') return String(value ?? '') >= String(filter.value);
+      if (filter.kind === 'lt') return String(value ?? '') < String(filter.value);
+      return true;
+    }));
+  }
+
+  function createSelectBuilder<T extends Record<string, unknown>>(rowsFactory: () => T[]) {
+    const filters: Array<{ kind: 'eq' | 'in' | 'gte' | 'lt' | 'is'; column: string; value: unknown }> = [];
+    const builder = {
+      select() { return builder; },
+      eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+      in(column: string, value: unknown[]) { filters.push({ kind: 'in', column, value }); return builder; },
+      gte(column: string, value: unknown) { filters.push({ kind: 'gte', column, value }); return builder; },
+      lt(column: string, value: unknown) { filters.push({ kind: 'lt', column, value }); return builder; },
+      is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+      maybeSingle: async () => {
+        const rows = applyFilters(rowsFactory(), filters);
+        return { data: rows[0] ?? null, error: null };
+      },
+      then(resolve: (value: { data: T[]; error: null }) => unknown) {
+        const rows = applyFilters(rowsFactory(), filters);
+        return Promise.resolve({ data: rows, error: null }).then(resolve);
+      },
+    };
+    return builder;
+  }
+
+  const supabase = {
+    auth: {
+      admin: {
+        getUserById: vi.fn(async (userId: string) => ({
+          data: {
+            user: {
+              id: userId,
+              email: userId === 'user-admin' ? 'admin@sprintable.test' : `${userId}@example.test`,
+            },
+          },
+          error: null,
+        })),
+      },
+    },
+    from(table: string) {
+      if (table === 'billing_limits') {
+        return {
+          ...createSelectBuilder(() => state.billingLimits ? [state.billingLimits] : []),
+          upsert: async (payload: Record<string, unknown>) => {
+            state.billingLimits = {
+              org_id: 'org-1',
+              monthly_cap_cents: (payload.monthly_cap_cents as number | null | undefined) ?? null,
+              daily_cap_cents: (payload.daily_cap_cents as number | null | undefined) ?? null,
+              alert_threshold_pct: (payload.alert_threshold_pct as number | null | undefined) ?? 80,
+            };
+            return { error: null };
+          },
+        };
+      }
+
+      if (table === 'subscriptions') {
+        return createSelectBuilder(() => state.subscriptions as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'plan_tiers') {
+        return createSelectBuilder(() => state.planTiers as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'agent_runs') {
+        const filters: Array<{ kind: 'eq' | 'in' | 'gte' | 'lt' | 'is'; column: string; value: unknown }> = [];
+        let updatePayload: Record<string, unknown> | null = null;
+        const builder = {
+          select() { return builder; },
+          update(payload: Record<string, unknown>) { updatePayload = payload; return builder; },
+          eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+          in(column: string, value: unknown[]) { filters.push({ kind: 'in', column, value }); return builder; },
+          gte(column: string, value: unknown) { filters.push({ kind: 'gte', column, value }); return builder; },
+          lt(column: string, value: unknown) { filters.push({ kind: 'lt', column, value }); return builder; },
+          is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+          then(resolve: (value: { data: unknown[]; error: null }) => unknown) {
+            const rows = applyFilters(state.runs as unknown as Array<Record<string, unknown>>, filters);
+            if (updatePayload) {
+              rows.forEach((row) => Object.assign(row, updatePayload));
+              return Promise.resolve({ data: rows, error: null }).then(resolve);
+            }
+            return Promise.resolve({ data: rows, error: null }).then(resolve);
+          },
+        };
+        return builder;
+      }
+
+      if (table === 'agent_deployments') {
+        const filters: Array<{ kind: 'eq' | 'in' | 'gte' | 'lt' | 'is'; column: string; value: unknown }> = [];
+        let updatePayload: Record<string, unknown> | null = null;
+        const builder = {
+          select() { return builder; },
+          update(payload: Record<string, unknown>) { updatePayload = payload; return builder; },
+          eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+          in(column: string, value: unknown[]) { filters.push({ kind: 'in', column, value }); return builder; },
+          is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+          then(resolve: (value: { data: unknown[]; error: null }) => unknown) {
+            const rows = applyFilters(state.deployments as unknown as Array<Record<string, unknown>>, filters);
+            if (updatePayload) {
+              rows.forEach((row) => Object.assign(row, updatePayload));
+              return Promise.resolve({ data: rows, error: null }).then(resolve);
+            }
+            return Promise.resolve({ data: rows, error: null }).then(resolve);
+          },
+        };
+        return builder;
+      }
+
+      if (table === 'billing_limit_alerts') {
+        return {
+          insert: async (payload: Record<string, unknown>) => {
+            const key = `${payload.org_id}:${payload.usage_month}:${payload.alert_type}`;
+            const exists = state.alerts.some((row) => `${row.org_id}:${row.usage_month}:${row.alert_type}` === key);
+            if (exists) {
+              return { error: { code: '23505', message: 'duplicate key' } };
+            }
+            state.alerts.push(payload as never);
+            return { error: null };
+          },
+        };
+      }
+
+      if (table === 'memo_replies') {
+        return {
+          insert: async (payload: Record<string, unknown>) => {
+            state.memoReplies.push(payload);
+            return { error: null };
+          },
+        };
+      }
+
+      if (table === 'org_members') {
+        return createSelectBuilder(() => state.orgMembers as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'team_members') {
+        return createSelectBuilder(() => state.teamMembers as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'notifications') {
+        return {
+          insert: async (payload: Record<string, unknown> | Array<Record<string, unknown>>) => {
+            state.notifications.push(...(Array.isArray(payload) ? payload : [payload]));
+            return { error: null };
+          },
+        };
+      }
+
+      if (table === 'messaging_bridge_org_auths') {
+        return createSelectBuilder(() => state.slackAuth ? [state.slackAuth as Record<string, unknown>] : []);
+      }
+
+      if (table === 'messaging_bridge_channels') {
+        return createSelectBuilder(() => state.slackChannels as Array<Record<string, unknown>>);
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+
+  return { supabase, state };
+}
+
+describe('BillingLimitEnforcer', () => {
+  afterEach(() => {
+    delete process.env.RESEND_API_KEY;
+    delete process.env.BILLING_ALERT_EMAIL_FROM;
+  });
+
+  it('returns the free-plan default monthly cap when explicit settings are missing', async () => {
+    const { supabase } = createSupabaseStub();
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn: vi.fn(),
+      now: () => new Date('2026-04-07T12:00:00.000Z'),
+    });
+
+    const settings = await enforcer.getResolvedSettings('org-1');
+
+    expect(settings).toMatchObject({
+      monthlyCapCents: 1000,
+      dailyCapCents: null,
+      alertThresholdPct: 80,
+      source: 'plan_default',
+      tierName: 'free',
+    });
+  });
+
+  it('keeps monthly usage snapshots on created_at month boundaries', async () => {
+    const { supabase } = createSupabaseStub({
+      runs: [{
+        id: 'run-cross-month',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'completed',
+        created_at: '2026-03-31T23:50:00.000Z',
+        computed_cost_cents: 900,
+      }],
+    });
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn: vi.fn(),
+      now: () => new Date('2026-04-12T12:00:00.000Z'),
+    });
+
+    const march = await enforcer.getMonthlyUsageSnapshot('org-1', '2026-03');
+    const april = await enforcer.getMonthlyUsageSnapshot('org-1', '2026-04');
+
+    expect(march).toEqual({ usageMonth: '2026-03-01', monthToDateCostCents: 900 });
+    expect(april).toEqual({ usageMonth: '2026-04-01', monthToDateCostCents: 0 });
+  });
+
+  it('ignores running and hitl_pending runs in monthly usage snapshots', async () => {
+    const { supabase } = createSupabaseStub({
+      runs: [{
+        id: 'run-completed',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'completed',
+        created_at: '2026-04-07T03:00:00.000Z',
+        computed_cost_cents: 700,
+      }, {
+        id: 'run-running',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'running',
+        created_at: '2026-04-07T04:00:00.000Z',
+        computed_cost_cents: 500,
+      }, {
+        id: 'run-hitl',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'hitl_pending',
+        created_at: '2026-04-07T05:00:00.000Z',
+        computed_cost_cents: 400,
+      }],
+    });
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn: vi.fn(),
+      now: () => new Date('2026-04-12T12:00:00.000Z'),
+    });
+
+    const usage = await enforcer.getMonthlyUsageSnapshot('org-1', '2026-04');
+
+    expect(usage).toEqual({ usageMonth: '2026-04-01', monthToDateCostCents: 700 });
+  });
+
+  it('drops same-day execution and leaves a memo reply when the daily cap is already consumed', async () => {
+    const { supabase, state } = createSupabaseStub({
+      billingLimits: { monthly_cap_cents: 2000, daily_cap_cents: 100, alert_threshold_pct: 80 },
+      runs: [{
+        id: 'run-1',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'completed',
+        created_at: '2026-04-07T03:00:00.000Z',
+        computed_cost_cents: 100,
+      }],
+    });
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn: vi.fn(),
+      now: () => new Date('2026-04-07T12:00:00.000Z'),
+    });
+
+    const result = await enforcer.enforceBeforeRun({
+      run: { id: 'run-2', org_id: 'org-1', project_id: 'project-1', agent_id: 'agent-1', memo_id: 'memo-1' },
+      memo: { id: 'memo-1', title: 'Daily billing check' },
+    });
+
+    expect(result.status).toBe('daily_cap_exceeded');
+    expect(state.memoReplies).toContainEqual(expect.objectContaining({
+      memo_id: 'memo-1',
+      created_by: 'agent-1',
+      content: '일일 한도 초과, 내일 재개',
+    }));
+  });
+
+  it('sends the threshold alert only once per month', async () => {
+    const fireWebhooksFn = vi.fn(async () => undefined);
+    const fetchFn = vi.fn(async () => ({ ok: true, json: async () => ({ ok: true }) } as Response));
+    const { supabase, state } = createSupabaseStub({
+      billingLimits: { monthly_cap_cents: 1000, daily_cap_cents: null, alert_threshold_pct: 80 },
+      runs: [{
+        id: 'run-1',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'completed',
+        created_at: '2026-04-07T03:00:00.000Z',
+        computed_cost_cents: 850,
+      }],
+      slackAuth: { access_token_ref: 'xoxb-test-token', expires_at: null },
+      slackChannels: [{ org_id: 'org-1', channel_id: 'C123', platform: 'slack', is_active: true }],
+    });
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn,
+      fetchFn,
+      now: () => new Date('2026-04-07T12:00:00.000Z'),
+    });
+
+    const first = await enforcer.enforceAfterRun({
+      run: { id: 'run-1', org_id: 'org-1', project_id: 'project-1', agent_id: 'agent-1', memo_id: 'memo-1' },
+      memo: { id: 'memo-1', title: 'Threshold' },
+    });
+    const second = await enforcer.enforceAfterRun({
+      run: { id: 'run-1', org_id: 'org-1', project_id: 'project-1', agent_id: 'agent-1', memo_id: 'memo-1' },
+      memo: { id: 'memo-1', title: 'Threshold' },
+    });
+
+    expect(first.thresholdAlertSent).toBe(true);
+    expect(second.thresholdAlertSent).toBe(false);
+    expect(state.alerts).toHaveLength(1);
+    expect(state.notifications).toHaveLength(1);
+    expect(fireWebhooksFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('suspends live deployments when the monthly cap is exceeded and sends admin email alerts', async () => {
+    process.env.RESEND_API_KEY = 'resend-test-key';
+    process.env.BILLING_ALERT_EMAIL_FROM = 'alerts@sprintable.test';
+    const fireWebhooksFn = vi.fn(async () => undefined);
+    const fetchFn = vi.fn(async () => ({ ok: true, json: async () => ({ id: 'email-1' }) } as Response));
+    const { supabase, state } = createSupabaseStub({
+      billingLimits: { monthly_cap_cents: 1000, daily_cap_cents: null, alert_threshold_pct: 80 },
+      runs: [{
+        id: 'run-1',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'completed',
+        created_at: '2026-04-07T03:00:00.000Z',
+        computed_cost_cents: 1201,
+      }, {
+        id: 'run-queued',
+        org_id: 'org-1',
+        deployment_id: 'deployment-1',
+        status: 'queued',
+        created_at: '2026-04-07T04:00:00.000Z',
+        computed_cost_cents: 0,
+      }],
+      deployments: [
+        { id: 'deployment-1', org_id: 'org-1', status: 'ACTIVE', deleted_at: null },
+        { id: 'deployment-2', org_id: 'org-1', status: 'DEPLOYING', deleted_at: null },
+        { id: 'deployment-3', org_id: 'org-1', status: 'SUSPENDED', deleted_at: null },
+      ],
+    });
+    const enforcer = new BillingLimitEnforcer(supabase as never, {
+      fireWebhooksFn,
+      fetchFn,
+      now: () => new Date('2026-04-07T12:00:00.000Z'),
+    });
+
+    const result = await enforcer.enforceAfterRun({
+      run: { id: 'run-1', org_id: 'org-1', project_id: 'project-1', agent_id: 'agent-1', memo_id: 'memo-1' },
+      memo: { id: 'memo-1', title: 'Monthly cap' },
+    });
+
+    expect(result.monthlyCapExceeded).toBe(true);
+    expect(result.suspendedDeploymentCount).toBe(2);
+    expect(state.deployments.filter((row) => ['deployment-1', 'deployment-2'].includes(row.id)).every((row) => row.status === 'SUSPENDED')).toBe(true);
+    expect(state.runs.find((row) => row.id === 'run-queued')?.status).toBe('held');
+    expect(fireWebhooksFn).toHaveBeenCalledWith(expect.anything(), 'org-1', expect.objectContaining({ event: 'billing.limit.monthly_cap_exceeded' }));
+    expect(fetchFn).toHaveBeenCalledWith('https://api.resend.com/emails', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ Authorization: 'Bearer resend-test-key' }),
+    }));
+  });
+});

--- a/ee/apps/web/src/services/billing-limit-enforcer.ts
+++ b/ee/apps/web/src/services/billing-limit-enforcer.ts
@@ -1,0 +1,616 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { fireWebhooks } from './webhook-notify';
+import { isExpiredIsoTimestamp, resolveMessagingBridgeSecretRef } from './slack-channel-mapping';
+import { getUsageMonthRange } from './monthly-agent-usage';
+import { getEntitlementBearingSubscription } from '@/lib/billing-policy';
+
+interface BillingLimitRow {
+  monthly_cap_cents: number | null;
+  daily_cap_cents: number | null;
+  alert_threshold_pct: number | null;
+}
+
+interface SubscriptionRow {
+  tier_id: string;
+}
+
+interface TeamMemberRecipientRow {
+  id: string;
+  user_id: string | null;
+}
+
+interface AdminAlertRecipient extends TeamMemberRecipientRow {
+  email: string;
+}
+
+interface AlertRow {
+  org_id: string;
+  usage_month: string;
+  alert_type: string;
+  threshold_pct: number | null;
+}
+
+interface SlackAuthRow {
+  access_token_ref: string;
+  expires_at: string | null;
+}
+
+interface SlackChannelRow {
+  channel_id: string;
+}
+
+interface BillingLimitDeps {
+  fetchFn?: typeof fetch;
+  fireWebhooksFn?: typeof fireWebhooks;
+  now?: () => Date;
+}
+
+export interface BillingLimitSettings {
+  monthlyCapCents: number | null;
+  dailyCapCents: number | null;
+  alertThresholdPct: number;
+  source: 'explicit' | 'plan_default';
+  tierName: string;
+}
+
+export interface BillingPreExecutionResult {
+  status: 'allow' | 'daily_cap_exceeded' | 'monthly_cap_exceeded';
+  reason: string | null;
+}
+
+export interface BillingPostExecutionResult {
+  thresholdAlertSent: boolean;
+  monthlyCapExceeded: boolean;
+  suspendedDeploymentCount: number;
+}
+
+export interface BillingLimitsInput {
+  monthlyCapCents?: number | null;
+  dailyCapCents?: number | null;
+  alertThresholdPct?: number;
+}
+
+interface ExecutionScope {
+  id: string;
+  org_id: string;
+  project_id: string;
+  agent_id: string;
+  memo_id: string | null;
+}
+
+interface MemoScope {
+  id: string;
+  title: string | null;
+}
+
+const DEFAULT_ALERT_THRESHOLD_PCT = 80;
+const FREE_PLAN_DEFAULT_MONTHLY_CAP_CENTS = 1_000;
+const DAILY_LIMIT_REPLY = '일일 한도 초과, 내일 재개';
+const DAILY_LIMIT_ERROR_CODE = 'billing_daily_cap_exceeded';
+const MONTHLY_LIMIT_ERROR_CODE = 'billing_monthly_cap_exceeded';
+const MONTHLY_THRESHOLD_ALERT_PREFIX = 'threshold';
+const MONTHLY_LIMIT_ALERT_TYPE = 'monthly_cap_exceeded';
+const RESEND_API_URL = 'https://api.resend.com/emails';
+
+function normalizeCap(value: number | null | undefined): number | null {
+  if (value == null || value <= 0) return null;
+  return value;
+}
+
+function startOfUtcDay(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+}
+
+function startOfNextUtcDay(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+}
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+function buildThresholdAlertType(thresholdPct: number) {
+  return `${MONTHLY_THRESHOLD_ALERT_PREFIX}_${thresholdPct}`;
+}
+
+function defaultPlanLimits(tierName: string): BillingLimitSettings {
+  if (tierName === 'free') {
+    return {
+      monthlyCapCents: FREE_PLAN_DEFAULT_MONTHLY_CAP_CENTS,
+      dailyCapCents: null,
+      alertThresholdPct: DEFAULT_ALERT_THRESHOLD_PCT,
+      source: 'plan_default',
+      tierName,
+    };
+  }
+
+  return {
+    monthlyCapCents: null,
+    dailyCapCents: null,
+    alertThresholdPct: DEFAULT_ALERT_THRESHOLD_PCT,
+    source: 'plan_default',
+    tierName,
+  };
+}
+
+export class BillingLimitEnforcer {
+  private readonly fetchFn: typeof fetch;
+  private readonly fireWebhooksFn: typeof fireWebhooks;
+  private readonly now: () => Date;
+
+  constructor(
+    private readonly supabase: SupabaseClient,
+    deps: BillingLimitDeps = {},
+  ) {
+    this.fetchFn = deps.fetchFn ?? fetch;
+    this.fireWebhooksFn = deps.fireWebhooksFn ?? fireWebhooks;
+    this.now = deps.now ?? (() => new Date());
+  }
+
+  async getResolvedSettings(orgId: string): Promise<BillingLimitSettings> {
+    const [limitResult, tierName] = await Promise.all([
+      this.supabase
+        .from('billing_limits')
+        .select('monthly_cap_cents, daily_cap_cents, alert_threshold_pct')
+        .eq('org_id', orgId)
+        .maybeSingle(),
+      this.getTierName(orgId),
+    ]);
+
+    if (limitResult.error) throw limitResult.error;
+    const limit = (limitResult.data as BillingLimitRow | null) ?? null;
+
+    if (!limit) {
+      return defaultPlanLimits(tierName);
+    }
+
+    return {
+      monthlyCapCents: normalizeCap(limit.monthly_cap_cents),
+      dailyCapCents: normalizeCap(limit.daily_cap_cents),
+      alertThresholdPct: limit.alert_threshold_pct ?? DEFAULT_ALERT_THRESHOLD_PCT,
+      source: 'explicit',
+      tierName,
+    };
+  }
+
+  async saveSettings(orgId: string, input: BillingLimitsInput): Promise<BillingLimitSettings> {
+    const { data: existing, error: existingError } = await this.supabase
+      .from('billing_limits')
+      .select('monthly_cap_cents, daily_cap_cents, alert_threshold_pct')
+      .eq('org_id', orgId)
+      .maybeSingle();
+
+    if (existingError) throw existingError;
+    const current = (existing as BillingLimitRow | null) ?? null;
+    const patch = {
+      org_id: orgId,
+      monthly_cap_cents: input.monthlyCapCents === undefined
+        ? normalizeCap(current?.monthly_cap_cents ?? null)
+        : normalizeCap(input.monthlyCapCents),
+      daily_cap_cents: input.dailyCapCents === undefined
+        ? normalizeCap(current?.daily_cap_cents ?? null)
+        : normalizeCap(input.dailyCapCents),
+      alert_threshold_pct: input.alertThresholdPct ?? current?.alert_threshold_pct ?? DEFAULT_ALERT_THRESHOLD_PCT,
+    };
+
+    const { error } = await this.supabase
+      .from('billing_limits')
+      .upsert(patch, { onConflict: 'org_id' });
+
+    if (error) throw error;
+    return this.getResolvedSettings(orgId);
+  }
+
+  async enforceBeforeRun(input: { run: ExecutionScope; memo: MemoScope }): Promise<BillingPreExecutionResult> {
+    const settings = await this.getResolvedSettings(input.run.org_id);
+    const usage = await this.getUsage(input.run.org_id);
+
+    if (settings.monthlyCapCents != null && usage.monthlySpentCents >= settings.monthlyCapCents) {
+      const suspendedDeploymentCount = await this.suspendOrgDeployments(input.run.org_id);
+      await this.sendMonthlyCapExceededAlerts({
+        orgId: input.run.org_id,
+        memoId: input.memo.id,
+        spentCents: usage.monthlySpentCents,
+        capCents: settings.monthlyCapCents,
+        usageMonth: usage.usageMonth,
+        suspendedDeploymentCount,
+      });
+
+      return {
+        status: 'monthly_cap_exceeded',
+        reason: '월 한도 초과로 조직 에이전트를 자동 정지했습니다.',
+      };
+    }
+
+    if (settings.dailyCapCents != null && usage.dailySpentCents >= settings.dailyCapCents) {
+      await this.supabase.from('memo_replies').insert({
+        memo_id: input.memo.id,
+        content: DAILY_LIMIT_REPLY,
+        created_by: input.run.agent_id,
+      });
+
+      return {
+        status: 'daily_cap_exceeded',
+        reason: DAILY_LIMIT_REPLY,
+      };
+    }
+
+    return { status: 'allow', reason: null };
+  }
+
+  async enforceAfterRun(input: { run: ExecutionScope; memo: MemoScope }): Promise<BillingPostExecutionResult> {
+    const settings = await this.getResolvedSettings(input.run.org_id);
+    const usage = await this.getUsage(input.run.org_id);
+    let thresholdAlertSent = false;
+    let monthlyCapExceeded = false;
+    let suspendedDeploymentCount = 0;
+
+    if (settings.monthlyCapCents != null) {
+      const thresholdAmount = Math.ceil((settings.monthlyCapCents * settings.alertThresholdPct) / 100);
+      if (usage.monthlySpentCents >= thresholdAmount) {
+        thresholdAlertSent = await this.sendThresholdAlert({
+          orgId: input.run.org_id,
+          memoId: input.memo.id,
+          spentCents: usage.monthlySpentCents,
+          capCents: settings.monthlyCapCents,
+          thresholdPct: settings.alertThresholdPct,
+          usageMonth: usage.usageMonth,
+        });
+      }
+
+      if (usage.monthlySpentCents > settings.monthlyCapCents) {
+        monthlyCapExceeded = true;
+        suspendedDeploymentCount = await this.suspendOrgDeployments(input.run.org_id);
+        await this.sendMonthlyCapExceededAlerts({
+          orgId: input.run.org_id,
+          memoId: input.memo.id,
+          spentCents: usage.monthlySpentCents,
+          capCents: settings.monthlyCapCents,
+          usageMonth: usage.usageMonth,
+          suspendedDeploymentCount,
+        });
+      }
+    }
+
+    return {
+      thresholdAlertSent,
+      monthlyCapExceeded,
+      suspendedDeploymentCount,
+    };
+  }
+
+  async getUsageSnapshot(orgId: string) {
+    const usage = await this.getUsage(orgId);
+    return {
+      usageMonth: usage.usageMonth,
+      usageDate: usage.usageDate,
+      monthToDateCostCents: usage.monthlySpentCents,
+      dayToDateCostCents: usage.dailySpentCents,
+    };
+  }
+
+  async getMonthlyUsageSnapshot(orgId: string, month: string) {
+    const range = getUsageMonthRange(month);
+    const monthToDateCostCents = await this.sumCompletedRunCosts(orgId, range.monthStartIso, range.nextMonthStartIso);
+
+    return {
+      usageMonth: range.monthStart,
+      monthToDateCostCents,
+    };
+  }
+
+  private async getTierName(orgId: string): Promise<string> {
+    const subscription = await getEntitlementBearingSubscription<{ tier?: string | null; status?: string | null }>(
+      this.supabase,
+      orgId,
+    );
+    return String(subscription?.tier ?? 'free').toLowerCase();
+  }
+
+  private async getUsage(orgId: string) {
+    const now = this.now();
+    const currentMonth = now.toISOString().slice(0, 7);
+    const dayStart = startOfUtcDay(now).toISOString();
+    const nextDayStart = startOfNextUtcDay(now).toISOString();
+
+    const [monthlyUsage, dailySpentCents] = await Promise.all([
+      this.getMonthlyUsageSnapshot(orgId, currentMonth),
+      this.sumCompletedRunCosts(orgId, dayStart, nextDayStart),
+    ]);
+
+    return {
+      usageMonth: monthlyUsage.usageMonth,
+      usageDate: dayStart.slice(0, 10),
+      monthlySpentCents: monthlyUsage.monthToDateCostCents,
+      dailySpentCents,
+    };
+  }
+
+  private async sumCompletedRunCosts(orgId: string, fromIso: string, toIso: string): Promise<number> {
+    const { data, error } = await this.supabase
+      .from('agent_runs')
+      .select('computed_cost_cents')
+      .eq('org_id', orgId)
+      .in('status', ['completed', 'failed'])
+      .gte('created_at', fromIso)
+      .lt('created_at', toIso);
+
+    if (error) throw error;
+    return (data ?? []).reduce((sum, row) => sum + Number((row as { computed_cost_cents?: number | null }).computed_cost_cents ?? 0), 0);
+  }
+
+  private async suspendOrgDeployments(orgId: string): Promise<number> {
+    const { data: activeDeployments, error: activeError } = await this.supabase
+      .from('agent_deployments')
+      .select('id')
+      .eq('org_id', orgId)
+      .is('deleted_at', null)
+      .in('status', ['DEPLOYING', 'ACTIVE']);
+
+    if (activeError) throw activeError;
+    const deploymentIds = (activeDeployments ?? []).map((deployment) => String((deployment as { id: string }).id));
+    if (!deploymentIds.length) return 0;
+
+    const { error: deploymentError } = await this.supabase
+      .from('agent_deployments')
+      .update({ status: 'SUSPENDED' })
+      .in('id', deploymentIds);
+
+    if (deploymentError) throw deploymentError;
+
+    const { error: queueError } = await this.supabase
+      .from('agent_runs')
+      .update({
+        status: 'held',
+        result_summary: 'Queued run held because the monthly billing cap was exceeded',
+      })
+      .in('deployment_id', deploymentIds)
+      .eq('status', 'queued');
+
+    if (queueError) throw queueError;
+    return deploymentIds.length;
+  }
+
+  private async sendThresholdAlert(input: {
+    orgId: string;
+    memoId: string;
+    spentCents: number;
+    capCents: number;
+    thresholdPct: number;
+    usageMonth: string;
+  }): Promise<boolean> {
+    const claimed = await this.claimAlert({
+      org_id: input.orgId,
+      usage_month: input.usageMonth,
+      alert_type: buildThresholdAlertType(input.thresholdPct),
+      threshold_pct: input.thresholdPct,
+    });
+
+    if (!claimed) return false;
+
+    const title = `월 비용 사용량 ${input.thresholdPct}% 도달`;
+    const body = `이번 달 에이전트 비용이 ${formatUsd(input.spentCents)} / ${formatUsd(input.capCents)}에 도달했습니다.`;
+
+    await this.notifyOrgAdmins(input.orgId, title, body, input.memoId);
+    await this.fireWebhooksFn(this.supabase, input.orgId, {
+      event: 'billing.limit.threshold_reached',
+      data: {
+        org_id: input.orgId,
+        memo_id: input.memoId,
+        spent_cents: input.spentCents,
+        monthly_cap_cents: input.capCents,
+        threshold_pct: input.thresholdPct,
+        usage_month: input.usageMonth,
+      },
+    });
+    await this.sendSlackAlert(input.orgId, `:warning: ${title}\n${body}`);
+    return true;
+  }
+
+  private async sendMonthlyCapExceededAlerts(input: {
+    orgId: string;
+    memoId: string;
+    spentCents: number;
+    capCents: number;
+    usageMonth: string;
+    suspendedDeploymentCount: number;
+  }) {
+    const claimed = await this.claimAlert({
+      org_id: input.orgId,
+      usage_month: input.usageMonth,
+      alert_type: MONTHLY_LIMIT_ALERT_TYPE,
+      threshold_pct: null,
+    });
+
+    if (!claimed) return;
+
+    const title = '월 비용 한도 초과';
+    const body = `이번 달 에이전트 비용이 ${formatUsd(input.spentCents)} / ${formatUsd(input.capCents)}를 넘어 조직 에이전트 ${input.suspendedDeploymentCount}개를 자동 정지했습니다.`;
+
+    await this.notifyOrgAdmins(input.orgId, title, body, input.memoId);
+    await this.sendMonthlyCapExceededEmail(input.orgId, title, body, input.memoId);
+    await this.fireWebhooksFn(this.supabase, input.orgId, {
+      event: 'billing.limit.monthly_cap_exceeded',
+      data: {
+        org_id: input.orgId,
+        memo_id: input.memoId,
+        spent_cents: input.spentCents,
+        monthly_cap_cents: input.capCents,
+        usage_month: input.usageMonth,
+        suspended_deployment_count: input.suspendedDeploymentCount,
+      },
+    });
+    await this.sendSlackAlert(input.orgId, `:no_entry: ${title}\n${body}`);
+  }
+
+  private async claimAlert(alert: AlertRow): Promise<boolean> {
+    const { error } = await this.supabase
+      .from('billing_limit_alerts')
+      .insert(alert);
+
+    if (!error) return true;
+    if ((error as { code?: string }).code === '23505') return false;
+    throw error;
+  }
+
+  private async notifyOrgAdmins(orgId: string, title: string, body: string, memoId: string) {
+    const recipients = await this.listAdminRecipients(orgId);
+    if (!recipients.length) return;
+
+    const rows = recipients.map((recipient) => ({
+      org_id: orgId,
+      user_id: recipient.id,
+      type: 'warning',
+      title,
+      body,
+      reference_type: 'memo',
+      reference_id: memoId,
+    }));
+
+    const { error } = await this.supabase.from('notifications').insert(rows);
+    if (error) throw error;
+  }
+
+  private async sendMonthlyCapExceededEmail(orgId: string, title: string, body: string, memoId: string) {
+    const recipients = await this.listAdminEmailRecipients(orgId);
+    if (!recipients.length) return;
+
+    const apiKey = process.env['RESEND_API_KEY'];
+    const from = process.env['BILLING_ALERT_EMAIL_FROM'];
+    if (!apiKey || !from) return;
+
+    const response = await this.fetchFn(RESEND_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify({
+        from,
+        to: recipients.map((recipient) => recipient.email),
+        subject: `[Sprintable] ${title}`,
+        text: `${body}\n\nMemo: ${memoId}`,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`billing_limit_email_failed:${response.status}`);
+    }
+  }
+
+  private async listAdminRecipients(orgId: string): Promise<TeamMemberRecipientRow[]> {
+    const { data: orgMembers, error: orgMembersError } = await this.supabase
+      .from('org_members')
+      .select('user_id')
+      .eq('org_id', orgId)
+      .in('role', ['owner', 'admin']);
+
+    if (orgMembersError) throw orgMembersError;
+    const userIds = (orgMembers ?? [])
+      .map((row) => (row as { user_id?: string | null }).user_id ?? null)
+      .filter((userId): userId is string => Boolean(userId));
+
+    if (!userIds.length) return [];
+
+    const { data: teamMembers, error: teamMembersError } = await this.supabase
+      .from('team_members')
+      .select('id, user_id')
+      .eq('org_id', orgId)
+      .eq('type', 'human')
+      .eq('is_active', true)
+      .in('user_id', userIds);
+
+    if (teamMembersError) throw teamMembersError;
+    const uniqueById = new Map<string, TeamMemberRecipientRow>();
+    for (const member of teamMembers ?? []) {
+      uniqueById.set(String((member as TeamMemberRecipientRow).id), member as TeamMemberRecipientRow);
+    }
+    return [...uniqueById.values()];
+  }
+
+  private async listAdminEmailRecipients(orgId: string): Promise<AdminAlertRecipient[]> {
+    const recipients = await this.listAdminRecipients(orgId);
+    if (!recipients.length) return [];
+
+    const uniqueByEmail = new Map<string, AdminAlertRecipient>();
+    await Promise.all(recipients.map(async (recipient) => {
+      if (!recipient.user_id) return;
+      const result = await this.supabase.auth.admin.getUserById(recipient.user_id);
+      if (result.error) throw result.error;
+      const email = result.data?.user?.email?.trim();
+      if (!email) return;
+      uniqueByEmail.set(email.toLowerCase(), {
+        ...recipient,
+        email,
+      });
+    }));
+
+    return [...uniqueByEmail.values()];
+  }
+
+  private async sendSlackAlert(orgId: string, text: string) {
+    const { data: auth, error: authError } = await this.supabase
+      .from('messaging_bridge_org_auths')
+      .select('access_token_ref, expires_at')
+      .eq('org_id', orgId)
+      .eq('platform', 'slack')
+      .maybeSingle();
+
+    if (authError) throw authError;
+    const slackAuth = (auth as SlackAuthRow | null) ?? null;
+    if (!slackAuth) return;
+
+    const token = resolveMessagingBridgeSecretRef(slackAuth.access_token_ref);
+    if (!token || isExpiredIsoTimestamp(slackAuth.expires_at, this.now().getTime())) return;
+
+    const { data: channels, error: channelsError } = await this.supabase
+      .from('messaging_bridge_channels')
+      .select('channel_id')
+      .eq('org_id', orgId)
+      .eq('platform', 'slack')
+      .eq('is_active', true);
+
+    if (channelsError) throw channelsError;
+    const channelIds = [...new Set((channels ?? []).map((channel) => String((channel as SlackChannelRow).channel_id)).filter(Boolean))];
+    if (!channelIds.length) return;
+
+    await Promise.allSettled(channelIds.map(async (channelId) => {
+      await this.fetchFn('https://slack.com/api/chat.postMessage', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+        body: JSON.stringify({
+          channel: channelId,
+          text,
+        }),
+      });
+    }));
+  }
+}
+
+export function createBlockedBillingPatch(code: 'daily_cap_exceeded' | 'monthly_cap_exceeded', reason: string) {
+  const errorCode = code === 'daily_cap_exceeded' ? DAILY_LIMIT_ERROR_CODE : MONTHLY_LIMIT_ERROR_CODE;
+  return {
+    status: 'failed' as const,
+    finished_at: new Date().toISOString(),
+    llm_call_count: 0,
+    tool_call_history: [],
+    output_memo_ids: [],
+    last_error_code: errorCode,
+    error_message: reason,
+    result_summary: reason,
+    failure_disposition: 'non_retryable' as const,
+    duration_ms: 0,
+    model: null,
+    input_tokens: null,
+    output_tokens: null,
+    cost_usd: 0,
+    computed_cost_cents: 0,
+    llm_provider: null,
+    llm_provider_key: null,
+    per_run_cap_cents: null,
+    billing_notes: [errorCode],
+  };
+}

--- a/ee/apps/web/src/services/subscription.test.ts
+++ b/ee/apps/web/src/services/subscription.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it } from 'vitest';
+import { SubscriptionService } from './subscription';
+import type { CheckoutLifecycleStatus, PaymentProvider, WebhookEvent } from '@/lib/payment/types';
+
+interface SubscriptionRow {
+  org_id: string;
+  tier_id: string | null;
+  offering_snapshot_id: string | null;
+  status: string;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  payment_provider: PaymentProvider | null;
+  provider_subscription_id: string | null;
+  canceled_at: string | null;
+  grace_period_end: string | null;
+  last_webhook_event_id: string | null;
+  last_webhook_event_at: string | null;
+}
+
+interface CheckoutSessionRow {
+  org_id: string;
+  requested_tier_id: string | null;
+  provider: PaymentProvider;
+  price_id: string | null;
+  provider_transaction_id: string;
+  provider_subscription_id: string | null;
+  status: CheckoutLifecycleStatus;
+  checkout_url: string | null;
+  last_webhook_event_id: string | null;
+  last_webhook_event_at: string | null;
+}
+
+type Filter = { kind: 'eq' | 'is' | 'lte'; column: string; value: unknown };
+
+function createSupabaseStub(options?: {
+  subscriptions?: SubscriptionRow[];
+  checkoutSessions?: CheckoutSessionRow[];
+  planTiers?: Array<{ id: string }>;
+  planOfferingSnapshots?: Array<{ id: string; tier_id: string; effective_until: string | null; version: number }>;
+}) {
+  const state = {
+    subscriptions: options?.subscriptions ?? [],
+    checkoutSessions: options?.checkoutSessions ?? [],
+    planTiers: options?.planTiers ?? [{ id: 'tier-team' }, { id: 'tier-pro' }, { id: '00000000-0000-0000-0000-000000000a01' }],
+    planOfferingSnapshots: options?.planOfferingSnapshots ?? [
+      { id: 'snap-team-v1', tier_id: 'tier-team', effective_until: null, version: 1 },
+      { id: 'snap-pro-v1', tier_id: 'tier-pro', effective_until: null, version: 1 },
+      { id: 'snap-free-v1', tier_id: '00000000-0000-0000-0000-000000000a01', effective_until: null, version: 1 },
+    ],
+  };
+
+  function matches(row: Record<string, unknown>, filters: Filter[]) {
+    return filters.every((filter) => {
+      const value = row[filter.column];
+      if (filter.kind === 'eq') return value === filter.value;
+      if (filter.kind === 'is') return filter.value === null ? value == null : value === filter.value;
+      if (filter.kind === 'lte') {
+        if (value == null) return false;
+        return String(value) <= String(filter.value);
+      }
+      return true;
+    });
+  }
+
+  function createSelectBuilder(rowsFactory: () => Array<Record<string, unknown>>) {
+    const filters: Filter[] = [];
+    let orderColumn: string | null = null;
+    let ascending = true;
+    const builder = {
+      select() { return builder; },
+      eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+      is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+      lte(column: string, value: unknown) { filters.push({ kind: 'lte', column, value }); return builder; },
+      order(column: string, options?: { ascending?: boolean }) { orderColumn = column; ascending = options?.ascending ?? true; return builder; },
+      maybeSingle: async () => {
+        let rows = rowsFactory().filter((row) => matches(row, filters));
+        if (orderColumn) {
+          rows = rows.sort((a, b) => ascending
+            ? Number(a[orderColumn as keyof typeof a]) - Number(b[orderColumn as keyof typeof b])
+            : Number(b[orderColumn as keyof typeof b]) - Number(a[orderColumn as keyof typeof a]));
+        }
+        return { data: rows[0] ?? null, error: null };
+      },
+      single: async () => {
+        const rows = rowsFactory().filter((row) => matches(row, filters));
+        return { data: rows[0] ?? null, error: rows[0] ? null : { code: 'PGRST116', message: 'Row not found' } };
+      },
+    };
+    return builder;
+  }
+
+  function createUpdateBuilder<T extends Record<string, unknown>>(rows: T[]) {
+    return (payload: Record<string, unknown>) => {
+      const filters: Filter[] = [];
+      const builder = {
+        eq(column: string, value: unknown) { filters.push({ kind: 'eq', column, value }); return builder; },
+        is(column: string, value: unknown) { filters.push({ kind: 'is', column, value }); return builder; },
+        lte(column: string, value: unknown) { filters.push({ kind: 'lte', column, value }); return builder; },
+        select() {
+          return {
+            maybeSingle: async () => {
+              const row = rows.find((item) => matches(item as unknown as Record<string, unknown>, filters));
+              if (!row) return { data: null, error: null };
+              Object.assign(row, payload);
+              return { data: row, error: null };
+            },
+            single: async () => {
+              const row = rows.find((item) => matches(item as unknown as Record<string, unknown>, filters));
+              if (!row) return { data: null, error: { code: 'PGRST116', message: 'Row not found' } };
+              Object.assign(row, payload);
+              return { data: row, error: null };
+            },
+          };
+        },
+      };
+      return builder;
+    };
+  }
+
+  function buildSubscriptionRow(payload: Record<string, unknown>): SubscriptionRow {
+    return {
+      org_id: String(payload.org_id),
+      tier_id: (payload.tier_id as string | null | undefined) ?? null,
+      offering_snapshot_id: (payload.offering_snapshot_id as string | null | undefined) ?? null,
+      status: String(payload.status ?? 'active'),
+      current_period_start: (payload.current_period_start as string | null | undefined) ?? null,
+      current_period_end: (payload.current_period_end as string | null | undefined) ?? null,
+      payment_provider: (payload.payment_provider as PaymentProvider | null | undefined) ?? null,
+      provider_subscription_id: (payload.provider_subscription_id as string | null | undefined) ?? null,
+      canceled_at: (payload.canceled_at as string | null | undefined) ?? null,
+      grace_period_end: (payload.grace_period_end as string | null | undefined) ?? null,
+      last_webhook_event_id: (payload.last_webhook_event_id as string | null | undefined) ?? null,
+      last_webhook_event_at: (payload.last_webhook_event_at as string | null | undefined) ?? null,
+    };
+  }
+
+  function buildCheckoutRow(payload: Record<string, unknown>): CheckoutSessionRow {
+    return {
+      org_id: String(payload.org_id),
+      requested_tier_id: (payload.requested_tier_id as string | null | undefined) ?? null,
+      provider: payload.provider as PaymentProvider,
+      price_id: (payload.price_id as string | null | undefined) ?? null,
+      provider_transaction_id: String(payload.provider_transaction_id),
+      provider_subscription_id: (payload.provider_subscription_id as string | null | undefined) ?? null,
+      status: payload.status as CheckoutLifecycleStatus,
+      checkout_url: (payload.checkout_url as string | null | undefined) ?? null,
+      last_webhook_event_id: (payload.last_webhook_event_id as string | null | undefined) ?? null,
+      last_webhook_event_at: (payload.last_webhook_event_at as string | null | undefined) ?? null,
+    };
+  }
+
+  const supabase = {
+    from(table: string) {
+      if (table === 'plan_tiers') {
+        return createSelectBuilder(() => state.planTiers as unknown as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'plan_offering_snapshots') {
+        return createSelectBuilder(() => state.planOfferingSnapshots as unknown as Array<Record<string, unknown>>);
+      }
+
+      if (table === 'subscriptions') {
+        return {
+          ...createSelectBuilder(() => state.subscriptions as unknown as Array<Record<string, unknown>>),
+          upsert(payload: Record<string, unknown>) {
+            const row = buildSubscriptionRow(payload);
+            const index = state.subscriptions.findIndex((item) => item.org_id === row.org_id);
+            if (index >= 0) state.subscriptions[index] = { ...state.subscriptions[index], ...row };
+            else state.subscriptions.push(row);
+            return {
+              select() {
+                return {
+                  single: async () => ({ data: row, error: null }),
+                };
+              },
+            };
+          },
+          insert(payload: Record<string, unknown>) {
+            const row = buildSubscriptionRow(payload);
+            const exists = state.subscriptions.some((item) => item.org_id === row.org_id);
+            return {
+              select() {
+                return {
+                  single: async () => exists
+                    ? { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint' } }
+                    : (() => {
+                        state.subscriptions.push(row);
+                        return { data: row, error: null };
+                      })(),
+                };
+              },
+            };
+          },
+          update: createUpdateBuilder(state.subscriptions as unknown as Array<Record<string, unknown>>),
+        };
+      }
+
+      if (table === 'subscription_checkout_sessions') {
+        return {
+          ...createSelectBuilder(() => state.checkoutSessions as unknown as Array<Record<string, unknown>>),
+          upsert(payload: Record<string, unknown>) {
+            const row = buildCheckoutRow(payload);
+            const index = state.checkoutSessions.findIndex((item) => item.provider === row.provider && item.provider_transaction_id === row.provider_transaction_id);
+            if (index >= 0) state.checkoutSessions[index] = { ...state.checkoutSessions[index], ...row };
+            else state.checkoutSessions.push(row);
+            return {
+              select() {
+                return {
+                  single: async () => ({ data: row, error: null }),
+                };
+              },
+            };
+          },
+          insert(payload: Record<string, unknown>) {
+            const row = buildCheckoutRow(payload);
+            const exists = state.checkoutSessions.some((item) => item.provider === row.provider && item.provider_transaction_id === row.provider_transaction_id);
+            return {
+              select() {
+                return {
+                  single: async () => exists
+                    ? { data: null, error: { code: '23505', message: 'duplicate key value violates unique constraint' } }
+                    : (() => {
+                        state.checkoutSessions.push(row);
+                        return { data: row, error: null };
+                      })(),
+                };
+              },
+            };
+          },
+          update: createUpdateBuilder(state.checkoutSessions as unknown as Array<Record<string, unknown>>),
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+
+  return { supabase: supabase as never, state };
+}
+
+function createWebhookEvent(overrides: Partial<WebhookEvent>): WebhookEvent {
+  return {
+    type: 'transaction.created',
+    eventId: 'evt_1',
+    occurredAt: '2026-04-11T09:00:00.000Z',
+    providerSubscriptionId: null,
+    providerTransactionId: 'txn_1',
+    orgId: 'org-1',
+    tierId: 'tier-team',
+    currentPeriodStart: null,
+    currentPeriodEnd: null,
+    checkoutStatus: 'pending',
+    subscriptionStatus: null,
+    ...overrides,
+  };
+}
+
+describe('SubscriptionService', () => {
+  it('tracks checkout lifecycle from pending to completed', async () => {
+    const { supabase, state } = createSupabaseStub();
+    const service = new SubscriptionService(supabase);
+
+    await service.processWebhookEvent(createWebhookEvent({
+      type: 'transaction.created',
+      eventId: 'evt_created',
+      checkoutStatus: 'pending',
+    }), 'paddle');
+
+    await service.processWebhookEvent(createWebhookEvent({
+      type: 'transaction.completed',
+      eventId: 'evt_completed',
+      occurredAt: '2026-04-11T09:05:00.000Z',
+      checkoutStatus: 'completed',
+    }), 'paddle');
+
+    expect(state.checkoutSessions).toHaveLength(1);
+    expect(state.checkoutSessions[0]).toMatchObject({
+      provider_transaction_id: 'txn_1',
+      status: 'completed',
+      last_webhook_event_id: 'evt_completed',
+    });
+  });
+
+  it('resolves missing org and tier from the checkout session and activates entitlement on subscription.created', async () => {
+    const { supabase, state } = createSupabaseStub();
+    const service = new SubscriptionService(supabase);
+
+    await service.recordCheckoutSession({
+      orgId: 'org-1',
+      tierId: 'tier-team',
+      provider: 'paddle',
+      priceId: 'pri_team_monthly',
+      providerTransactionId: 'txn_1',
+      checkoutUrl: 'https://pay.example.test/txn_1',
+    });
+
+    await service.processWebhookEvent(createWebhookEvent({
+      type: 'subscription.created',
+      eventId: 'evt_subscription_created',
+      occurredAt: '2026-04-11T09:10:00.000Z',
+      providerSubscriptionId: 'sub_1',
+      orgId: null,
+      tierId: null,
+      currentPeriodStart: '2026-04-11T09:10:00.000Z',
+      currentPeriodEnd: '2026-05-11T09:10:00.000Z',
+      checkoutStatus: 'completed',
+      subscriptionStatus: 'trialing',
+    }), 'paddle');
+
+    expect(state.checkoutSessions[0]).toMatchObject({
+      provider_transaction_id: 'txn_1',
+      provider_subscription_id: 'sub_1',
+      status: 'completed',
+    });
+    expect(state.subscriptions[0]).toMatchObject({
+      org_id: 'org-1',
+      tier_id: 'tier-team',
+      offering_snapshot_id: 'snap-team-v1',
+      status: 'trialing',
+      payment_provider: 'paddle',
+      provider_subscription_id: 'sub_1',
+      last_webhook_event_id: 'evt_subscription_created',
+    });
+  });
+
+  it('keeps a newer webhook state when an older event arrives later', async () => {
+    const { supabase, state } = createSupabaseStub({
+      subscriptions: [{
+        org_id: 'org-1',
+        tier_id: 'tier-team',
+        offering_snapshot_id: 'snap-team-v1',
+        status: 'active',
+        current_period_start: '2026-04-11T10:00:00.000Z',
+        current_period_end: '2026-05-11T10:00:00.000Z',
+        payment_provider: 'paddle',
+        provider_subscription_id: 'sub_1',
+        canceled_at: null,
+        grace_period_end: null,
+        last_webhook_event_id: 'evt_latest',
+        last_webhook_event_at: '2026-04-11T10:00:00.000Z',
+      }],
+      checkoutSessions: [{
+        org_id: 'org-1',
+        requested_tier_id: 'tier-team',
+        provider: 'paddle',
+        price_id: 'pri_team_monthly',
+        provider_transaction_id: 'txn_1',
+        provider_subscription_id: 'sub_1',
+        status: 'completed',
+        checkout_url: 'https://pay.example.test/txn_1',
+        last_webhook_event_id: 'evt_latest',
+        last_webhook_event_at: '2026-04-11T10:00:00.000Z',
+      }],
+    });
+    const service = new SubscriptionService(supabase);
+
+    const stale = await service.processWebhookEvent(createWebhookEvent({
+      type: 'subscription.past_due',
+      eventId: 'evt_stale',
+      occurredAt: '2026-04-11T09:00:00.000Z',
+      providerSubscriptionId: 'sub_1',
+      currentPeriodStart: '2026-04-11T09:00:00.000Z',
+      currentPeriodEnd: '2026-05-11T09:00:00.000Z',
+      checkoutStatus: null,
+      subscriptionStatus: 'past_due',
+    }), 'paddle');
+
+    expect(stale.duplicateOrStale).toBe(true);
+    expect(state.subscriptions[0]).toMatchObject({
+      status: 'active',
+      last_webhook_event_id: 'evt_latest',
+      offering_snapshot_id: 'snap-team-v1',
+    });
+    expect(state.checkoutSessions[0]).toMatchObject({
+      status: 'completed',
+      last_webhook_event_id: 'evt_latest',
+    });
+  });
+});

--- a/ee/apps/web/src/services/subscription.ts
+++ b/ee/apps/web/src/services/subscription.ts
@@ -1,0 +1,582 @@
+/**
+ * AC6/7: 구독 관리 서비스
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  WebhookEvent,
+  PaymentProvider,
+  CheckoutLifecycleStatus,
+  SubscriptionLifecycleStatus,
+} from '@/lib/payment/types';
+
+const FREE_TIER_ID = '00000000-0000-0000-0000-000000000a01';
+const GRACE_PERIOD_DAYS = 7;
+
+type SubscriptionRow = {
+  org_id: string;
+  tier_id: string | null;
+  offering_snapshot_id: string | null;
+  status: string;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  payment_provider: PaymentProvider | null;
+  provider_subscription_id: string | null;
+  canceled_at: string | null;
+  grace_period_end: string | null;
+  last_webhook_event_id: string | null;
+  last_webhook_event_at: string | null;
+};
+
+type CheckoutSessionRow = {
+  org_id: string;
+  requested_tier_id: string | null;
+  provider: PaymentProvider;
+  price_id: string | null;
+  provider_transaction_id: string;
+  provider_subscription_id: string | null;
+  status: CheckoutLifecycleStatus;
+  checkout_url: string | null;
+  last_webhook_event_id: string | null;
+  last_webhook_event_at: string | null;
+};
+
+function addDaysIso(base: string | Date, days: number) {
+  const date = new Date(base);
+  date.setDate(date.getDate() + days);
+  return date.toISOString();
+}
+
+function isUniqueViolation(error: unknown) {
+  return Boolean(error && typeof error === 'object' && 'code' in error && (error as { code?: string }).code === '23505');
+}
+
+export class SubscriptionService {
+  constructor(private readonly supabase: SupabaseClient) {}
+
+  async recordCheckoutSession(input: {
+    orgId: string;
+    tierId: string;
+    provider: PaymentProvider;
+    priceId: string;
+    providerTransactionId: string;
+    checkoutUrl: string;
+  }) {
+    const { data, error } = await this.supabase
+      .from('subscription_checkout_sessions')
+      .upsert(
+        {
+          org_id: input.orgId,
+          requested_tier_id: input.tierId,
+          provider: input.provider,
+          price_id: input.priceId,
+          provider_transaction_id: input.providerTransactionId,
+          status: 'pending',
+          checkout_url: input.checkoutUrl,
+        },
+        { onConflict: 'provider,provider_transaction_id' },
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  /** 구독 활성화 — 웹훅 수신 후 호출 */
+  async activateSubscription(
+    orgId: string,
+    tierId: string,
+    provider: PaymentProvider,
+    providerSubId: string | null,
+    periodStart: string | null,
+    periodEnd: string | null,
+    options?: {
+      status?: Extract<SubscriptionLifecycleStatus, 'active' | 'trialing'>;
+      eventId?: string | null;
+      occurredAt?: string | null;
+    },
+  ) {
+    const existing = await this.getSubscriptionByOrg(orgId);
+    const snapshotId = await this.resolveSnapshotId(tierId, existing);
+
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .upsert(
+        {
+          org_id: orgId,
+          tier_id: tierId,
+          offering_snapshot_id: snapshotId,
+          status: options?.status ?? 'active',
+          payment_provider: provider,
+          provider_subscription_id: providerSubId,
+          current_period_start: periodStart,
+          current_period_end: periodEnd,
+          canceled_at: null,
+          grace_period_end: null,
+          ...(options?.eventId ? { last_webhook_event_id: options.eventId } : {}),
+          ...(options?.occurredAt ? { last_webhook_event_at: options.occurredAt } : {}),
+        },
+        { onConflict: 'org_id' },
+      )
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  /** AC7: 구독 취소 — canceled_at + grace_period_end 설정 */
+  async cancelSubscription(orgId: string) {
+    const now = new Date();
+    const gracePeriodEnd = addDaysIso(now, GRACE_PERIOD_DAYS);
+
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .update({
+        status: 'canceled',
+        canceled_at: now.toISOString(),
+        grace_period_end: gracePeriodEnd,
+      })
+      .eq('org_id', orgId)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  /** AC7: grace period 만료 후 Free 다운그레이드 */
+  async downgradeToFree(orgId: string) {
+    const snapshotId = await this.resolveSnapshotId(FREE_TIER_ID, null);
+
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .update({
+        tier_id: FREE_TIER_ID,
+        offering_snapshot_id: snapshotId,
+        status: 'active',
+        payment_provider: null,
+        provider_subscription_id: null,
+        canceled_at: null,
+        grace_period_end: null,
+      })
+      .eq('org_id', orgId)
+      .select()
+      .single();
+
+    if (error) throw error;
+    return data;
+  }
+
+  private async getSubscriptionByOrg(orgId: string) {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .select('org_id, tier_id, offering_snapshot_id, status, current_period_start, current_period_end, payment_provider, provider_subscription_id, canceled_at, grace_period_end, last_webhook_event_id, last_webhook_event_at')
+      .eq('org_id', orgId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as SubscriptionRow | null) ?? null;
+  }
+
+  private async getSubscriptionByProvider(provider: PaymentProvider, providerSubscriptionId: string) {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .select('org_id, tier_id, offering_snapshot_id, status, current_period_start, current_period_end, payment_provider, provider_subscription_id, canceled_at, grace_period_end, last_webhook_event_id, last_webhook_event_at')
+      .eq('payment_provider', provider)
+      .eq('provider_subscription_id', providerSubscriptionId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as SubscriptionRow | null) ?? null;
+  }
+
+  private async getCheckoutSessionByTransaction(provider: PaymentProvider, providerTransactionId: string) {
+    const { data, error } = await this.supabase
+      .from('subscription_checkout_sessions')
+      .select('org_id, requested_tier_id, provider, price_id, provider_transaction_id, provider_subscription_id, status, checkout_url, last_webhook_event_id, last_webhook_event_at')
+      .eq('provider', provider)
+      .eq('provider_transaction_id', providerTransactionId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as CheckoutSessionRow | null) ?? null;
+  }
+
+  private async getCheckoutSessionBySubscription(provider: PaymentProvider, providerSubscriptionId: string) {
+    const { data, error } = await this.supabase
+      .from('subscription_checkout_sessions')
+      .select('org_id, requested_tier_id, provider, price_id, provider_transaction_id, provider_subscription_id, status, checkout_url, last_webhook_event_id, last_webhook_event_at')
+      .eq('provider', provider)
+      .eq('provider_subscription_id', providerSubscriptionId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as CheckoutSessionRow | null) ?? null;
+  }
+
+  private async isKnownTier(tierId: string) {
+    const { data, error } = await this.supabase
+      .from('plan_tiers')
+      .select('id')
+      .eq('id', tierId)
+      .maybeSingle();
+
+    if (error) throw error;
+    return Boolean(data?.id);
+  }
+
+  private async getActiveSnapshotId(tierId: string) {
+    const { data, error } = await this.supabase
+      .from('plan_offering_snapshots')
+      .select('id')
+      .eq('tier_id', tierId)
+      .is('effective_until', null)
+      .order('version', { ascending: false })
+      .maybeSingle();
+
+    if (error) throw error;
+    return (data as { id?: string } | null)?.id ?? null;
+  }
+
+  private async resolveSnapshotId(tierId: string, existing: SubscriptionRow | null) {
+    if (existing?.tier_id === tierId && existing.offering_snapshot_id) return existing.offering_snapshot_id;
+    const snapshotId = await this.getActiveSnapshotId(tierId);
+    if (!snapshotId) throw new Error(`No active offering snapshot for tier ${tierId}`);
+    return snapshotId;
+  }
+
+  private async resolveContext(event: WebhookEvent, provider: PaymentProvider) {
+    const subscriptionByProvider = event.providerSubscriptionId
+      ? await this.getSubscriptionByProvider(provider, event.providerSubscriptionId)
+      : null;
+    const checkoutByTransaction = event.providerTransactionId
+      ? await this.getCheckoutSessionByTransaction(provider, event.providerTransactionId)
+      : null;
+    const checkoutBySubscription = event.providerSubscriptionId
+      ? await this.getCheckoutSessionBySubscription(provider, event.providerSubscriptionId)
+      : null;
+
+    let orgId = event.orgId ?? subscriptionByProvider?.org_id ?? checkoutByTransaction?.org_id ?? checkoutBySubscription?.org_id ?? null;
+    const subscriptionByOrg = orgId ? await this.getSubscriptionByOrg(orgId) : null;
+    orgId = orgId ?? subscriptionByOrg?.org_id ?? null;
+
+    const tierCandidates = [
+      event.tierId,
+      subscriptionByProvider?.tier_id,
+      checkoutByTransaction?.requested_tier_id,
+      checkoutBySubscription?.requested_tier_id,
+      subscriptionByOrg?.tier_id,
+    ].filter((value): value is string => Boolean(value));
+
+    let tierId: string | null = null;
+    for (const candidate of tierCandidates) {
+      if (await this.isKnownTier(candidate)) {
+        tierId = candidate;
+        break;
+      }
+    }
+
+    return {
+      orgId,
+      tierId,
+      subscription: subscriptionByOrg ?? subscriptionByProvider,
+      checkoutSession: checkoutByTransaction ?? checkoutBySubscription,
+    };
+  }
+
+  private async insertCheckoutWebhookState(row: {
+    org_id: string;
+    requested_tier_id: string;
+    provider: PaymentProvider;
+    price_id: string | null;
+    provider_transaction_id: string;
+    provider_subscription_id: string | null;
+    status: CheckoutLifecycleStatus;
+    checkout_url: string | null;
+    last_webhook_event_id: string;
+    last_webhook_event_at: string;
+  }) {
+    const { data, error } = await this.supabase
+      .from('subscription_checkout_sessions')
+      .insert(row)
+      .select('org_id, requested_tier_id, provider, price_id, provider_transaction_id, provider_subscription_id, status, checkout_url, last_webhook_event_id, last_webhook_event_at')
+      .single();
+
+    return { data: (data as CheckoutSessionRow | null) ?? null, error };
+  }
+
+  private async updateCheckoutWebhookStateIfCurrent(
+    provider: PaymentProvider,
+    providerTransactionId: string,
+    occurredAt: string,
+    patch: {
+      org_id: string;
+      requested_tier_id: string;
+      provider_subscription_id: string | null;
+      status: CheckoutLifecycleStatus;
+      last_webhook_event_id: string;
+      last_webhook_event_at: string;
+    },
+  ) {
+    const base = () => this.supabase
+      .from('subscription_checkout_sessions')
+      .update(patch)
+      .eq('provider', provider)
+      .eq('provider_transaction_id', providerTransactionId);
+
+    const { data: nullApplied, error: nullError } = await base()
+      .is('last_webhook_event_at', null)
+      .select('org_id, requested_tier_id, provider, price_id, provider_transaction_id, provider_subscription_id, status, checkout_url, last_webhook_event_id, last_webhook_event_at')
+      .maybeSingle();
+    if (nullError) throw nullError;
+    if (nullApplied) return nullApplied as CheckoutSessionRow;
+
+    const { data: orderedApplied, error: orderedError } = await base()
+      .lte('last_webhook_event_at', occurredAt)
+      .select('org_id, requested_tier_id, provider, price_id, provider_transaction_id, provider_subscription_id, status, checkout_url, last_webhook_event_id, last_webhook_event_at')
+      .maybeSingle();
+    if (orderedError) throw orderedError;
+    return (orderedApplied as CheckoutSessionRow | null) ?? null;
+  }
+
+  private async applyCheckoutSessionEvent(
+    provider: PaymentProvider,
+    event: WebhookEvent,
+    context: Awaited<ReturnType<SubscriptionService['resolveContext']>>,
+  ) {
+    const targetSession = context.checkoutSession;
+    const providerTransactionId = event.providerTransactionId ?? targetSession?.provider_transaction_id ?? null;
+    const status = event.checkoutStatus ?? targetSession?.status ?? null;
+
+    if (!providerTransactionId || !status) return { changed: false, row: targetSession };
+
+    const orgId = context.orgId ?? targetSession?.org_id ?? null;
+    const tierId = context.tierId ?? targetSession?.requested_tier_id ?? null;
+    if (!orgId || !tierId) throw new Error(`Cannot resolve checkout lifecycle context for ${event.type}`);
+
+    const row = {
+      org_id: orgId,
+      requested_tier_id: tierId,
+      provider,
+      price_id: targetSession?.price_id ?? null,
+      provider_transaction_id: providerTransactionId,
+      provider_subscription_id: event.providerSubscriptionId ?? targetSession?.provider_subscription_id ?? null,
+      status,
+      checkout_url: targetSession?.checkout_url ?? null,
+      last_webhook_event_id: event.eventId,
+      last_webhook_event_at: event.occurredAt,
+    };
+
+    const inserted = await this.insertCheckoutWebhookState(row);
+    if (!inserted.error) return { changed: true, row: inserted.data };
+    if (!isUniqueViolation(inserted.error)) throw inserted.error;
+
+    const updated = await this.updateCheckoutWebhookStateIfCurrent(
+      provider,
+      providerTransactionId,
+      event.occurredAt,
+      {
+        org_id: orgId,
+        requested_tier_id: tierId,
+        provider_subscription_id: row.provider_subscription_id,
+        status,
+        last_webhook_event_id: event.eventId,
+        last_webhook_event_at: event.occurredAt,
+      },
+    );
+
+    if (updated) return { changed: true, row: updated };
+    return {
+      changed: false,
+      row: await this.getCheckoutSessionByTransaction(provider, providerTransactionId),
+    };
+  }
+
+  private async insertSubscriptionWebhookState(row: {
+    org_id: string;
+    tier_id: string;
+    offering_snapshot_id: string;
+    status: SubscriptionLifecycleStatus;
+    payment_provider: PaymentProvider;
+    provider_subscription_id: string | null;
+    current_period_start: string | null;
+    current_period_end: string | null;
+    canceled_at: string | null;
+    grace_period_end: string | null;
+    last_webhook_event_id: string;
+    last_webhook_event_at: string;
+  }) {
+    const { data, error } = await this.supabase
+      .from('subscriptions')
+      .insert(row)
+      .select('org_id, tier_id, offering_snapshot_id, status, current_period_start, current_period_end, payment_provider, provider_subscription_id, canceled_at, grace_period_end, last_webhook_event_id, last_webhook_event_at')
+      .single();
+
+    return { data: (data as SubscriptionRow | null) ?? null, error };
+  }
+
+  private async updateSubscriptionWebhookStateIfCurrent(
+    orgId: string,
+    occurredAt: string,
+    patch: {
+      tier_id: string;
+      offering_snapshot_id: string;
+      status: SubscriptionLifecycleStatus;
+      payment_provider: PaymentProvider;
+      provider_subscription_id: string | null;
+      current_period_start: string | null;
+      current_period_end: string | null;
+      canceled_at: string | null;
+      grace_period_end: string | null;
+      last_webhook_event_id: string;
+      last_webhook_event_at: string;
+    },
+  ) {
+    const base = () => this.supabase
+      .from('subscriptions')
+      .update(patch)
+      .eq('org_id', orgId);
+
+    const { data: nullApplied, error: nullError } = await base()
+      .is('last_webhook_event_at', null)
+      .select('org_id, tier_id, offering_snapshot_id, status, current_period_start, current_period_end, payment_provider, provider_subscription_id, canceled_at, grace_period_end, last_webhook_event_id, last_webhook_event_at')
+      .maybeSingle();
+    if (nullError) throw nullError;
+    if (nullApplied) return nullApplied as SubscriptionRow;
+
+    const { data: orderedApplied, error: orderedError } = await base()
+      .lte('last_webhook_event_at', occurredAt)
+      .select('org_id, tier_id, offering_snapshot_id, status, current_period_start, current_period_end, payment_provider, provider_subscription_id, canceled_at, grace_period_end, last_webhook_event_id, last_webhook_event_at')
+      .maybeSingle();
+    if (orderedError) throw orderedError;
+    return (orderedApplied as SubscriptionRow | null) ?? null;
+  }
+
+  private async applySubscriptionState(
+    provider: PaymentProvider,
+    event: WebhookEvent,
+    context: Awaited<ReturnType<SubscriptionService['resolveContext']>>,
+    state: {
+      status: SubscriptionLifecycleStatus;
+      currentPeriodStart: string | null;
+      currentPeriodEnd: string | null;
+      canceledAt: string | null;
+      gracePeriodEnd: string | null;
+    },
+  ) {
+    if (!context.orgId || !context.tierId) throw new Error(`Cannot resolve subscription context for ${event.type}`);
+
+    const snapshotId = await this.resolveSnapshotId(context.tierId, context.subscription);
+    const row = {
+      org_id: context.orgId,
+      tier_id: context.tierId,
+      offering_snapshot_id: snapshotId,
+      status: state.status,
+      payment_provider: provider,
+      provider_subscription_id: event.providerSubscriptionId,
+      current_period_start: state.currentPeriodStart,
+      current_period_end: state.currentPeriodEnd,
+      canceled_at: state.canceledAt,
+      grace_period_end: state.gracePeriodEnd,
+      last_webhook_event_id: event.eventId,
+      last_webhook_event_at: event.occurredAt,
+    };
+
+    const inserted = await this.insertSubscriptionWebhookState(row);
+    if (!inserted.error) return { changed: true, row: inserted.data };
+    if (!isUniqueViolation(inserted.error)) throw inserted.error;
+
+    const updated = await this.updateSubscriptionWebhookStateIfCurrent(
+      context.orgId,
+      event.occurredAt,
+      {
+        tier_id: context.tierId,
+        offering_snapshot_id: snapshotId,
+        status: state.status,
+        payment_provider: provider,
+        provider_subscription_id: event.providerSubscriptionId,
+        current_period_start: state.currentPeriodStart,
+        current_period_end: state.currentPeriodEnd,
+        canceled_at: state.canceledAt,
+        grace_period_end: state.gracePeriodEnd,
+        last_webhook_event_id: event.eventId,
+        last_webhook_event_at: event.occurredAt,
+      },
+    );
+
+    if (updated) return { changed: true, row: updated };
+    return {
+      changed: false,
+      row: await this.getSubscriptionByOrg(context.orgId),
+    };
+  }
+
+  private async syncCheckoutLifecycle(
+    event: WebhookEvent,
+    provider: PaymentProvider,
+    context: Awaited<ReturnType<SubscriptionService['resolveContext']>>,
+  ) {
+    return this.applyCheckoutSessionEvent(provider, event, context);
+  }
+
+  private async syncSubscriptionLifecycle(
+    event: WebhookEvent,
+    provider: PaymentProvider,
+    context: Awaited<ReturnType<SubscriptionService['resolveContext']>>,
+  ) {
+    if (!event.subscriptionStatus) return { changed: false, row: context.subscription };
+
+    switch (event.subscriptionStatus) {
+      case 'active':
+      case 'trialing':
+        return this.applySubscriptionState(provider, event, context, {
+          status: event.subscriptionStatus,
+          currentPeriodStart: event.currentPeriodStart,
+          currentPeriodEnd: event.currentPeriodEnd,
+          canceledAt: null,
+          gracePeriodEnd: null,
+        });
+
+      case 'past_due':
+        return this.applySubscriptionState(provider, event, context, {
+          status: 'past_due',
+          currentPeriodStart: event.currentPeriodStart ?? context.subscription?.current_period_start ?? null,
+          currentPeriodEnd: event.currentPeriodEnd ?? context.subscription?.current_period_end ?? null,
+          canceledAt: null,
+          gracePeriodEnd: context.subscription?.grace_period_end ?? null,
+        });
+
+      case 'canceled': {
+        const gracePeriodEnd = context.subscription?.grace_period_end
+          ?? context.subscription?.current_period_end
+          ?? event.currentPeriodEnd
+          ?? event.occurredAt;
+        return this.applySubscriptionState(provider, event, context, {
+          status: 'canceled',
+          currentPeriodStart: context.subscription?.current_period_start ?? event.currentPeriodStart ?? null,
+          currentPeriodEnd: context.subscription?.current_period_end ?? event.currentPeriodEnd ?? null,
+          canceledAt: event.occurredAt,
+          gracePeriodEnd,
+        });
+      }
+    }
+  }
+
+  /** AC6: 웹훅 이벤트 분기 처리 */
+  async processWebhookEvent(event: WebhookEvent, provider: PaymentProvider) {
+    const context = await this.resolveContext(event, provider);
+    const checkout = await this.syncCheckoutLifecycle(event, provider, context);
+    const subscription = await this.syncSubscriptionLifecycle(event, provider, context);
+
+    return {
+      eventId: event.eventId,
+      type: event.type,
+      checkoutChanged: checkout.changed,
+      subscriptionChanged: subscription.changed,
+      checkoutStatus: checkout.row?.status ?? event.checkoutStatus,
+      subscriptionStatus: subscription.row?.status ?? event.subscriptionStatus,
+      duplicateOrStale: !checkout.changed && !subscription.changed,
+    };
+  }
+}

--- a/ee/billing/package.json
+++ b/ee/billing/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@moonklabs/billing-ee",
+  "version": "0.1.0",
+  "private": true,
+  "description": "EE billing dependencies manifest — Polar SDK and payment provider deps",
+  "dependencies": {
+    "@polar-sh/checkout": "^0.2.0",
+    "@polar-sh/sdk": "^0.47.0"
+  }
+}


### PR DESCRIPTION
## Summary

SaaS 과금 코드 전량 `ee/apps/web/src/` + `ee/billing/` 으로 분리. OSS stubs는 그대로 유지.

**ee/apps/web/src/lib/**
- `billing-policy.ts` / test — `getEntitlementBearingSubscription` 등 구독 상태 판단
- `check-feature.ts` / test — 요금제별 기능/리소스 제한 (@deprecated, Phase 4 제거 예정)
- `entitlement.ts` — `checkEntitlement()` 실제 구현 (TIER_QUOTAS 기반)
- `polar-products.ts` — Polar 상품 ID 매핑 (sandbox/live)

**ee/apps/web/src/services/**
- `billing-limit-enforcer.ts` / test — billing 한도 집행 (월/일 cap, alert)
- `subscription.ts` / test — 구독 관리 (checkout lifecycle, webhook)
- `agent-run-billing.ts` / test — LLM 과금 계산 실제 구현 (cost 0 stub 대체)

**ee/apps/web/src/app/api/**
- `billing/` (cancel, portal, route)
- `checkout/` (polar, generic)
- `subscription/portal/`
- `webhooks/` (polar, payment)
- `v1/billing/` (agent-usage alerts/breakdown/export, limits)

**ee/apps/web/src/components/settings/billing-section.tsx**
**ee/apps/web/src/app/(authenticated)/settings/billing/page.tsx**

**ee/billing/package.json** — `@polar-sh/sdk ^0.47.0` + `@polar-sh/checkout ^0.2.0` (AC5)

## Test plan

- [ ] TypeScript 에러 없음 (기존 react-email 제외)
- [ ] OSS `apps/web/` 변경 없음 — billing stubs 그대로
- [ ] `ee/billing/package.json`에 `@polar-sh/*` deps 선언 확인
- [ ] `ee/apps/web/src/` 35파일 Git 추적 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)