### PR TITLE
feat(backend): S16 Docs 도메인 이관 — FastAPI /api/v2/docs/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,13 +2,13 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import epics, health, sprints, tasks
+from app.routers import docs, epics, health, sprints, tasks
 
 app = FastAPI(
     title="Sprintable API v2",
     description="FastAPI backend — Phase B migration layer",
     version="0.1.0",
-    docs_url="/api/v2/docs" if settings.debug else None,
+    docs_url="/api/v2/_swagger" if settings.debug else None,
     redoc_url=None,
 )
 
@@ -24,6 +24,7 @@ app.include_router(health.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)
 app.include_router(tasks.router)
+app.include_router(docs.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -1,7 +1,8 @@
 import uuid
+from typing import List
 
 from sqlalchemy import ForeignKey, Integer, Text
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -27,6 +28,8 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     icon: Mapped[str | None] = mapped_column(Text, nullable=True)
     sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     doc_type: Mapped[str] = mapped_column(Text, nullable=False, default="page")
+    content_format: Mapped[str] = mapped_column(Text, nullable=False, default="markdown")
+    tags: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
 
     children: Mapped[list["Doc"]] = relationship("Doc", back_populates="parent", lazy="select")
     parent: Mapped["Doc | None"] = relationship("Doc", back_populates="children", remote_side=[id])

--- a/backend/app/repositories/doc.py
+++ b/backend/app/repositories/doc.py
@@ -1,0 +1,43 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.doc import Doc
+from app.repositories.base import BaseRepository
+
+
+class DocRepository(BaseRepository[Doc]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Doc, session, org_id)
+
+    async def list_tree(self, project_id: uuid.UUID, parent_id: uuid.UUID | None = None) -> list[Doc]:
+        """project 내 특정 parent 하위 docs 조회 (트리 1레벨)."""
+        q = select(Doc).where(
+            self._org_filter(),
+            Doc.project_id == project_id,
+            Doc.deleted_at.is_(None),
+        )
+        if parent_id is None:
+            q = q.where(Doc.parent_id.is_(None))
+        else:
+            q = q.where(Doc.parent_id == parent_id)
+        q = q.order_by(Doc.sort_order)
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def search_by_tags(self, project_id: uuid.UUID, tags: list[str]) -> list[Doc]:
+        """tags 배열이 주어진 태그를 모두 포함하는 docs 조회 (@> 연산자)."""
+        from sqlalchemy import cast
+        from sqlalchemy.dialects.postgresql import ARRAY
+        from sqlalchemy import Text
+
+        q = select(Doc).where(
+            self._org_filter(),
+            Doc.project_id == project_id,
+            Doc.deleted_at.is_(None),
+            Doc.tags.contains(cast(tags, ARRAY(Text))),
+        )
+        result = await self.session.execute(q)
+        return list(result.scalars().all())

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -1,0 +1,109 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.doc import DocRepository
+from app.schemas.doc import DocCreate, DocResponse, DocUpdate
+
+router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> DocRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return DocRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[DocResponse])
+async def list_docs(
+    project_id: uuid.UUID | None = Query(default=None),
+    parent_id: uuid.UUID | None = Query(default=None),
+    doc_type: str | None = Query(default=None),
+    tags: str | None = Query(default=None, description="comma-separated tags"),
+    repo: DocRepository = Depends(_get_repo),
+) -> list[DocResponse]:
+    if tags and project_id:
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()]
+        docs = await repo.search_by_tags(project_id, tag_list)
+        return [DocResponse.model_validate(d) for d in docs]
+
+    if project_id and parent_id is not None:
+        docs = await repo.list_tree(project_id, parent_id)
+        return [DocResponse.model_validate(d) for d in docs]
+
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if doc_type:
+        filters["doc_type"] = doc_type
+    docs = await repo.list(**filters)
+    return [DocResponse.model_validate(d) for d in docs]
+
+
+@router.post("", response_model=DocResponse, status_code=201)
+async def create_doc(
+    body: DocCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> DocResponse:
+    repo = DocRepository(session, body.org_id)
+    doc = await repo.create(
+        project_id=body.project_id,
+        title=body.title,
+        slug=body.slug,
+        content=body.content,
+        parent_id=body.parent_id,
+        created_by=body.created_by,
+        icon=body.icon,
+        sort_order=body.sort_order,
+        doc_type=body.doc_type,
+        content_format=body.content_format,
+        tags=body.tags,
+    )
+    return DocResponse.model_validate(doc)
+
+
+@router.get("/{id}", response_model=DocResponse)
+async def get_doc(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+) -> DocResponse:
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    return DocResponse.model_validate(doc)
+
+
+@router.patch("/{id}", response_model=DocResponse)
+async def update_doc(
+    id: uuid.UUID,
+    body: DocUpdate,
+    repo: DocRepository = Depends(_get_repo),
+) -> DocResponse:
+    data = body.model_dump(exclude_unset=True)
+    doc = await repo.update(id, **data)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    return DocResponse.model_validate(doc)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_doc(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    return {"ok": True}

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -1,0 +1,51 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DocCreate(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    slug: str
+    content: str = ""
+    parent_id: uuid.UUID | None = None
+    created_by: uuid.UUID | None = None
+    icon: str | None = None
+    sort_order: int = 0
+    doc_type: str = "page"
+    content_format: str = "markdown"
+    tags: list[str] = []
+
+
+class DocUpdate(BaseModel):
+    title: str | None = None
+    slug: str | None = None
+    content: str | None = None
+    parent_id: uuid.UUID | None = None
+    icon: str | None = None
+    sort_order: int | None = None
+    doc_type: str | None = None
+    content_format: str | None = None
+    tags: list[str] | None = None
+
+
+class DocResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    parent_id: uuid.UUID | None = None
+    created_by: uuid.UUID | None = None
+    title: str
+    slug: str
+    content: str
+    icon: str | None = None
+    sort_order: int
+    doc_type: str
+    content_format: str
+    tags: list[str]
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -1,0 +1,190 @@
+"""S16 AC5: Doc router + repository 단위 테스트 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+DOC_ID = uuid.uuid4()
+
+
+def _mock_doc() -> MagicMock:
+    d = MagicMock()
+    d.id = DOC_ID
+    d.org_id = ORG_ID
+    d.project_id = PROJECT_ID
+    d.parent_id = None
+    d.created_by = None
+    d.title = "Getting Started"
+    d.slug = "getting-started"
+    d.content = "# Hello"
+    d.icon = None
+    d.sort_order = 0
+    d.doc_type = "page"
+    d.content_format = "markdown"
+    d.tags = []
+    d.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    d.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return d
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_docs_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_doc()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_doc_201():
+    client, session, app = await _client()
+    try:
+        doc = _mock_doc()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = doc
+
+            async with client as c:
+                resp = await c.post("/api/v2/docs", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Getting Started",
+                    "slug": "getting-started",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["slug"] == "getting-started"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_doc_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_doc()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/docs/{DOC_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(DOC_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_doc_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/docs/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_doc_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_doc()
+        updated.title = "Updated Title"
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/docs/{DOC_ID}", json={"title": "Updated Title"})
+
+        assert resp.status_code == 200
+        assert resp.json()["title"] == "Updated Title"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_doc_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_doc()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/docs/{DOC_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_docs_with_parent_id_200():
+    """트리 구조 — parent_id 필터."""
+    client, session, app = await _client()
+    try:
+        child_doc = _mock_doc()
+        child_doc.parent_id = DOC_ID
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [child_doc]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/docs?project_id={PROJECT_ID}&parent_id={DOC_ID}")
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/doc.py`: `content_format`(markdown) + `tags`(PostgreSQL ARRAY) 컬럼 추가 (마이그레이션 2건 반영)
- `schemas/doc.py`: DocCreate / DocUpdate / DocResponse Pydantic DTO
- `repositories/doc.py`: `DocRepository(BaseRepository[Doc])` — `list_tree(project_id, parent_id)` + `search_by_tags(project_id, tags)` 특수 메서드
- `routers/docs.py`: `GET/POST /api/v2/docs`, `GET/PATCH/DELETE /api/v2/docs/{id}` — project_id / parent_id / tags / doc_type 필터 지원
- `main.py`: docs router 등록 + **`docs_url` → `/api/v2/_swagger`** (Swagger UI가 `/api/v2/docs` 선점하던 충돌 수정)

## Bug Found & Fixed
FastAPI `docs_url="/api/v2/docs"` 설정이 Swagger UI HTML을 `/api/v2/docs`에 마운트해 GET 요청을 가로채던 문제 수정 → `/api/v2/_swagger`로 변경

## Test plan
- [x] `pytest tests/test_docs.py` → 7 passed (list / tree-parent_id / create / get / 404 / update / delete)
- [x] `pytest` (전체) → 47 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)