### PR TITLE
feat(arch): E-ARCH-MONOREPO S5 — LICENSE_CONSENT 런타임 게이팅 정식 구현

### DIFF
--- a/apps/web/src/lib/ee-enabled.ts
+++ b/apps/web/src/lib/ee-enabled.ts
@@ -1,7 +1,41 @@
 /**
- * EE enablement check — placeholder implementation.
- * S5에서 LICENSE_CONSENT 검증 로직으로 교체 예정.
+ * EE (Enterprise Edition) runtime gating.
+ *
+ * Activation: set LICENSE_CONSENT=agreed in the environment.
+ * OSS builds that omit this variable get all EE features disabled.
+ *
+ * MVP: environment-variable only (no license server). A license server
+ * validation layer can be layered on top later.
+ *
+ * Cal.com / Infisical 패턴 참조 — 서버 검증 없이 env 기반.
  */
+
+const VALID_CONSENT = 'agreed';
+
+/** Returns true when the EE feature set is activated. */
 export function isEEEnabled(): boolean {
-  return process.env.LICENSE_CONSENT === 'agreed';
+  const raw = process.env['LICENSE_CONSENT'];
+  if (!raw) return false;
+  return raw.trim().toLowerCase() === VALID_CONSENT;
+}
+
+/**
+ * Throws an `EENotEnabledError` (HTTP 403) when EE is not active.
+ * Use in server-side Route Handlers.
+ */
+export function assertEEEnabled(): void {
+  if (!isEEEnabled()) throw new EENotEnabledError();
+}
+
+export class EENotEnabledError extends Error {
+  readonly status = 403 as const;
+  readonly code = 'EE_NOT_ENABLED' as const;
+
+  constructor() {
+    super(
+      'Enterprise Edition features are not enabled. ' +
+      'Set LICENSE_CONSENT=agreed to activate.',
+    );
+    this.name = 'EENotEnabledError';
+  }
 }

--- a/apps/web/src/lib/ee-gate.ts
+++ b/apps/web/src/lib/ee-gate.ts
@@ -1,0 +1,23 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { isEEEnabled } from './ee-enabled';
+
+type RouteHandler<P = Record<string, string>> = (
+  req: NextRequest,
+  ctx: { params: P },
+) => Promise<Response> | Response;
+
+const EE_DISABLED_RESPONSE = NextResponse.json(
+  { error: { code: 'EE_NOT_ENABLED', message: 'Enterprise Edition not enabled. Set LICENSE_CONSENT=agreed.' } },
+  { status: 403 },
+);
+
+/**
+ * Wraps a Next.js Route Handler with an EE license gate.
+ * Returns HTTP 403 when LICENSE_CONSENT is not set to 'agreed'.
+ */
+export function withEEGate<P = Record<string, string>>(handler: RouteHandler<P>): RouteHandler<P> {
+  return (req, ctx) => {
+    if (!isEEEnabled()) return EE_DISABLED_RESPONSE;
+    return handler(req, ctx);
+  };
+}

--- a/ee/apps/web/src/app/(authenticated)/layout.tsx
+++ b/ee/apps/web/src/app/(authenticated)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getMyMembershipContext } from '@/lib/auth-helpers';
+import { isEEEnabled } from '@/lib/ee-enabled';
 import { DashboardShell } from '../dashboard/dashboard-shell';
 import { UpgradeBanner } from '@/components/upgrade-banner';
 import { UpgradeModal } from '@/components/upgrade-modal';
@@ -17,6 +18,7 @@ export default async function AuthenticatedLayout({
     if (!user) redirect('/login');
 
     const { me, memberships } = await getMyMembershipContext(supabase, user);
+    const eeEnabled = isEEEnabled();
 
     return (
       <DashboardShell
@@ -26,8 +28,8 @@ export default async function AuthenticatedLayout({
         projectName={me?.project_name}
         projectMemberships={memberships.map((membership) => ({ projectId: membership.project_id, projectName: membership.project_name }))}
       >
-        <UpgradeBanner />
-        <UpgradeModal />
+        {eeEnabled && <UpgradeBanner />}
+        {eeEnabled && <UpgradeModal />}
         {children}
       </DashboardShell>
     );

--- a/ee/apps/web/src/proxy.ts
+++ b/ee/apps/web/src/proxy.ts
@@ -1,0 +1,142 @@
+export const runtime = 'nodejs';
+
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+import { isEEEnabled } from '@/lib/ee-enabled';
+
+const PUBLIC_EXACT = [
+  '/',
+  '/llms.txt',
+  '/llms-full.txt',
+  '/llms-baos.txt',
+];
+
+const PUBLIC_PREFIX = [
+  '/api/',
+  '/login',
+  '/signup',
+  '/forgot-password',
+  '/auth/callback',
+  '/auth/login',
+  '/invite',
+  '/internal-dogfood',
+];
+
+/** API path prefixes that require an active EE license. */
+const EE_API_PREFIXES = [
+  '/api/billing',
+  '/api/checkout',
+  '/api/subscription/portal',
+  '/api/webhooks/polar',
+  '/api/webhooks/payment',
+  '/api/v1/billing',
+  '/api/usage',
+] as const;
+
+const EE_DISABLED_RESPONSE = new NextResponse(
+  JSON.stringify({ error: { code: 'EE_NOT_ENABLED', message: 'Enterprise Edition not enabled. Set LICENSE_CONSENT=agreed.' } }),
+  { status: 403, headers: { 'Content-Type': 'application/json' } },
+);
+
+function isOssMode(): boolean {
+  return process.env['OSS_MODE'] === 'true';
+}
+
+export async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+
+  // EE gate — block SaaS-only API paths when LICENSE_CONSENT is not set
+  if (EE_API_PREFIXES.some((prefix) => pathname.startsWith(prefix))) {
+    if (!isEEEnabled()) return EE_DISABLED_RESPONSE;
+  }
+
+  // OSS_MODE: bypass Supabase auth entirely
+  if (isOssMode()) {
+    if (pathname === '/') {
+      const url = request.nextUrl.clone();
+      url.pathname = '/inbox';
+      return NextResponse.redirect(url);
+    }
+
+    if (pathname === '/login' || pathname.startsWith('/auth/callback')) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/inbox';
+      url.search = '';
+      return NextResponse.redirect(url);
+    }
+
+    return NextResponse.next({ request });
+  }
+
+  const isPublicPath =
+    PUBLIC_EXACT.includes(pathname) ||
+    PUBLIC_PREFIX.some((prefix) => pathname.startsWith(prefix));
+
+  if (isPublicPath) {
+    return NextResponse.next({ request });
+  }
+
+  // Agent API keys are for MCP/HTTP API only — block UI route access
+  const authHeader = request.headers.get('Authorization');
+  if (authHeader?.startsWith('Bearer ')) {
+    return new NextResponse(
+      JSON.stringify({ error: { code: 'FORBIDDEN', message: 'Agent API keys cannot access UI routes' } }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabase = createServerClient(
+    process.env['NEXT_PUBLIC_SUPABASE_URL']!,
+    process.env['NEXT_PUBLIC_SUPABASE_ANON_KEY']!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet: Array<{ name: string; value: string; options: Record<string, unknown> }>) {
+          const cookieDomain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+          for (const { name, value } of cookiesToSet) {
+            request.cookies.set(name, value);
+          }
+          supabaseResponse = NextResponse.next({ request });
+          for (const { name, value, options } of cookiesToSet) {
+            supabaseResponse.cookies.set(name, value, {
+              ...(options as Parameters<typeof supabaseResponse.cookies.set>[2]),
+              ...(cookieDomain ? { domain: cookieDomain } : {}),
+            });
+          }
+        },
+      },
+    },
+  );
+
+  const { data: claimsData } = await supabase.auth.getClaims();
+
+  if (!claimsData?.claims) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/login';
+    return NextResponse.redirect(url);
+  }
+
+  const exp = (claimsData.claims as { exp?: number }).exp;
+  const now = Math.floor(Date.now() / 1000);
+  if (exp !== undefined && exp - now < 300) {
+    await supabase.auth.refreshSession();
+  }
+
+  if (request.nextUrl.pathname === '/login') {
+    const url = request.nextUrl.clone();
+    url.pathname = '/inbox';
+    return NextResponse.redirect(url);
+  }
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: [
+    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
+  ],
+};


### PR DESCRIPTION
## Summary

S4 placeholder `isEEEnabled()`를 정식 게이팅 로직으로 교체. API + UI 양쪽 게이팅 완성.

### `apps/web/src/lib/ee-enabled.ts` (강화)
- `isEEEnabled()`: `trim().toLowerCase()` 유효성 검증 (단순 문자열 비교 → 정식 검증)
- `assertEEEnabled()`: `EENotEnabledError` throw
- `EENotEnabledError`: `status: 403`, `code: 'EE_NOT_ENABLED'`

### `apps/web/src/lib/ee-gate.ts` (신규)
- `withEEGate()`: Route Handler 래퍼 — `isEEEnabled()` false 시 HTTP 403 반환

### `ee/apps/web/src/proxy.ts` (신규, Next.js 16 Node.js runtime)
- `EE_API_PREFIXES`: `billing/`, `checkout/`, `webhooks/polar`, `webhooks/payment`, `v1/billing/`, `usage/`
- 요청 진입 시 EE 게이트 체크 → 403 `EE_NOT_ENABLED`
- OSS `proxy.ts` 인증 로직 전량 유지 (Supabase auth, OSS_MODE bypass)

### `ee/apps/web/src/app/(authenticated)/layout.tsx` (UI 게이팅)
- 서버 컴포넌트에서 `isEEEnabled()` 체크
- false 시 `UpgradeBanner`, `UpgradeModal` 비노출

## Test plan

- [ ] `LICENSE_CONSENT` 미설정: `GET /api/billing` → HTTP 403 `EE_NOT_ENABLED`
- [ ] `LICENSE_CONSENT=agreed`: `GET /api/billing` → 정상 응답
- [ ] `LICENSE_CONSENT` 미설정: 레이아웃에서 UpgradeBanner/UpgradeModal 비노출
- [ ] TypeScript 에러 없음 (기존 react-email 제외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)