### PR TITLE
feat(backend): S38 Account Management + Subscription Status

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, tasks, team_members, webhooks
+from app.routers import account, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -48,6 +48,8 @@ app.include_router(webhooks.router)
 app.include_router(api_keys.router)
 app.include_router(agent_runs.router)
 app.include_router(policy_documents.router)
+app.include_router(subscription.router)
+app.include_router(account.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.agent_run import AgentRun
 from app.models.api_key import ApiKey
+from app.models.org_subscription import OrgSubscription
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
@@ -20,6 +21,7 @@ from app.models.team import TeamMember
 __all__ = [
     "AgentRun",
     "ApiKey",
+    "OrgSubscription",
     "PolicyDocument",
     "AuditLog",
     "WebhookConfig",

--- a/backend/app/models/org_subscription.py
+++ b/backend/app/models/org_subscription.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class OrgSubscription(Base):
+    __tablename__ = "org_subscriptions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, unique=True
+    )
+    polar_customer_id: Mapped[str] = mapped_column(Text, nullable=False)
+    polar_subscription_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    tier: Mapped[str] = mapped_column(Text, nullable=False, default="free")
+    billing_cycle: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    current_period_start: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    current_period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.schemas.subscription import AccountDeleteResponse
+
+router = APIRouter(prefix="/api/v2/account", tags=["account"])
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+@router.post("/delete", response_model=AccountDeleteResponse)
+async def delete_account(
+    user_id: uuid.UUID | None = None,
+    org_id: uuid.UUID = Depends(_get_org_id),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> AccountDeleteResponse:
+    now = datetime.now(timezone.utc).isoformat()
+    uid = user_id or auth.user_id
+
+    await session.execute(
+        text("UPDATE org_members SET deleted_at = :now WHERE user_id = :uid::uuid"),
+        {"now": now, "uid": str(uid)},
+    )
+    await session.execute(
+        text(
+            "UPDATE team_members SET deleted_at = :now, is_active = false, updated_at = :now"
+            " WHERE user_id = :uid::uuid"
+        ),
+        {"now": now, "uid": str(uid)},
+    )
+
+    return AccountDeleteResponse(ok=True, grace_period_days=30)

--- a/backend/app/routers/subscription.py
+++ b/backend/app/routers/subscription.py
@@ -1,0 +1,39 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.org_subscription import OrgSubscription
+from app.schemas.subscription import SubscriptionStatusResponse
+
+router = APIRouter(prefix="/api/v2/subscription", tags=["subscription"])
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+@router.get("/status", response_model=SubscriptionStatusResponse)
+async def get_subscription_status(
+    org_id: uuid.UUID = Depends(_get_org_id),
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> SubscriptionStatusResponse:
+    result = await session.execute(
+        select(OrgSubscription.status, OrgSubscription.tier, OrgSubscription.current_period_end).where(
+            OrgSubscription.org_id == org_id
+        )
+    )
+    row = result.first()
+    if row is None:
+        return SubscriptionStatusResponse(status="active", tier="free", grace_until=None)
+    return SubscriptionStatusResponse(status=row[0], tier=row[1], grace_until=row[2])

--- a/backend/app/schemas/subscription.py
+++ b/backend/app/schemas/subscription.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SubscriptionStatusResponse(BaseModel):
+    status: str
+    tier: str
+    grace_until: datetime | None = None
+
+
+class AccountDeleteResponse(BaseModel):
+    ok: bool
+    grace_period_days: int = 30

--- a/backend/tests/test_s38.py
+++ b/backend/tests/test_s38.py
@@ -1,0 +1,181 @@
+"""S38 AC: Account + Subscription Status 라우터 (7건 이상)."""
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(USER_ID)
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ── Subscription Status ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_subscription_status_200():
+    client, session, app = await _client()
+    try:
+        grace = datetime.now(timezone.utc) + timedelta(days=7)
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("active", "pro", grace)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/subscription/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+        assert resp.json()["tier"] == "pro"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_subscription_status_no_record_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.first.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/subscription/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "active"
+        assert resp.json()["tier"] == "free"
+        assert resp.json()["grace_until"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_subscription_status_grace_period_200():
+    client, session, app = await _client()
+    try:
+        grace = datetime.now(timezone.utc) + timedelta(days=3)
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("grace", "pro", grace)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/subscription/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "grace"
+        assert resp.json()["grace_until"] is not None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── Account Delete ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_account_delete_200():
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=MagicMock())
+
+        async with client as c:
+            resp = await c.post("/api/v2/account/delete")
+
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        assert resp.json()["grace_period_days"] == 30
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_account_delete_updates_org_and_team_members():
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=MagicMock())
+
+        async with client as c:
+            await c.post("/api/v2/account/delete")
+
+        assert session.execute.call_count == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_subscription_missing_org_id_400():
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(USER_ID)
+    ctx.email = "test@example.com"
+    ctx.claims = {}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        from httpx import ASGITransport, AsyncClient
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/subscription/status")
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_subscription_free_tier_default():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.first.return_value = ("active", "free", None)
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/subscription/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["tier"] == "free"
+        assert resp.json()["grace_until"] is None
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `OrgSubscription` 모델 신규 (org_subscriptions 테이블 — polar_customer_id/subscription_id/tier/status/billing_cycle/period)
- **Subscription** `GET /api/v2/subscription/status` — org 구독 상태 반환 (row 없으면 free/active 기본값)
- **Account** `POST /api/v2/account/delete` — org_members.deleted_at + team_members.deleted_at,is_active=false soft delete, 30일 유예
- models/__init__.py OrgSubscription export 추가
- 테스트 7건 PASS

## Test plan
- [ ] `uv run pytest tests/test_s38.py` — 7건 PASS 확인
- [ ] GET /api/v2/subscription/status org 없으면 free/active 기본값 확인
- [ ] POST /api/v2/account/delete org_members + team_members 2건 execute 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)