### PR TITLE
fix(fastapi): /api/v2/me member_id optional — auth context fallback

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -14,12 +14,13 @@ router = APIRouter(prefix="/api/v2/me", tags=["me"])
 
 @router.get("", response_model=MeResponse)
 async def get_me(
-    member_id: uuid.UUID = Query(...),
+    member_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    resolved_id = member_id or uuid.UUID(auth.user_id)
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id)
+        select(TeamMember).where(TeamMember.id == resolved_id)
     )
     member = result.scalar_one_or_none()
     if member is None:


### PR DESCRIPTION
## Summary

- `/api/v2/me` GET endpoint에서 `member_id: uuid.UUID = Query(...)` 필수 → optional 변경
- `member_id` 미제공 시 `auth.user_id`(인증된 멤버 ID)로 fallback
- Next.js `getAuthContext` API key 경로: `fastapiCall('GET', '/api/v2/me', rawApiKey)` — member_id 없이 호출 가능하도록

## Root Cause

API key 인증 시 auth context에 user_id가 있지만 /api/v2/me 가 member_id 쿼리 파라미터를 필수로 요구하여 422 반환.

🤖 Generated with [Claude Code](https://claude.com/claude-code)