### PR TITLE
feat(s47): Bridge — Slack Events/Interactions + Teams Events FastAPI v2 migration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -54,6 +54,7 @@ app.include_router(oss.router)
 app.include_router(agent_deployments.router)
 app.include_router(agent_personas.router)
 app.include_router(agent_routing_rules.router)
+app.include_router(bridge.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun
+from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
 from app.models.policy_document import PolicyDocument
@@ -26,6 +27,8 @@ __all__ = [
     "AgentPersona",
     "AgentRoutingRule",
     "AgentRun",
+    "BridgeChannelMapping",
+    "BridgeUserMapping",
     "ApiKey",
     "OrgSubscription",
     "PolicyDocument",

--- a/backend/app/models/bridge.py
+++ b/backend/app/models/bridge.py
@@ -1,0 +1,38 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class BridgeChannelMapping(Base):
+    __tablename__ = "messaging_bridge_channels"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    channel_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    config: Mapped[dict] = mapped_column(JSONB, nullable=True, default=dict)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class BridgeUserMapping(Base):
+    __tablename__ = "messaging_bridge_users"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    platform: Mapped[str] = mapped_column(Text, nullable=False)
+    platform_user_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    team_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/bridge_inbound.py
+++ b/backend/app/repositories/bridge_inbound.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import time
+import uuid
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
+from app.models.memo import Memo
+from app.models.team import TeamMember
+
+_RATE_LIMIT_WINDOW = 60
+_RATE_LIMIT_MAX = 60
+_rate_buckets: dict[str, list[float]] = defaultdict(list)
+
+
+def check_rate_limit(key: str, now: float | None = None) -> bool:
+    now = now or time.time()
+    bucket = _rate_buckets[key]
+    recent = [t for t in bucket if now - t < _RATE_LIMIT_WINDOW]
+    if len(recent) >= _RATE_LIMIT_MAX:
+        _rate_buckets[key] = recent
+        return False
+    recent.append(now)
+    _rate_buckets[key] = recent
+    return True
+
+
+class BridgeInboundRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def find_channel_mapping(self, platform: str, channel_id: str) -> BridgeChannelMapping | None:
+        result = await self.session.execute(
+            select(BridgeChannelMapping).where(
+                BridgeChannelMapping.platform == platform,
+                BridgeChannelMapping.channel_id == channel_id,
+                BridgeChannelMapping.is_active.is_(True),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def find_user_mapping(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        platform: str,
+        platform_user_id: str,
+    ) -> BridgeUserMapping | None:
+        result = await self.session.execute(
+            select(BridgeUserMapping).where(
+                BridgeUserMapping.org_id == org_id,
+                BridgeUserMapping.platform == platform,
+                BridgeUserMapping.platform_user_id == platform_user_id,
+                BridgeUserMapping.is_active.is_(True),
+            )
+        )
+        mapping = result.scalar_one_or_none()
+        if mapping is None:
+            return None
+
+        member = await self.session.execute(
+            select(TeamMember.id).where(
+                TeamMember.id == mapping.team_member_id,
+                TeamMember.org_id == org_id,
+                TeamMember.project_id == project_id,
+                TeamMember.is_active.is_(True),
+            )
+        )
+        if member.scalar_one_or_none() is None:
+            return None
+        return mapping
+
+    async def find_fallback_author(self, org_id: uuid.UUID, project_id: uuid.UUID) -> uuid.UUID | None:
+        for member_type in ("agent", "human"):
+            result = await self.session.execute(
+                select(TeamMember.id)
+                .where(
+                    TeamMember.org_id == org_id,
+                    TeamMember.project_id == project_id,
+                    TeamMember.type == member_type,
+                    TeamMember.is_active.is_(True),
+                )
+                .order_by(TeamMember.created_at.asc())
+                .limit(1)
+            )
+            found = result.scalar_one_or_none()
+            if found:
+                return found
+        return None
+
+    async def find_existing_memo_by_event_id(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        platform: str,
+        event_id: str | None,
+    ) -> str | None:
+        if not event_id:
+            return None
+        result = await self.session.execute(
+            select(Memo.id).where(
+                Memo.org_id == org_id,
+                Memo.project_id == project_id,
+                Memo.memo_metadata["source"].as_string() == platform,
+                Memo.memo_metadata["event_id"].as_string() == event_id,
+                Memo.deleted_at.is_(None),
+            )
+        )
+        row = result.scalar_one_or_none()
+        return str(row) if row else None
+
+    async def create_memo(
+        self,
+        org_id: uuid.UUID,
+        project_id: uuid.UUID,
+        created_by: uuid.UUID,
+        title: str,
+        content: str,
+        memo_type: str,
+        metadata: dict[str, Any],
+        assigned_to: uuid.UUID | None,
+    ) -> str:
+        now = datetime.now(timezone.utc)
+        memo = Memo(
+            org_id=org_id,
+            project_id=project_id,
+            created_by=created_by,
+            assigned_to=assigned_to,
+            memo_type=memo_type,
+            title=title,
+            content=content,
+            status="open",
+            memo_metadata=metadata,
+            created_at=now,
+            updated_at=now,
+        )
+        self.session.add(memo)
+        await self.session.flush()
+        return str(memo.id)
+
+
+def build_bridge_metadata(platform: str, event: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "source": platform,
+        "channel_id": event.get("channelId"),
+        "thread_ts": event.get("threadTs"),
+        "team_id": event.get("teamId"),
+    }
+    if event.get("eventId"):
+        metadata["event_id"] = event["eventId"]
+    if platform == "slack":
+        metadata["slack_ts"] = event.get("messageTs")
+    elif platform == "teams":
+        raw = event.get("raw") or {}
+        metadata["teams_activity_id"] = raw.get("id") or event.get("messageTs")
+        metadata["teams_service_url"] = raw.get("serviceUrl")
+        metadata["teams_conversation_id"] = (raw.get("conversation") or {}).get("id") or event.get("channelId")
+    return metadata

--- a/backend/app/routers/bridge.py
+++ b/backend/app/routers/bridge.py
@@ -1,0 +1,296 @@
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import parse_qs
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sqlalchemy import select, update
+
+from app.dependencies.database import get_db
+from app.repositories.bridge_inbound import BridgeInboundRepository, build_bridge_metadata, check_rate_limit
+from app.utils.slack_verify import verify_slack_signature
+from app.utils.teams_verify import verify_teams_request
+
+router = APIRouter(prefix="/api/v2/bridge", tags=["bridge"])
+
+
+# ─── helpers ──────────────────────────────────────────────────────────────────
+
+def _ok(data: object) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None})
+
+
+def _err(code: str, message: str, status: int = 400) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _memo_title(text: str, label: str | None) -> str:
+    preview = (text.strip() or "Bridge message")[:80]
+    return f"[{label}] {preview}" if label else preview
+
+
+def _memo_content(platform: str, event: dict[str, Any], label: str | None) -> str:
+    body = event.get("messageText", "").strip() or "(빈 메시지)"
+    if not label:
+        return body
+    return f"[{label}]\n{platform}_user_id: {event.get('userId') or 'unknown'}\n\n{body}"
+
+
+# ─── POST /api/v2/bridge/slack/events ─────────────────────────────────────────
+
+@router.post("/slack/events", response_model=None)
+async def slack_events(request: Request, session: AsyncSession = Depends(get_db)) -> JSONResponse:
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+    if not signing_secret:
+        return _err("CONFIGURATION_ERROR", "Slack signing secret not configured", 500)
+
+    raw_body = (await request.body()).decode()
+    if not verify_slack_signature(
+        signing_secret,
+        request.headers.get("x-slack-signature"),
+        request.headers.get("x-slack-request-timestamp"),
+        raw_body,
+    ):
+        return _err("UNAUTHORIZED", "Invalid Slack signature", 401)
+
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return _err("BAD_REQUEST", "Invalid JSON body", 400)
+
+    if payload.get("type") == "url_verification":
+        return JSONResponse({"challenge": payload.get("challenge", "")})
+
+    if payload.get("type") != "event_callback" or not payload.get("event"):
+        return _ok({"action": "ignored"})
+
+    event = payload["event"]
+    channel_id = event.get("channel")
+
+    repo = BridgeInboundRepository(session)
+    mapping = await repo.find_channel_mapping("slack", channel_id)
+    if not mapping:
+        return _ok({"action": "ignored"})
+
+    if not check_rate_limit(f"slack:{channel_id}"):
+        return _ok({"action": "rate_limited", "memo_id": None, "notice_sent": False})
+
+    user_id_val = event.get("user")
+    if not user_id_val:
+        return _ok({"action": "ignored"})
+
+    norm_event = {
+        "channelId": channel_id,
+        "userId": user_id_val,
+        "eventId": payload.get("event_id"),
+        "messageText": event.get("text", ""),
+        "messageTs": event.get("ts"),
+        "threadTs": event.get("thread_ts"),
+        "teamId": payload.get("team_id"),
+        "raw": event,
+    }
+
+    org_id = uuid.UUID(str(mapping.org_id))
+    project_id = uuid.UUID(str(mapping.project_id))
+
+    user_mapping = await repo.find_user_mapping(org_id, project_id, "slack", user_id_val)
+    author_id = (
+        uuid.UUID(str(user_mapping.team_member_id)) if user_mapping
+        else await repo.find_fallback_author(org_id, project_id)
+    )
+    if not author_id:
+        return _ok({"action": "ignored"})
+
+    label = None if user_mapping else "Slack 연동 미설정 사용자"
+    metadata = build_bridge_metadata("slack", norm_event)
+
+    memo_id = await repo.create_memo(
+        org_id=org_id,
+        project_id=project_id,
+        created_by=author_id,
+        title=_memo_title(norm_event["messageText"], label),
+        content=_memo_content("slack", norm_event, label),
+        memo_type="memo",
+        metadata=metadata,
+        assigned_to=None,
+    )
+    await session.commit()
+    return _ok({"action": "created", "memo_id": memo_id, "notice_sent": None})
+
+
+# ─── POST /api/v2/bridge/slack/interactions ───────────────────────────────────
+
+@router.post("/slack/interactions")
+async def slack_interactions(request: Request, session: AsyncSession = Depends(get_db)) -> JSONResponse:
+    signing_secret = os.environ.get("SLACK_SIGNING_SECRET")
+    if not signing_secret:
+        return JSONResponse({"text": "Slack signing secret missing"}, status_code=500)
+
+    raw_body = (await request.body()).decode()
+    if not verify_slack_signature(
+        signing_secret,
+        request.headers.get("x-slack-signature"),
+        request.headers.get("x-slack-request-timestamp"),
+        raw_body,
+    ):
+        return JSONResponse({"text": "Invalid Slack signature"}, status_code=401)
+
+    form = parse_qs(raw_body)
+    payload_raw = (form.get("payload") or [None])[0]
+    if not payload_raw:
+        return JSONResponse({"text": "Missing payload"}, status_code=400)
+
+    try:
+        payload: dict[str, Any] = json.loads(payload_raw)
+    except json.JSONDecodeError:
+        return JSONResponse({"text": "Invalid payload JSON"}, status_code=400)
+
+    actions = payload.get("actions") or []
+    action = actions[0] if actions else {}
+    action_id = action.get("action_id", "")
+    if action_id not in ("hitl_approve", "hitl_reject"):
+        return JSONResponse({"response_type": "ephemeral", "text": "지원하지 않는 HITL action인."}, status_code=400)
+
+    value_raw = action.get("value")
+    try:
+        request_id_str = json.loads(value_raw or "{}").get("requestId")
+    except (json.JSONDecodeError, AttributeError):
+        request_id_str = None
+
+    if not request_id_str:
+        return JSONResponse({"response_type": "ephemeral", "text": "HITL 요청 정보를 읽지 못한."}, status_code=400)
+
+    slack_user_id = (payload.get("user") or {}).get("id")
+    if not slack_user_id:
+        return JSONResponse({"response_type": "ephemeral", "text": "Slack 사용자 정보를 확인하지 못한."})
+
+    bridge_repo = BridgeInboundRepository(session)
+
+    try:
+        request_id = uuid.UUID(request_id_str)
+    except ValueError:
+        return JSONResponse({"response_type": "ephemeral", "text": "HITL 요청 ID가 유효하지 않는."}, status_code=400)
+
+    # Fetch HITL request directly from DB (no hitl.py dependency)
+    from sqlalchemy import text as sql_text
+    hitl_result = await session.execute(
+        sql_text("SELECT id, org_id, project_id, status FROM agent_hitl_requests WHERE id = :id"),
+        {"id": str(request_id)},
+    )
+    hitl_row = hitl_result.mappings().one_or_none()
+    if not hitl_row:
+        return JSONResponse({"response_type": "ephemeral", "text": "HITL 요청을 찾지 못한."}, status_code=404)
+    if hitl_row["status"] != "pending":
+        return JSONResponse({"response_type": "ephemeral", "text": "이미 처리된 HITL 요청인."})
+
+    org_id = uuid.UUID(str(hitl_row["org_id"]))
+    project_id = uuid.UUID(str(hitl_row["project_id"]))
+
+    user_mapping = await bridge_repo.find_user_mapping(org_id, project_id, "slack", slack_user_id)
+    if not user_mapping:
+        return JSONResponse({"response_type": "ephemeral", "text": "Slack 계정이 Sprintable 팀원에 연결되지 않은."})
+
+    actor_id = uuid.UUID(str(user_mapping.team_member_id))
+    new_status = "approved" if action_id == "hitl_approve" else "rejected"
+    response_text = "Slack에서 승인한" if new_status == "approved" else f"{payload.get('user', {}).get('username', 'Slack admin')}가 Slack에서 거부한"
+    now = datetime.now(timezone.utc)
+
+    await session.execute(
+        sql_text(
+            "UPDATE agent_hitl_requests SET status = :status, response_text = :response_text, "
+            "responded_by = :actor_id, responded_at = :now, updated_at = :now "
+            "WHERE id = :id AND status = 'pending'"
+        ),
+        {"status": new_status, "response_text": response_text, "actor_id": str(actor_id), "now": now, "id": str(request_id)},
+    )
+    await session.commit()
+
+    text_msg = "HITL 승인 처리한." if new_status == "approved" else "HITL 거부 처리한."
+    return JSONResponse({"response_type": "ephemeral", "text": text_msg})
+
+
+# ─── POST /api/v2/bridge/teams/events ─────────────────────────────────────────
+
+@router.post("/teams/events")
+async def teams_events(request: Request, session: AsyncSession = Depends(get_db)) -> JSONResponse:
+    activity: dict[str, Any] | None = await request.json()
+    if not activity:
+        return JSONResponse({"error": "Invalid Teams activity payload"}, status_code=400)
+
+    if activity.get("type") == "conversationUpdate":
+        return JSONResponse({"ok": True})
+
+    channel_data = activity.get("channelData") or {}
+    channel = channel_data.get("channel") or {}
+    source_channel_id = channel.get("id") or activity.get("conversation", {}).get("id")
+    if not source_channel_id:
+        return JSONResponse({"error": "Unable to resolve Teams source channel"}, status_code=400)
+
+    repo = BridgeInboundRepository(session)
+    mapping = await repo.find_channel_mapping("teams", source_channel_id)
+    if not mapping:
+        return JSONResponse({"ok": True, "skipped": "channel_not_mapped"})
+
+    config = mapping.config or {}
+    bot_app_id = config.get("botAppId")
+    verified = await verify_teams_request(
+        authorization_header=request.headers.get("authorization"),
+        service_url=activity.get("serviceUrl"),
+        bot_app_id=bot_app_id,
+    )
+    if not verified:
+        return JSONResponse({"error": "Invalid Teams signature"}, status_code=401)
+
+    if activity.get("type") != "message":
+        return JSONResponse({"ok": True, "skipped": "ignored_activity"})
+
+    from_user = activity.get("from") or {}
+    user_aad_id = from_user.get("aadObjectId") or from_user.get("id")
+    if not user_aad_id:
+        return JSONResponse({"ok": True, "skipped": "no_user_id"})
+
+    org_id = uuid.UUID(str(mapping.org_id))
+    project_id = uuid.UUID(str(mapping.project_id))
+
+    user_mapping = await repo.find_user_mapping(org_id, project_id, "teams", user_aad_id)
+    author_id = (
+        uuid.UUID(str(user_mapping.team_member_id)) if user_mapping
+        else await repo.find_fallback_author(org_id, project_id)
+    )
+    if not author_id:
+        return JSONResponse({"ok": True, "skipped": "no_author"})
+
+    message_text = activity.get("text", "").strip()
+    norm_event = {
+        "channelId": source_channel_id,
+        "userId": user_aad_id,
+        "eventId": activity.get("id"),
+        "messageText": message_text,
+        "messageTs": activity.get("id"),
+        "threadTs": None,
+        "teamId": channel_data.get("team", {}).get("id"),
+        "raw": activity,
+    }
+
+    label = None if user_mapping else "Microsoft Teams 연동 미설정 사용자"
+    metadata = build_bridge_metadata("teams", norm_event)
+
+    memo_id = await repo.create_memo(
+        org_id=org_id,
+        project_id=project_id,
+        created_by=author_id,
+        title=_memo_title(message_text, label),
+        content=_memo_content("teams", norm_event, label),
+        memo_type="memo",
+        metadata=metadata,
+        assigned_to=None,
+    )
+    await session.commit()
+    return JSONResponse({"ok": True, "result": {"action": "created", "memoId": memo_id}})

--- a/backend/app/utils/slack_verify.py
+++ b/backend/app/utils/slack_verify.py
@@ -1,0 +1,25 @@
+import hashlib
+import hmac
+import time
+
+
+def verify_slack_signature(
+    signing_secret: str,
+    signature: str | None,
+    timestamp: str | None,
+    raw_body: str,
+) -> bool:
+    if not signature or not timestamp:
+        return False
+    try:
+        ts = int(timestamp)
+    except ValueError:
+        return False
+    if abs(time.time() - ts) > 300:
+        return False
+    expected = "v0=" + hmac.new(
+        signing_secret.encode(),
+        f"v0:{timestamp}:{raw_body}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)

--- a/backend/app/utils/teams_verify.py
+++ b/backend/app/utils/teams_verify.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import time
+from typing import Any
+
+import httpx
+
+
+_OPENID_URL = "https://login.botframework.com/v1/.well-known/openidconfiguration"
+_JWKS_CACHE: dict[str, Any] = {}
+_JWKS_FETCHED_AT: float = 0.0
+_JWKS_TTL = 3600
+
+
+def _b64decode(s: str) -> bytes:
+    pad = (4 - len(s) % 4) % 4
+    return base64.urlsafe_b64decode(s + "=" * pad)
+
+
+def _decode_json(segment: str) -> dict[str, Any]:
+    try:
+        return json.loads(_b64decode(segment))
+    except Exception:
+        return {}
+
+
+async def _get_jwks() -> list[dict[str, Any]]:
+    global _JWKS_CACHE, _JWKS_FETCHED_AT
+    now = time.time()
+    if _JWKS_CACHE and (now - _JWKS_FETCHED_AT) < _JWKS_TTL:
+        return _JWKS_CACHE.get("keys", [])
+    async with httpx.AsyncClient(timeout=5.0) as client:
+        oidc = (await client.get(_OPENID_URL)).json()
+        jwks = (await client.get(oidc["jwks_uri"])).json()
+    _JWKS_CACHE = jwks
+    _JWKS_FETCHED_AT = now
+    return jwks.get("keys", [])
+
+
+def _rsa_verify(token: str, key: dict[str, Any]) -> bool:
+    try:
+        from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicNumbers
+        from cryptography.hazmat.primitives.asymmetric import padding
+        from cryptography.hazmat.primitives import hashes
+        from cryptography.exceptions import InvalidSignature
+
+        n = int.from_bytes(_b64decode(key["n"]), "big")
+        e = int.from_bytes(_b64decode(key["e"]), "big")
+        pub = RSAPublicNumbers(e, n).public_key()
+
+        parts = token.split(".")
+        message = f"{parts[0]}.{parts[1]}".encode()
+        sig = _b64decode(parts[2])
+        pub.verify(sig, message, padding.PKCS1v15(), hashes.SHA256())
+        return True
+    except (ImportError, InvalidSignature, Exception):
+        return False
+
+
+async def verify_teams_request(
+    authorization_header: str | None,
+    service_url: str | None,
+    bot_app_id: str | None,
+) -> bool:
+    if not authorization_header or not bot_app_id or not service_url:
+        return False
+    if not authorization_header.lower().startswith("bearer "):
+        return False
+    token = authorization_header[7:].strip()
+    parts = token.split(".")
+    if len(parts) != 3:
+        return False
+
+    header = _decode_json(parts[0])
+    payload = _decode_json(parts[1])
+    if header.get("alg") != "RS256" or not header.get("kid"):
+        return False
+
+    keys = await _get_jwks()
+    key = next((k for k in keys if k.get("kid") == header["kid"]), None)
+    if not key:
+        return False
+
+    if not _rsa_verify(token, key):
+        return False
+
+    now = int(time.time())
+    if payload.get("nbf", 0) > now + 60:
+        return False
+    if payload.get("exp", 0) < now - 60:
+        return False
+    if payload.get("aud") != bot_app_id:
+        return False
+
+    return True

--- a/backend/tests/test_s47.py
+++ b/backend/tests/test_s47.py
@@ -1,0 +1,231 @@
+"""S47 AC: Bridge — Slack Events/Interactions + Teams Events FastAPI /api/v2/bridge/**"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+HITL_ID = uuid.uuid4()
+TEAM_MEMBER_ID = uuid.uuid4()
+SIGNING_SECRET = "test-secret-1234"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _slack_sig(body: str, secret: str = SIGNING_SECRET) -> tuple[str, str]:
+    ts = str(int(time.time()))
+    sig = "v0=" + hmac.new(secret.encode(), f"v0:{ts}:{body}".encode(), hashlib.sha256).hexdigest()
+    return ts, sig
+
+
+def _make_channel_mapping(platform: str = "slack") -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.platform = platform
+    m.channel_id = "C123"
+    m.config = {}
+    m.is_active = True
+    return m
+
+
+def _make_user_mapping() -> MagicMock:
+    m = MagicMock()
+    m.team_member_id = TEAM_MEMBER_ID
+    m.display_name = "Test User"
+    return m
+
+
+# ─── Slack Events ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_slack_events_url_verification():
+    client, session, app = await _client()
+    try:
+        body = json.dumps({"type": "url_verification", "challenge": "abc123"})
+        ts, sig = _slack_sig(body)
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            async with client as c:
+                resp = await c.post(
+                    "/api/v2/bridge/slack/events",
+                    content=body,
+                    headers={"x-slack-signature": sig, "x-slack-request-timestamp": ts, "content-type": "application/json"},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["challenge"] == "abc123"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_slack_events_invalid_signature_401():
+    client, session, app = await _client()
+    try:
+        body = json.dumps({"type": "event_callback"})
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            async with client as c:
+                resp = await c.post(
+                    "/api/v2/bridge/slack/events",
+                    content=body,
+                    headers={"x-slack-signature": "v0=bad", "x-slack-request-timestamp": str(int(time.time())), "content-type": "application/json"},
+                )
+        assert resp.status_code == 401
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_slack_events_channel_not_mapped_ignored():
+    client, session, app = await _client()
+    try:
+        body = json.dumps({"type": "event_callback", "event": {"type": "message", "channel": "C999", "user": "U1", "text": "hi"}})
+        ts, sig = _slack_sig(body)
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            with patch("app.repositories.bridge_inbound.BridgeInboundRepository.find_channel_mapping", new_callable=AsyncMock) as mock_find:
+                mock_find.return_value = None
+                async with client as c:
+                    resp = await c.post(
+                        "/api/v2/bridge/slack/events",
+                        content=body,
+                        headers={"x-slack-signature": sig, "x-slack-request-timestamp": ts, "content-type": "application/json"},
+                    )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["action"] == "ignored"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_slack_events_creates_memo():
+    client, session, app = await _client()
+    try:
+        body = json.dumps({"type": "event_callback", "team_id": "T1", "event_id": "ev1", "event": {"type": "message", "channel": "C123", "user": "U1", "text": "hello"}})
+        ts, sig = _slack_sig(body)
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            with patch("app.repositories.bridge_inbound.BridgeInboundRepository.find_channel_mapping", new_callable=AsyncMock) as mock_channel:
+                mock_channel.return_value = _make_channel_mapping()
+                with patch("app.repositories.bridge_inbound.BridgeInboundRepository.find_user_mapping", new_callable=AsyncMock) as mock_user:
+                    mock_user.return_value = _make_user_mapping()
+                    with patch("app.repositories.bridge_inbound.BridgeInboundRepository.create_memo", new_callable=AsyncMock) as mock_create:
+                        mock_create.return_value = str(uuid.uuid4())
+                        async with client as c:
+                            resp = await c.post(
+                                "/api/v2/bridge/slack/events",
+                                content=body,
+                                headers={"x-slack-signature": sig, "x-slack-request-timestamp": ts, "content-type": "application/json"},
+                            )
+        assert resp.status_code == 200
+        body_json = resp.json()
+        assert body_json["data"]["action"] == "created"
+        assert body_json["data"]["memo_id"] is not None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── Slack Interactions ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_slack_interactions_invalid_sig_401():
+    client, session, app = await _client()
+    try:
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            async with client as c:
+                resp = await c.post(
+                    "/api/v2/bridge/slack/interactions",
+                    content="payload={}",
+                    headers={"x-slack-signature": "v0=bad", "x-slack-request-timestamp": str(int(time.time())), "content-type": "application/x-www-form-urlencoded"},
+                )
+        assert resp.status_code == 401
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_slack_interactions_hitl_approve():
+    client, session, app = await _client()
+    try:
+        interaction = {
+            "type": "block_actions",
+            "user": {"id": "USLACK", "username": "testuser"},
+            "team": {"id": "T1"},
+            "actions": [{"action_id": "hitl_approve", "value": json.dumps({"requestId": str(HITL_ID)})}],
+        }
+        form_body = f"payload={json.dumps(interaction)}"
+        ts, sig = _slack_sig(form_body)
+
+        mock_row = {"id": str(HITL_ID), "org_id": str(ORG_ID), "project_id": str(PROJECT_ID), "status": "pending"}
+
+        with patch.dict("os.environ", {"SLACK_SIGNING_SECRET": SIGNING_SECRET}):
+            mock_result = MagicMock()
+            mock_result.mappings.return_value.one_or_none.return_value = mock_row
+            session.execute = AsyncMock(return_value=mock_result)
+            with patch("app.repositories.bridge_inbound.BridgeInboundRepository.find_user_mapping", new_callable=AsyncMock) as mock_user:
+                mock_user.return_value = _make_user_mapping()
+                async with client as c:
+                    resp = await c.post(
+                        "/api/v2/bridge/slack/interactions",
+                        content=form_body,
+                        headers={"x-slack-signature": sig, "x-slack-request-timestamp": ts, "content-type": "application/x-www-form-urlencoded"},
+                    )
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── Teams Events ──────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_teams_events_conversation_update_ok():
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post(
+                "/api/v2/bridge/teams/events",
+                json={"type": "conversationUpdate"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_teams_events_channel_not_mapped():
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.bridge_inbound.BridgeInboundRepository.find_channel_mapping", new_callable=AsyncMock) as mock_find:
+            mock_find.return_value = None
+            async with client as c:
+                resp = await c.post(
+                    "/api/v2/bridge/teams/events",
+                    json={"type": "message", "channelData": {"channel": {"id": "19:abc"}}, "conversation": {"id": "conv1"}},
+                )
+        assert resp.status_code == 200
+        assert resp.json()["skipped"] == "channel_not_mapped"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `BridgeChannelMapping` + `BridgeUserMapping` SQLAlchemy 모델 (messaging_bridge_channels/users 테이블)
- `BridgeInboundRepository`: 채널/유저 매핑 조회, fallback author, 메모 직접 생성
- `verify_slack_signature` (HMAC-SHA256) + `verify_teams_request` (RS256 JWT + JWKS 캐시)
- `POST /api/v2/bridge/slack/events` — URL verification + rate limit + 메모 생성
- `POST /api/v2/bridge/slack/interactions` — HITL approve/reject (SQL text 직접 처리)
- `POST /api/v2/bridge/teams/events` — Teams activity → 채널 매핑 → 메모 생성

## Test plan
- [ ] `POST /api/v2/bridge/slack/events` URL verification challenge 반환
- [ ] Slack 서명 불일치 → 401
- [ ] 채널 매핑 없음 → ignored
- [ ] 정상 메시지 → 메모 생성 + action: created
- [ ] Slack interactions 서명 불일치 → 401
- [ ] HITL approve → 200 + 승인 처리
- [ ] Teams conversationUpdate → 200 ok
- [ ] Teams 채널 미매핑 → skipped
- [ ] 8/8 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)