### PR TITLE
feat(s48): Mockups CRUD + Usage Meters FastAPI v2 migration

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, hitl, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, bridge, current_project, dashboard, docs, epics, health, hitl, invitations, me, meetings, members, memos, notifications, org_members, organizations, oss, policy_documents, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, mockups, webhooks, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -58,6 +58,7 @@ app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
 app.include_router(hitl.router)
 app.include_router(workflow_versions.router)
+app.include_router(mockups.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -4,6 +4,7 @@ from app.models.agent_run import AgentRun
 from app.models.agent_session import AgentSession
 from app.models.bridge import BridgeChannelMapping, BridgeUserMapping
 from app.models.hitl import HitlPolicy, HitlRequest
+from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
 from app.models.workflow_version import WorkflowVersion
 from app.models.api_key import ApiKey
 from app.models.org_subscription import OrgSubscription
@@ -35,6 +36,11 @@ __all__ = [
     "BridgeUserMapping",
     "HitlPolicy",
     "HitlRequest",
+    "MockupComponent",
+    "MockupPage",
+    "MockupScenario",
+    "MockupVersion",
+    "UsageMeter",
     "ApiKey",
     "OrgSubscription",
     "PolicyDocument",

--- a/backend/app/models/mockup.py
+++ b/backend/app/models/mockup.py
@@ -1,0 +1,71 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class MockupPage(Base):
+    __tablename__ = "mockup_pages"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    slug: Mapped[str] = mapped_column(Text, nullable=False)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    category: Mapped[str | None] = mapped_column(Text, nullable=True)
+    viewport: Mapped[str | None] = mapped_column(Text, nullable=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class MockupComponent(Base):
+    __tablename__ = "mockup_components"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    page_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    type: Mapped[str] = mapped_column(Text, nullable=False)
+    props: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class MockupScenario(Base):
+    __tablename__ = "mockup_scenarios"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    page_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    override_props: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    is_default: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    sort_order: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class MockupVersion(Base):
+    __tablename__ = "mockup_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    page_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    snapshot: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class UsageMeter(Base):
+    __tablename__ = "usage_meters"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    meter_type: Mapped[str] = mapped_column(Text, nullable=False)
+    current_value: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    limit_value: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    period_start: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    period_end: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/mockups.py
+++ b/backend/app/routers/mockups.py
@@ -38,6 +38,21 @@ def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | N
     return uuid.UUID(str(o)), uuid.UUID(str(p))
 
 
+async def _verify_page_ownership(
+    session: AsyncSession,
+    page_id: uuid.UUID,
+    project_id: uuid.UUID,
+) -> bool:
+    result = await session.execute(
+        select(MockupPage.id).where(
+            MockupPage.id == page_id,
+            MockupPage.project_id == project_id,
+            MockupPage.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
 # ─── Mockups CRUD ─────────────────────────────────────────────────────────────
 
 @router.get("/mockups")
@@ -102,7 +117,11 @@ async def get_mockup(
         return _err("FORBIDDEN", "org_id required", 403)
 
     result = await session.execute(
-        select(MockupPage).where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+        select(MockupPage).where(
+            MockupPage.id == page_id,
+            MockupPage.project_id == project_id,
+            MockupPage.deleted_at.is_(None),
+        )
     )
     page = result.scalar_one_or_none()
     if not page:
@@ -135,12 +154,16 @@ async def update_mockup(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, _ = _get_org_project(auth)
+    org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
 
     result = await session.execute(
-        select(MockupPage).where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+        select(MockupPage).where(
+            MockupPage.id == page_id,
+            MockupPage.project_id == project_id,
+            MockupPage.deleted_at.is_(None),
+        )
     )
     page = result.scalar_one_or_none()
     if not page:
@@ -156,6 +179,30 @@ async def update_mockup(
         updates["viewport"] = body.viewport
 
     if body.components is not None:
+        # 버전 스냅샷 저장 (rollback 데이터 보장)
+        comps_r = await session.execute(
+            select(MockupComponent).where(MockupComponent.page_id == page_id).order_by(MockupComponent.sort_order)
+        )
+        scen_r = await session.execute(
+            select(MockupScenario).where(MockupScenario.page_id == page_id).order_by(MockupScenario.sort_order)
+        )
+        snapshot = {
+            "title": page.title,
+            "components": [
+                {"type": c.type, "props": c.props, "sort_order": c.sort_order}
+                for c in comps_r.scalars().all()
+            ],
+            "scenarios": [
+                {"name": s.name, "override_props": s.override_props, "is_default": s.is_default, "sort_order": s.sort_order}
+                for s in scen_r.scalars().all()
+            ],
+        }
+        session.add(MockupVersion(
+            page_id=page_id,
+            version=page.version or 1,
+            snapshot=snapshot,
+        ))
+
         await session.execute(
             text("DELETE FROM mockup_components WHERE page_id = :pid"), {"pid": str(page_id)}
         )
@@ -180,13 +227,13 @@ async def delete_mockup(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    org_id, _ = _get_org_project(auth)
+    org_id, project_id = _get_org_project(auth)
     if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
 
     await session.execute(
         update(MockupPage)
-        .where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+        .where(MockupPage.id == page_id, MockupPage.project_id == project_id, MockupPage.deleted_at.is_(None))
         .values(deleted_at=datetime.now(timezone.utc))
     )
     await session.commit()
@@ -201,8 +248,11 @@ async def list_versions(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
 
     result = await session.execute(
         select(MockupVersion.id, MockupVersion.version, MockupVersion.created_at)
@@ -220,8 +270,11 @@ async def restore_version(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
 
     result = await session.execute(
         select(MockupVersion).where(MockupVersion.id == body.version_id, MockupVersion.page_id == page_id)
@@ -273,8 +326,11 @@ async def list_scenarios(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
     result = await session.execute(
         select(MockupScenario).where(MockupScenario.page_id == page_id).order_by(MockupScenario.sort_order)
     )
@@ -289,8 +345,11 @@ async def create_scenario(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
     s = MockupScenario(page_id=page_id, name=body.name, override_props=body.override_props, is_default=False)
     session.add(s)
     await session.commit()
@@ -304,8 +363,11 @@ async def update_scenario(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
     vals: dict[str, Any] = {}
     if body.name is not None:
         vals["name"] = body.name
@@ -328,8 +390,11 @@ async def delete_scenario(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
-    if not _get_org_project(auth)[0]:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
         return _err("FORBIDDEN", "org_id required", 403)
+    if not await _verify_page_ownership(session, page_id, project_id):
+        return _err("NOT_FOUND", "Mockup not found", 404)
     result = await session.execute(
         select(MockupScenario).where(MockupScenario.id == body.scenario_id, MockupScenario.page_id == page_id)
     )

--- a/backend/app/routers/mockups.py
+++ b/backend/app/routers/mockups.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse
+from sqlalchemy import select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.mockup import MockupComponent, MockupPage, MockupScenario, MockupVersion, UsageMeter
+from app.schemas.mockup import (
+    CreateMockupRequest, CreateScenarioRequest, DeleteScenarioRequest,
+    MockupComponentOut, MockupPageSummary, RestoreVersionRequest,
+    UpdateMockupRequest, UpdateScenarioRequest, UsageMeterOut,
+)
+
+router = APIRouter(prefix="/api/v2", tags=["mockups"])
+
+
+def _ok(data: object, status: int = 200) -> JSONResponse:
+    return JSONResponse({"data": data, "error": None, "meta": None}, status_code=status)
+
+
+def _err(code: str, message: str, status: int) -> JSONResponse:
+    return JSONResponse({"data": None, "error": {"code": code, "message": message}, "meta": None}, status_code=status)
+
+
+def _get_org_project(auth: AuthContext) -> tuple[uuid.UUID | None, uuid.UUID | None]:
+    meta = auth.claims.get("app_metadata", {})
+    o = meta.get("org_id")
+    p = meta.get("project_id")
+    if not o or not p:
+        return None, None
+    return uuid.UUID(str(o)), uuid.UUID(str(p))
+
+
+# ─── Mockups CRUD ─────────────────────────────────────────────────────────────
+
+@router.get("/mockups")
+async def list_mockups(
+    page: int = Query(default=1, ge=1),
+    limit: int = Query(default=20, ge=1, le=100),
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    offset = (page - 1) * limit
+    result = await session.execute(
+        select(MockupPage)
+        .where(MockupPage.project_id == project_id, MockupPage.deleted_at.is_(None))
+        .order_by(MockupPage.created_at.desc())
+        .offset(offset).limit(limit)
+    )
+    rows = result.scalars().all()
+    items = [MockupPageSummary.model_validate(r).model_dump(mode="json") for r in rows]
+    return _ok({"items": items, "page": page, "limit": limit})
+
+
+@router.post("/mockups", status_code=201)
+async def create_mockup(
+    body: CreateMockupRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    now = datetime.now(timezone.utc)
+    page = MockupPage(
+        org_id=org_id, project_id=project_id,
+        slug=body.slug, title=body.title,
+        category=body.category, viewport=body.viewport,
+        created_by=auth.user_id, created_at=now, updated_at=now,
+    )
+    session.add(page)
+    await session.flush()
+
+    # default scenario
+    session.add(MockupScenario(
+        page_id=page.id, name="Default", override_props={}, is_default=True, sort_order=0,
+    ))
+    await session.commit()
+    return _ok(MockupPageSummary.model_validate(page).model_dump(mode="json"), 201)
+
+
+@router.get("/mockups/{page_id}")
+async def get_mockup(
+    page_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, project_id = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    result = await session.execute(
+        select(MockupPage).where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+    )
+    page = result.scalar_one_or_none()
+    if not page:
+        return _err("NOT_FOUND", "Mockup not found", 404)
+
+    comps_r = await session.execute(
+        select(MockupComponent).where(MockupComponent.page_id == page_id).order_by(MockupComponent.sort_order)
+    )
+    scenarios_r = await session.execute(
+        select(MockupScenario).where(MockupScenario.page_id == page_id).order_by(MockupScenario.sort_order)
+    )
+    components = [MockupComponentOut.model_validate(c).model_dump(mode="json") for c in comps_r.scalars().all()]
+    scenarios = [{"name": s.name, "overrides": s.override_props, "is_default": s.is_default} for s in scenarios_r.scalars().all()]
+
+    data: dict[str, Any] = {
+        "id": str(page.id), "org_id": str(page.org_id), "project_id": str(page.project_id),
+        "slug": page.slug, "title": page.title, "category": page.category,
+        "viewport": page.viewport, "version": page.version,
+        "created_by": str(page.created_by) if page.created_by else None,
+        "created_at": page.created_at.isoformat(), "updated_at": page.updated_at.isoformat(),
+        "components": components, "scenarios": scenarios,
+    }
+    return _ok(data)
+
+
+@router.put("/mockups/{page_id}")
+async def update_mockup(
+    page_id: uuid.UUID,
+    body: UpdateMockupRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, _ = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    result = await session.execute(
+        select(MockupPage).where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+    )
+    page = result.scalar_one_or_none()
+    if not page:
+        return _err("NOT_FOUND", "Mockup not found", 404)
+
+    now = datetime.now(timezone.utc)
+    updates: dict[str, Any] = {"updated_at": now}
+    if body.title is not None:
+        updates["title"] = body.title
+    if body.category is not None:
+        updates["category"] = body.category
+    if body.viewport is not None:
+        updates["viewport"] = body.viewport
+
+    if body.components is not None:
+        await session.execute(
+            text("DELETE FROM mockup_components WHERE page_id = :pid"), {"pid": str(page_id)}
+        )
+        for comp in body.components:
+            session.add(MockupComponent(
+                page_id=page_id,
+                type=comp.get("type", "box"),
+                props=comp.get("props", {}),
+                sort_order=comp.get("sort_order", 0),
+                parent_id=uuid.UUID(comp["parent_id"]) if comp.get("parent_id") else None,
+            ))
+        updates["version"] = (page.version or 1) + 1
+
+    await session.execute(update(MockupPage).where(MockupPage.id == page_id).values(**updates))
+    await session.commit()
+    return _ok({"ok": True})
+
+
+@router.delete("/mockups/{page_id}")
+async def delete_mockup(
+    page_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, _ = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    await session.execute(
+        update(MockupPage)
+        .where(MockupPage.id == page_id, MockupPage.deleted_at.is_(None))
+        .values(deleted_at=datetime.now(timezone.utc))
+    )
+    await session.commit()
+    return _ok({"ok": True})
+
+
+# ─── Versions ─────────────────────────────────────────────────────────────────
+
+@router.get("/mockups/{page_id}/versions")
+async def list_versions(
+    page_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    result = await session.execute(
+        select(MockupVersion.id, MockupVersion.version, MockupVersion.created_at)
+        .where(MockupVersion.page_id == page_id)
+        .order_by(MockupVersion.version.desc())
+    )
+    rows = [{"id": str(r.id), "version": r.version, "created_at": r.created_at.isoformat()} for r in result.all()]
+    return _ok(rows)
+
+
+@router.post("/mockups/{page_id}/versions")
+async def restore_version(
+    page_id: uuid.UUID,
+    body: RestoreVersionRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    result = await session.execute(
+        select(MockupVersion).where(MockupVersion.id == body.version_id, MockupVersion.page_id == page_id)
+    )
+    ver = result.scalar_one_or_none()
+    if not ver:
+        return _err("NOT_FOUND", "Version not found", 404)
+
+    snapshot = ver.snapshot or {}
+    now = datetime.now(timezone.utc)
+
+    await session.execute(text("DELETE FROM mockup_components WHERE page_id = :pid"), {"pid": str(page_id)})
+    components = snapshot.get("components") or []
+    for comp in components:
+        session.add(MockupComponent(
+            page_id=page_id,
+            type=comp.get("type", "box"),
+            props=comp.get("props", {}),
+            sort_order=comp.get("sort_order", 0),
+        ))
+
+    updates: dict[str, Any] = {"updated_at": now}
+    if snapshot.get("title"):
+        updates["title"] = snapshot["title"]
+
+    scenarios = snapshot.get("scenarios") or []
+    if scenarios:
+        await session.execute(text("DELETE FROM mockup_scenarios WHERE page_id = :pid"), {"pid": str(page_id)})
+        for s in scenarios:
+            session.add(MockupScenario(
+                page_id=page_id,
+                name=s.get("name", "Scenario"),
+                override_props=s.get("override_props", {}),
+                is_default=s.get("is_default", False),
+                sort_order=s.get("sort_order", 0),
+            ))
+
+    await session.execute(text("SELECT increment_mockup_version(:pid)"), {"pid": str(page_id)})
+    await session.execute(update(MockupPage).where(MockupPage.id == page_id).values(**updates))
+    await session.commit()
+    return _ok({"ok": True})
+
+
+# ─── Scenarios ────────────────────────────────────────────────────────────────
+
+@router.get("/mockups/{page_id}/scenarios")
+async def list_scenarios(
+    page_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+    result = await session.execute(
+        select(MockupScenario).where(MockupScenario.page_id == page_id).order_by(MockupScenario.sort_order)
+    )
+    rows = [{"id": str(s.id), "page_id": str(s.page_id), "name": s.name, "override_props": s.override_props, "is_default": s.is_default, "sort_order": s.sort_order} for s in result.scalars().all()]
+    return _ok(rows)
+
+
+@router.post("/mockups/{page_id}/scenarios", status_code=201)
+async def create_scenario(
+    page_id: uuid.UUID,
+    body: CreateScenarioRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+    s = MockupScenario(page_id=page_id, name=body.name, override_props=body.override_props, is_default=False)
+    session.add(s)
+    await session.commit()
+    return _ok({"id": str(s.id), "page_id": str(s.page_id), "name": s.name, "override_props": s.override_props, "is_default": s.is_default, "sort_order": s.sort_order}, 201)
+
+
+@router.patch("/mockups/{page_id}/scenarios")
+async def update_scenario(
+    page_id: uuid.UUID,
+    body: UpdateScenarioRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+    vals: dict[str, Any] = {}
+    if body.name is not None:
+        vals["name"] = body.name
+    if body.override_props is not None:
+        vals["override_props"] = body.override_props
+    if body.sort_order is not None:
+        vals["sort_order"] = body.sort_order
+    if vals:
+        await session.execute(
+            update(MockupScenario).where(MockupScenario.id == body.scenario_id, MockupScenario.page_id == page_id).values(**vals)
+        )
+        await session.commit()
+    return _ok({"ok": True})
+
+
+@router.delete("/mockups/{page_id}/scenarios")
+async def delete_scenario(
+    page_id: uuid.UUID,
+    body: DeleteScenarioRequest,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    if not _get_org_project(auth)[0]:
+        return _err("FORBIDDEN", "org_id required", 403)
+    result = await session.execute(
+        select(MockupScenario).where(MockupScenario.id == body.scenario_id, MockupScenario.page_id == page_id)
+    )
+    s = result.scalar_one_or_none()
+    if not s:
+        return _err("NOT_FOUND", "Scenario not found", 404)
+    if s.is_default:
+        return _err("CANNOT_DELETE_DEFAULT", "Cannot delete default scenario", 400)
+    await session.delete(s)
+    await session.commit()
+    return _ok({"ok": True})
+
+
+# ─── Usage Meters ─────────────────────────────────────────────────────────────
+
+@router.get("/usage")
+async def get_usage_meters(
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    org_id, _ = _get_org_project(auth)
+    if not org_id:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    now = datetime.now(timezone.utc)
+    period_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    result = await session.execute(
+        select(UsageMeter.meter_type, UsageMeter.current_value, UsageMeter.limit_value, UsageMeter.period_start, UsageMeter.period_end)
+        .where(UsageMeter.org_id == org_id, UsageMeter.period_start >= period_start)
+        .order_by(UsageMeter.meter_type)
+    )
+    rows = [UsageMeterOut.model_validate(r).model_dump(mode="json") for r in result.all()]
+    return _ok(rows)

--- a/backend/app/schemas/mockup.py
+++ b/backend/app/schemas/mockup.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MockupPageSummary(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    slug: str
+    title: str
+    category: str | None = None
+    viewport: str | None = None
+    version: int
+    created_at: datetime
+
+
+class MockupComponentOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    page_id: uuid.UUID
+    type: str
+    props: dict[str, Any]
+    sort_order: int
+    parent_id: uuid.UUID | None = None
+
+
+class MockupScenarioOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    page_id: uuid.UUID
+    name: str
+    override_props: dict[str, Any]
+    is_default: bool
+    sort_order: int
+
+
+class MockupPageDetail(BaseModel):
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    slug: str
+    title: str
+    category: str | None = None
+    viewport: str | None = None
+    version: int
+    created_by: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+    components: list[MockupComponentOut]
+    scenarios: list[dict[str, Any]]
+
+
+class CreateMockupRequest(BaseModel):
+    slug: str
+    title: str
+    category: str | None = None
+    viewport: str | None = None
+
+
+class UpdateMockupRequest(BaseModel):
+    title: str | None = None
+    category: str | None = None
+    viewport: str | None = None
+    components: list[dict[str, Any]] | None = None
+
+
+class MockupVersionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    id: uuid.UUID
+    version: int
+    created_at: datetime
+
+
+class RestoreVersionRequest(BaseModel):
+    version_id: uuid.UUID
+
+
+class CreateScenarioRequest(BaseModel):
+    name: str = "New Scenario"
+    override_props: dict[str, Any] = {}
+
+
+class UpdateScenarioRequest(BaseModel):
+    scenario_id: uuid.UUID
+    name: str | None = None
+    override_props: dict[str, Any] | None = None
+    sort_order: int | None = None
+
+
+class DeleteScenarioRequest(BaseModel):
+    scenario_id: uuid.UUID
+
+
+class UsageMeterOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    meter_type: str
+    current_value: int
+    limit_value: int | None = None
+    period_start: datetime
+    period_end: datetime | None = None

--- a/backend/tests/test_s48.py
+++ b/backend/tests/test_s48.py
@@ -1,0 +1,207 @@
+"""S48 AC: Mockups CRUD + Usage Meters — FastAPI /api/v2/mockups/** + /api/v2/usage"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+PAGE_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    ctx = MagicMock()
+    ctx.user_id = USER_ID
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}}
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _make_page():
+    from datetime import datetime, timezone
+    m = MagicMock()
+    m.id = PAGE_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.slug = "test-page"
+    m.title = "Test Page"
+    m.category = None
+    m.viewport = None
+    m.version = 1
+    m.created_by = USER_ID
+    m.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    m.deleted_at = None
+    return m
+
+
+# ─── Mockups CRUD ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_mockups_200():
+    client, session, app = await _client()
+    try:
+        page = _make_page()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [page]
+        session.execute = AsyncMock(return_value=mock_result)
+        async with client as c:
+            resp = await c.get("/api/v2/mockups")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert body["data"]["items"][0]["slug"] == "test-page"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_mockup_201():
+    client, session, app = await _client()
+    try:
+        page = _make_page()
+        session.flush = AsyncMock()
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [page]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.mockups.MockupPage") as MockPage:
+            instance = _make_page()
+            MockPage.return_value = instance
+            async with client as c:
+                resp = await c.post("/api/v2/mockups", json={"slug": "new-page", "title": "New Page"})
+        assert resp.status_code in (200, 201)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_mockup_200():
+    client, session, app = await _client()
+    try:
+        page = _make_page()
+        mock_page_result = MagicMock()
+        mock_page_result.scalar_one_or_none.return_value = page
+        mock_comps_result = MagicMock()
+        mock_comps_result.scalars.return_value.all.return_value = []
+        mock_scen_result = MagicMock()
+        mock_scen_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(side_effect=[mock_page_result, mock_comps_result, mock_scen_result])
+        async with client as c:
+            resp = await c.get(f"/api/v2/mockups/{PAGE_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["slug"] == "test-page"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_mockup_not_found_404():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+        async with client as c:
+            resp = await c.get(f"/api/v2/mockups/{uuid.uuid4()}")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_mockup_200():
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=MagicMock())
+        session.commit = AsyncMock()
+        async with client as c:
+            resp = await c.delete(f"/api/v2/mockups/{PAGE_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── Scenarios ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_scenarios_200():
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []
+        session.execute = AsyncMock(return_value=mock_result)
+        async with client as c:
+            resp = await c.get(f"/api/v2/mockups/{PAGE_ID}/scenarios")
+        assert resp.status_code == 200
+        assert resp.json()["data"] == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_default_scenario_400():
+    client, session, app = await _client()
+    try:
+        scenario = MagicMock()
+        scenario.is_default = True
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = scenario
+        session.execute = AsyncMock(return_value=mock_result)
+        import json as _json
+        async with client as c:
+            resp = await c.request("DELETE", f"/api/v2/mockups/{PAGE_ID}/scenarios", content=_json.dumps({"scenario_id": str(uuid.uuid4())}), headers={"content-type": "application/json"})
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "CANNOT_DELETE_DEFAULT"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── Usage Meters ─────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_usage_200():
+    client, session, app = await _client()
+    try:
+        from datetime import datetime, timezone
+        row = MagicMock()
+        row.meter_type = "max_mockups"
+        row.current_value = 3
+        row.limit_value = 10
+        row.period_start = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        row.period_end = None
+        mock_result = MagicMock()
+        mock_result.all.return_value = [row]
+        session.execute = AsyncMock(return_value=mock_result)
+        async with client as c:
+            resp = await c.get("/api/v2/usage")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["error"] is None
+        assert body["data"][0]["meter_type"] == "max_mockups"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `MockupPage` / `MockupComponent` / `MockupScenario` / `MockupVersion` / `UsageMeter` SQLAlchemy 모델
- `GET/POST /api/v2/mockups` — 목록(pagination) + 생성(default scenario 자동 추가)
- `GET/PUT/DELETE /api/v2/mockups/{id}` — 상세(components+scenarios 포함) + 수정 + 소프트 삭제
- `GET/POST /api/v2/mockups/{id}/versions` — 버전 히스토리 + 롤백
- `GET/POST/PATCH/DELETE /api/v2/mockups/{id}/scenarios` — 시나리오 CRUD (default 삭제 방지)
- `GET /api/v2/usage` — 현월 usage_meters 조회

## Test plan
- [ ] `GET /api/v2/mockups` → 200 + 페이지 목록
- [ ] `POST /api/v2/mockups` → 201 + 생성된 페이지
- [ ] `GET /api/v2/mockups/{id}` → 200 + components/scenarios 포함
- [ ] `GET /api/v2/mockups/{unknown}` → 404
- [ ] `DELETE /api/v2/mockups/{id}` → 200
- [ ] `GET /api/v2/mockups/{id}/scenarios` → 200 + 목록
- [ ] `DELETE /api/v2/mockups/{id}/scenarios` (default) → 400
- [ ] `GET /api/v2/usage` → 200 + meters
- [ ] 8/8 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)