### PR TITLE
feat(test): S40 Sprint 6 통합 테스트

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -50,6 +50,7 @@ app.include_router(agent_runs.router)
 app.include_router(policy_documents.router)
 app.include_router(subscription.router)
 app.include_router(account.router)
+app.include_router(oss.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/routers/oss.py
+++ b/backend/app/routers/oss.py
@@ -1,0 +1,56 @@
+import os
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.pm import Story
+
+router = APIRouter(prefix="/api/v2/oss", tags=["oss"])
+
+_SAMPLE_STORIES = [
+    {"title": "SPR-1: GitHub Webhook 연동하기", "status": "backlog", "priority": "high"},
+    {"title": "SPR-2: 첫 번째 스프린트 계획", "status": "in-progress", "priority": "medium"},
+    {"title": "SPR-3: Hello Sprintable!", "status": "done", "priority": "low"},
+]
+
+
+@router.post("/seed")
+async def oss_seed(
+    project_id: uuid.UUID,
+    org_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    count_r = await session.execute(
+        select(func.count()).select_from(Story).where(
+            Story.project_id == project_id, Story.org_id == org_id, Story.deleted_at.is_(None)
+        )
+    )
+    if count_r.scalar_one() > 0:
+        return {"seeded": False, "reason": "already_has_data"}
+
+    for story_data in _SAMPLE_STORIES:
+        session.add(
+            Story(
+                project_id=project_id,
+                org_id=org_id,
+                title=story_data["title"],
+                status=story_data["status"],
+                priority=story_data["priority"],
+            )
+        )
+    await session.flush()
+
+    return {"seeded": True, "count": len(_SAMPLE_STORIES)}
+
+
+@router.get("/webhook-status")
+async def oss_webhook_status(
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    connected = bool(os.environ.get("GITHUB_WEBHOOK_SECRET"))
+    return {"connected": connected}

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -249,3 +249,136 @@ async def test_project_settings_get_via_conftest(test_client, mock_session, proj
     resp = await test_client.get(f"/api/v2/project-settings?project_id={project_id}")
     assert resp.status_code == 200
     assert resp.json()["standup_deadline"] == "09:00:00"
+
+
+# ── Sprint 6: S33~S39 도메인 통합 테스트 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dashboard_get_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/dashboard 200."""
+    import uuid as _uuid
+    member_id = _uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = project_id
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/dashboard?member_id={member_id}&project_id={project_id}")
+    assert resp.status_code == 200
+    assert "my_stories" in resp.json()
+
+
+@pytest.mark.anyio
+async def test_current_project_get_via_conftest(test_client, mock_session):
+    """GET /api/v2/current-project 200 (member 없으면 null)."""
+    import uuid as _uuid
+    member_id = _uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.first.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/current-project?member_id={member_id}")
+    assert resp.status_code == 200
+    assert resp.json()["project_id"] is None
+
+
+@pytest.mark.anyio
+async def test_members_list_via_conftest_s6(test_client, mock_session, project_id):
+    """GET /api/v2/members 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/members?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_webhooks_config_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/webhooks/config 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/webhooks/config")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_agent_keys_list_via_conftest(test_client, mock_session):
+    """GET /api/v2/agents/{id}/api-keys — agent 없으면 404."""
+    import uuid as _uuid
+    agent_id = _uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/agents/{agent_id}/api-keys")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_agent_runs_list_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/agent-runs 200."""
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/agent-runs?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_notification_settings_get_via_conftest_s6(test_client, mock_session):
+    """GET /api/v2/notification-settings 200."""
+    import uuid as _uuid
+    member_id = _uuid.uuid4()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/notification-settings?member_id={member_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_policy_documents_get_via_conftest(test_client, mock_session, project_id):
+    """GET /api/v2/policy-documents 200."""
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get(f"/api/v2/policy-documents?project_id={project_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+@pytest.mark.anyio
+async def test_subscription_status_via_conftest(test_client, mock_session):
+    """GET /api/v2/subscription/status 200 (기본값 반환)."""
+    mock_result = MagicMock()
+    mock_result.first.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    resp = await test_client.get("/api/v2/subscription/status")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "active"
+    assert resp.json()["tier"] == "free"
+
+
+@pytest.mark.anyio
+async def test_oss_seed_already_seeded_via_conftest(test_client, mock_session, project_id, org_id):
+    """POST /api/v2/oss/seed — 데이터 있으면 already_has_data 200."""
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = 3
+    mock_session.execute = AsyncMock(return_value=count_result)
+
+    resp = await test_client.post(f"/api/v2/oss/seed?project_id={project_id}&org_id={org_id}")
+    assert resp.status_code == 200
+    assert resp.json()["seeded"] is False
+    assert resp.json()["reason"] == "already_has_data"


### PR DESCRIPTION
## Summary
- `test_integration.py`에 Sprint 6 도메인 통합 테스트 10건 추가 (S33~S39):
  1. dashboard GET 200
  2. current-project GET 200 (member 없으면 null)
  3. members list GET 200
  4. webhooks/config GET 200
  5. agents/{id}/api-keys GET 404 (agent 없음)
  6. agent-runs GET 200
  7. notification-settings GET 200
  8. policy-documents GET 200
  9. subscription/status GET 200 (기본값 free/active)
  10. oss/seed POST 200 (already_has_data)
- S39 `oss.py` 포함 (S39 PR #317 미머지 상태)
- 전체 pytest: **232건 PASS, 회귀 0** ✅

## Test plan
- [ ] `uv run pytest tests/test_integration.py` — 30건 PASS (기존 20 + 신규 10)
- [ ] `uv run pytest` — 232건 전량 PASS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)