### PR TITLE
feat(backend): S27 Notifications + Inbox 도메인 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, memos, org_members, projects, retros, sprints, standups, stories, tasks, team_members
+from app.routers import docs, epics, health, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -33,6 +33,7 @@ app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(memos.router)
+app.include_router(notifications.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification import InboxItem, Notification, NotificationSetting
+from app.repositories.base import BaseRepository
+
+
+class NotificationRepository(BaseRepository[Notification]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(Notification, session, org_id)
+
+    async def list(self, user_id: uuid.UUID, is_read: bool | None = None) -> list[Notification]:
+        q = select(Notification).where(
+            self._org_filter(),
+            Notification.user_id == user_id,
+        )
+        if is_read is not None:
+            q = q.where(Notification.is_read == is_read)
+        q = q.order_by(Notification.created_at.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def count_unread(self, user_id: uuid.UUID) -> int:
+        from sqlalchemy import func, select
+        q = select(func.count()).select_from(Notification).where(
+            self._org_filter(),
+            Notification.user_id == user_id,
+            Notification.is_read.is_(False),
+        )
+        result = await self.session.execute(q)
+        return result.scalar_one()
+
+    async def mark_all_read(self, user_id: uuid.UUID) -> None:
+        await self.session.execute(
+            update(Notification)
+            .where(
+                Notification.org_id == self.org_id,
+                Notification.user_id == user_id,
+                Notification.is_read.is_(False),
+            )
+            .values(is_read=True)
+        )
+
+
+class NotificationSettingRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_by_member(self, member_id: uuid.UUID) -> list[NotificationSetting]:
+        result = await self.session.execute(
+            select(NotificationSetting).where(NotificationSetting.member_id == member_id)
+        )
+        return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        org_id: uuid.UUID,
+        member_id: uuid.UUID,
+        channel: str,
+        event_type: str,
+        enabled: bool,
+    ) -> NotificationSetting:
+        existing = await self.session.execute(
+            select(NotificationSetting).where(
+                NotificationSetting.member_id == member_id,
+                NotificationSetting.channel == channel,
+                NotificationSetting.event_type == event_type,
+            )
+        )
+        setting = existing.scalar_one_or_none()
+        if setting is None:
+            setting = NotificationSetting(
+                org_id=org_id,
+                member_id=member_id,
+                channel=channel,
+                event_type=event_type,
+                enabled=enabled,
+            )
+            self.session.add(setting)
+        else:
+            setting.enabled = enabled
+        await self.session.flush()
+        await self.session.refresh(setting)
+        return setting
+
+
+class InboxRepository(BaseRepository[InboxItem]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(InboxItem, session, org_id)
+
+    async def list(
+        self, assignee_member_id: uuid.UUID, state: str | None = None
+    ) -> list[InboxItem]:
+        q = select(InboxItem).where(
+            self._org_filter(),
+            InboxItem.assignee_member_id == assignee_member_id,
+        )
+        if state is not None:
+            q = q.where(InboxItem.state == state)
+        q = q.order_by(InboxItem.waiting_since.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def list_incoming(self, assignee_member_id: uuid.UUID) -> list[InboxItem]:
+        return await self.list(assignee_member_id, state="pending")
+
+    async def resolve(
+        self,
+        id: uuid.UUID,
+        resolved_by: uuid.UUID,
+        resolved_option_id: uuid.UUID | None = None,
+        resolved_note: str | None = None,
+    ) -> InboxItem | None:
+        return await self.update(
+            id,
+            state="resolved",
+            resolved_by=resolved_by,
+            resolved_option_id=resolved_option_id,
+            resolved_note=resolved_note,
+            resolved_at=datetime.now(timezone.utc),
+        )
+
+    async def dismiss(self, id: uuid.UUID) -> InboxItem | None:
+        return await self.update(id, state="dismissed")

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,145 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
+from app.schemas.notification import (
+    InboxItemResponse,
+    NotificationResponse,
+    NotificationSettingResponse,
+    ResolveInboxItem,
+    UpsertNotificationSetting,
+)
+
+router = APIRouter(prefix="/api/v2", tags=["notifications"])
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+def _notif_repo(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> NotificationRepository:
+    return NotificationRepository(session, org_id)
+
+
+def _inbox_repo(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> InboxRepository:
+    return InboxRepository(session, org_id)
+
+
+@router.get("/notifications", response_model=list[NotificationResponse])
+async def list_notifications(
+    user_id: uuid.UUID = Query(...),
+    is_read: bool | None = Query(default=None),
+    repo: NotificationRepository = Depends(_notif_repo),
+) -> list[NotificationResponse]:
+    items = await repo.list(user_id=user_id, is_read=is_read)
+    return [NotificationResponse.model_validate(n) for n in items]
+
+
+@router.get("/notifications/count")
+async def count_unread(
+    user_id: uuid.UUID = Query(...),
+    repo: NotificationRepository = Depends(_notif_repo),
+) -> dict:
+    count = await repo.count_unread(user_id=user_id)
+    return {"count": count}
+
+
+@router.patch("/notifications/mark-all-read", status_code=200)
+async def mark_all_read(
+    user_id: uuid.UUID = Query(...),
+    repo: NotificationRepository = Depends(_notif_repo),
+) -> dict:
+    await repo.mark_all_read(user_id=user_id)
+    return {"ok": True}
+
+
+@router.get("/notification-settings", response_model=list[NotificationSettingResponse])
+async def get_notification_settings(
+    member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> list[NotificationSettingResponse]:
+    repo = NotificationSettingRepository(session)
+    settings = await repo.get_by_member(member_id=member_id)
+    return [NotificationSettingResponse.model_validate(s) for s in settings]
+
+
+@router.put("/notification-settings", response_model=NotificationSettingResponse, status_code=200)
+async def upsert_notification_setting(
+    member_id: uuid.UUID = Query(...),
+    body: UpsertNotificationSetting = ...,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> NotificationSettingResponse:
+    repo = NotificationSettingRepository(session)
+    setting = await repo.upsert(
+        org_id=org_id,
+        member_id=member_id,
+        channel=body.channel,
+        event_type=body.event_type,
+        enabled=body.enabled,
+    )
+    return NotificationSettingResponse.model_validate(setting)
+
+
+@router.get("/inbox", response_model=list[InboxItemResponse])
+async def list_inbox(
+    assignee_member_id: uuid.UUID = Query(...),
+    state: str | None = Query(default=None),
+    repo: InboxRepository = Depends(_inbox_repo),
+) -> list[InboxItemResponse]:
+    items = await repo.list(assignee_member_id=assignee_member_id, state=state)
+    return [InboxItemResponse.model_validate(i) for i in items]
+
+
+@router.get("/inbox/incoming", response_model=list[InboxItemResponse])
+async def list_incoming(
+    assignee_member_id: uuid.UUID = Query(...),
+    repo: InboxRepository = Depends(_inbox_repo),
+) -> list[InboxItemResponse]:
+    items = await repo.list_incoming(assignee_member_id=assignee_member_id)
+    return [InboxItemResponse.model_validate(i) for i in items]
+
+
+@router.post("/inbox/{id}/resolve", response_model=InboxItemResponse)
+async def resolve_inbox_item(
+    id: uuid.UUID,
+    body: ResolveInboxItem,
+    repo: InboxRepository = Depends(_inbox_repo),
+) -> InboxItemResponse:
+    item = await repo.resolve(
+        id=id,
+        resolved_by=body.resolved_by,
+        resolved_option_id=body.resolved_option_id,
+        resolved_note=body.resolved_note,
+    )
+    if item is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+    return InboxItemResponse.model_validate(item)
+
+
+@router.post("/inbox/{id}/dismiss", response_model=InboxItemResponse)
+async def dismiss_inbox_item(
+    id: uuid.UUID,
+    repo: InboxRepository = Depends(_inbox_repo),
+) -> InboxItemResponse:
+    item = await repo.dismiss(id=id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="InboxItem not found")
+    return InboxItemResponse.model_validate(item)

--- a/backend/app/schemas/notification.py
+++ b/backend/app/schemas/notification.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class NotificationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    user_id: uuid.UUID
+    type: str
+    title: str
+    body: str | None = None
+    is_read: bool
+    reference_type: str | None = None
+    reference_id: uuid.UUID | None = None
+    created_at: datetime
+
+
+class NotificationSettingResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    member_id: uuid.UUID
+    channel: str
+    event_type: str
+    enabled: bool
+
+
+class UpsertNotificationSetting(BaseModel):
+    channel: str
+    event_type: str
+    enabled: bool = True
+
+
+class InboxItemResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    assignee_member_id: uuid.UUID
+    from_agent_id: uuid.UUID | None = None
+    story_id: uuid.UUID | None = None
+    memo_id: uuid.UUID | None = None
+    resolved_by: uuid.UUID | None = None
+    kind: str
+    title: str
+    context: str | None = None
+    agent_summary: str | None = None
+    origin_chain: list[Any]
+    options: list[Any]
+    after_decision: str | None = None
+    priority: str
+    state: str
+    resolved_option_id: uuid.UUID | None = None
+    resolved_note: str | None = None
+    source_type: str
+    source_id: str
+    waiting_since: datetime
+    created_at: datetime
+    resolved_at: datetime | None = None
+
+
+class ResolveInboxItem(BaseModel):
+    resolved_by: uuid.UUID
+    resolved_option_id: uuid.UUID | None = None
+    resolved_note: str | None = None

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,291 @@
+"""S27 AC: Notifications + Inbox router 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+NOTIF_ID = uuid.uuid4()
+INBOX_ID = uuid.uuid4()
+
+
+def _mock_notification(is_read: bool = False) -> MagicMock:
+    n = MagicMock()
+    n.id = NOTIF_ID
+    n.org_id = ORG_ID
+    n.user_id = MEMBER_ID
+    n.type = "info"
+    n.title = "Test Notification"
+    n.body = "본문"
+    n.is_read = is_read
+    n.reference_type = None
+    n.reference_id = None
+    n.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return n
+
+
+def _mock_setting() -> MagicMock:
+    s = MagicMock()
+    s.id = uuid.uuid4()
+    s.org_id = ORG_ID
+    s.member_id = MEMBER_ID
+    s.channel = "in_app"
+    s.event_type = "story_assigned"
+    s.enabled = True
+    return s
+
+
+def _mock_inbox(state: str = "pending") -> MagicMock:
+    i = MagicMock()
+    i.id = INBOX_ID
+    i.org_id = ORG_ID
+    i.project_id = PROJECT_ID
+    i.assignee_member_id = MEMBER_ID
+    i.from_agent_id = None
+    i.story_id = None
+    i.memo_id = None
+    i.resolved_by = None
+    i.kind = "approval"
+    i.title = "승인 요청"
+    i.context = None
+    i.agent_summary = None
+    i.origin_chain = []
+    i.options = []
+    i.after_decision = None
+    i.priority = "normal"
+    i.state = state
+    i.resolved_option_id = None
+    i.resolved_note = None
+    i.source_type = "agent_run"
+    i.source_id = "run-abc"
+    i.waiting_since = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    i.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    i.resolved_at = None
+    return i
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_notifications_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_notification()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/notifications?user_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["is_read"] is False
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_notifications_is_read_filter_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/notifications?user_id={MEMBER_ID}&is_read=true")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_count_unread_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.count_unread", new_callable=AsyncMock) as mock_count:
+            mock_count.return_value = 3
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/notifications/count?user_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["count"] == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_mark_all_read_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.mark_all_read", new_callable=AsyncMock) as mock_mark:
+            mock_mark.return_value = None
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/notifications/mark-all-read?user_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_notification_settings_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationSettingRepository.get_by_member", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = [_mock_setting()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/notification-settings?member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["event_type"] == "story_assigned"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_notification_setting_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationSettingRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+            mock_upsert.return_value = _mock_setting()
+
+            async with client as c:
+                resp = await c.put(
+                    f"/api/v2/notification-settings?member_id={MEMBER_ID}",
+                    json={"channel": "in_app", "event_type": "story_assigned", "enabled": True},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_inbox_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_inbox()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox?assignee_member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["state"] == "pending"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_incoming_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.list_incoming", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_inbox()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/inbox/incoming?assignee_member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["kind"] == "approval"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_200():
+    client, session, app = await _client()
+    try:
+        resolved = _mock_inbox("resolved")
+        resolved.resolved_by = MEMBER_ID
+        resolved.resolved_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+
+        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = resolved
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{INBOX_ID}/resolve",
+                    json={"resolved_by": str(MEMBER_ID)},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "resolved"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dismiss_inbox_200():
+    client, session, app = await _client()
+    try:
+        dismissed = _mock_inbox("dismissed")
+
+        with patch("app.repositories.notification.InboxRepository.dismiss", new_callable=AsyncMock) as mock_dismiss:
+            mock_dismiss.return_value = dismissed
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/inbox/{INBOX_ID}/dismiss")
+
+        assert resp.status_code == 200
+        assert resp.json()["state"] == "dismissed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_inbox_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.InboxRepository.resolve", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = None
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/inbox/{uuid.uuid4()}/resolve",
+                    json={"resolved_by": str(MEMBER_ID)},
+                )
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `Notification`, `NotificationSetting`, `InboxItem` 3개 모델 → `/api/v2/notifications`, `/api/v2/notification-settings`, `/api/v2/inbox` 라우터 이관
- `NotificationRepository`, `NotificationSettingRepository`, `InboxRepository` 신설
- 엔드포인트 10개: GET/PATCH notifications + count + settings PUT + inbox list/incoming/resolve/dismiss
- 테스트 11건 전량 PASS

## Test plan
- [ ] `uv run pytest tests/test_notifications.py` — 11건 PASS 확인
- [ ] GET /api/v2/notifications?user_id= 응답 확인
- [ ] POST /api/v2/inbox/{id}/resolve 상태 전환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)