### PR TITLE
feat(backend): S41 Agent Deployments CRUD + Preflight + Verification 이관

### DIFF
--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -276,7 +276,7 @@ export function AgentDeploymentWizard({
     if (!deploymentId || !deploying) return;
     let cancelled = false;
     const timer = setInterval(async () => {
-      const response = await fetch(`/api/v1/agent-deployments/${deploymentId}`, { cache: 'no-store' });
+      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}`, { cache: 'no-store' });
       const json = await response.json();
       if (!response.ok) {
         if (!cancelled) {
@@ -338,7 +338,7 @@ export function AgentDeploymentWizard({
     setPreflightRunning(true);
     setFailureMessage(null);
     try {
-      const response = await fetch('/api/v1/agent-deployments/preflight', {
+      const response = await fetch('/api/v2/agent-deployments/preflight', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(deploymentPayload),
@@ -370,7 +370,7 @@ export function AgentDeploymentWizard({
     setFailureMessage(null);
     setDeploymentStatus('DEPLOYING');
     try {
-      const response = await fetch('/api/v1/agent-deployments', {
+      const response = await fetch('/api/v2/agent-deployments', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(deploymentPayload),
@@ -415,7 +415,7 @@ export function AgentDeploymentWizard({
     if (!deploymentId) return;
     setVerificationSubmitting(true);
     try {
-      const response = await fetch(`/api/v1/agent-deployments/${deploymentId}/verification`, {
+      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}/verification`, {
         method: 'POST',
       });
       const json = await response.json();

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -16,6 +16,7 @@ import { AgentDeploymentVerificationStep } from '@/components/agents/agent-deplo
 import { ANTHROPIC_MODELS, GOOGLE_MODELS, GROQ_MODELS, LLMProvider, OPENAI_MODELS } from '@/lib/llm/types';
 import type { ManagedAgentDeploymentVerification } from '@/lib/managed-agent-contract';
 import { buildAutomaticRoutingTemplate, resolveAutoRoutingPersonaRole, type AutoRoutingPersonaRole } from '@/services/agent-routing-template';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 export interface WizardAgent {
   id: string;
@@ -158,6 +159,12 @@ export function AgentDeploymentWizard({
   const [failureMessage, setFailureMessage] = useState<string | null>(null);
   const [overwriteRoutingRules, setOverwriteRoutingRules] = useState(false);
 
+  const getAuthHeaders = async (): Promise<Record<string, string>> => {
+    const supabase = createSupabaseBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
+  };
+
   const builtinPersonas = personas.filter((persona) => persona.is_builtin);
   const customPersonas = personas.filter((persona) => !persona.is_builtin);
   const selectedPersona = personas.find((persona) => persona.id === selectedPersonaId) ?? null;
@@ -276,7 +283,8 @@ export function AgentDeploymentWizard({
     if (!deploymentId || !deploying) return;
     let cancelled = false;
     const timer = setInterval(async () => {
-      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}`, { cache: 'no-store' });
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}`, { cache: 'no-store', headers: authHeaders });
       const json = await response.json();
       if (!response.ok) {
         if (!cancelled) {
@@ -338,9 +346,10 @@ export function AgentDeploymentWizard({
     setPreflightRunning(true);
     setFailureMessage(null);
     try {
+      const authHeaders = await getAuthHeaders();
       const response = await fetch('/api/v2/agent-deployments/preflight', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify(deploymentPayload),
       });
 
@@ -370,9 +379,10 @@ export function AgentDeploymentWizard({
     setFailureMessage(null);
     setDeploymentStatus('DEPLOYING');
     try {
+      const authHeaders = await getAuthHeaders();
       const response = await fetch('/api/v2/agent-deployments', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify(deploymentPayload),
       });
 
@@ -415,8 +425,10 @@ export function AgentDeploymentWizard({
     if (!deploymentId) return;
     setVerificationSubmitting(true);
     try {
+      const authHeaders = await getAuthHeaders();
       const response = await fetch(`/api/v2/agent-deployments/${deploymentId}/verification`, {
         method: 'POST',
+        headers: authHeaders,
       });
       const json = await response.json();
       if (!response.ok) {

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -154,7 +154,7 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
   const fetchDeployments = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      const res = await fetch('/api/v1/agent-deployments');
+      const res = await fetch('/api/v2/agent-deployments');
       if (!res.ok) return;
       const json = await res.json() as { data: AgentDeploymentCard[] | null };
       if (json.data) {
@@ -203,7 +203,7 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
     if (!pendingAction) return;
     setTransitioning(true);
     try {
-      const res = await fetch(`/api/v1/agent-deployments/${pendingAction.deploymentId}`, {
+      const res = await fetch(`/api/v2/agent-deployments/${pendingAction.deploymentId}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: pendingAction.targetStatus }),

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/dialog';
 import { getDeploymentHealthState, getDeploymentRecoveryCueKeys, hasActiveFailureSignal } from '@/services/agent-deployment-console';
 import { getTriggerMemoHref } from '@/services/agent-run-history';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 export interface AgentDeploymentCard {
   id: string;
@@ -150,11 +151,18 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
     }
   }, [addToast]);
 
+  const getAuthHeaders = async (): Promise<Record<string, string>> => {
+    const supabase = createSupabaseBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
+  };
+
   // Auto-refresh polling
   const fetchDeployments = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      const res = await fetch('/api/v2/agent-deployments');
+      const authHeaders = await getAuthHeaders();
+      const res = await fetch('/api/v2/agent-deployments', { headers: authHeaders });
       if (!res.ok) return;
       const json = await res.json() as { data: AgentDeploymentCard[] | null };
       if (json.data) {
@@ -203,9 +211,10 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
     if (!pendingAction) return;
     setTransitioning(true);
     try {
+      const authHeaders = await getAuthHeaders();
       const res = await fetch(`/api/v2/agent-deployments/${pendingAction.deploymentId}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({ status: pendingAction.targetStatus }),
       });
       if (!res.ok) {

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -51,6 +51,7 @@ app.include_router(policy_documents.router)
 app.include_router(subscription.router)
 app.include_router(account.router)
 app.include_router(oss.router)
+app.include_router(agent_deployments.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
 from app.models.agent_run import AgentRun
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
@@ -19,6 +20,9 @@ from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 
 __all__ = [
+    "AgentAuditLog",
+    "AgentDeployment",
+    "AgentPersona",
     "AgentRun",
     "ApiKey",
     "OrgSubscription",

--- a/backend/app/models/agent_deployment.py
+++ b/backend/app/models/agent_deployment.py
@@ -1,0 +1,67 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentDeployment(Base):
+    __tablename__ = "agent_deployments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    persona_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    runtime: Mapped[str] = mapped_column(Text, nullable=False, default="webhook")
+    model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="DEPLOYING")
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    last_deployed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    failure_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_detail: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    failed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AgentPersona(Base):
+    __tablename__ = "agent_personas"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    is_builtin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class AgentAuditLog(Base):
+    __tablename__ = "agent_audit_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    severity: Mapped[str] = mapped_column(Text, nullable=False, default="info")
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -15,8 +15,14 @@ class AgentRun(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
+    )
     agent_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    deployment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
     )
     story_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
@@ -31,11 +37,19 @@ class AgentRun(Base):
     cost_usd: Mapped[float | None] = mapped_column(Numeric(10, 6), nullable=True)
     status: Mapped[str] = mapped_column(Text, nullable=False, default="running")
     result_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
     duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
     last_error_code: Mapped[str | None] = mapped_column(Text, nullable=True)
     failure_disposition: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_retries: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     llm_call_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     run_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/agent_deployments.py
+++ b/backend/app/routers/agent_deployments.py
@@ -1,0 +1,187 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.schemas.agent_deployment import (
+    AgentDeploymentResponse,
+    CreateDeploymentRequest,
+    PatchDeploymentRequest,
+)
+from app.services.deployment_lifecycle import DeploymentLifecycleError, DeploymentLifecycleService
+
+router = APIRouter(prefix="/api/v2/agent-deployments", tags=["agent-deployments"])
+
+
+def _svc(session: AsyncSession = Depends(get_db)) -> DeploymentLifecycleService:
+    return DeploymentLifecycleService(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int, details: dict | None = None) -> JSONResponse:
+    error: dict = {"code": code, "message": message}
+    if details:
+        error["details"] = details
+    return JSONResponse({"data": None, "error": error, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID, uuid.UUID]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("")
+async def list_deployment_cards(
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    cards = await svc.build_cards(org_id, project_id, requested_for_member_id=auth.user_id)
+    return _ok([c.model_dump() for c in cards])
+
+
+@router.post("")
+async def create_deployment(
+    body: CreateDeploymentRequest,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        result = await svc.create_deployment(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=body.agent_id,
+            actor_id=uuid.UUID(auth.user_id),
+            name=body.name,
+            runtime=body.runtime,
+            model=body.model,
+            version=body.version,
+            persona_id=body.persona_id,
+            config=body.config,
+            overwrite_routing_rules=body.overwrite_routing_rules,
+        )
+        return _ok(result.model_dump(mode="json"), status=202)
+    except DeploymentLifecycleError as e:
+        return _err(e.code, str(e), e.status, e.details or None)
+
+
+@router.post("/preflight")
+async def run_preflight(
+    body: CreateDeploymentRequest,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    preflight = await svc.run_deployment_preflight(
+        org_id=org_id,
+        project_id=project_id,
+        agent_id=body.agent_id,
+        name=body.name,
+        runtime=body.runtime,
+        model=body.model,
+        version=body.version,
+        persona_id=body.persona_id,
+        config=body.config,
+        overwrite_routing_rules=body.overwrite_routing_rules,
+        actor_id=uuid.UUID(auth.user_id),
+    )
+    return _ok({"preflight": preflight.model_dump(mode="json")})
+
+
+@router.get("/{id}")
+async def get_deployment(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        dep = await svc._get_deployment(org_id, project_id, id)
+        return _ok(AgentDeploymentResponse.model_validate(dep).model_dump(mode="json"))
+    except DeploymentLifecycleError as e:
+        return _err(e.code, str(e), e.status)
+
+
+@router.patch("/{id}")
+async def patch_deployment(
+    id: uuid.UUID,
+    body: PatchDeploymentRequest,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        result = await svc.transition_deployment(
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=uuid.UUID(auth.user_id),
+            deployment_id=id,
+            status=body.status,
+            failure=body.failure,
+        )
+        return _ok(result.model_dump(mode="json"))
+    except DeploymentLifecycleError as e:
+        return _err(e.code, str(e), e.status)
+
+
+@router.delete("/{id}")
+async def delete_deployment(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        result = await svc.terminate_deployment(
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=uuid.UUID(auth.user_id),
+            deployment_id=id,
+        )
+        return _ok(result.model_dump(mode="json"))
+    except DeploymentLifecycleError as e:
+        return _err(e.code, str(e), e.status)
+
+
+@router.post("/{id}/verification")
+async def complete_verification(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    svc: DeploymentLifecycleService = Depends(_svc),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        dep = await svc.complete_verification(
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=uuid.UUID(auth.user_id),
+            deployment_id=id,
+        )
+        return _ok({"deployment": dep.model_dump(mode="json")})
+    except DeploymentLifecycleError as e:
+        return _err(e.code, str(e), e.status)

--- a/backend/app/schemas/agent_deployment.py
+++ b/backend/app/schemas/agent_deployment.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AgentDeploymentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    agent_id: uuid.UUID
+    persona_id: uuid.UUID | None
+    name: str
+    runtime: str
+    model: str | None
+    version: str | None
+    status: str
+    config: dict[str, Any]
+    last_deployed_at: datetime | None
+    failure_code: str | None
+    failure_message: str | None
+    failure_detail: dict[str, Any] | None
+    failed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DeploymentFailureInput(BaseModel):
+    code: str
+    message: str
+    detail: dict[str, Any] | None = None
+
+
+class CreateDeploymentRequest(BaseModel):
+    agent_id: uuid.UUID
+    name: str
+    runtime: str | None = None
+    model: str | None = None
+    version: str | None = None
+    persona_id: uuid.UUID | None = None
+    config: dict[str, Any] | None = None
+    overwrite_routing_rules: bool | None = None
+
+
+class PatchDeploymentRequest(BaseModel):
+    status: str
+    failure: DeploymentFailureInput | None = None
+
+
+class DeploymentMutationResponse(BaseModel):
+    deployment: AgentDeploymentResponse
+    queue_held_count: int
+    queue_resumed_count: int
+    queue_failed_count: int
+
+
+class DeploymentPreflightResponse(BaseModel):
+    ok: bool
+    checked_at: str
+    blocking_reasons: list[str]
+    warnings: list[str]
+    routing_template_id: str
+    routing_rule_count: int
+    existing_routing_rule_count: int
+    requires_routing_overwrite_confirmation: bool
+    mcp_validation_errors: list[str]
+
+
+class DeploymentPreflightWrapperResponse(BaseModel):
+    preflight: DeploymentPreflightResponse
+
+
+class DeploymentVerificationResponse(BaseModel):
+    deployment: AgentDeploymentResponse
+
+
+class DeploymentFailureSignal(BaseModel):
+    run_id: str
+    memo_id: str | None
+    failed_at: str
+    error_message: str | None
+    last_error_code: str | None
+    result_summary: str | None
+    failure_disposition: str | None
+    next_retry_at: str | None
+    can_manual_retry: bool
+
+
+class DeploymentCardResponse(BaseModel):
+    id: str
+    name: str
+    status: str
+    model: str | None
+    runtime: str
+    agent_name: str
+    persona_name: str | None
+    updated_at: str
+    last_run_at: str | None
+    latest_successful_run_at: str | None
+    executions_today: int
+    tokens_today: int
+    pending_hitl_count: int
+    next_hitl_deadline_at: str | None
+    latest_failed_run: DeploymentFailureSignal | None

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -1,0 +1,839 @@
+"""Agent deployment lifecycle service — S41 FastAPI port."""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
+from app.models.agent_run import AgentRun
+from app.models.team import TeamMember
+from app.models.webhook_config import WebhookConfig
+from app.schemas.agent_deployment import (
+    AgentDeploymentResponse,
+    DeploymentCardResponse,
+    DeploymentFailureInput,
+    DeploymentFailureSignal,
+    DeploymentMutationResponse,
+    DeploymentPreflightResponse,
+)
+
+ACTIVE_STATUSES = ("DEPLOYING", "ACTIVE", "SUSPENDED")
+TRANSITIONS: dict[str, list[str]] = {
+    "DEPLOYING": ["ACTIVE", "SUSPENDED", "DEPLOY_FAILED", "TERMINATED"],
+    "ACTIVE": ["SUSPENDED", "DEPLOY_FAILED", "TERMINATED"],
+    "SUSPENDED": ["ACTIVE", "DEPLOY_FAILED", "TERMINATED"],
+    "DEPLOY_FAILED": ["DEPLOYING", "TERMINATED"],
+    "TERMINATED": [],
+}
+
+
+class DeploymentLifecycleError(Exception):
+    def __init__(self, code: str, status: int, message: str, details: dict | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+        self.details = details or {}
+
+
+# ---------------------------------------------------------------------------
+# Webhook dispatch
+# ---------------------------------------------------------------------------
+
+def _build_signature_headers(secret: str | None, body: str) -> dict[str, str]:
+    if not secret:
+        return {}
+    ts = str(int(time.time() * 1000))
+    sig = hmac.new(secret.encode(), f"{ts}.{body}".encode(), hashlib.sha256).hexdigest()
+    return {
+        "X-Sprintable-Signature": f"sha256={sig}",
+        "X-Sprintable-Timestamp": ts,
+    }
+
+
+async def _fire_webhooks(session: AsyncSession, org_id: uuid.UUID, event: str, data: dict[str, Any]) -> None:
+    result = await session.execute(
+        select(WebhookConfig.url, WebhookConfig.secret, WebhookConfig.events)
+        .where(WebhookConfig.org_id == org_id, WebhookConfig.is_active.is_(True))
+    )
+    configs = result.all()
+    if not configs:
+        return
+
+    payload_obj = {"event": event, "data": data}
+    body = json.dumps(payload_obj)
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        for row in configs:
+            url, secret, events = row
+            if events and event not in events:
+                continue
+            headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
+            try:
+                await client.post(url, content=body, headers=headers)
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Routing template helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_persona_role(slug: str | None, base_slug: str | None) -> str:
+    val = (base_slug or slug or "").strip().lower()
+    if val == "product-owner":
+        return "product-owner"
+    if val == "developer":
+        return "developer"
+    if val == "qa":
+        return "qa"
+    return "unknown"
+
+
+def _build_routing_template(agents: list[dict], existing_rule_count: int) -> dict[str, Any]:
+    seen: set[str] = set()
+    deduped = []
+    for a in agents:
+        if a["agentId"] not in seen:
+            seen.add(a["agentId"])
+            deduped.append(a)
+
+    po = next((a for a in deduped if a["role"] == "product-owner"), None)
+    dev = next((a for a in deduped if a["role"] == "developer"), None)
+    qa = next((a for a in deduped if a["role"] == "qa"), None)
+
+    if len(deduped) <= 1 and dev:
+        return {"templateId": "solo-dev", "rules": [], "requiresOverwriteConfirmation": False, "existingRuleCount": existing_rule_count}
+
+    if not po or not dev:
+        return {"templateId": "none", "rules": [], "requiresOverwriteConfirmation": False, "existingRuleCount": existing_rule_count}
+
+    template_id = "po-dev-qa" if qa else "po-dev"
+    roles = ["product-owner", "developer", "qa"] if qa else ["product-owner", "developer"]
+    meta: dict[str, Any] = {"auto_generated": True, "template_id": template_id, "generated_from_roles": roles}
+    rules = [
+        {"agent_id": str(po["agentId"]), "persona_id": po.get("personaId"), "deployment_id": po.get("deploymentId"), "name": f"{po['agentName']} auto route requirement/user_story", "priority": 10, "match_type": "event", "conditions": {"memo_type": ["requirement", "user_story"]}, "action": {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}, "target_runtime": "openclaw", "target_model": None, "is_enabled": True, "metadata": meta},
+        {"agent_id": str(dev["agentId"]), "persona_id": dev.get("personaId"), "deployment_id": dev.get("deploymentId"), "name": f"{dev['agentName']} auto route task/dev_task", "priority": 20, "match_type": "event", "conditions": {"memo_type": ["task", "dev_task"]}, "action": {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}, "target_runtime": "openclaw", "target_model": None, "is_enabled": True, "metadata": meta},
+    ]
+    if qa:
+        rules.append({"agent_id": str(qa["agentId"]), "persona_id": qa.get("personaId"), "deployment_id": qa.get("deploymentId"), "name": f"{qa['agentName']} auto route review", "priority": 30, "match_type": "event", "conditions": {"memo_type": ["review"]}, "action": {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}, "target_runtime": "openclaw", "target_model": None, "is_enabled": True, "metadata": meta})
+
+    return {"templateId": template_id, "rules": rules, "requiresOverwriteConfirmation": existing_rule_count > 0, "existingRuleCount": existing_rule_count}
+
+
+async def _replace_routing_rules(session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, actor_id: uuid.UUID, rules: list[dict]) -> None:
+    await session.execute(
+        text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, :rules::jsonb)"),
+        {
+            "org_id": str(org_id),
+            "project_id": str(project_id),
+            "actor_id": str(actor_id),
+            "rules": json.dumps(rules),
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main service
+# ---------------------------------------------------------------------------
+
+class DeploymentLifecycleService:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def _get_agent(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID) -> TeamMember:
+        r = await self.session.execute(
+            select(TeamMember).where(
+                TeamMember.id == agent_id,
+                TeamMember.org_id == org_id,
+                TeamMember.project_id == project_id,
+                TeamMember.type == "agent",
+            )
+        )
+        agent = r.scalar_one_or_none()
+        if not agent:
+            raise DeploymentLifecycleError("AGENT_NOT_FOUND", 404, "Agent not found in current project")
+        return agent
+
+    async def _get_deployment(self, org_id: uuid.UUID, project_id: uuid.UUID, deployment_id: uuid.UUID) -> AgentDeployment:
+        r = await self.session.execute(
+            select(AgentDeployment).where(
+                AgentDeployment.id == deployment_id,
+                AgentDeployment.org_id == org_id,
+                AgentDeployment.project_id == project_id,
+                AgentDeployment.deleted_at.is_(None),
+            )
+        )
+        dep = r.scalar_one_or_none()
+        if not dep:
+            raise DeploymentLifecycleError("DEPLOYMENT_NOT_FOUND", 404, "Deployment not found in current project")
+        return dep
+
+    async def _get_persona(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID, persona_id: uuid.UUID) -> AgentPersona:
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.id == persona_id,
+                AgentPersona.org_id == org_id,
+                AgentPersona.deleted_at.is_(None),
+            )
+        )
+        persona = r.scalar_one_or_none()
+        if not persona:
+            raise DeploymentLifecycleError("PERSONA_NOT_FOUND", 404, "Persona not found in the current organization")
+        if persona.is_builtin and (persona.project_id != project_id or persona.agent_id != agent_id):
+            raise DeploymentLifecycleError("PERSONA_NOT_FOUND", 404, "Persona not found for this agent in the current project")
+        return persona
+
+    async def _assert_no_duplicate_live(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID, exclude_id: uuid.UUID | None = None) -> None:
+        q = select(AgentDeployment.id).where(
+            AgentDeployment.org_id == org_id,
+            AgentDeployment.project_id == project_id,
+            AgentDeployment.agent_id == agent_id,
+            AgentDeployment.deleted_at.is_(None),
+            AgentDeployment.status.in_(ACTIVE_STATUSES),
+        )
+        if exclude_id:
+            q = q.where(AgentDeployment.id != exclude_id)
+        r = await self.session.execute(q)
+        if r.scalar_one_or_none():
+            raise DeploymentLifecycleError("DUPLICATE_AGENT_DEPLOYMENT", 409, "A live deployment already exists for this agent in the current project")
+
+    async def _count_routing_rules(self, org_id: uuid.UUID, project_id: uuid.UUID) -> int:
+        r = await self.session.execute(
+            text("SELECT COUNT(*) FROM agent_routing_rules WHERE org_id = :org_id AND project_id = :project_id AND deleted_at IS NULL"),
+            {"org_id": str(org_id), "project_id": str(project_id)},
+        )
+        return r.scalar_one() or 0
+
+    async def _list_live_deployments(self, org_id: uuid.UUID, project_id: uuid.UUID) -> list[AgentDeployment]:
+        r = await self.session.execute(
+            select(AgentDeployment).where(
+                AgentDeployment.org_id == org_id,
+                AgentDeployment.project_id == project_id,
+                AgentDeployment.deleted_at.is_(None),
+                AgentDeployment.status.in_(ACTIVE_STATUSES),
+            )
+        )
+        return list(r.scalars().all())
+
+    async def _preview_routing_template(self, org_id: uuid.UUID, project_id: uuid.UUID, pending_agent: dict) -> dict[str, Any]:
+        live = await self._list_live_deployments(org_id, project_id)
+        rule_count = await self._count_routing_rules(org_id, project_id)
+
+        agent_ids = {d.agent_id for d in live}
+        persona_ids = {d.persona_id for d in live if d.persona_id}
+        if pending_agent.get("personaId"):
+            persona_ids.add(uuid.UUID(str(pending_agent["personaId"])))
+
+        agent_name_by_id: dict[uuid.UUID, str] = {}
+        if agent_ids:
+            r = await self.session.execute(
+                select(TeamMember.id, TeamMember.name).where(TeamMember.id.in_(agent_ids))
+            )
+            agent_name_by_id = {row.id: row.name for row in r.all()}
+
+        persona_by_id: dict[uuid.UUID, AgentPersona] = {}
+        if persona_ids:
+            r2 = await self.session.execute(
+                select(AgentPersona).where(AgentPersona.id.in_(persona_ids), AgentPersona.deleted_at.is_(None))
+            )
+            persona_by_id = {p.id: p for p in r2.scalars().all()}
+
+        def _get_base_persona_id(persona: AgentPersona | None) -> uuid.UUID | None:
+            if not persona or not isinstance(persona.config, dict):
+                return None
+            bpid = persona.config.get("base_persona_id")
+            if isinstance(bpid, str) and bpid.strip():
+                try:
+                    return uuid.UUID(bpid)
+                except ValueError:
+                    return None
+            return None
+
+        base_persona_ids = {_get_base_persona_id(p) for p in persona_by_id.values() if _get_base_persona_id(p)}
+        base_persona_by_id: dict[uuid.UUID, AgentPersona] = {}
+        if base_persona_ids:
+            r3 = await self.session.execute(
+                select(AgentPersona).where(AgentPersona.id.in_(base_persona_ids), AgentPersona.deleted_at.is_(None))
+            )
+            base_persona_by_id = {p.id: p for p in r3.scalars().all()}
+
+        def _resolve_role(dep_persona_id: uuid.UUID | None) -> str:
+            persona = persona_by_id.get(dep_persona_id) if dep_persona_id else None
+            base_pid = _get_base_persona_id(persona)
+            base_persona = base_persona_by_id.get(base_pid) if base_pid else None
+            return _resolve_persona_role(
+                persona.slug if persona else None,
+                base_persona.slug if base_persona else None,
+            )
+
+        agents = [
+            {
+                "agentId": str(d.agent_id),
+                "agentName": agent_name_by_id.get(d.agent_id, str(d.agent_id)),
+                "role": _resolve_role(d.persona_id),
+                "personaId": str(d.persona_id) if d.persona_id else None,
+                "deploymentId": str(d.id),
+            }
+            for d in live
+        ]
+        agents.append(pending_agent)
+
+        return _build_routing_template(agents, rule_count)
+
+    async def _log_audit(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID, event_type: str, severity: str, payload: dict) -> None:
+        log = AgentAuditLog(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            event_type=event_type,
+            severity=severity,
+            summary=event_type,
+            payload=payload,
+        )
+        self.session.add(log)
+        await self.session.flush()
+
+    async def _hold_queued_runs(self, deployment_id: uuid.UUID) -> int:
+        r = await self.session.execute(
+            update(AgentRun)
+            .where(AgentRun.deployment_id == deployment_id, AgentRun.status == "queued")
+            .values(status="held", result_summary="Queued run held while deployment is suspended")
+            .returning(AgentRun.id)
+        )
+        return len(r.all())
+
+    async def _resume_held_runs(self, deployment_id: uuid.UUID) -> int:
+        r = await self.session.execute(
+            update(AgentRun)
+            .where(AgentRun.deployment_id == deployment_id, AgentRun.status == "held")
+            .values(status="queued", result_summary="Queued run resumed after deployment activation")
+            .returning(AgentRun.id)
+        )
+        return len(r.all())
+
+    async def _fail_queued_runs(self, deployment_id: uuid.UUID, error_code: str, message: str) -> int:
+        now = datetime.now(timezone.utc)
+        r = await self.session.execute(
+            update(AgentRun)
+            .where(AgentRun.deployment_id == deployment_id, AgentRun.status.in_(["queued", "held"]))
+            .values(status="failed", last_error_code=error_code, result_summary=message, finished_at=now)
+            .returning(AgentRun.id)
+        )
+        return len(r.all())
+
+    async def run_deployment_preflight(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        name: str,
+        runtime: str | None,
+        model: str | None,
+        version: str | None,
+        persona_id: uuid.UUID | None,
+        config: dict | None,
+        overwrite_routing_rules: bool | None,
+        actor_id: uuid.UUID,
+    ) -> DeploymentPreflightResponse:
+        checked_at = datetime.now(timezone.utc).isoformat()
+        blocking_reasons: list[str] = []
+        warnings: list[str] = []
+        routing_preview: dict[str, Any] = {"templateId": "none", "rules": [], "requiresOverwriteConfirmation": False, "existingRuleCount": 0}
+
+        try:
+            agent = await self._get_agent(org_id, project_id, agent_id)
+            if not agent.is_active:
+                blocking_reasons.append("Cannot deploy to an inactive agent")
+
+            persona = None
+            if persona_id:
+                try:
+                    persona = await self._get_persona(org_id, project_id, agent_id, persona_id)
+                except DeploymentLifecycleError as e:
+                    blocking_reasons.append(str(e))
+
+            persona_slug = persona.slug if persona else None
+            persona_role = _resolve_persona_role(persona_slug, None)
+
+            routing_preview = await self._preview_routing_template(org_id, project_id, {
+                "agentId": str(agent_id),
+                "agentName": agent.name,
+                "role": persona_role,
+                "personaId": str(persona_id) if persona_id else None,
+                "deploymentId": None,
+            })
+
+            if routing_preview["rules"] and routing_preview["requiresOverwriteConfirmation"] and not overwrite_routing_rules:
+                blocking_reasons.append("Existing routing rules require explicit overwrite confirmation before applying an automatic template")
+
+            try:
+                await self._assert_no_duplicate_live(org_id, project_id, agent_id)
+            except DeploymentLifecycleError as e:
+                blocking_reasons.append(str(e))
+
+        except DeploymentLifecycleError as e:
+            blocking_reasons.append(str(e))
+
+        return DeploymentPreflightResponse(
+            ok=len(blocking_reasons) == 0,
+            checked_at=checked_at,
+            blocking_reasons=blocking_reasons,
+            warnings=warnings,
+            routing_template_id=routing_preview.get("templateId", "none"),
+            routing_rule_count=len(routing_preview.get("rules", [])),
+            existing_routing_rule_count=routing_preview.get("existingRuleCount", 0),
+            requires_routing_overwrite_confirmation=routing_preview.get("requiresOverwriteConfirmation", False),
+            mcp_validation_errors=[],
+        )
+
+    async def create_deployment(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        name: str,
+        runtime: str | None = None,
+        model: str | None = None,
+        version: str | None = None,
+        persona_id: uuid.UUID | None = None,
+        config: dict | None = None,
+        overwrite_routing_rules: bool | None = None,
+    ) -> DeploymentMutationResponse:
+        preflight = await self.run_deployment_preflight(
+            org_id=org_id, project_id=project_id, agent_id=agent_id,
+            name=name, runtime=runtime, model=model, version=version,
+            persona_id=persona_id, config=config,
+            overwrite_routing_rules=overwrite_routing_rules, actor_id=actor_id,
+        )
+        if not preflight.ok:
+            raise DeploymentLifecycleError(
+                "DEPLOYMENT_PREFLIGHT_FAILED", 409,
+                "Resolve preflight issues before deploying",
+                {"preflight": preflight.model_dump()},
+            )
+
+        agent = await self._get_agent(org_id, project_id, agent_id)
+        if not agent.is_active:
+            raise DeploymentLifecycleError("AGENT_INACTIVE", 409, "Cannot deploy to an inactive agent")
+
+        deployment_config = config or {
+            "schema_version": 1,
+            "llm_mode": "managed",
+            "provider": "openai",
+            "scope_mode": "projects",
+            "project_ids": [str(project_id)],
+            "verification": {"status": "pending", "required_checkpoints": ["dashboard_active", "routing_reviewed", "mcp_reviewed"]},
+        }
+
+        dep = AgentDeployment(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            persona_id=persona_id,
+            name=name,
+            runtime=runtime or "webhook",
+            model=model,
+            version=version,
+            status="DEPLOYING",
+            config=deployment_config,
+            created_by=actor_id,
+            failure_code=None,
+            failure_message=None,
+            failure_detail=None,
+            failed_at=None,
+        )
+        self.session.add(dep)
+        await self.session.flush()
+        await self.session.refresh(dep)
+
+        try:
+            persona = await self._get_persona(org_id, project_id, agent_id, persona_id) if persona_id else None
+            persona_slug = persona.slug if persona else None
+            persona_role = _resolve_persona_role(persona_slug, None)
+
+            routing_preview = await self._preview_routing_template(org_id, project_id, {
+                "agentId": str(agent_id),
+                "agentName": agent.name,
+                "role": persona_role,
+                "personaId": str(persona_id) if persona_id else None,
+                "deploymentId": str(dep.id),
+            })
+
+            if routing_preview["rules"]:
+                await _replace_routing_rules(self.session, org_id, project_id, actor_id, routing_preview["rules"])
+
+            await self._log_audit(org_id, project_id, agent_id, "agent_deployment.initializing", "info", {
+                "deployment_id": str(dep.id),
+                "actor_id": str(actor_id),
+                "runtime": dep.runtime,
+                "model": dep.model,
+            })
+
+            await _fire_webhooks(self.session, org_id, "agent_deployment.initializing", {
+                "deployment_id": str(dep.id),
+                "org_id": str(org_id),
+                "project_id": str(project_id),
+                "agent_id": str(agent_id),
+                "actor_id": str(actor_id),
+                "status": dep.status,
+                "runtime": dep.runtime,
+                "model": dep.model,
+                "version": dep.version,
+            })
+
+            return await self.transition_deployment(org_id, project_id, actor_id, dep.id, "ACTIVE", None)
+
+        except Exception as e:
+            code = e.code.lower() if isinstance(e, DeploymentLifecycleError) else "deployment_activation_failed"
+            msg = str(e) if isinstance(e, DeploymentLifecycleError) else "Managed deployment activation failed"
+            return await self.transition_deployment(
+                org_id, project_id, actor_id, dep.id, "DEPLOY_FAILED",
+                DeploymentFailureInput(code=code, message=msg, detail={"error": str(e)}),
+            )
+
+    async def transition_deployment(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        deployment_id: uuid.UUID,
+        status: str,
+        failure: DeploymentFailureInput | None,
+    ) -> DeploymentMutationResponse:
+        dep = await self._get_deployment(org_id, project_id, deployment_id)
+        previous_status = dep.status
+
+        if status not in TRANSITIONS.get(previous_status, []):
+            raise DeploymentLifecycleError(
+                "INVALID_DEPLOYMENT_TRANSITION", 409,
+                f"Cannot transition deployment from {previous_status} to {status}",
+            )
+
+        if status in ACTIVE_STATUSES:
+            await self._assert_no_duplicate_live(org_id, project_id, dep.agent_id, dep.id)
+
+        now = datetime.now(timezone.utc)
+        queue_held = 0
+        queue_resumed = 0
+        queue_failed = 0
+
+        if status == "SUSPENDED":
+            queue_held = await self._hold_queued_runs(dep.id)
+
+        if status == "ACTIVE" and previous_status == "SUSPENDED":
+            queue_resumed = await self._resume_held_runs(dep.id)
+
+        if status == "DEPLOY_FAILED":
+            queue_failed = await self._fail_queued_runs(dep.id, "deployment_failed", "Queued run cancelled because deployment failed")
+
+        patch: dict[str, Any] = {"status": status, "updated_at": now}
+        if status == "ACTIVE":
+            patch["last_deployed_at"] = now
+            patch["failure_code"] = None
+            patch["failure_message"] = None
+            patch["failure_detail"] = None
+            patch["failed_at"] = None
+        if status == "SUSPENDED":
+            patch["failure_code"] = None
+            patch["failure_message"] = None
+            patch["failure_detail"] = None
+            patch["failed_at"] = None
+        if status == "DEPLOY_FAILED":
+            f = failure or DeploymentFailureInput(code="deployment_failed", message="Deployment failed")
+            patch["failure_code"] = f.code
+            patch["failure_message"] = f.message
+            patch["failure_detail"] = f.detail or {}
+            patch["failed_at"] = now
+
+        await self.session.execute(
+            update(AgentDeployment).where(AgentDeployment.id == dep.id).values(**patch)
+        )
+        await self.session.flush()
+        await self.session.refresh(dep)
+
+        event_map = {
+            "ACTIVE": "agent_deployment.resumed" if previous_status == "SUSPENDED" else "agent_deployment.activated",
+            "SUSPENDED": "agent_deployment.suspended",
+            "DEPLOY_FAILED": "agent_deployment.deploy_failed",
+            "TERMINATED": "agent_deployment.terminated",
+        }
+        event = event_map.get(status, "agent_deployment.updated")
+        severity = "error" if status == "DEPLOY_FAILED" else "warn" if status == "TERMINATED" else "info"
+
+        await self._log_audit(org_id, project_id, dep.agent_id, event, severity, {
+            "deployment_id": str(dep.id),
+            "actor_id": str(actor_id),
+            "from_status": previous_status,
+            "to_status": status,
+            "queue_held_count": queue_held,
+            "queue_resumed_count": queue_resumed,
+            "queue_failed_count": queue_failed,
+            "failure_code": failure.code if failure else None,
+            "failure_message": failure.message if failure else None,
+        })
+
+        await _fire_webhooks(self.session, org_id, event, {
+            "deployment_id": str(dep.id),
+            "org_id": str(org_id),
+            "project_id": str(project_id),
+            "agent_id": str(dep.agent_id),
+            "actor_id": str(actor_id),
+            "from_status": previous_status,
+            "status": status,
+            "queue_held_count": queue_held,
+            "queue_resumed_count": queue_resumed,
+            "queue_failed_count": queue_failed,
+        })
+
+        return DeploymentMutationResponse(
+            deployment=AgentDeploymentResponse.model_validate(dep),
+            queue_held_count=queue_held,
+            queue_resumed_count=queue_resumed,
+            queue_failed_count=queue_failed,
+        )
+
+    async def terminate_deployment(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        deployment_id: uuid.UUID,
+    ) -> DeploymentMutationResponse:
+        dep = await self._get_deployment(org_id, project_id, deployment_id)
+        previous_status = dep.status
+
+        if "TERMINATED" not in TRANSITIONS.get(previous_status, []):
+            raise DeploymentLifecycleError(
+                "INVALID_DEPLOYMENT_TRANSITION", 409,
+                f"Cannot transition deployment from {previous_status} to TERMINATED",
+            )
+
+        now = datetime.now(timezone.utc)
+        queue_failed = await self._fail_queued_runs(dep.id, "deployment_terminated", "Queued run cancelled because deployment was terminated")
+
+        await self.session.execute(
+            update(AgentDeployment).where(AgentDeployment.id == dep.id).values(
+                status="TERMINATED", deleted_at=now, updated_at=now
+            )
+        )
+        await self.session.flush()
+        await self.session.refresh(dep)
+
+        await self._log_audit(org_id, project_id, dep.agent_id, "agent_deployment.terminated", "warn", {
+            "deployment_id": str(dep.id),
+            "actor_id": str(actor_id),
+            "from_status": previous_status,
+            "to_status": "TERMINATED",
+            "queue_failed_count": queue_failed,
+        })
+
+        await _fire_webhooks(self.session, org_id, "agent_deployment.terminated", {
+            "deployment_id": str(dep.id),
+            "org_id": str(org_id),
+            "project_id": str(project_id),
+            "agent_id": str(dep.agent_id),
+            "actor_id": str(actor_id),
+            "from_status": previous_status,
+            "status": "TERMINATED",
+            "queue_failed_count": queue_failed,
+        })
+
+        return DeploymentMutationResponse(
+            deployment=AgentDeploymentResponse.model_validate(dep),
+            queue_held_count=0,
+            queue_resumed_count=0,
+            queue_failed_count=queue_failed,
+        )
+
+    async def complete_verification(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        deployment_id: uuid.UUID,
+    ) -> AgentDeploymentResponse:
+        dep = await self._get_deployment(org_id, project_id, deployment_id)
+        if dep.status != "ACTIVE":
+            raise DeploymentLifecycleError(
+                "DEPLOYMENT_VERIFICATION_REQUIRES_ACTIVE_STATUS", 409,
+                "Deployment must be active before verification can be completed",
+            )
+
+        config = dep.config or {}
+        now = datetime.now(timezone.utc).isoformat()
+        verification = {
+            "status": "completed",
+            "required_checkpoints": ["dashboard_active", "routing_reviewed", "mcp_reviewed"],
+            "completed_at": now,
+            "completed_by": str(actor_id),
+        }
+        next_config = {**config, "verification": verification}
+
+        await self.session.execute(
+            update(AgentDeployment).where(AgentDeployment.id == dep.id).values(
+                config=next_config, updated_at=datetime.now(timezone.utc)
+            )
+        )
+        await self.session.flush()
+        await self.session.refresh(dep)
+
+        await self._log_audit(org_id, project_id, dep.agent_id, "agent_deployment.verification_completed", "info", {
+            "deployment_id": str(dep.id),
+            "actor_id": str(actor_id),
+            "verification_status": "completed",
+            "verification_completed_at": now,
+            "verification_completed_by": str(actor_id),
+        })
+
+        await _fire_webhooks(self.session, org_id, "agent_deployment.verification_completed", {
+            "deployment_id": str(dep.id),
+            "org_id": str(org_id),
+            "project_id": str(project_id),
+            "agent_id": str(dep.agent_id),
+            "actor_id": str(actor_id),
+            "verification_status": "completed",
+            "verification_completed_at": now,
+        })
+
+        return AgentDeploymentResponse.model_validate(dep)
+
+    async def build_cards(self, org_id: uuid.UUID, project_id: uuid.UUID, requested_for_member_id: str | None = None) -> list[DeploymentCardResponse]:
+        r = await self.session.execute(
+            select(AgentDeployment).where(
+                AgentDeployment.org_id == org_id,
+                AgentDeployment.project_id == project_id,
+                AgentDeployment.deleted_at.is_(None),
+                AgentDeployment.status.in_(["DEPLOYING", "ACTIVE", "SUSPENDED", "DEPLOY_FAILED"]),
+            ).order_by(AgentDeployment.updated_at.desc())
+        )
+        deployments = list(r.scalars().all())
+        if not deployments:
+            return []
+
+        dep_ids = [d.id for d in deployments]
+        agent_ids = list({d.agent_id for d in deployments})
+        persona_ids = list({d.persona_id for d in deployments if d.persona_id})
+
+        agent_name_by_id: dict[uuid.UUID, str] = {}
+        if agent_ids:
+            ar = await self.session.execute(select(TeamMember.id, TeamMember.name).where(TeamMember.id.in_(agent_ids)))
+            agent_name_by_id = {row.id: row.name for row in ar.all()}
+
+        persona_name_by_id: dict[uuid.UUID, str] = {}
+        if persona_ids:
+            pr = await self.session.execute(
+                select(AgentPersona.id, AgentPersona.name).where(AgentPersona.id.in_(persona_ids), AgentPersona.deleted_at.is_(None))
+            )
+            persona_name_by_id = {row.id: row.name for row in pr.all()}
+
+        from datetime import date
+        today_start = datetime.combine(date.today(), datetime.min.time()).replace(tzinfo=timezone.utc)
+
+        runs_today_r = await self.session.execute(
+            select(AgentRun.deployment_id, AgentRun.input_tokens, AgentRun.output_tokens)
+            .where(AgentRun.deployment_id.in_(dep_ids), AgentRun.created_at >= today_start)
+        )
+        exec_count: dict[uuid.UUID, int] = {}
+        tokens: dict[uuid.UUID, int] = {}
+        for row in runs_today_r.all():
+            dep_id = row.deployment_id
+            exec_count[dep_id] = exec_count.get(dep_id, 0) + 1
+            tokens[dep_id] = tokens.get(dep_id, 0) + (row.input_tokens or 0) + (row.output_tokens or 0)
+
+        latest_runs_r = await self.session.execute(
+            select(AgentRun.deployment_id, AgentRun.finished_at, AgentRun.started_at, AgentRun.created_at)
+            .where(AgentRun.deployment_id.in_(dep_ids))
+            .order_by(AgentRun.created_at.desc())
+        )
+        last_run_by_dep: dict[uuid.UUID, str | None] = {}
+        for row in latest_runs_r.all():
+            if row.deployment_id not in last_run_by_dep:
+                last_run_by_dep[row.deployment_id] = (
+                    row.finished_at.isoformat() if row.finished_at
+                    else row.started_at.isoformat() if row.started_at
+                    else row.created_at.isoformat()
+                )
+
+        latest_success_r = await self.session.execute(
+            select(AgentRun.deployment_id, AgentRun.finished_at, AgentRun.started_at, AgentRun.created_at)
+            .where(AgentRun.deployment_id.in_(dep_ids), AgentRun.status == "completed")
+            .order_by(AgentRun.created_at.desc())
+        )
+        latest_success_by_dep: dict[uuid.UUID, str | None] = {}
+        for row in latest_success_r.all():
+            if row.deployment_id not in latest_success_by_dep:
+                latest_success_by_dep[row.deployment_id] = (
+                    row.finished_at.isoformat() if row.finished_at
+                    else row.started_at.isoformat() if row.started_at
+                    else row.created_at.isoformat()
+                )
+
+        latest_failed_r = await self.session.execute(
+            select(
+                AgentRun.id, AgentRun.deployment_id, AgentRun.memo_id,
+                AgentRun.result_summary, AgentRun.last_error_code,
+                AgentRun.failure_disposition, AgentRun.next_retry_at,
+                AgentRun.retry_count, AgentRun.max_retries,
+                AgentRun.finished_at, AgentRun.started_at, AgentRun.created_at,
+            )
+            .where(AgentRun.deployment_id.in_(dep_ids), AgentRun.status == "failed")
+            .order_by(AgentRun.created_at.desc())
+        )
+        latest_failed_by_dep: dict[uuid.UUID, DeploymentFailureSignal] = {}
+        for row in latest_failed_r.all():
+            dep_id = row.deployment_id
+            if dep_id not in latest_failed_by_dep:
+                failed_at = (
+                    row.finished_at.isoformat() if row.finished_at
+                    else row.started_at.isoformat() if row.started_at
+                    else row.created_at.isoformat()
+                )
+                can_retry = bool(
+                    row.failure_disposition == "retryable"
+                    and row.next_retry_at
+                    and row.retry_count is not None
+                    and row.max_retries is not None
+                    and row.retry_count < row.max_retries
+                )
+                latest_failed_by_dep[dep_id] = DeploymentFailureSignal(
+                    run_id=str(row.id),
+                    memo_id=str(row.memo_id) if row.memo_id else None,
+                    failed_at=failed_at,
+                    error_message=None,
+                    last_error_code=row.last_error_code,
+                    result_summary=row.result_summary,
+                    failure_disposition=row.failure_disposition,
+                    next_retry_at=row.next_retry_at.isoformat() if row.next_retry_at else None,
+                    can_manual_retry=can_retry,
+                )
+
+        return [
+            DeploymentCardResponse(
+                id=str(d.id),
+                name=d.name,
+                status=d.status,
+                model=d.model,
+                runtime=d.runtime,
+                agent_name=agent_name_by_id.get(d.agent_id, "Agent"),
+                persona_name=persona_name_by_id.get(d.persona_id) if d.persona_id else None,
+                updated_at=d.updated_at.isoformat(),
+                last_run_at=last_run_by_dep.get(d.id),
+                latest_successful_run_at=latest_success_by_dep.get(d.id),
+                executions_today=exec_count.get(d.id, 0),
+                tokens_today=tokens.get(d.id, 0),
+                pending_hitl_count=0,
+                next_hitl_deadline_at=None,
+                latest_failed_run=latest_failed_by_dep.get(d.id),
+            )
+            for d in deployments
+        ]

--- a/backend/tests/test_s41.py
+++ b/backend/tests/test_s41.py
@@ -1,0 +1,246 @@
+"""S41 AC: Agent Deployments CRUD + Preflight + Verification — FastAPI /api/v2/agent-deployments/**"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+DEPLOYMENT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": ctx.user_id}
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+    async def override_auth():
+        return ctx
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app, ctx
+
+
+def _make_deployment(status: str = "ACTIVE") -> MagicMock:
+    dep = MagicMock()
+    dep.id = DEPLOYMENT_ID
+    dep.org_id = ORG_ID
+    dep.project_id = PROJECT_ID
+    dep.agent_id = AGENT_ID
+    dep.persona_id = None
+    dep.name = "Test Deployment"
+    dep.runtime = "webhook"
+    dep.model = None
+    dep.version = None
+    dep.status = status
+    dep.config = {"schema_version": 1, "llm_mode": "managed", "provider": "openai", "scope_mode": "projects", "project_ids": [str(PROJECT_ID)]}
+    dep.last_deployed_at = None
+    dep.failure_code = None
+    dep.failure_message = None
+    dep.failure_detail = None
+    dep.failed_at = None
+    dep.created_at = MagicMock(isoformat=lambda: "2026-04-30T00:00:00+00:00")
+    dep.updated_at = MagicMock(isoformat=lambda: "2026-04-30T00:00:00+00:00")
+    dep.deleted_at = None
+    return dep
+
+
+@pytest.mark.anyio
+async def test_get_deployment_cards_200():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.build_cards", new_callable=AsyncMock) as mock_cards:
+            mock_cards.return_value = []
+            async with client as c:
+                resp = await c.get("/api/v2/agent-deployments")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"] == []
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_deployment_by_id_200():
+    client, session, app, ctx = await _client()
+    try:
+        dep = _make_deployment()
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService._get_deployment", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = dep
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["status"] == "ACTIVE"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_deployment_not_found_404():
+    client, session, app, ctx = await _client()
+    try:
+        from app.services.deployment_lifecycle import DeploymentLifecycleError
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService._get_deployment", new_callable=AsyncMock) as mock_get:
+            mock_get.side_effect = DeploymentLifecycleError("DEPLOYMENT_NOT_FOUND", 404, "Deployment not found in current project")
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}")
+            assert resp.status_code == 404
+            body = resp.json()
+            assert body["data"] is None
+            assert body["error"]["code"] == "DEPLOYMENT_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_run_preflight_200():
+    client, session, app, ctx = await _client()
+    try:
+        from app.schemas.agent_deployment import DeploymentPreflightResponse
+        preflight = DeploymentPreflightResponse(
+            ok=True, checked_at="2026-04-30T00:00:00+00:00",
+            blocking_reasons=[], warnings=[],
+            routing_template_id="solo-dev", routing_rule_count=0,
+            existing_routing_rule_count=0, requires_routing_overwrite_confirmation=False,
+            mcp_validation_errors=[],
+        )
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.run_deployment_preflight", new_callable=AsyncMock) as mock_pf:
+            mock_pf.return_value = preflight
+            payload = {
+                "agent_id": str(AGENT_ID),
+                "name": "Test Deploy",
+                "config": {"llm_mode": "managed", "provider": "openai", "scope_mode": "projects", "project_ids": [str(PROJECT_ID)]},
+            }
+            async with client as c:
+                resp = await c.post("/api/v2/agent-deployments/preflight", json=payload)
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["preflight"]["ok"] is True
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_deployment_202():
+    client, session, app, ctx = await _client()
+    try:
+        from app.schemas.agent_deployment import DeploymentMutationResponse, AgentDeploymentResponse
+        dep = _make_deployment("ACTIVE")
+        dep_resp = AgentDeploymentResponse.model_validate(dep)
+        mutation = DeploymentMutationResponse(
+            deployment=dep_resp, queue_held_count=0, queue_resumed_count=0, queue_failed_count=0
+        )
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.create_deployment", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = mutation
+            payload = {
+                "agent_id": str(AGENT_ID),
+                "name": "Test Deploy",
+                "config": {"llm_mode": "managed", "provider": "openai", "scope_mode": "projects", "project_ids": [str(PROJECT_ID)]},
+            }
+            async with client as c:
+                resp = await c.post("/api/v2/agent-deployments", json=payload)
+            assert resp.status_code == 202
+            body = resp.json()
+            assert body["data"]["deployment"]["status"] == "ACTIVE"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_patch_deployment_transition_200():
+    client, session, app, ctx = await _client()
+    try:
+        from app.schemas.agent_deployment import DeploymentMutationResponse, AgentDeploymentResponse
+        dep = _make_deployment("SUSPENDED")
+        dep_resp = AgentDeploymentResponse.model_validate(dep)
+        mutation = DeploymentMutationResponse(
+            deployment=dep_resp, queue_held_count=2, queue_resumed_count=0, queue_failed_count=0
+        )
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.transition_deployment", new_callable=AsyncMock) as mock_tx:
+            mock_tx.return_value = mutation
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}", json={"status": "SUSPENDED"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["queue_held_count"] == 2
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_deployment_200():
+    client, session, app, ctx = await _client()
+    try:
+        from app.schemas.agent_deployment import DeploymentMutationResponse, AgentDeploymentResponse
+        dep = _make_deployment("TERMINATED")
+        dep_resp = AgentDeploymentResponse.model_validate(dep)
+        mutation = DeploymentMutationResponse(
+            deployment=dep_resp, queue_held_count=0, queue_resumed_count=0, queue_failed_count=1
+        )
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.terminate_deployment", new_callable=AsyncMock) as mock_term:
+            mock_term.return_value = mutation
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["queue_failed_count"] == 1
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_complete_verification_200():
+    client, session, app, ctx = await _client()
+    try:
+        from app.schemas.agent_deployment import AgentDeploymentResponse
+        dep = _make_deployment("ACTIVE")
+        dep_resp = AgentDeploymentResponse.model_validate(dep)
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.complete_verification", new_callable=AsyncMock) as mock_verify:
+            mock_verify.return_value = dep_resp
+            async with client as c:
+                resp = await c.post(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}/verification")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["deployment"]["status"] == "ACTIVE"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_invalid_transition_409():
+    client, session, app, ctx = await _client()
+    try:
+        from app.services.deployment_lifecycle import DeploymentLifecycleError
+        with patch("app.services.deployment_lifecycle.DeploymentLifecycleService.transition_deployment", new_callable=AsyncMock) as mock_tx:
+            mock_tx.side_effect = DeploymentLifecycleError("INVALID_DEPLOYMENT_TRANSITION", 409, "Cannot transition")
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-deployments/{DEPLOYMENT_ID}", json={"status": "DEPLOYING"})
+            assert resp.status_code == 409
+            body = resp.json()
+            assert body["error"]["code"] == "INVALID_DEPLOYMENT_TRANSITION"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- FastAPI `/api/v2/agent-deployments/**` 7개 엔드포인트 신규 구현
- `DeploymentLifecycleService`: create/transition/terminate/preflight/verification 전체 lifecycle 포팅
- `AgentDeployment`, `AgentPersona`, `AgentAuditLog` SQLAlchemy 모델 신규
- `AgentRun` 모델에 `deployment_id`, `started_at`, `finished_at` 등 누락 컬럼 추가
- 프론트엔드 fetch 경로 v1 → v2 전환 (agent-deployment-wizard, agents-dashboard)
- 응답 포맷: `{ data, error, meta }` envelope (v1 호환)

## Acceptance Criteria

- [x] `GET /api/v2/agent-deployments` — deployment card list (buildDeploymentCards 포팅)
- [x] `POST /api/v2/agent-deployments` — create deployment (preflight → insert → routing rules → audit → webhook)
- [x] `POST /api/v2/agent-deployments/preflight` — preflight check
- [x] `GET /api/v2/agent-deployments/{id}` — single deployment fetch
- [x] `PATCH /api/v2/agent-deployments/{id}` — status transition (ACTIVE/SUSPENDED/DEPLOY_FAILED)
- [x] `DELETE /api/v2/agent-deployments/{id}` — terminate (soft delete)
- [x] `POST /api/v2/agent-deployments/{id}/verification` — complete verification
- [x] 241/241 backend tests PASS, tsc CLEAN

## Test plan

- [ ] `GET /api/v2/agent-deployments` 카드 목록 반환 확인
- [ ] `POST /api/v2/agent-deployments/preflight` ok/blocking_reasons 확인
- [ ] `POST /api/v2/agent-deployments` 202 + deployment.status = ACTIVE 확인
- [ ] `PATCH` SUSPENDED/ACTIVE 전환 확인 (queue_held_count / queue_resumed_count)
- [ ] `DELETE` TERMINATED + queue_failed_count 확인
- [ ] `POST /{id}/verification` config.verification.status = completed 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)