### PR TITLE
feat(backend): S22 Org Members 도메인 이관 — FastAPI /api/v2/org-members/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, projects, sprints, stories, tasks, team_members
+from app.routers import docs, epics, health, meetings, org_members, projects, sprints, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -29,6 +29,7 @@ app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)
 app.include_router(team_members.router)
+app.include_router(org_members.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/project.py
+++ b/backend/app/models/project.py
@@ -32,3 +32,4 @@ class OrgMember(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/repositories/org_member.py
+++ b/backend/app/repositories/org_member.py
@@ -1,0 +1,65 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import OrgMember
+
+
+class OrgMemberRepository:
+    """org_id 기반 스코핑 — OrgScopedMixin 미사용이므로 BaseRepository 미상속."""
+
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    def _base_filter(self):
+        return (OrgMember.org_id == self.org_id, OrgMember.deleted_at.is_(None))
+
+    async def get(self, id: uuid.UUID) -> OrgMember | None:
+        result = await self.session.execute(
+            select(OrgMember).where(*self._base_filter(), OrgMember.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_user(self, user_id: uuid.UUID) -> OrgMember | None:
+        result = await self.session.execute(
+            select(OrgMember).where(*self._base_filter(), OrgMember.user_id == user_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def list(self, **filters: Any) -> list[OrgMember]:
+        q = select(OrgMember).where(*self._base_filter())
+        for attr, val in filters.items():
+            q = q.where(getattr(OrgMember, attr) == val)
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def create(self, **data: Any) -> OrgMember:
+        obj = OrgMember(org_id=self.org_id, **data)
+        self.session.add(obj)
+        await self.session.flush()
+        await self.session.refresh(obj)
+        return obj
+
+    async def update(self, id: uuid.UUID, **data: Any) -> OrgMember | None:
+        await self.session.execute(
+            update(OrgMember)
+            .where(OrgMember.org_id == self.org_id, OrgMember.id == id)
+            .values(**data)
+        )
+        return await self.get(id)
+
+    async def soft_delete(self, id: uuid.UUID) -> bool:
+        """deleted_at 설정으로 soft delete."""
+        from datetime import datetime, timezone
+        member = await self.get(id)
+        if member is None:
+            return False
+        await self.session.execute(
+            update(OrgMember)
+            .where(OrgMember.org_id == self.org_id, OrgMember.id == id)
+            .values(deleted_at=datetime.now(timezone.utc))
+        )
+        return True

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -1,0 +1,82 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.org_member import OrgMemberRepository
+from app.schemas.org_member import OrgMemberCreate, OrgMemberResponse, OrgMemberUpdate
+
+router = APIRouter(prefix="/api/v2/org-members", tags=["org-members"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> OrgMemberRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    return OrgMemberRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[OrgMemberResponse])
+async def list_org_members(
+    repo: OrgMemberRepository = Depends(_get_repo),
+) -> list[OrgMemberResponse]:
+    members = await repo.list()
+    return [OrgMemberResponse.model_validate(m) for m in members]
+
+
+@router.post("", response_model=OrgMemberResponse, status_code=201)
+async def create_org_member(
+    body: OrgMemberCreate,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> OrgMemberResponse:
+    repo = OrgMemberRepository(session, body.org_id)
+    member = await repo.create(user_id=body.user_id, role=body.role)
+    return OrgMemberResponse.model_validate(member)
+
+
+@router.get("/{id}", response_model=OrgMemberResponse)
+async def get_org_member(
+    id: uuid.UUID,
+    repo: OrgMemberRepository = Depends(_get_repo),
+) -> OrgMemberResponse:
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Org member not found")
+    return OrgMemberResponse.model_validate(member)
+
+
+@router.patch("/{id}", response_model=OrgMemberResponse)
+async def update_org_member(
+    id: uuid.UUID,
+    body: OrgMemberUpdate,
+    repo: OrgMemberRepository = Depends(_get_repo),
+) -> OrgMemberResponse:
+    from app.schemas.org_member import ORG_ROLES
+    if body.role and body.role not in ORG_ROLES:
+        raise HTTPException(status_code=400, detail=f"role must be one of: {', '.join(ORG_ROLES)}")
+    data = body.model_dump(exclude_unset=True)
+    member = await repo.update(id, **data)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Org member not found")
+    return OrgMemberResponse.model_validate(member)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_org_member(
+    id: uuid.UUID,
+    repo: OrgMemberRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.soft_delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Org member not found")
+    return {"ok": True}

--- a/backend/app/schemas/org_member.py
+++ b/backend/app/schemas/org_member.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+ORG_ROLES = ("owner", "admin", "member")
+
+
+class OrgMemberCreate(BaseModel):
+    org_id: uuid.UUID
+    user_id: uuid.UUID
+    role: str = "member"
+
+
+class OrgMemberUpdate(BaseModel):
+    role: str | None = None
+
+
+class OrgMemberResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    user_id: uuid.UUID
+    role: str
+    created_at: datetime
+    deleted_at: datetime | None = None

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -1,0 +1,178 @@
+"""S22 AC: OrgMember router + repository 단위 테스트 (6건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+def _mock_member(role: str = "member") -> MagicMock:
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.user_id = USER_ID
+    m.role = role
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.deleted_at = None
+    return m
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_org_members_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_member()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/org-members")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["role"] == "member"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_org_member_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.org_member.OrgMemberRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_member()
+
+            async with client as c:
+                resp = await c.post("/api/v2/org-members", json={
+                    "org_id": str(ORG_ID),
+                    "user_id": str(USER_ID),
+                    "role": "member",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["user_id"] == str(USER_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_org_member_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_member()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/org-members/{MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(MEMBER_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_org_member_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/org-members/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_role_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_member("admin")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = updated
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "admin"})
+
+        assert resp.status_code == 200
+        assert resp.json()["role"] == "admin"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_invalid_role_400():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "superuser"})
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_soft_delete_200():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = _mock_member() if call_count == 1 else None
+            result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/org-members/{MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `models/project.py`: OrgMember에 `deleted_at` 추가 (20260401022000 반영)
- `schemas/org_member.py`: OrgMemberCreate / OrgMemberUpdate / OrgMemberResponse + `ORG_ROLES = (owner, admin, member)` 유효성 검증
- `repositories/org_member.py`: `OrgMemberRepository` — BaseRepository 미상속, `org_id + deleted_at IS NULL` 필터, `soft_delete()`
- `routers/org_members.py`: `GET/POST /api/v2/org-members`, `GET/PATCH/DELETE /api/v2/org-members/{id}`

## Key Design
- OrgScopedMixin 미사용 → MeetingRepository 패턴과 동일하게 독립 구현
- PATCH role → `owner/admin/member` 외 400 반환
- DELETE → `deleted_at = now()` soft delete

## Test plan
- [x] `pytest tests/test_org_members.py` → 7 passed (list/create/get/404/update/invalid-role-400/soft-delete)
- [x] `pytest` (전체) → 80 passed
- [ ] PO 리뷰
- [ ] QA 킥

🤖 Generated with [Claude Code](https://claude.com/claude-code)