### PR TITLE
feat(test): S32 Sprint 5 통합 테스트

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,21 +1,40 @@
+from app.models.audit import AuditLog
 from app.models.doc import Doc
+from app.models.invitation import Invitation
 from app.models.meeting import Meeting
+from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
+from app.models.notification import InboxItem, Notification, NotificationSetting
+from app.models.organization import Organization
 from app.models.pm import Epic, Sprint, Story, Task
 from app.models.project import OrgMember, Project
+from app.models.project_setting import ProjectSetting
 from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+from app.models.reward import RewardLedger
 from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 
 __all__ = [
+    "AuditLog",
     "Doc",
     "Epic",
+    "InboxItem",
+    "Invitation",
     "Meeting",
+    "Memo",
+    "MemoDocLink",
+    "MemoRead",
+    "MemoReply",
+    "Notification",
+    "NotificationSetting",
     "OrgMember",
+    "Organization",
     "Project",
+    "ProjectSetting",
     "RetroAction",
     "RetroItem",
     "RetroSession",
     "RetroVote",
+    "RewardLedger",
     "Sprint",
     "StandupEntry",
     "StandupFeedback",

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -1,4 +1,4 @@
-"""S18+S25: conftest fixture 기반 통합 테스트 — Sprint 3+4 도메인 헬스 체크."""
+"""S18+S25+S32: conftest fixture 기반 통합 테스트 — Sprint 3+4+5 도메인 헬스 체크."""
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
@@ -147,3 +147,105 @@ async def test_retros_list_via_conftest(test_client, mock_session, project_id):
     resp = await test_client.get(f"/api/v2/retros?project_id={project_id}")
     assert resp.status_code == 200
     assert resp.json() == []
+
+
+# ── Sprint 5: S26~S31 도메인 통합 테스트 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_memos_list_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/memos 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/memos?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_notifications_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/notifications 200."""
+    member_id = uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/notifications?user_id={member_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_analytics_overview_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/analytics/overview 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.scalar_one.return_value = 0
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/analytics/overview?project_id={project_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "sprints" in data
+    assert "epics" in data
+
+
+@pytest.mark.anyio
+async def test_invitations_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/invitations 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/invitations")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_rewards_list_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/rewards 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/rewards?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_audit_logs_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/audit-logs 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/audit-logs")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_me_get_via_conftest(test_client, mock_session):
+    """GET /api/v2/me 404 (member 없음) — 라우터 연결 확인."""
+    member_id = uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/me?member_id={member_id}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_project_settings_get_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/project-settings 200 (기본값 반환)."""
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/project-settings?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json()["standup_deadline"] == "09:00:00"


### PR DESCRIPTION
## Summary
- `test_integration.py`에 Sprint 5 도메인 통합 테스트 8건 추가 (S26~S31)
  - memos list, notifications list, analytics overview, invitations list, rewards list, audit-logs list, me get (404), project-settings get (기본값)
- `models/__init__.py`에 Sprint 5 신규 모델 전량 익스포트
  - AuditLog, Invitation, Memo/Reply/Read/DocLink, Notification/Setting, InboxItem, Organization, ProjectSetting, RewardLedger

## Test plan
- [ ] `uv run pytest tests/test_integration.py` — 20건 PASS (기존 12 + 신규 8)
- [ ] `uv run pytest` — 175건 전량 PASS, 회귀 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)