### PR TITLE
fix(C-S10-v2): remove invalid extractEmbedIds re-export from route.ts

### DIFF
--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -39,6 +39,3 @@ export async function GET(request: Request) {
     return handleApiError(err);
   }
 }
-
-// extractEmbedIds re-export for use in other modules if needed
-export { extractEmbedIds };


### PR DESCRIPTION
PR #359에서 추가된 `export { extractEmbedIds }` re-export 제거. Next.js Route Handler는 HTTP 메서드 외 named export 금지. Cloud Build 02a69045 FAILURE 원인.