### PR TITLE
fix(fastapi): API key hash — removeprefix 재제거 (PR #368 hash revert)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -29,7 +29,7 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     from app.models.api_key import ApiKey
     from app.models.team import TeamMember
 
-    key_hash = hash_token(raw_key.removeprefix("sk_live_"))
+    key_hash = hash_token(raw_key)
     now = datetime.now(timezone.utc)
 
     result = await db.execute(


### PR DESCRIPTION
## Summary

PR #368에서 `removeprefix("sk_live_")` 재추가 → DB 해시 불일치 → 401 재발

Build 420837c (PR #367까지)에서 `/api/memos`, `/api/stories` 200 PASS 확인됨.
PR #368의 FastAPI hash 변경이 401 복원의 원인.

**Fix:** `hash_token(raw_key.removeprefix("sk_live_"))` → `hash_token(raw_key)`

DB `agent_api_keys.key_hash` = Next.js `SHA256(full_key)` → FastAPI도 동일하게 full key 해싱.

🤖 Generated with [Claude Code](https://claude.com/claude-code)