### PR TITLE
feat(backend): S33 Dashboard + Current Project + Members API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, audit_logs, docs, epics, health, invitations, me, meetings, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -38,6 +38,9 @@ app.include_router(analytics.router)
 app.include_router(invitations.router)
 app.include_router(rewards.router)
 app.include_router(audit_logs.router)
+app.include_router(dashboard.router)
+app.include_router(current_project.router)
+app.include_router(members.router)
 app.include_router(organizations.router)
 app.include_router(me.router)
 app.include_router(project_settings.router)

--- a/backend/app/routers/current_project.py
+++ b/backend/app/routers/current_project.py
@@ -1,0 +1,70 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.project import Project
+from app.models.team import TeamMember
+from app.schemas.current_project import CurrentProjectResponse, SetCurrentProject
+
+router = APIRouter(prefix="/api/v2/current-project", tags=["current-project"])
+
+
+@router.get("", response_model=CurrentProjectResponse)
+async def get_current_project(
+    member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> CurrentProjectResponse:
+    tm_r = await session.execute(
+        select(TeamMember.project_id, TeamMember.org_id).where(
+            TeamMember.id == member_id, TeamMember.is_active.is_(True)
+        ).limit(1)
+    )
+    row = tm_r.first()
+    if row is None:
+        return CurrentProjectResponse(project_id=None, project_name=None, org_id=None)
+
+    proj_r = await session.execute(
+        select(Project.name).where(Project.id == row[0])
+    )
+    project_name = proj_r.scalar_one_or_none()
+
+    return CurrentProjectResponse(
+        project_id=row[0],
+        project_name=project_name,
+        org_id=row[1],
+    )
+
+
+@router.post("", response_model=CurrentProjectResponse)
+async def set_current_project(
+    body: SetCurrentProject,
+    member_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> CurrentProjectResponse:
+    tm_r = await session.execute(
+        select(TeamMember.org_id).where(
+            TeamMember.id == member_id,
+            TeamMember.project_id == body.project_id,
+            TeamMember.is_active.is_(True),
+        )
+    )
+    org_id = tm_r.scalar_one_or_none()
+    if org_id is None:
+        raise HTTPException(status_code=403, detail="Project membership not found")
+
+    proj_r = await session.execute(
+        select(Project.name).where(Project.id == body.project_id)
+    )
+    project_name = proj_r.scalar_one_or_none()
+
+    return CurrentProjectResponse(
+        project_id=body.project_id,
+        project_name=project_name,
+        org_id=org_id,
+    )

--- a/backend/app/routers/dashboard.py
+++ b/backend/app/routers/dashboard.py
@@ -1,0 +1,67 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.memo import Memo
+from app.models.pm import Story, Task
+from app.models.team import TeamMember
+from app.schemas.dashboard import DashboardResponse, MemoItem, StoryItem, TaskItem
+
+router = APIRouter(prefix="/api/v2/dashboard", tags=["dashboard"])
+
+
+@router.get("", response_model=DashboardResponse)
+async def get_dashboard(
+    member_id: uuid.UUID = Query(...),
+    project_id: uuid.UUID | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> DashboardResponse:
+    if project_id is None:
+        tm_r = await session.execute(
+            select(TeamMember.project_id).where(
+                TeamMember.id == member_id, TeamMember.is_active.is_(True)
+            ).limit(1)
+        )
+        project_id = tm_r.scalar_one_or_none()
+        if project_id is None:
+            raise HTTPException(status_code=404, detail="Member not found or inactive")
+
+    stories_r = await session.execute(
+        select(Story.id, Story.title, Story.status, Story.story_points).where(
+            Story.project_id == project_id,
+            Story.assignee_id == member_id,
+            Story.status != "done",
+            Story.deleted_at.is_(None),
+        )
+    )
+    story_rows = stories_r.all()
+
+    tasks_r = await session.execute(
+        select(Task.id, Task.title, Task.status).where(
+            Task.assignee_id == member_id,
+            Task.status != "done",
+            Task.deleted_at.is_(None),
+        )
+    )
+    task_rows = tasks_r.all()
+
+    memos_r = await session.execute(
+        select(Memo.id, Memo.title, Memo.status).where(
+            Memo.project_id == project_id,
+            Memo.assigned_to == member_id,
+            Memo.status == "open",
+            Memo.deleted_at.is_(None),
+        )
+    )
+    memo_rows = memos_r.all()
+
+    return DashboardResponse(
+        my_stories=[StoryItem(id=r[0], title=r[1], status=r[2], story_points=r[3]) for r in story_rows],
+        my_tasks=[TaskItem(id=r[0], title=r[1], status=r[2]) for r in task_rows],
+        open_memos=[MemoItem(id=r[0], title=r[1], status=r[2]) for r in memo_rows],
+    )

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -1,0 +1,40 @@
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.team import TeamMember
+
+router = APIRouter(prefix="/api/v2/members", tags=["members"])
+
+
+class MemberResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    type: str
+    role: str
+    is_active: bool
+    webhook_url: str | None = None
+
+
+@router.get("", response_model=list[MemberResponse])
+async def list_members(
+    project_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> list[MemberResponse]:
+    result = await session.execute(
+        select(TeamMember).where(
+            TeamMember.project_id == project_id,
+            TeamMember.is_active.is_(True),
+        ).order_by(TeamMember.name)
+    )
+    members = result.scalars().all()
+    return [MemberResponse.model_validate(m) for m in members]

--- a/backend/app/schemas/current_project.py
+++ b/backend/app/schemas/current_project.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel
+
+
+class CurrentProjectResponse(BaseModel):
+    project_id: uuid.UUID | None
+    project_name: str | None
+    org_id: uuid.UUID | None
+
+
+class SetCurrentProject(BaseModel):
+    project_id: uuid.UUID

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class StoryItem(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+    story_points: int | None = None
+
+
+class TaskItem(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+
+
+class MemoItem(BaseModel):
+    id: uuid.UUID
+    title: str | None
+    status: str
+
+
+class DashboardResponse(BaseModel):
+    my_stories: list[StoryItem]
+    my_tasks: list[TaskItem]
+    open_memos: list[MemoItem]

--- a/backend/tests/test_s33.py
+++ b/backend/tests/test_s33.py
@@ -1,0 +1,193 @@
+"""S33 AC: Dashboard + Current Project + Members 라우터 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── Dashboard ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dashboard_200():
+    client, session, app = await _client()
+    try:
+        empty = MagicMock()
+        empty.all.return_value = []
+        session.execute = AsyncMock(return_value=empty)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/dashboard?member_id={MEMBER_ID}&project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "my_stories" in data
+        assert "my_tasks" in data
+        assert "open_memos" in data
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dashboard_missing_member_id_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/dashboard")
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dashboard_empty_result_200():
+    client, session, app = await _client()
+    try:
+        empty = MagicMock()
+        empty.all.return_value = []
+        session.execute = AsyncMock(return_value=empty)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/dashboard?member_id={MEMBER_ID}&project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["my_stories"] == []
+        assert resp.json()["my_tasks"] == []
+        assert resp.json()["open_memos"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Current Project ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_current_project_get_200():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.first.return_value = (PROJECT_ID, ORG_ID)
+            else:
+                result.scalar_one_or_none.return_value = "Test Project"
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/current-project?member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["project_id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_current_project_post_200():
+    client, session, app = await _client()
+    try:
+        call_count = 0
+
+        async def mock_execute(stmt, *a, **kw):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = ORG_ID
+            else:
+                result.scalar_one_or_none.return_value = "Test Project"
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/current-project?member_id={MEMBER_ID}",
+                json={"project_id": str(PROJECT_ID)},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["project_id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Members ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_members_list_200():
+    client, session, app = await _client()
+    try:
+        member_mock = MagicMock()
+        member_mock.id = MEMBER_ID
+        member_mock.name = "Alice"
+        member_mock.type = "human"
+        member_mock.role = "admin"
+        member_mock.is_active = True
+        member_mock.webhook_url = None
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [member_mock]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/members?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_members_missing_project_id_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/members")
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
Sprint 6 첫 번째 스토리 — 3개 라우터 신규:

- **Dashboard** (`GET /api/v2/dashboard?member_id&project_id`)
  - stories (assignee + status != done), tasks (assignee + status != done), memos (assigned_to + status=open)
  - project_id 없으면 team_members에서 자동 조회
- **Current Project** (`GET/POST /api/v2/current-project?member_id`)
  - GET: team_members에서 첫 project + name 반환
  - POST: membership 검증 후 project 반환
- **Members** (`GET /api/v2/members?project_id`)
  - is_active=true TeamMember 목록 (id/name/type/role/is_active/webhook_url)

테스트 7건 PASS + 전체 회귀 182건 PASS

## Test plan
- [ ] `uv run pytest tests/test_s33.py` — 7건 PASS 확인
- [ ] GET /api/v2/dashboard?member_id= stories/tasks/memos 복합 응답 확인
- [ ] GET /api/v2/members?project_id= active 멤버 목록 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)