### PR TITLE
feat(backend): S43 Agent Routing Rules CRUD 이관

### DIFF
--- a/apps/web/src/components/agents/agent-workflow-editor.tsx
+++ b/apps/web/src/components/agents/agent-workflow-editor.tsx
@@ -31,6 +31,7 @@ import { PageHeader } from '@/components/ui/page-header';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { getRollbackSnapshotFromRules, type RoutingRuleSummary, type WorkflowVersionSummary } from '@/services/agent-routing-rule';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import {
   WORKFLOW_MEMO_TYPE_OPTIONS,
   WORKFLOW_ORIGINAL_ASSIGNEE_ID,
@@ -553,15 +554,22 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
 
   // ─── API actions ───────────────────────────────────────────────────────────
 
+  const getAuthHeaders = async (): Promise<Record<string, string>> => {
+    const supabase = createSupabaseBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
+  };
+
   const saveWorkflow = useCallback(async () => {
     setSaving(true);
     try {
       if (!draftWorkflow.rules) throw new Error(draftWorkflow.error ?? t('workflowSaveErrorBody'));
 
       const desired = draftWorkflow.rules;
-      const response = await fetch('/api/v1/agent-routing-rules', {
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch('/api/v2/agent-routing-rules', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({
           items: desired.map((rule) => ({
             id: rule.id,
@@ -604,9 +612,10 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
     if (!rollbackSnapshot?.items.length) return;
     setSaving(true);
     try {
-      const response = await fetch('/api/v1/agent-routing-rules', {
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch('/api/v2/agent-routing-rules', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({ items: rollbackSnapshot.items }),
       });
       const json = await response.json().catch(() => null) as ApiResponse<RoutingRuleSummary[]> | null;
@@ -651,9 +660,10 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
     if (savedRules.length === 0) return;
     setSaving(true);
     try {
-      const response = await fetch('/api/v1/agent-routing-rules', {
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch('/api/v2/agent-routing-rules', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({ disable_all: true }),
       });
       const json = await response.json().catch(() => null) as ApiResponse<RoutingRuleSummary[]> | null;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -52,6 +52,7 @@ app.include_router(subscription.router)
 app.include_router(account.router)
 app.include_router(oss.router)
 app.include_router(agent_deployments.router)
+app.include_router(agent_routing_rules.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
+from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
@@ -23,6 +24,7 @@ __all__ = [
     "AgentAuditLog",
     "AgentDeployment",
     "AgentPersona",
+    "AgentRoutingRule",
     "AgentRun",
     "ApiKey",
     "OrgSubscription",

--- a/backend/app/models/agent_routing_rule.py
+++ b/backend/app/models/agent_routing_rule.py
@@ -1,0 +1,36 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentRoutingRule(Base):
+    __tablename__ = "agent_routing_rules"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    persona_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    deployment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    priority: Mapped[int] = mapped_column(Integer, nullable=False, default=100)
+    match_type: Mapped[str] = mapped_column(Text, nullable=False, default="event")
+    conditions: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    action: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    target_runtime: Mapped[str] = mapped_column(Text, nullable=False, default="openclaw")
+    target_model: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    rule_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -189,7 +189,7 @@ class AgentRoutingRuleRepository:
         items: list[dict],
     ) -> list[RoutingRuleResponse]:
         await self.session.execute(
-            text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, :rules::jsonb)"),
+            text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, CAST(:rules AS jsonb))"),
             {
                 "org_id": str(org_id),
                 "project_id": str(project_id),

--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_routing_rule import AgentRoutingRule
+from app.schemas.agent_routing_rule import RoutingRuleResponse
+
+_DEFAULT_RUNTIME = "openclaw"
+_DEFAULT_MATCH_TYPE = "event"
+
+
+def _normalize_conditions(value: Any) -> dict[str, Any]:
+    if not value or not isinstance(value, dict):
+        return {"memo_type": []}
+    memo_type = value.get("memo_type", [])
+    if not isinstance(memo_type, list):
+        memo_type = []
+    return {"memo_type": [str(m).strip().lower() for m in memo_type if str(m).strip()]}
+
+
+def _normalize_action(value: Any) -> dict[str, Any]:
+    if not value or not isinstance(value, dict):
+        return {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}
+    mode = value.get("auto_reply_mode", "process_and_report")
+    if mode not in ("process_and_forward", "process_and_report"):
+        mode = "process_and_report"
+    fwd = value.get("forward_to_agent_id")
+    if mode == "process_and_forward" and isinstance(fwd, str) and fwd.strip():
+        forward_to = fwd.strip()
+    else:
+        forward_to = None
+    return {"auto_reply_mode": mode, "forward_to_agent_id": forward_to}
+
+
+def _to_response(rule: AgentRoutingRule) -> RoutingRuleResponse:
+    return RoutingRuleResponse(
+        id=rule.id,
+        org_id=rule.org_id,
+        project_id=rule.project_id,
+        agent_id=rule.agent_id,
+        persona_id=rule.persona_id,
+        deployment_id=rule.deployment_id,
+        name=rule.name,
+        priority=rule.priority,
+        match_type=rule.match_type,
+        conditions=_normalize_conditions(rule.conditions),
+        action=_normalize_action(rule.action),
+        target_runtime=rule.target_runtime,
+        target_model=rule.target_model,
+        is_enabled=rule.is_enabled,
+        metadata=rule.rule_metadata or {},
+        created_by=rule.created_by,
+        created_at=rule.created_at,
+        updated_at=rule.updated_at,
+    )
+
+
+class AgentRoutingRuleRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list(self, org_id: uuid.UUID, project_id: uuid.UUID) -> list[RoutingRuleResponse]:
+        r = await self.session.execute(
+            select(AgentRoutingRule)
+            .where(
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+            .order_by(AgentRoutingRule.priority.asc(), AgentRoutingRule.created_at.asc())
+        )
+        return [_to_response(rule) for rule in r.scalars().all()]
+
+    async def get(self, rule_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> RoutingRuleResponse | None:
+        r = await self.session.execute(
+            select(AgentRoutingRule).where(
+                AgentRoutingRule.id == rule_id,
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+        )
+        rule = r.scalar_one_or_none()
+        return _to_response(rule) if rule else None
+
+    async def create(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        agent_id: uuid.UUID,
+        name: str,
+        priority: int = 100,
+        match_type: str = _DEFAULT_MATCH_TYPE,
+        conditions: dict | None = None,
+        action: dict | None = None,
+        target_runtime: str = _DEFAULT_RUNTIME,
+        target_model: str | None = None,
+        is_enabled: bool = True,
+        persona_id: uuid.UUID | None = None,
+        deployment_id: uuid.UUID | None = None,
+    ) -> RoutingRuleResponse:
+        rule = AgentRoutingRule(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=agent_id,
+            persona_id=persona_id,
+            deployment_id=deployment_id,
+            name=name.strip(),
+            priority=priority,
+            match_type=match_type or _DEFAULT_MATCH_TYPE,
+            conditions=_normalize_conditions(conditions),
+            action=_normalize_action(action),
+            target_runtime=(target_runtime or _DEFAULT_RUNTIME).strip(),
+            target_model=target_model.strip() if target_model else None,
+            is_enabled=is_enabled,
+            rule_metadata={},
+            created_by=actor_id,
+        )
+        self.session.add(rule)
+        await self.session.flush()
+        await self.session.refresh(rule)
+        return _to_response(rule)
+
+    async def update(
+        self,
+        rule_id: uuid.UUID,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        **fields: Any,
+    ) -> RoutingRuleResponse | None:
+        r = await self.session.execute(
+            select(AgentRoutingRule).where(
+                AgentRoutingRule.id == rule_id,
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+        )
+        rule = r.scalar_one_or_none()
+        if rule is None:
+            return None
+
+        patch: dict[str, Any] = {"updated_at": datetime.now(timezone.utc)}
+        if "name" in fields and fields["name"]:
+            patch["name"] = fields["name"].strip()
+        if "agent_id" in fields and fields["agent_id"]:
+            patch["agent_id"] = fields["agent_id"]
+        if "persona_id" in fields:
+            patch["persona_id"] = fields["persona_id"]
+        if "deployment_id" in fields:
+            patch["deployment_id"] = fields["deployment_id"]
+        if "priority" in fields and fields["priority"] is not None:
+            patch["priority"] = fields["priority"]
+        if "match_type" in fields and fields["match_type"]:
+            patch["match_type"] = fields["match_type"]
+        if "conditions" in fields:
+            patch["conditions"] = _normalize_conditions(fields["conditions"])
+        if "action" in fields:
+            patch["action"] = _normalize_action(fields["action"])
+        if "target_runtime" in fields and fields["target_runtime"]:
+            patch["target_runtime"] = fields["target_runtime"].strip()
+        if "target_model" in fields:
+            val = fields["target_model"]
+            patch["target_model"] = val.strip() if val else None
+        if "is_enabled" in fields and fields["is_enabled"] is not None:
+            patch["is_enabled"] = fields["is_enabled"]
+        if "metadata" in fields and fields["metadata"] is not None:
+            patch["rule_metadata"] = fields["metadata"]
+
+        await self.session.execute(
+            update(AgentRoutingRule).where(AgentRoutingRule.id == rule_id).values(**patch)
+        )
+        await self.session.flush()
+        await self.session.refresh(rule)
+        return _to_response(rule)
+
+    async def replace(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        items: list[dict],
+    ) -> list[RoutingRuleResponse]:
+        await self.session.execute(
+            text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, :rules::jsonb)"),
+            {
+                "org_id": str(org_id),
+                "project_id": str(project_id),
+                "actor_id": str(actor_id),
+                "rules": json.dumps(items),
+            },
+        )
+        await self.session.flush()
+        return await self.list(org_id, project_id)
+
+    async def reorder(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        items: list[dict],
+    ) -> list[RoutingRuleResponse]:
+        now = datetime.now(timezone.utc)
+        for item in items:
+            await self.session.execute(
+                update(AgentRoutingRule)
+                .where(
+                    AgentRoutingRule.id == uuid.UUID(str(item["id"])),
+                    AgentRoutingRule.org_id == org_id,
+                    AgentRoutingRule.project_id == project_id,
+                    AgentRoutingRule.deleted_at.is_(None),
+                )
+                .values(priority=item["priority"], updated_at=now)
+            )
+        await self.session.flush()
+        return await self.list(org_id, project_id)
+
+    async def disable_all(self, org_id: uuid.UUID, project_id: uuid.UUID) -> list[RoutingRuleResponse]:
+        await self.session.execute(
+            update(AgentRoutingRule)
+            .where(
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+            .values(is_enabled=False, updated_at=datetime.now(timezone.utc))
+        )
+        await self.session.flush()
+        return await self.list(org_id, project_id)
+
+    async def delete(self, rule_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> bool:
+        r = await self.session.execute(
+            select(AgentRoutingRule).where(
+                AgentRoutingRule.id == rule_id,
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+        )
+        rule = r.scalar_one_or_none()
+        if rule is None:
+            return False
+        await self.session.execute(
+            update(AgentRoutingRule)
+            .where(AgentRoutingRule.id == rule_id)
+            .values(deleted_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc))
+        )
+        await self.session.flush()
+        return True

--- a/backend/app/routers/agent_routing_rules.py
+++ b/backend/app/routers/agent_routing_rules.py
@@ -1,0 +1,166 @@
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+from app.schemas.agent_routing_rule import (
+    CreateRoutingRuleRequest,
+    DisableAllRequest,
+    ReorderRulesRequest,
+    ReplaceRulesRequest,
+    UpdateRoutingRuleRequest,
+)
+
+router = APIRouter(prefix="/api/v2/agent-routing-rules", tags=["agent-routing-rules"])
+
+
+def _repo(session: AsyncSession = Depends(get_db)) -> AgentRoutingRuleRepository:
+    return AgentRoutingRuleRepository(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("")
+async def list_or_get_rules(
+    id: uuid.UUID | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRoutingRuleRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    if id:
+        rule = await repo.get(id, org_id, project_id)
+        if rule is None:
+            return _err("NOT_FOUND", "Routing rule not found", 404)
+        return _ok(rule.model_dump(mode="json"))
+    rules = await repo.list(org_id, project_id)
+    return _ok([r.model_dump(mode="json") for r in rules])
+
+
+@router.post("")
+async def create_rule(
+    body: CreateRoutingRuleRequest,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRoutingRuleRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    rule = await repo.create(
+        org_id=org_id,
+        project_id=project_id,
+        actor_id=uuid.UUID(auth.user_id),
+        agent_id=body.agent_id,
+        name=body.name,
+        priority=body.priority or 100,
+        match_type=body.match_type or "event",
+        conditions=body.conditions,
+        action=body.action,
+        target_runtime=body.target_runtime or "openclaw",
+        target_model=body.target_model,
+        is_enabled=body.is_enabled if body.is_enabled is not None else True,
+        persona_id=body.persona_id,
+        deployment_id=body.deployment_id,
+    )
+    return _ok(rule.model_dump(mode="json"), status=201)
+
+
+@router.put("")
+async def replace_or_update_rules(
+    body: dict,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRoutingRuleRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    if "items" in body:
+        req = ReplaceRulesRequest.model_validate(body)
+        items = [
+            {
+                "id": str(item.id) if item.id else None,
+                "agent_id": str(item.agent_id),
+                "persona_id": str(item.persona_id) if item.persona_id else None,
+                "deployment_id": str(item.deployment_id) if item.deployment_id else None,
+                "name": item.name,
+                "priority": item.priority or 100,
+                "match_type": item.match_type or "event",
+                "conditions": item.conditions or {"memo_type": []},
+                "action": item.action or {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None},
+                "target_runtime": item.target_runtime or "openclaw",
+                "target_model": item.target_model,
+                "is_enabled": item.is_enabled if item.is_enabled is not None else True,
+                "metadata": item.metadata or {},
+            }
+            for item in req.items
+        ]
+        rules = await repo.replace(org_id, project_id, uuid.UUID(auth.user_id), items)
+        return _ok([r.model_dump(mode="json") for r in rules])
+
+    req_update = UpdateRoutingRuleRequest.model_validate(body)
+    rule = await repo.update(
+        req_update.id,
+        org_id,
+        project_id,
+        **{k: v for k, v in req_update.model_dump().items() if k != "id"},
+    )
+    if rule is None:
+        return _err("NOT_FOUND", "Routing rule not found", 404)
+    return _ok(rule.model_dump(mode="json"))
+
+
+@router.patch("")
+async def reorder_or_disable_rules(
+    body: dict,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRoutingRuleRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    if body.get("disable_all") is True:
+        rules = await repo.disable_all(org_id, project_id)
+        return _ok([r.model_dump(mode="json") for r in rules])
+
+    req = ReorderRulesRequest.model_validate(body)
+    items = [{"id": str(item.id), "priority": item.priority} for item in req.items]
+    rules = await repo.reorder(org_id, project_id, items)
+    return _ok([r.model_dump(mode="json") for r in rules])
+
+
+@router.delete("")
+async def delete_rule(
+    id: uuid.UUID = Query(...),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentRoutingRuleRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    ok = await repo.delete(id, org_id, project_id)
+    if not ok:
+        return _err("NOT_FOUND", "Routing rule not found", 404)
+    return _ok({"ok": True, "id": str(id)})

--- a/backend/app/schemas/agent_routing_rule.py
+++ b/backend/app/schemas/agent_routing_rule.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class RoutingRuleResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    agent_id: uuid.UUID
+    persona_id: uuid.UUID | None
+    deployment_id: uuid.UUID | None
+    name: str
+    priority: int
+    match_type: str
+    conditions: dict[str, Any]
+    action: dict[str, Any]
+    target_runtime: str
+    target_model: str | None
+    is_enabled: bool
+    metadata: dict[str, Any]
+    created_by: uuid.UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class CreateRoutingRuleRequest(BaseModel):
+    agent_id: uuid.UUID
+    persona_id: uuid.UUID | None = None
+    deployment_id: uuid.UUID | None = None
+    name: str
+    priority: int | None = None
+    match_type: str | None = None
+    conditions: dict[str, Any] | None = None
+    action: dict[str, Any] | None = None
+    target_runtime: str | None = None
+    target_model: str | None = None
+    is_enabled: bool | None = None
+
+
+class UpdateRoutingRuleRequest(BaseModel):
+    id: uuid.UUID
+    agent_id: uuid.UUID | None = None
+    persona_id: uuid.UUID | None = None
+    deployment_id: uuid.UUID | None = None
+    name: str | None = None
+    priority: int | None = None
+    match_type: str | None = None
+    conditions: dict[str, Any] | None = None
+    action: dict[str, Any] | None = None
+    target_runtime: str | None = None
+    target_model: str | None = None
+    is_enabled: bool | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ReplaceRuleItem(BaseModel):
+    id: uuid.UUID | None = None
+    agent_id: uuid.UUID
+    persona_id: uuid.UUID | None = None
+    deployment_id: uuid.UUID | None = None
+    name: str
+    priority: int | None = None
+    match_type: str | None = None
+    conditions: dict[str, Any] | None = None
+    action: dict[str, Any] | None = None
+    target_runtime: str | None = None
+    target_model: str | None = None
+    is_enabled: bool | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ReplaceRulesRequest(BaseModel):
+    items: list[ReplaceRuleItem]
+
+
+class ReorderItem(BaseModel):
+    id: uuid.UUID
+    priority: int
+
+
+class ReorderRulesRequest(BaseModel):
+    items: list[ReorderItem]
+
+
+class DisableAllRequest(BaseModel):
+    disable_all: bool

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -131,7 +131,7 @@ def _build_routing_template(agents: list[dict], existing_rule_count: int) -> dic
 
 async def _replace_routing_rules(session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, actor_id: uuid.UUID, rules: list[dict]) -> None:
     await session.execute(
-        text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, :rules::jsonb)"),
+        text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, CAST(:rules AS jsonb))"),
         {
             "org_id": str(org_id),
             "project_id": str(project_id),

--- a/backend/tests/test_s43.py
+++ b/backend/tests/test_s43.py
@@ -1,0 +1,197 @@
+"""S43 AC: Agent Routing Rules CRUD — FastAPI /api/v2/agent-routing-rules/**"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+RULE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": ctx.user_id}
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+    async def override_auth():
+        return ctx
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _make_rule() -> "RoutingRuleResponse":
+    from app.schemas.agent_routing_rule import RoutingRuleResponse
+    now = datetime.now(timezone.utc)
+    return RoutingRuleResponse(
+        id=RULE_ID,
+        org_id=ORG_ID,
+        project_id=PROJECT_ID,
+        agent_id=AGENT_ID,
+        persona_id=None,
+        deployment_id=None,
+        name="Test Rule",
+        priority=10,
+        match_type="event",
+        conditions={"memo_type": ["task"]},
+        action={"auto_reply_mode": "process_and_report", "forward_to_agent_id": None},
+        target_runtime="openclaw",
+        target_model=None,
+        is_enabled=True,
+        metadata={},
+        created_by=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.anyio
+async def test_list_rules_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_make_rule()]
+            async with client as c:
+                resp = await c.get("/api/v2/agent-routing-rules")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["data"]) == 1
+            assert body["data"][0]["name"] == "Test Rule"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_rule_by_id_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_rule()
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-routing-rules?id={RULE_ID}")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["priority"] == 10
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_rule_201():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _make_rule()
+            payload = {"agent_id": str(AGENT_ID), "name": "Test Rule", "conditions": {"memo_type": ["task"]}}
+            async with client as c:
+                resp = await c.post("/api/v2/agent-routing-rules", json=payload)
+            assert resp.status_code == 201
+            assert resp.json()["data"]["match_type"] == "event"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_replace_rules_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.replace", new_callable=AsyncMock) as mock_replace:
+            mock_replace.return_value = [_make_rule()]
+            payload = {"items": [{"agent_id": str(AGENT_ID), "name": "Test Rule"}]}
+            async with client as c:
+                resp = await c.put("/api/v2/agent-routing-rules", json=payload)
+            assert resp.status_code == 200
+            assert len(resp.json()["data"]) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_rule_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.update", new_callable=AsyncMock) as mock_update:
+            updated = _make_rule()
+            updated.name = "Updated Rule"
+            mock_update.return_value = updated
+            payload = {"id": str(RULE_ID), "name": "Updated Rule"}
+            async with client as c:
+                resp = await c.put("/api/v2/agent-routing-rules", json=payload)
+            assert resp.status_code == 200
+            assert resp.json()["data"]["name"] == "Updated Rule"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_reorder_rules_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.reorder", new_callable=AsyncMock) as mock_reorder:
+            mock_reorder.return_value = [_make_rule()]
+            payload = {"items": [{"id": str(RULE_ID), "priority": 5}]}
+            async with client as c:
+                resp = await c.patch("/api/v2/agent-routing-rules", json=payload)
+            assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_disable_all_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.disable_all", new_callable=AsyncMock) as mock_disable:
+            disabled = _make_rule()
+            disabled.is_enabled = False
+            mock_disable.return_value = [disabled]
+            async with client as c:
+                resp = await c.patch("/api/v2/agent-routing-rules", json={"disable_all": True})
+            assert resp.status_code == 200
+            assert resp.json()["data"][0]["is_enabled"] is False
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_rule_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = True
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-routing-rules?id={RULE_ID}")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_rule_not_found_404():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_routing_rule.AgentRoutingRuleRepository.delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = False
+            async with client as c:
+                resp = await c.delete(f"/api/v2/agent-routing-rules?id={RULE_ID}")
+            assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- FastAPI `/api/v2/agent-routing-rules/**` 5개 엔드포인트 신규
- `replace_agent_routing_rules` DB RPC 활용 (S41에서 이미 검증됨)
- `AgentRoutingRule` SQLAlchemy 모델 신규 (metadata→rule_metadata 예약어 회피)
- reorder + disable_all + normalize_conditions/action 포함
- 프론트엔드 3개 fetch v1→v2 + Bearer 토큰 주입 (agent-workflow-editor.tsx)

## Test plan

- [ ] `GET /api/v2/agent-routing-rules` 목록 반환 확인
- [ ] `POST` 규칙 생성 201 확인
- [ ] `PUT` items 배열 → replace_rules RPC 호출 확인
- [ ] `PUT` id 포함 단건 → update_rule 확인
- [ ] `PATCH` disable_all: true → 전체 비활성화 확인
- [ ] `PATCH` items 배열 → reorder 확인
- [ ] `DELETE?id=` 삭제 + 404 확인
- [ ] 250/250 PASS, tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)