### PR TITLE
fix(build): remove invalid export from Route Handler (Next.js 15+)

### DIFF
--- a/apps/web/src/app/api/docs/preview/extract-embed-ids.ts
+++ b/apps/web/src/app/api/docs/preview/extract-embed-ids.ts
@@ -1,0 +1,10 @@
+export function extractEmbedIds(html: string | null | undefined): string[] {
+  if (!html) return [];
+  const ids: string[] = [];
+  const regex = /data-doc-id="([^"]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = regex.exec(html)) !== null) {
+    if (m[1]) ids.push(m[1]);
+  }
+  return ids;
+}

--- a/apps/web/src/app/api/docs/preview/route.test.ts
+++ b/apps/web/src/app/api/docs/preview/route.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { extractEmbedIds } from './route';
+import { extractEmbedIds } from './extract-embed-ids';
 
 // ---------------------------------------------------------------------------
 // Pure helper — extractEmbedIds

--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -9,9 +9,8 @@ import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 /**
  * Extract all doc IDs referenced by page-embed nodes from an HTML string.
- * Exported for unit testing.
  */
-export function extractEmbedIds(html: string | null | undefined): string[] {
+function extractEmbedIds(html: string | null | undefined): string[] {
   if (!html) return [];
   const ids: string[] = [];
   const regex = /data-doc-id="([^"]+)"/g;

--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -6,20 +6,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
 import { isOssMode, createDocRepository } from '@/lib/storage/factory';
-
-/**
- * Extract all doc IDs referenced by page-embed nodes from an HTML string.
- */
-function extractEmbedIds(html: string | null | undefined): string[] {
-  if (!html) return [];
-  const ids: string[] = [];
-  const regex = /data-doc-id="([^"]+)"/g;
-  let m: RegExpExecArray | null;
-  while ((m = regex.exec(html)) !== null) {
-    if (m[1]) ids.push(m[1]);
-  }
-  return ids;
-}
+import { extractEmbedIds } from './extract-embed-ids';
 
 /**
  * BFS over the embed graph starting from `startDocId`, collecting all

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -7,7 +7,7 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { getInternalDogfoodActors, isInternalDogfoodEnabled, readInternalDogfoodSession, resolveInternalDogfoodActor } from '@/lib/internal-dogfood';
 
 interface PageProps {
-  searchParams?: Promise<Record<string, string | string[] | undefined>> | Record<string, string | string[] | undefined>;
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
 }
 
 function readString(value: string | string[] | undefined) {
@@ -17,7 +17,7 @@ function readString(value: string | string[] | undefined) {
 export default async function InternalDogfoodPage({ searchParams }: PageProps) {
   if (!isInternalDogfoodEnabled()) notFound();
 
-  const params = searchParams ? await Promise.resolve(searchParams) : {};
+  const params = searchParams ? await searchParams : {};
   const error = readString(params.error);
   const createdMemoId = readString(params.created_memo_id);
   const createdStoryId = readString(params.created_story_id);


### PR DESCRIPTION
## Summary
- Next.js 15+ Route Handler에서 HTTP 메서드명 외 임의 named export 금지
- `extractEmbedIds` 함수의 `export` 키워드 제거 — 내부 호출자(`collectTransitiveEmbeds`)는 동일 파일이므로 영향 없음
- 테스트 파일에서 import 시 접근 불가하나, 빌드 에러 해결 우선

## Change
`apps/web/src/app/api/docs/preview/route.ts`: `export function extractEmbedIds` → `function extractEmbedIds`

## Test plan
- [ ] Cloud Build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)