### PR TITLE
fix(build): copy packages with node_modules from deps stage

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -19,7 +19,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
-COPY packages/ packages/
+COPY --from=deps /app/packages ./packages
 COPY apps/web/ apps/web/
 # ee overlay (SaaS 빌드 시 주입, OSS에서는 빈 디렉토리 허용)
 COPY ee/ ee/


### PR DESCRIPTION
## Summary
- `packages/storage-supabase/src/SupabaseDocRepository.ts`에서 `@supabase/supabase-js` 미발견 에러
- 원인: `COPY packages/ packages/` — 소스만 복사, deps stage에서 설치된 `packages/*/node_modules` 미포함
- 수정: `COPY --from=deps /app/packages ./packages` — node_modules 포함된 버전으로 교체

## Change
`apps/web/Dockerfile` line 22: 1줄 변경

## Test plan
- [ ] Cloud Build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)