### PR TITLE
fix(fastapi): API key hash mismatch — full key 해시로 통일

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -29,7 +29,7 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     from app.models.api_key import ApiKey
     from app.models.team import TeamMember
 
-    key_hash = hash_token(raw_key.removeprefix("sk_live_"))
+    key_hash = hash_token(raw_key)
     now = datetime.now(timezone.utc)
 
     result = await db.execute(


### PR DESCRIPTION
## Summary

- FastAPI `_resolve_api_key`에서 `raw_key.removeprefix("sk_live_")` 후 해싱 → DB 조회 불일치
- Next.js `hashApiKey()`는 전체 키(`sk_live_xxx`) SHA256 해싱 (prefix 포함)
- Fix: `hash_token(raw_key)` — prefix 제거 없이 full key 해싱

## Root Cause

DB `agent_api_keys.key_hash` = `SHA256("sk_live_1dfcab01...")`  
FastAPI 조회 = `SHA256("1dfcab01...")` → 항상 not found → 401

## Test plan

- [ ] PR 머지 후 Cloud Build + Cloud Run prod 재배포
- [ ] `/api/memos` (x-api-key) → 200 확인
- [ ] `/api/stories` (x-api-key) → 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)