### PR TITLE
feat(d-s7): dev/prod IAM 분리 + GitHub branch 배포 분기 (2SP)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -2,8 +2,13 @@ name: Cloud Build (GCP)
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
+    inputs:
+      env:
+        description: 'Deploy environment'
+        required: false
+        default: ''
 
 concurrency:
   group: cloud-build-${{ github.ref }}
@@ -34,11 +39,20 @@ jobs:
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
+      - name: Set deploy environment
+        id: env
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" ]]; then
+            echo "target=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=dev" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Submit Cloud Build
         run: |
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}" \
             --suppress-logs \
             .

--- a/backend/scripts/deploy_backend.sh
+++ b/backend/scripts/deploy_backend.sh
@@ -36,6 +36,7 @@ case "${ENV}" in
         MEMORY="512Mi"
         CPU="1"
         FRONTEND_URL="${FRONTEND_ORIGIN:-https://sprintable-frontend-dev-placeholder.run.app}"
+        RUNTIME_SA="cloudrun-runtime-dev@${GCP_PROJECT}.iam.gserviceaccount.com"
         ;;
     prod)
         SERVICE_NAME="sprintable-backend-prod"
@@ -45,6 +46,7 @@ case "${ENV}" in
         MEMORY="1Gi"
         CPU="2"
         FRONTEND_URL="${FRONTEND_ORIGIN:-https://app.sprintable.ai}"
+        RUNTIME_SA="cloudrun-runtime-prod@${GCP_PROJECT}.iam.gserviceaccount.com"
         ;;
     *)
         echo "Usage: $0 [dev|prod]"; exit 1 ;;
@@ -64,6 +66,7 @@ gcloud run deploy "${SERVICE_NAME}" \
     --project="${GCP_PROJECT}" \
     --platform=managed \
     --no-allow-unauthenticated \
+    --service-account="${RUNTIME_SA}" \
     --port=8000 \
     --memory="${MEMORY}" \
     --cpu="${CPU}" \

--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -34,6 +34,7 @@ case "${ENV}" in
         MEMORY="512Mi"
         CPU="1"
         FASTAPI_SERVICE="sprintable-backend-dev"
+        RUNTIME_SA="cloudrun-runtime-dev@${GCP_PROJECT}.iam.gserviceaccount.com"
         ;;
     prod)
         SERVICE_NAME="sprintable-frontend-prod"
@@ -42,6 +43,7 @@ case "${ENV}" in
         MEMORY="1Gi"
         CPU="2"
         FASTAPI_SERVICE="sprintable-backend-prod"
+        RUNTIME_SA="cloudrun-runtime-prod@${GCP_PROJECT}.iam.gserviceaccount.com"
         ;;
     *)
         echo "Usage: $0 [dev|prod]"; exit 1 ;;
@@ -67,6 +69,7 @@ gcloud run deploy "${SERVICE_NAME}" \
     --project="${GCP_PROJECT}" \
     --platform=managed \
     --allow-unauthenticated \
+    --service-account="${RUNTIME_SA}" \
     --port=3000 \
     --memory="${MEMORY}" \
     --cpu="${CPU}" \

--- a/backend/scripts/setup_iam.sh
+++ b/backend/scripts/setup_iam.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# D-S7: IAM 최소 권한 설정 스크립트
+#
+# Cloud Run 런타임 SA (dev + prod) 생성 + 최소 권한:
+#   - secretmanager.secretAccessor
+#   - cloudsql.client
+#
+# GitHub Actions SA (D-S2에서 생성됨)는 다음 역할만 유지:
+#   - cloudbuild.builds.editor
+#   - artifactregistry.writer
+#   (run.admin, secretAccessor는 Cloud Run SA로 이동 — 최소 권한 원칙)
+#
+# 사용법:
+#   GCP_PROJECT=sprintable-494803 bash backend/scripts/setup_iam.sh
+
+set -euo pipefail
+
+GCP_PROJECT="${GCP_PROJECT:-sprintable-494803}"
+GCP_REGION="${GCP_REGION:-asia-northeast3}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# ─── API 활성화 ───────────────────────────────────────────────────────────────
+log "Enabling required APIs..."
+gcloud services enable \
+    iam.googleapis.com \
+    iamcredentials.googleapis.com \
+    run.googleapis.com \
+    --project="${GCP_PROJECT}"
+
+# ─── Cloud Run 런타임 SA 생성 헬퍼 ───────────────────────────────────────────
+create_runtime_sa() {
+    local env="$1"
+    local sa_name="cloudrun-runtime-${env}"
+    local sa_email="${sa_name}@${GCP_PROJECT}.iam.gserviceaccount.com"
+
+    log "Creating Cloud Run runtime SA for ${env}: ${sa_email}"
+    gcloud iam service-accounts create "${sa_name}" \
+        --display-name="Cloud Run Runtime (${env})" \
+        --project="${GCP_PROJECT}" 2>/dev/null || log "SA already exists, skipping create."
+
+    # 최소 권한 역할만 부여
+    for ROLE in \
+        roles/secretmanager.secretAccessor \
+        roles/cloudsql.client; do
+        gcloud projects add-iam-policy-binding "${GCP_PROJECT}" \
+            --member="serviceAccount:${sa_email}" \
+            --role="${ROLE}" \
+            --condition=None
+    done
+
+    log "SA ${sa_email} — roles: secretAccessor + cloudsql.client"
+    echo "${sa_email}"
+}
+
+# ─── dev / prod SA 생성 ───────────────────────────────────────────────────────
+SA_DEV=$(create_runtime_sa "dev")
+SA_PROD=$(create_runtime_sa "prod")
+
+# ─── GitHub Actions SA 권한 정리 (run.admin 불필요) ──────────────────────────
+# deploy_frontend/backend.sh는 Cloud Build에서 실행되므로
+# GitHub Actions SA에서 run.admin 제거 (최소 권한 강화)
+GHA_SA="github-actions@${GCP_PROJECT}.iam.gserviceaccount.com"
+log "Removing run.admin from GitHub Actions SA (${GHA_SA})..."
+gcloud projects remove-iam-policy-binding "${GCP_PROJECT}" \
+    --member="serviceAccount:${GHA_SA}" \
+    --role="roles/run.admin" \
+    --condition=None 2>/dev/null || log "run.admin not found, skipping."
+
+log "=== IAM setup complete ==="
+cat <<OUTPUT
+
+Cloud Run 배포 시 SA 지정 바라는:
+  deploy_frontend.sh dev  → --service-account=${SA_DEV}
+  deploy_frontend.sh prod → --service-account=${SA_PROD}
+  deploy_backend.sh dev   → --service-account=${SA_DEV}
+  deploy_backend.sh prod  → --service-account=${SA_PROD}
+OUTPUT

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,13 +1,14 @@
-# D-S2: Cloud Build — Frontend + Backend 멀티 이미지 빌드
-# GCP 프로젝트: sprintable | 리전: asia-northeast3
+# D-S2/D-S7: Cloud Build — Frontend + Backend 멀티 이미지 빌드
+# GCP 프로젝트: sprintable-494803 | 리전: asia-northeast3
 #
-# 트리거: main 브랜치 push (GitHub Actions → Cloud Build)
-# 이미지 태그: $COMMIT_SHA + latest
+# 트리거: main→prod, develop→dev (GitHub Actions cloud-build.yml)
+# 이미지 태그: $COMMIT_SHA + $ENV (latest-dev / latest-prod)
 # 캐시: Artifact Registry 레이어 캐시
 
 substitutions:
   _AR_REGION: asia-northeast3
   _AR_REPO: sprintable
+  _DEPLOY_ENV: dev  # main push 시 prod로 오버라이드됨
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -20,9 +21,9 @@ steps:
       - -t
       - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:${COMMIT_SHA}
       - -t
-      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
       - --cache-from
-      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
       - --build-arg
       - BUILDKIT_INLINE_CACHE=1
       - .
@@ -39,9 +40,9 @@ steps:
       - -t
       - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
       - -t
-      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest-${_DEPLOY_ENV}
       - --cache-from
-      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest-${_DEPLOY_ENV}
       - --build-arg
       - BUILDKIT_INLINE_CACHE=1
       - ./backend
@@ -50,9 +51,9 @@ steps:
 
 images:
   - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:${COMMIT_SHA}
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest
+  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
   - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest
+  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest-${_DEPLOY_ENV}
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
## Summary

- `backend/scripts/setup_iam.sh` — Cloud Run 런타임 SA `cloudrun-runtime-{dev|prod}@sprintable-494803` 생성. 최소 권한(secretAccessor + cloudsql.client). GitHub Actions SA에서 `run.admin` 제거
- `deploy_frontend/backend.sh` — `--service-account ${RUNTIME_SA}` 추가 (env별 독립 SA)
- `cloudbuild.yaml` — `_DEPLOY_ENV` substitution 추가, 이미지 태그 `latest-dev` / `latest-prod` 분리
- `.github/workflows/cloud-build.yml` — `develop` 브랜치 트리거 추가, `main→prod` / `develop→dev` 배포 분기

## IAM 구조

| SA | 역할 | 용도 |
|----|------|------|
| `github-actions@...` | cloudbuild.builds.editor, artifactregistry.writer | CI/CD |
| `cloudrun-runtime-dev@...` | secretAccessor, cloudsql.client | Cloud Run dev 런타임 |
| `cloudrun-runtime-prod@...` | secretAccessor, cloudsql.client | Cloud Run prod 런타임 |

## Test plan

- [ ] backend pytest 337/337 PASS ✅
- [ ] shell script syntax 9개 모두 OK ✅
- [ ] Billing 연결 후 `setup_iam.sh` → SA 3개 생성 확인
- [ ] develop push → cloud-build.yml dev 배포 분기 확인
- [ ] main push → prod 배포 분기 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)