### PR TITLE
feat(s46): Workflow Versions + Rollback FastAPI v2 migration

### DIFF
--- a/apps/web/src/components/agents/agent-workflow-editor.tsx
+++ b/apps/web/src/components/agents/agent-workflow-editor.tsx
@@ -632,16 +632,23 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
   }, [addToast, rollbackSnapshot, syncCanvasFromRules, t]);
 
   useEffect(() => {
-    fetch('/api/v1/workflow-versions')
-      .then((r) => r.json())
-      .then((json: { data?: WorkflowVersionSummary[] }) => { if (Array.isArray(json.data)) setVersions(json.data); })
-      .catch(() => null);
+    void (async () => {
+      try {
+        const authHeaders = await getAuthHeaders();
+        const r = await fetch('/api/v2/workflow-versions', { headers: authHeaders });
+        const json = await r.json() as { data?: WorkflowVersionSummary[] };
+        if (Array.isArray(json.data)) setVersions(json.data);
+      } catch {
+        // ignore
+      }
+    })();
   }, [savedRules]);
 
   const rollbackToVersion = useCallback(async (versionId: string) => {
     setSaving(true);
     try {
-      const response = await fetch(`/api/v1/workflow-versions/${versionId}/rollback`, { method: 'POST' });
+      const authHeaders = await getAuthHeaders();
+      const response = await fetch(`/api/v2/workflow-versions/${versionId}/rollback`, { method: 'POST', headers: authHeaders });
       const json = await response.json().catch(() => null) as { data?: RoutingRuleSummary[] } | null;
       if (!response.ok || !json?.data || !Array.isArray(json.data)) throw new Error(t('workflowRollbackErrorBody'));
       setSavedRules(json.data);

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, hitl, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, hitl, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -57,6 +57,7 @@ app.include_router(agent_routing_rules.router)
 app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
 app.include_router(hitl.router)
+app.include_router(workflow_versions.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.hitl import HitlPolicy, HitlRequest
+from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.policy_document import PolicyDocument
@@ -65,4 +66,5 @@ __all__ = [
     "Story",
     "Task",
     "TeamMember",
+    "WorkflowVersion",
 ]

--- a/backend/app/models/workflow_version.py
+++ b/backend/app/models/workflow_version.py
@@ -1,0 +1,23 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class WorkflowVersion(Base):
+    __tablename__ = "workflow_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
+    change_summary: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/workflow_version.py
+++ b/backend/app/repositories/workflow_version.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.workflow_version import WorkflowVersion
+from app.repositories.agent_routing_rule import AgentRoutingRuleRepository
+from app.schemas.agent_routing_rule import RoutingRuleResponse
+from app.schemas.workflow_version import ChangeSummary, WorkflowVersionResponse
+
+
+def _to_response(row: WorkflowVersion) -> WorkflowVersionResponse:
+    raw_summary = row.change_summary or {}
+    return WorkflowVersionResponse(
+        id=row.id,
+        org_id=row.org_id,
+        project_id=row.project_id,
+        version=row.version,
+        snapshot=row.snapshot or [],
+        change_summary=ChangeSummary(
+            added_rules=raw_summary.get("added_rules", 0),
+            removed_rules=raw_summary.get("removed_rules", 0),
+            changed_rules=raw_summary.get("changed_rules", 0),
+        ),
+        created_by=row.created_by,
+        created_at=row.created_at,
+    )
+
+
+class WorkflowVersionRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def list(self, org_id: uuid.UUID, project_id: uuid.UUID) -> list[WorkflowVersionResponse]:
+        result = await self.session.execute(
+            select(WorkflowVersion)
+            .where(
+                WorkflowVersion.org_id == org_id,
+                WorkflowVersion.project_id == project_id,
+            )
+            .order_by(WorkflowVersion.version.desc())
+        )
+        return [_to_response(row) for row in result.scalars().all()]
+
+    async def get(self, version_id: uuid.UUID, org_id: uuid.UUID, project_id: uuid.UUID) -> WorkflowVersion | None:
+        result = await self.session.execute(
+            select(WorkflowVersion).where(
+                WorkflowVersion.id == version_id,
+                WorkflowVersion.org_id == org_id,
+                WorkflowVersion.project_id == project_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def rollback(
+        self,
+        version_id: uuid.UUID,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        actor_id: uuid.UUID,
+    ) -> list[RoutingRuleResponse] | None:
+        row = await self.get(version_id, org_id, project_id)
+        if row is None:
+            return None
+
+        snapshot_items = row.snapshot or []
+        rule_repo = AgentRoutingRuleRepository(self.session)
+        return await rule_repo.replace(
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=actor_id,
+            items=snapshot_items,
+        )

--- a/backend/app/routers/workflow_versions.py
+++ b/backend/app/routers/workflow_versions.py
@@ -41,7 +41,7 @@ async def list_workflow_versions(
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
     versions = await repo.list(org_id=org_id, project_id=project_id)
-    return _ok([v.model_dump() for v in versions])
+    return _ok([v.model_dump(mode="json") for v in versions])
 
 
 @router.post("/{version_id}/rollback")
@@ -61,4 +61,4 @@ async def rollback_to_version(
     )
     if rules is None:
         return _err("NOT_FOUND", "Workflow version not found", 404)
-    return _ok([r.model_dump() for r in rules])
+    return _ok([r.model_dump(mode="json") for r in rules])

--- a/backend/app/routers/workflow_versions.py
+++ b/backend/app/routers/workflow_versions.py
@@ -1,0 +1,64 @@
+import uuid
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.repositories.workflow_version import WorkflowVersionRepository
+
+router = APIRouter(prefix="/api/v2/workflow-versions", tags=["workflow-versions"])
+
+
+def _repo(session: AsyncSession = Depends(get_db)) -> WorkflowVersionRepository:
+    return WorkflowVersionRepository(session)
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    meta = auth.claims.get("app_metadata", {})
+    org_id_str = meta.get("org_id")
+    project_id_str = meta.get("project_id")
+    if not org_id_str or not project_id_str:
+        return None, None
+    return uuid.UUID(str(org_id_str)), uuid.UUID(str(project_id_str))
+
+
+@router.get("")
+async def list_workflow_versions(
+    auth: AuthContext = Depends(get_current_user),
+    repo: WorkflowVersionRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    versions = await repo.list(org_id=org_id, project_id=project_id)
+    return _ok([v.model_dump() for v in versions])
+
+
+@router.post("/{version_id}/rollback")
+async def rollback_to_version(
+    version_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    repo: WorkflowVersionRepository = Depends(_repo),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+    rules = await repo.rollback(
+        version_id=version_id,
+        org_id=org_id,
+        project_id=project_id,
+        actor_id=auth.user_id,
+    )
+    if rules is None:
+        return _err("NOT_FOUND", "Workflow version not found", 404)
+    return _ok([r.model_dump() for r in rules])

--- a/backend/app/schemas/workflow_version.py
+++ b/backend/app/schemas/workflow_version.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ChangeSummary(BaseModel):
+    added_rules: int = 0
+    removed_rules: int = 0
+    changed_rules: int = 0
+
+
+class WorkflowVersionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    version: int
+    snapshot: list[dict[str, Any]]
+    change_summary: ChangeSummary
+    created_by: uuid.UUID | None = None
+    created_at: datetime

--- a/backend/tests/test_s46.py
+++ b/backend/tests/test_s46.py
@@ -1,0 +1,156 @@
+"""S46 AC: Workflow Versions + Rollback — FastAPI /api/v2/workflow-versions/**"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+VERSION_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = USER_ID
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}, "sub": str(USER_ID)}
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app, ctx
+
+
+def _make_version_dict():
+    return {
+        "id": str(VERSION_ID),
+        "org_id": str(ORG_ID),
+        "project_id": str(PROJECT_ID),
+        "version": 3,
+        "snapshot": [],
+        "change_summary": {"added_rules": 1, "removed_rules": 0, "changed_rules": 0},
+        "created_by": str(USER_ID),
+        "created_at": "2026-04-30T00:00:00+00:00",
+    }
+
+
+def _make_rule_dict():
+    return {
+        "id": str(uuid.uuid4()),
+        "org_id": str(ORG_ID),
+        "project_id": str(PROJECT_ID),
+        "agent_id": str(uuid.uuid4()),
+        "persona_id": None,
+        "deployment_id": None,
+        "name": "Rule A",
+        "priority": 100,
+        "match_type": "event",
+        "conditions": {"memo_type": []},
+        "action": {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None},
+        "target_runtime": "openclaw",
+        "target_model": None,
+        "is_enabled": True,
+        "metadata": {},
+        "created_by": str(USER_ID),
+        "created_at": "2026-04-30T00:00:00+00:00",
+        "updated_at": "2026-04-30T00:00:00+00:00",
+    }
+
+
+@pytest.mark.anyio
+async def test_list_workflow_versions_200():
+    client, session, app, ctx = await _client()
+    try:
+        v = MagicMock()
+        v.model_dump.return_value = _make_version_dict()
+        with patch("app.repositories.workflow_version.WorkflowVersionRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = [v]
+            async with client as c:
+                resp = await c.get("/api/v2/workflow-versions")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert len(body["data"]) == 1
+        assert body["data"][0]["version"] == 3
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_workflow_versions_empty():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.repositories.workflow_version.WorkflowVersionRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+            async with client as c:
+                resp = await c.get("/api/v2/workflow-versions")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rollback_to_version_200():
+    client, session, app, ctx = await _client()
+    try:
+        rule = MagicMock()
+        rule.model_dump.return_value = _make_rule_dict()
+        with patch("app.repositories.workflow_version.WorkflowVersionRepository.rollback", new_callable=AsyncMock) as mock_rb:
+            mock_rb.return_value = [rule]
+            async with client as c:
+                resp = await c.post(f"/api/v2/workflow-versions/{VERSION_ID}/rollback")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert len(body["data"]) == 1
+        assert body["data"][0]["name"] == "Rule A"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_rollback_to_version_not_found_404():
+    client, session, app, ctx = await _client()
+    try:
+        with patch("app.repositories.workflow_version.WorkflowVersionRepository.rollback", new_callable=AsyncMock) as mock_rb:
+            mock_rb.return_value = None
+            async with client as c:
+                resp = await c.post(f"/api/v2/workflow-versions/{uuid.uuid4()}/rollback")
+        assert resp.status_code == 404
+        body = resp.json()
+        assert body["error"]["code"] == "NOT_FOUND"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_workflow_versions_no_auth_403():
+    client, session, app, ctx = await _client()
+    ctx.claims = {}
+    try:
+        with patch("app.repositories.workflow_version.WorkflowVersionRepository.list", new_callable=AsyncMock) as mock_list:
+            mock_list.return_value = []
+            async with client as c:
+                resp = await c.get("/api/v2/workflow-versions")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `WorkflowVersion` SQLAlchemy 모델 (`workflow_versions` 테이블)
- `WorkflowVersionRepository`: list + rollback (S43 `AgentRoutingRuleRepository.replace()` 재활용)
- `GET /api/v2/workflow-versions` — 버전 목록 (내림차순)
- `POST /api/v2/workflow-versions/{id}/rollback` — 해당 버전 snapshot으로 룰 교체
- `agent-workflow-editor`: `/api/v1/workflow-versions` → `/api/v2` + Bearer token 주입 (2개 fetch)

## Test plan
- [ ] `GET /api/v2/workflow-versions` → 200 + 버전 목록
- [ ] `GET /api/v2/workflow-versions` (빈 목록) → 200 + []
- [ ] `POST /api/v2/workflow-versions/{id}/rollback` → 200 + 룰 목록
- [ ] `POST /api/v2/workflow-versions/{unknown}/rollback` → 404
- [ ] `GET /api/v2/workflow-versions` (org_id 없음) → 403
- [ ] 5/5 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)