### PR TITLE
feat(proxy): S12 /api/v2/** Next.js→FastAPI 프록시 설정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,6 +9,15 @@ const nextConfig: NextConfig = {
     position: 'bottom-right',
   },
   serverExternalPackages: ['@sprintable/storage-sqlite'],
+  async rewrites() {
+    const fastapiUrl = process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000';
+    return [
+      {
+        source: '/api/v2/:path*',
+        destination: `${fastapiUrl}/api/v2/:path*`,
+      },
+    ];
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/apps/web/src/next-config.test.ts
+++ b/apps/web/src/next-config.test.ts
@@ -1,0 +1,42 @@
+/**
+ * S12 AC1: next.config.ts rewrites 구조 검증
+ * /api/v2/** → NEXT_PUBLIC_FASTAPI_URL/api/v2/**
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+describe('next.config rewrites', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it('proxies /api/v2/:path* to NEXT_PUBLIC_FASTAPI_URL', async () => {
+    process.env.NEXT_PUBLIC_FASTAPI_URL = 'http://localhost:8000';
+
+    const mod = await import('../next.config');
+    const config = mod.default as { rewrites?: () => Promise<Array<{ source: string; destination: string }>> };
+
+    const rules = await config.rewrites?.();
+    expect(rules).toBeDefined();
+    expect(rules).toHaveLength(1);
+    expect(rules![0].source).toBe('/api/v2/:path*');
+    expect(rules![0].destination).toBe('http://localhost:8000/api/v2/:path*');
+  });
+
+  it('falls back to http://localhost:8000 when env is unset', async () => {
+    delete process.env.NEXT_PUBLIC_FASTAPI_URL;
+
+    const mod = await import('../next.config');
+    const config = mod.default as { rewrites?: () => Promise<Array<{ source: string; destination: string }>> };
+
+    const rules = await config.rewrites?.();
+    expect(rules![0].destination).toBe('http://localhost:8000/api/v2/:path*');
+  });
+});

--- a/backend/tests/test_proxy.py
+++ b/backend/tests/test_proxy.py
@@ -1,0 +1,90 @@
+"""S12 AC2+AC5: CORS 미들웨어 + /api/v2/health 프록시 경로 검증."""
+import pytest
+from httpx import ASGITransport, AsyncClient
+from unittest.mock import AsyncMock, patch
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_cors_allows_localhost_3000():
+    from app.main import app
+
+    with patch("app.routers.health.get_db") as mock_get_db:
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=None)
+
+        async def _override():
+            yield mock_session
+
+        mock_get_db.return_value = _override()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.options(
+                "/api/v2/health",
+                headers={
+                    "Origin": "http://localhost:3000",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Headers": "Authorization",
+                },
+            )
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "http://localhost:3000"
+    assert response.headers.get("access-control-allow-credentials") == "true"
+
+
+@pytest.mark.anyio
+async def test_cors_allows_sprintable_ai():
+    from app.main import app
+
+    with patch("app.routers.health.get_db") as mock_get_db:
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=None)
+
+        async def _override():
+            yield mock_session
+
+        mock_get_db.return_value = _override()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.options(
+                "/api/v2/health",
+                headers={
+                    "Origin": "https://app.sprintable.ai",
+                    "Access-Control-Request-Method": "GET",
+                    "Access-Control-Request-Headers": "Authorization",
+                },
+            )
+
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == "https://app.sprintable.ai"
+
+
+@pytest.mark.anyio
+async def test_health_via_proxy_path():
+    """AC5: /api/v2/health → FastAPI 정상 응답."""
+    from app.main import app
+
+    with patch("app.routers.health.get_db") as mock_get_db:
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(return_value=None)
+
+        async def _override():
+            yield mock_session
+
+        mock_get_db.return_value = _override()
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get(
+                "/api/v2/health",
+                headers={"Origin": "http://localhost:3000", "Authorization": "Bearer test-token"},
+            )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["version"] == "v2"


### PR DESCRIPTION
## Summary
- `apps/web/next.config.ts`: `/api/v2/:path*` → `NEXT_PUBLIC_FASTAPI_URL/api/v2/:path*` rewrites 추가
- `NEXT_PUBLIC_FASTAPI_URL` 미설정 시 `http://localhost:8000` 기본값
- `backend/app/main.py` CORS: `localhost:3000` + `app.sprintable.ai` 기 구성 완료 (AC2 pass)
- 레거시 `/api/**` 라우트 영향 없음 — rewrites는 `/api/v2/**`만 대상 (AC4 pass)

## Test plan
- [x] `vitest run apps/web/src/next-config.test.ts` → 2 passed (rewrites 구조 + 기본값)
- [x] `pytest tests/test_proxy.py` → 3 passed (CORS preflight localhost:3000, app.sprintable.ai, health 헤더 전달)
- [x] `pnpm vitest run` → 162 files, 1043 passed (회귀 없음)
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)