### PR TITLE
fix(factory): getSpAt — API key 헤더 우선, OAuth 쿠키 fallback

### DIFF
--- a/apps/web/src/lib/storage/factory.ts
+++ b/apps/web/src/lib/storage/factory.ts
@@ -21,7 +21,14 @@ export function isOssMode(): boolean {
 
 async function getSpAt(): Promise<string> {
   try {
-    const { cookies } = await import('next/headers');
+    const { cookies, headers } = await import('next/headers');
+    // API key 요청: x-api-key 또는 Authorization: Bearer sk_live_* 헤더 우선
+    const headerStore = await headers();
+    const xApiKey = headerStore.get('x-api-key');
+    if (xApiKey) return xApiKey;
+    const authHeader = headerStore.get('authorization');
+    if (authHeader?.startsWith('Bearer sk_live_')) return authHeader.slice(7);
+    // OAuth 세션: sp_at 쿠키
     const store = await cookies();
     return store.get('sp_at')?.value ?? '';
   } catch {


### PR DESCRIPTION
## Summary

- `factory.ts` `getSpAt()`가 `sp_at` 쿠키만 읽어서 API key 요청 시 빈 token → FastAPI 401
- Fix: `x-api-key` 헤더 또는 `Authorization: Bearer sk_live_*` 헤더 존재 시 해당 값 사용
- OAuth 세션(쿠키)은 그대로 fallback

## Root Cause

API key 요청 → `getAuthContext` 성공 → 라우트 핸들러에서 `createMemoRepository()` 호출 → `getSpAt()` → 쿠키 없음 → `''` 반환 → `fastapiCall('GET', '/api/v2/memos', '')` → FastAPI 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)