### PR TITLE
feat(s45): HITL policy + requests FastAPI v2 migration

### DIFF
--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { AlertTriangle, CheckCircle2, Clock3, ShieldAlert } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -30,11 +31,20 @@ export function AgentHitlPolicyEditor() {
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
+  const getAuthHeaders = async (): Promise<Record<string, string>> => {
+    const supabase = createSupabaseBrowserClient();
+    const { data: { session } } = await supabase.auth.getSession();
+    const headers: Record<string, string> = {};
+    if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+    return headers;
+  };
+
   const fetchPolicy = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/v1/hitl-policy');
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch('/api/v2/hitl/policy', { headers: authHeaders });
       if (!response.ok) throw new Error(t('policyLoadFailed'));
       const json = await response.json() as { data?: HitlPolicySnapshot };
       if (!json.data) throw new Error(t('policyLoadFailed'));
@@ -82,9 +92,10 @@ export function AgentHitlPolicyEditor() {
     setSaving(true);
     setError(null);
     try {
-      const response = await fetch('/api/v1/hitl-policy', {
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch('/api/v2/hitl/policy', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify({
           approval_rules: policy.approval_rules,
           timeout_classes: policy.timeout_classes,

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ArrowLeft, Bot, Clock3, RefreshCw, TriangleAlert, User } from 'lucide-react';
+import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -62,7 +63,12 @@ export function AgentHitlRequestsList() {
     else setLoading(true);
 
     try {
-      const res = await fetch('/api/v1/hitl-requests?status=pending');
+      const supabase = createSupabaseBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      const headers: Record<string, string> = {};
+      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
+
+      const res = await fetch('/api/v2/hitl/requests?status=pending', { headers });
       if (!res.ok) return;
       const json = await res.json() as { data?: HitlRequestItem[] };
       setRequests(json.data ?? []);

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, hitl, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -56,6 +56,7 @@ app.include_router(agent_personas.router)
 app.include_router(agent_routing_rules.router)
 app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
+app.include_router(hitl.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.hitl import HitlPolicy, HitlRequest
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.policy_document import PolicyDocument
@@ -31,6 +32,8 @@ __all__ = [
     "AgentSession",
     "BridgeChannelMapping",
     "BridgeUserMapping",
+    "HitlPolicy",
+    "HitlRequest",
     "ApiKey",
     "OrgSubscription",
     "PolicyDocument",

--- a/backend/app/models/hitl.py
+++ b/backend/app/models/hitl.py
@@ -51,3 +51,4 @@ class HitlRequest(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/models/hitl.py
+++ b/backend/app/models/hitl.py
@@ -1,0 +1,53 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class HitlPolicy(Base):
+    __tablename__ = "agent_hitl_policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, unique=True)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    updated_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class HitlRequest(Base):
+    __tablename__ = "agent_hitl_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    deployment_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    session_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    run_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    request_type: Mapped[str] = mapped_column(Text, nullable=False, default="approval")
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    prompt: Mapped[str] = mapped_column(Text, nullable=False)
+    requested_for: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")
+    response_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    responded_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    responded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    hitl_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/hitl.py
+++ b/backend/app/repositories/hitl.py
@@ -164,6 +164,7 @@ class HitlRepository:
         stmt = select(HitlRequest).where(
             HitlRequest.org_id == org_id,
             HitlRequest.project_id == project_id,
+            HitlRequest.deleted_at.is_(None),
         )
         if status:
             stmt = stmt.where(HitlRequest.status == status)
@@ -205,16 +206,19 @@ class HitlRepository:
         self,
         request_id: uuid.UUID,
         org_id: uuid.UUID,
+        project_id: uuid.UUID | None,
         actor_id: uuid.UUID,
         status: str,
         response_text: str | None,
     ) -> HitlRequest | None:
-        result = await self.session.execute(
-            select(HitlRequest).where(
-                HitlRequest.id == request_id,
-                HitlRequest.org_id == org_id,
-            )
+        stmt = select(HitlRequest).where(
+            HitlRequest.id == request_id,
+            HitlRequest.org_id == org_id,
+            HitlRequest.deleted_at.is_(None),
         )
+        if project_id is not None:
+            stmt = stmt.where(HitlRequest.project_id == project_id)
+        result = await self.session.execute(stmt)
         row = result.scalar_one_or_none()
         if row is None:
             return None

--- a/backend/app/repositories/hitl.py
+++ b/backend/app/repositories/hitl.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hitl import HitlPolicy, HitlRequest
+from app.schemas.hitl import (
+    HitlApprovalRule,
+    HitlHighRiskActionItem,
+    HitlPolicySnapshot,
+    HitlRequestResponse,
+    HitlTimeoutClass,
+)
+
+_HIGH_RISK_CATALOG: list[HitlHighRiskActionItem] = [
+    HitlHighRiskActionItem(
+        key="destructive_change",
+        severity="critical",
+        default_request_type="approval",
+        default_timeout_class="fast",
+        prompt_label="Destructive memo/story resolution, deletion, or irreversible state change",
+    ),
+    HitlHighRiskActionItem(
+        key="external_side_effect",
+        severity="high",
+        default_request_type="approval",
+        default_timeout_class="standard",
+        prompt_label="Outbound write to external systems, public channels, or third-party tools",
+    ),
+    HitlHighRiskActionItem(
+        key="credential_or_billing_change",
+        severity="critical",
+        default_request_type="approval",
+        default_timeout_class="fast",
+        prompt_label="Credential rotation, billing-impacting action, or managed-cost override",
+    ),
+]
+
+_DEFAULT_APPROVAL_RULES: list[HitlApprovalRule] = [
+    HitlApprovalRule(key="manual_hitl_request", request_type="approval", timeout_class="standard"),
+    HitlApprovalRule(key="billing_cap_exceeded", request_type="approval", timeout_class="fast"),
+]
+
+_DEFAULT_TIMEOUT_CLASSES: list[HitlTimeoutClass] = [
+    HitlTimeoutClass(key="fast", duration_minutes=240, reminder_minutes_before=60, escalation_mode="timeout_memo_and_escalate"),
+    HitlTimeoutClass(key="standard", duration_minutes=1440, reminder_minutes_before=60, escalation_mode="timeout_memo"),
+    HitlTimeoutClass(key="extended", duration_minutes=4320, reminder_minutes_before=240, escalation_mode="timeout_memo_and_escalate"),
+]
+
+
+def _merge_by_key(defaults: list, overrides: list) -> list:
+    override_map = {item.key: item for item in overrides}
+    return [override_map.get(d.key, d) for d in defaults]
+
+
+def _build_prompt_summary(approval_rules: list[HitlApprovalRule], timeout_classes: list[HitlTimeoutClass]) -> str:
+    timeout_map = {tc.key: tc for tc in timeout_classes}
+    high_risk_lines = "\n".join(
+        f"- {item.prompt_label} -> {item.default_request_type}/{item.default_timeout_class}"
+        for item in _HIGH_RISK_CATALOG
+    )
+    approval_lines = "\n".join(
+        f"- {rule.key} -> {rule.request_type}, timeout={rule.timeout_class}"
+        + (f" ({timeout_map[rule.timeout_class].duration_minutes}m, remind {timeout_map[rule.timeout_class].reminder_minutes_before}m before, {timeout_map[rule.timeout_class].escalation_mode})" if rule.timeout_class in timeout_map else "")
+        for rule in approval_rules
+    )
+    return "\n".join([
+        "HITL policy",
+        "High-risk action catalog:",
+        high_risk_lines or "- (none)",
+        "Approval-needed events:",
+        approval_lines or "- (none)",
+    ])
+
+
+def _build_snapshot(config: dict | None) -> HitlPolicySnapshot:
+    raw = config or {}
+    raw_rules = raw.get("approval_rules", [])
+    raw_timeouts = raw.get("timeout_classes", [])
+
+    try:
+        loaded_rules = [HitlApprovalRule(**r) for r in raw_rules if isinstance(r, dict)]
+        loaded_timeouts = [HitlTimeoutClass(**t) for t in raw_timeouts if isinstance(t, dict)]
+    except Exception:
+        loaded_rules, loaded_timeouts = [], []
+
+    approval_rules = _merge_by_key(_DEFAULT_APPROVAL_RULES, loaded_rules)
+    timeout_classes = _merge_by_key(_DEFAULT_TIMEOUT_CLASSES, loaded_timeouts)
+
+    return HitlPolicySnapshot(
+        schema_version=1,
+        high_risk_actions=_HIGH_RISK_CATALOG,
+        approval_rules=approval_rules,
+        timeout_classes=timeout_classes,
+        prompt_summary=_build_prompt_summary(approval_rules, timeout_classes),
+    )
+
+
+class HitlRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_policy(self, org_id: uuid.UUID, project_id: uuid.UUID) -> HitlPolicySnapshot:
+        result = await self.session.execute(
+            select(HitlPolicy.config).where(
+                HitlPolicy.org_id == org_id,
+                HitlPolicy.project_id == project_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+        return _build_snapshot(row)
+
+    async def save_policy(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        approval_rules: list[HitlApprovalRule],
+        timeout_classes: list[HitlTimeoutClass],
+    ) -> HitlPolicySnapshot:
+        merged_rules = _merge_by_key(_DEFAULT_APPROVAL_RULES, approval_rules)
+        merged_timeouts = _merge_by_key(_DEFAULT_TIMEOUT_CLASSES, timeout_classes)
+        config = {
+            "schema_version": 1,
+            "approval_rules": [r.model_dump() for r in merged_rules],
+            "timeout_classes": [t.model_dump() for t in merged_timeouts],
+        }
+        now = datetime.now(timezone.utc)
+
+        existing = await self.session.execute(
+            select(HitlPolicy).where(HitlPolicy.project_id == project_id)
+        )
+        row = existing.scalar_one_or_none()
+
+        if row is None:
+            self.session.add(HitlPolicy(
+                org_id=org_id,
+                project_id=project_id,
+                config=config,
+                created_by=actor_id,
+                updated_by=actor_id,
+                created_at=now,
+                updated_at=now,
+            ))
+        else:
+            await self.session.execute(
+                update(HitlPolicy)
+                .where(HitlPolicy.project_id == project_id)
+                .values(config=config, updated_by=actor_id, updated_at=now)
+            )
+        await self.session.commit()
+
+        return _build_snapshot(config)
+
+    async def list_requests(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        status: str | None = None,
+    ) -> list[HitlRequestResponse]:
+        stmt = select(HitlRequest).where(
+            HitlRequest.org_id == org_id,
+            HitlRequest.project_id == project_id,
+        )
+        if status:
+            stmt = stmt.where(HitlRequest.status == status)
+        stmt = stmt.order_by(HitlRequest.created_at.desc())
+
+        result = await self.session.execute(stmt)
+        rows = result.scalars().all()
+
+        return [
+            HitlRequestResponse(
+                id=r.id,
+                org_id=r.org_id,
+                project_id=r.project_id,
+                agent_id=r.agent_id,
+                deployment_id=r.deployment_id,
+                session_id=r.session_id,
+                run_id=r.run_id,
+                request_type=r.request_type,
+                title=r.title,
+                prompt=r.prompt,
+                requested_for=r.requested_for,
+                status=r.status,
+                response_text=r.response_text,
+                responded_by=r.responded_by,
+                responded_at=r.responded_at,
+                expires_at=r.expires_at,
+                hitl_metadata=r.hitl_metadata or {},
+                created_at=r.created_at,
+                updated_at=r.updated_at,
+                agent_name=r.hitl_metadata.get("agent_name") if r.hitl_metadata else None,
+                requested_for_name=r.hitl_metadata.get("requested_for_name") if r.hitl_metadata else None,
+                source_memo_id=r.hitl_metadata.get("source_memo_id") if r.hitl_metadata else None,
+                hitl_memo_id=r.hitl_metadata.get("hitl_memo_id") if r.hitl_metadata else None,
+            )
+            for r in rows
+        ]
+
+    async def resolve_request(
+        self,
+        request_id: uuid.UUID,
+        org_id: uuid.UUID,
+        actor_id: uuid.UUID,
+        status: str,
+        response_text: str | None,
+    ) -> HitlRequest | None:
+        result = await self.session.execute(
+            select(HitlRequest).where(
+                HitlRequest.id == request_id,
+                HitlRequest.org_id == org_id,
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row is None:
+            return None
+        if row.status != "pending":
+            return None
+
+        now = datetime.now(timezone.utc)
+        await self.session.execute(
+            update(HitlRequest)
+            .where(HitlRequest.id == request_id)
+            .values(
+                status=status,
+                response_text=response_text,
+                responded_by=actor_id,
+                responded_at=now,
+                updated_at=now,
+            )
+        )
+        await self.session.commit()
+        await self.session.refresh(row)
+        return row

--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -84,12 +84,13 @@ async def resolve_hitl_request(
     auth: AuthContext = Depends(get_current_user),
     repo: HitlRepository = Depends(_repo),
 ) -> JSONResponse:
-    org_id, _ = _get_org_project(auth)
+    org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     row = await repo.resolve_request(
         request_id=request_id,
         org_id=org_id,
+        project_id=project_id,
         actor_id=auth.user_id,
         status=body.status,
         response_text=body.response_text,

--- a/backend/app/routers/hitl.py
+++ b/backend/app/routers/hitl.py
@@ -1,0 +1,103 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.hitl import HitlRepository
+from app.schemas.hitl import PatchHitlPolicyRequest, ResolveHitlRequestBody
+
+router = APIRouter(prefix="/api/v2/hitl", tags=["hitl"])
+
+
+def _repo(session: AsyncSession = Depends(get_db)) -> HitlRepository:
+    return HitlRepository(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("/policy")
+async def get_hitl_policy(
+    auth: AuthContext = Depends(get_current_user),
+    repo: HitlRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    snapshot = await repo.get_policy(org_id, project_id)
+    return _ok(snapshot.model_dump())
+
+
+@router.patch("/policy")
+async def update_hitl_policy(
+    body: PatchHitlPolicyRequest,
+    auth: AuthContext = Depends(get_current_user),
+    repo: HitlRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    snapshot = await repo.save_policy(
+        org_id=org_id,
+        project_id=project_id,
+        actor_id=auth.user_id,
+        approval_rules=body.approval_rules,
+        timeout_classes=body.timeout_classes,
+    )
+    return _ok(snapshot.model_dump())
+
+
+@router.get("/requests")
+async def list_hitl_requests(
+    status: str | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    repo: HitlRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    requests = await repo.list_requests(org_id=org_id, project_id=project_id, status=status)
+    return _ok([r.model_dump() for r in requests])
+
+
+@router.patch("/requests/{request_id}")
+async def resolve_hitl_request(
+    request_id: uuid.UUID,
+    body: ResolveHitlRequestBody,
+    auth: AuthContext = Depends(get_current_user),
+    repo: HitlRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, _ = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    row = await repo.resolve_request(
+        request_id=request_id,
+        org_id=org_id,
+        actor_id=auth.user_id,
+        status=body.status,
+        response_text=body.response_text,
+    )
+    if row is None:
+        return _err("NOT_FOUND_OR_NOT_PENDING", "Request not found or not in pending status", 404)
+    return _ok({
+        "id": str(row.id),
+        "status": row.status,
+        "responded_at": row.responded_at.isoformat() if row.responded_at else None,
+    })

--- a/backend/app/schemas/hitl.py
+++ b/backend/app/schemas/hitl.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class HitlHighRiskActionItem(BaseModel):
+    key: str
+    severity: str
+    default_request_type: str
+    default_timeout_class: str
+    prompt_label: str
+
+
+class HitlApprovalRule(BaseModel):
+    key: str
+    request_type: str
+    timeout_class: str
+    approval_required: bool = True
+
+
+class HitlTimeoutClass(BaseModel):
+    key: str
+    duration_minutes: int
+    reminder_minutes_before: int
+    escalation_mode: str
+
+
+class HitlPolicySnapshot(BaseModel):
+    schema_version: Literal[1] = 1
+    high_risk_actions: list[HitlHighRiskActionItem]
+    approval_rules: list[HitlApprovalRule]
+    timeout_classes: list[HitlTimeoutClass]
+    prompt_summary: str
+
+
+class PatchHitlPolicyRequest(BaseModel):
+    approval_rules: list[HitlApprovalRule]
+    timeout_classes: list[HitlTimeoutClass]
+
+
+class HitlRequestResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    agent_id: uuid.UUID
+    deployment_id: uuid.UUID | None = None
+    session_id: uuid.UUID | None = None
+    run_id: uuid.UUID | None = None
+    request_type: str
+    title: str
+    prompt: str
+    requested_for: uuid.UUID
+    status: str
+    response_text: str | None = None
+    responded_by: uuid.UUID | None = None
+    responded_at: datetime | None = None
+    expires_at: datetime | None = None
+    hitl_metadata: dict[str, Any]
+    created_at: datetime
+    updated_at: datetime
+    # enriched
+    agent_name: str | None = None
+    requested_for_name: str | None = None
+    source_memo_id: str | None = None
+    hitl_memo_id: str | None = None
+
+
+class ResolveHitlRequestBody(BaseModel):
+    status: Literal["approved", "rejected"]
+    response_text: str | None = None

--- a/backend/tests/test_s45.py
+++ b/backend/tests/test_s45.py
@@ -1,0 +1,227 @@
+"""S45 AC: HITL Policy + Requests — FastAPI /api/v2/hitl/**"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+REQUEST_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = USER_ID
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": str(USER_ID)}
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app, ctx
+
+
+def _make_snapshot_dict():
+    return {
+        "schema_version": 1,
+        "high_risk_actions": [
+            {"key": "destructive_change", "severity": "critical", "default_request_type": "approval", "default_timeout_class": "fast", "prompt_label": "Destructive change"},
+        ],
+        "approval_rules": [
+            {"key": "manual_hitl_request", "request_type": "approval", "timeout_class": "standard", "approval_required": True},
+        ],
+        "timeout_classes": [
+            {"key": "standard", "duration_minutes": 1440, "reminder_minutes_before": 60, "escalation_mode": "timeout_memo"},
+        ],
+        "prompt_summary": "HITL policy\n...",
+    }
+
+
+def _make_request_dict():
+    return {
+        "id": str(REQUEST_ID),
+        "org_id": str(ORG_ID),
+        "project_id": str(PROJECT_ID),
+        "agent_id": str(AGENT_ID),
+        "deployment_id": None,
+        "session_id": None,
+        "run_id": None,
+        "request_type": "approval",
+        "title": "Test HITL",
+        "prompt": "Please approve",
+        "requested_for": str(USER_ID),
+        "status": "pending",
+        "response_text": None,
+        "responded_by": None,
+        "responded_at": None,
+        "expires_at": None,
+        "hitl_metadata": {},
+        "created_at": "2026-04-30T00:00:00+00:00",
+        "updated_at": "2026-04-30T00:00:00+00:00",
+        "agent_name": None,
+        "requested_for_name": None,
+        "source_memo_id": None,
+        "hitl_memo_id": None,
+    }
+
+
+# --- Policy ---
+
+@pytest.mark.anyio
+async def test_get_hitl_policy_returns_snapshot():
+    client, session, app, ctx = await _client()
+    try:
+        snapshot = MagicMock()
+        snapshot.model_dump.return_value = _make_snapshot_dict()
+        with patch("app.repositories.hitl.HitlRepository.get_policy", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = snapshot
+            async with client as c:
+                resp = await c.get("/api/v2/hitl/policy")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert body["data"]["schema_version"] == 1
+        assert "approval_rules" in body["data"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_patch_hitl_policy_saves_and_returns():
+    client, session, app, ctx = await _client()
+    try:
+        snapshot = MagicMock()
+        snapshot.model_dump.return_value = _make_snapshot_dict()
+        with patch("app.repositories.hitl.HitlRepository.save_policy", new_callable=AsyncMock) as mock_save:
+            mock_save.return_value = snapshot
+            payload = {
+                "approval_rules": [{"key": "manual_hitl_request", "request_type": "approval", "timeout_class": "standard", "approval_required": True}],
+                "timeout_classes": [{"key": "standard", "duration_minutes": 1440, "reminder_minutes_before": 60, "escalation_mode": "timeout_memo"}],
+            }
+            async with client as c:
+                resp = await c.patch("/api/v2/hitl/policy", json=payload)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert body["data"]["schema_version"] == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_hitl_policy_default_when_no_record():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.repositories.hitl.HitlRepository.get_policy", new_callable=AsyncMock) as mock_get:
+            from app.repositories.hitl import _build_snapshot
+            mock_get.return_value = _build_snapshot(None)
+            async with client as c:
+                resp = await c.get("/api/v2/hitl/policy")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["data"]["approval_rules"]) == 2
+        assert len(body["data"]["timeout_classes"]) == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+# --- Requests ---
+
+@pytest.mark.anyio
+async def test_list_hitl_requests_pending():
+    client, session, app, ctx = await _client()
+    try:
+        item = MagicMock()
+        item.model_dump.return_value = _make_request_dict()
+        with patch("app.repositories.hitl.HitlRepository.list_requests", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [item]
+            async with client as c:
+                resp = await c.get("/api/v2/hitl/requests?status=pending")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert len(body["data"]) == 1
+        assert body["data"][0]["status"] == "pending"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_hitl_requests_empty():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.repositories.hitl.HitlRepository.list_requests", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+            async with client as c:
+                resp = await c.get("/api/v2/hitl/requests")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_hitl_request_approved():
+    client, session, app, ctx = await _client()
+    try:
+        from datetime import datetime, timezone
+        row = MagicMock()
+        row.id = REQUEST_ID
+        row.status = "approved"
+        row.responded_at = datetime(2026, 4, 30, 0, 0, 0, tzinfo=timezone.utc)
+        with patch("app.repositories.hitl.HitlRepository.resolve_request", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = row
+            async with client as c:
+                resp = await c.patch(f"/api/v2/hitl/requests/{REQUEST_ID}", json={"status": "approved"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert body["data"]["status"] == "approved"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_hitl_request_not_found_404():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.repositories.hitl.HitlRepository.resolve_request", new_callable=AsyncMock) as mock_resolve:
+            mock_resolve.return_value = None
+            async with client as c:
+                resp = await c.patch(f"/api/v2/hitl/requests/{uuid.uuid4()}", json={"status": "rejected"})
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["error"]["code"] == "NOT_FOUND_OR_NOT_PENDING"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_resolve_hitl_request_invalid_status_422():
+    client, session, app, ctx = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/hitl/requests/{REQUEST_ID}", json={"status": "pending"})
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `HitlPolicy` + `HitlRequest` SQLAlchemy 모델 (`hitl_metadata` reserved word alias 패턴)
- `HitlRepository`: policy GET/SAVE (default snapshot builder), requests LIST/RESOLVE
- 4 endpoints: `GET/PATCH /api/v2/hitl/policy`, `GET /api/v2/hitl/requests`, `PATCH /api/v2/hitl/requests/{id}`
- `agent-hitl-policy-editor` + `agent-hitl-requests-list` v1→v2 + Bearer 토큰 주입

## Test plan
- [ ] `GET /api/v2/hitl/policy` — default snapshot 반환 (DB 레코드 없을 시)
- [ ] `PATCH /api/v2/hitl/policy` — approval_rules + timeout_classes 저장 후 snapshot 반환
- [ ] `GET /api/v2/hitl/requests?status=pending` — pending 목록 반환
- [ ] `PATCH /api/v2/hitl/requests/{id}` approved → 200
- [ ] `PATCH /api/v2/hitl/requests/{id}` not found → 404
- [ ] `PATCH /api/v2/hitl/requests/{id}` invalid status → 422
- [ ] 8/8 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)