### PR TITLE
feat(c-s5): RLS 49개 테이블 비활성화 + FastAPI 권한 검증 dependency (5SP)

### DIFF
--- a/backend/alembic/versions/0002_disable_rls.py
+++ b/backend/alembic/versions/0002_disable_rls.py
@@ -1,0 +1,85 @@
+"""disable row level security on all FastAPI-managed tables
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-30
+
+C-S5: PostgREST RLS 의존 제거. FastAPI 레이어에서 org_id/project_id 스코핑 및
+owner/role 검증을 수행하므로 DB 레벨 RLS 불필요.
+DROP은 C-S9 데이터 마이그레이션 시 일괄 처리.
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+# FastAPI backend가 접근하는 모든 테이블 목록
+_TABLES = [
+    "agent_api_keys",
+    "agent_audit_logs",
+    "agent_deployments",
+    "agent_hitl_policies",
+    "agent_hitl_requests",
+    "agent_personas",
+    "agent_routing_rules",
+    "agent_runs",
+    "agent_sessions",
+    "docs",
+    "epics",
+    "inbox_items",
+    "invitations",
+    "meetings",
+    "memo_assignees",
+    "memo_doc_links",
+    "memo_mentions",
+    "memo_reads",
+    "memo_replies",
+    "memos",
+    "messaging_bridge_channels",
+    "messaging_bridge_users",
+    "mockup_components",
+    "mockup_pages",
+    "mockup_scenarios",
+    "mockup_versions",
+    "notification_settings",
+    "notifications",
+    "org_members",
+    "org_subscriptions",
+    "organizations",
+    "permission_audit_logs",
+    "policy_documents",
+    "project_settings",
+    "projects",
+    "retro_actions",
+    "retro_items",
+    "retro_sessions",
+    "retro_votes",
+    "reward_ledger",
+    "sprints",
+    "standup_entries",
+    "standup_feedback",
+    "stories",
+    "tasks",
+    "team_members",
+    "usage_meters",
+    "webhook_configs",
+    "workflow_versions",
+]
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"ALTER TABLE IF EXISTS {table} DISABLE ROW LEVEL SECURITY"
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(
+            f"ALTER TABLE IF EXISTS {table} ENABLE ROW LEVEL SECURITY"
+        )

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,6 +1,10 @@
-from dataclasses import dataclass
+from __future__ import annotations
 
-from fastapi import Depends, HTTPException, status
+import uuid
+from dataclasses import dataclass, field
+from typing import Literal
+
+from fastapi import Depends, Header, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from app.core.security import JWTError, decode_jwt
@@ -13,15 +17,12 @@ class AuthContext:
     user_id: str
     email: str | None
     claims: dict
+    org_id: str | None = field(default=None)
 
 
 def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
 ) -> AuthContext:
-    """
-    JWT 인증 스켈레톤 — 토큰 파싱만 수행.
-    서명 검증은 Phase B S1에서 완성.
-    """
     if credentials is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
 
@@ -35,8 +36,85 @@ def get_current_user(
     if not user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
 
+    org_id: str | None = payload.get("app_metadata", {}).get("org_id")
+
     return AuthContext(
         user_id=user_id,
         email=payload.get("email"),
         claims=payload,
+        org_id=org_id,
     )
+
+
+# ─── Scope dependencies ───────────────────────────────────────────────────────
+
+def get_org_scope(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    """org_id를 JWT app_metadata 또는 X-Org-Id 헤더에서 추출. 없으면 400."""
+    raw = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (JWT app_metadata.org_id or X-Org-Id header)",
+        )
+    try:
+        return uuid.UUID(str(raw))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid org_id format")
+
+
+RoleType = Literal["admin", "member", "viewer"]
+
+
+def require_role(*allowed_roles: RoleType):
+    """JWT app_metadata.role이 허용 역할 중 하나인지 검증하는 dependency factory."""
+    def _check(auth: AuthContext = Depends(get_current_user)) -> AuthContext:
+        role = auth.claims.get("app_metadata", {}).get("role", "member")
+        if role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Role '{role}' not allowed. Required: {list(allowed_roles)}",
+            )
+        return auth
+    return _check
+
+
+def require_admin(auth: AuthContext = Depends(get_current_user)) -> AuthContext:
+    """admin role 전용 엔드포인트 가드."""
+    role = auth.claims.get("app_metadata", {}).get("role", "member")
+    if role != "admin":
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin role required",
+        )
+    return auth
+
+
+def require_project_access(
+    project_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+) -> uuid.UUID:
+    """JWT app_metadata.project_ids에 project_id가 포함되어 있는지 검증.
+    project_ids 클레임이 없으면(레거시 토큰) 통과 — Phase C 전환 기간 호환."""
+    project_ids = auth.claims.get("app_metadata", {}).get("project_ids")
+    if project_ids is not None:
+        if str(project_id) not in [str(pid) for pid in project_ids]:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Access to project {project_id} denied",
+            )
+    return project_id
+
+
+def get_scope_context(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+) -> dict:
+    """org_id + project_id 컨텍스트를 한번에 추출."""
+    org_id = get_org_scope(auth, x_org_id)
+    project_id_raw = auth.claims.get("app_metadata", {}).get("project_id") or x_project_id
+    project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
+    return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -1,0 +1,178 @@
+"""C-S5: RLS → FastAPI 권한 검증 전환 — dependency injection 테스트"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# ─── get_org_scope ────────────────────────────────────────────────────────────
+
+def _make_auth(org_id: str | None = None, role: str = "member", project_ids: list | None = None):
+    from app.dependencies.auth import AuthContext
+    app_metadata: dict = {}
+    if org_id:
+        app_metadata["org_id"] = org_id
+    if role:
+        app_metadata["role"] = role
+    if project_ids is not None:
+        app_metadata["project_ids"] = project_ids
+    return AuthContext(user_id="user-1", email="u@test.com", claims={"app_metadata": app_metadata})
+
+
+def test_get_org_scope_from_jwt():
+    from app.dependencies.auth import get_org_scope
+    org = uuid.uuid4()
+    auth = _make_auth(org_id=str(org))
+    result = get_org_scope(auth=auth, x_org_id=None)
+    assert result == org
+
+
+def test_get_org_scope_from_header():
+    from app.dependencies.auth import get_org_scope
+    org = uuid.uuid4()
+    auth = _make_auth(org_id=None)
+    result = get_org_scope(auth=auth, x_org_id=str(org))
+    assert result == org
+
+
+def test_get_org_scope_jwt_takes_precedence():
+    from app.dependencies.auth import get_org_scope
+    jwt_org = uuid.uuid4()
+    header_org = uuid.uuid4()
+    auth = _make_auth(org_id=str(jwt_org))
+    result = get_org_scope(auth=auth, x_org_id=str(header_org))
+    assert result == jwt_org
+
+
+def test_get_org_scope_missing_raises_400():
+    from app.dependencies.auth import get_org_scope
+    auth = _make_auth(org_id=None)
+    with pytest.raises(HTTPException) as exc:
+        get_org_scope(auth=auth, x_org_id=None)
+    assert exc.value.status_code == 400
+
+
+def test_get_org_scope_invalid_uuid_raises_400():
+    from app.dependencies.auth import get_org_scope
+    auth = _make_auth(org_id=None)
+    with pytest.raises(HTTPException) as exc:
+        get_org_scope(auth=auth, x_org_id="not-a-uuid")
+    assert exc.value.status_code == 400
+
+
+# ─── require_role ─────────────────────────────────────────────────────────────
+
+def test_require_role_passes_for_allowed():
+    from app.dependencies.auth import require_role
+    auth = _make_auth(role="admin")
+    checker = require_role("admin", "member")
+    result = checker(auth=auth)
+    assert result.user_id == "user-1"
+
+
+def test_require_role_raises_403_for_disallowed():
+    from app.dependencies.auth import require_role
+    auth = _make_auth(role="viewer")
+    checker = require_role("admin", "member")
+    with pytest.raises(HTTPException) as exc:
+        checker(auth=auth)
+    assert exc.value.status_code == 403
+
+
+def test_require_role_defaults_to_member():
+    from app.dependencies.auth import require_role
+    from app.dependencies.auth import AuthContext
+    auth = AuthContext(user_id="u", email=None, claims={})
+    checker = require_role("member")
+    result = checker(auth=auth)
+    assert result is auth
+
+
+# ─── require_admin ────────────────────────────────────────────────────────────
+
+def test_require_admin_passes():
+    from app.dependencies.auth import require_admin
+    auth = _make_auth(role="admin")
+    result = require_admin(auth=auth)
+    assert result is auth
+
+
+def test_require_admin_blocks_member():
+    from app.dependencies.auth import require_admin
+    auth = _make_auth(role="member")
+    with pytest.raises(HTTPException) as exc:
+        require_admin(auth=auth)
+    assert exc.value.status_code == 403
+
+
+# ─── require_project_access ───────────────────────────────────────────────────
+
+def test_require_project_access_passes_when_project_in_list():
+    from app.dependencies.auth import require_project_access
+    pid = uuid.uuid4()
+    auth = _make_auth(project_ids=[str(pid)])
+    result = require_project_access(project_id=pid, auth=auth)
+    assert result == pid
+
+
+def test_require_project_access_blocks_unlisted_project():
+    from app.dependencies.auth import require_project_access
+    pid = uuid.uuid4()
+    other = uuid.uuid4()
+    auth = _make_auth(project_ids=[str(other)])
+    with pytest.raises(HTTPException) as exc:
+        require_project_access(project_id=pid, auth=auth)
+    assert exc.value.status_code == 403
+
+
+def test_require_project_access_allows_legacy_token_without_project_ids():
+    """project_ids 클레임 없는 레거시 토큰은 Phase C 전환 기간 허용."""
+    from app.dependencies.auth import require_project_access
+    pid = uuid.uuid4()
+    auth = _make_auth(project_ids=None)
+    result = require_project_access(project_id=pid, auth=auth)
+    assert result == pid
+
+
+# ─── get_scope_context ────────────────────────────────────────────────────────
+
+def test_get_scope_context_returns_org_and_project():
+    from app.dependencies.auth import get_scope_context
+    org = uuid.uuid4()
+    proj = uuid.uuid4()
+    auth = _make_auth(org_id=str(org))
+    ctx = get_scope_context(auth=auth, x_org_id=None, x_project_id=str(proj))
+    assert ctx["org_id"] == org
+    assert ctx["project_id"] == proj
+    assert ctx["user_id"] == "user-1"
+
+
+def test_get_scope_context_project_none_when_not_provided():
+    from app.dependencies.auth import get_scope_context
+    org = uuid.uuid4()
+    auth = _make_auth(org_id=str(org))
+    ctx = get_scope_context(auth=auth, x_org_id=None, x_project_id=None)
+    assert ctx["org_id"] == org
+    assert ctx["project_id"] is None
+
+
+# ─── AuthContext org_id field ──────────────────────────────────────────────────
+
+def test_auth_context_includes_org_id_from_jwt():
+    """get_current_user가 JWT app_metadata.org_id를 AuthContext.org_id에 포함."""
+    with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
+        from app.core.security import create_access_token
+        token = create_access_token("user-1", email="a@b.com", app_metadata={"org_id": "org-abc"})
+
+    from fastapi.security import HTTPAuthorizationCredentials
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+
+    with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
+        from app.dependencies.auth import get_current_user
+        ctx = get_current_user(credentials=creds)
+
+    assert ctx.org_id == "org-abc"
+    assert ctx.user_id == "user-1"


### PR DESCRIPTION
## Summary

**FastAPI 권한 검증 dependency 확립 (`app/dependencies/auth.py`)**
- `AuthContext.org_id` 필드 추가 — JWT `app_metadata.org_id` 자동 추출
- `get_org_scope()`: JWT `app_metadata` + `X-Org-Id` 헤더에서 org_id UUID 추출. 미제공 시 400
- `require_role(*roles)`: `app_metadata.role` 검증. 불일치 시 403
- `require_admin()`: admin 전용 가드
- `require_project_access()`: `project_ids` 클레임 기반 프로젝트 접근 제어. 레거시 토큰(클레임 없음) 전환 기간 허용
- `get_scope_context()`: org_id + project_id + user_id 컨텍스트 일괄 추출

**RLS 비활성화 (`alembic/versions/0002_disable_rls.py`)**
- FastAPI-managed 49개 테이블 `DISABLE ROW LEVEL SECURITY`
- `downgrade()`: `ENABLE ROW LEVEL SECURITY` 복구
- DROP 정책은 C-S9 데이터 마이그레이션 시 일괄 처리

## Test plan

- [ ] `test_c_s5.py` 16개 PASS
- [ ] 전체 백엔드 테스트 337 PASS
- [ ] `get_org_scope(auth, x_org_id=None)` → JWT org_id 반환
- [ ] `get_org_scope(auth_no_jwt, x_org_id="...")` → 헤더 org_id 반환
- [ ] `get_org_scope(none, none)` → 400
- [ ] `require_role("admin")(viewer_auth)` → 403
- [ ] `require_project_access(pid, legacy_auth)` → 통과 (레거시 호환)
- [ ] alembic upgrade 0002 → 49개 테이블 RLS 비활성화

🤖 Generated with [Claude Code](https://claude.com/claude-code)