### PR TITLE
feat(backend): S26 Memos 도메인 이관 — FastAPI /api/v2/memos/**

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, org_members, projects, retros, sprints, standups, stories, tasks, team_members
+from app.routers import docs, epics, health, meetings, memos, org_members, projects, retros, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -32,6 +32,7 @@ app.include_router(team_members.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)
+app.include_router(memos.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/memo.py
+++ b/backend/app/models/memo.py
@@ -1,0 +1,135 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, TSVECTOR, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, SoftDeleteMixin, TimestampMixin
+
+
+class Memo(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
+    __tablename__ = "memos"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=True
+    )
+    assigned_to: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    supersedes_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="SET NULL"), nullable=True
+    )
+    resolved_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    memo_type: Mapped[str] = mapped_column(Text, nullable=False, default="memo")
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="open")
+    memo_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    search_vector: Mapped[str | None] = mapped_column(TSVECTOR, nullable=True)
+
+    replies: Mapped[list["MemoReply"]] = relationship("MemoReply", back_populates="memo", lazy="select")
+    assignees: Mapped[list["MemoAssignee"]] = relationship("MemoAssignee", back_populates="memo", lazy="select")
+    doc_links: Mapped[list["MemoDocLink"]] = relationship("MemoDocLink", back_populates="memo", lazy="select")
+    mentions: Mapped[list["MemoMention"]] = relationship("MemoMention", back_populates="memo", lazy="select")
+    reads: Mapped[list["MemoRead"]] = relationship("MemoRead", back_populates="memo", lazy="select")
+
+
+class MemoReply(Base):
+    __tablename__ = "memo_replies"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    review_type: Mapped[str] = mapped_column(Text, nullable=False, default="comment")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="replies")
+
+
+class MemoAssignee(Base):
+    __tablename__ = "memo_assignees"
+
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), primary_key=True
+    )
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), primary_key=True
+    )
+    assigned_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    assigned_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="assignees")
+
+
+class MemoRead(Base):
+    __tablename__ = "memo_reads"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    team_member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    read_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="reads")
+
+
+class MemoDocLink(Base):
+    __tablename__ = "memo_doc_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    doc_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("docs.id", ondelete="CASCADE"), nullable=False
+    )
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="doc_links")
+
+
+class MemoMention(Base):
+    __tablename__ = "memo_mentions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    mentioned_user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="mentions")

--- a/backend/app/repositories/memo.py
+++ b/backend/app/repositories/memo.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
+from app.repositories.base import BaseRepository
+
+
+class MemoRepository(BaseRepository[Memo]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Memo, session, org_id)
+
+    async def list(self, **filters: Any) -> list[Memo]:
+        q = select(Memo).where(self._org_filter(), Memo.deleted_at.is_(None))
+        if "project_id" in filters:
+            q = q.where(Memo.project_id == filters["project_id"])
+        if "assigned_to" in filters:
+            q = q.where(Memo.assigned_to == filters["assigned_to"])
+        if "status" in filters:
+            q = q.where(Memo.status == filters["status"])
+        if "q" in filters and filters["q"]:
+            search = f"%{filters['q']}%"
+            q = q.where(or_(Memo.title.ilike(search), Memo.content.ilike(search)))
+        q = q.order_by(Memo.created_at.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def soft_delete(self, id: uuid.UUID) -> bool:
+        memo = await self.get(id)
+        if memo is None:
+            return False
+        from sqlalchemy import update
+        await self.session.execute(
+            update(Memo).where(Memo.id == id).values(deleted_at=datetime.now(timezone.utc))
+        )
+        return True
+
+    async def resolve(self, id: uuid.UUID, resolved_by: uuid.UUID) -> Memo | None:
+        return await self.update(id, status="resolved", resolved_by=resolved_by,
+                                 resolved_at=datetime.now(timezone.utc))
+
+    async def archive(self, id: uuid.UUID) -> Memo | None:
+        return await self.update(id, archived_at=datetime.now(timezone.utc))
+
+    async def mark_read(self, id: uuid.UUID, team_member_id: uuid.UUID) -> None:
+        existing = await self.session.execute(
+            select(MemoRead).where(MemoRead.memo_id == id, MemoRead.team_member_id == team_member_id)
+        )
+        if existing.scalar_one_or_none() is None:
+            self.session.add(MemoRead(memo_id=id, team_member_id=team_member_id))
+            await self.session.flush()
+
+    async def get_doc_links(self, id: uuid.UUID) -> list[MemoDocLink]:
+        result = await self.session.execute(
+            select(MemoDocLink).where(MemoDocLink.memo_id == id)
+        )
+        return list(result.scalars().all())
+
+
+class MemoReplyRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create(self, **data: Any) -> MemoReply:
+        reply = MemoReply(**data)
+        self.session.add(reply)
+        await self.session.flush()
+        await self.session.refresh(reply)
+        return reply
+
+    async def list_by_memo(self, memo_id: uuid.UUID) -> list[MemoReply]:
+        result = await self.session.execute(
+            select(MemoReply).where(MemoReply.memo_id == memo_id).order_by(MemoReply.created_at)
+        )
+        return list(result.scalars().all())

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -1,0 +1,178 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.memo import MemoReplyRepository, MemoRepository
+from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResponse, ReplyResponse, UpdateMemo
+
+router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> MemoRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required",
+        )
+    return MemoRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[MemoListResponse])
+async def list_memos(
+    project_id: uuid.UUID | None = Query(default=None),
+    assigned_to: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    q: str | None = Query(default=None),
+    repo: MemoRepository = Depends(_get_repo),
+) -> list[MemoListResponse]:
+    filters: dict = {}
+    if project_id:
+        filters["project_id"] = project_id
+    if assigned_to:
+        filters["assigned_to"] = assigned_to
+    if status_filter:
+        filters["status"] = status_filter
+    if q:
+        filters["q"] = q
+    memos = await repo.list(**filters)
+    return [MemoListResponse.model_validate(m) for m in memos]
+
+
+@router.post("", response_model=MemoListResponse, status_code=201)
+async def create_memo(
+    body: CreateMemo,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MemoListResponse:
+    repo = MemoRepository(session, body.org_id)
+    memo = await repo.create(
+        project_id=body.project_id,
+        content=body.content,
+        memo_type=body.memo_type,
+        title=body.title,
+        assigned_to=body.assigned_to,
+        created_by=body.created_by,
+        supersedes_id=body.supersedes_id,
+        memo_metadata=body.memo_metadata,
+    )
+    return MemoListResponse.model_validate(memo)
+
+
+@router.get("/{id}", response_model=MemoResponse)
+async def get_memo(
+    id: uuid.UUID,
+    repo: MemoRepository = Depends(_get_repo),
+) -> MemoResponse:
+    memo = await repo.get(id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return MemoResponse.model_validate(memo)
+
+
+@router.patch("/{id}", response_model=MemoListResponse)
+async def update_memo(
+    id: uuid.UUID,
+    body: UpdateMemo,
+    repo: MemoRepository = Depends(_get_repo),
+) -> MemoListResponse:
+    data = body.model_dump(exclude_unset=True)
+    memo = await repo.update(id, **data)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return MemoListResponse.model_validate(memo)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_memo(
+    id: uuid.UUID,
+    repo: MemoRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.soft_delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return {"ok": True}
+
+
+@router.post("/{id}/replies", response_model=ReplyResponse, status_code=201)
+async def add_reply(
+    id: uuid.UUID,
+    body: CreateReply,
+    db: AsyncSession = Depends(get_db),
+    repo: MemoRepository = Depends(_get_repo),
+) -> ReplyResponse:
+    memo = await repo.get(id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    reply_repo = MemoReplyRepository(db)
+    reply = await reply_repo.create(
+        memo_id=id, content=body.content, created_by=body.created_by, review_type=body.review_type
+    )
+    return ReplyResponse.model_validate(reply)
+
+
+@router.post("/{id}/resolve", response_model=MemoListResponse)
+async def resolve_memo(
+    id: uuid.UUID,
+    resolved_by: uuid.UUID = Query(...),
+    repo: MemoRepository = Depends(_get_repo),
+) -> MemoListResponse:
+    memo = await repo.resolve(id, resolved_by)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return MemoListResponse.model_validate(memo)
+
+
+@router.post("/{id}/archive", response_model=MemoListResponse)
+async def archive_memo(
+    id: uuid.UUID,
+    repo: MemoRepository = Depends(_get_repo),
+) -> MemoListResponse:
+    memo = await repo.archive(id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    return MemoListResponse.model_validate(memo)
+
+
+@router.post("/{id}/read", status_code=200)
+async def mark_read(
+    id: uuid.UUID,
+    team_member_id: uuid.UUID = Query(...),
+    repo: MemoRepository = Depends(_get_repo),
+) -> dict:
+    memo = await repo.get(id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    await repo.mark_read(id, team_member_id)
+    return {"ok": True}
+
+
+@router.get("/{id}/linked-docs")
+async def get_linked_docs(
+    id: uuid.UUID,
+    repo: MemoRepository = Depends(_get_repo),
+) -> list[dict]:
+    memo = await repo.get(id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    links = await repo.get_doc_links(id)
+    return [{"id": str(l.id), "memo_id": str(l.memo_id), "doc_id": str(l.doc_id)} for l in links]
+
+
+@router.post("/convert", status_code=201)
+async def convert_to_doc(
+    memo_id: uuid.UUID = Query(...),
+    repo: MemoRepository = Depends(_get_repo),
+) -> dict:
+    memo = await repo.get(memo_id)
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Memo not found")
+    # Phase B stub — actual doc creation in Phase D
+    return {"ok": True, "memo_id": str(memo_id), "doc_id": None}

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -1,0 +1,67 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreateMemo(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    content: str
+    memo_type: str = "memo"
+    title: str | None = None
+    assigned_to: uuid.UUID | None = None
+    created_by: uuid.UUID | None = None
+    supersedes_id: uuid.UUID | None = None
+    memo_metadata: dict[str, Any] = {}
+
+
+class UpdateMemo(BaseModel):
+    title: str | None = None
+    content: str | None = None
+    assigned_to: uuid.UUID | None = None
+    status: str | None = None
+    memo_metadata: dict[str, Any] | None = None
+
+
+class MemoListResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    memo_type: str
+    title: str | None = None
+    content: str
+    created_by: uuid.UUID | None = None
+    assigned_to: uuid.UUID | None = None
+    status: str
+    supersedes_id: uuid.UUID | None = None
+    resolved_by: uuid.UUID | None = None
+    resolved_at: datetime | None = None
+    archived_at: datetime | None = None
+    memo_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+
+
+class MemoResponse(MemoListResponse):
+    deleted_at: datetime | None = None
+
+
+class CreateReply(BaseModel):
+    content: str
+    created_by: uuid.UUID
+    review_type: str = "comment"
+
+
+class ReplyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    memo_id: uuid.UUID
+    created_by: uuid.UUID
+    content: str
+    review_type: str
+    created_at: datetime

--- a/backend/tests/test_memos.py
+++ b/backend/tests/test_memos.py
@@ -1,0 +1,244 @@
+"""S26 AC: Memo router + repository 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMO_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+def _mock_memo(status: str = "open") -> MagicMock:
+    m = MagicMock()
+    m.id = MEMO_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.memo_type = "memo"
+    m.title = "Test Memo"
+    m.content = "내용"
+    m.created_by = MEMBER_ID
+    m.assigned_to = None
+    m.status = status
+    m.supersedes_id = None
+    m.resolved_by = None
+    m.resolved_at = None
+    m.archived_at = None
+    m.deleted_at = None
+    m.memo_metadata = {}
+    m.search_vector = None
+    m.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return m
+
+
+def _mock_reply() -> MagicMock:
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.memo_id = MEMO_ID
+    r.created_by = MEMBER_ID
+    r.content = "답글 내용"
+    r.review_type = "comment"
+    r.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return r
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_memos_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.memo.MemoRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_memo()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/memos?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["status"] == "open"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_memos_with_q_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.memo.MemoRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/memos?q=검색어")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_memo_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_memo()
+
+            async with client as c:
+                resp = await c.post("/api/v2/memos", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "content": "내용",
+                    "created_by": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["memo_type"] == "memo"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_memo_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_memo()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/memos/{MEMO_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(MEMO_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_memo_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/memos/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_soft_delete_memo_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.memo.MemoRepository.soft_delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = True
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/memos/{MEMO_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_add_reply_201():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = _mock_memo()
+            return result
+
+        session.execute = mock_execute
+
+        with patch("app.repositories.memo.MemoReplyRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_reply()
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/memos/{MEMO_ID}/replies", json={
+                    "content": "답글 내용",
+                    "created_by": str(MEMBER_ID),
+                    "review_type": "comment",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["review_type"] == "comment"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_memo_200():
+    client, session, app = await _client()
+    try:
+        resolved = _mock_memo("resolved")
+        with patch("app.repositories.memo.MemoRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = resolved
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/memos/{MEMO_ID}/resolve?resolved_by={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "resolved"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_archive_memo_200():
+    client, session, app = await _client()
+    try:
+        archived = _mock_memo()
+        archived.archived_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+        with patch("app.repositories.memo.MemoRepository.archive", new_callable=AsyncMock) as mock_archive:
+            mock_archive.return_value = archived
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/memos/{MEMO_ID}/archive")
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- models/memo.py: 6개 모델 신규 (Memo/Reply/Assignee/Read/DocLink/Mention)
-  →  (SQLAlchemy 예약어 우회, DB column은 )
-  —  메서드명이 builtin shadowing 방지
- ~12 엔드포인트 (list/create/get/patch/delete + replies/resolve/archive/read/linked-docs/convert)

## Test plan
- pytest tests/test_memos.py → 9 passed
- pytest (전체) → 118 passed

Generated with Claude Code