### PR TITLE
feat(test): S25 Sprint 4 통합 테스트 + models/__init__.py

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -2,6 +2,8 @@ from app.models.doc import Doc
 from app.models.meeting import Meeting
 from app.models.pm import Epic, Sprint, Story, Task
 from app.models.project import OrgMember, Project
+from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 
 __all__ = [
@@ -10,7 +12,13 @@ __all__ = [
     "Meeting",
     "OrgMember",
     "Project",
+    "RetroAction",
+    "RetroItem",
+    "RetroSession",
+    "RetroVote",
     "Sprint",
+    "StandupEntry",
+    "StandupFeedback",
     "Story",
     "Task",
     "TeamMember",

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,4 +1,4 @@
-"""S18: conftest fixture 기반 통합 테스트 — 각 도메인 헬스 체크."""
+"""S18+S25: conftest fixture 기반 통합 테스트 — Sprint 3+4 도메인 헬스 체크."""
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -71,5 +71,79 @@ async def test_meetings_list_via_conftest(test_client, mock_session, project_id)
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/meetings?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ── Sprint 4: S19~S24 도메인 통합 테스트 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_stories_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/stories 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/stories")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_projects_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/projects 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/projects")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_team_members_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/team-members 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/team-members")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_org_members_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/org-members 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/org-members")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_standups_list_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/standups 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/standups?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_retros_list_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/retros 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/retros?project_id={project_id}")
     assert resp.status_code == 200
     assert resp.json() == []


### PR DESCRIPTION
## Summary
- test_integration.py: Sprint 4 도메인 6건 추가 (stories/projects/team-members/org-members/standups/retros)
- models/__init__.py: Standup + Retro 모델 익스포트 추가
- S23(standups)/S24(retros) 코드 cherry-pick 포함 → S23/S24 머지 후 rebase 예정

## Test plan
- pytest tests/test_integration.py → 12 passed (Sprint 3 6 + Sprint 4 6)
- pytest (전체) → 109 passed

Generated with Claude Code