### PR TITLE
feat(backend): S19 Stories 도메인 이관 — FastAPI /api/v2/stories/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, sprints, tasks
+from app.routers import docs, epics, health, meetings, sprints, stories, tasks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -26,6 +26,7 @@ app.include_router(epics.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)
+app.include_router(stories.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date
 
-from sqlalchemy import Date, ForeignKey, Integer, String, Text
+from sqlalchemy import BigInteger, Date, ForeignKey, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -67,11 +67,16 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
     )
+    meeting_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(30), nullable=False, default="backlog")
     priority: Mapped[str] = mapped_column(String(20), nullable=False, default="medium")
     story_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    acceptance_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
+    position: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
 
     epic: Mapped[Epic | None] = relationship("Epic", back_populates="stories")
     sprint: Mapped[Sprint | None] = relationship("Sprint", back_populates="stories")

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -1,0 +1,44 @@
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.pm import Story
+from app.repositories.base import BaseRepository
+from app.schemas.story import STATUS_TRANSITIONS
+
+
+class StoryRepository(BaseRepository[Story]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Story, session, org_id)
+
+    async def transition_status(self, id: uuid.UUID) -> Story:
+        story = await self.get(id)
+        if story is None:
+            raise ValueError(f"Story {id} not found")
+        next_status = STATUS_TRANSITIONS.get(story.status)
+        if next_status is None:
+            raise ValueError(f"No forward transition from status: {story.status}")
+        updated = await self.update(id, status=next_status)
+        assert updated is not None
+        return updated
+
+    async def set_status(self, id: uuid.UUID, new_status: str) -> Story:
+        story = await self.get(id)
+        if story is None:
+            raise ValueError(f"Story {id} not found")
+
+        from app.schemas.story import STORY_STATUSES
+        if new_status not in STORY_STATUSES:
+            raise ValueError(f"Invalid status: {new_status}")
+
+        # 순차 전이 검증
+        current_idx = list(STORY_STATUSES).index(story.status)
+        new_idx = list(STORY_STATUSES).index(new_status)
+        if abs(new_idx - current_idx) > 1:
+            raise ValueError(
+                f"Non-sequential transition not allowed: {story.status} → {new_status}"
+            )
+
+        updated = await self.update(id, status=new_status)
+        assert updated is not None
+        return updated

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,0 +1,121 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.story import StoryRepository
+from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+
+router = APIRouter(prefix="/api/v2/stories", tags=["stories"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> StoryRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return StoryRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[StoryResponse])
+async def list_stories(
+    project_id: uuid.UUID | None = Query(default=None),
+    epic_id: uuid.UUID | None = Query(default=None),
+    sprint_id: uuid.UUID | None = Query(default=None),
+    assignee_id: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    repo: StoryRepository = Depends(_get_repo),
+) -> list[StoryResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if epic_id:
+        filters["epic_id"] = epic_id
+    if sprint_id:
+        filters["sprint_id"] = sprint_id
+    if assignee_id:
+        filters["assignee_id"] = assignee_id
+    if status_filter:
+        filters["status"] = status_filter
+    stories = await repo.list(**filters)
+    return [StoryResponse.model_validate(s) for s in stories]
+
+
+@router.post("", response_model=StoryResponse, status_code=201)
+async def create_story(
+    body: StoryCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> StoryResponse:
+    repo = StoryRepository(session, body.org_id)
+    story = await repo.create(
+        project_id=body.project_id,
+        title=body.title,
+        epic_id=body.epic_id,
+        sprint_id=body.sprint_id,
+        assignee_id=body.assignee_id,
+        meeting_id=body.meeting_id,
+        status=body.status,
+        priority=body.priority,
+        story_points=body.story_points,
+        description=body.description,
+        acceptance_criteria=body.acceptance_criteria,
+        position=body.position,
+    )
+    return StoryResponse.model_validate(story)
+
+
+@router.get("/{id}", response_model=StoryResponse)
+async def get_story(
+    id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+) -> StoryResponse:
+    story = await repo.get(id)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return StoryResponse.model_validate(story)
+
+
+@router.patch("/{id}", response_model=StoryResponse)
+async def update_story(
+    id: uuid.UUID,
+    body: StoryUpdate,
+    repo: StoryRepository = Depends(_get_repo),
+) -> StoryResponse:
+    data = body.model_dump(exclude_unset=True)
+    story = await repo.update(id, **data)
+    if story is None:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return StoryResponse.model_validate(story)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_story(
+    id: uuid.UUID,
+    repo: StoryRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Story not found")
+    return {"ok": True}
+
+
+@router.patch("/{id}/status", response_model=StoryResponse)
+async def update_story_status(
+    id: uuid.UUID,
+    body: StoryStatusUpdate,
+    repo: StoryRepository = Depends(_get_repo),
+) -> StoryResponse:
+    try:
+        story = await repo.set_status(id, body.status)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return StoryResponse.model_validate(story)

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -1,0 +1,66 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+STORY_STATUSES = ("backlog", "ready-for-dev", "in-progress", "in-review", "done")
+STATUS_TRANSITIONS: dict[str, str] = {
+    "backlog": "ready-for-dev",
+    "ready-for-dev": "in-progress",
+    "in-progress": "in-review",
+    "in-review": "done",
+}
+
+
+class StoryCreate(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    epic_id: uuid.UUID | None = None
+    sprint_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    meeting_id: uuid.UUID | None = None
+    status: str = "backlog"
+    priority: str = "medium"
+    story_points: int | None = None
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    position: int | None = None
+
+
+class StoryUpdate(BaseModel):
+    title: str | None = None
+    epic_id: uuid.UUID | None = None
+    sprint_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    meeting_id: uuid.UUID | None = None
+    priority: str | None = None
+    story_points: int | None = None
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    position: int | None = None
+
+
+class StoryStatusUpdate(BaseModel):
+    status: str
+
+
+class StoryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    epic_id: uuid.UUID | None = None
+    sprint_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    meeting_id: uuid.UUID | None = None
+    title: str
+    status: str
+    priority: str
+    story_points: int | None = None
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    position: int | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -1,0 +1,228 @@
+"""S19 AC5: Story router + repository 단위 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+
+
+def _mock_story(status: str = "backlog") -> MagicMock:
+    s = MagicMock()
+    s.id = STORY_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.epic_id = None
+    s.sprint_id = None
+    s.assignee_id = None
+    s.meeting_id = None
+    s.title = "Story 1"
+    s.status = status
+    s.priority = "medium"
+    s.story_points = 3
+    s.description = None
+    s.acceptance_criteria = None
+    s.position = None
+    s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return s
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_stories_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_story()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/stories?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["status"] == "backlog"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_story_201():
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Story 1",
+                    "story_points": 3,
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["story_points"] == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_story_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_story()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/stories/{STORY_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(STORY_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_story_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/stories/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_story_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_story()
+        updated.story_points = 5
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={"story_points": 5})
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_story_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_story()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/stories/{STORY_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_status_transition_200():
+    """backlog → ready-for-dev 순차 전이 성공."""
+    client, session, app = await _client()
+    try:
+        backlog_story = _mock_story("backlog")
+        ready_story = _mock_story("ready-for-dev")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = backlog_story
+            else:
+                result.scalar_one_or_none.return_value = ready_story
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.patch(
+                f"/api/v2/stories/{STORY_ID}/status",
+                json={"status": "ready-for-dev"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready-for-dev"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_status_transition_invalid_400():
+    """backlog → done 비순차 전이 → 400."""
+    client, session, app = await _client()
+    try:
+        backlog_story = _mock_story("backlog")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = backlog_story
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(
+                f"/api/v2/stories/{STORY_ID}/status",
+                json={"status": "done"},
+            )
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/pm.py`: Story에 `acceptance_criteria`(TEXT) + `position`(BIGINT) + `meeting_id`(UUID FK→meetings) 3개 컬럼 추가 (마이그레이션 3건 반영)
- `schemas/story.py`: StoryCreate / StoryUpdate / StoryResponse + StoryStatusUpdate + 상태 머신 상수 (`STORY_STATUSES`, `STATUS_TRANSITIONS`)
- `repositories/story.py`: `StoryRepository(BaseRepository[Story])` — `set_status()` 순차 전이 강제 검증 + `transition_status()` 자동 진행
- `routers/stories.py`: `GET/POST /api/v2/stories`, `GET/PATCH/DELETE /api/v2/stories/{id}`, **`PATCH /api/v2/stories/{id}/status`** (state machine)

## State Machine
```
backlog → ready-for-dev → in-progress → in-review → done
```
- 1칸 이상 건너뛰는 전이 → 400 Bad Request

## Test plan
- [x] `pytest tests/test_stories.py` → 8 passed (CRUD 5 + 상태전이 성공/실패 + 404)
- [x] `pytest` (전체) → 67 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)