### PR TITLE
feat(backend): S14 Epics 도메인 이관 — FastAPI /api/v2/epics/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import health, sprints
+from app.routers import epics, health, sprints
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -22,6 +22,7 @@ app.add_middleware(
 
 app.include_router(health.router)
 app.include_router(sprints.router)
+app.include_router(epics.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -39,9 +39,13 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default="open")
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     priority: Mapped[str] = mapped_column(String(20), nullable=False, default="medium")
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    objective: Mapped[str | None] = mapped_column(Text, nullable=True)
+    success_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
+    target_sp: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    target_date: Mapped[date | None] = mapped_column(Date, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="epics")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="epic", lazy="select")

--- a/backend/app/repositories/epic.py
+++ b/backend/app/repositories/epic.py
@@ -1,0 +1,41 @@
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Epic, Story
+from app.repositories.base import BaseRepository
+from app.schemas.epic import EpicProgressResponse
+
+
+class EpicRepository(BaseRepository[Epic]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Epic, session, org_id)
+
+    async def get_progress(self, id: uuid.UUID) -> EpicProgressResponse:
+        result = await self.session.execute(
+            select(
+                func.count(Story.id).label("total_stories"),
+                func.sum(Story.story_points).label("total_sp"),
+                func.count(Story.id).filter(Story.status == "done").label("done_stories"),
+                func.sum(Story.story_points).filter(Story.status == "done").label("done_sp"),
+            ).where(
+                Story.epic_id == id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        row = result.one()
+        total_stories = row.total_stories or 0
+        done_stories = row.done_stories or 0
+        total_sp = int(row.total_sp or 0)
+        done_sp = int(row.done_sp or 0)
+        completion_pct = round((done_sp / total_sp) * 100) if total_sp > 0 else 0
+
+        return EpicProgressResponse(
+            epic_id=id,
+            total_stories=total_stories,
+            done_stories=done_stories,
+            total_sp=total_sp,
+            done_sp=done_sp,
+            completion_pct=completion_pct,
+        )

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -1,0 +1,107 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.epic import EpicRepository
+from app.schemas.epic import EpicCreate, EpicProgressResponse, EpicResponse, EpicUpdate
+
+router = APIRouter(prefix="/api/v2/epics", tags=["epics"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> EpicRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return EpicRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[EpicResponse])
+async def list_epics(
+    project_id: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    repo: EpicRepository = Depends(_get_repo),
+) -> list[EpicResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if status_filter:
+        filters["status"] = status_filter
+    epics = await repo.list(**filters)
+    return [EpicResponse.model_validate(e) for e in epics]
+
+
+@router.post("", response_model=EpicResponse, status_code=201)
+async def create_epic(
+    body: EpicCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> EpicResponse:
+    repo = EpicRepository(session, body.org_id)
+    epic = await repo.create(
+        project_id=body.project_id,
+        title=body.title,
+        status=body.status,
+        priority=body.priority,
+        description=body.description,
+        objective=body.objective,
+        success_criteria=body.success_criteria,
+        target_sp=body.target_sp,
+        target_date=body.target_date,
+    )
+    return EpicResponse.model_validate(epic)
+
+
+@router.get("/{id}", response_model=EpicResponse)
+async def get_epic(
+    id: uuid.UUID,
+    repo: EpicRepository = Depends(_get_repo),
+) -> EpicResponse:
+    epic = await repo.get(id)
+    if epic is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
+    return EpicResponse.model_validate(epic)
+
+
+@router.patch("/{id}", response_model=EpicResponse)
+async def update_epic(
+    id: uuid.UUID,
+    body: EpicUpdate,
+    repo: EpicRepository = Depends(_get_repo),
+) -> EpicResponse:
+    data = body.model_dump(exclude_unset=True)
+    epic = await repo.update(id, **data)
+    if epic is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
+    return EpicResponse.model_validate(epic)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_epic(
+    id: uuid.UUID,
+    repo: EpicRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Epic not found")
+    return {"ok": True}
+
+
+@router.get("/{id}/progress", response_model=EpicProgressResponse)
+async def get_epic_progress(
+    id: uuid.UUID,
+    repo: EpicRepository = Depends(_get_repo),
+) -> EpicProgressResponse:
+    epic = await repo.get(id)
+    if epic is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
+    return await repo.get_progress(id)

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -1,0 +1,58 @@
+import uuid
+from datetime import date, datetime
+
+from pydantic import BaseModel, ConfigDict
+
+EPIC_STATUSES = ("draft", "active", "done", "archived")
+EPIC_PRIORITIES = ("critical", "high", "medium", "low")
+
+
+class EpicCreate(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    status: str = "active"
+    priority: str = "medium"
+    description: str | None = None
+    objective: str | None = None
+    success_criteria: str | None = None
+    target_sp: int | None = None
+    target_date: date | None = None
+
+
+class EpicUpdate(BaseModel):
+    title: str | None = None
+    status: str | None = None
+    priority: str | None = None
+    description: str | None = None
+    objective: str | None = None
+    success_criteria: str | None = None
+    target_sp: int | None = None
+    target_date: date | None = None
+
+
+class EpicResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    status: str
+    priority: str
+    description: str | None = None
+    objective: str | None = None
+    success_criteria: str | None = None
+    target_sp: int | None = None
+    target_date: date | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class EpicProgressResponse(BaseModel):
+    epic_id: uuid.UUID
+    total_stories: int
+    done_stories: int
+    total_sp: int
+    done_sp: int
+    completion_pct: int

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -1,0 +1,218 @@
+"""S14 AC5: Epic router + repository 단위 테스트 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+EPIC_ID = uuid.uuid4()
+
+
+def _mock_epic(status: str = "active") -> MagicMock:
+    e = MagicMock()
+    e.id = EPIC_ID
+    e.org_id = ORG_ID
+    e.project_id = PROJECT_ID
+    e.title = "Epic 1"
+    e.status = status
+    e.priority = "medium"
+    e.description = None
+    e.objective = None
+    e.success_criteria = None
+    e.target_sp = None
+    e.target_date = None
+    e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return e
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── GET list ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_epics_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_epic()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/epics")
+
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── POST create ───────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_epic_201():
+    client, session, app = await _client()
+    try:
+        epic = _mock_epic()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = epic
+
+            async with client as c:
+                resp = await c.post("/api/v2/epics", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Epic 1",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Epic 1"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── GET detail ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_epic_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_epic()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/epics/{EPIC_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(EPIC_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── GET 404 ───────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_epic_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/epics/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── PATCH update ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_epic_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_epic("done")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/epics/{EPIC_ID}", json={"status": "done"})
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── DELETE ────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delete_epic_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_epic()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/epics/{EPIC_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── GET progress ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_epic_progress_200():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # get epic
+                result.scalar_one_or_none.return_value = _mock_epic()
+            else:
+                # progress aggregation
+                row = MagicMock()
+                row.total_stories = 4
+                row.done_stories = 2
+                row.total_sp = 20
+                row.done_sp = 10
+                result.one.return_value = row
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/epics/{EPIC_ID}/progress")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total_stories"] == 4
+        assert body["done_stories"] == 2
+        assert body["completion_pct"] == 50
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/pm.py`: Epic 모델에 `objective` / `success_criteria` / `target_sp` / `target_date` 추가 (20260424 마이그레이션 반영), status 기본값 `active`
- `schemas/epic.py`: EpicCreate / EpicUpdate / EpicResponse + EpicProgressResponse Pydantic DTO
- `repositories/epic.py`: `EpicRepository(BaseRepository[Epic])` — `get_progress()` stories 기반 SP 집계
- `routers/epics.py`: 6개 엔드포인트 — `GET/POST /api/v2/epics`, `GET/PATCH/DELETE /api/v2/epics/{id}`, `GET /api/v2/epics/{id}/progress`

## Test plan
- [x] `pytest tests/test_epics.py` → 7 passed (list/create/get/404/update/delete/progress)
- [x] `pytest` (전체) → 32 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)