### PR TITLE
feat(backend): S31 Audit Logs + Organizations + Me + ProjectSettings 도메인 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, docs, epics, health, invitations, meetings, memos, notifications, org_members, projects, retros, rewards, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, audit_logs, docs, epics, health, invitations, me, meetings, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -37,6 +37,10 @@ app.include_router(notifications.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)
 app.include_router(rewards.router)
+app.include_router(audit_logs.router)
+app.include_router(organizations.router)
+app.include_router(me.router)
+app.include_router(project_settings.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/audit.py
+++ b/backend/app/models/audit.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "permission_audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    actor_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    target_user_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    old_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    audit_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/organization.py
+++ b/backend/app/models/organization.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    plan: Mapped[str] = mapped_column(Text, nullable=False, default="free")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/project_setting.py
+++ b/backend/app/models/project_setting.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime, time
+
+from sqlalchemy import DateTime, ForeignKey, Time, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ProjectSetting(Base):
+    __tablename__ = "project_settings"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), primary_key=True
+    )
+    standup_deadline: Mapped[time] = mapped_column(Time, nullable=False, default=time(9, 0))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/audit.py
+++ b/backend/app/repositories/audit.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+
+
+class AuditLogRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def list(self, limit: int = 50, cursor: str | None = None) -> list[AuditLog]:
+        q = select(AuditLog).where(AuditLog.org_id == self.org_id)
+        if cursor:
+            from sqlalchemy import and_
+            q = q.where(AuditLog.created_at < cursor)
+        q = q.order_by(AuditLog.created_at.desc()).limit(min(limit, 200))
+        result = await self.session.execute(q)
+        return list(result.scalars().all())

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization import Organization
+
+
+class OrganizationRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get(self, org_id: uuid.UUID) -> Organization | None:
+        result = await self.session.execute(
+            select(Organization).where(Organization.id == org_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def slug_exists(self, slug: str) -> bool:
+        result = await self.session.execute(
+            select(Organization.id).where(Organization.slug == slug)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def create(self, name: str, slug: str, owner_member_id: uuid.UUID) -> Organization | None:
+        if await self.slug_exists(slug):
+            return None
+        org = Organization(name=name, slug=slug)
+        self.session.add(org)
+        await self.session.flush()
+        await self.session.refresh(org)
+        await self.session.execute(
+            text(
+                "INSERT INTO org_members (org_id, user_id, role)"
+                " SELECT :org_id, user_id, 'owner' FROM team_members WHERE id = :member_id"
+                " ON CONFLICT (org_id, user_id) DO NOTHING"
+            ),
+            {"org_id": str(org.id), "member_id": str(owner_member_id)},
+        )
+        return org
+
+    async def delete(self, org_id: uuid.UUID, requester_member_id: uuid.UUID) -> dict:
+        org = await self.get(org_id)
+        if org is None:
+            return {"ok": False, "reason": "not_found"}
+
+        owner_check = await self.session.execute(
+            text(
+                "SELECT 1 FROM org_members om"
+                " JOIN team_members tm ON tm.user_id = om.user_id"
+                " WHERE om.org_id = :org_id AND tm.id = :member_id AND om.role = 'owner'"
+            ),
+            {"org_id": str(org_id), "member_id": str(requester_member_id)},
+        )
+        if owner_check.first() is None:
+            return {"ok": False, "reason": "forbidden"}
+
+        sub_check = await self.session.execute(
+            text(
+                "SELECT 1 FROM org_subscriptions"
+                " WHERE org_id = :org_id AND status = 'active' LIMIT 1"
+            ),
+            {"org_id": str(org_id)},
+        )
+        if sub_check.first() is not None:
+            return {"ok": False, "reason": "active_subscription"}
+
+        await self.session.delete(org)
+        return {"ok": True}

--- a/backend/app/routers/audit_logs.py
+++ b/backend/app/routers/audit_logs.py
@@ -1,0 +1,32 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.audit import AuditLogRepository
+from app.schemas.audit import AuditLogResponse
+
+router = APIRouter(prefix="/api/v2/audit-logs", tags=["audit-logs"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> AuditLogRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return AuditLogRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("", response_model=list[AuditLogResponse])
+async def list_audit_logs(
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    repo: AuditLogRepository = Depends(_get_repo),
+) -> list[AuditLogResponse]:
+    items = await repo.list(limit=limit, cursor=cursor)
+    return [AuditLogResponse.model_validate(i) for i in items]

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,0 +1,46 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.team import TeamMember
+from app.schemas.me import MeResponse, UpdateMe
+
+router = APIRouter(prefix="/api/v2/me", tags=["me"])
+
+
+@router.get("", response_model=MeResponse)
+async def get_me(
+    member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeResponse:
+    result = await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    return MeResponse.model_validate(member)
+
+
+@router.patch("", response_model=MeResponse)
+async def update_me(
+    member_id: uuid.UUID = Query(...),
+    body: UpdateMe = ...,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MeResponse:
+    result = await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id)
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=404, detail="Member not found")
+    member.name = body.name
+    await session.flush()
+    await session.refresh(member)
+    return MeResponse.model_validate(member)

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -1,0 +1,46 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.organization import OrganizationRepository
+from app.schemas.organization import CreateOrganization, OrganizationResponse
+
+router = APIRouter(prefix="/api/v2/organizations", tags=["organizations"])
+
+
+def _get_repo(session: AsyncSession = Depends(get_db)) -> OrganizationRepository:
+    return OrganizationRepository(session)
+
+
+@router.post("", response_model=OrganizationResponse, status_code=201)
+async def create_organization(
+    body: CreateOrganization,
+    _auth: AuthContext = Depends(get_current_user),
+    repo: OrganizationRepository = Depends(_get_repo),
+) -> OrganizationResponse:
+    org = await repo.create(name=body.name, slug=body.slug, owner_member_id=body.owner_member_id)
+    if org is None:
+        raise HTTPException(status_code=409, detail="Slug already exists")
+    return OrganizationResponse.model_validate(org)
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_organization(
+    id: uuid.UUID,
+    requester_member_id: uuid.UUID = Query(...),
+    _auth: AuthContext = Depends(get_current_user),
+    repo: OrganizationRepository = Depends(_get_repo),
+) -> dict:
+    result = await repo.delete(org_id=id, requester_member_id=requester_member_id)
+    if not result["ok"]:
+        reason = result.get("reason")
+        if reason == "not_found":
+            raise HTTPException(status_code=404, detail="Organization not found")
+        if reason == "forbidden":
+            raise HTTPException(status_code=403, detail="Only owner can delete organization")
+        if reason == "active_subscription":
+            raise HTTPException(status_code=409, detail="Cannot delete organization with active subscription")
+    return {"ok": True}

--- a/backend/app/routers/project_settings.py
+++ b/backend/app/routers/project_settings.py
@@ -1,0 +1,57 @@
+import uuid
+from datetime import time
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.project_setting import ProjectSetting
+from app.schemas.project_setting import ProjectSettingResponse, UpdateProjectSetting
+
+router = APIRouter(prefix="/api/v2/project-settings", tags=["project-settings"])
+
+_DEFAULT_DEADLINE = time(9, 0)
+
+
+@router.get("", response_model=ProjectSettingResponse)
+async def get_project_settings(
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> ProjectSettingResponse:
+    result = await session.execute(
+        select(ProjectSetting).where(ProjectSetting.project_id == project_id)
+    )
+    setting = result.scalar_one_or_none()
+    if setting is None:
+        from datetime import datetime, timezone
+        return ProjectSettingResponse(
+            project_id=project_id,
+            standup_deadline=_DEFAULT_DEADLINE,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+    return ProjectSettingResponse.model_validate(setting)
+
+
+@router.patch("", response_model=ProjectSettingResponse)
+async def upsert_project_settings(
+    body: UpdateProjectSetting,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> ProjectSettingResponse:
+    deadline = time.fromisoformat(body.standup_deadline)
+    result = await session.execute(
+        select(ProjectSetting).where(ProjectSetting.project_id == body.project_id)
+    )
+    setting = result.scalar_one_or_none()
+    if setting is None:
+        setting = ProjectSetting(project_id=body.project_id, standup_deadline=deadline)
+        session.add(setting)
+    else:
+        setting.standup_deadline = deadline
+    await session.flush()
+    await session.refresh(setting)
+    return ProjectSettingResponse.model_validate(setting)

--- a/backend/app/schemas/audit.py
+++ b/backend/app/schemas/audit.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AuditLogResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    actor_id: uuid.UUID
+    action: str
+    target_user_id: uuid.UUID | None = None
+    old_role: str | None = None
+    new_role: str | None = None
+    audit_metadata: dict[str, Any] = {}
+    created_at: datetime

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MeResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    type: str
+    role: str
+    is_active: bool
+
+
+class UpdateMe(BaseModel):
+    name: str

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreateOrganization(BaseModel):
+    name: str
+    slug: str
+    owner_member_id: uuid.UUID
+
+
+class OrganizationResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    slug: str
+    plan: str
+    created_at: datetime
+    updated_at: datetime

--- a/backend/app/schemas/project_setting.py
+++ b/backend/app/schemas/project_setting.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, time
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ProjectSettingResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    project_id: uuid.UUID
+    standup_deadline: time
+    created_at: datetime
+    updated_at: datetime
+
+
+class UpdateProjectSetting(BaseModel):
+    project_id: uuid.UUID
+    standup_deadline: str = "09:00"

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -1,0 +1,264 @@
+"""S31 AC: Audit Logs + Organizations + Me + ProjectSettings 라우터 (8건 이상 합산)."""
+import uuid
+from datetime import datetime, time, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ORG_ENTRY_ID = uuid.uuid4()
+
+
+def _mock_audit_log() -> MagicMock:
+    a = MagicMock()
+    a.id = uuid.uuid4()
+    a.org_id = ORG_ID
+    a.actor_id = MEMBER_ID
+    a.action = "role_changed"
+    a.target_user_id = uuid.uuid4()
+    a.old_role = "member"
+    a.new_role = "admin"
+    a.audit_metadata = {}
+    a.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return a
+
+
+def _mock_org() -> MagicMock:
+    o = MagicMock()
+    o.id = ORG_ENTRY_ID
+    o.name = "Test Org"
+    o.slug = "test-org"
+    o.plan = "free"
+    o.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    o.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return o
+
+
+def _mock_member() -> MagicMock:
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.name = "Alice"
+    m.type = "human"
+    m.role = "admin"
+    m.is_active = True
+    return m
+
+
+def _mock_setting() -> MagicMock:
+    s = MagicMock()
+    s.project_id = PROJECT_ID
+    s.standup_deadline = time(9, 0)
+    s.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return s
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── Audit Logs ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_audit_logs_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.audit.AuditLogRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_audit_log()]
+
+            async with client as c:
+                resp = await c.get("/api/v2/audit-logs?limit=10")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["action"] == "role_changed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_audit_logs_empty_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.audit.AuditLogRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get("/api/v2/audit-logs")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Organizations ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_organization_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.organization.OrganizationRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_org()
+
+            async with client as c:
+                resp = await c.post("/api/v2/organizations", json={
+                    "name": "Test Org",
+                    "slug": "test-org",
+                    "owner_member_id": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["slug"] == "test-org"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_organization_409_slug_conflict():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.organization.OrganizationRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/organizations", json={
+                    "name": "Test Org",
+                    "slug": "existing-slug",
+                    "owner_member_id": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_organization_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.organization.OrganizationRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = {"ok": True}
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/organizations/{ORG_ENTRY_ID}?requester_member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_organization_403_not_owner():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.organization.OrganizationRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = {"ok": False, "reason": "forbidden"}
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/organizations/{ORG_ENTRY_ID}?requester_member_id={MEMBER_ID}")
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Me ────────────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_me_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_member()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/me?member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_me_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/me?member_id={uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── ProjectSettings ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_project_settings_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_setting()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["standup_deadline"] == "09:00:00"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_project_settings_default_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/project-settings?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["standup_deadline"] == "09:00:00"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
4개 도메인 동시 이관:
- **AuditLog** 모델 신규 (permission_audit_logs, 조회 전용, metadata→audit_metadata 예약어 우회)
- **Organization** 모델 신규 (create + slug unique 검증 + org_members owner INSERT, delete + owner/subscription 체크)
- **Me** 라우터 (GET/PATCH — team_members 조회, member_id query param)
- **ProjectSettings** 라우터 (GET/PATCH upsert — standup_deadline, 기본값 09:00 fallback)

엔드포인트 8개:
- `GET /api/v2/audit-logs` (limit+cursor)
- `POST /api/v2/organizations`
- `DELETE /api/v2/organizations/{id}` (owner+subscription 체크)
- `GET /api/v2/me`
- `PATCH /api/v2/me`
- `GET /api/v2/project-settings`
- `PATCH /api/v2/project-settings` (upsert)

테스트 10건 전량 PASS

## Test plan
- [ ] `uv run pytest tests/test_s31.py` — 10건 PASS 확인
- [ ] POST /api/v2/organizations slug 중복 409 확인
- [ ] DELETE /api/v2/organizations/{id} 비owner 403 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)