### PR TITLE
feat(d-s1): Cloud SQL 인스턴스 프로비저닝 (dev/prod) — 3SP

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,11 +1,28 @@
-# Supabase / PostgreSQL
+# ─── Database ────────────────────────────────────────────────────────────────
+# 로컬 개발 (Supabase local / Docker PostgreSQL)
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@localhost:54322/postgres
+
+# Cloud SQL Auth Proxy 연결 (D-S1 이후)
+# Cloud SQL Proxy 실행: ./cloud-sql-proxy sprintable:asia-northeast3:sprintable-dev --port 5433
+# DATABASE_URL=postgresql+asyncpg://sprintable:PASSWORD@127.0.0.1:5433/sprintable
+
+# Cloud SQL Unix socket 연결 (Cloud Run 배포 시)
+# DATABASE_URL=postgresql+asyncpg://sprintable:PASSWORD@/sprintable?host=/cloudsql/sprintable:asia-northeast3:sprintable-dev
+
+# ─── Cloud SQL (D-S1: Phase D GCP 인프라) ────────────────────────────────────
+CLOUD_SQL_INSTANCE_DEV=sprintable:asia-northeast3:sprintable-dev
+CLOUD_SQL_INSTANCE_PROD=sprintable:asia-northeast3:sprintable-prod
+
+# ─── JWT ─────────────────────────────────────────────────────────────────────
+JWT_SECRET=your-jwt-secret-min-32-chars
+
+# ─── Supabase (Phase C 과도기 유지) ──────────────────────────────────────────
 SUPABASE_JWT_SECRET=your-supabase-jwt-secret
 SUPABASE_URL=https://your-project.supabase.co
 
-# App
+# ─── App ─────────────────────────────────────────────────────────────────────
 APP_ENV=development
 DEBUG=true
 
-# EE gating (SaaS 기능 활성화)
+# ─── EE / SaaS gating ────────────────────────────────────────────────────────
 LICENSE_CONSENT=

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -5,9 +5,20 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", extra="ignore")
 
     # Database
+    # Cloud SQL Auth Proxy 연결 예시:
+    #   postgresql+asyncpg://sprintable:PASSWORD@127.0.0.1:5433/sprintable
+    # Cloud SQL Unix socket 연결 예시 (Cloud Run 등):
+    #   postgresql+asyncpg://sprintable:PASSWORD@/sprintable?host=/cloudsql/sprintable:asia-northeast3:sprintable-dev
     database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:54322/postgres"
 
-    # Supabase / JWT
+    # Cloud SQL (D-S1: Phase D GCP 인프라)
+    cloud_sql_instance_dev: str = "sprintable:asia-northeast3:sprintable-dev"
+    cloud_sql_instance_prod: str = "sprintable:asia-northeast3:sprintable-prod"
+
+    # JWT
+    jwt_secret: str = ""
+
+    # Supabase (Phase C 과도기 — DB 쿼리 라우트 125개 전환 완료 전까지 유지)
     supabase_jwt_secret: str = ""
     supabase_url: str = ""
 
@@ -21,6 +32,10 @@ class Settings(BaseSettings):
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"
+
+    @property
+    def effective_jwt_secret(self) -> str:
+        return self.jwt_secret or self.supabase_jwt_secret
 
 
 settings = Settings()

--- a/backend/scripts/provision_cloud_sql.sh
+++ b/backend/scripts/provision_cloud_sql.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# D-S1: Cloud SQL PostgreSQL 15 인스턴스 프로비저닝 스크립트
+#
+# 사전 조건:
+#   - GCP 프로젝트에 Billing 계정 연결 완료
+#   - Cloud SQL Admin API, Compute Engine API, Service Networking API 활성화
+#   - gcloud auth login 완료
+#
+# 사용법:
+#   bash backend/scripts/provision_cloud_sql.sh [dev|prod|both]
+#
+# 환경변수 (선택):
+#   GCP_PROJECT   (기본: sprintable)
+#   GCP_REGION    (기본: asia-northeast3)
+#   VPC_NETWORK   (기본: default)
+
+set -euo pipefail
+
+GCP_PROJECT="${GCP_PROJECT:-sprintable}"
+GCP_REGION="${GCP_REGION:-asia-northeast3}"
+VPC_NETWORK="${VPC_NETWORK:-default}"
+TARGET="${1:-both}"
+
+INSTANCE_DEV="sprintable-dev"
+INSTANCE_PROD="sprintable-prod"
+DB_NAME="sprintable"
+DB_USER="sprintable"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# ─── API 활성화 ───────────────────────────────────────────────────────────────
+enable_apis() {
+    log "Enabling required GCP APIs..."
+    gcloud services enable \
+        sqladmin.googleapis.com \
+        compute.googleapis.com \
+        servicenetworking.googleapis.com \
+        --project="${GCP_PROJECT}"
+    log "APIs enabled."
+}
+
+# ─── Private IP VPC 피어링 설정 ───────────────────────────────────────────────
+setup_private_ip() {
+    log "Setting up Private Services Access for VPC '${VPC_NETWORK}'..."
+    # IP range 이미 존재하면 skip
+    if ! gcloud compute addresses describe google-managed-services-"${VPC_NETWORK}" \
+            --global --project="${GCP_PROJECT}" &>/dev/null; then
+        gcloud compute addresses create google-managed-services-"${VPC_NETWORK}" \
+            --global \
+            --purpose=VPC_PEERING \
+            --prefix-length=16 \
+            --network="${VPC_NETWORK}" \
+            --project="${GCP_PROJECT}"
+    fi
+    # 피어링 이미 존재하면 skip
+    gcloud services vpc-peerings connect \
+        --service=servicenetworking.googleapis.com \
+        --ranges=google-managed-services-"${VPC_NETWORK}" \
+        --network="${VPC_NETWORK}" \
+        --project="${GCP_PROJECT}" 2>/dev/null || log "VPC peering already exists, skipping."
+    log "Private Services Access configured."
+}
+
+# ─── Dev 인스턴스 생성 ────────────────────────────────────────────────────────
+create_dev() {
+    log "Creating dev instance '${INSTANCE_DEV}' (db-f1-micro)..."
+    gcloud sql instances create "${INSTANCE_DEV}" \
+        --database-version=POSTGRES_15 \
+        --tier=db-f1-micro \
+        --region="${GCP_REGION}" \
+        --network="${VPC_NETWORK}" \
+        --no-assign-ip \
+        --enable-google-private-path \
+        --backup-start-time=03:00 \
+        --retained-backups-count=7 \
+        --storage-size=10 \
+        --storage-type=SSD \
+        --project="${GCP_PROJECT}"
+
+    gcloud sql databases create "${DB_NAME}" \
+        --instance="${INSTANCE_DEV}" --project="${GCP_PROJECT}"
+
+    gcloud sql users create "${DB_USER}" \
+        --instance="${INSTANCE_DEV}" \
+        --password="$(openssl rand -base64 24)" \
+        --project="${GCP_PROJECT}"
+
+    log "Dev instance ready: ${INSTANCE_DEV}"
+    log "Connection: ${GCP_PROJECT}:${GCP_REGION}:${INSTANCE_DEV}"
+}
+
+# ─── Prod 인스턴스 생성 ───────────────────────────────────────────────────────
+create_prod() {
+    log "Creating prod instance '${INSTANCE_PROD}' (db-custom-2-7680)..."
+    gcloud sql instances create "${INSTANCE_PROD}" \
+        --database-version=POSTGRES_15 \
+        --tier=db-custom-2-7680 \
+        --region="${GCP_REGION}" \
+        --network="${VPC_NETWORK}" \
+        --no-assign-ip \
+        --enable-google-private-path \
+        --backup-start-time=03:00 \
+        --retained-backups-count=7 \
+        --enable-point-in-time-recovery \
+        --retained-transaction-log-days=7 \
+        --storage-size=50 \
+        --storage-type=SSD \
+        --storage-auto-increase \
+        --project="${GCP_PROJECT}"
+
+    gcloud sql databases create "${DB_NAME}" \
+        --instance="${INSTANCE_PROD}" --project="${GCP_PROJECT}"
+
+    gcloud sql users create "${DB_USER}" \
+        --instance="${INSTANCE_PROD}" \
+        --password="$(openssl rand -base64 24)" \
+        --project="${GCP_PROJECT}"
+
+    log "Prod instance ready: ${INSTANCE_PROD}"
+    log "Connection: ${GCP_PROJECT}:${GCP_REGION}:${INSTANCE_PROD}"
+}
+
+# ─── Cloud SQL Auth Proxy 설치 안내 ───────────────────────────────────────────
+print_proxy_instructions() {
+    cat <<'PROXY'
+
+=== Cloud SQL Auth Proxy 설정 ===
+
+1. Proxy 다운로드 (macOS):
+   curl -o cloud-sql-proxy https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.15.2/cloud-sql-proxy.darwin.arm64
+   chmod +x cloud-sql-proxy
+
+2. Dev 인스턴스 연결:
+   ./cloud-sql-proxy sprintable:asia-northeast3:sprintable-dev --port 5433 &
+
+3. FastAPI .env 설정:
+   DATABASE_URL=postgresql+asyncpg://sprintable:PASSWORD@127.0.0.1:5433/sprintable
+
+4. Alembic 마이그레이션 적용:
+   alembic upgrade head
+
+5. 연결 검증:
+   curl http://localhost:8000/api/v2/health
+PROXY
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+enable_apis
+setup_private_ip
+
+case "${TARGET}" in
+    dev)  create_dev ;;
+    prod) create_prod ;;
+    both) create_dev; create_prod ;;
+    *) echo "Usage: $0 [dev|prod|both]"; exit 1 ;;
+esac
+
+print_proxy_instructions
+log "=== Provisioning complete ==="


### PR DESCRIPTION
## Summary

GCP Billing 미연결로 실제 인스턴스 생성 불가 상태 → 선행 작업 PR (오르테가군 승인).

- `backend/scripts/provision_cloud_sql.sh` — dev(db-f1-micro) + prod(db-custom-2-7680) gcloud 자동화 스크립트. VPC 피어링, Private IP, PITR, Auth Proxy 안내 포함
- `backend/app/core/config.py` — `cloud_sql_instance_dev/prod`, `jwt_secret`, `effective_jwt_secret` 추가
- `backend/.env.example` — Cloud SQL, JWT 환경변수 문서화

## 실행 순서 (Billing 연결 후)

```bash
# 1. 인스턴스 생성
bash backend/scripts/provision_cloud_sql.sh both

# 2. Cloud SQL Auth Proxy 실행
./cloud-sql-proxy sprintable:asia-northeast3:sprintable-dev --port 5433 &

# 3. .env 설정 후 Alembic 적용
DATABASE_URL=postgresql+asyncpg://sprintable:PASSWORD@127.0.0.1:5433/sprintable
alembic upgrade head

# 4. 연결 검증
curl http://localhost:8000/api/v2/health
# → {"status":"ok","version":"v2","db":"ok"}
```

## Test plan

- [ ] backend pytest 337/337 PASS ✅
- [ ] shell script syntax 오류 없음 ✅
- [ ] GCP Billing 연결 후 `provision_cloud_sql.sh both` 실행 → 인스턴스 2개 생성
- [ ] Auth Proxy 연결 + `/api/v2/health` db:ok 확인
- [ ] Alembic 0001→0002→0003 체인 적용 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)