### PR TITLE
fix(build): use process.cwd() for turbopack.root + force no-cache [v2]

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,7 +6,7 @@ const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 const nextConfig: NextConfig = {
   output: 'standalone',
   turbopack: {
-    root: __dirname,
+    root: process.cwd(),
   },
   devIndicators: {
     position: 'bottom-right',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,6 +16,7 @@ steps:
     name: gcr.io/cloud-builders/docker
     args:
       - build
+      - --no-cache
       - -f
       - apps/web/Dockerfile
       - -t


### PR DESCRIPTION
## Summary
- PR #346의 `__dirname` 방식이 Next.js TS config ESM 컨텍스트에서 `undefined`로 평가됨 (2회 빌드 실패 확인)
- `process.cwd()`로 교체 — Docker `WORKDIR /app/apps/web`에서 `next build` 실행 시 올바른 경로 반환
- `--no-cache` 추가 — Cloud Build 워커 로컬 Docker 레이어 캐시 강제 무효화 (같은 sha256 2회 관찰)

## Root Cause
1. `__dirname` → ESM 컨텍스트에서 undefined → `turbopack.root` 무효
2. Cloud Build 워커 Docker 캐시가 첫 번째 실패 빌드 레이어를 재사용

## Changes
- `apps/web/next.config.ts`: `__dirname` → `process.cwd()`
- `cloudbuild.yaml`: frontend build에 `--no-cache` 추가 (캐시 안정화 후 제거 예정)

## Follow-up
빌드 성공 확인 후 `--no-cache` 제거 PR 별도 생성 예정.

## Test plan
- [ ] Cloud Build 재실행으로 frontend 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)