### PR TITLE
feat(test): S18 통합 테스트 프레임워크 + CI backend pytest 연동

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  backend-test:
+    name: Backend pytest
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 'latest'
+
+      - name: Run pytest
+        run: cd backend && uv run pytest
+
   ci:
     name: Lint, Type Check, Test, Build
     runs-on: ubuntu-latest

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,63 @@
+"""Shared pytest fixtures for backend tests."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def org_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def project_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mock_session() -> AsyncMock:
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    session.delete = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def auth_ctx(org_id: uuid.UUID) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+    return ctx
+
+
+@pytest.fixture
+async def test_client(mock_session: AsyncMock, auth_ctx: MagicMock):
+    """AsyncClient with mocked DB session + auth. Clears dependency_overrides on teardown."""
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    async def _override_db():
+        yield mock_session
+
+    async def _override_auth():
+        return auth_ctx
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_current_user] = _override_auth
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,0 +1,75 @@
+"""S18: conftest fixture 기반 통합 테스트 — 각 도메인 헬스 체크."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_health_via_conftest(test_client, mock_session):
+    """conftest test_client fixture 사용 — health endpoint."""
+    mock_session.execute = AsyncMock(return_value=None)
+    resp = await test_client.get("/api/v2/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+@pytest.mark.anyio
+async def test_sprints_list_via_conftest(test_client, mock_session, org_id):
+    """conftest fixture로 sprints list 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/sprints")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_epics_list_via_conftest(test_client, mock_session):
+    """conftest fixture로 epics list 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/epics")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_tasks_list_via_conftest(test_client, mock_session):
+    """conftest fixture로 tasks list 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/tasks")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_docs_list_via_conftest(test_client, mock_session, project_id):
+    """conftest fixture로 docs list 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/docs?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_meetings_list_via_conftest(test_client, mock_session, project_id):
+    """conftest fixture로 meetings list 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/meetings?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- `backend/tests/conftest.py`: 공통 pytest fixtures
  - `anyio_backend`, `org_id`, `project_id`, `mock_session`(AsyncMock), `auth_ctx`(MagicMock), `test_client`(AsyncClient+ASGITransport+dependency_overrides 자동 설정/해제)
- `backend/tests/test_integration.py`: conftest fixture 기반 6개 도메인 통합 테스트 (health / sprints / epics / tasks / docs / meetings)
- `.github/workflows/ci.yml`: `backend-test` job 추가 (`astral-sh/setup-uv@v5` + `cd backend && uv run pytest`)

## Before/After
- **Before**: 8개 테스트 파일이 각자 `_client()` 헬퍼 중복 구현, CI에 backend 미포함
- **After**: conftest fixture로 공통화 가능 (기존 테스트 리팩터링은 선택), CI에서 backend pytest 블로킹 실행

## Test plan
- [x] `pytest tests/test_integration.py` → 6 passed
- [x] `pytest` (전체) → 59 passed (기존 53 + 통합 6, 회귀 없음)
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)