### PR TITLE
feat(backend): S17 Meetings 도메인 이관 — FastAPI /api/v2/meetings/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, sprints, tasks
+from app.routers import docs, epics, health, meetings, sprints, tasks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -25,6 +25,7 @@ app.include_router(sprints.router)
 app.include_router(epics.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
+app.include_router(meetings.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/repositories/meeting.py
+++ b/backend/app/repositories/meeting.py
@@ -1,0 +1,62 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.meeting import Meeting
+
+
+class MeetingRepository:
+    """project_id 기반 스코핑 — org_id 없으므로 BaseRepository 미상속."""
+
+    def __init__(self, session: AsyncSession, project_id: uuid.UUID) -> None:
+        self.session = session
+        self.project_id = project_id
+
+    def _project_filter(self) -> Any:
+        return Meeting.project_id == self.project_id
+
+    async def get(self, id: uuid.UUID) -> Meeting | None:
+        result = await self.session.execute(
+            select(Meeting).where(
+                self._project_filter(),
+                Meeting.id == id,
+                Meeting.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def list(self, **filters: Any) -> list[Meeting]:
+        q = select(Meeting).where(
+            self._project_filter(),
+            Meeting.deleted_at.is_(None),
+        )
+        for attr, val in filters.items():
+            q = q.where(getattr(Meeting, attr) == val)
+        q = q.order_by(Meeting.date.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def create(self, **data: Any) -> Meeting:
+        obj = Meeting(project_id=self.project_id, **data)
+        self.session.add(obj)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj
+
+    async def update(self, id: uuid.UUID, **data: Any) -> Meeting | None:
+        await self.session.execute(
+            update(Meeting)
+            .where(self._project_filter(), Meeting.id == id)
+            .values(**data)
+        )
+        return await self.get(id)
+
+    async def delete(self, id: uuid.UUID) -> bool:
+        obj = await self.get(id)
+        if obj is None:
+            return False
+        await self.session.delete(obj)
+        await self.session.flush()
+        return True

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -1,0 +1,87 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.meeting import MeetingRepository
+from app.schemas.meeting import MeetingCreate, MeetingResponse, MeetingUpdate
+
+router = APIRouter(prefix="/api/v2/meetings", tags=["meetings"])
+
+
+def _get_repo(
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeetingRepository:
+    return MeetingRepository(session, project_id)
+
+
+@router.get("", response_model=list[MeetingResponse])
+async def list_meetings(
+    meeting_type: str | None = Query(default=None),
+    repo: MeetingRepository = Depends(_get_repo),
+) -> list[MeetingResponse]:
+    filters: dict = {}
+    if meeting_type:
+        filters["meeting_type"] = meeting_type
+    meetings = await repo.list(**filters)
+    return [MeetingResponse.model_validate(m) for m in meetings]
+
+
+@router.post("", response_model=MeetingResponse, status_code=201)
+async def create_meeting(
+    body: MeetingCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeetingResponse:
+    repo = MeetingRepository(session, body.project_id)
+    data = body.model_dump(exclude={"project_id"}, exclude_none=False)
+    meeting = await repo.create(**{k: v for k, v in data.items() if v is not None or k in ("participants", "decisions", "action_items")})
+    return MeetingResponse.model_validate(meeting)
+
+
+@router.get("/{id}", response_model=MeetingResponse)
+async def get_meeting(
+    id: uuid.UUID,
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeetingResponse:
+    repo = MeetingRepository(session, project_id)
+    meeting = await repo.get(id)
+    if meeting is None:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+    return MeetingResponse.model_validate(meeting)
+
+
+@router.patch("/{id}", response_model=MeetingResponse)
+async def update_meeting(
+    id: uuid.UUID,
+    body: MeetingUpdate,
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeetingResponse:
+    repo = MeetingRepository(session, project_id)
+    data = body.model_dump(exclude_unset=True)
+    meeting = await repo.update(id, **data)
+    if meeting is None:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+    return MeetingResponse.model_validate(meeting)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_meeting(
+    id: uuid.UUID,
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    repo = MeetingRepository(session, project_id)
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+    return {"ok": True}

--- a/backend/app/schemas/meeting.py
+++ b/backend/app/schemas/meeting.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+MEETING_TYPES = ("standup", "retro", "general", "review")
+
+
+class MeetingCreate(BaseModel):
+    project_id: uuid.UUID
+    title: str
+    meeting_type: str = "general"
+    date: datetime | None = None
+    duration_min: int | None = None
+    participants: list[Any] = []
+    raw_transcript: str | None = None
+    ai_summary: str | None = None
+    decisions: list[Any] = []
+    action_items: list[Any] = []
+    created_by: uuid.UUID | None = None
+
+
+class MeetingUpdate(BaseModel):
+    title: str | None = None
+    meeting_type: str | None = None
+    date: datetime | None = None
+    duration_min: int | None = None
+    participants: list[Any] | None = None
+    raw_transcript: str | None = None
+    ai_summary: str | None = None
+    decisions: list[Any] | None = None
+    action_items: list[Any] | None = None
+
+
+class MeetingResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    created_by: uuid.UUID | None = None
+    title: str
+    meeting_type: str
+    date: datetime
+    duration_min: int | None = None
+    participants: list[Any]
+    raw_transcript: str | None = None
+    ai_summary: str | None = None
+    decisions: list[Any]
+    action_items: list[Any]
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_meetings.py
+++ b/backend/tests/test_meetings.py
@@ -1,0 +1,178 @@
+"""S17 AC5: Meeting router + repository 단위 테스트 (5건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+PROJECT_ID = uuid.uuid4()
+MEETING_ID = uuid.uuid4()
+
+
+def _mock_meeting(meeting_type: str = "general") -> MagicMock:
+    m = MagicMock()
+    m.id = MEETING_ID
+    m.project_id = PROJECT_ID
+    m.created_by = None
+    m.title = "Sprint Review"
+    m.meeting_type = meeting_type
+    m.date = datetime(2026, 5, 1, 10, 0, tzinfo=timezone.utc)
+    m.duration_min = 60
+    m.participants = []
+    m.raw_transcript = None
+    m.ai_summary = None
+    m.decisions = []
+    m.action_items = []
+    m.deleted_at = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return m
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_meetings_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_meeting()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/meetings?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["meeting_type"] == "general"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_meeting_201():
+    client, session, app = await _client()
+    try:
+        meeting = _mock_meeting()
+        session.add = MagicMock()
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        with patch("app.repositories.meeting.MeetingRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = meeting
+
+            async with client as c:
+                resp = await c.post("/api/v2/meetings", json={
+                    "project_id": str(PROJECT_ID),
+                    "title": "Sprint Review",
+                    "meeting_type": "review",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Sprint Review"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_meeting_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_meeting()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/meetings/{MEETING_ID}?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(MEETING_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_meeting_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/meetings/{uuid.uuid4()}?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_meeting_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_meeting()
+        updated.ai_summary = "Updated summary"
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(
+                f"/api/v2/meetings/{MEETING_ID}?project_id={PROJECT_ID}",
+                json={"ai_summary": "Updated summary"},
+            )
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_meeting_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_meeting()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/meetings/{MEETING_ID}?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `schemas/meeting.py`: MeetingCreate / MeetingUpdate / MeetingResponse Pydantic DTO (participants/decisions/action_items JSONB 지원)
- `repositories/meeting.py`: `MeetingRepository` — **org_id 없음**, project_id 기반 독립 구현 (BaseRepository 미상속)
- `routers/meetings.py`: `GET/POST /api/v2/meetings?project_id=` + `GET/PATCH/DELETE /api/v2/meetings/{id}?project_id=`
- `main.py`: meetings router 등록

## Key Design
Meeting은 `OrgScopedMixin` 미사용 → BaseRepository 상속 불가. `MeetingRepository`를 별도 구현:
- `project_id` 기반 스코핑 (`_project_filter()`)
- `deleted_at IS NULL` 소프트 삭제 필터 적용
- date DESC 기본 정렬

## Test plan
- [x] `pytest tests/test_meetings.py` → 6 passed (list/create/get/404/update/delete)
- [x] `pytest` (전체) → 53 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)