### PR TITLE
feat(backend): S28 Analytics 도메인 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import docs, epics, health, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, docs, epics, health, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -34,6 +34,7 @@ app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(memos.router)
 app.include_router(notifications.router)
+app.include_router(analytics.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.memo import Memo
+from app.models.pm import Epic, Sprint, Story, Task
+from app.models.team import TeamMember
+
+
+class AnalyticsRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def get_overview(self, project_id: uuid.UUID) -> dict:
+        sprints_r = await self.session.execute(
+            select(Sprint.status).where(Sprint.project_id == project_id, Sprint.org_id == self.org_id)
+        )
+        sprint_rows = sprints_r.all()
+
+        epics_r = await self.session.execute(
+            select(func.count()).select_from(Epic).where(Epic.project_id == project_id, Epic.org_id == self.org_id)
+        )
+        epic_count = epics_r.scalar_one()
+
+        stories_r = await self.session.execute(
+            select(Story.status, Story.story_points).where(
+                Story.project_id == project_id, Story.org_id == self.org_id, Story.deleted_at.is_(None)
+            )
+        )
+        story_rows = stories_r.all()
+
+        tasks_r = await self.session.execute(
+            select(func.count()).select_from(Task).join(Story, Task.story_id == Story.id).where(
+                Story.project_id == project_id, Task.org_id == self.org_id, Task.deleted_at.is_(None)
+            )
+        )
+        task_count = tasks_r.scalar_one()
+
+        memos_r = await self.session.execute(
+            select(Memo.status).where(
+                Memo.project_id == project_id, Memo.org_id == self.org_id, Memo.deleted_at.is_(None)
+            )
+        )
+        memo_rows = memos_r.all()
+
+        members_r = await self.session.execute(
+            select(TeamMember.type).where(
+                TeamMember.project_id == project_id, TeamMember.org_id == self.org_id, TeamMember.is_active.is_(True)
+            )
+        )
+        member_rows = members_r.all()
+
+        return {
+            "sprints": {
+                "total": len(sprint_rows),
+                "active": sum(1 for r in sprint_rows if r[0] == "active"),
+            },
+            "epics": epic_count,
+            "stories": {
+                "total": len(story_rows),
+                "done": sum(1 for r in story_rows if r[0] == "done"),
+                "total_points": sum((r[1] or 0) for r in story_rows),
+            },
+            "tasks": task_count,
+            "memos": {
+                "total": len(memo_rows),
+                "open": sum(1 for r in memo_rows if r[0] == "open"),
+            },
+            "members": {
+                "total": len(member_rows),
+                "humans": sum(1 for r in member_rows if r[0] == "human"),
+                "agents": sum(1 for r in member_rows if r[0] == "agent"),
+            },
+        }
+
+    async def get_member_workload(self, project_id: uuid.UUID, member_id: uuid.UUID) -> dict:
+        stories_r = await self.session.execute(
+            select(Story.status, Story.story_points).where(
+                Story.project_id == project_id,
+                Story.org_id == self.org_id,
+                Story.assignee_id == member_id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        story_rows = stories_r.all()
+
+        tasks_r = await self.session.execute(
+            select(Task.status).join(Story, Task.story_id == Story.id).where(
+                Story.project_id == project_id,
+                Task.org_id == self.org_id,
+                Task.assignee_id == member_id,
+                Task.deleted_at.is_(None),
+            )
+        )
+        task_rows = tasks_r.all()
+
+        return {
+            "stories": {
+                "total": len(story_rows),
+                "in_progress": sum(1 for r in story_rows if r[0] == "in-progress"),
+                "points": sum((r[1] or 0) for r in story_rows),
+            },
+            "tasks": {
+                "total": len(task_rows),
+                "in_progress": sum(1 for r in task_rows if r[0] == "in-progress"),
+            },
+        }
+
+    async def get_velocity_history(self, project_id: uuid.UUID) -> list[dict]:
+        result = await self.session.execute(
+            select(Sprint.id, Sprint.title, Sprint.velocity, Sprint.status, Sprint.start_date, Sprint.end_date)
+            .where(Sprint.project_id == project_id, Sprint.org_id == self.org_id, Sprint.status == "closed")
+            .order_by(Sprint.end_date)
+        )
+        return [
+            {"id": r[0], "title": r[1], "velocity": r[2], "status": r[3], "start_date": r[4], "end_date": r[5]}
+            for r in result.all()
+        ]
+
+    async def get_recent_activity(self, project_id: uuid.UUID, limit: int = 10) -> dict:
+        stories_r = await self.session.execute(
+            select(Story.id, Story.title, Story.status, Story.updated_at)
+            .where(Story.project_id == project_id, Story.org_id == self.org_id, Story.deleted_at.is_(None))
+            .order_by(Story.updated_at.desc())
+            .limit(limit)
+        )
+        story_rows = stories_r.all()
+
+        memos_r = await self.session.execute(
+            select(Memo.id, Memo.title, Memo.status, Memo.created_at)
+            .where(Memo.project_id == project_id, Memo.org_id == self.org_id, Memo.deleted_at.is_(None))
+            .order_by(Memo.created_at.desc())
+            .limit(limit)
+        )
+        memo_rows = memos_r.all()
+
+        agents_r = await self.session.execute(
+            select(TeamMember.id).where(
+                TeamMember.project_id == project_id, TeamMember.org_id == self.org_id,
+                TeamMember.type == "agent", TeamMember.is_active.is_(True),
+            )
+        )
+        agent_ids = [r[0] for r in agents_r.all()]
+
+        agent_runs: list[dict] = []
+        if agent_ids:
+            runs_r = await self.session.execute(
+                text(
+                    "SELECT id, agent_id, trigger, status, created_at FROM agent_runs"
+                    " WHERE agent_id = ANY(:ids)"
+                    " ORDER BY created_at DESC LIMIT :lim"
+                ),
+                {"ids": agent_ids, "lim": limit},
+            )
+            agent_runs = [
+                {"id": r[0], "agent_id": r[1], "trigger": r[2], "status": r[3], "created_at": r[4]}
+                for r in runs_r.all()
+            ]
+
+        return {
+            "recent_stories": [
+                {"id": r[0], "title": r[1], "status": r[2], "updated_at": r[3]} for r in story_rows
+            ],
+            "recent_memos": [
+                {"id": r[0], "title": r[1], "status": r[2], "created_at": r[3]} for r in memo_rows
+            ],
+            "recent_agent_runs": agent_runs,
+        }
+
+    async def get_epic_progress(self, project_id: uuid.UUID, epic_id: uuid.UUID) -> dict:
+        result = await self.session.execute(
+            select(Story.status, Story.story_points).where(
+                Story.project_id == project_id,
+                Story.org_id == self.org_id,
+                Story.epic_id == epic_id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        rows = result.all()
+        total = len(rows)
+        done = sum(1 for r in rows if r[0] == "done")
+        total_pts = sum((r[1] or 0) for r in rows)
+        done_pts = sum((r[1] or 0) for r in rows if r[0] == "done")
+        return {
+            "total_stories": total,
+            "done_stories": done,
+            "total_points": total_pts,
+            "done_points": done_pts,
+            "completion_pct": round((done / total) * 100) if total > 0 else 0,
+        }
+
+    async def get_agent_stats(self, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:
+        member_r = await self.session.execute(
+            select(TeamMember.id).where(
+                TeamMember.id == agent_id,
+                TeamMember.project_id == project_id,
+                TeamMember.org_id == self.org_id,
+                TeamMember.type == "agent",
+            )
+        )
+        if member_r.scalar_one_or_none() is None:
+            return None  # type: ignore[return-value]
+
+        runs_r = await self.session.execute(
+            text(
+                "SELECT status, input_tokens, output_tokens, cost_usd, duration_ms"
+                " FROM agent_runs WHERE agent_id = :agent_id"
+                " ORDER BY created_at DESC LIMIT 1000"
+            ),
+            {"agent_id": str(agent_id)},
+        )
+        rows = runs_r.all()
+        completed = [r for r in rows if r[0] == "completed"]
+        total_tokens = sum((r[1] or 0) + (r[2] or 0) for r in completed)
+        total_cost = sum((r[3] or 0) for r in completed)
+        avg_dur = round(sum((r[4] or 0) for r in completed) / len(completed)) if completed else 0
+        return {
+            "total_runs": len(rows),
+            "completed": len(completed),
+            "failed": sum(1 for r in rows if r[0] == "failed"),
+            "total_tokens": total_tokens,
+            "total_cost_usd": total_cost,
+            "avg_duration_ms": avg_dur,
+        }
+
+    async def get_project_health(self, project_id: uuid.UUID) -> dict:
+        sprint_r = await self.session.execute(
+            select(Sprint.id, Sprint.title, Sprint.start_date, Sprint.end_date, Sprint.duration)
+            .where(Sprint.project_id == project_id, Sprint.org_id == self.org_id, Sprint.status == "active")
+            .limit(1)
+        )
+        sprint_row = sprint_r.first()
+
+        open_memos_r = await self.session.execute(
+            select(func.count()).select_from(Memo).where(
+                Memo.project_id == project_id, Memo.org_id == self.org_id,
+                Memo.status == "open", Memo.deleted_at.is_(None),
+            )
+        )
+        open_memo_count = open_memos_r.scalar_one()
+
+        unassigned_r = await self.session.execute(
+            select(func.count()).select_from(Story).where(
+                Story.project_id == project_id, Story.org_id == self.org_id,
+                Story.assignee_id.is_(None), Story.status != "done", Story.deleted_at.is_(None),
+            )
+        )
+        unassigned_count = unassigned_r.scalar_one()
+
+        sprint_progress = 0
+        if sprint_row:
+            stories_r = await self.session.execute(
+                select(Story.status).where(Story.sprint_id == sprint_row[0], Story.deleted_at.is_(None))
+            )
+            story_statuses = [r[0] for r in stories_r.all()]
+            total = len(story_statuses)
+            done = sum(1 for s in story_statuses if s == "done")
+            sprint_progress = round((done / total) * 100) if total > 0 else 0
+
+        return {
+            "active_sprint": {
+                "id": sprint_row[0], "title": sprint_row[1],
+                "start_date": sprint_row[2], "end_date": sprint_row[3],
+            } if sprint_row else None,
+            "sprint_progress": sprint_progress,
+            "open_memos": open_memo_count,
+            "unassigned_stories": unassigned_count,
+            "health": "warning" if open_memo_count > 10 or unassigned_count > 5 else "good",
+        }
+
+    async def get_burndown(self, sprint_id: uuid.UUID) -> dict | None:
+        sprint_r = await self.session.execute(
+            select(Sprint).where(Sprint.id == sprint_id)
+        )
+        sprint = sprint_r.scalar_one_or_none()
+        if sprint is None:
+            return None
+
+        stories_r = await self.session.execute(
+            select(Story.story_points, Story.status, Story.updated_at)
+            .where(Story.sprint_id == sprint_id, Story.deleted_at.is_(None))
+        )
+        stories = stories_r.all()
+
+        total_pts = sum((r[0] or 0) for r in stories)
+        done_pts = sum((r[0] or 0) for r in stories if r[1] == "done")
+        remaining = total_pts - done_pts
+
+        duration = sprint.duration or 14
+        start_date = sprint.start_date
+
+        ideal_line = []
+        for day in range(duration + 1):
+            if start_date:
+                from datetime import timedelta
+                day_date = (datetime.combine(start_date, datetime.min.time()) + timedelta(days=day)).strftime("%Y-%m-%d")
+            else:
+                day_date = str(day)
+            ideal_line.append({"date": day_date, "points": round(total_pts * (1 - day / duration)) if duration else 0})
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        start_str = start_date.isoformat() if start_date else today
+        actual_line = [
+            {"date": start_str, "points": total_pts},
+            {"date": today, "points": remaining},
+        ]
+
+        return {
+            "sprint": {
+                "id": sprint.id, "title": sprint.title, "status": sprint.status,
+                "start_date": sprint.start_date, "end_date": sprint.end_date,
+                "duration": sprint.duration, "velocity": sprint.velocity,
+            },
+            "total_points": total_pts,
+            "done_points": done_pts,
+            "remaining_points": remaining,
+            "completion_pct": round((done_pts / total_pts) * 100) if total_pts > 0 else 0,
+            "stories_count": len(stories),
+            "done_count": sum(1 for r in stories if r[1] == "done"),
+            "ideal_line": ideal_line,
+            "actual_line": actual_line,
+        }
+
+    async def get_sprint_velocity(self, sprint_id: uuid.UUID) -> dict | None:
+        result = await self.session.execute(
+            select(Sprint.velocity, Sprint.title, Sprint.status).where(Sprint.id == sprint_id)
+        )
+        row = result.first()
+        if row is None:
+            return None
+        return {"velocity": row[0], "title": row[1], "status": row[2]}
+
+    async def get_leaderboard(
+        self,
+        project_id: uuid.UUID,
+        period: str = "all",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> list[dict]:
+        limit = min(limit, 100)
+
+        if period == "all":
+            q = "SELECT member_id, balance FROM reward_balances WHERE project_id = :pid ORDER BY balance DESC"
+            params: dict = {"pid": str(project_id), "lim": limit}
+            if cursor:
+                q += " AND balance < :cursor"
+                params["cursor"] = float(cursor)
+            q += " LIMIT :lim"
+            result = await self.session.execute(text(q), params)
+            return [{"member_id": r[0], "balance": float(r[1])} for r in result.all()]
+
+        period_ms = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
+        seconds = period_ms.get(period, 86400)
+        params2: dict = {"pid": str(project_id), "seconds": seconds}
+        q2 = (
+            "SELECT member_id, SUM(amount) AS balance FROM reward_ledger"
+            " WHERE project_id = :pid AND created_at >= NOW() - (:seconds || ' seconds')::interval"
+            " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
+        )
+        params2["lim"] = limit
+        result2 = await self.session.execute(text(q2), params2)
+        return [{"member_id": r[0], "balance": float(r[1])} for r in result2.all()]

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,0 +1,138 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.analytics import AnalyticsRepository
+from app.schemas.analytics import (
+    AgentStatsResponse,
+    BurndownResponse,
+    EpicProgressResponse,
+    LeaderboardEntry,
+    MemberWorkloadResponse,
+    ProjectHealthResponse,
+    ProjectOverviewResponse,
+    RecentActivityResponse,
+    SprintVelocityItem,
+    SprintVelocityResponse,
+)
+
+router = APIRouter(prefix="/api/v2", tags=["analytics"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> AnalyticsRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return AnalyticsRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("/analytics/overview", response_model=ProjectOverviewResponse)
+async def get_overview(
+    project_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> ProjectOverviewResponse:
+    data = await repo.get_overview(project_id)
+    return ProjectOverviewResponse.model_validate(data)
+
+
+@router.get("/analytics/workload", response_model=MemberWorkloadResponse)
+async def get_member_workload(
+    project_id: uuid.UUID = Query(...),
+    member_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> MemberWorkloadResponse:
+    data = await repo.get_member_workload(project_id, member_id)
+    return MemberWorkloadResponse.model_validate(data)
+
+
+@router.get("/analytics/velocity-history", response_model=list[SprintVelocityItem])
+async def get_velocity_history(
+    project_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> list[SprintVelocityItem]:
+    items = await repo.get_velocity_history(project_id)
+    return [SprintVelocityItem.model_validate(i) for i in items]
+
+
+@router.get("/analytics/activity", response_model=RecentActivityResponse)
+async def get_recent_activity(
+    project_id: uuid.UUID = Query(...),
+    limit: int = Query(default=10, ge=1, le=100),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> RecentActivityResponse:
+    data = await repo.get_recent_activity(project_id, limit)
+    return RecentActivityResponse.model_validate(data)
+
+
+@router.get("/analytics/epic-progress", response_model=EpicProgressResponse)
+async def get_epic_progress(
+    project_id: uuid.UUID = Query(...),
+    epic_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> EpicProgressResponse:
+    data = await repo.get_epic_progress(project_id, epic_id)
+    return EpicProgressResponse.model_validate(data)
+
+
+@router.get("/analytics/agent-stats", response_model=AgentStatsResponse)
+async def get_agent_stats(
+    project_id: uuid.UUID = Query(...),
+    agent_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> AgentStatsResponse:
+    data = await repo.get_agent_stats(project_id, agent_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Agent not found in project")
+    return AgentStatsResponse.model_validate(data)
+
+
+@router.get("/analytics/health", response_model=ProjectHealthResponse)
+async def get_project_health(
+    project_id: uuid.UUID = Query(...),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> ProjectHealthResponse:
+    data = await repo.get_project_health(project_id)
+    return ProjectHealthResponse.model_validate(data)
+
+
+@router.get("/sprints/{sprint_id}/burndown", response_model=BurndownResponse)
+async def get_burndown(
+    sprint_id: uuid.UUID,
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> BurndownResponse:
+    data = await repo.get_burndown(sprint_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    return BurndownResponse.model_validate(data)
+
+
+@router.get("/sprints/{sprint_id}/velocity", response_model=SprintVelocityResponse)
+async def get_sprint_velocity(
+    sprint_id: uuid.UUID,
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> SprintVelocityResponse:
+    data = await repo.get_sprint_velocity(sprint_id)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+    return SprintVelocityResponse.model_validate(data)
+
+
+@router.get("/rewards/leaderboard", response_model=list[LeaderboardEntry])
+async def get_leaderboard(
+    project_id: uuid.UUID = Query(...),
+    period: str = Query(default="all"),
+    limit: int = Query(default=50, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    repo: AnalyticsRepository = Depends(_get_repo),
+) -> list[LeaderboardEntry]:
+    if period not in ("daily", "weekly", "monthly", "all"):
+        raise HTTPException(status_code=400, detail="period must be one of: daily, weekly, monthly, all")
+    items = await repo.get_leaderboard(project_id, period, limit, cursor)
+    return [LeaderboardEntry.model_validate(i) for i in items]

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class SprintsOverview(BaseModel):
+    total: int
+    active: int
+
+
+class StoriesOverview(BaseModel):
+    total: int
+    done: int
+    total_points: int
+
+
+class MemosOverview(BaseModel):
+    total: int
+    open: int
+
+
+class MembersOverview(BaseModel):
+    total: int
+    humans: int
+    agents: int
+
+
+class ProjectOverviewResponse(BaseModel):
+    sprints: SprintsOverview
+    epics: int
+    stories: StoriesOverview
+    tasks: int
+    memos: MemosOverview
+    members: MembersOverview
+
+
+class StoriesWorkload(BaseModel):
+    total: int
+    in_progress: int
+    points: int
+
+
+class TasksWorkload(BaseModel):
+    total: int
+    in_progress: int
+
+
+class MemberWorkloadResponse(BaseModel):
+    stories: StoriesWorkload
+    tasks: TasksWorkload
+
+
+class SprintVelocityItem(BaseModel):
+    id: uuid.UUID
+    title: str
+    velocity: int | None
+    status: str
+    start_date: date | None
+    end_date: date | None
+
+
+class RecentStory(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    updated_at: datetime
+
+
+class RecentMemo(BaseModel):
+    id: uuid.UUID
+    title: str | None
+    status: str
+    created_at: datetime
+
+
+class RecentAgentRun(BaseModel):
+    id: uuid.UUID
+    agent_id: uuid.UUID
+    trigger: str
+    status: str
+    created_at: datetime
+
+
+class RecentActivityResponse(BaseModel):
+    recent_stories: list[RecentStory]
+    recent_memos: list[RecentMemo]
+    recent_agent_runs: list[RecentAgentRun]
+
+
+class EpicProgressResponse(BaseModel):
+    total_stories: int
+    done_stories: int
+    total_points: int
+    done_points: int
+    completion_pct: int
+
+
+class AgentStatsResponse(BaseModel):
+    total_runs: int
+    completed: int
+    failed: int
+    total_tokens: int
+    total_cost_usd: float
+    avg_duration_ms: int
+
+
+class ActiveSprintInfo(BaseModel):
+    id: uuid.UUID
+    title: str
+    start_date: date | None
+    end_date: date | None
+
+
+class ProjectHealthResponse(BaseModel):
+    active_sprint: ActiveSprintInfo | None
+    sprint_progress: int
+    open_memos: int
+    unassigned_stories: int
+    health: str
+
+
+class BurndownPoint(BaseModel):
+    date: str
+    points: int
+
+
+class SprintInfo(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    start_date: date | None
+    end_date: date | None
+    duration: int
+    velocity: int | None
+
+
+class BurndownResponse(BaseModel):
+    sprint: SprintInfo
+    total_points: int
+    done_points: int
+    remaining_points: int
+    completion_pct: int
+    stories_count: int
+    done_count: int
+    ideal_line: list[BurndownPoint]
+    actual_line: list[BurndownPoint]
+
+
+class SprintVelocityResponse(BaseModel):
+    velocity: int | None
+    title: str
+    status: str
+
+
+class LeaderboardEntry(BaseModel):
+    member_id: uuid.UUID
+    balance: float

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,315 @@
+"""S28 AC: Analytics 라우터 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SPRINT_ID = uuid.uuid4()
+EPIC_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_get_overview_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "sprints": {"total": 5, "active": 1},
+            "epics": 3,
+            "stories": {"total": 20, "done": 8, "total_points": 100},
+            "tasks": 15,
+            "memos": {"total": 7, "open": 3},
+            "members": {"total": 4, "humans": 2, "agents": 2},
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_overview", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/overview?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["epics"] == 3
+        assert data["sprints"]["active"] == 1
+        assert data["members"]["agents"] == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_member_workload_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "stories": {"total": 3, "in_progress": 1, "points": 13},
+            "tasks": {"total": 5, "in_progress": 2},
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_member_workload", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/workload?project_id={PROJECT_ID}&member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["stories"]["total"] == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_velocity_history_200():
+    client, session, app = await _client()
+    try:
+        mock_data = [
+            {"id": SPRINT_ID, "title": "Sprint 1", "velocity": 30, "status": "closed",
+             "start_date": date(2026, 4, 1), "end_date": date(2026, 4, 14)},
+        ]
+        with patch("app.repositories.analytics.AnalyticsRepository.get_velocity_history", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/velocity-history?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["velocity"] == 30
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_recent_activity_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "recent_stories": [{"id": str(uuid.uuid4()), "title": "Story A", "status": "in-progress", "updated_at": "2026-04-30T00:00:00+00:00"}],
+            "recent_memos": [],
+            "recent_agent_runs": [],
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_recent_activity", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/activity?project_id={PROJECT_ID}&limit=5")
+
+        assert resp.status_code == 200
+        assert len(resp.json()["recent_stories"]) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_epic_progress_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "total_stories": 10,
+            "done_stories": 4,
+            "total_points": 50,
+            "done_points": 20,
+            "completion_pct": 40,
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_epic_progress", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/epic-progress?project_id={PROJECT_ID}&epic_id={EPIC_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["completion_pct"] == 40
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_agent_stats_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "total_runs": 100,
+            "completed": 90,
+            "failed": 10,
+            "total_tokens": 50000,
+            "total_cost_usd": 1.5,
+            "avg_duration_ms": 3200,
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_agent_stats", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/agent-stats?project_id={PROJECT_ID}&agent_id={AGENT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["completed"] == 90
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_agent_stats_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.analytics.AnalyticsRepository.get_agent_stats", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = None
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/agent-stats?project_id={PROJECT_ID}&agent_id={AGENT_ID}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_project_health_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "active_sprint": {"id": SPRINT_ID, "title": "Sprint 5", "start_date": date(2026, 4, 28), "end_date": date(2026, 5, 11)},
+            "sprint_progress": 25,
+            "open_memos": 2,
+            "unassigned_stories": 1,
+            "health": "good",
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_project_health", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/analytics/health?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["health"] == "good"
+        assert resp.json()["sprint_progress"] == 25
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_burndown_200():
+    client, session, app = await _client()
+    try:
+        mock_data = {
+            "sprint": {
+                "id": SPRINT_ID, "title": "Sprint 5", "status": "active",
+                "start_date": date(2026, 4, 28), "end_date": date(2026, 5, 11),
+                "duration": 14, "velocity": None,
+            },
+            "total_points": 40,
+            "done_points": 10,
+            "remaining_points": 30,
+            "completion_pct": 25,
+            "stories_count": 8,
+            "done_count": 2,
+            "ideal_line": [{"date": "2026-04-28", "points": 40}],
+            "actual_line": [{"date": "2026-04-28", "points": 40}, {"date": "2026-04-30", "points": 30}],
+        }
+        with patch("app.repositories.analytics.AnalyticsRepository.get_burndown", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/sprints/{SPRINT_ID}/burndown")
+
+        assert resp.status_code == 200
+        assert resp.json()["remaining_points"] == 30
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_burndown_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.analytics.AnalyticsRepository.get_burndown", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = None
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/sprints/{uuid.uuid4()}/burndown")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_sprint_velocity_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.analytics.AnalyticsRepository.get_sprint_velocity", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = {"velocity": 35, "title": "Sprint 5", "status": "active"}
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/sprints/{SPRINT_ID}/velocity")
+
+        assert resp.status_code == 200
+        assert resp.json()["velocity"] == 35
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_leaderboard_200():
+    client, session, app = await _client()
+    try:
+        mock_data = [
+            {"member_id": MEMBER_ID, "balance": 150.0},
+            {"member_id": AGENT_ID, "balance": 80.0},
+        ]
+        with patch("app.repositories.analytics.AnalyticsRepository.get_leaderboard", new_callable=AsyncMock) as mock_fn:
+            mock_fn.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=all")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+        assert resp.json()[0]["balance"] == 150.0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_leaderboard_invalid_period_400():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.analytics.AnalyticsRepository.get_leaderboard", new_callable=AsyncMock):
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=invalid")
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `AnalyticsRepository` 신설 — Sprint/Story/Task/Epic/TeamMember/Memo ORM + agent_runs/reward_balances/reward_ledger text() 쿼리
- 엔드포인트 10개: analytics 7종 + sprints burndown/velocity + rewards leaderboard
- burndown/velocity/leaderboard를 analytics.py에 통합 (모든 집계를 한 파일로)
- 테스트 13건 전량 PASS

## Test plan
- [ ] `uv run pytest tests/test_analytics.py` — 13건 PASS 확인
- [ ] GET /api/v2/analytics/overview?project_id= 응답 확인
- [ ] GET /api/v2/sprints/{id}/burndown 번다운 데이터 확인
- [ ] GET /api/v2/rewards/leaderboard?period=weekly 집계 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)