### PR TITLE
fix(p0): 에이전트 Webhook URL 관리 UI + API

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { requireOrgAdmin } from '@/lib/admin-check';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
+import { AgentWebhookManager } from '@/components/agents/agent-webhook-manager';
 import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
 
 export default async function ApiKeysPage() {
@@ -39,10 +40,10 @@ export default async function ApiKeysPage() {
   // API Key 관리는 admin만 가능
   await requireOrgAdmin(supabase, me.org_id).catch(() => redirect('/dashboard'));
 
-  // 프로젝트 내 모든 에이전트 조회
+  // 프로젝트 내 모든 에이전트 조회 (webhook_url 포함)
   const { data: agents } = await supabase
     .from('team_members')
-    .select('id, name, type')
+    .select('id, name, type, webhook_url')
     .eq('org_id', me.org_id)
     .eq('project_id', me.project_id)
     .eq('type', 'agent')
@@ -54,7 +55,7 @@ export default async function ApiKeysPage() {
       <div>
         <h1 className="text-3xl font-bold">Agent API Keys</h1>
         <p className="text-muted-foreground mt-2">
-          Manage API keys for agent authentication
+          Manage API keys and webhook URLs for agent authentication
         </p>
       </div>
 
@@ -63,11 +64,17 @@ export default async function ApiKeysPage() {
       ) : (
         <div className="space-y-6">
           {agents.map((agent) => (
-            <AgentApiKeyManager
-              key={agent.id}
-              agentId={agent.id as string}
-              agentName={agent.name as string}
-            />
+            <div key={agent.id} className="space-y-3">
+              <AgentApiKeyManager
+                agentId={agent.id as string}
+                agentName={agent.name as string}
+              />
+              <AgentWebhookManager
+                agentId={agent.id as string}
+                agentName={agent.name as string}
+                currentWebhookUrl={(agent.webhook_url as string | null) ?? null}
+              />
+            </div>
           ))}
         </div>
       )}

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -111,16 +111,35 @@ export async function PATCH(
 
     let body: unknown;
     try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON', 400); }
-    const { role: newRole } = body as { role?: string };
-    if (!newRole) return apiError('BAD_REQUEST', 'role required', 400);
+    const { role: newRole, webhook_url: rawWebhookUrl } = body as { role?: string; webhook_url?: string | null };
+
+    if (!newRole && rawWebhookUrl === undefined) {
+      return apiError('BAD_REQUEST', 'At least one of role or webhook_url is required', 400);
+    }
+
+    // webhook_url: HTTPS 또는 null/빈문자열(→null 클리어)
+    let webhookUrl: string | null | undefined;
+    if (rawWebhookUrl !== undefined) {
+      if (rawWebhookUrl === null || rawWebhookUrl === '') {
+        webhookUrl = null;
+      } else if (/^https:\/\//i.test(rawWebhookUrl)) {
+        webhookUrl = rawWebhookUrl;
+      } else {
+        return apiError('BAD_REQUEST', 'webhook_url must be a valid HTTPS URL or empty to clear', 400);
+      }
+    }
+
+    const updatePayload: Record<string, unknown> = {};
+    if (newRole) updatePayload['role'] = newRole;
+    if (webhookUrl !== undefined) updatePayload['webhook_url'] = webhookUrl;
 
     const oldRole = target.role as string;
 
     const { data: updated, error: updateError } = await supabase
       .from('team_members')
-      .update({ role: newRole })
+      .update(updatePayload)
       .eq('id', id)
-      .select('id, name, type, role, user_id, project_id, is_active')
+      .select('id, name, type, role, user_id, project_id, is_active, webhook_url')
       .single();
 
     if (updateError) throw updateError;

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -222,8 +222,9 @@ export async function POST(request: Request) {
         role: body.role ?? 'member',
         user_id: body.user_id ?? null,
         agent_config: parsedAgentConfig.data,
+        ...(body.webhook_url ? { webhook_url: body.webhook_url } : {}),
       })
-      .select('id, name, type, role, user_id, project_id, is_active')
+      .select('id, name, type, role, user_id, project_id, is_active, webhook_url')
       .single();
 
     if (error) throw error;

--- a/apps/web/src/components/agents/agent-webhook-manager.tsx
+++ b/apps/web/src/components/agents/agent-webhook-manager.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/toast';
+
+interface AgentWebhookManagerProps {
+  agentId: string;
+  agentName: string;
+  currentWebhookUrl: string | null;
+}
+
+export function AgentWebhookManager({ agentId, agentName, currentWebhookUrl }: AgentWebhookManagerProps) {
+  const tc = useTranslations('common');
+  const [webhookUrl, setWebhookUrl] = useState(currentWebhookUrl ?? '');
+  const [saving, setSaving] = useState(false);
+  const { addToast } = useToast();
+
+  const handleSave = async () => {
+    const trimmed = webhookUrl.trim();
+    if (trimmed && !/^https:\/\//i.test(trimmed)) {
+      addToast({ title: 'Webhook URL must start with https://', type: 'error' });
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/team-members/${agentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhook_url: trimmed || null }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({})) as { error?: { message?: string } };
+        addToast({ title: json.error?.message ?? 'Failed to save webhook URL', type: 'error' });
+        return;
+      }
+      addToast({ title: `Webhook URL updated for ${agentName}`, type: 'success' });
+    } catch {
+      addToast({ title: 'Network error — please retry', type: 'error' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border bg-muted/30 p-4 space-y-3">
+      <div>
+        <p className="text-sm font-medium text-foreground">Webhook URL</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Events will be POSTed to this endpoint. Must be HTTPS.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <Input
+          value={webhookUrl}
+          onChange={(e) => setWebhookUrl(e.target.value)}
+          placeholder="https://your-agent.example.com/webhook"
+          className="flex-1 font-mono text-xs"
+          type="url"
+        />
+        <Button size="sm" disabled={saving} onClick={() => void handleSave()}>
+          {saving ? tc('loading') : tc('save')}
+        </Button>
+      </div>
+      {currentWebhookUrl && (
+        <p className="text-[11px] text-muted-foreground truncate">
+          Current: <span className="font-mono">{currentWebhookUrl}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -44,6 +44,7 @@ export const createTeamMemberSchema = z.object({
   name: z.string().trim().min(1).optional().nullable(),
   role: z.string().trim().min(1).optional().default('member'),
   agent_config: z.record(z.string(), z.unknown()).optional().nullable(),
+  webhook_url: z.string().url().startsWith('https://').optional().nullable(),
 }).superRefine((value, ctx) => {
   if (value.type === 'human' && !value.user_id) {
     ctx.addIssue({


### PR DESCRIPTION
## Summary

에이전트 webhook URL 설정 기능 부재로 워크플로우 웹훅 수신 불가 → P0 긴급 수정.

### `packages/shared/src/schemas/index.ts`
- `createTeamMemberSchema` — `webhook_url` 필드 추가 (`z.string().url().startsWith('https://')`, optional/nullable)

### `apps/web/src/app/api/team-members/[id]/route.ts` PATCH
- `{ role?, webhook_url? }` 파싱 (둘 중 하나 이상 필수)
- `webhook_url`: HTTPS URL 검증, 빈문자열/null → DB null 클리어
- role 단독 업데이트 기존 동작 유지 (regression 방지)
- select에 `webhook_url` 포함

### `apps/web/src/app/api/team-members/route.ts` POST
- agent insert 시 optional `webhook_url` 지원
- select에 `webhook_url` 포함

### `apps/web/src/components/agents/agent-webhook-manager.tsx` (신규)
- 현재 `webhook_url` 표시 + HTTPS Input + Save 버튼
- 클라이언트 HTTPS validation + PATCH 호출 + 성공/실패 toast

### `apps/web/src/app/(authenticated)/agents/api-keys/page.tsx`
- agent 쿼리에 `webhook_url` 포함
- 각 에이전트 카드 하단에 `AgentWebhookManager` 렌더링

## Test plan

- [ ] agent 카드에 Webhook URL 입력창 표시 확인
- [ ] HTTPS URL 저장 → DB 반영 + 성공 toast
- [ ] 빈값 저장 → `null` 클리어 + 성공 toast
- [ ] `http://` URL → 에러 toast (HTTPS 필수)
- [ ] role 단독 PATCH 기존 동작 유지 확인
- [ ] TypeScript 에러 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)