### PR TITLE
feat(backend): S21 Team Members 도메인 이관 — FastAPI /api/v2/team-members/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, projects, sprints, stories, tasks
+from app.routers import docs, epics, health, meetings, projects, sprints, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -28,6 +28,7 @@ app.include_router(docs.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)
+app.include_router(team_members.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -23,6 +23,8 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     agent_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     webhook_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8")
+    agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="team_members")
 

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,0 +1,28 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.team import TeamMember
+from app.repositories.base import BaseRepository
+
+
+class TeamMemberRepository(BaseRepository[TeamMember]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(TeamMember, session, org_id)
+
+    async def list(self, **filters: Any) -> list[TeamMember]:
+        q = select(TeamMember).where(self._org_filter())
+        for attr, val in filters.items():
+            q = q.where(getattr(TeamMember, attr) == val)
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def deactivate(self, id: uuid.UUID) -> bool:
+        """DELETE 대신 is_active=False soft deactivate."""
+        member = await self.get(id)
+        if member is None:
+            return False
+        await self.update(id, is_active=False)
+        return True

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -1,0 +1,100 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.team_member import TeamMemberRepository
+from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
+
+router = APIRouter(prefix="/api/v2/team-members", tags=["team-members"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> TeamMemberRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return TeamMemberRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[TeamMemberResponse])
+async def list_team_members(
+    project_id: uuid.UUID | None = Query(default=None),
+    type_filter: str | None = Query(default=None, alias="type"),
+    is_active: bool | None = Query(default=None),
+    repo: TeamMemberRepository = Depends(_get_repo),
+) -> list[TeamMemberResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if type_filter:
+        filters["type"] = type_filter
+    if is_active is not None:
+        filters["is_active"] = is_active
+    members = await repo.list(**filters)
+    return [TeamMemberResponse.model_validate(m) for m in members]
+
+
+@router.post("", response_model=TeamMemberResponse, status_code=201)
+async def create_team_member(
+    body: TeamMemberCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> TeamMemberResponse:
+    repo = TeamMemberRepository(session, body.org_id)
+    member = await repo.create(
+        project_id=body.project_id,
+        type=body.type,
+        name=body.name,
+        role=body.role,
+        user_id=body.user_id,
+        avatar_url=body.avatar_url,
+        agent_config=body.agent_config,
+        webhook_url=body.webhook_url,
+        color=body.color,
+        agent_role=body.agent_role,
+    )
+    return TeamMemberResponse.model_validate(member)
+
+
+@router.get("/{id}", response_model=TeamMemberResponse)
+async def get_team_member(
+    id: uuid.UUID,
+    repo: TeamMemberRepository = Depends(_get_repo),
+) -> TeamMemberResponse:
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    return TeamMemberResponse.model_validate(member)
+
+
+@router.patch("/{id}", response_model=TeamMemberResponse)
+async def update_team_member(
+    id: uuid.UUID,
+    body: TeamMemberUpdate,
+    repo: TeamMemberRepository = Depends(_get_repo),
+) -> TeamMemberResponse:
+    data = body.model_dump(exclude_unset=True)
+    member = await repo.update(id, **data)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    return TeamMemberResponse.model_validate(member)
+
+
+@router.delete("/{id}", status_code=200)
+async def deactivate_team_member(
+    id: uuid.UUID,
+    repo: TeamMemberRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.deactivate(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    return {"ok": True, "deactivated": True}

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -1,0 +1,50 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class TeamMemberCreate(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    type: str  # 'human' | 'agent'
+    name: str
+    role: str = "member"
+    user_id: uuid.UUID | None = None
+    avatar_url: str | None = None
+    agent_config: dict[str, Any] | None = None
+    webhook_url: str | None = None
+    color: str = "#3385f8"
+    agent_role: str | None = None
+
+
+class TeamMemberUpdate(BaseModel):
+    name: str | None = None
+    role: str | None = None
+    avatar_url: str | None = None
+    agent_config: dict[str, Any] | None = None
+    webhook_url: str | None = None
+    color: str | None = None
+    agent_role: str | None = None
+    is_active: bool | None = None
+
+
+class TeamMemberResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    type: str
+    name: str
+    role: str
+    avatar_url: str | None = None
+    agent_config: dict[str, Any] | None = None
+    webhook_url: str | None = None
+    is_active: bool
+    color: str
+    agent_role: str | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -1,0 +1,218 @@
+"""S21 AC: TeamMember router + repository 단위 테스트 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.user_id = None
+    m.type = type_
+    m.name = "Alice"
+    m.role = "member"
+    m.avatar_url = None
+    m.agent_config = None
+    m.webhook_url = None
+    m.is_active = is_active
+    m.color = "#3385f8"
+    m.agent_role = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return m
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_team_members_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_member()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["color"] == "#3385f8"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_filter_by_type_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_member(type_="agent")]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members?project_id={PROJECT_ID}&type=agent")
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["type"] == "agent"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_team_member_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_member()
+
+            async with client as c:
+                resp = await c.post("/api/v2/team-members", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "type": "human",
+                    "name": "Alice",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_team_member_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_member()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members/{MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(MEMBER_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_team_member_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_team_member_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_member()
+        updated.color = "#ff0000"
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_deactivate_team_member_200():
+    """DELETE → soft deactivate (is_active=False)."""
+    client, session, app = await _client()
+    try:
+        active_member = _mock_member(is_active=True)
+        inactive_member = _mock_member(is_active=False)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count <= 2:
+                result.scalar_one_or_none.return_value = active_member
+            else:
+                result.scalar_one_or_none.return_value = inactive_member
+            result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/team-members/{MEMBER_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["deactivated"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_deactivate_not_found_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/team-members/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/team.py`: `color`(기본 `#3385f8`) + `agent_role`(nullable) 추가 (20260426170100 마이그레이션 반영)
- `schemas/team_member.py`: TeamMemberCreate / TeamMemberUpdate / TeamMemberResponse Pydantic DTO
- `repositories/team_member.py`: `TeamMemberRepository(BaseRepository[TeamMember])` — `deactivate()` soft delete (is_active=False)
- `routers/team_members.py`: `GET/POST /api/v2/team-members` + `GET/PATCH/DELETE /api/v2/team-members/{id}`

## Key Design
**DELETE = soft deactivate** — 실제 삭제 없이 `is_active=False`로 비활성화. 응답: `{"ok": true, "deactivated": true}`

필터: `project_id` / `type` (human|agent) / `is_active`

## Test plan
- [x] `pytest tests/test_team_members.py` → 8 passed (list×2 / create / get / 404 / update / deactivate / deactivate-404)
- [x] `pytest` (전체) → 75 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)