### PR TITLE
feat(backend): S24 Retros 도메인 이관 — FastAPI /api/v2/retros/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, org_members, projects, sprints, standups, stories, tasks, team_members
+from app.routers import docs, epics, health, meetings, org_members, projects, retros, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -31,6 +31,7 @@ app.include_router(projects.router)
 app.include_router(team_members.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)
+app.include_router(retros.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -1,0 +1,89 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, TimestampMixin
+
+RETRO_PHASES = ("collect", "group", "vote", "discuss", "action", "closed")
+PHASE_TRANSITIONS: dict[str, str] = {p: RETRO_PHASES[i + 1] for i, p in enumerate(RETRO_PHASES[:-1])}
+
+
+class RetroSession(Base, OrgScopedMixin, TimestampMixin):
+    __tablename__ = "retro_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    sprint_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    phase: Mapped[str] = mapped_column(Text, nullable=False, default="collect")
+
+    items: Mapped[list["RetroItem"]] = relationship("RetroItem", back_populates="session", lazy="select")
+    actions: Mapped[list["RetroAction"]] = relationship("RetroAction", back_populates="session", lazy="select")
+
+
+class RetroItem(Base):
+    __tablename__ = "retro_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    author_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    category: Mapped[str] = mapped_column(Text, nullable=False)
+    text: Mapped[str] = mapped_column(Text, nullable=False)
+    vote_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    session: Mapped[RetroSession] = relationship("RetroSession", back_populates="items")
+    votes: Mapped[list["RetroVote"]] = relationship("RetroVote", back_populates="item", lazy="select")
+
+
+class RetroVote(Base):
+    __tablename__ = "retro_votes"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    item_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("retro_items.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    voter_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    item: Mapped[RetroItem] = relationship("RetroItem", back_populates="votes")
+
+
+class RetroAction(Base):
+    __tablename__ = "retro_actions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    assignee_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="open")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    session: Mapped[RetroSession] = relationship("RetroSession", back_populates="actions")

--- a/backend/app/repositories/retro.py
+++ b/backend/app/repositories/retro.py
@@ -1,0 +1,112 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.retro import PHASE_TRANSITIONS, RetroAction, RetroItem, RetroSession, RetroVote
+from app.repositories.base import BaseRepository
+
+
+class RetroSessionRepository(BaseRepository[RetroSession]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(RetroSession, session, org_id)
+
+    async def advance_phase(self, id: uuid.UUID) -> RetroSession:
+        retro = await self.get(id)
+        if retro is None:
+            raise ValueError(f"RetroSession {id} not found")
+        next_phase = PHASE_TRANSITIONS.get(retro.phase)
+        if next_phase is None:
+            raise ValueError(f"Session is already in final phase: {retro.phase}")
+        updated = await self.update(id, phase=next_phase)
+        assert updated is not None
+        return updated
+
+    async def set_phase(self, id: uuid.UUID, new_phase: str) -> RetroSession:
+        from app.models.retro import RETRO_PHASES
+        retro = await self.get(id)
+        if retro is None:
+            raise ValueError(f"RetroSession {id} not found")
+        current_idx = list(RETRO_PHASES).index(retro.phase)
+        new_idx = list(RETRO_PHASES).index(new_phase) if new_phase in RETRO_PHASES else -1
+        if new_idx < 0:
+            raise ValueError(f"Invalid phase: {new_phase}")
+        if new_idx != current_idx + 1:
+            raise ValueError(f"Non-sequential transition: {retro.phase} → {new_phase}")
+        updated = await self.update(id, phase=new_phase)
+        assert updated is not None
+        return updated
+
+
+class RetroItemRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_by_session(self, session_id: uuid.UUID) -> list[RetroItem]:
+        result = await self.session.execute(
+            select(RetroItem).where(RetroItem.session_id == session_id).order_by(RetroItem.created_at)
+        )
+        return list(result.scalars().all())
+
+    async def create(self, **data: Any) -> RetroItem:
+        item = RetroItem(**data)
+        self.session.add(item)
+        await self.session.flush()
+        await self.session.refresh(item)
+        return item
+
+    async def delete(self, item_id: uuid.UUID) -> bool:
+        result = await self.session.execute(select(RetroItem).where(RetroItem.id == item_id))
+        item = result.scalar_one_or_none()
+        if item is None:
+            return False
+        await self.session.delete(item)
+        await self.session.flush()
+        return True
+
+
+class RetroVoteRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def vote(self, item_id: uuid.UUID, voter_id: uuid.UUID) -> RetroVote:
+        existing = await self.session.execute(
+            select(RetroVote).where(RetroVote.item_id == item_id, RetroVote.voter_id == voter_id)
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise ValueError("DUPLICATE_VOTE")
+        vote = RetroVote(item_id=item_id, voter_id=voter_id)
+        self.session.add(vote)
+        await self.session.flush()
+        await self.session.refresh(vote)
+        return vote
+
+
+class RetroActionRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list_by_session(self, session_id: uuid.UUID) -> list[RetroAction]:
+        result = await self.session.execute(
+            select(RetroAction).where(RetroAction.session_id == session_id).order_by(RetroAction.created_at)
+        )
+        return list(result.scalars().all())
+
+    async def create(self, **data: Any) -> RetroAction:
+        action = RetroAction(**data)
+        self.session.add(action)
+        await self.session.flush()
+        await self.session.refresh(action)
+        return action
+
+    async def get(self, action_id: uuid.UUID) -> RetroAction | None:
+        result = await self.session.execute(select(RetroAction).where(RetroAction.id == action_id))
+        return result.scalar_one_or_none()
+
+    async def update(self, action_id: uuid.UUID, **data: Any) -> RetroAction | None:
+        from sqlalchemy import update
+        await self.session.execute(
+            update(RetroAction).where(RetroAction.id == action_id).values(**data)
+        )
+        return await self.get(action_id)

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -1,0 +1,246 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.retro import (
+    RetroActionRepository,
+    RetroItemRepository,
+    RetroSessionRepository,
+    RetroVoteRepository,
+)
+from app.schemas.retro import (
+    ActionResponse,
+    CreateAction,
+    CreateItem,
+    CreateSession,
+    ItemResponse,
+    PhaseTransition,
+    SessionListResponse,
+    SessionResponse,
+    UpdateAction,
+    VoteResponse,
+)
+
+router = APIRouter(prefix="/api/v2/retros", tags=["retros"])
+
+
+def _get_session_repo(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> RetroSessionRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required",
+        )
+    return RetroSessionRepository(db, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[SessionListResponse])
+async def list_sessions(
+    project_id: uuid.UUID | None = Query(default=None),
+    sprint_id: uuid.UUID | None = Query(default=None),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> list[SessionListResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if sprint_id:
+        filters["sprint_id"] = sprint_id
+    sessions = await repo.list(**filters)
+    return [SessionListResponse.model_validate(s) for s in sessions]
+
+
+@router.post("", response_model=SessionListResponse, status_code=201)
+async def create_session(
+    body: CreateSession,
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> SessionListResponse:
+    repo = RetroSessionRepository(db, body.org_id)
+    session = await repo.create(
+        project_id=body.project_id,
+        title=body.title,
+        sprint_id=body.sprint_id,
+        created_by=body.created_by,
+    )
+    return SessionListResponse.model_validate(session)
+
+
+@router.get("/{id}", response_model=SessionResponse)
+async def get_session(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionResponse:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+
+    item_repo = RetroItemRepository(db)
+    action_repo = RetroActionRepository(db)
+    items = await item_repo.list_by_session(id)
+    actions = await action_repo.list_by_session(id)
+
+    data = SessionResponse.model_validate(session)
+    data.items = [ItemResponse.model_validate(i) for i in items]
+    data.actions = [ActionResponse.model_validate(a) for a in actions]
+    return data
+
+
+@router.patch("/{id}/phase", response_model=SessionListResponse)
+async def advance_phase(
+    id: uuid.UUID,
+    body: PhaseTransition,
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> SessionListResponse:
+    try:
+        session = await repo.set_phase(id, body.phase)
+    except (ValueError, Exception) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return SessionListResponse.model_validate(session)
+
+
+@router.post("/{id}/items", response_model=ItemResponse, status_code=201)
+async def add_item(
+    id: uuid.UUID,
+    body: CreateItem,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> ItemResponse:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    item_repo = RetroItemRepository(db)
+    item = await item_repo.create(
+        session_id=id, category=body.category, text=body.text, author_id=body.author_id
+    )
+    return ItemResponse.model_validate(item)
+
+
+@router.delete("/{id}/items/{item_id}", status_code=200)
+async def delete_item(
+    id: uuid.UUID,
+    item_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> dict:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    item_repo = RetroItemRepository(db)
+    ok = await item_repo.delete(item_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return {"ok": True}
+
+
+@router.post("/{id}/items/{item_id}/vote", response_model=VoteResponse, status_code=201)
+async def vote_item(
+    id: uuid.UUID,
+    item_id: uuid.UUID,
+    voter_id: uuid.UUID = Query(...),
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> VoteResponse:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    vote_repo = RetroVoteRepository(db)
+    try:
+        vote = await vote_repo.vote(item_id, voter_id)
+    except ValueError as exc:
+        if "DUPLICATE_VOTE" in str(exc):
+            raise HTTPException(status_code=409, detail="Already voted") from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return VoteResponse.model_validate(vote)
+
+
+@router.get("/{id}/actions", response_model=list[ActionResponse])
+async def list_actions(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> list[ActionResponse]:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    action_repo = RetroActionRepository(db)
+    actions = await action_repo.list_by_session(id)
+    return [ActionResponse.model_validate(a) for a in actions]
+
+
+@router.post("/{id}/actions", response_model=ActionResponse, status_code=201)
+async def create_action(
+    id: uuid.UUID,
+    body: CreateAction,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> ActionResponse:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    action_repo = RetroActionRepository(db)
+    action = await action_repo.create(
+        session_id=id, title=body.title, assignee_id=body.assignee_id
+    )
+    return ActionResponse.model_validate(action)
+
+
+@router.patch("/{id}/actions/{action_id}", response_model=ActionResponse)
+async def update_action(
+    id: uuid.UUID,
+    action_id: uuid.UUID,
+    body: UpdateAction,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> ActionResponse:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+    action_repo = RetroActionRepository(db)
+    data = body.model_dump(exclude_unset=True)
+    action = await action_repo.update(action_id, **data)
+    if action is None:
+        raise HTTPException(status_code=404, detail="Action not found")
+    return ActionResponse.model_validate(action)
+
+
+@router.get("/{id}/export")
+async def export_session(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: RetroSessionRepository = Depends(_get_session_repo),
+) -> Response:
+    session = await repo.get(id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Retro session not found")
+
+    item_repo = RetroItemRepository(db)
+    action_repo = RetroActionRepository(db)
+    items = await item_repo.list_by_session(id)
+    actions = await action_repo.list_by_session(id)
+
+    lines = [
+        f"# {session.title}",
+        f"**Phase:** {session.phase}",
+        "",
+        "## 잘된 점 (Good)",
+        *[f"- {i.text} ({i.vote_count} votes)" for i in items if i.category == "good"],
+        "",
+        "## 아쉬운 점 (Bad)",
+        *[f"- {i.text} ({i.vote_count} votes)" for i in items if i.category == "bad"],
+        "",
+        "## 개선할 점 (Improve)",
+        *[f"- {i.text} ({i.vote_count} votes)" for i in items if i.category == "improve"],
+        "",
+        "## Action Items",
+        *[f"- [{a.status}] {a.title}" for a in actions],
+    ]
+
+    return Response(content="\n".join(lines), media_type="text/markdown")

--- a/backend/app/schemas/retro.py
+++ b/backend/app/schemas/retro.py
@@ -1,0 +1,94 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreateSession(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    title: str
+    sprint_id: uuid.UUID | None = None
+    created_by: uuid.UUID | None = None
+
+
+class ItemResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    session_id: uuid.UUID
+    author_id: uuid.UUID | None = None
+    category: str
+    text: str
+    vote_count: int
+    created_at: datetime
+
+
+class ActionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    session_id: uuid.UUID
+    assignee_id: uuid.UUID | None = None
+    title: str
+    status: str
+    created_at: datetime
+
+
+class SessionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    sprint_id: uuid.UUID | None = None
+    created_by: uuid.UUID | None = None
+    title: str
+    phase: str
+    created_at: datetime
+    updated_at: datetime
+    items: list[ItemResponse] = []
+    actions: list[ActionResponse] = []
+
+
+class SessionListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    sprint_id: uuid.UUID | None = None
+    title: str
+    phase: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class PhaseTransition(BaseModel):
+    phase: str
+
+
+class CreateItem(BaseModel):
+    category: str  # good | bad | improve
+    text: str
+    author_id: uuid.UUID | None = None
+
+
+class CreateAction(BaseModel):
+    title: str
+    assignee_id: uuid.UUID | None = None
+
+
+class UpdateAction(BaseModel):
+    title: str | None = None
+    assignee_id: uuid.UUID | None = None
+    status: str | None = None
+
+
+class VoteResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    item_id: uuid.UUID
+    voter_id: uuid.UUID
+    created_at: datetime

--- a/backend/tests/test_retros.py
+++ b/backend/tests/test_retros.py
@@ -1,0 +1,289 @@
+"""S24 AC: Retro router + repository 단위 테스트 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SESSION_ID = uuid.uuid4()
+ITEM_ID = uuid.uuid4()
+VOTER_ID = uuid.uuid4()
+
+
+def _mock_session(phase: str = "collect") -> MagicMock:
+    s = MagicMock()
+    s.id = SESSION_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.sprint_id = None
+    s.created_by = None
+    s.title = "Sprint 3 Retro"
+    s.phase = phase
+    s.items = []
+    s.actions = []
+    s.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    return s
+
+
+def _mock_item() -> MagicMock:
+    i = MagicMock()
+    i.id = ITEM_ID
+    i.session_id = SESSION_ID
+    i.author_id = None
+    i.category = "good"
+    i.text = "팀워크 좋았는"
+    i.vote_count = 2
+    i.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    return i
+
+
+def _mock_action() -> MagicMock:
+    a = MagicMock()
+    a.id = uuid.uuid4()
+    a.session_id = SESSION_ID
+    a.assignee_id = None
+    a.title = "CI 속도 개선"
+    a.status = "open"
+    a.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    return a
+
+
+def _mock_vote() -> MagicMock:
+    v = MagicMock()
+    v.id = uuid.uuid4()
+    v.item_id = ITEM_ID
+    v.voter_id = VOTER_ID
+    v.created_at = datetime(2026, 4, 29, tzinfo=timezone.utc)
+    return v
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_retro_sessions_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_session()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/retros?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["phase"] == "collect"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_retro_session_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_session()
+
+            async with client as c:
+                resp = await c.post("/api/v2/retros", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Sprint 3 Retro",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Sprint 3 Retro"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_retro_session_with_items_200():
+    """GET /{id} → items + actions nested."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_session()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/retros/{SESSION_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == str(SESSION_ID)
+        assert "items" in body
+        assert "actions" in body
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_retro_session_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/retros/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_advance_phase_200():
+    """collect → group 순차 전이."""
+    client, session, app = await _client()
+    try:
+        collect_session = _mock_session("collect")
+        group_session = _mock_session("group")
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = collect_session
+            else:
+                result.scalar_one_or_none.return_value = group_session
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/retros/{SESSION_ID}/phase", json={"phase": "group"})
+
+        assert resp.status_code == 200
+        assert resp.json()["phase"] == "group"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_add_item_201():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = _mock_session() if call_count == 1 else _mock_item()
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+        session.add = MagicMock()
+
+        with patch("app.repositories.retro.RetroItemRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_item()
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/retros/{SESSION_ID}/items", json={
+                    "category": "good",
+                    "text": "팀워크 좋았는",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["category"] == "good"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_vote_duplicate_409():
+    """중복 투표 → 409."""
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = _mock_session()
+            else:
+                result.scalar_one_or_none.return_value = _mock_vote()  # 이미 존재
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/retros/{SESSION_ID}/items/{ITEM_ID}/vote?voter_id={VOTER_ID}"
+            )
+
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_export_markdown_200():
+    client, session, app = await _client()
+    try:
+        retro_session = _mock_session("closed")
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = retro_session
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/retros/{SESSION_ID}/export")
+
+        assert resp.status_code == 200
+        assert "Sprint 3 Retro" in resp.text
+        assert "# " in resp.text
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- models/retro.py: RetroSession/Item/Vote/Action 4개 모델 신규
- repositories/retro.py: phase 순차 전이 + 중복 투표 409
- routers/retros.py: ~10 엔드포인트 (session/items/vote/actions/export-md)

## Test plan
- pytest tests/test_retros.py → 8 passed
- pytest (전체) → 96 passed

Generated with Claude Code