### PR TITLE
feat(backend): S29 Invitations 도메인 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, docs, epics, health, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, docs, epics, health, invitations, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -35,6 +35,7 @@ app.include_router(retros.router)
 app.include_router(memos.router)
 app.include_router(notifications.router)
 app.include_router(analytics.router)
+app.include_router(invitations.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -1,0 +1,31 @@
+import secrets
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Invitation(Base):
+    __tablename__ = "invitations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    invited_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    role: Mapped[str] = mapped_column(Text, nullable=False, default="member")
+    token: Mapped[str] = mapped_column(Text, nullable=False, unique=True, default=lambda: secrets.token_hex(32))
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/invitation.py
+++ b/backend/app/repositories/invitation.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.invitation import Invitation
+from app.repositories.base import BaseRepository
+
+
+class InvitationRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def list(self, project_id: uuid.UUID | None = None) -> list[Invitation]:
+        q = select(Invitation).where(Invitation.org_id == self.org_id)
+        if project_id is not None:
+            q = q.where(Invitation.project_id == project_id)
+        q = q.order_by(Invitation.created_at.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def get(self, id: uuid.UUID) -> Invitation | None:
+        result = await self.session.execute(
+            select(Invitation).where(Invitation.id == id, Invitation.org_id == self.org_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_token(self, token: str) -> Invitation | None:
+        result = await self.session.execute(
+            select(Invitation).where(Invitation.token == token)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        email: str,
+        role: str,
+        invited_by: uuid.UUID,
+        project_id: uuid.UUID | None = None,
+    ) -> Invitation:
+        inv = Invitation(
+            org_id=self.org_id,
+            project_id=project_id,
+            email=email,
+            role=role,
+            invited_by=invited_by,
+            expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+        )
+        self.session.add(inv)
+        await self.session.flush()
+        await self.session.refresh(inv)
+        return inv
+
+    async def revoke(self, id: uuid.UUID) -> Invitation | None:
+        inv = await self.get(id)
+        if inv is None:
+            return None
+        inv.status = "revoked"
+        await self.session.flush()
+        await self.session.refresh(inv)
+        return inv
+
+    async def resend(self, id: uuid.UUID) -> Invitation | None:
+        inv = await self.get(id)
+        if inv is None:
+            return None
+        if inv.status == "revoked":
+            return None
+        inv.token = secrets.token_hex(32)
+        inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+        inv.status = "pending"
+        await self.session.flush()
+        await self.session.refresh(inv)
+        return inv
+
+    async def accept(self, token: str) -> Invitation | None:
+        inv = await self.get_by_token(token)
+        if inv is None:
+            return None
+        if inv.status != "pending":
+            return None
+        if inv.expires_at < datetime.now(timezone.utc):
+            return None
+        inv.status = "accepted"
+        inv.accepted_at = datetime.now(timezone.utc)
+        await self.session.flush()
+        await self.session.refresh(inv)
+        return inv

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -1,0 +1,79 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.invitation import InvitationRepository
+from app.schemas.invitation import AcceptInvitation, CreateInvitation, InvitationResponse
+
+router = APIRouter(prefix="/api/v2/invitations", tags=["invitations"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> InvitationRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return InvitationRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[InvitationResponse])
+async def list_invitations(
+    project_id: uuid.UUID | None = Query(default=None),
+    repo: InvitationRepository = Depends(_get_repo),
+) -> list[InvitationResponse]:
+    items = await repo.list(project_id=project_id)
+    return [InvitationResponse.model_validate(i) for i in items]
+
+
+@router.post("", response_model=InvitationResponse, status_code=201)
+async def create_invitation(
+    body: CreateInvitation,
+    repo: InvitationRepository = Depends(_get_repo),
+) -> InvitationResponse:
+    inv = await repo.create(
+        email=body.email,
+        role=body.role,
+        invited_by=body.invited_by,
+        project_id=body.project_id,
+    )
+    return InvitationResponse.model_validate(inv)
+
+
+@router.delete("/{id}", response_model=InvitationResponse)
+async def revoke_invitation(
+    id: uuid.UUID,
+    repo: InvitationRepository = Depends(_get_repo),
+) -> InvitationResponse:
+    inv = await repo.revoke(id)
+    if inv is None:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    return InvitationResponse.model_validate(inv)
+
+
+@router.post("/{id}/resend", response_model=InvitationResponse)
+async def resend_invitation(
+    id: uuid.UUID,
+    repo: InvitationRepository = Depends(_get_repo),
+) -> InvitationResponse:
+    inv = await repo.resend(id)
+    if inv is None:
+        raise HTTPException(status_code=404, detail="Invitation not found or revoked")
+    return InvitationResponse.model_validate(inv)
+
+
+@router.post("/accept", status_code=200)
+async def accept_invitation(
+    body: AcceptInvitation,
+    repo: InvitationRepository = Depends(_get_repo),
+) -> dict:
+    inv = await repo.accept(body.token)
+    if inv is None:
+        raise HTTPException(status_code=400, detail="Invalid, expired, or already used token")
+    # Phase D: org_member + team_member 생성은 Supabase RPC(accept_invitation) 위임
+    return {"ok": True, "org_id": str(inv.org_id), "project_id": str(inv.project_id) if inv.project_id else None}

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreateInvitation(BaseModel):
+    email: str
+    role: str = "member"
+    invited_by: uuid.UUID
+    project_id: uuid.UUID | None = None
+
+
+class InvitationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID | None = None
+    invited_by: uuid.UUID
+    email: str
+    role: str
+    status: str
+    expires_at: datetime
+    accepted_at: datetime | None = None
+    created_at: datetime
+
+
+class AcceptInvitation(BaseModel):
+    token: str

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -1,0 +1,210 @@
+"""S29 AC: Invitations 라우터 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+INV_ID = uuid.uuid4()
+TOKEN = "abc123deadbeef"
+
+
+def _mock_invitation(status: str = "pending") -> MagicMock:
+    inv = MagicMock()
+    inv.id = INV_ID
+    inv.org_id = ORG_ID
+    inv.project_id = PROJECT_ID
+    inv.invited_by = MEMBER_ID
+    inv.email = "new@example.com"
+    inv.role = "member"
+    inv.token = TOKEN
+    inv.status = status
+    inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    inv.accepted_at = None
+    inv.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return inv
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_invitations_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_invitation()]
+
+            async with client as c:
+                resp = await c.get("/api/v2/invitations")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["email"] == "new@example.com"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_invitations_with_project_filter_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/invitations?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+        mock_list.assert_called_once_with(project_id=PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_invitation_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_invitation()
+
+            async with client as c:
+                resp = await c.post("/api/v2/invitations", json={
+                    "email": "new@example.com",
+                    "role": "member",
+                    "invited_by": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["status"] == "pending"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_revoke_invitation_200():
+    client, session, app = await _client()
+    try:
+        revoked = _mock_invitation("revoked")
+        with patch("app.repositories.invitation.InvitationRepository.revoke", new_callable=AsyncMock) as mock_revoke:
+            mock_revoke.return_value = revoked
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/invitations/{INV_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "revoked"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_revoke_invitation_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.revoke", new_callable=AsyncMock) as mock_revoke:
+            mock_revoke.return_value = None
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/invitations/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resend_invitation_200():
+    client, session, app = await _client()
+    try:
+        refreshed = _mock_invitation("pending")
+        refreshed.token = "newtokenhex"
+        with patch("app.repositories.invitation.InvitationRepository.resend", new_callable=AsyncMock) as mock_resend:
+            mock_resend.return_value = refreshed
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/invitations/{INV_ID}/resend")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "pending"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resend_invitation_404_when_revoked():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.resend", new_callable=AsyncMock) as mock_resend:
+            mock_resend.return_value = None
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/invitations/{INV_ID}/resend")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_accept_invitation_200():
+    client, session, app = await _client()
+    try:
+        accepted = _mock_invitation("accepted")
+        with patch("app.repositories.invitation.InvitationRepository.accept", new_callable=AsyncMock) as mock_accept:
+            mock_accept.return_value = accepted
+
+            async with client as c:
+                resp = await c.post("/api/v2/invitations/accept", json={"token": TOKEN})
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_accept_invitation_400_invalid_token():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.invitation.InvitationRepository.accept", new_callable=AsyncMock) as mock_accept:
+            mock_accept.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/invitations/accept", json={"token": "badtoken"})
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `Invitation` 모델 신규 (invitations 테이블: id/org_id/project_id/email/role/token/status/expires_at/accepted_at/invited_by/created_at)
- `InvitationRepository` 신설 — list/create/revoke/resend/accept/get_by_token
- 엔드포인트 5개:
  - `GET /api/v2/invitations` (project_id 필터)
  - `POST /api/v2/invitations` (초대 생성)
  - `DELETE /api/v2/invitations/{id}` (revoke)
  - `POST /api/v2/invitations/{id}/resend` (토큰 갱신)
  - `POST /api/v2/invitations/accept` (토큰 기반 수락)
- accept: status/accepted_at 업데이트. org_member+team_member 생성은 Phase D Supabase RPC 위임
- 테스트 9건 전량 PASS

## Test plan
- [ ] `uv run pytest tests/test_invitations.py` — 9건 PASS 확인
- [ ] POST /api/v2/invitations 초대 생성 확인
- [ ] POST /api/v2/invitations/accept 수락 후 status=accepted 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)