### PR TITLE
fix(hotfix): MeResponse org_id + project_id 추가

### DIFF
--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -10,6 +10,8 @@ class MeResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
     name: str
     type: str
     role: str


### PR DESCRIPTION
## 수정

`backend/app/schemas/me.py` MeResponse에 `org_id`, `project_id` 2필드 추가.

MCP `send_memo` "project_id is required" 실패 원인. `from_attributes=True`로 TeamMember 모델에서 자동 직렬화.

🤖 Generated with [Claude Code](https://claude.com/claude-code)