### PR TITLE
feat(d-s8): 모니터링 + 알럿 + JSON 구조화 로깅 (2SP)

### DIFF
--- a/backend/app/core/logging_config.py
+++ b/backend/app/core/logging_config.py
@@ -1,0 +1,51 @@
+"""Cloud Logging 호환 JSON 구조화 로깅 설정."""
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+
+class JsonFormatter(logging.Formatter):
+    """Cloud Logging JSON 포맷 — severity + message + labels."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        import json
+        severity_map = {
+            logging.DEBUG: "DEBUG",
+            logging.INFO: "INFO",
+            logging.WARNING: "WARNING",
+            logging.ERROR: "ERROR",
+            logging.CRITICAL: "CRITICAL",
+        }
+        payload: dict[str, Any] = {
+            "severity": severity_map.get(record.levelno, "DEFAULT"),
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if hasattr(record, "request_id"):
+            payload["httpRequest"] = {"requestId": record.request_id}
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(json_logs: bool = True) -> None:
+    """Cloud Run 환경: JSON 로그. 로컬: 일반 텍스트."""
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers.clear()
+
+    handler = logging.StreamHandler(sys.stdout)
+    if json_logs:
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(
+            "%(asctime)s %(levelname)s %(name)s — %(message)s"
+        ))
+    root.addHandler(handler)
+
+    # uvicorn 로거 레벨 통일
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error"):
+        logging.getLogger(name).handlers.clear()
+        logging.getLogger(name).propagate = True

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,12 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.core.config import settings
+from app.core.logging_config import configure_logging
+
+configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, current_project, dashboard, docs, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
 
 app = FastAPI(

--- a/backend/monitoring/alert_policies.json
+++ b/backend/monitoring/alert_policies.json
@@ -1,0 +1,71 @@
+[
+  {
+    "displayName": "Sprintable — 5xx Error Rate > 1%",
+    "combiner": "OR",
+    "conditions": [{
+      "displayName": "Cloud Run 5xx > 1% for 5 min",
+      "conditionThreshold": {
+        "filter": "metric.type=\"run.googleapis.com/request_count\" resource.type=\"cloud_run_revision\" resource.labels.service_name=starts_with(\"sprintable-\") metric.labels.response_code_class=\"5xx\"",
+        "aggregations": [{
+          "alignmentPeriod": "300s",
+          "perSeriesAligner": "ALIGN_RATE",
+          "crossSeriesReducer": "REDUCE_SUM",
+          "groupByFields": ["resource.labels.service_name"]
+        }],
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 0.01,
+        "duration": "300s",
+        "trigger": {"count": 1}
+      }
+    }],
+    "alertStrategy": {"autoClose": "1800s"},
+    "notificationChannels": [],
+    "severity": "ERROR"
+  },
+  {
+    "displayName": "Sprintable — Cloud SQL CPU > 80%",
+    "combiner": "OR",
+    "conditions": [{
+      "displayName": "Cloud SQL CPU utilization > 80%",
+      "conditionThreshold": {
+        "filter": "metric.type=\"cloudsql.googleapis.com/database/cpu/utilization\" resource.type=\"cloudsql_database\" resource.labels.database_id=starts_with(\"sprintable-494803:sprintable-\")",
+        "aggregations": [{
+          "alignmentPeriod": "60s",
+          "perSeriesAligner": "ALIGN_MEAN",
+          "crossSeriesReducer": "REDUCE_MEAN",
+          "groupByFields": ["resource.labels.database_id"]
+        }],
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 0.80,
+        "duration": "300s",
+        "trigger": {"count": 1}
+      }
+    }],
+    "alertStrategy": {"autoClose": "1800s"},
+    "notificationChannels": [],
+    "severity": "WARNING"
+  },
+  {
+    "displayName": "Sprintable — Cloud Run Memory > 90%",
+    "combiner": "OR",
+    "conditions": [{
+      "displayName": "Cloud Run memory utilization > 90%",
+      "conditionThreshold": {
+        "filter": "metric.type=\"run.googleapis.com/container/memory/utilizations\" resource.type=\"cloud_run_revision\" resource.labels.service_name=starts_with(\"sprintable-\")",
+        "aggregations": [{
+          "alignmentPeriod": "60s",
+          "perSeriesAligner": "ALIGN_PERCENTILE_99",
+          "crossSeriesReducer": "REDUCE_MEAN",
+          "groupByFields": ["resource.labels.service_name"]
+        }],
+        "comparison": "COMPARISON_GT",
+        "thresholdValue": 0.90,
+        "duration": "300s",
+        "trigger": {"count": 1}
+      }
+    }],
+    "alertStrategy": {"autoClose": "1800s"},
+    "notificationChannels": [],
+    "severity": "WARNING"
+  }
+]

--- a/backend/monitoring/dashboard.json
+++ b/backend/monitoring/dashboard.json
@@ -1,0 +1,127 @@
+{
+  "displayName": "Sprintable GCP Dashboard",
+  "mosaicLayout": {
+    "columns": 12,
+    "tiles": [
+      {
+        "xPos": 0, "yPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Frontend — Request Count",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"run.googleapis.com/request_count\" resource.labels.service_name=starts_with(\"sprintable-frontend\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "crossSeriesReducer": "REDUCE_SUM", "groupByFields": ["resource.labels.service_name"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.service_name}"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 6, "yPos": 0, "width": 6, "height": 4,
+        "widget": {
+          "title": "Backend — Request Count",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"run.googleapis.com/request_count\" resource.labels.service_name=starts_with(\"sprintable-backend\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "crossSeriesReducer": "REDUCE_SUM", "groupByFields": ["resource.labels.service_name"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.service_name}"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 4, "width": 6, "height": 4,
+        "widget": {
+          "title": "Cloud Run — P99 Latency (ms)",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"run.googleapis.com/request_latencies\" resource.labels.service_name=starts_with(\"sprintable-\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_PERCENTILE_99", "crossSeriesReducer": "REDUCE_MEAN", "groupByFields": ["resource.labels.service_name"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.service_name} p99"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 6, "yPos": 4, "width": 6, "height": 4,
+        "widget": {
+          "title": "Cloud Run — 5xx Error Rate",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"run.googleapis.com/request_count\" resource.labels.service_name=starts_with(\"sprintable-\") metric.labels.response_code_class=\"5xx\"",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_RATE", "crossSeriesReducer": "REDUCE_SUM", "groupByFields": ["resource.labels.service_name"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.service_name} 5xx"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 0, "yPos": 8, "width": 4, "height": 4,
+        "widget": {
+          "title": "Cloud SQL — CPU Utilization",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"cloudsql.googleapis.com/database/cpu/utilization\" resource.labels.database_id=starts_with(\"sprintable-494803:sprintable-\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN", "crossSeriesReducer": "REDUCE_MEAN", "groupByFields": ["resource.labels.database_id"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.database_id} CPU"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 4, "yPos": 8, "width": 4, "height": 4,
+        "widget": {
+          "title": "Cloud SQL — Memory Usage",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"cloudsql.googleapis.com/database/memory/utilization\" resource.labels.database_id=starts_with(\"sprintable-494803:sprintable-\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN", "crossSeriesReducer": "REDUCE_MEAN", "groupByFields": ["resource.labels.database_id"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.database_id} Memory"
+            }]
+          }
+        }
+      },
+      {
+        "xPos": 8, "yPos": 8, "width": 4, "height": 4,
+        "widget": {
+          "title": "Cloud SQL — Active Connections",
+          "xyChart": {
+            "dataSets": [{
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "filter": "metric.type=\"cloudsql.googleapis.com/database/postgresql/num_backends\" resource.labels.database_id=starts_with(\"sprintable-494803:sprintable-\")",
+                  "aggregation": {"alignmentPeriod": "60s", "perSeriesAligner": "ALIGN_MEAN", "crossSeriesReducer": "REDUCE_SUM", "groupByFields": ["resource.labels.database_id"]}
+                }
+              },
+              "legendTemplate": "${resource.labels.database_id} connections"
+            }]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/backend/scripts/setup_monitoring.sh
+++ b/backend/scripts/setup_monitoring.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# D-S8: Cloud Monitoring 대시보드 + 알럿 정책 설정 스크립트
+#
+# ─── 로그 필터 쿼리 참조 ─────────────────────────────────────────────────────
+#
+# Cloud Run 에러 로그:
+#   resource.type="cloud_run_revision"
+#   resource.labels.service_name=~"sprintable-"
+#   severity>=ERROR
+#
+# FastAPI 5xx 요청:
+#   resource.type="cloud_run_revision"
+#   resource.labels.service_name=~"sprintable-backend"
+#   httpRequest.status>=500
+#
+# Cloud SQL 슬로우 쿼리:
+#   resource.type="cloudsql_database"
+#   resource.labels.database_id=~"sprintable-494803:sprintable-"
+#   log_name=~"postgres.log"
+#   textPayload=~"duration:"
+#
+# 사용법:
+#   bash backend/scripts/setup_monitoring.sh [dashboard|alerts|channel|all]
+#
+# 환경변수:
+#   GCP_PROJECT          (기본: sprintable-494803)
+#   ALERT_EMAIL          알럿 수신 이메일 (선택)
+#   DISCORD_WEBHOOK_URL  Discord 웹훅 URL (선택)
+
+set -euo pipefail
+
+GCP_PROJECT="${GCP_PROJECT:-sprintable-494803}"
+ALERT_EMAIL="${ALERT_EMAIL:-}"
+DISCORD_WEBHOOK_URL="${DISCORD_WEBHOOK_URL:-}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONITORING_DIR="${SCRIPT_DIR}/../monitoring"
+CMD="${1:-all}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+
+# ─── API 활성화 ───────────────────────────────────────────────────────────────
+enable_apis() {
+    log "Enabling Monitoring API..."
+    gcloud services enable monitoring.googleapis.com --project="${GCP_PROJECT}"
+}
+
+# ─── 대시보드 생성 ────────────────────────────────────────────────────────────
+create_dashboard() {
+    log "Creating Cloud Monitoring dashboard..."
+    gcloud monitoring dashboards create \
+        --config-from-file="${MONITORING_DIR}/dashboard.json" \
+        --project="${GCP_PROJECT}"
+    log "Dashboard created."
+}
+
+# ─── 알림 채널 생성 ───────────────────────────────────────────────────────────
+create_channels() {
+    CHANNEL_IDS=()
+
+    if [[ -n "${ALERT_EMAIL}" ]]; then
+        log "Creating email notification channel: ${ALERT_EMAIL}"
+        CHANNEL_ID=$(gcloud alpha monitoring channels create \
+            --display-name="Sprintable Alert Email" \
+            --type=email \
+            --channel-labels="email_address=${ALERT_EMAIL}" \
+            --project="${GCP_PROJECT}" \
+            --format="value(name)")
+        CHANNEL_IDS+=("${CHANNEL_ID}")
+        log "Email channel: ${CHANNEL_ID}"
+    fi
+
+    if [[ -n "${DISCORD_WEBHOOK_URL}" ]]; then
+        log "Creating Discord webhook channel..."
+        CHANNEL_ID=$(gcloud alpha monitoring channels create \
+            --display-name="Sprintable Discord Alert" \
+            --type=webhooks \
+            --channel-labels="url=${DISCORD_WEBHOOK_URL}" \
+            --project="${GCP_PROJECT}" \
+            --format="value(name)")
+        CHANNEL_IDS+=("${CHANNEL_ID}")
+        log "Discord channel: ${CHANNEL_ID}"
+    fi
+
+    echo "${CHANNEL_IDS[@]:-}"
+}
+
+# ─── 알럿 정책 생성 ───────────────────────────────────────────────────────────
+create_alerts() {
+    local channel_ids=("$@")
+    local policies_file="${MONITORING_DIR}/alert_policies.json"
+
+    log "Creating alert policies from ${policies_file}..."
+    local count
+    count=$(python3 -c "import json; data=json.load(open('${policies_file}')); print(len(data))")
+
+    for i in $(seq 0 $((count - 1))); do
+        local policy
+        policy=$(python3 -c "
+import json, sys
+data = json.load(open('${policies_file}'))
+p = data[${i}]
+if ${#channel_ids[@]} > 0:
+    p['notificationChannels'] = [c for c in '${channel_ids[*]:-}'.split() if c]
+print(json.dumps(p))
+")
+        echo "${policy}" | gcloud alpha monitoring policies create \
+            --policy-from-file=- \
+            --project="${GCP_PROJECT}"
+        log "Alert policy created: $(echo "${policy}" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("displayName",""))')"
+    done
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+enable_apis
+
+case "${CMD}" in
+    dashboard)
+        create_dashboard
+        ;;
+    alerts)
+        CHANNELS=($(create_channels))
+        create_alerts "${CHANNELS[@]:-}"
+        ;;
+    channel)
+        create_channels
+        ;;
+    all)
+        create_dashboard
+        CHANNELS=($(create_channels))
+        create_alerts "${CHANNELS[@]:-}"
+        ;;
+    *) echo "Usage: $0 [dashboard|alerts|channel|all]"; exit 1 ;;
+esac
+
+log "=== Monitoring setup complete ==="

--- a/backend/scripts/setup_monitoring.sh
+++ b/backend/scripts/setup_monitoring.sh
@@ -36,7 +36,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MONITORING_DIR="${SCRIPT_DIR}/../monitoring"
 CMD="${1:-all}"
 
-log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*"; }
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2; }
 
 # ─── API 활성화 ───────────────────────────────────────────────────────────────
 enable_apis() {


### PR DESCRIPTION
## Summary

- `backend/monitoring/dashboard.json` — Cloud Monitoring 대시보드 (Cloud Run 3 + Cloud SQL 3 = 7 위젯)
- `backend/monitoring/alert_policies.json` — 알럿 정책 3건 (5xx > 1%, CPU > 80%, 메모리 > 90%)
- `backend/scripts/setup_monitoring.sh` — 대시보드 + 알럿 + 알림 채널(이메일/Discord) 자동화. 로그 필터 쿼리 주석 포함
- `backend/app/core/logging_config.py` — Cloud Logging 호환 JSON 구조화 로거 (`severity` + `message` + `httpRequest`)
- `backend/app/main.py` — `configure_logging()` 적용 (APP_ENV=development → 텍스트, 그 외 → JSON)

## 실행 순서 (Billing 연결 후)

```bash
# 이메일 알럿
ALERT_EMAIL=dev@moonklabs.com bash backend/scripts/setup_monitoring.sh all

# Discord 웹훅 알럿
DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/... bash backend/scripts/setup_monitoring.sh all
```

## Test plan

- [ ] backend pytest 337/337 PASS ✅
- [ ] dashboard.json JSON 문법 OK ✅
- [ ] alert_policies.json JSON 문법 OK ✅
- [ ] shell script syntax OK ✅
- [ ] Billing 연결 후 `setup_monitoring.sh all` → 대시보드 + 알럿 3건 생성 확인
- [ ] Cloud Run 배포 후 JSON 로그 Cloud Logging 수집 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)