### PR TITLE
fix(build): add turbopack.root to fix monorepo build failure

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,6 +5,9 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  turbopack: {
+    root: __dirname,
+  },
   devIndicators: {
     position: 'bottom-right',
   },


### PR DESCRIPTION
## Summary
- Next.js 16.2.2 + Turbopack이 `src/app`을 프로젝트 루트로 잘못 추론하여 Cloud Build 실패 발생
- `apps/web/next.config.ts`에 `turbopack.root: __dirname` 추가로 수정
- 에러: `Turbopack build failed: couldn't find next/package.json from /app/apps/web/src/app`

## Root Cause
Turbopack이 monorepo layout에서 `src/app` 디렉토리를 프로젝트 루트로 추론하는 Next.js 16.2.2 회귀 이슈.
`turbopack.root`를 명시적으로 지정하면 해결됨.

## Changes
- `apps/web/next.config.ts`: `turbopack: { root: __dirname }` 추가

## Test plan
- [ ] Cloud Build 재실행으로 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)