### PR TITLE
feat(backend): S13 Sprints 도메인 이관 — FastAPI /api/v2/sprints/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import health
+from app.routers import health, sprints
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -21,6 +21,7 @@ app.add_middleware(
 )
 
 app.include_router(health.router)
+app.include_router(sprints.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/repositories/sprint.py
+++ b/backend/app/repositories/sprint.py
@@ -1,0 +1,54 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Sprint, Story
+from app.repositories.base import BaseRepository
+
+
+class SprintRepository(BaseRepository[Sprint]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Sprint, session, org_id)
+
+    async def activate(self, id: uuid.UUID) -> Sprint:
+        sprint = await self.get(id)
+        if sprint is None:
+            raise ValueError(f"Sprint {id} not found")
+        if sprint.status != "planning":
+            raise ValueError(f"Cannot activate sprint with status: {sprint.status}")
+
+        result = await self.session.execute(
+            select(Sprint).where(
+                Sprint.org_id == self.org_id,
+                Sprint.project_id == sprint.project_id,
+                Sprint.status == "active",
+            )
+        )
+        if result.scalar_one_or_none() is not None:
+            raise ValueError("Active sprint already exists for this project")
+
+        updated = await self.update(id, status="active")
+        assert updated is not None
+        return updated
+
+    async def close(self, id: uuid.UUID) -> Sprint:
+        sprint = await self.get(id)
+        if sprint is None:
+            raise ValueError(f"Sprint {id} not found")
+        if sprint.status != "active":
+            raise ValueError(f"Cannot close sprint with status: {sprint.status}")
+
+        result = await self.session.execute(
+            select(Story).where(
+                Story.sprint_id == id,
+                Story.status == "done",
+                Story.deleted_at.is_(None),
+            )
+        )
+        done_stories = result.scalars().all()
+        velocity = sum(s.story_points or 0 for s in done_stories)
+
+        updated = await self.update(id, status="closed", velocity=velocity)
+        assert updated is not None
+        return updated

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -1,0 +1,129 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.sprint import SprintRepository
+from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate
+
+router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> SprintRepository:
+    org_id_str = (
+        auth.claims.get("app_metadata", {}).get("org_id")
+        or x_org_id
+    )
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required (X-Org-Id header or JWT app_metadata)")
+    return SprintRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[SprintResponse])
+async def list_sprints(
+    project_id: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    repo: SprintRepository = Depends(_get_repo),
+) -> list[SprintResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if status_filter:
+        filters["status"] = status_filter
+    sprints = await repo.list(**filters)
+    return [SprintResponse.model_validate(s) for s in sprints]
+
+
+@router.post("", response_model=SprintResponse, status_code=201)
+async def create_sprint(
+    body: SprintCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> SprintResponse:
+    repo = SprintRepository(session, body.org_id)
+    sprint = await repo.create(
+        project_id=body.project_id,
+        title=body.title,
+        start_date=body.start_date,
+        end_date=body.end_date,
+        team_size=body.team_size,
+    )
+    return SprintResponse.model_validate(sprint)
+
+
+@router.get("/{id}", response_model=SprintResponse)
+async def get_sprint(
+    id: uuid.UUID,
+    repo: SprintRepository = Depends(_get_repo),
+) -> SprintResponse:
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    return SprintResponse.model_validate(sprint)
+
+
+@router.patch("/{id}", response_model=SprintResponse)
+async def update_sprint(
+    id: uuid.UUID,
+    body: SprintUpdate,
+    repo: SprintRepository = Depends(_get_repo),
+) -> SprintResponse:
+    data = body.model_dump(exclude_unset=True)
+    sprint = await repo.update(id, **data)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    return SprintResponse.model_validate(sprint)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_sprint(
+    id: uuid.UUID,
+    repo: SprintRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    return {"ok": True}
+
+
+@router.post("/{id}/activate", response_model=SprintResponse)
+async def activate_sprint(
+    id: uuid.UUID,
+    repo: SprintRepository = Depends(_get_repo),
+) -> SprintResponse:
+    try:
+        sprint = await repo.activate(id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return SprintResponse.model_validate(sprint)
+
+
+@router.post("/{id}/close", response_model=SprintResponse)
+async def close_sprint(
+    id: uuid.UUID,
+    repo: SprintRepository = Depends(_get_repo),
+) -> SprintResponse:
+    try:
+        sprint = await repo.close(id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return SprintResponse.model_validate(sprint)
+
+
+@router.post("/{id}/kickoff")
+async def kickoff_sprint(
+    id: uuid.UUID,
+    body: KickoffBody = KickoffBody(),
+    repo: SprintRepository = Depends(_get_repo),
+) -> dict:
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    # Notification dispatch is Phase D — return stub for Phase B
+    return {"notified": 0, "sprint_id": str(id), "message": body.message}

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -1,0 +1,45 @@
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SprintBase(BaseModel):
+    title: str
+    start_date: date | None = None
+    end_date: date | None = None
+    team_size: int | None = None
+
+
+class SprintCreate(SprintBase):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+
+
+class SprintUpdate(BaseModel):
+    title: str | None = None
+    start_date: date | None = None
+    end_date: date | None = None
+    team_size: int | None = None
+    status: str | None = None
+    velocity: int | None = None
+    duration: int | None = None
+    report_doc_id: uuid.UUID | None = None
+
+
+class SprintResponse(SprintBase):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    status: str
+    velocity: int | None = None
+    duration: int
+    report_doc_id: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class KickoffBody(BaseModel):
+    message: str | None = None

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -1,0 +1,298 @@
+"""S13 AC5: Sprint router + repository 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SPRINT_ID = uuid.uuid4()
+VALID_TOKEN = "Bearer valid.jwt.token"
+
+
+def _mock_sprint(status: str = "planning") -> MagicMock:
+    s = MagicMock()
+    s.id = SPRINT_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.title = "Sprint 1"
+    s.status = status
+    s.start_date = date(2026, 5, 1)
+    s.end_date = date(2026, 5, 14)
+    s.velocity = None
+    s.team_size = None
+    s.duration = 14
+    s.report_doc_id = None
+    from datetime import datetime, timezone
+    s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return s
+
+
+def _auth_patch():
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    return patch("app.routers.sprints.get_current_user", return_value=lambda: ctx)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── GET list ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_sprints_200():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [sprint]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/sprints")
+
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── POST create ───────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_sprint_201():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = sprint
+
+            async with client as c:
+                resp = await c.post("/api/v2/sprints", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Sprint 1",
+                    "start_date": "2026-05-01",
+                    "end_date": "2026-05-14",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Sprint 1"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── GET detail ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_sprint_200():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/sprints/{SPRINT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(SPRINT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_sprint_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/sprints/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── PATCH update ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_sprint_200():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        sprint.title = "Updated Sprint"
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={"title": "Updated Sprint"})
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── DELETE ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_sprint_200():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/sprints/{SPRINT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── activate ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_activate_sprint_200():
+    client, session, app = await _client()
+    try:
+        planning_sprint = _mock_sprint("planning")
+        active_sprint = _mock_sprint("active")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # get sprint
+                result.scalar_one_or_none.return_value = planning_sprint
+            elif call_count == 2:
+                # check active sprint — none
+                result.scalar_one_or_none.return_value = None
+            else:
+                # update + re-get
+                result.scalar_one_or_none.return_value = active_sprint
+            result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/sprints/{SPRINT_ID}/activate")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── close ─────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_close_sprint_200():
+    client, session, app = await _client()
+    try:
+        active_sprint = _mock_sprint("active")
+        closed_sprint = _mock_sprint("closed")
+        closed_sprint.velocity = 10
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = active_sprint
+            elif call_count == 2:
+                # done stories
+                done_story = MagicMock()
+                done_story.story_points = 5
+                done_story2 = MagicMock()
+                done_story2.story_points = 5
+                result.scalars.return_value.all.return_value = [done_story, done_story2]
+            else:
+                result.scalar_one_or_none.return_value = closed_sprint
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/sprints/{SPRINT_ID}/close")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "closed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── kickoff ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_kickoff_sprint_200():
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint("active")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/sprints/{SPRINT_ID}/kickoff", json={"message": "Let's go!"})
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["notified"] == 0
+        assert body["sprint_id"] == str(SPRINT_ID)
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `backend/app/schemas/sprint.py`: SprintCreate / SprintUpdate / SprintResponse Pydantic DTO (현행 Next.js API 구조 호환)
- `backend/app/repositories/sprint.py`: `SprintRepository(BaseRepository[Sprint])` — `activate()` (planning→active, 중복 active 검증) + `close()` (active→closed, velocity 자동 계산)
- `backend/app/routers/sprints.py`: 8개 엔드포인트 — `GET/POST /api/v2/sprints`, `GET/PATCH/DELETE /api/v2/sprints/{id}`, `POST .../activate`, `POST .../close`, `POST .../kickoff`
- `org_id`: JWT `app_metadata.org_id` 우선, 폴백 `X-Org-Id` 헤더 (Phase B 임시)
- kickoff 알림은 Phase D에서 완성 — Phase B는 `{notified: 0}` stub 반환

## Test plan
- [x] `pytest tests/test_sprints.py` → 9 passed (list/create/get/404/update/delete/activate/close/kickoff)
- [x] `pytest` (전체) → 25 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)