### PR TITLE
feat(backend): S37 Policy Documents 이관 + Notification Settings 회귀 확인

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
+from app.routers import agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -47,6 +47,7 @@ app.include_router(project_settings.router)
 app.include_router(webhooks.router)
 app.include_router(api_keys.router)
 app.include_router(agent_runs.router)
+app.include_router(policy_documents.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.agent_run import AgentRun
 from app.models.api_key import ApiKey
+from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
 from app.models.doc import Doc
@@ -19,6 +20,7 @@ from app.models.team import TeamMember
 __all__ = [
     "AgentRun",
     "ApiKey",
+    "PolicyDocument",
     "AuditLog",
     "WebhookConfig",
     "Doc",

--- a/backend/app/models/policy_document.py
+++ b/backend/app/models/policy_document.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+
+class PolicyDocument(Base, OrgScopedMixin):
+    __tablename__ = "policy_documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    sprint_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    epic_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("epics.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    legacy_sprint_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    legacy_epic_key: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/policy_documents.py
+++ b/backend/app/routers/policy_documents.py
@@ -1,0 +1,48 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.policy_document import PolicyDocument
+from app.schemas.policy_document import PolicyDocumentResponse
+
+router = APIRouter(prefix="/api/v2/policy-documents", tags=["policy-documents"])
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+@router.get("", response_model=list[PolicyDocumentResponse])
+async def list_policy_documents(
+    project_id: uuid.UUID = Query(...),
+    sprint_id: uuid.UUID | None = Query(default=None),
+    q: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> list[PolicyDocumentResponse]:
+    stmt = select(PolicyDocument).where(
+        PolicyDocument.org_id == org_id,
+        PolicyDocument.project_id == project_id,
+        PolicyDocument.deleted_at.is_(None),
+    )
+    if sprint_id is not None:
+        stmt = stmt.where(PolicyDocument.sprint_id == sprint_id)
+    if q:
+        search = f"%{q}%"
+        stmt = stmt.where(
+            or_(PolicyDocument.title.ilike(search), PolicyDocument.content.ilike(search))
+        )
+    stmt = stmt.order_by(PolicyDocument.updated_at.desc())
+    result = await session.execute(stmt)
+    docs = result.scalars().all()
+    return [PolicyDocumentResponse.model_validate(d) for d in docs]

--- a/backend/app/schemas/policy_document.py
+++ b/backend/app/schemas/policy_document.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PolicyDocumentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    sprint_id: uuid.UUID
+    epic_id: uuid.UUID
+    title: str
+    content: str
+    legacy_sprint_key: str | None = None
+    legacy_epic_key: str | None = None
+    created_by: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime

--- a/backend/tests/test_s37.py
+++ b/backend/tests/test_s37.py
@@ -1,0 +1,196 @@
+"""S37 AC: Policy Documents + Notification Settings 라우터 (7건 이상)."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+SPRINT_ID = uuid.uuid4()
+EPIC_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+DOC_ID = uuid.uuid4()
+
+
+def _mock_doc() -> MagicMock:
+    d = MagicMock()
+    d.id = DOC_ID
+    d.org_id = ORG_ID
+    d.project_id = PROJECT_ID
+    d.sprint_id = SPRINT_ID
+    d.epic_id = EPIC_ID
+    d.title = "S1 Policy"
+    d.content = "내용"
+    d.legacy_sprint_key = None
+    d.legacy_epic_key = None
+    d.created_by = MEMBER_ID
+    d.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    d.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    d.deleted_at = None
+    return d
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── Policy Documents ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_policy_docs_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_doc()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/policy-documents?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+        assert resp.json()[0]["title"] == "S1 Policy"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_policy_docs_empty_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/policy-documents?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_policy_docs_sprint_filter_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [_mock_doc()]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/policy-documents?project_id={PROJECT_ID}&sprint_id={SPRINT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["sprint_id"] == str(SPRINT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_policy_docs_q_filter_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/policy-documents?project_id={PROJECT_ID}&q=검색")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_policy_docs_missing_project_id_422():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/policy-documents")
+
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Notification Settings (S27에서 구현됨 — 회귀 확인) ───────────────────────
+
+@pytest.mark.anyio
+async def test_get_notification_settings_200():
+    client, session, app = await _client()
+    try:
+        with patch(
+            "app.repositories.notification.NotificationSettingRepository.get_by_member",
+            new_callable=AsyncMock
+        ) as mock_get:
+            mock_get.return_value = []
+
+            async with client as c:
+                resp = await c.get(f"/api/v2/notification-settings?member_id={MEMBER_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_put_notification_setting_200():
+    client, session, app = await _client()
+    try:
+        setting_mock = MagicMock()
+        setting_mock.id = uuid.uuid4()
+        setting_mock.org_id = ORG_ID
+        setting_mock.member_id = MEMBER_ID
+        setting_mock.channel = "in_app"
+        setting_mock.event_type = "story_assigned"
+        setting_mock.enabled = True
+
+        with patch(
+            "app.repositories.notification.NotificationSettingRepository.upsert",
+            new_callable=AsyncMock
+        ) as mock_upsert:
+            mock_upsert.return_value = setting_mock
+
+            async with client as c:
+                resp = await c.put(
+                    f"/api/v2/notification-settings?member_id={MEMBER_ID}",
+                    json={"channel": "in_app", "event_type": "story_assigned", "enabled": True},
+                )
+
+        assert resp.status_code == 200
+        assert resp.json()["channel"] == "in_app"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `PolicyDocument` 모델 신규 (policy_documents 테이블 — org_id/project_id/sprint_id/epic_id/title/content/deleted_at)
- `GET /api/v2/policy-documents?project_id=` (sprint_id/q 옵션 필터, 검색 포함)
- Notification Settings (GET/PUT `/api/v2/notification-settings`) — S27에서 이미 구현됨, 회귀 테스트 포함
- models/__init__.py에 PolicyDocument export 추가
- 테스트 7건 PASS (policy_docs 5건 + notification-settings 2건 회귀)

## Test plan
- [ ] `uv run pytest tests/test_s37.py` — 7건 PASS 확인
- [ ] GET /api/v2/policy-documents?project_id=&q= 검색 필터 확인
- [ ] GET/PUT /api/v2/notification-settings 회귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)