### PR TITLE
fix(build): migrate MockupEditorPage params to Promise (Next.js 15+)

### DIFF
--- a/apps/web/src/app/(authenticated)/mockups/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/mockups/[id]/edit/page.tsx
@@ -1,11 +1,12 @@
 import { MockupEditorShell } from '@/components/mockups/mockup-editor-shell';
 
 interface MockupEditorPageProps {
-  params: {
+  params: Promise<{
     id: string;
-  };
+  }>;
 }
 
-export default function MockupEditorPage({ params }: MockupEditorPageProps) {
-  return <MockupEditorShell mockupId={params.id} />;
+export default async function MockupEditorPage({ params }: MockupEditorPageProps) {
+  const { id } = await params;
+  return <MockupEditorShell mockupId={id} />;
 }


### PR DESCRIPTION
## Summary
- Next.js 15/16 breaking change: page `params`가 `Promise<...>` constraint를 만족해야 함
- `MockupEditorPageProps.params: { id: string }` → `params: Promise<{ id: string }>`
- page 함수 `async` 추가 + `await params` 적용
- 이 패턴이 적용된 파일은 프로젝트 전체에서 이 1개 파일만 확인됨

## Change
`apps/web/src/app/(authenticated)/mockups/[id]/edit/page.tsx` — 5줄 변경

## Test plan
- [ ] Cloud Build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)