### PR TITLE
fix(hotfix): 메모 웹훅 미발송 — isOssMode() 조건 제거

### DIFF
--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -3,7 +3,7 @@ import { MemoService } from '@/services/memo';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { createMemoRepository, createTeamMemberRepository, isOssMode } from '@/lib/storage/factory';
+import { createMemoRepository, createTeamMemberRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -30,7 +30,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     const parsed = await parseBody(request, createMemoReplySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const dbClient = undefined;
     const repo = await createMemoRepository(dbClient);
-    const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;
+    const teamMemberRepo = await createTeamMemberRepository();
     const service = new MemoService(repo, dbClient, teamMemberRepo);
     const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
     const reply = await service.addReply(id, body.content, me.id, 'comment', resolvedIds);

--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -4,7 +4,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, createMemoSchema, MEMO_TYPES_REQUIRING_ASSIGNEE } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
-import { createMemoRepository, createTeamMemberRepository, createProjectRepository, isOssMode } from '@/lib/storage/factory';
+import { createMemoRepository, createTeamMemberRepository, createProjectRepository } from '@/lib/storage/factory';
 import { apiError } from '@/lib/api-response';
 
 export async function POST(request: Request) {
@@ -39,8 +39,8 @@ export async function POST(request: Request) {
     }
     const dbClient = undefined;
     const repo = await createMemoRepository(dbClient);
-    const teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined;
-    const projectRepo = isOssMode() ? await createProjectRepository() : undefined;
+    const teamMemberRepo = await createTeamMemberRepository();
+    const projectRepo = await createProjectRepository();
     const service = new MemoService(repo, dbClient, teamMemberRepo, projectRepo);
     const memo = await service.create({
       ...body,


### PR DESCRIPTION
## 수정

`memos/route.ts` + `memos/[id]/replies/route.ts`:
- `teamMemberRepo = isOssMode() ? await createTeamMemberRepository() : undefined` → 항상 생성
- `projectRepo = isOssMode() ? await createProjectRepository() : undefined` → 항상 생성

비-OSS 환경에서 `undefined` → 웹훅 분기 스킵 버그 해소. tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)