### PR TITLE
fix: pass NEXT_PUBLIC_FASTAPI_URL as Docker build arg for Next.js rewrites

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -25,6 +25,9 @@ COPY apps/web/ apps/web/
 COPY ee/ ee/
 WORKDIR /app/apps/web
 ENV NEXT_TELEMETRY_DISABLED=1
+# rewrites()가 빌드 시점에 routes-manifest.json으로 베이크인되므로 ARG로 주입 필요
+ARG NEXT_PUBLIC_FASTAPI_URL
+ENV NEXT_PUBLIC_FASTAPI_URL=${NEXT_PUBLIC_FASTAPI_URL}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ substitutions:
   _AR_REGION: asia-northeast3
   _AR_REPO: sprintable
   _DEPLOY_ENV: dev  # main push 시 prod로 오버라이드됨
+  _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app  # 트리거별 오버라이드
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -27,6 +28,8 @@ steps:
       - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
       - --build-arg
       - BUILDKIT_INLINE_CACHE=1
+      - --build-arg
+      - NEXT_PUBLIC_FASTAPI_URL=${_FASTAPI_URL}
       - .
     env:
       - DOCKER_BUILDKIT=1


### PR DESCRIPTION
## 문제

Frontend Cloud Run에서 `/api/v2/*` 프록시 요청이 항상 500을 반환하는 이슈.

**원인:** Next.js `rewrites()`는 `next build` 시점에 `routes-manifest.json`으로 베이크인됨. Cloud Build에서 `NEXT_PUBLIC_FASTAPI_URL` 빌드 arg 미전달 → 기본값 `localhost:8000`이 매니페스트에 고착.

**로그 증거:**
```
Failed to proxy http://localhost:8000/api/v2/health Error: connect ECONNREFUSED 127.0.0.1:8000
```

## 수정 내용

**`apps/web/Dockerfile`**
- builder stage에 `ARG NEXT_PUBLIC_FASTAPI_URL` + `ENV NEXT_PUBLIC_FASTAPI_URL=...` 추가
- `pnpm build` 실행 전에 위치하여 rewrites() 베이크인 시 올바른 URL 사용

**`cloudbuild.yaml`**
- `_FASTAPI_URL` 대체변수 추가 (기본값: dev 백엔드 URL, 트리거별 오버라이드 가능)
- frontend 빌드 step에 `--build-arg NEXT_PUBLIC_FASTAPI_URL=${_FASTAPI_URL}` 추가

## 검증 포인트

AC1. `cloudbuild.yaml` `substitutions`에 `_FASTAPI_URL` 추가됨
AC2. `--build-arg NEXT_PUBLIC_FASTAPI_URL=${_FASTAPI_URL}` frontend build step에 포함됨
AC3. `Dockerfile` builder stage에 `ARG NEXT_PUBLIC_FASTAPI_URL` + `ENV` 선언이 `RUN pnpm build` 이전에 위치함
AC4. 빌드 완료 후 `routes-manifest.json` rewrite destination이 `localhost:8000` 아닌 실제 backend URL임을 확인

🤖 Generated with Claude Code