### PR TITLE
feat(backend): S44 Agent Sessions Lifecycle 이관

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -54,6 +54,7 @@ app.include_router(oss.router)
 app.include_router(agent_deployments.router)
 app.include_router(agent_personas.router)
 app.include_router(agent_routing_rules.router)
+app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
 
 if settings.is_ee_enabled:

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
+from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
@@ -27,6 +28,7 @@ __all__ = [
     "AgentPersona",
     "AgentRoutingRule",
     "AgentRun",
+    "AgentSession",
     "BridgeChannelMapping",
     "BridgeUserMapping",
     "ApiKey",

--- a/backend/app/models/agent_session.py
+++ b/backend/app/models/agent_session.py
@@ -1,0 +1,44 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentSession(Base):
+    __tablename__ = "agent_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    persona_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    deployment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    session_key: Mapped[str] = mapped_column(Text, nullable=False)
+    channel: Mapped[str] = mapped_column(Text, nullable=False, default="internal")
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")
+    context_window_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    session_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    context_snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_activity_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    idle_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    suspended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    ended_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    terminated_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/repositories/agent_session.py
+++ b/backend/app/repositories/agent_session.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_session import AgentSession
+from app.schemas.agent_session import AgentSessionResponse
+
+VALID_STATUSES = frozenset({"active", "idle", "suspended", "terminated"})
+
+
+class AgentSessionError(Exception):
+    def __init__(self, code: str, status: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+
+
+def _to_response(session: AgentSession) -> AgentSessionResponse:
+    return AgentSessionResponse(
+        id=session.id,
+        org_id=session.org_id,
+        project_id=session.project_id,
+        agent_id=session.agent_id,
+        persona_id=session.persona_id,
+        deployment_id=session.deployment_id,
+        session_key=session.session_key,
+        channel=session.channel,
+        title=session.title,
+        status=session.status,
+        context_window_tokens=session.context_window_tokens,
+        session_metadata=session.session_metadata or {},
+        context_snapshot=session.context_snapshot or {},
+        created_by=session.created_by,
+        started_at=session.started_at,
+        last_activity_at=session.last_activity_at,
+        idle_at=session.idle_at,
+        suspended_at=session.suspended_at,
+        ended_at=session.ended_at,
+        terminated_at=session.terminated_at,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+    )
+
+
+class AgentSessionRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        agent_id: uuid.UUID | None = None,
+        status: str | None = None,
+        limit: int = 50,
+    ) -> list[AgentSessionResponse]:
+        q = (
+            select(AgentSession)
+            .where(
+                AgentSession.org_id == org_id,
+                AgentSession.project_id == project_id,
+                AgentSession.deleted_at.is_(None),
+            )
+            .order_by(AgentSession.last_activity_at.desc())
+            .limit(min(limit, 100))
+        )
+        if agent_id:
+            q = q.where(AgentSession.agent_id == agent_id)
+        if status:
+            q = q.where(AgentSession.status == status)
+        r = await self.session.execute(q)
+        return [_to_response(s) for s in r.scalars().all()]
+
+    async def get(self, session_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> AgentSessionResponse | None:
+        r = await self.session.execute(
+            select(AgentSession).where(
+                AgentSession.id == session_id,
+                AgentSession.org_id == org_id,
+                AgentSession.project_id == project_id,
+                AgentSession.deleted_at.is_(None),
+            )
+        )
+        s = r.scalar_one_or_none()
+        return _to_response(s) if s else None
+
+    async def transition(
+        self,
+        session_id: uuid.UUID,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        status: str,
+        reason: str | None = None,
+    ) -> AgentSessionResponse:
+        if status not in VALID_STATUSES:
+            raise AgentSessionError("INVALID_STATUS", 400, f"Invalid status: {status}")
+
+        r = await self.session.execute(
+            select(AgentSession).where(
+                AgentSession.id == session_id,
+                AgentSession.org_id == org_id,
+                AgentSession.project_id == project_id,
+                AgentSession.deleted_at.is_(None),
+            )
+        )
+        s = r.scalar_one_or_none()
+        if s is None:
+            raise AgentSessionError("SESSION_NOT_FOUND", 404, "Session not found")
+
+        now = datetime.now(timezone.utc)
+        patch: dict[str, Any] = {
+            "status": status,
+            "last_activity_at": now,
+            "updated_at": now,
+            "session_metadata": {
+                **(s.session_metadata or {}),
+                "transition_reason": "manual_transition",
+                "transition_note": reason,
+                "transition_actor_id": str(actor_id),
+            },
+        }
+
+        if status == "active":
+            patch.update({"idle_at": None, "suspended_at": None, "ended_at": None, "terminated_at": None})
+        elif status == "idle":
+            patch.update({"idle_at": now, "suspended_at": None, "ended_at": None, "terminated_at": None})
+        elif status == "suspended":
+            patch.update({"idle_at": None, "suspended_at": now, "ended_at": None, "terminated_at": None})
+        else:  # terminated
+            patch.update({"idle_at": None, "suspended_at": None, "ended_at": now, "terminated_at": now})
+
+        await self.session.execute(
+            update(AgentSession).where(AgentSession.id == session_id).values(**patch)
+        )
+        await self.session.flush()
+        await self.session.refresh(s)
+        return _to_response(s)

--- a/backend/app/routers/agent_sessions.py
+++ b/backend/app/routers/agent_sessions.py
@@ -1,0 +1,72 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.agent_session import AgentSessionError, AgentSessionRepository
+from app.schemas.agent_session import TransitionSessionRequest
+
+router = APIRouter(prefix="/api/v2/agent-sessions", tags=["agent-sessions"])
+
+
+def _repo(session: AsyncSession = Depends(get_db)) -> AgentSessionRepository:
+    return AgentSessionRepository(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("")
+async def list_sessions(
+    agent_id: uuid.UUID | None = Query(default=None),
+    status: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=100),
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentSessionRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    sessions = await repo.list(org_id, project_id, agent_id=agent_id, status=status, limit=limit)
+    return _ok({"sessions": [s.model_dump(mode="json") for s in sessions]})
+
+
+@router.patch("/{id}")
+async def transition_session(
+    id: uuid.UUID,
+    body: TransitionSessionRequest,
+    auth: AuthContext = Depends(get_current_user),
+    repo: AgentSessionRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    try:
+        session = await repo.transition(
+            session_id=id,
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=uuid.UUID(auth.user_id),
+            status=body.status,
+            reason=body.reason,
+        )
+        return _ok({"session": session.model_dump(mode="json"), "resumptions": []})
+    except AgentSessionError as e:
+        return _err(e.code, str(e), e.status)

--- a/backend/app/schemas/agent_session.py
+++ b/backend/app/schemas/agent_session.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AgentSessionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    agent_id: uuid.UUID
+    persona_id: uuid.UUID | None
+    deployment_id: uuid.UUID | None
+    session_key: str
+    channel: str
+    title: str | None
+    status: str
+    context_window_tokens: int | None
+    session_metadata: dict[str, Any]
+    context_snapshot: dict[str, Any]
+    created_by: uuid.UUID | None
+    started_at: datetime
+    last_activity_at: datetime
+    idle_at: datetime | None
+    suspended_at: datetime | None
+    ended_at: datetime | None
+    terminated_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TransitionSessionRequest(BaseModel):
+    status: str
+    reason: str | None = None
+
+
+class SessionResumeCandidate(BaseModel):
+    run_id: str
+    memo_id: str
+    org_id: str
+    project_id: str
+    agent_id: str
+
+
+class TransitionSessionResponse(BaseModel):
+    session: AgentSessionResponse
+    resumptions: list[SessionResumeCandidate]

--- a/backend/tests/test_s44.py
+++ b/backend/tests/test_s44.py
@@ -160,3 +160,20 @@ async def test_transition_session_terminated_200():
             assert resp.json()["data"]["session"]["status"] == "terminated"
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_transition_session_idle_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.transition", new_callable=AsyncMock) as mock_tx:
+            s = _make_session("idle")
+            s.idle_at = datetime.now(timezone.utc)
+            mock_tx.return_value = s
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-sessions/{SESSION_ID}", json={"status": "idle"})
+            assert resp.status_code == 200
+            assert resp.json()["data"]["session"]["status"] == "idle"
+            assert resp.json()["data"]["resumptions"] == []
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_s44.py
+++ b/backend/tests/test_s44.py
@@ -1,0 +1,162 @@
+"""S44 AC: Agent Sessions Lifecycle — FastAPI /api/v2/agent-sessions/**"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+SESSION_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": ctx.user_id}
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+    async def override_auth():
+        return ctx
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _make_session(status: str = "active") -> "AgentSessionResponse":
+    from app.schemas.agent_session import AgentSessionResponse
+    now = datetime.now(timezone.utc)
+    return AgentSessionResponse(
+        id=SESSION_ID,
+        org_id=ORG_ID,
+        project_id=PROJECT_ID,
+        agent_id=AGENT_ID,
+        persona_id=None,
+        deployment_id=None,
+        session_key="memo:abc123",
+        channel="memo",
+        title="Test Session",
+        status=status,
+        context_window_tokens=None,
+        session_metadata={},
+        context_snapshot={},
+        created_by=None,
+        started_at=now,
+        last_activity_at=now,
+        idle_at=None,
+        suspended_at=None,
+        ended_at=None,
+        terminated_at=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.anyio
+async def test_list_sessions_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [_make_session()]
+            async with client as c:
+                resp = await c.get("/api/v2/agent-sessions")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["data"]["sessions"]) == 1
+            assert body["data"]["sessions"][0]["status"] == "active"
+            assert body["error"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_sessions_with_filters_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+            async with client as c:
+                resp = await c.get(f"/api/v2/agent-sessions?agent_id={AGENT_ID}&status=idle&limit=10")
+            assert resp.status_code == 200
+            assert resp.json()["data"]["sessions"] == []
+            mock_list.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_transition_session_active_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.transition", new_callable=AsyncMock) as mock_tx:
+            mock_tx.return_value = _make_session("active")
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-sessions/{SESSION_ID}", json={"status": "active"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["data"]["session"]["status"] == "active"
+            assert body["data"]["resumptions"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_transition_session_suspended_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.transition", new_callable=AsyncMock) as mock_tx:
+            s = _make_session("suspended")
+            s.suspended_at = datetime.now(timezone.utc)
+            mock_tx.return_value = s
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-sessions/{SESSION_ID}", json={"status": "suspended", "reason": "manual test"})
+            assert resp.status_code == 200
+            assert resp.json()["data"]["session"]["status"] == "suspended"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_transition_session_not_found_404():
+    client, session, app = await _client()
+    try:
+        from app.repositories.agent_session import AgentSessionError
+        with patch("app.repositories.agent_session.AgentSessionRepository.transition", new_callable=AsyncMock) as mock_tx:
+            mock_tx.side_effect = AgentSessionError("SESSION_NOT_FOUND", 404, "Session not found")
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-sessions/{SESSION_ID}", json={"status": "active"})
+            assert resp.status_code == 404
+            assert resp.json()["error"]["code"] == "SESSION_NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_transition_session_terminated_200():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.agent_session.AgentSessionRepository.transition", new_callable=AsyncMock) as mock_tx:
+            s = _make_session("terminated")
+            s.ended_at = datetime.now(timezone.utc)
+            s.terminated_at = datetime.now(timezone.utc)
+            mock_tx.return_value = s
+            async with client as c:
+                resp = await c.patch(f"/api/v2/agent-sessions/{SESSION_ID}", json={"status": "terminated"})
+            assert resp.status_code == 200
+            assert resp.json()["data"]["session"]["status"] == "terminated"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- FastAPI `/api/v2/agent-sessions/**` 2개 엔드포인트 신규
- `AgentSession` SQLAlchemy 모델 (session_metadata → metadata 예약어 회피)
- status 전환별 타임스탬프 자동 관리 (idle_at/suspended_at/ended_at/terminated_at)
- resumptions: [] (execution loop은 외부 계층 담당)

## Endpoints

| Method | Path | Description |
|---|---|---|
| GET | `/api/v2/agent-sessions` | list (agent_id/status/limit 필터) |
| PATCH | `/api/v2/agent-sessions/{id}` | status transition + reason |

## Test plan

- [ ] `GET /api/v2/agent-sessions` 목록 반환 확인
- [ ] `GET` ?agent_id + ?status + ?limit 필터 확인
- [ ] `PATCH {status: "active"}` idle_at/suspended_at null 확인
- [ ] `PATCH {status: "suspended"}` suspended_at 설정 확인
- [ ] `PATCH {status: "terminated"}` ended_at/terminated_at 설정 확인
- [ ] 없는 session_id → 404 확인
- [ ] 247/247 PASS, tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)