### PR TITLE
fix(build): add outputFileTracingRoot for pnpm monorepo standalone

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -36,11 +36,11 @@ ENV NODE_ENV=production \
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/apps/web/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 
 USER nextjs
 EXPOSE 3000
 ENV PORT=3000 HOSTNAME="0.0.0.0"
-CMD ["node", "server.js"]
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,10 +1,12 @@
 import type { NextConfig } from 'next';
 import createNextIntlPlugin from 'next-intl/plugin';
+import path from 'path';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
   output: 'standalone',
+  outputFileTracingRoot: path.resolve(__dirname, '../..'),
   devIndicators: {
     position: 'bottom-right',
   },


### PR DESCRIPTION
## Summary
- Cloud Run 프론트엔드 시작 시 `Cannot find module 'next'` 에러 발생
- 원인: pnpm 모노레포에서 `output: 'standalone'` 빌드 시 `outputFileTracingRoot` 미설정 → Next.js가 `apps/web`만 추적하여 `packages/*` 의존성 누락
- 수정: `outputFileTracingRoot: path.resolve(__dirname, '../..')` — 모노레포 루트를 추적 대상으로 지정

## Change
`apps/web/next.config.ts`: `import path` 추가 + `outputFileTracingRoot` 설정

## Test plan
- [ ] Cloud Build 성공 확인
- [ ] Cloud Run 프론트엔드 정상 시작 확인 (`/api/health` 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)