### PR TITLE
feat(backend): S20 Projects 도메인 이관 — FastAPI /api/v2/projects/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, sprints, stories, tasks
+from app.routers import docs, epics, health, meetings, projects, sprints, stories, tasks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -27,6 +27,7 @@ app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
+app.include_router(projects.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/repositories/project.py
+++ b/backend/app/repositories/project.py
@@ -1,0 +1,11 @@
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import Project
+from app.repositories.base import BaseRepository
+
+
+class ProjectRepository(BaseRepository[Project]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Project, session, org_id)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,0 +1,79 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.project import ProjectRepository
+from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+
+router = APIRouter(prefix="/api/v2/projects", tags=["projects"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> ProjectRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return ProjectRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[ProjectResponse])
+async def list_projects(
+    repo: ProjectRepository = Depends(_get_repo),
+) -> list[ProjectResponse]:
+    projects = await repo.list()
+    return [ProjectResponse.model_validate(p) for p in projects]
+
+
+@router.post("", response_model=ProjectResponse, status_code=201)
+async def create_project(
+    body: ProjectCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> ProjectResponse:
+    repo = ProjectRepository(session, body.org_id)
+    project = await repo.create(name=body.name, description=body.description)
+    return ProjectResponse.model_validate(project)
+
+
+@router.get("/{id}", response_model=ProjectResponse)
+async def get_project(
+    id: uuid.UUID,
+    repo: ProjectRepository = Depends(_get_repo),
+) -> ProjectResponse:
+    project = await repo.get(id)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return ProjectResponse.model_validate(project)
+
+
+@router.patch("/{id}", response_model=ProjectResponse)
+async def update_project(
+    id: uuid.UUID,
+    body: ProjectUpdate,
+    repo: ProjectRepository = Depends(_get_repo),
+) -> ProjectResponse:
+    data = body.model_dump(exclude_unset=True)
+    project = await repo.update(id, **data)
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return ProjectResponse.model_validate(project)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_project(
+    id: uuid.UUID,
+    repo: ProjectRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return {"ok": True}

--- a/backend/app/schemas/project.py
+++ b/backend/app/schemas/project.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ProjectCreate(BaseModel):
+    org_id: uuid.UUID
+    name: str
+    description: str | None = None
+
+
+class ProjectUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+
+
+class ProjectResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    name: str
+    description: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,0 +1,156 @@
+"""S20 AC5: Project router + repository 단위 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+
+
+def _mock_project(name: str = "Sprintable") -> MagicMock:
+    p = MagicMock()
+    p.id = PROJECT_ID
+    p.org_id = ORG_ID
+    p.name = name
+    p.description = None
+    p.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    p.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return p
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_projects_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_project()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/projects")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_project_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_project()
+
+            async with client as c:
+                resp = await c.post("/api/v2/projects", json={
+                    "org_id": str(ORG_ID),
+                    "name": "Sprintable",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Sprintable"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_project_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_project()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/projects/{PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_project_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/projects/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_project_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_project("Updated Name")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/projects/{PROJECT_ID}", json={"name": "Updated Name"})
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_project_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_project()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/projects/{PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `schemas/project.py`: ProjectCreate / ProjectUpdate / ProjectResponse Pydantic DTO
- `repositories/project.py`: `ProjectRepository(BaseRepository[Project])` — 추가 로직 불필요
- `routers/projects.py`: `GET/POST /api/v2/projects`, `GET/PATCH/DELETE /api/v2/projects/{id}`

## Test plan
- [x] `pytest tests/test_projects.py` → 6 passed (list/create/get/404/update/delete)
- [x] `pytest` (전체) → 73 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)