### PR TITLE
feat(backend): S42 Agent Personas CRUD 이관

### DIFF
--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -11,6 +11,7 @@ import { OperatorInput, OperatorSelect, OperatorTextarea } from '@/components/ui
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import type { PersonaToolOption } from '@/services/persona-composer';
 import { estimatePromptTokens } from '@/services/persona-composer';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 
 export interface PersonaComposerAgent {
   id: string;
@@ -143,9 +144,13 @@ export function AgentPersonaComposer({
     setCreatedPersona(null);
 
     try {
-      const response = await fetch('/api/v1/agent-personas', {
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+      const response = await fetch('/api/v2/agent-personas', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: JSON.stringify({
           agent_id: selectedAgentId,
           name: name.trim(),

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -52,6 +52,7 @@ app.include_router(subscription.router)
 app.include_router(account.router)
 app.include_router(oss.router)
 app.include_router(agent_deployments.router)
+app.include_router(agent_personas.router)
 app.include_router(agent_routing_rules.router)
 
 if settings.is_ee_enabled:

--- a/backend/app/models/agent_deployment.py
+++ b/backend/app/models/agent_deployment.py
@@ -46,8 +46,20 @@ class AgentPersona(Base):
     agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     name: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    system_prompt: Mapped[str] = mapped_column(Text, nullable=False, default="")
+    style_prompt: Mapped[str | None] = mapped_column(Text, nullable=True)
+    model: Mapped[str | None] = mapped_column(Text, nullable=True)
     config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     is_builtin: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
 

--- a/backend/app/repositories/agent_persona.py
+++ b/backend/app/repositories/agent_persona.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_deployment import AgentDeployment, AgentPersona
+from app.schemas.agent_persona import PersonaSummaryResponse
+
+
+def _slugify(value: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "persona"
+
+
+def _build_summary(persona: AgentPersona, is_in_use: bool, base: AgentPersona | None = None) -> PersonaSummaryResponse:
+    config: dict[str, Any] = persona.config or {}
+    base_persona_id = config.get("base_persona_id") if isinstance(config.get("base_persona_id"), str) else None
+    tool_allowlist: list[str] = config.get("tool_allowlist", []) if isinstance(config.get("tool_allowlist"), list) else []
+
+    own_prompt = (persona.system_prompt or "").strip()
+    base_prompt = (base.system_prompt or "").strip() if base else ""
+    resolved_system = "\n\n".join(p for p in [base_prompt, own_prompt] if p) or ""
+
+    own_style = (persona.style_prompt or "").strip() or None
+    base_style = (base.style_prompt or "").strip() if base else None
+    resolved_style = "\n\n".join(p for p in [base_style, own_style] if p) or None
+
+    version_metadata: dict[str, Any] = config.get("version_metadata") or {}
+    permission_boundary: dict[str, Any] = {"tool_allowlist": tool_allowlist, "restrictions": []}
+
+    base_data = (
+        {"id": str(base.id), "name": base.name, "slug": base.slug, "is_builtin": base.is_builtin}
+        if base else None
+    )
+
+    return PersonaSummaryResponse(
+        id=persona.id,
+        org_id=persona.org_id,
+        project_id=persona.project_id,
+        agent_id=persona.agent_id,
+        name=persona.name,
+        slug=persona.slug,
+        description=persona.description,
+        system_prompt=own_prompt,
+        style_prompt=own_style,
+        resolved_system_prompt=resolved_system,
+        resolved_style_prompt=resolved_style,
+        model=persona.model,
+        config=persona.config,
+        is_builtin=persona.is_builtin,
+        is_default=persona.is_default,
+        is_in_use=is_in_use,
+        tool_allowlist=tool_allowlist,
+        base_persona_id=base_persona_id,
+        base_persona=base_data,
+        version_metadata=version_metadata,
+        permission_boundary=permission_boundary,
+        change_history=[],
+        created_by=persona.created_by,
+        created_at=persona.created_at,
+        updated_at=persona.updated_at,
+    )
+
+
+class AgentPersonaRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def _is_in_use(self, persona_id: uuid.UUID) -> bool:
+        r = await self.session.execute(
+            select(AgentDeployment.id).where(
+                AgentDeployment.persona_id == persona_id,
+                AgentDeployment.deleted_at.is_(None),
+            ).limit(1)
+        )
+        return r.scalar_one_or_none() is not None
+
+    async def _get_base(self, config: dict, org_id: uuid.UUID) -> AgentPersona | None:
+        base_id = config.get("base_persona_id")
+        if not base_id or not isinstance(base_id, str):
+            return None
+        try:
+            base_uuid = uuid.UUID(base_id)
+        except ValueError:
+            return None
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.id == base_uuid,
+                AgentPersona.org_id == org_id,
+                AgentPersona.deleted_at.is_(None),
+            )
+        )
+        return r.scalar_one_or_none()
+
+    async def _decorate(self, persona: AgentPersona) -> PersonaSummaryResponse:
+        base = await self._get_base(persona.config or {}, persona.org_id)
+        in_use = await self._is_in_use(persona.id)
+        return _build_summary(persona, in_use, base)
+
+    async def list(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        include_builtin: bool = False,
+    ) -> list[PersonaSummaryResponse]:
+        q = select(AgentPersona).where(
+            AgentPersona.org_id == org_id,
+            AgentPersona.project_id == project_id,
+            AgentPersona.agent_id == agent_id,
+            AgentPersona.deleted_at.is_(None),
+        ).order_by(AgentPersona.is_default.desc(), AgentPersona.created_at.asc())
+        if not include_builtin:
+            q = q.where(AgentPersona.is_builtin.is_(False))
+        r = await self.session.execute(q)
+        personas = list(r.scalars().all())
+        return [await self._decorate(p) for p in personas]
+
+    async def get(self, persona_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> PersonaSummaryResponse | None:
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.id == persona_id,
+                AgentPersona.org_id == org_id,
+                AgentPersona.project_id == project_id,
+                AgentPersona.deleted_at.is_(None),
+            )
+        )
+        persona = r.scalar_one_or_none()
+        if persona is None:
+            return None
+        return await self._decorate(persona)
+
+    async def create(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        name: str,
+        slug: str | None = None,
+        description: str | None = None,
+        system_prompt: str | None = None,
+        style_prompt: str | None = None,
+        model: str | None = None,
+        base_persona_id: uuid.UUID | None = None,
+        tool_allowlist: list[str] | None = None,
+        is_default: bool = False,
+    ) -> PersonaSummaryResponse:
+        if is_default:
+            await self._clear_default(org_id, project_id, agent_id)
+
+        config: dict[str, Any] = {}
+        if base_persona_id:
+            config["base_persona_id"] = str(base_persona_id)
+        if tool_allowlist is not None:
+            config["tool_allowlist"] = tool_allowlist
+
+        persona = AgentPersona(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            name=name.strip(),
+            slug=_slugify(slug or name),
+            description=description.strip() if description else None,
+            system_prompt=(system_prompt or "").strip(),
+            style_prompt=style_prompt.strip() if style_prompt else None,
+            model=model.strip() if model else None,
+            config=config,
+            is_builtin=False,
+            is_default=is_default,
+            created_by=actor_id,
+        )
+        self.session.add(persona)
+        await self.session.flush()
+        await self.session.refresh(persona)
+        return await self._decorate(persona)
+
+    async def update(
+        self,
+        persona_id: uuid.UUID,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        **fields: Any,
+    ) -> PersonaSummaryResponse | None:
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.id == persona_id,
+                AgentPersona.org_id == org_id,
+                AgentPersona.project_id == project_id,
+                AgentPersona.deleted_at.is_(None),
+            )
+        )
+        persona = r.scalar_one_or_none()
+        if persona is None:
+            return None
+        if persona.is_builtin:
+            raise ValueError("Built-in personas cannot be modified")
+
+        config = dict(persona.config or {})
+        if "base_persona_id" in fields:
+            bpid = fields.pop("base_persona_id")
+            config["base_persona_id"] = str(bpid) if bpid else None
+        if "tool_allowlist" in fields:
+            tl = fields.pop("tool_allowlist")
+            if tl is not None:
+                config["tool_allowlist"] = tl
+
+        if fields.get("is_default"):
+            await self._clear_default(org_id, project_id, persona.agent_id, exclude_id=persona_id)
+
+        patch: dict[str, Any] = {"config": config, "updated_at": datetime.now(timezone.utc)}
+        for key in ("name", "slug", "description", "system_prompt", "style_prompt", "model", "is_default"):
+            if key in fields and fields[key] is not None:
+                val = fields[key]
+                if key == "name":
+                    val = val.strip()
+                elif key == "slug":
+                    val = _slugify(val)
+                elif key in ("description", "system_prompt", "style_prompt"):
+                    val = val.strip() if val else None
+                elif key == "model":
+                    val = val.strip() if val else None
+                patch[key] = val
+
+        await self.session.execute(
+            update(AgentPersona).where(AgentPersona.id == persona_id).values(**patch)
+        )
+        await self.session.flush()
+        await self.session.refresh(persona)
+        return await self._decorate(persona)
+
+    async def delete(self, persona_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> bool:
+        r = await self.session.execute(
+            select(AgentPersona).where(
+                AgentPersona.id == persona_id,
+                AgentPersona.org_id == org_id,
+                AgentPersona.project_id == project_id,
+                AgentPersona.deleted_at.is_(None),
+            )
+        )
+        persona = r.scalar_one_or_none()
+        if persona is None:
+            return False
+        if persona.is_builtin:
+            raise ValueError("Built-in personas cannot be deleted")
+        in_use = await self._is_in_use(persona_id)
+        if in_use:
+            raise ValueError("Cannot delete a persona that is currently in use")
+
+        await self.session.execute(
+            update(AgentPersona).where(AgentPersona.id == persona_id).values(
+                deleted_at=datetime.now(timezone.utc),
+                is_default=False,
+                updated_at=datetime.now(timezone.utc),
+            )
+        )
+        await self.session.flush()
+        return True
+
+    async def seed_builtin(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID) -> dict:
+        from sqlalchemy import text
+        await self.session.execute(
+            text("SELECT seed_builtin_personas(:org_id::uuid, :project_id::uuid, :agent_id::uuid)"),
+            {"org_id": str(org_id), "project_id": str(project_id), "agent_id": str(agent_id)},
+        )
+        await self.session.flush()
+        return {"seeded": True}
+
+    async def _clear_default(self, org_id: uuid.UUID, project_id: uuid.UUID, agent_id: uuid.UUID, exclude_id: uuid.UUID | None = None) -> None:
+        q = update(AgentPersona).where(
+            AgentPersona.org_id == org_id,
+            AgentPersona.project_id == project_id,
+            AgentPersona.agent_id == agent_id,
+            AgentPersona.is_default.is_(True),
+            AgentPersona.deleted_at.is_(None),
+        ).values(is_default=False)
+        if exclude_id:
+            from sqlalchemy import and_
+            q = update(AgentPersona).where(
+                AgentPersona.org_id == org_id,
+                AgentPersona.project_id == project_id,
+                AgentPersona.agent_id == agent_id,
+                AgentPersona.is_default.is_(True),
+                AgentPersona.deleted_at.is_(None),
+                AgentPersona.id != exclude_id,
+            ).values(is_default=False)
+        await self.session.execute(q)

--- a/backend/app/routers/agent_personas.py
+++ b/backend/app/routers/agent_personas.py
@@ -1,0 +1,146 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.agent_persona import AgentPersonaRepository
+from app.schemas.agent_persona import CreatePersonaRequest, UpdatePersonaRequest
+
+router = APIRouter(prefix="/api/v2/agent-personas", tags=["agent-personas"])
+
+
+def _repo(session: AsyncSession = Depends(get_db)) -> AgentPersonaRepository:
+    return AgentPersonaRepository(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID, uuid.UUID]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("")
+async def list_personas(
+    agent_id: uuid.UUID = Query(...),
+    include_builtin: bool = Query(default=False),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    personas = await repo.list(org_id, project_id, agent_id, include_builtin=include_builtin)
+    return _ok([p.model_dump(mode="json") for p in personas])
+
+
+@router.post("", status_code=201)
+async def create_persona(
+    body: CreatePersonaRequest,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        persona = await repo.create(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=body.agent_id,
+            actor_id=uuid.UUID(auth.user_id),
+            name=body.name,
+            slug=body.slug,
+            description=body.description,
+            system_prompt=body.system_prompt,
+            style_prompt=body.style_prompt,
+            model=body.model,
+            base_persona_id=body.base_persona_id,
+            tool_allowlist=body.tool_allowlist,
+            is_default=body.is_default or False,
+        )
+        return _ok(persona.model_dump(mode="json"), status=201)
+    except ValueError as e:
+        return _err("VALIDATION_ERROR", str(e), 400)
+
+
+@router.post("/seed")
+async def seed_builtin_personas(
+    agent_id: uuid.UUID = Query(...),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    result = await repo.seed_builtin(org_id, project_id, agent_id)
+    return _ok(result)
+
+
+@router.get("/{id}")
+async def get_persona(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    persona = await repo.get(id, org_id, project_id)
+    if persona is None:
+        return _err("NOT_FOUND", "Persona not found", 404)
+    return _ok(persona.model_dump(mode="json"))
+
+
+@router.patch("/{id}")
+async def update_persona(
+    id: uuid.UUID,
+    body: UpdatePersonaRequest,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        persona = await repo.update(
+            id, org_id, project_id,
+            actor_id=uuid.UUID(auth.user_id),
+            **{k: v for k, v in body.model_dump().items() if v is not None},
+        )
+        if persona is None:
+            return _err("NOT_FOUND", "Persona not found", 404)
+        return _ok(persona.model_dump(mode="json"))
+    except ValueError as e:
+        return _err("FORBIDDEN", str(e), 403)
+
+
+@router.delete("/{id}")
+async def delete_persona(
+    id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentPersonaRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        ok = await repo.delete(id, org_id, project_id)
+        if not ok:
+            return _err("NOT_FOUND", "Persona not found", 404)
+        return _ok({"ok": True, "id": str(id)})
+    except ValueError as e:
+        return _err("FORBIDDEN", str(e), 403)

--- a/backend/app/schemas/agent_persona.py
+++ b/backend/app/schemas/agent_persona.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PersonaBaseResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    agent_id: uuid.UUID
+    name: str
+    slug: str
+    description: str | None
+    system_prompt: str
+    style_prompt: str | None
+    model: str | None
+    config: dict[str, Any]
+    is_builtin: bool
+    is_default: bool
+    created_by: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class PersonaSummaryResponse(PersonaBaseResponse):
+    resolved_system_prompt: str
+    resolved_style_prompt: str | None
+    tool_allowlist: list[str]
+    base_persona_id: str | None
+    base_persona: dict[str, Any] | None
+    is_in_use: bool
+    version_metadata: dict[str, Any]
+    permission_boundary: dict[str, Any]
+    change_history: list[dict[str, Any]]
+
+
+class CreatePersonaRequest(BaseModel):
+    agent_id: uuid.UUID
+    name: str
+    slug: str | None = None
+    description: str | None = None
+    system_prompt: str | None = None
+    style_prompt: str | None = None
+    model: str | None = None
+    base_persona_id: uuid.UUID | None = None
+    tool_allowlist: list[str] | None = None
+    is_default: bool | None = None
+
+
+class UpdatePersonaRequest(BaseModel):
+    name: str | None = None
+    slug: str | None = None
+    description: str | None = None
+    system_prompt: str | None = None
+    style_prompt: str | None = None
+    model: str | None = None
+    base_persona_id: uuid.UUID | None = None
+    tool_allowlist: list[str] | None = None
+    is_default: bool | None = None

--- a/backend/tests/test_s42.py
+++ b/backend/tests/test_s42.py
@@ -179,6 +179,34 @@ async def test_delete_builtin_persona_403():
 
 
 @pytest.mark.anyio
+async def test_delete_in_use_persona_403():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.side_effect = ValueError("Cannot delete a persona that is currently in use")
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-personas/{PERSONA_ID}")
+            assert resp.status_code == 403
+            assert "in use" in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_builtin_persona_403():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.side_effect = ValueError("Built-in personas cannot be modified")
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-personas/{PERSONA_ID}", json={"name": "New Name"})
+            assert resp.status_code == 403
+            assert "Built-in" in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_seed_builtin_200():
     client, session, app = await _client()
     try:

--- a/backend/tests/test_s42.py
+++ b/backend/tests/test_s42.py
@@ -1,0 +1,192 @@
+"""S42 AC: Agent Personas CRUD — FastAPI /api/v2/agent-personas/**"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+PERSONA_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": ctx.user_id}
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+    async def override_auth():
+        return ctx
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _make_persona_summary():
+    from app.schemas.agent_persona import PersonaSummaryResponse
+    now = datetime.now(timezone.utc)
+    return PersonaSummaryResponse(
+        id=PERSONA_ID,
+        org_id=ORG_ID,
+        project_id=PROJECT_ID,
+        agent_id=AGENT_ID,
+        name="Test Persona",
+        slug="test-persona",
+        description=None,
+        system_prompt="You are a helpful assistant.",
+        style_prompt=None,
+        resolved_system_prompt="You are a helpful assistant.",
+        resolved_style_prompt=None,
+        model=None,
+        config={},
+        is_builtin=False,
+        is_default=True,
+        is_in_use=False,
+        tool_allowlist=[],
+        base_persona_id=None,
+        base_persona=None,
+        version_metadata={},
+        permission_boundary={"tool_allowlist": [], "restrictions": []},
+        change_history=[],
+        created_by=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.anyio
+async def test_list_personas_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_make_persona_summary()]
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-personas?agent_id={AGENT_ID}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["data"]) == 1
+            assert body["data"][0]["name"] == "Test Persona"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_persona_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_persona_summary()
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-personas/{PERSONA_ID}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["slug"] == "test-persona"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_persona_not_found_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-personas/{PERSONA_ID}")
+            assert resp.status_code == 404
+            assert resp.json()["error"]["code"] == "NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_persona_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _make_persona_summary()
+            payload = {"agent_id": str(AGENT_ID), "name": "Test Persona", "system_prompt": "You are a helpful assistant."}
+            async with client as c:
+                resp = await c.post("/api/v2/agent-personas", json=payload)
+            assert resp.status_code == 201
+            body = resp.json()
+            assert body["data"]["name"] == "Test Persona"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_persona_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.update", new_callable=AsyncMock) as mock_update:
+            updated = _make_persona_summary()
+            updated.name = "Updated Persona"
+            mock_update.return_value = updated
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-personas/{PERSONA_ID}", json={"name": "Updated Persona"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["name"] == "Updated Persona"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_persona_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = True
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-personas/{PERSONA_ID}")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_builtin_persona_403():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.side_effect = ValueError("Built-in personas cannot be deleted")
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-personas/{PERSONA_ID}")
+            assert resp.status_code == 403
+            assert "Built-in" in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_seed_builtin_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_persona.AgentPersonaRepository.seed_builtin", new_callable=AsyncMock) as mock_seed:
+            mock_seed.return_value = {"seeded": True}
+            async with client as c:
+                resp = await c.post(f"/api/v2/agent-personas/seed?agent_id={AGENT_ID}")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["seeded"] is True
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- FastAPI `/api/v2/agent-personas/**` 6개 엔드포인트 신규 구현
- `AgentPersonaRepository`: CRUD + seed_builtin + is_in_use check + base persona inheritance
- `AgentPersona` 모델에 누락 컬럼 추가 (description, system_prompt, is_default 등)
- `PersonaSummaryResponse`: resolved prompts, tool_allowlist, base_persona, version_metadata 포함
- 프론트엔드 `agent-persona-composer.tsx`: v1→v2 + Bearer 토큰 주입

## Endpoints

| Method | Path | Description |
|---|---|---|
| GET | `/api/v2/agent-personas` | list (include_builtin opt) |
| POST | `/api/v2/agent-personas` | create (201) |
| POST | `/api/v2/agent-personas/seed` | seed_builtin_personas RPC |
| GET | `/api/v2/agent-personas/{id}` | get single |
| PATCH | `/api/v2/agent-personas/{id}` | update |
| DELETE | `/api/v2/agent-personas/{id}` | soft delete + is_in_use guard |

## Test plan

- [ ] `GET /api/v2/agent-personas?agent_id=X` 목록 반환 확인
- [ ] `POST /api/v2/agent-personas` 201 + persona 생성 확인
- [ ] `GET /api/v2/agent-personas/{id}` 단건 조회 확인
- [ ] `PATCH` name/system_prompt 수정 확인
- [ ] `DELETE` 비활성 퍼소나 삭제 + is_in_use 403 확인
- [ ] `/api/v2/agent-personas/seed?agent_id=X` 빌트인 시드 확인
- [ ] 249/249 PASS, tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)