### PR TITLE
feat(backend): S15 Tasks 도메인 이관 — FastAPI /api/v2/tasks/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import epics, health, sprints
+from app.routers import epics, health, sprints, tasks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -23,6 +23,7 @@ app.add_middleware(
 app.include_router(health.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)
+app.include_router(tasks.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -78,7 +78,7 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     tasks: Mapped[list["Task"]] = relationship("Task", back_populates="story", lazy="select")
 
 
-class Task(Base, OrgScopedMixin, TimestampMixin):
+class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     __tablename__ = "tasks"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)

--- a/backend/app/repositories/task.py
+++ b/backend/app/repositories/task.py
@@ -1,0 +1,11 @@
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Task
+from app.repositories.base import BaseRepository
+
+
+class TaskRepository(BaseRepository[Task]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Task, session, org_id)

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,0 +1,95 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.task import TaskRepository
+from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+
+router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> TaskRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return TaskRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[TaskResponse])
+async def list_tasks(
+    story_id: uuid.UUID | None = Query(default=None),
+    assignee_id: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    repo: TaskRepository = Depends(_get_repo),
+) -> list[TaskResponse]:
+    filters: dict = {}
+    if story_id:
+        filters["story_id"] = story_id
+    if assignee_id:
+        filters["assignee_id"] = assignee_id
+    if status_filter:
+        filters["status"] = status_filter
+    tasks = await repo.list(**filters)
+    return [TaskResponse.model_validate(t) for t in tasks]
+
+
+@router.post("", response_model=TaskResponse, status_code=201)
+async def create_task(
+    body: TaskCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> TaskResponse:
+    repo = TaskRepository(session, body.org_id)
+    task = await repo.create(
+        story_id=body.story_id,
+        title=body.title,
+        assignee_id=body.assignee_id,
+        status=body.status,
+        story_points=body.story_points,
+    )
+    return TaskResponse.model_validate(task)
+
+
+@router.get("/{id}", response_model=TaskResponse)
+async def get_task(
+    id: uuid.UUID,
+    repo: TaskRepository = Depends(_get_repo),
+) -> TaskResponse:
+    task = await repo.get(id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return TaskResponse.model_validate(task)
+
+
+@router.patch("/{id}", response_model=TaskResponse)
+async def update_task(
+    id: uuid.UUID,
+    body: TaskUpdate,
+    repo: TaskRepository = Depends(_get_repo),
+) -> TaskResponse:
+    data = body.model_dump(exclude_unset=True)
+    task = await repo.update(id, **data)
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return TaskResponse.model_validate(task)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_task(
+    id: uuid.UUID,
+    repo: TaskRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Task not found")
+    return {"ok": True}

--- a/backend/app/schemas/task.py
+++ b/backend/app/schemas/task.py
@@ -1,0 +1,34 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TaskCreate(BaseModel):
+    story_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    assignee_id: uuid.UUID | None = None
+    status: str = "todo"
+    story_points: int | None = None
+
+
+class TaskUpdate(BaseModel):
+    title: str | None = None
+    status: str | None = None
+    assignee_id: uuid.UUID | None = None
+    story_points: int | None = None
+
+
+class TaskResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    story_id: uuid.UUID
+    org_id: uuid.UUID
+    assignee_id: uuid.UUID | None = None
+    title: str
+    status: str
+    story_points: int | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_tasks.py
+++ b/backend/tests/test_tasks.py
@@ -1,0 +1,198 @@
+"""S15 AC5: Task router + repository 단위 테스트 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+TASK_ID = uuid.uuid4()
+
+
+def _mock_task(status: str = "todo") -> MagicMock:
+    t = MagicMock()
+    t.id = TASK_ID
+    t.org_id = ORG_ID
+    t.story_id = STORY_ID
+    t.assignee_id = None
+    t.title = "Task 1"
+    t.status = status
+    t.story_points = None
+    t.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    t.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return t
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_tasks_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_task()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/tasks?story_id={STORY_ID}")
+
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_tasks_no_filter_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/tasks")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_task_201():
+    client, session, app = await _client()
+    try:
+        task = _mock_task()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = task
+
+            async with client as c:
+                resp = await c.post("/api/v2/tasks", json={
+                    "story_id": str(STORY_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Task 1",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Task 1"
+        assert resp.json()["status"] == "todo"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_task_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_task()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/tasks/{TASK_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(TASK_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_task_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/tasks/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_task_status_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_task("done")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/tasks/{TASK_ID}", json={"status": "done"})
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "done"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_task_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_task()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/tasks/{TASK_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_task_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/tasks/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/pm.py`: Task에 `SoftDeleteMixin` 추가 (`deleted_at` 마이그레이션 반영)
- `schemas/task.py`: TaskCreate / TaskUpdate / TaskResponse Pydantic DTO
- `repositories/task.py`: `TaskRepository(BaseRepository[Task])` — BaseRepository CRUD 그대로 상속
- `routers/tasks.py`: `GET/POST /api/v2/tasks` (story_id / assignee_id / status 필터), `GET/PATCH/DELETE /api/v2/tasks/{id}`

## Test plan
- [x] `pytest tests/test_tasks.py` → 8 passed (list×2 / create / get / 404 / update / delete / delete-404)
- [x] `pytest` (전체) → 40 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)