### PR TITLE
hotfix(C-S10): rebase 유입 파일 3건 @supabase 전환 누락

### DIFF
--- a/apps/web/src/app/api/docs/[id]/updated-at/route.ts
+++ b/apps/web/src/app/api/docs/[id]/updated-at/route.ts
@@ -1,18 +1,14 @@
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createDocRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-/** GET — updated_at 타임스탬프만 반환 (충돌 감지 경량 폴링용) */
 export async function GET(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
+    const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -22,16 +18,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       return apiSuccess({ updated_at: doc.updated_at });
     }
 
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-    const { data, error } = await dbClient
-      .from('docs')
-      .select('updated_at')
-      .eq('id', id)
-      .eq('project_id', me.project_id)
-      .single();
-
-    if (error || !data) return ApiErrors.notFound();
-    return apiSuccess({ updated_at: (data as { updated_at: string }).updated_at });
+    return apiError('NOT_IMPLEMENTED', 'SaaS overlay required', 501);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/meetings/[id]/recording/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/recording/route.ts
@@ -22,7 +22,8 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? (await (await import('@/lib/supabase/admin')).createSupabaseAdminClient()) : undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dbClient: any = undefined; // SaaS overlay에서 처리
 
     // AC9: Feature gating — 녹음 기능 티어 검증
     const featureCheck = await checkFeatureLimit(dbClient, me.org_id, 'stt_recording');

--- a/apps/web/src/app/api/notifications/count/route.ts
+++ b/apps/web/src/app/api/notifications/count/route.ts
@@ -1,15 +1,11 @@
-import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createNotificationRepository } from '@/lib/storage/factory';
 
-/** GET — 안읽음 뱃지용 COUNT만 반환 (full list 조회 없음) */
 export async function GET(request: Request) {
   try {
-    const supabase = await createSupabaseServerClient();
-    const me = await getAuthContext(supabase, request);
+    const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
@@ -21,26 +17,7 @@ export async function GET(request: Request) {
       return apiSuccess({ memoUnreadCount, inboxUnreadCount });
     }
 
-    const dbClient = me.type === 'agent' ? createSupabaseAdminClient() : supabase;
-
-    const [memoResult, totalResult] = await Promise.all([
-      dbClient
-        .from('notifications')
-        .select('id', { count: 'exact', head: true })
-        .eq('user_id', me.id)
-        .eq('is_read', false)
-        .like('type', 'memo%'),
-      dbClient
-        .from('notifications')
-        .select('id', { count: 'exact', head: true })
-        .eq('user_id', me.id)
-        .eq('is_read', false),
-    ]);
-
-    return apiSuccess({
-      memoUnreadCount: memoResult.count ?? 0,
-      inboxUnreadCount: totalResult.count ?? 0,
-    });
+    return apiError('NOT_IMPLEMENTED', 'SaaS overlay required', 501);
   } catch (err: unknown) {
     return handleApiError(err);
   }


### PR DESCRIPTION
## 원인

PR #356 rebase 시 main에서 유입된 신규 파일 3건이 C-S10 전환에서 누락됨.

## 수정 파일

| 파일 | 에러 | 수정 |
|---|---|---|
| `docs/[id]/updated-at/route.ts` | `getAuthContext(supabase, request)` 미전환 | `getAuthContext(request)` + NOT_IMPLEMENTED |
| `notifications/count/route.ts` | 동일 패턴 | 동일 |
| `meetings/[id]/recording/route.ts` | `dbClient: never` 타입 추론 | `any` stub |

## 검증

```
grep -r "@supabase" apps/web/src/ → 0건 ✅
pnpm exec tsc --noEmit --incremental false → 0 errors ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)