### PR TITLE
feat(backend): S36 Agent Runs CRUD

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
+from app.routers import agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -46,6 +46,7 @@ app.include_router(me.router)
 app.include_router(project_settings.router)
 app.include_router(webhooks.router)
 app.include_router(api_keys.router)
+app.include_router(agent_runs.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.agent_run import AgentRun
 from app.models.api_key import ApiKey
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
@@ -16,6 +17,7 @@ from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 
 __all__ = [
+    "AgentRun",
     "ApiKey",
     "AuditLog",
     "WebhookConfig",

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -1,0 +1,41 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Numeric, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentRun(Base):
+    __tablename__ = "agent_runs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    agent_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    story_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
+    )
+    memo_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="SET NULL"), nullable=True
+    )
+    trigger: Mapped[str] = mapped_column(Text, nullable=False, default="manual")
+    model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_usd: Mapped[float | None] = mapped_column(Numeric(10, 6), nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="running")
+    result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_disposition: Mapped[str | None] = mapped_column(Text, nullable=True)
+    llm_call_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    run_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/agent_run.py
+++ b/backend/app/repositories/agent_run.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_run import AgentRun
+
+
+class AgentRunRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list(
+        self,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID | None = None,
+        limit: int = 50,
+        cursor: str | None = None,
+    ) -> list[AgentRun]:
+        from app.models.team import TeamMember
+        agent_ids_q = select(TeamMember.id).where(TeamMember.project_id == project_id)
+        agent_ids_r = await self.session.execute(agent_ids_q)
+        agent_ids = [r[0] for r in agent_ids_r.all()]
+
+        q = select(AgentRun).where(AgentRun.agent_id.in_(agent_ids))
+        if agent_id is not None:
+            q = q.where(AgentRun.agent_id == agent_id)
+        if cursor:
+            q = q.where(AgentRun.created_at < cursor)
+        q = q.order_by(AgentRun.created_at.desc()).limit(min(limit, 200))
+        result = await self.session.execute(q)
+        return list(result.scalars().all())
+
+    async def get(self, id: uuid.UUID) -> AgentRun | None:
+        result = await self.session.execute(
+            select(AgentRun).where(AgentRun.id == id)
+        )
+        return result.scalar_one_or_none()
+
+    async def create(
+        self,
+        org_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        trigger: str = "manual",
+        **kwargs: Any,
+    ) -> AgentRun:
+        run = AgentRun(org_id=org_id, agent_id=agent_id, trigger=trigger, **kwargs)
+        self.session.add(run)
+        await self.session.flush()
+        await self.session.refresh(run)
+        return run
+
+    async def update(self, id: uuid.UUID, **fields: Any) -> AgentRun | None:
+        run = await self.get(id)
+        if run is None:
+            return None
+        for k, v in fields.items():
+            if v is not None or k in ("result_summary", "last_error_code"):
+                setattr(run, k, v)
+        await self.session.flush()
+        await self.session.refresh(run)
+        return run

--- a/backend/app/routers/agent_runs.py
+++ b/backend/app/routers/agent_runs.py
@@ -1,0 +1,85 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.team import TeamMember
+from app.repositories.agent_run import AgentRunRepository
+from app.schemas.agent_run import AgentRunResponse, CreateAgentRun, UpdateAgentRun
+
+router = APIRouter(prefix="/api/v2/agent-runs", tags=["agent-runs"])
+
+
+def _get_repo(session: AsyncSession = Depends(get_db)) -> AgentRunRepository:
+    return AgentRunRepository(session)
+
+
+@router.get("", response_model=list[AgentRunResponse])
+async def list_agent_runs(
+    project_id: uuid.UUID = Query(...),
+    agent_id: uuid.UUID | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    cursor: str | None = Query(default=None),
+    _auth: AuthContext = Depends(get_current_user),
+    repo: AgentRunRepository = Depends(_get_repo),
+) -> list[AgentRunResponse]:
+    runs = await repo.list(project_id=project_id, agent_id=agent_id, limit=limit, cursor=cursor)
+    return [AgentRunResponse.model_validate(r) for r in runs]
+
+
+@router.post("", response_model=AgentRunResponse, status_code=201)
+async def create_agent_run(
+    body: CreateAgentRun,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+    repo: AgentRunRepository = Depends(_get_repo),
+) -> AgentRunResponse:
+    member_r = await session.execute(
+        select(TeamMember.org_id).where(
+            TeamMember.id == body.agent_id, TeamMember.type == "agent"
+        )
+    )
+    org_id = member_r.scalar_one_or_none()
+    if org_id is None:
+        raise HTTPException(status_code=400, detail="agent_id not found or not an agent")
+
+    run = await repo.create(
+        org_id=org_id,
+        agent_id=body.agent_id,
+        trigger=body.trigger,
+        model=body.model,
+        story_id=body.story_id,
+        memo_id=body.memo_id,
+        status=body.status,
+        result_summary=body.result_summary,
+        input_tokens=body.input_tokens,
+        output_tokens=body.output_tokens,
+        cost_usd=body.cost_usd,
+        duration_ms=body.duration_ms,
+    )
+    return AgentRunResponse.model_validate(run)
+
+
+@router.patch("/{id}", response_model=AgentRunResponse)
+async def update_agent_run(
+    id: uuid.UUID,
+    body: UpdateAgentRun,
+    _auth: AuthContext = Depends(get_current_user),
+    repo: AgentRunRepository = Depends(_get_repo),
+) -> AgentRunResponse:
+    run = await repo.update(
+        id,
+        status=body.status,
+        result_summary=body.result_summary,
+        input_tokens=body.input_tokens,
+        output_tokens=body.output_tokens,
+        cost_usd=body.cost_usd,
+        duration_ms=body.duration_ms,
+        last_error_code=body.last_error_code,
+    )
+    if run is None:
+        raise HTTPException(status_code=404, detail="Agent run not found")
+    return AgentRunResponse.model_validate(run)

--- a/backend/app/schemas/agent_run.py
+++ b/backend/app/schemas/agent_run.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CreateAgentRun(BaseModel):
+    agent_id: uuid.UUID
+    trigger: str = "manual"
+    model: str | None = None
+    story_id: uuid.UUID | None = None
+    memo_id: uuid.UUID | None = None
+    status: str = "running"
+    result_summary: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+
+
+class UpdateAgentRun(BaseModel):
+    status: str
+    result_summary: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+    last_error_code: str | None = None
+
+
+class AgentRunResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    agent_id: uuid.UUID
+    story_id: uuid.UUID | None = None
+    memo_id: uuid.UUID | None = None
+    trigger: str
+    model: str | None = None
+    status: str
+    result_summary: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+    duration_ms: int | None = None
+    last_error_code: str | None = None
+    llm_call_count: int
+    run_metadata: dict[str, Any]
+    created_at: datetime

--- a/backend/tests/test_s36.py
+++ b/backend/tests/test_s36.py
@@ -1,0 +1,215 @@
+"""S36 AC: Agent Runs CRUD 라우터 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+RUN_ID = uuid.uuid4()
+
+
+def _mock_run(status: str = "running") -> MagicMock:
+    r = MagicMock()
+    r.id = RUN_ID
+    r.org_id = ORG_ID
+    r.agent_id = AGENT_ID
+    r.story_id = None
+    r.memo_id = None
+    r.trigger = "manual"
+    r.model = "claude-opus-4-7"
+    r.status = status
+    r.result_summary = None
+    r.input_tokens = None
+    r.output_tokens = None
+    r.cost_usd = None
+    r.duration_ms = None
+    r.last_error_code = None
+    r.llm_call_count = 0
+    r.run_metadata = {}
+    r.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    return r
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_list_agent_runs_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_run.AgentRunRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_mock_run()]
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-runs?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["status"] == "running"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_agent_runs_empty_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_run.AgentRunRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-runs?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_agent_runs_missing_project_id_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/agent-runs")
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_agent_run_201():
+    client, session, app = await _client()
+    try:
+        mock_member = MagicMock()
+        mock_member.scalar_one_or_none.return_value = ORG_ID
+        session.execute = AsyncMock(return_value=mock_member)
+
+        with patch("app.repositories.agent_run.AgentRunRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_run()
+
+            async with client as c:
+                resp = await c.post("/api/v2/agent-runs", json={
+                    "agent_id": str(AGENT_ID),
+                    "trigger": "manual",
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["status"] == "running"
+        assert resp.json()["trigger"] == "manual"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_agent_run_invalid_agent_400():
+    client, session, app = await _client()
+    try:
+        mock_member = MagicMock()
+        mock_member.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_member)
+
+        async with client as c:
+            resp = await c.post("/api/v2/agent-runs", json={
+                "agent_id": str(uuid.uuid4()),
+                "trigger": "manual",
+            })
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_completed_200():
+    client, session, app = await _client()
+    try:
+        completed = _mock_run("completed")
+        completed.result_summary = "작업 완료"
+        completed.input_tokens = 1500
+        completed.output_tokens = 300
+
+        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = completed
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-runs/{RUN_ID}", json={
+                    "status": "completed",
+                    "result_summary": "작업 완료",
+                    "input_tokens": 1500,
+                    "output_tokens": 300,
+                })
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "completed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_failed_200():
+    client, session, app = await _client()
+    try:
+        failed = _mock_run("failed")
+        failed.last_error_code = "timeout"
+
+        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = failed
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-runs/{RUN_ID}", json={
+                    "status": "failed",
+                    "last_error_code": "timeout",
+                })
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "failed"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_agent_run_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_run.AgentRunRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = None
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-runs/{uuid.uuid4()}", json={"status": "completed"})
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `AgentRun` 모델 신규 (agent_runs 테이블 — org_id/agent_id/story_id/memo_id/trigger/model/status/tokens/cost/duration/metadata 등)
- `AgentRunRepository` — list(project_id 기반)/create/update
- 엔드포인트 3개:
  - `GET /api/v2/agent-runs?project_id=` (agent_id/limit/cursor 필터)
  - `POST /api/v2/agent-runs` (agent_id 검증 후 org_id 자동 조회)
  - `PATCH /api/v2/agent-runs/{id}` (status/tokens/cost/error 업데이트)
- metadata → `run_metadata`로 예약어 우회 (S26/S31 패턴)
- models/__init__.py에 AgentRun export 추가
- 테스트 8건 PASS

## Test plan
- [ ] `uv run pytest tests/test_s36.py` — 8건 PASS 확인
- [ ] POST /api/v2/agent-runs 유효하지 않은 agent_id → 400 확인
- [ ] PATCH /api/v2/agent-runs/{id} status=completed 업데이트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)