### PR TITLE
feat(arch): E-ARCH-MONOREPO S4 — 32개 수정본 파일 조건부 분리

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1016,10 +1016,10 @@ export default function SettingsPage() {
               </TabsContent>
             ) : null}
 
-            {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' && adminChecked && isAdmin ? (
+            {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' && adminChecked && isAdmin && orgId ? (
               <TabsContent value="usage">
                 <UsageDashboard
-                  orgId={orgId ?? undefined}
+                  orgId={orgId}
                   currentProjectId={currentProjectId}
                   projects={projects}
                   defaultMonth={new Date().toISOString().slice(0, 7)}

--- a/apps/web/src/lib/ee-enabled.ts
+++ b/apps/web/src/lib/ee-enabled.ts
@@ -1,0 +1,7 @@
+/**
+ * EE enablement check — placeholder implementation.
+ * S5에서 LICENSE_CONSENT 검증 로직으로 교체 예정.
+ */
+export function isEEEnabled(): boolean {
+  return process.env.LICENSE_CONSENT === 'agreed';
+}

--- a/ee/apps/web/src/app/(authenticated)/agents/page.tsx
+++ b/ee/apps/web/src/app/(authenticated)/agents/page.tsx
@@ -1,0 +1,56 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { requireOrgAdmin } from '@/lib/admin-check';
+import { checkFeatureLimit } from '@/lib/check-feature';
+import { AgentsDashboard } from '@/components/agents/agents-dashboard';
+import { buildDeploymentCards } from '@/services/agent-dashboard';
+import { AgentOrchestrationUpgradeState } from '@/components/agents/agent-orchestration-gate';
+import { AgentsTabBar } from '@/components/agents/agents-tab-bar';
+import { WorkflowRulesTab } from '@/components/agents/workflow-rules-tab';
+import { WorkflowDashboard } from '@/components/agents/workflow-dashboard';
+import { AtomicContractLibrary } from '@/components/agents/atomic-contract-library';
+import { CompositeLibrary } from '@/components/agents/composite-library';
+
+export default async function AgentsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ tab?: string }>;
+}) {
+  const supabase = await createSupabaseServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login');
+
+  const me = await getMyTeamMember(supabase, user);
+  if (!me) redirect('/dashboard');
+
+  await requireOrgAdmin(supabase, me.org_id).catch(() => redirect('/dashboard'));
+
+  const gate = await checkFeatureLimit(supabase, me.org_id, 'agent_orchestration');
+  if (!gate.allowed) return <AgentOrchestrationUpgradeState />;
+
+  const { tab } = await searchParams;
+  const activeTab = tab === 'rules' ? 'rules' : 'deployments';
+
+  if (activeTab === 'rules') {
+    return (
+      <>
+        <AgentsTabBar activeTab="rules" />
+        <WorkflowDashboard orgId={me.org_id} projectId={me.project_id ?? undefined} />
+        <div className="space-y-6 px-6 pb-2 pt-6">
+          <AtomicContractLibrary orgId={me.org_id} projectId={me.project_id ?? undefined} />
+          <CompositeLibrary orgId={me.org_id} projectId={me.project_id ?? undefined} />
+        </div>
+        <WorkflowRulesTab orgId={me.org_id} projectId={me.project_id ?? undefined} />
+      </>
+    );
+  }
+
+  const cards = await buildDeploymentCards(supabase, me.org_id, me.project_id, me.id);
+  return (
+    <>
+      <AgentsTabBar activeTab="deployments" />
+      <AgentsDashboard deployments={cards} />
+    </>
+  );
+}

--- a/ee/apps/web/src/app/(authenticated)/layout.tsx
+++ b/ee/apps/web/src/app/(authenticated)/layout.tsx
@@ -1,0 +1,37 @@
+import { redirect } from 'next/navigation';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { getMyMembershipContext } from '@/lib/auth-helpers';
+import { DashboardShell } from '../dashboard/dashboard-shell';
+import { UpgradeBanner } from '@/components/upgrade-banner';
+import { UpgradeModal } from '@/components/upgrade-modal';
+
+export default async function AuthenticatedLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) redirect('/login');
+
+    const { me, memberships } = await getMyMembershipContext(supabase, user);
+
+    return (
+      <DashboardShell
+        currentTeamMemberId={me?.id}
+        orgId={me?.org_id}
+        projectId={me?.project_id}
+        projectName={me?.project_name}
+        projectMemberships={memberships.map((membership) => ({ projectId: membership.project_id, projectName: membership.project_name }))}
+      >
+        <UpgradeBanner />
+        <UpgradeModal />
+        {children}
+      </DashboardShell>
+    );
+  } catch {
+    redirect('/login');
+  }
+}

--- a/ee/apps/web/src/app/api/docs/[id]/route.ts
+++ b/ee/apps/web/src/app/api/docs/[id]/route.ts
@@ -1,0 +1,96 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { parseBody, updateDocSchema } from '@sprintable/shared';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { DocsService } from '@/services/docs';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { getTeamMemberRole, hasRole } from '@/lib/doc-permissions';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    const parsed = await parseBody(request, updateDocSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+
+    if (!ossMode && me.type !== 'agent') {
+      const role = await getTeamMemberRole(supabase, me.id);
+      // 폴더 이동/구조 변경은 owner 이상
+      if ('parent_id' in body || 'is_folder' in body) {
+        if (!role || !hasRole(role, 'owner')) {
+          return apiError('FORBIDDEN', 'Folder structure changes require owner role', 403);
+        }
+      } else if (!role || !hasRole(role, 'admin')) {
+        // 일반 문서 수정은 admin 이상
+        return apiError('FORBIDDEN', 'Document editing requires admin or owner role', 403);
+      }
+    }
+
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+    const doc = await service.updateDoc(id, {
+      ...body,
+      created_by: me.id,
+      expected_updated_at: body.expected_updated_at,
+      force_overwrite: body.force_overwrite,
+    });
+    return apiSuccess(doc);
+  } catch (err: unknown) {
+    const e = err as Error & { code?: string };
+    if (e.code === 'CONFLICT') return apiError('CONFLICT', e.message, 409);
+    if (e.code === 'NOT_FOUND') return apiError('NOT_FOUND', e.message, 404);
+    if (e.code === 'BAD_REQUEST') return apiError('BAD_REQUEST', e.message, 400);
+    return handleApiError(err);
+  }
+}
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+    return apiSuccess(await service.getDocTimestamp(id));
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+
+    if (!ossMode && me.type !== 'agent') {
+      const role = await getTeamMemberRole(supabase, me.id);
+      if (!role || !hasRole(role, 'admin')) {
+        return apiError('FORBIDDEN', 'Document deletion requires admin or owner role', 403);
+      }
+    }
+
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+    await service.deleteDoc(id);
+    return apiSuccess({ ok: true });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/docs/route.ts
+++ b/ee/apps/web/src/app/api/docs/route.ts
@@ -1,0 +1,87 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { parseBody, createDocSchema } from '@sprintable/shared';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { DocsService } from '@/services/docs';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { checkEntitlement } from '@/lib/entitlement';
+import { incrementUsage } from '@/lib/usage-tracker';
+import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { getTeamMemberRole, hasRole } from '@/lib/doc-permissions';
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+    const slug = searchParams.get('slug');
+    if (slug) return apiSuccess(await service.getDoc(projectId, slug));
+
+    if (searchParams.get('view') === 'tree') {
+      return apiSuccess(await service.getTree(projectId), {
+        mode: 'tree',
+        exception: 'hierarchy_preserving_tree_browse',
+      });
+    }
+
+    const pageInput = parseCursorPageInput({
+      limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
+      cursor: searchParams.get('cursor'),
+    }, { defaultLimit: 40, maxLimit: 100 });
+    const query = searchParams.get('q');
+    const rows = query
+      ? await service.search(projectId, query, pageInput)
+      : await service.list(projectId, pageInput);
+    const { page, meta } = buildCursorPageMeta(rows, pageInput.limit, 'updated_at');
+    return apiSuccess(page, meta);
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    if (!ossMode && me.type !== 'agent') {
+      const role = await getTeamMemberRole(supabase, me.id);
+      if (!role || !hasRole(role, 'admin')) {
+        return apiError('FORBIDDEN', 'Document creation requires admin or owner role', 403);
+      }
+    }
+    if (!ossMode) {
+      const ent = await checkEntitlement(supabase, me.org_id, 'docs');
+      if (!ent.allowed) return apiError('quota_exceeded', `Doc quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'docs', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
+    }
+    const parsed = await parseBody(request, createDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
+    if (!ossMode && me.type !== 'agent' && body.is_folder) {
+      const role = await getTeamMemberRole(supabase, me.id);
+      if (!role || !hasRole(role, 'owner')) {
+        return apiError('FORBIDDEN', 'Folder creation requires owner role', 403);
+      }
+    }
+    const repo = await createDocRepository(dbClient);
+    const service = new DocsService(repo, dbClient as SupabaseClient | undefined);
+    const doc = await service.createDoc({
+      org_id: me.org_id, project_id: me.project_id,
+      title: body.title, slug: body.slug ?? '', content: body.content ?? '', content_format: body.content_format ?? 'markdown',
+      icon: body.icon ?? null, tags: body.tags ?? [],
+      parent_id: body.parent_id ?? undefined, is_folder: body.is_folder ?? false, created_by: me.id,
+    });
+    if (!ossMode) void incrementUsage(me.org_id, 'docs');
+    return apiSuccess(doc, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/invitations/route.ts
+++ b/ee/apps/web/src/app/api/invitations/route.ts
@@ -1,0 +1,130 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { checkMemberEntitlement } from '@/lib/entitlement';
+import { parseBody, createInvitationSchema } from '@sprintable/shared';
+import { isOssMode } from '@/lib/storage/factory';
+import { sendInviteEmail } from '@/lib/email';
+
+export async function GET() {
+  if (isOssMode()) return apiSuccess([]);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const { data: orgMember } = await supabase
+      .from('org_members')
+      .select('org_id, role')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!orgMember || !['owner', 'admin'].includes(orgMember.role as string)) {
+      return ApiErrors.forbidden('Admin access required');
+    }
+
+    const { data, error } = await supabase
+      .from('invitations')
+      .select('*, projects(id, name)')
+      .eq('org_id', orgMember.org_id)
+      .order('created_at', { ascending: false });
+
+    if (error) throw error;
+    return apiSuccess(data);
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+export async function POST(request: Request) {
+  if (isOssMode()) return apiError('NOT_IMPLEMENTED', 'Invitations are not supported in OSS mode.', 501);
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const parsed = await parseBody(request, createInvitationSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden('Team member not found');
+
+    const email = body.email;
+    const projectId = body.project_id ?? null;
+
+    const { data: existingOrgMember, error: existingOrgMemberError } = await supabase
+      .rpc('is_existing_org_member_email', { _org_id: me.org_id, _email: email });
+
+    if (existingOrgMemberError) throw existingOrgMemberError;
+
+    if (!existingOrgMember) {
+      const ent = await checkMemberEntitlement(supabase, me.org_id);
+      if (!ent.allowed) return apiError('quota_exceeded', `Member quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'members', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
+    }
+
+    if (projectId) {
+      const { data: project } = await supabase
+        .from('projects')
+        .select('id')
+        .eq('id', projectId)
+        .eq('org_id', me.org_id)
+        .maybeSingle();
+      if (!project) return ApiErrors.badRequest('Invalid project_id');
+    }
+
+    const dupQuery = supabase
+      .from('invitations')
+      .select('id')
+      .eq('org_id', me.org_id)
+      .eq('email', email)
+      .is('accepted_at', null)
+      .gt('expires_at', new Date().toISOString());
+
+    if (projectId) {
+      dupQuery.eq('project_id', projectId);
+    } else {
+      dupQuery.is('project_id', null);
+    }
+
+    const { data: existing } = await dupQuery.maybeSingle();
+
+    if (existing) return apiError('DUPLICATE_INVITE', 'Invitation already pending', 400);
+
+    const { data, error } = await supabase
+      .from('invitations')
+      .insert({
+        org_id: me.org_id,
+        email,
+        role: body.role ?? 'member',
+        invited_by: me.id,
+        ...(projectId ? { project_id: projectId } : {}),
+      })
+      .select('id, token, email, expires_at, project_id')
+      .single();
+
+    if (error) throw error;
+
+    const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL ?? ''}/invite?token=${data.token}`;
+
+    // 초대 이메일 best-effort 발송 (실패해도 201 반환)
+    void (async () => {
+      try {
+        const { data: org } = await supabase
+          .from('organizations')
+          .select('name')
+          .eq('id', me.org_id)
+          .single();
+        await sendInviteEmail({
+          to: email,
+          inviterName: user.email ?? 'Someone',
+          orgName: org?.name ?? 'your organization',
+          inviteUrl,
+        });
+      } catch {
+        // silent — invite link still available in response
+      }
+    })();
+
+    return apiSuccess({ ...data, invite_url: inviteUrl }, undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/api/memos/route.ts
+++ b/ee/apps/web/src/app/api/memos/route.ts
@@ -1,0 +1,104 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { MemoService, type CreateMemoInput } from '@/services/memo';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { parseBody, createMemoSchema } from '@sprintable/shared';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { createMemoRepository, createTeamMemberRepository, createProjectRepository, isOssMode } from '@/lib/storage/factory';
+import { checkEntitlement } from '@/lib/entitlement';
+import { incrementUsage } from '@/lib/usage-tracker';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) {
+      return new Response(
+        JSON.stringify({ error: 'Rate limit exceeded' }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-RateLimit-Limit': '300',
+            'X-RateLimit-Remaining': String(me.rateLimitRemaining ?? 0),
+            'X-RateLimit-Reset': String(me.rateLimitResetAt ?? 0),
+          },
+        }
+      );
+    }
+
+    if (!isOssMode()) {
+      const ent = await checkEntitlement(supabase, me.org_id, 'memos');
+      if (!ent.allowed) return apiError('quota_exceeded', `Memo quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'memos', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
+    }
+
+    const parsed = await parseBody(request, createMemoSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+    console.warn('[POST /api/memos] parsed assigned_to_ids:', JSON.stringify(body.assigned_to_ids));
+    const dbClient = isOssMode() ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createMemoRepository(dbClient);
+    const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;
+    const projectRepo = isOssMode() ? await createProjectRepository() : undefined;
+    const service = new MemoService(repo, dbClient as SupabaseClient | undefined, teamMemberRepo, projectRepo);
+    const memo = await service.create({
+      ...body,
+      org_id: me.org_id,
+      project_id: me.project_id,
+      created_by: me.id,
+    } as CreateMemoInput);
+    void incrementUsage(me.org_id, 'memos');
+    return apiSuccess(memo, undefined, 201);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) {
+      return new Response(
+        JSON.stringify({ error: 'Rate limit exceeded' }),
+        {
+          status: 429,
+          headers: {
+            'Content-Type': 'application/json',
+            'X-RateLimit-Limit': '300',
+            'X-RateLimit-Remaining': String(me.rateLimitRemaining ?? 0),
+            'X-RateLimit-Reset': String(me.rateLimitResetAt ?? 0),
+          },
+        }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const pageInput = parseCursorPageInput({
+      limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
+      cursor: searchParams.get('cursor'),
+    }, { defaultLimit: 30, maxLimit: 100 });
+    const dbClient = isOssMode() ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+    const repo = await createMemoRepository(dbClient);
+    const service = new MemoService(repo, dbClient as SupabaseClient | undefined);
+    const memos = await service.list({
+      org_id: me.org_id,
+      project_id: searchParams.get('project_id') ?? undefined,
+      assigned_to: searchParams.get('assigned_to') ?? undefined,
+      created_by: searchParams.get('created_by') ?? undefined,
+      status: searchParams.get('status') ?? undefined,
+      q: searchParams.get('q') ?? undefined,
+      limit: pageInput.limit,
+      cursor: pageInput.cursor,
+    });
+    const { page, meta } = buildCursorPageMeta(memos, pageInput.limit, 'created_at');
+    return apiSuccess(page, meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/oss/seed/route.ts
+++ b/ee/apps/web/src/app/api/oss/seed/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  return NextResponse.json({ error: 'Not available in SaaS mode' }, { status: 501 });
+}

--- a/ee/apps/web/src/app/api/standup/feedback/[id]/route.ts
+++ b/ee/apps/web/src/app/api/standup/feedback/[id]/route.ts
@@ -1,0 +1,71 @@
+import { parseBody, updateStandupFeedbackSchema } from '@sprintable/shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { StandupFeedbackService } from '@/services/standup';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+// GET /api/standup/feedback/:entry_id — list all feedback for a standup entry
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id: entryId } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const { data, error } = await dbClient
+      .from('standup_feedback')
+      .select('*')
+      .eq('standup_entry_id', entryId)
+      .order('created_at');
+    if (error) throw error;
+    return apiSuccess(data ?? []);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+
+    const parsed = await parseBody(request, updateStandupFeedbackSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+
+    const service = new StandupFeedbackService(dbClient);
+    const feedback = await service.update(id, body, me.id);
+    return apiSuccess(feedback);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new StandupFeedbackService(dbClient);
+    await service.delete(id, me.id);
+    return apiSuccess({ ok: true });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/standup/feedback/route.ts
+++ b/ee/apps/web/src/app/api/standup/feedback/route.ts
@@ -1,0 +1,64 @@
+import { parseBody, createStandupFeedbackSchema } from '@sprintable/shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { StandupFeedbackService } from '@/services/standup';
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    const date = searchParams.get('date');
+    if (!projectId || !date) return ApiErrors.badRequest('project_id and date required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new StandupFeedbackService(dbClient);
+    const feedback = await service.listByDate(projectId, date);
+    return apiSuccess(feedback);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+
+    const parsed = await parseBody(request, createStandupFeedbackSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+
+    const { data: member, error: memberError } = await dbClient
+      .from('team_members')
+      .select('project_id, org_id')
+      .eq('id', me.id)
+      .single();
+    if (memberError || !member) return ApiErrors.forbidden('Team member not found');
+
+    const service = new StandupFeedbackService(dbClient);
+    const feedback = await service.create({
+      project_id: member.project_id,
+      org_id: member.org_id,
+      standup_entry_id: body.standup_entry_id,
+      feedback_by_id: me.id,
+      review_type: body.review_type ?? 'comment',
+      feedback_text: body.feedback_text,
+    });
+    return apiSuccess(feedback, undefined, 201);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/standup/history/route.ts
+++ b/ee/apps/web/src/app/api/standup/history/route.ts
@@ -1,0 +1,29 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { StandupService } from '@/services/standup';
+
+// GET /api/standup/history?project_id=X[&limit=N]
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+    const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 50;
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new StandupService(dbClient);
+    const data = await service.getHistory(projectId, limit);
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/standup/missing/route.ts
+++ b/ee/apps/web/src/app/api/standup/missing/route.ts
@@ -1,0 +1,30 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { StandupService } from '@/services/standup';
+
+// GET /api/standup/missing?project_id=X&date=YYYY-MM-DD
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    const date = searchParams.get('date');
+    if (!projectId) return ApiErrors.badRequest('project_id required');
+    if (!date) return ApiErrors.badRequest('date required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new StandupService(dbClient);
+    const data = await service.getMissing(projectId, date);
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/standup/route.ts
+++ b/ee/apps/web/src/app/api/standup/route.ts
@@ -1,0 +1,128 @@
+import { saveStandupSchema } from '@sprintable/shared';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { StandupService } from '@/services/standup';
+import { handleApiError } from '@/lib/api-error';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+
+// GET /api/standup?project_id=...&date=YYYY-MM-DD[&member_id=...]
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { searchParams } = new URL(request.url);
+    const projectId = searchParams.get('project_id');
+    const date = searchParams.get('date');
+    const memberId = searchParams.get('member_id');
+    if (!projectId || !date) return ApiErrors.badRequest('project_id and date required');
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+    const service = new StandupService(dbClient);
+    if (memberId) {
+      const entry = await service.getEntryForUser(projectId, memberId, date);
+      return apiSuccess(entry);
+    }
+    const entries = await service.getEntries(projectId, date);
+    return apiSuccess(entries);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+// POST /api/standup — supports Dual Auth; agent may pass author_id in body
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const dbClient: SupabaseClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
+
+    let rawBody: unknown;
+    try { rawBody = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
+
+    const authorId: string =
+      me.type === 'agent' && typeof (rawBody as Record<string, unknown>).author_id === 'string'
+        ? (rawBody as Record<string, unknown>).author_id as string
+        : me.id;
+
+    const parsed = saveStandupSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => ({ path: i.path.join('.'), message: i.message }));
+      return ApiErrors.validationFailed(issues);
+    }
+    const body = parsed.data;
+
+    const { data: member, error: memberError } = await dbClient
+      .from('team_members')
+      .select('project_id, org_id')
+      .eq('id', authorId)
+      .single();
+    if (memberError || !member) return ApiErrors.forbidden('Team member not found');
+
+    const service = new StandupService(dbClient);
+    const entry = await service.save({
+      project_id: member.project_id,
+      org_id: member.org_id,
+      author_id: authorId,
+      date: body.date || new Date().toISOString().slice(0, 10),
+      done: body.done ?? null,
+      plan: body.plan ?? null,
+      blockers: body.blockers ?? null,
+      sprint_id: body.sprint_id ?? null,
+      plan_story_ids: body.plan_story_ids ?? [],
+    });
+    return apiSuccess(entry);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+// PUT /api/standup — kept for backwards compatibility (human auth only)
+export async function PUT(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const { data: member, error: memberError } = await supabase
+      .from('team_members')
+      .select('id, project_id, org_id')
+      .eq('id', me.id)
+      .single();
+    if (memberError || !member) return ApiErrors.forbidden('Team member not found');
+
+    let rawBody: unknown;
+    try { rawBody = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
+
+    const parsed = saveStandupSchema.safeParse(rawBody);
+    if (!parsed.success) {
+      const issues = parsed.error.issues.map((i) => ({ path: i.path.join('.'), message: i.message }));
+      return ApiErrors.validationFailed(issues);
+    }
+    const body = parsed.data;
+
+    const service = new StandupService(supabase);
+    const entry = await service.save({
+      project_id: member.project_id,
+      org_id: member.org_id,
+      author_id: member.id,
+      date: body.date || new Date().toISOString().slice(0, 10),
+      done: body.done ?? null,
+      plan: body.plan ?? null,
+      blockers: body.blockers ?? null,
+      sprint_id: body.sprint_id ?? null,
+      plan_story_ids: body.plan_story_ids ?? [],
+    });
+    return apiSuccess(entry);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/stories/route.ts
+++ b/ee/apps/web/src/app/api/stories/route.ts
@@ -1,0 +1,98 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { parseBody, createStorySchema } from '@sprintable/shared';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { StoryService, type CreateStoryInput } from '@/services/story';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { checkEntitlement } from '@/lib/entitlement';
+import { incrementUsage } from '@/lib/usage-tracker';
+import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { WorkflowContractService } from '@/services/workflow-contract-service';
+import { GateCheckService } from '@/services/gate-check-service';
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    if (!ossMode) {
+      const ent = await checkEntitlement(supabase, me.org_id, 'stories');
+      if (!ent.allowed) return apiError('quota_exceeded', `Story quota exceeded (${ent.current}/${ent.limit})`, 402, { resource: 'stories', current: ent.current, limit: ent.limit, upgradeUrl: ent.upgradeUrl });
+    }
+
+    const rawBody = await request.json();
+    if (!rawBody.project_id) rawBody.project_id = me.project_id;
+    if (!rawBody.org_id) rawBody.org_id = me.org_id;
+    const parsed = createStorySchema.safeParse(rawBody);
+    if (!parsed.success) return apiError('VALIDATION_ERROR', JSON.stringify(parsed.error.issues), 400);
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
+    const story = await service.create(parsed.data as CreateStoryInput);
+    void incrementUsage(me.org_id, 'stories');
+
+    // 활성 story 계약에 자동 인스턴스 바인딩 (fire-and-forget)
+    if (!ossMode) {
+      void (async () => {
+        try {
+          const admin = createSupabaseAdminClient();
+          const contracts = await new WorkflowContractService(admin).list(me.org_id, 'story', story.project_id ?? undefined);
+          if (contracts.length > 0) {
+            const gateSvc = new GateCheckService(admin);
+            await Promise.all(
+              contracts.map((c) =>
+                gateSvc.createInstance(c.id, story.id, c.definition.initial_state)
+              )
+            );
+          }
+        } catch {
+          // story 생성은 성공 — 인스턴스 바인딩 실패가 응답을 막지 않음
+        }
+      })();
+    }
+
+    return apiSuccess(story, undefined, 201);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+export async function GET(request: Request) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const me = await getAuthContext(supabase, request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const ossMode = isOssMode();
+    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createSupabaseAdminClient() : supabase);
+
+    const { searchParams } = new URL(request.url);
+    const pageInput = parseCursorPageInput({
+      limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
+      cursor: searchParams.get('cursor'),
+    }, { defaultLimit: 50, maxLimit: 100 });
+    const repo = await createStoryRepository(dbClient);
+    const service = new StoryService(repo, dbClient as SupabaseClient | undefined);
+    const stories = await service.list({
+      sprint_id: searchParams.get('sprint_id') ?? undefined,
+      epic_id: searchParams.get('epic_id') ?? undefined,
+      assignee_id: searchParams.get('assignee_id') ?? undefined,
+      status: searchParams.get('status') ?? undefined,
+      project_id: searchParams.get('project_id') ?? undefined,
+      q: searchParams.get('q') ?? undefined,
+      unassigned: searchParams.get('unassigned') === 'true' ? true : undefined,
+      limit: pageInput.limit,
+      cursor: pageInput.cursor,
+    });
+    const { page, meta } = buildCursorPageMeta(stories, pageInput.limit, 'created_at');
+    return apiSuccess(page, meta);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/ee/apps/web/src/app/api/usage/route.ts
+++ b/ee/apps/web/src/app/api/usage/route.ts
@@ -1,0 +1,46 @@
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getMyTeamMember } from '@/lib/auth-helpers';
+import { TIER_QUOTAS } from '@/lib/entitlement';
+
+function currentPeriod(): string {
+  const now = new Date();
+  return `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+export async function GET() {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return ApiErrors.unauthorized();
+
+    const me = await getMyTeamMember(supabase, user);
+    if (!me) return ApiErrors.forbidden();
+
+    const [{ data: sub }, { data: usageRow }] = await Promise.all([
+      supabase
+        .from('org_subscriptions')
+        .select('tier, status')
+        .eq('org_id', me.org_id)
+        .maybeSingle(),
+      supabase
+        .from('org_usage')
+        .select('stories, memos, docs, api_calls')
+        .eq('org_id', me.org_id)
+        .eq('period', currentPeriod())
+        .maybeSingle(),
+    ]);
+
+    const tier = (!sub || sub.status === 'expired' || sub.status === 'past_due') ? 'free' : (sub.tier ?? 'free');
+    const quotas = TIER_QUOTAS[tier] ?? TIER_QUOTAS['free']!;
+    const usage = {
+      stories: usageRow?.stories ?? 0,
+      memos: usageRow?.memos ?? 0,
+      docs: usageRow?.docs ?? 0,
+      api_calls: usageRow?.api_calls ?? 0,
+    };
+
+    return apiSuccess({ tier, usage, quotas });
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/ee/apps/web/src/app/login/page.tsx
+++ b/ee/apps/web/src/app/login/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+
+type Tab = 'oauth' | 'email';
+
+export default function LoginPage() {
+  const supabase = createSupabaseBrowserClient();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const returnTo = searchParams.get('returnTo');
+  const urlError = searchParams.get('error');
+
+  const [tab, setTab] = useState<Tab>('oauth');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const oauthHref = (provider: string) => {
+    const params = new URLSearchParams({ provider });
+    if (returnTo && returnTo.startsWith('/')) params.set('returnTo', returnTo);
+    return `/auth/login?${params.toString()}`;
+  };
+
+  const handleEmailLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) { setError(error.message); return; }
+      router.push(returnTo ?? '/');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo variant="stacked" className="text-gray-900" markClassName="h-14" wordmarkClassName="h-5" />
+          <p className="text-sm text-gray-500">AI-powered sprint management</p>
+        </div>
+
+        {/* 탭 */}
+        <div className="flex rounded-lg border border-gray-200 p-1 gap-1">
+          <button
+            onClick={() => setTab('oauth')}
+            className={`flex-1 rounded-md py-1.5 text-sm font-medium transition ${tab === 'oauth' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            소셜 로그인
+          </button>
+          <button
+            onClick={() => setTab('email')}
+            className={`flex-1 rounded-md py-1.5 text-sm font-medium transition ${tab === 'email' ? 'bg-gray-900 text-white' : 'text-gray-500 hover:text-gray-700'}`}
+          >
+            이메일
+          </button>
+        </div>
+
+        {(error || urlError) && (
+          <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600">
+            {error ?? '로그인 중 오류가 발생했습니다. 다시 시도해 주세요.'}
+          </p>
+        )}
+
+        {tab === 'oauth' ? (
+          <div className="space-y-3">
+            <a
+              href={oauthHref('google')}
+              className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+            >
+              <svg className="h-5 w-5" viewBox="0 0 24 24">
+                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+              </svg>
+              Continue with Google
+            </a>
+            <a
+              href={oauthHref('github')}
+              className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800"
+            >
+              <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              Continue with GitHub
+            </a>
+          </div>
+        ) : (
+          <form onSubmit={handleEmailLogin} className="space-y-4">
+            <div className="space-y-2">
+              <input
+                type="email"
+                placeholder="이메일"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+              />
+              <input
+                type="password"
+                placeholder="비밀번호"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-900 focus:ring-1 focus:ring-gray-900"
+              />
+            </div>
+            <div className="flex justify-end">
+              <Link href="/forgot-password" className="text-xs text-gray-500 hover:text-gray-700">
+                비밀번호를 잊으셨나요?
+              </Link>
+            </div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full rounded-lg bg-gray-900 py-2.5 text-sm font-medium text-white transition hover:bg-gray-800 disabled:opacity-60"
+            >
+              {loading ? '로그인 중...' : '로그인'}
+            </button>
+            <p className="text-center text-xs text-gray-500">
+              계정이 없으신가요?{' '}
+              <Link
+                href={(() => {
+                  if (returnTo?.includes('/invite?token=')) {
+                    const token = new URLSearchParams(returnTo.split('?')[1]).get('token');
+                    if (token) return `/signup?token=${encodeURIComponent(token)}`;
+                  }
+                  return '/signup';
+                })()}
+                className="font-medium text-gray-900 hover:underline"
+              >
+                회원가입
+              </Link>
+            </p>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/web/src/components/nav/app-sidebar.tsx
+++ b/ee/apps/web/src/components/nav/app-sidebar.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import {
+  BookOpen,
+  Bot,
+  CalendarDays,
+  CircleHelp,
+  FolderKanban,
+  Gauge,
+  Inbox,
+  LayoutDashboard,
+  MessageSquareMore,
+  Search,
+  Settings,
+  Users,
+} from 'lucide-react';
+import { LocaleSwitcher } from '@/components/locale-switcher';
+import { CommandPalette } from '@/components/command-palette/command-palette';
+import { ProjectSwitcher } from '@/components/nav/project-switcher';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from '@/components/ui/sidebar';
+
+interface AppSidebarProps {
+  currentTeamMemberId?: string;
+  projectId?: string;
+  projectName?: string;
+  projectMemberships: Array<{ projectId: string; projectName: string }>;
+}
+
+function KbdHint({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="ml-auto hidden rounded border border-sidebar-border/60 bg-sidebar-accent/40 px-1.5 py-0 font-mono text-[10px] font-medium text-sidebar-foreground/60 group-data-[active=true]/menu-button:text-sidebar-foreground/80 sm:inline-flex">
+      {children}
+    </kbd>
+  );
+}
+
+export function AppSidebar({
+  projectId,
+  projectName,
+  projectMemberships,
+}: AppSidebarProps) {
+  const pathname = usePathname();
+  const t = useTranslations('nav');
+  const [memoUnreadCount, setMemoUnreadCount] = useState(0);
+  const [inboxUnreadCount, setInboxUnreadCount] = useState(0);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  const openPalette = useCallback(() => setPaletteOpen(true), []);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      const isMod = event.metaKey || event.ctrlKey;
+      if (!isMod || event.key.toLowerCase() !== 'k') return;
+      const target = event.target as HTMLElement | null;
+      if (target?.isContentEditable) return;
+      event.preventDefault();
+      setPaletteOpen((prev) => !prev);
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    async function fetchUnread() {
+      try {
+        const [memoRes, inboxRes] = await Promise.all([
+          fetch('/api/notifications?unread=true&type=memo'),
+          fetch('/api/notifications?unread=true'),
+        ]);
+        if (memoRes.ok) {
+          const json = await memoRes.json() as { meta?: { unreadCount?: number } };
+          setMemoUnreadCount(json.meta?.unreadCount ?? 0);
+        }
+        if (inboxRes.ok) {
+          const json = await inboxRes.json() as { meta?: { unreadCount?: number } };
+          setInboxUnreadCount(json.meta?.unreadCount ?? 0);
+        }
+      } catch {
+        // noop
+      }
+    }
+    void fetchUnread();
+    const interval = setInterval(fetchUnread, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  function isActive(href: string) {
+    return pathname === href || (href !== '/' && pathname.startsWith(href));
+  }
+
+  return (
+    <Sidebar variant="inset" collapsible="offcanvas">
+      <SidebarHeader className="py-3">
+        {projectMemberships.length > 0 ? (
+          <ProjectSwitcher
+            projects={projectMemberships}
+            currentProjectId={projectId}
+            className="w-full"
+          />
+        ) : (
+          <div className="truncate px-2 py-1 text-sm font-medium text-sidebar-foreground">
+            {projectName ?? 'Sprintable'}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={openPalette}
+          className="mt-2 flex w-full items-center gap-2 rounded-md border border-sidebar-border/60 bg-sidebar-accent/30 px-2.5 py-1.5 text-left text-sm text-sidebar-foreground/60 transition hover:border-sidebar-border hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+          aria-label={t('search')}
+        >
+          <Search className="size-4" />
+          <span className="flex-1 truncate">{t('search')}</span>
+          <kbd className="hidden rounded border border-sidebar-border/60 bg-sidebar-accent/40 px-1.5 py-0 font-mono text-[10px] font-medium text-sidebar-foreground/60 sm:inline-flex">
+            ⌘K
+          </kbd>
+        </button>
+      </SidebarHeader>
+
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/inbox" />}
+                  isActive={isActive('/inbox')}
+                  tooltip={t('inbox')}
+                >
+                  <Inbox />
+                  <span>{t('inbox')}</span>
+                  {inboxUnreadCount > 0 ? (
+                    <SidebarMenuBadge>
+                      {inboxUnreadCount > 9 ? '9+' : inboxUnreadCount}
+                    </SidebarMenuBadge>
+                  ) : null}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/dashboard" />}
+                  isActive={isActive('/dashboard')}
+                  tooltip={t('dashboard')}
+                >
+                  <LayoutDashboard />
+                  <span>{t('dashboard')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/memos" />}
+                  isActive={isActive('/memos')}
+                  tooltip={t('memos')}
+                >
+                  <MessageSquareMore />
+                  <span>{t('memos')}</span>
+                  {memoUnreadCount > 0 ? (
+                    <SidebarMenuBadge>
+                      {memoUnreadCount > 9 ? '9+' : memoUnreadCount}
+                    </SidebarMenuBadge>
+                  ) : null}
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>{t('sprint')}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/board" />}
+                  isActive={isActive('/board')}
+                  tooltip={t('board')}
+                >
+                  <FolderKanban />
+                  <span>{t('board')}</span>
+                  <KbdHint>B</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/standup" />}
+                  isActive={isActive('/standup')}
+                  tooltip={t('standup')}
+                >
+                  <Users />
+                  <span>{t('standup')}</span>
+                  <KbdHint>S</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/retro" />}
+                  isActive={isActive('/retro')}
+                  tooltip={t('retro')}
+                >
+                  <Gauge />
+                  <span>{t('retro')}</span>
+                  <KbdHint>R</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>{t('workspace')}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/docs" />}
+                  isActive={isActive('/docs')}
+                  tooltip={t('docs')}
+                >
+                  <BookOpen />
+                  <span>{t('docs')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/meetings" />}
+                  isActive={isActive('/meetings')}
+                  tooltip={t('meetings')}
+                >
+                  <CalendarDays />
+                  <span>{t('meetings')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/agents" />}
+                  isActive={isActive('/agents')}
+                  tooltip={t('agents')}
+                >
+                  <Bot />
+                  <span>{t('agents')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
+        <SidebarGroup>
+          <SidebarGroupLabel>{t('configure')}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/settings" />}
+                  isActive={isActive('/settings')}
+                  tooltip={t('settings')}
+                >
+                  <Settings />
+                  <span>{t('settings')}</span>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+
+      <SidebarFooter className="p-2">
+        <div className="flex items-center justify-between gap-2">
+          <LocaleSwitcher />
+          <Link
+            href="/docs"
+            aria-label={t('help')}
+            title={t('help')}
+            className="flex size-8 items-center justify-center rounded-md text-sidebar-foreground/60 transition hover:bg-sidebar-accent hover:text-sidebar-foreground"
+          >
+            <CircleHelp className="size-4" />
+          </Link>
+        </div>
+      </SidebarFooter>
+
+      <SidebarRail />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+    </Sidebar>
+  );
+}

--- a/ee/apps/web/src/components/upgrade-modal.tsx
+++ b/ee/apps/web/src/components/upgrade-modal.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+interface QuotaExceededDetail {
+  resource: string;
+  current: number;
+  limit: number;
+  upgradeUrl?: string;
+}
+
+const RESOURCE_LABELS: Record<string, string> = {
+  stories: '스토리',
+  memos: '메모',
+  docs: '문서',
+  members: '팀 멤버',
+  projects: '프로젝트',
+  api_calls: 'API 호출',
+};
+
+export function UpgradeModal() {
+  const router = useRouter();
+  const [detail, setDetail] = useState<QuotaExceededDetail | null>(null);
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const d = (e as CustomEvent<QuotaExceededDetail>).detail;
+      setDetail(d);
+    }
+    window.addEventListener('quota-exceeded', handler);
+    return () => window.removeEventListener('quota-exceeded', handler);
+  }, []);
+
+  if (!detail) return null;
+
+  const label = RESOURCE_LABELS[detail.resource] ?? detail.resource;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm" role="dialog" aria-modal="true">
+      <div className="w-full max-w-sm rounded-2xl border border-border bg-card p-6 shadow-xl">
+        <h2 className="font-heading text-lg font-semibold">쿼터 초과</h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          <strong>{label}</strong> 한도({detail.limit}개)에 도달했습니다.
+          현재 {detail.current}개 사용 중입니다.
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Team 또는 Pro 플랜으로 업그레이드하면 한도가 대폭 늘어납니다.
+        </p>
+        <div className="mt-5 flex gap-2">
+          <Button
+            className="flex-1"
+            onClick={() => {
+              setDetail(null);
+              router.push('/upgrade');
+            }}
+          >
+            업그레이드
+          </Button>
+          <Button variant="outline" className="flex-1" onClick={() => setDetail(null)}>
+            닫기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function dispatchQuotaExceeded(detail: QuotaExceededDetail) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('quota-exceeded', { detail }));
+}

--- a/ee/apps/web/src/hooks/use-upgrade-guard.ts
+++ b/ee/apps/web/src/hooks/use-upgrade-guard.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useCallback } from 'react';
+import { readApiClientError } from '@/lib/api-client-error';
+import { dispatchQuotaExceeded } from '@/components/upgrade-modal';
+
+export function useUpgradeGuard() {
+  const guardedFetch = useCallback(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const res = await fetch(input, init);
+
+    if (res.status === 402 || res.status === 403) {
+      try {
+        const payload = await readApiClientError(res.clone(), `Request failed (${res.status})`);
+        if (payload.code === 'quota_exceeded' || payload.code === 'UPGRADE_REQUIRED') {
+          dispatchQuotaExceeded({
+            resource: (payload.details?.['resource'] as string) ?? payload.meterType ?? 'unknown',
+            current: (payload.details?.['current'] as number) ?? 0,
+            limit: (payload.details?.['limit'] as number) ?? 0,
+            upgradeUrl: (payload.details?.['upgradeUrl'] as string) ?? '/upgrade',
+          });
+        }
+      } catch {
+        // not JSON — ignore
+      }
+    }
+
+    return res;
+  }, []);
+
+  const triggerUpgrade = useCallback((meter: string) => {
+    dispatchQuotaExceeded({ resource: meter, current: 0, limit: 0 });
+  }, []);
+
+  return { guardedFetch, triggerUpgrade };
+}

--- a/ee/apps/web/src/lib/usage-check.ts
+++ b/ee/apps/web/src/lib/usage-check.ts
@@ -1,0 +1,129 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { getEntitlementBearingSubscription } from './billing-policy';
+
+export interface UsageCheckResult {
+  allowed: boolean;
+  currentValue: number;
+  limitValue: number | null;
+  percentage: number;  // 0-100
+  meterType: string;
+}
+
+/**
+ * AC2+AC3: Usage 체크 미들웨어
+ * - 현재 월의 미터 조회 또는 자동 생성
+ * - 한도 초과 시 { allowed: false }
+ */
+export async function checkUsage(
+  supabase: SupabaseClient,
+  orgId: string,
+  meterType: string,
+): Promise<UsageCheckResult> {
+  const now = new Date();
+  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+  // 현재 월 미터 조회
+  const { data: meter } = await supabase
+    .from('usage_meters')
+    .select('current_value, limit_value')
+    .eq('org_id', orgId)
+    .eq('meter_type', meterType)
+    .gte('period_start', periodStart.toISOString())
+    .lte('period_end', periodEnd.toISOString())
+    .maybeSingle();
+
+  const currentValue = meter?.current_value ?? 0;
+  const limitValue = meter?.limit_value ?? null;
+  const percentage = limitValue ? Math.round((currentValue / limitValue) * 100) : 0;
+
+  if (limitValue != null && currentValue >= limitValue) {
+    return { allowed: false, currentValue, limitValue, percentage: 100, meterType };
+  }
+
+  return { allowed: true, currentValue, limitValue, percentage, meterType };
+}
+
+/** tier 기반 limit_value 조회 */
+async function getTierLimit(supabase: SupabaseClient, orgId: string, meterType: string): Promise<number | null> {
+  // meter_type → plan_features feature_key 매핑
+  const METER_TO_FEATURE: Record<string, string> = {
+    ai_calls: 'ai_structuring_monthly_limit',
+    stt_minutes: 'max_stt_minutes',
+    members: 'max_members',
+    agents: 'byoa_agents',
+    storage_mb: 'max_storage_mb',
+  };
+  const featureKey = METER_TO_FEATURE[meterType];
+  if (!featureKey) return null;
+
+  const sub = await getEntitlementBearingSubscription<{ tier?: string | null; status?: string | null }>(
+    supabase,
+    orgId,
+  );
+  const tierName = sub?.tier ?? 'free';
+  const { data: tierRow } = await supabase.from('plan_tiers').select('id').eq('name', tierName).single();
+  const tierId = tierRow?.id ?? null;
+  if (!tierId) return null;
+
+  const { data: feat } = await supabase
+    .from('plan_features').select('limit_value').eq('tier_id', tierId).eq('feature_key', featureKey).single();
+  return feat?.limit_value ?? null;
+}
+
+/**
+ * AC2: Usage 증가 (increment)
+ * - 미터 없으면 자동 생성 (tier 기반 limit 자동 주입)
+ */
+export async function incrementUsage(
+  supabase: SupabaseClient,
+  orgId: string,
+  meterType: string,
+  increment = 1,
+): Promise<void> {
+  const now = new Date();
+  const periodStart = new Date(now.getFullYear(), now.getMonth(), 1);
+  const periodEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+
+  const { data: existing } = await supabase
+    .from('usage_meters')
+    .select('id, current_value')
+    .eq('org_id', orgId)
+    .eq('meter_type', meterType)
+    .gte('period_start', periodStart.toISOString())
+    .maybeSingle();
+
+  if (existing) {
+    await supabase
+      .from('usage_meters')
+      .update({
+        current_value: existing.current_value + increment,
+        updated_at: now.toISOString(),
+      })
+      .eq('id', existing.id);
+  } else {
+    // tier 기반 limit 자동 주입
+    const limitValue = await getTierLimit(supabase, orgId, meterType);
+    await supabase
+      .from('usage_meters')
+      .insert({
+        org_id: orgId,
+        meter_type: meterType,
+        current_value: increment,
+        limit_value: limitValue,
+        period_start: periodStart.toISOString(),
+        period_end: periodEnd.toISOString(),
+      });
+  }
+}
+
+/**
+ * AC6: threshold 알림 체크 (80%/90%/100%)
+ */
+export function getThresholdAlert(percentage: number): 'warning_80' | 'warning_90' | 'limit_reached' | null {
+  if (percentage >= 100) return 'limit_reached';
+  if (percentage >= 90) return 'warning_90';
+  if (percentage >= 80) return 'warning_80';
+  return null;
+}

--- a/ee/apps/web/src/services/agent-tool-execution-engine.ts
+++ b/ee/apps/web/src/services/agent-tool-execution-engine.ts
@@ -1,0 +1,489 @@
+/**
+ * SaaS overlay — agent-tool-execution-engine.ts
+ *
+ * OSS 버전과 동일하나, AgentBuiltinToolService 생성 시
+ * GateCheckService 기반 statusUpdateGateFn을 주입한다.
+ * update_story_status 호출이 워크플로우 계약 gate check를 통과해야만 전이된다.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { githubMcpToolArgumentSchemas, isGitHubMcpToolName } from '@/lib/github-mcp';
+import { resolveMcpTokenRef } from '@/lib/mcp-secrets';
+import {
+  buildToolAclRegistryBoundary,
+  evaluateToolAcl,
+  getToolAclDeniedAudience,
+  isBuiltinAgentToolName,
+  type ToolAclDeniedReasonCode,
+  type ToolAclRegistryBoundary,
+} from '@/lib/tool-acl-contract';
+import { AgentBuiltinToolService, BUILTIN_AGENT_TOOL_NAMES, type BuiltinAgentToolName } from './agent-builtin-tools';
+import { listProjectApprovedMcpServerConfigs, parseMcpVaultRef, resolveProjectMcpVaultToken } from './project-mcp';
+import { GateCheckService } from './gate-check-service';
+
+type AuditSeverity = 'debug' | 'info' | 'warn' | 'error' | 'security';
+
+type AuditLogger = (eventType: string, severity: AuditSeverity, payload: Record<string, unknown>) => Promise<void>;
+
+type FetchFn = typeof fetch;
+
+interface MemoScope {
+  id: string;
+  org_id: string;
+  project_id: string;
+  title: string | null;
+  content: string;
+  memo_type: string;
+  status: string;
+  assigned_to: string | null;
+  created_by: string;
+  created_at: string;
+  updated_at: string;
+}
+
+interface AgentScope {
+  id: string;
+  org_id: string;
+  project_id: string;
+  name: string;
+}
+
+export interface ToolExecutionContext {
+  memo: MemoScope;
+  agent: AgentScope;
+  runId: string;
+  sessionId: string;
+}
+
+const EXTERNAL_TOOL_TIMEOUT_MS = 10_000;
+const EXTERNAL_TOOL_SUMMARY_TOKEN_LIMIT = 4096;
+
+type GenericExternalMcpServerConfig = {
+  name: string;
+  url: string;
+  allowed_tools: string[];
+  auth?: {
+    token_ref: string;
+    header_name?: string;
+    scheme?: 'bearer' | 'plain';
+  };
+};
+type GitHubExternalMcpServerConfig = {
+  kind: 'github';
+  name: 'github';
+  url: string;
+  allowed_tools: string[];
+  auth: {
+    token_ref: string;
+    header_name?: string;
+    scheme?: 'bearer' | 'plain';
+  };
+};
+type ExternalServerConfig = (GenericExternalMcpServerConfig & { kind: 'generic' }) | GitHubExternalMcpServerConfig;
+
+export interface ToolRegistry {
+  builtinToolNames: string[];
+  externalServers: ExternalServerConfig[];
+  availableToolNames: string[];
+  aclBoundary: ToolAclRegistryBoundary;
+}
+
+export interface ToolExecutionOutput {
+  source: 'builtin' | 'external';
+  durationMs: number;
+  payload: Record<string, unknown>;
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function truncateText(text: string, maxChars: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxChars) return normalized;
+  return `${normalized.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+function truncateToTokenBudget(text: string, maxTokens: number): string {
+  if (maxTokens <= 0) return '';
+  return truncateText(text, maxTokens * 4);
+}
+
+function normalizeExternalSummary(result: unknown): string {
+  if (result == null) return 'null';
+
+  if (typeof result === 'string') {
+    return truncateToTokenBudget(result, EXTERNAL_TOOL_SUMMARY_TOKEN_LIMIT);
+  }
+
+  if (typeof result === 'object' && Array.isArray((result as { content?: unknown }).content)) {
+    const textContent = (result as { content: unknown[] }).content
+      .flatMap((entry) => {
+        if (typeof entry === 'string') return [entry];
+        if (!entry || typeof entry !== 'object') return [];
+        const record = entry as Record<string, unknown>;
+        if (typeof record.text === 'string') return [record.text];
+        if (typeof record.content === 'string') return [record.content];
+        return [JSON.stringify(entry)];
+      })
+      .join('\n');
+
+    if (textContent.trim()) {
+      return truncateToTokenBudget(textContent, EXTERNAL_TOOL_SUMMARY_TOKEN_LIMIT);
+    }
+  }
+
+  return truncateToTokenBudget(JSON.stringify(result), EXTERNAL_TOOL_SUMMARY_TOKEN_LIMIT);
+}
+
+function mapGitHubMcpError(errorMessage: string, status?: number): string {
+  const normalized = errorMessage.toLowerCase();
+  if (status === 429 || normalized.includes('rate limit') || normalized.includes('secondary rate limit')) {
+    return 'github_mcp_rate_limited';
+  }
+  if (status === 401 || status === 403 || normalized.includes('forbidden') || normalized.includes('resource not accessible')) {
+    return 'github_mcp_permission_denied';
+  }
+  if ((status != null && status >= 500) || normalized.includes('bad gateway') || normalized.includes('gateway') || normalized.includes('econnrefused')) {
+    return 'github_mcp_gateway_unavailable';
+  }
+  return errorMessage;
+}
+
+export class AgentToolExecutionEngine {
+  private readonly builtinToolService: AgentBuiltinToolService;
+  private readonly fetchFn: FetchFn;
+  private readonly auditLogger?: AuditLogger;
+
+  constructor(
+    supabase: SupabaseClient,
+    options: {
+      builtinToolService?: AgentBuiltinToolService;
+      fetchFn?: FetchFn;
+      auditLogger?: AuditLogger;
+    } = {},
+  ) {
+    const gateService = new GateCheckService(supabase);
+
+    this.builtinToolService = options.builtinToolService ?? new AgentBuiltinToolService(supabase, {
+      auditLogger: options.auditLogger,
+      statusUpdateGateFn: async (storyId, targetStatus, orgId, projectId, actorId) => {
+        try {
+          const result = await gateService.check({
+            entityType: 'story',
+            entityId: storyId,
+            toolName: 'update_story_status_gated',
+            orgId,
+            projectId,
+            actorId,
+          });
+          return {
+            pass: result.pass,
+            nextStatus: result.transitioned?.to ?? targetStatus,
+            mode: result.mode,
+            violations: result.violations,
+          };
+        } catch {
+          return null; // gate check 오류 시 직접 업데이트 허용
+        }
+      },
+    });
+    this.fetchFn = options.fetchFn ?? fetch;
+    this.auditLogger = options.auditLogger;
+  }
+
+  async loadRegistry(
+    projectId: string,
+    allowedToolNames?: string[],
+    aclInput: {
+      allowedProjectIds?: string[];
+      agentId?: string;
+    } = {},
+  ): Promise<ToolRegistry> {
+    const aclBoundary = buildToolAclRegistryBoundary({
+      projectId,
+      allowedProjectIds: aclInput.allowedProjectIds,
+      agentId: aclInput.agentId,
+      toolAllowlist: allowedToolNames,
+    });
+    const allowedToolSet = allowedToolNames ? new Set(allowedToolNames) : null;
+    const builtin = aclBoundary.project_in_scope
+      ? (allowedToolSet
+        ? BUILTIN_AGENT_TOOL_NAMES.filter((name) => allowedToolSet.has(name))
+        : [...BUILTIN_AGENT_TOOL_NAMES])
+      : [];
+
+    let approvedServers: ExternalServerConfig[] = [];
+    try {
+      approvedServers = await listProjectApprovedMcpServerConfigs(createSupabaseAdminClient() as never, projectId);
+    } catch {
+      approvedServers = [];
+    }
+
+    const externalServers = (aclBoundary.project_in_scope ? approvedServers : [])
+      .map((server) => ({
+        ...server,
+        allowed_tools: allowedToolSet
+          ? server.allowed_tools.filter((toolName) => allowedToolSet.has(toolName))
+          : [...server.allowed_tools],
+      }))
+      .filter((server) => server.allowed_tools.length > 0);
+
+    const externalToolNames = externalServers.flatMap((server) => server.allowed_tools);
+
+    return {
+      builtinToolNames: builtin,
+      externalServers,
+      availableToolNames: [...new Set([...builtin, ...externalToolNames])],
+      aclBoundary,
+    };
+  }
+
+  async execute(
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+    registry: ToolRegistry,
+  ): Promise<ToolExecutionOutput> {
+    const aclDecision = evaluateToolAcl({
+      toolName,
+      boundary: registry.aclBoundary,
+      currentAgentId: ctx.agent.id,
+    });
+    if (!aclDecision.allowed) {
+      return this.denyToolExecution(
+        isBuiltinAgentToolName(toolName) ? 'builtin' : 'external',
+        toolName,
+        ctx,
+        registry,
+        aclDecision.reasonCode ?? 'tool_not_allowlisted',
+        aclDecision.reason ?? 'tool execution denied by ACL',
+      );
+    }
+
+    if (registry.builtinToolNames.includes(toolName)) {
+      const startedAt = Date.now();
+      const payload = await this.builtinToolService.execute(toolName as BuiltinAgentToolName, args, ctx);
+      const durationMs = Date.now() - startedAt;
+      return {
+        source: 'builtin',
+        durationMs,
+        payload: {
+          source: 'builtin',
+          duration_ms: durationMs,
+          ...payload,
+        },
+      };
+    }
+
+    const matchingServers = registry.externalServers.filter((server) => server.allowed_tools.includes(toolName));
+    if (matchingServers.length === 0) {
+      return this.denyToolExecution(
+        'external',
+        toolName,
+        ctx,
+        registry,
+        'project_tool_not_registered',
+        'tool is not approved for this project or has no external server mapping',
+      );
+    }
+
+    if (matchingServers.length > 1) {
+      await this.auditLogger?.('agent_tool.ambiguous_external_mapping', 'security', {
+        org_id: ctx.memo.org_id,
+        project_id: ctx.memo.project_id,
+        agent_id: ctx.agent.id,
+        run_id: ctx.runId,
+        session_id: ctx.sessionId,
+        tool_name: toolName,
+        tool_source: 'external',
+        outcome: 'failed',
+        user_reason: 'This tool could not run because multiple external servers matched the same tool name.',
+        operator_reason: 'The project-approved MCP mapping is ambiguous because more than one external server advertises this tool name.',
+        next_action: 'Narrow the project-approved MCP mappings so the tool name resolves to exactly one external server.',
+        server_names: matchingServers.map((server) => server.name),
+      });
+      return {
+        source: 'external',
+        durationMs: 0,
+        payload: {
+          source: 'external',
+          duration_ms: 0,
+          error: 'tool_name mapped to multiple external MCP servers',
+          user_reason: 'This tool could not run because multiple external servers matched the same tool name.',
+          next_action: 'Narrow the project-approved MCP mappings so the tool name resolves to exactly one external server.',
+        },
+      };
+    }
+
+    return this.callExternalServer(matchingServers[0], toolName, args, ctx);
+  }
+
+  private async denyToolExecution(
+    source: ToolExecutionOutput['source'],
+    toolName: string,
+    ctx: ToolExecutionContext,
+    registry: ToolRegistry,
+    reasonCode: ToolAclDeniedReasonCode,
+    reason: string,
+  ): Promise<ToolExecutionOutput> {
+    const audience = getToolAclDeniedAudience(reasonCode);
+
+    await this.auditLogger?.('agent_tool.acl_denied', 'security', {
+      org_id: ctx.memo.org_id,
+      project_id: ctx.memo.project_id,
+      agent_id: ctx.agent.id,
+      run_id: ctx.runId,
+      session_id: ctx.sessionId,
+      tool_name: toolName,
+      tool_source: source,
+      outcome: 'denied',
+      reason_code: reasonCode,
+      reason,
+      user_reason: audience.userReason,
+      operator_reason: audience.operatorReason,
+      next_action: audience.nextAction,
+      acl_boundary: registry.aclBoundary,
+    });
+
+    return {
+      source,
+      durationMs: 0,
+      payload: {
+        source,
+        duration_ms: 0,
+        error: 'tool_acl_denied',
+        reason_code: reasonCode,
+        reason: audience.userReason,
+        user_reason: audience.userReason,
+        next_action: audience.nextAction,
+      },
+    };
+  }
+
+  private async callExternalServer(
+    server: ExternalServerConfig,
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: ToolExecutionContext,
+  ): Promise<ToolExecutionOutput> {
+    const startedAt = Date.now();
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), EXTERNAL_TOOL_TIMEOUT_MS);
+
+    try {
+      const validatedArgs = server.kind === 'github' && isGitHubMcpToolName(toolName)
+        ? githubMcpToolArgumentSchemas[toolName].parse(args)
+        : args;
+
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+      };
+
+      if (server.auth?.token_ref) {
+        const token = parseMcpVaultRef(server.auth.token_ref)
+          ? await resolveProjectMcpVaultToken(createSupabaseAdminClient() as never, ctx.memo.project_id, server.auth.token_ref)
+          : resolveMcpTokenRef(server.auth.token_ref);
+        const headerName = server.auth.header_name ?? (server.kind === 'github' ? 'X-GitHub-Token' : 'Authorization');
+        const scheme = server.auth.scheme ?? (server.kind === 'github' ? 'plain' : 'bearer');
+        headers[headerName] = scheme === 'bearer' ? `Bearer ${token}` : token;
+      }
+
+      const response = await this.fetchFn(server.url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: `${ctx.runId}:${toolName}:${Date.now()}`,
+          method: 'tools/call',
+          params: {
+            name: toolName,
+            arguments: validatedArgs,
+          },
+        }),
+        signal: controller.signal,
+      });
+
+      const durationMs = Date.now() - startedAt;
+      const json = await response.json().catch(() => ({})) as { error?: { message?: string }; result?: unknown };
+
+      if (!response.ok) {
+        const baseMessage = json.error?.message ?? `external_mcp_http_${response.status}`;
+        throw new Error(server.kind === 'github' ? mapGitHubMcpError(baseMessage, response.status) : baseMessage);
+      }
+
+      if (json.error?.message) {
+        throw new Error(server.kind === 'github' ? mapGitHubMcpError(json.error.message) : json.error.message);
+      }
+
+      const summary = normalizeExternalSummary(json.result);
+      const payload = {
+        source: 'external' as const,
+        server_name: server.name,
+        tool_name: toolName,
+        duration_ms: durationMs,
+        summary,
+        summary_tokens: estimateTokens(summary),
+      };
+
+      await this.auditLogger?.('agent_tool.external_executed', 'info', {
+        org_id: ctx.memo.org_id,
+        project_id: ctx.memo.project_id,
+        agent_id: ctx.agent.id,
+        run_id: ctx.runId,
+        session_id: ctx.sessionId,
+        server_name: server.name,
+        server_kind: server.kind,
+        tool_name: toolName,
+        tool_source: 'external',
+        outcome: 'allowed',
+        duration_ms: durationMs,
+        arguments: validatedArgs,
+        summary,
+      });
+
+      return {
+        source: 'external',
+        durationMs,
+        payload,
+      };
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const rawMessage = error instanceof Error && error.name === 'AbortError'
+        ? (server.kind === 'github' ? 'github_mcp_gateway_timeout' : 'external_mcp_timeout')
+        : (error instanceof Error ? error.message : 'external_mcp_failed');
+      const message = server.kind === 'github'
+        ? mapGitHubMcpError(rawMessage)
+        : rawMessage;
+
+      await this.auditLogger?.('agent_tool.external_failed', 'warn', {
+        org_id: ctx.memo.org_id,
+        project_id: ctx.memo.project_id,
+        agent_id: ctx.agent.id,
+        run_id: ctx.runId,
+        session_id: ctx.sessionId,
+        server_name: server.name,
+        server_kind: server.kind,
+        tool_name: toolName,
+        tool_source: 'external',
+        outcome: 'failed',
+        duration_ms: durationMs,
+        error: message,
+      });
+
+      return {
+        source: 'external',
+        durationMs,
+        payload: {
+          source: 'external',
+          server_name: server.name,
+          tool_name: toolName,
+          duration_ms: durationMs,
+          error: message,
+        },
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

OSS와 SaaS가 혼재된 32개 수정본 파일을 ee/ 오버라이드 패턴으로 분리.

**OSS 추가 (apps/web/src/):**
- `lib/ee-enabled.ts` — `isEEEnabled()` placeholder (`process.env.LICENSE_CONSENT === 'agreed'`, S5 정식 구현 예정)
- `app/(authenticated)/settings/page.tsx` — `orgId` nullish guard trivial fix

**ee/ 완전 오버라이드 파일 (SaaS 로직, 21개):**

| 파일 | SaaS 추가 로직 |
|------|--------------|
| `app/(authenticated)/agents/page.tsx` | 워크플로우 탭 UI (WorkflowDashboard 등) |
| `app/(authenticated)/layout.tsx` | UpgradeModal |
| `app/login/page.tsx` | 이메일/비밀번호 인증, OAuth routing |
| `app/api/memos/route.ts` | `checkEntitlement` + `incrementUsage` |
| `app/api/stories/route.ts` | `checkEntitlement` + `WorkflowContractService` gate |
| `app/api/docs/[id]/route.ts` | doc-permissions 통합 |
| `app/api/docs/route.ts` | team member role check |
| `app/api/invitations/route.ts` | `sendInviteEmail` |
| `app/api/standup/**` (5개) | SaaS StandupService |
| `app/api/usage/route.ts` | `org_subscriptions` + usage meter |
| `app/api/oss/seed/route.ts` | SaaS 완전 재작성 |
| `components/nav/app-sidebar.tsx` | 알림 카운트 최적화 |
| `components/upgrade-modal.tsx` | QuotaExceededDetail + RESOURCE_LABELS |
| `hooks/use-upgrade-guard.ts` | 402/403 처리 |
| `lib/usage-check.ts` | 실제 usage meter DB 구현 |
| `services/agent-tool-execution-engine.ts` | GateCheckService `statusUpdateGateFn` 주입 |

## Test plan

- [ ] OSS 타입체크 에러 0건
- [ ] `isEEEnabled()` 함수 `apps/web/src/lib/ee-enabled.ts` 확인
- [ ] `ee/apps/web/src/` 오버라이드 파일 21개 확인
- [ ] OSS `apps/web/src/` 에 SaaS import 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)