### PR TITLE
feat(backend): S30 Rewards 도메인 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, docs, epics, health, invitations, meetings, memos, notifications, org_members, projects, retros, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, docs, epics, health, invitations, meetings, memos, notifications, org_members, projects, retros, rewards, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -36,6 +36,7 @@ app.include_router(memos.router)
 app.include_router(notifications.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)
+app.include_router(rewards.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/reward.py
+++ b/backend/app/models/reward.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Numeric, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+
+class RewardLedger(Base, OrgScopedMixin):
+    __tablename__ = "reward_ledger"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    granted_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    amount: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(Text, nullable=False, default="TJSB")
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    reference_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    reference_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/reward.py
+++ b/backend/app/repositories/reward.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.reward import RewardLedger
+from app.models.team import TeamMember
+
+
+class RewardRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def list(self, project_id: uuid.UUID, member_id: uuid.UUID | None = None) -> list[RewardLedger]:
+        q = select(RewardLedger).where(
+            RewardLedger.org_id == self.org_id,
+            RewardLedger.project_id == project_id,
+        )
+        if member_id is not None:
+            q = q.where(RewardLedger.member_id == member_id)
+        q = q.order_by(RewardLedger.created_at.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def get_balance(self, project_id: uuid.UUID, member_id: uuid.UUID) -> float:
+        result = await self.session.execute(
+            select(func.coalesce(func.sum(RewardLedger.amount), 0)).where(
+                RewardLedger.org_id == self.org_id,
+                RewardLedger.project_id == project_id,
+                RewardLedger.member_id == member_id,
+            )
+        )
+        return float(result.scalar_one())
+
+    async def grant(
+        self,
+        project_id: uuid.UUID,
+        member_id: uuid.UUID,
+        amount: float,
+        reason: str,
+        granted_by: uuid.UUID,
+        reference_type: str | None = None,
+        reference_id: uuid.UUID | None = None,
+    ) -> RewardLedger | None:
+        member_check = await self.session.execute(
+            select(TeamMember.id).where(
+                TeamMember.id == member_id,
+                TeamMember.project_id == project_id,
+                TeamMember.org_id == self.org_id,
+            )
+        )
+        if member_check.scalar_one_or_none() is None:
+            return None
+
+        entry = RewardLedger(
+            org_id=self.org_id,
+            project_id=project_id,
+            member_id=member_id,
+            amount=amount,
+            reason=reason,
+            granted_by=granted_by,
+            reference_type=reference_type,
+            reference_id=reference_id,
+        )
+        self.session.add(entry)
+        await self.session.flush()
+        await self.session.refresh(entry)
+        return entry
+
+    async def leaderboard(
+        self,
+        project_id: uuid.UUID,
+        period: str = "all",
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> list[dict]:
+        limit = min(limit, 100)
+
+        if period == "all":
+            q = (
+                "SELECT member_id, balance FROM reward_balances"
+                " WHERE project_id = :pid"
+            )
+            params: dict = {"pid": str(project_id), "lim": limit}
+            if cursor:
+                q += " AND balance < :cursor"
+                params["cursor"] = float(cursor)
+            q += " ORDER BY balance DESC LIMIT :lim"
+            result = await self.session.execute(text(q), params)
+            return [{"member_id": r[0], "balance": float(r[1])} for r in result.all()]
+
+        period_seconds = {"daily": 86400, "weekly": 7 * 86400, "monthly": 30 * 86400}
+        seconds = period_seconds.get(period, 86400)
+        params2: dict = {"pid": str(project_id), "seconds": seconds, "lim": limit}
+        q2 = (
+            "SELECT member_id, CAST(SUM(amount) AS float) AS balance FROM reward_ledger"
+            " WHERE project_id = :pid"
+            " AND created_at >= NOW() - (:seconds || ' seconds')::interval"
+            " GROUP BY member_id ORDER BY balance DESC LIMIT :lim"
+        )
+        result2 = await self.session.execute(text(q2), params2)
+        return [{"member_id": r[0], "balance": float(r[1])} for r in result2.all()]

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -10,7 +10,6 @@ from app.schemas.analytics import (
     AgentStatsResponse,
     BurndownResponse,
     EpicProgressResponse,
-    LeaderboardEntry,
     MemberWorkloadResponse,
     ProjectHealthResponse,
     ProjectOverviewResponse,
@@ -122,17 +121,3 @@ async def get_sprint_velocity(
     if data is None:
         raise HTTPException(status_code=404, detail="Sprint not found")
     return SprintVelocityResponse.model_validate(data)
-
-
-@router.get("/rewards/leaderboard", response_model=list[LeaderboardEntry])
-async def get_leaderboard(
-    project_id: uuid.UUID = Query(...),
-    period: str = Query(default="all"),
-    limit: int = Query(default=50, ge=1, le=100),
-    cursor: str | None = Query(default=None),
-    repo: AnalyticsRepository = Depends(_get_repo),
-) -> list[LeaderboardEntry]:
-    if period not in ("daily", "weekly", "monthly", "all"):
-        raise HTTPException(status_code=400, detail="period must be one of: daily, weekly, monthly, all")
-    items = await repo.get_leaderboard(project_id, period, limit, cursor)
-    return [LeaderboardEntry.model_validate(i) for i in items]

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -1,0 +1,75 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.reward import RewardRepository
+from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
+
+router = APIRouter(prefix="/api/v2/rewards", tags=["rewards"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> RewardRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return RewardRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[RewardLedgerResponse])
+async def list_rewards(
+    project_id: uuid.UUID = Query(...),
+    member_id: uuid.UUID | None = Query(default=None),
+    repo: RewardRepository = Depends(_get_repo),
+) -> list[RewardLedgerResponse]:
+    items = await repo.list(project_id=project_id, member_id=member_id)
+    return [RewardLedgerResponse.model_validate(i) for i in items]
+
+
+@router.get("/balance", response_model=BalanceResponse)
+async def get_balance(
+    project_id: uuid.UUID = Query(...),
+    member_id: uuid.UUID = Query(...),
+    repo: RewardRepository = Depends(_get_repo),
+) -> BalanceResponse:
+    balance = await repo.get_balance(project_id=project_id, member_id=member_id)
+    return BalanceResponse(project_id=project_id, member_id=member_id, balance=balance)
+
+
+@router.post("", response_model=RewardLedgerResponse, status_code=201)
+async def grant_reward(
+    body: GrantReward,
+    repo: RewardRepository = Depends(_get_repo),
+) -> RewardLedgerResponse:
+    entry = await repo.grant(
+        project_id=body.project_id,
+        member_id=body.member_id,
+        amount=body.amount,
+        reason=body.reason,
+        granted_by=body.granted_by,
+        reference_type=body.reference_type,
+        reference_id=body.reference_id,
+    )
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Member not found in project")
+    return RewardLedgerResponse.model_validate(entry)
+
+
+@router.get("/leaderboard", response_model=list[LeaderboardEntry])
+async def get_leaderboard(
+    project_id: uuid.UUID = Query(...),
+    period: str = Query(default="all"),
+    limit: int = Query(default=50, ge=1, le=100),
+    cursor: str | None = Query(default=None),
+    repo: RewardRepository = Depends(_get_repo),
+) -> list[LeaderboardEntry]:
+    if period not in ("daily", "weekly", "monthly", "all"):
+        raise HTTPException(status_code=400, detail="period must be one of: daily, weekly, monthly, all")
+    items = await repo.leaderboard(project_id=project_id, period=period, limit=limit, cursor=cursor)
+    return [LeaderboardEntry.model_validate(i) for i in items]

--- a/backend/app/schemas/reward.py
+++ b/backend/app/schemas/reward.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class GrantReward(BaseModel):
+    project_id: uuid.UUID
+    member_id: uuid.UUID
+    amount: float
+    reason: str
+    granted_by: uuid.UUID
+    reference_type: str | None = None
+    reference_id: uuid.UUID | None = None
+
+
+class RewardLedgerResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    member_id: uuid.UUID
+    granted_by: uuid.UUID | None = None
+    amount: float
+    currency: str
+    reason: str
+    reference_type: str | None = None
+    reference_id: uuid.UUID | None = None
+    created_at: datetime
+
+
+class BalanceResponse(BaseModel):
+    project_id: uuid.UUID
+    member_id: uuid.UUID
+    balance: float
+
+
+class LeaderboardEntry(BaseModel):
+    member_id: uuid.UUID
+    balance: float

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -281,35 +281,3 @@ async def test_get_sprint_velocity_200():
         app.dependency_overrides.clear()
 
 
-@pytest.mark.anyio
-async def test_get_leaderboard_200():
-    client, session, app = await _client()
-    try:
-        mock_data = [
-            {"member_id": MEMBER_ID, "balance": 150.0},
-            {"member_id": AGENT_ID, "balance": 80.0},
-        ]
-        with patch("app.repositories.analytics.AnalyticsRepository.get_leaderboard", new_callable=AsyncMock) as mock_fn:
-            mock_fn.return_value = mock_data
-
-            async with client as c:
-                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=all")
-
-        assert resp.status_code == 200
-        assert len(resp.json()) == 2
-        assert resp.json()[0]["balance"] == 150.0
-    finally:
-        app.dependency_overrides.clear()
-
-
-@pytest.mark.anyio
-async def test_get_leaderboard_invalid_period_400():
-    client, session, app = await _client()
-    try:
-        with patch("app.repositories.analytics.AnalyticsRepository.get_leaderboard", new_callable=AsyncMock):
-            async with client as c:
-                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=invalid")
-
-        assert resp.status_code == 400
-    finally:
-        app.dependency_overrides.clear()

--- a/backend/tests/test_rewards.py
+++ b/backend/tests/test_rewards.py
@@ -1,0 +1,200 @@
+"""S30 AC: Rewards 라우터 단위 테스트 (8건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+GRANTER_ID = uuid.uuid4()
+ENTRY_ID = uuid.uuid4()
+
+
+def _mock_entry(amount: float = 10.0) -> MagicMock:
+    e = MagicMock()
+    e.id = ENTRY_ID
+    e.org_id = ORG_ID
+    e.project_id = PROJECT_ID
+    e.member_id = MEMBER_ID
+    e.granted_by = GRANTER_ID
+    e.amount = amount
+    e.currency = "TJSB"
+    e.reason = "스프린트 완료"
+    e.reference_type = None
+    e.reference_id = None
+    e.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return e
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_rewards_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_entry()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["reason"] == "스프린트 완료"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_rewards_with_member_filter_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_entry()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards?project_id={PROJECT_ID}&member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        mock_list.assert_called_once_with(project_id=PROJECT_ID, member_id=MEMBER_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_balance_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.get_balance", new_callable=AsyncMock) as mock_bal:
+            mock_bal.return_value = 150.0
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/balance?project_id={PROJECT_ID}&member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["balance"] == 150.0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+            mock_grant.return_value = _mock_entry(25.0)
+
+            async with client as c:
+                resp = await c.post("/api/v2/rewards", json={
+                    "project_id": str(PROJECT_ID),
+                    "member_id": str(MEMBER_ID),
+                    "amount": 25.0,
+                    "reason": "스프린트 완료",
+                    "granted_by": str(GRANTER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["currency"] == "TJSB"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_grant_reward_404_member_not_in_project():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.grant", new_callable=AsyncMock) as mock_grant:
+            mock_grant.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/rewards", json={
+                    "project_id": str(PROJECT_ID),
+                    "member_id": str(uuid.uuid4()),
+                    "amount": 10.0,
+                    "reason": "테스트",
+                    "granted_by": str(GRANTER_ID),
+                })
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_leaderboard_all_200():
+    client, session, app = await _client()
+    try:
+        mock_data = [
+            {"member_id": MEMBER_ID, "balance": 200.0},
+            {"member_id": GRANTER_ID, "balance": 100.0},
+        ]
+        with patch("app.repositories.reward.RewardRepository.leaderboard", new_callable=AsyncMock) as mock_lb:
+            mock_lb.return_value = mock_data
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=all")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+        assert resp.json()[0]["balance"] == 200.0
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_leaderboard_weekly_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.reward.RewardRepository.leaderboard", new_callable=AsyncMock) as mock_lb:
+            mock_lb.return_value = [{"member_id": MEMBER_ID, "balance": 50.0}]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=weekly&limit=10")
+
+        assert resp.status_code == 200
+        mock_lb.assert_called_once_with(project_id=PROJECT_ID, period="weekly", limit=10, cursor=None)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_leaderboard_invalid_period_400():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/rewards/leaderboard?project_id={PROJECT_ID}&period=invalid")
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `RewardLedger` 모델 신규 (reward_ledger 테이블 — OrgScopedMixin)
- `RewardRepository` — list/get_balance/grant(멤버 소속 검증)/leaderboard(all-time view + 기간별 GROUP BY)
- 엔드포인트 4개:
  - `GET /api/v2/rewards` (project_id + member_id 필터)
  - `GET /api/v2/rewards/balance` (project_id + member_id)
  - `POST /api/v2/rewards` (지급, member 소속 검증 필수)
  - `GET /api/v2/rewards/leaderboard` (period: daily/weekly/monthly/all + cursor 페이지네이션)
- S28 analytics.py의 `/rewards/leaderboard` 경로 중복 제거 → rewards.py로 통합
- 테스트 8건 PASS + analytics 회귀 11건 PASS (총 19건)

## Test plan
- [ ] `uv run pytest tests/test_rewards.py tests/test_analytics.py` — 19건 PASS 확인
- [ ] GET /api/v2/rewards/balance 잔액 조회 확인
- [ ] POST /api/v2/rewards 멤버 미소속 시 404 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)