### PR TITLE
feat(backend): S34 Webhook Config CRUD

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members
+from app.routers import analytics, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -44,6 +44,7 @@ app.include_router(members.router)
 app.include_router(organizations.router)
 app.include_router(me.router)
 app.include_router(project_settings.router)
+app.include_router(webhooks.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.audit import AuditLog
+from app.models.webhook_config import WebhookConfig
 from app.models.doc import Doc
 from app.models.invitation import Invitation
 from app.models.meeting import Meeting
@@ -15,6 +16,7 @@ from app.models.team import TeamMember
 
 __all__ = [
     "AuditLog",
+    "WebhookConfig",
     "Doc",
     "Epic",
     "InboxItem",

--- a/backend/app/models/webhook_config.py
+++ b/backend/app/models/webhook_config.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class WebhookConfig(Base):
+    __tablename__ = "webhook_configs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )
+    url: Mapped[str] = mapped_column(Text, nullable=False)
+    secret: Mapped[str | None] = mapped_column(Text, nullable=True)
+    events: Mapped[list] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    channel: Mapped[str] = mapped_column(Text, nullable=False, default="generic")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/webhook_config.py
+++ b/backend/app/repositories/webhook_config.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.webhook_config import WebhookConfig
+
+
+class WebhookConfigRepository:
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    async def list(self, project_id: uuid.UUID | None = None) -> list[WebhookConfig]:
+        q = select(WebhookConfig).where(WebhookConfig.org_id == self.org_id)
+        if project_id is not None:
+            q = q.where(WebhookConfig.project_id == project_id)
+        q = q.order_by(WebhookConfig.created_at.desc())
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def get(self, id: uuid.UUID) -> WebhookConfig | None:
+        result = await self.session.execute(
+            select(WebhookConfig).where(WebhookConfig.id == id, WebhookConfig.org_id == self.org_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_project(self, project_id: uuid.UUID) -> list[WebhookConfig]:
+        result = await self.session.execute(
+            select(WebhookConfig).where(
+                WebhookConfig.project_id == project_id,
+                WebhookConfig.is_active.is_(True),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        member_id: uuid.UUID,
+        url: str,
+        project_id: uuid.UUID | None = None,
+        events: list[str] | None = None,
+        is_active: bool = True,
+    ) -> WebhookConfig:
+        existing = await self.session.execute(
+            select(WebhookConfig).where(
+                WebhookConfig.org_id == self.org_id,
+                WebhookConfig.url == url,
+            )
+        )
+        config = existing.scalar_one_or_none()
+
+        if config is None:
+            config = WebhookConfig(
+                org_id=self.org_id,
+                member_id=member_id,
+                url=url,
+                project_id=project_id,
+                events=events or [],
+                is_active=is_active,
+            )
+            self.session.add(config)
+        else:
+            if project_id is not None:
+                config.project_id = project_id
+            if events is not None:
+                config.events = events
+            config.is_active = is_active
+
+        await self.session.flush()
+        await self.session.refresh(config)
+        return config
+
+    async def delete(self, id: uuid.UUID) -> bool:
+        config = await self.get(id)
+        if config is None:
+            return False
+        await self.session.delete(config)
+        return True

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -1,0 +1,57 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.webhook_config import WebhookConfigRepository
+from app.schemas.webhook_config import UpsertWebhookConfig, WebhookConfigResponse
+
+router = APIRouter(prefix="/api/v2/webhooks", tags=["webhooks"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> WebhookConfigRepository:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return WebhookConfigRepository(session, uuid.UUID(str(org_id_str)))
+
+
+@router.get("/config", response_model=list[WebhookConfigResponse])
+async def list_webhook_configs(
+    project_id: uuid.UUID | None = Query(default=None),
+    repo: WebhookConfigRepository = Depends(_get_repo),
+) -> list[WebhookConfigResponse]:
+    items = await repo.list(project_id=project_id)
+    return [WebhookConfigResponse.model_validate(i) for i in items]
+
+
+@router.put("/config", response_model=WebhookConfigResponse)
+async def upsert_webhook_config(
+    body: UpsertWebhookConfig,
+    repo: WebhookConfigRepository = Depends(_get_repo),
+) -> WebhookConfigResponse:
+    config = await repo.upsert(
+        member_id=body.member_id,
+        url=body.url,
+        project_id=body.project_id,
+        events=body.events,
+        is_active=body.is_active,
+    )
+    return WebhookConfigResponse.model_validate(config)
+
+
+@router.delete("/config", status_code=200)
+async def delete_webhook_config(
+    id: uuid.UUID = Query(...),
+    repo: WebhookConfigRepository = Depends(_get_repo),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="WebhookConfig not found")
+    return {"ok": True}

--- a/backend/app/schemas/webhook_config.py
+++ b/backend/app/schemas/webhook_config.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class WebhookConfigResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    member_id: uuid.UUID
+    project_id: uuid.UUID | None = None
+    url: str
+    events: list[str]
+    channel: str
+    is_active: bool
+    created_at: datetime
+
+
+class UpsertWebhookConfig(BaseModel):
+    member_id: uuid.UUID
+    url: str
+    project_id: uuid.UUID | None = None
+    events: list[str] | None = None
+    is_active: bool = True
+
+    @field_validator("url")
+    @classmethod
+    def url_must_be_https(cls, v: str) -> str:
+        if not v.startswith("https://"):
+            raise ValueError("url must start with https://")
+        return v

--- a/backend/tests/test_s34.py
+++ b/backend/tests/test_s34.py
@@ -1,0 +1,210 @@
+"""S34 AC: Webhook Config CRUD 라우터 (8건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+CONFIG_ID = uuid.uuid4()
+
+
+def _mock_config(is_active: bool = True) -> MagicMock:
+    c = MagicMock()
+    c.id = CONFIG_ID
+    c.org_id = ORG_ID
+    c.member_id = MEMBER_ID
+    c.project_id = PROJECT_ID
+    c.url = "https://hooks.example.com/webhook"
+    c.events = ["memo.created", "story.updated"]
+    c.channel = "generic"
+    c.is_active = is_active
+    c.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return c
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_configs_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_config()]
+
+            async with client as c:
+                resp = await c.get("/api/v2/webhooks/config")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["url"] == "https://hooks.example.com/webhook"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_configs_empty_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get("/api/v2/webhooks/config")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_config_create_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+            mock_upsert.return_value = _mock_config()
+
+            async with client as c:
+                resp = await c.put("/api/v2/webhooks/config", json={
+                    "member_id": str(MEMBER_ID),
+                    "url": "https://hooks.example.com/webhook",
+                    "events": ["memo.created"],
+                    "is_active": True,
+                })
+
+        assert resp.status_code == 200
+        assert resp.json()["is_active"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_config_update_200():
+    client, session, app = await _client()
+    try:
+        updated = _mock_config(is_active=False)
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+            mock_upsert.return_value = updated
+
+            async with client as c:
+                resp = await c.put("/api/v2/webhooks/config", json={
+                    "member_id": str(MEMBER_ID),
+                    "url": "https://hooks.example.com/webhook",
+                    "is_active": False,
+                })
+
+        assert resp.status_code == 200
+        assert resp.json()["is_active"] is False
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_config_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = True
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/webhooks/config?id={CONFIG_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_config_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = False
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/webhooks/config?id={uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_upsert_non_https_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.put("/api/v2/webhooks/config", json={
+                "member_id": str(MEMBER_ID),
+                "url": "http://insecure.example.com/webhook",
+            })
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_by_project_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_config()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/webhooks/config?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        mock_list.assert_called_once_with(project_id=PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_configs_with_events_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.webhook_config.WebhookConfigRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_config()]
+
+            async with client as c:
+                resp = await c.get("/api/v2/webhooks/config")
+
+        assert resp.status_code == 200
+        assert "memo.created" in resp.json()[0]["events"]
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `WebhookConfig` 모델 신규 (webhook_configs 테이블 — org_id/member_id/project_id/url/events/channel/is_active)
- `WebhookConfigRepository` — list/get/upsert(org+url 중복 체크)/delete/get_by_project
- 엔드포인트 3개:
  - `GET /api/v2/webhooks/config` (project_id 필터)
  - `PUT /api/v2/webhooks/config` (upsert, HTTPS URL validation)
  - `DELETE /api/v2/webhooks/config?id=` (404 if not found)
- models/__init__.py에 WebhookConfig export 추가
- 테스트 9건 PASS + 전체 회귀 191건 PASS

## Test plan
- [ ] `uv run pytest tests/test_s34.py` — 9건 PASS 확인
- [ ] PUT http:// URL → 422 확인
- [ ] DELETE 없는 ID → 404 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)