### PR TITLE
feat(C-S11): createAdminClient 잔존 전량 제거 + lib/db/admin.ts 삭제

### DIFF
--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -1,5 +1,5 @@
 import { updateEpicSchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { EpicService } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
     const repo = await createEpicRepository(dbClient);
     const service = new EpicService(repo);
     return apiSuccess(await service.getByIdWithStories(id, { org_id: me.org_id, project_id: me.project_id }));
@@ -28,7 +28,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
 
     let rawBody: unknown;
     try { rawBody = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
@@ -60,7 +60,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
       if (denied) return denied;
     }
 
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
     const repo = await createEpicRepository(dbClient);
     const service = new EpicService(repo);
     await service.delete(id, me.org_id);

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -1,5 +1,5 @@
 import { createEpicSchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { EpicService, type CreateEpicInput } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
@@ -14,7 +14,7 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
     const pageInput = parseCursorPageInput({
@@ -38,7 +38,7 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
 
     // 권한 체크: agent 또는 admin/owner만 에픽 생성 가능
     if (!isOssMode() && me.type !== 'agent') {

--- a/apps/web/src/app/api/inbox/incoming/route.ts
+++ b/apps/web/src/app/api/inbox/incoming/route.ts
@@ -1,7 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { createAdminClient } from '@/lib/db/admin';
-import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
+import { createInboxItemRepository } from '@/lib/storage/factory';
 import { incomingInboxItemSchema } from '@sprintable/shared';
 import { verifyIncomingHmac } from '@/services/inbox-item.service';
 
@@ -43,8 +42,7 @@ export async function POST(request: Request) {
       return ApiErrors.validationFailed(issues);
     }
 
-    const ossMode = isOssMode();
-    const repo = await createInboxItemRepository(ossMode ? undefined : createAdminClient());
+    const repo = await createInboxItemRepository(undefined);
 
     const item = await repo.create({
       org_id: orgIdHeader,

--- a/apps/web/src/app/api/sprints/[id]/activate/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/activate/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
@@ -16,7 +16,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as any | undefined);

--- a/apps/web/src/app/api/sprints/[id]/burndown/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/burndown/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -16,7 +16,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as any | undefined);

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -16,7 +16,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
     const date = searchParams.get('date');

--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
@@ -19,7 +19,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     if (!ossMode && dbClient && me.type !== 'agent') {
       const denied = await requireRole(dbClient, me.org_id, EDIT_ROLES, 'Admin or PO access required to close sprint');

--- a/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -16,7 +16,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const body = await request.json().catch(() => ({})) as { message?: string };
     const repo = await createSprintRepository(dbClient);

--- a/apps/web/src/app/api/sprints/[id]/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { parseBody, updateSprintSchema } from '@sprintable/shared';
@@ -17,7 +17,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as any | undefined);
@@ -36,7 +36,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const parsed = await parseBody(request, updateSprintSchema);
     if (!parsed.success) return parsed.response;
@@ -57,7 +57,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as any | undefined);

--- a/apps/web/src/app/api/sprints/route.ts
+++ b/apps/web/src/app/api/sprints/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { SprintService, type CreateSprintInput } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
@@ -14,7 +14,7 @@ export async function POST(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     let rawBody: unknown;
     try { rawBody = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
     const repo = await createSprintRepository(dbClient);

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -23,7 +23,7 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupHistory(projectId, limit));
     }
 
-    const dbClient: any = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient: any = undefined;
     const service = new StandupService(dbClient);
     const data = await service.getHistory(projectId, limit);
     return apiSuccess(data);

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -24,7 +24,7 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupMissing(projectId, date));
     }
 
-    const dbClient: any = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient: any = undefined;
     const service = new StandupService(dbClient);
     const data = await service.getMissing(projectId, date);
     return apiSuccess(data);

--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const url = new URL(request.url);
     const limit = url.searchParams.get('limit');

--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const url = new URL(request.url);
     const limit = url.searchParams.get('limit');
@@ -45,7 +45,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const body = await request.json();
     if (!body.content || typeof body.content !== 'string') {

--- a/apps/web/src/app/api/stories/[id]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/route.ts
@@ -1,6 +1,6 @@
 
 import { parseBody, updateStorySchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
@@ -17,7 +17,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createStoryRepository(dbClient);
     const service = new StoryService(repo, dbClient as any | undefined);
@@ -41,7 +41,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const parsed = await parseBody(request, updateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createStoryRepository(dbClient);
@@ -89,7 +89,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const repo = await createStoryRepository(dbClient);
     const service = new StoryService(repo, dbClient as any | undefined);

--- a/apps/web/src/app/api/stories/backlog/route.ts
+++ b/apps/web/src/app/api/stories/backlog/route.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -12,7 +12,7 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id');

--- a/apps/web/src/app/api/stories/bulk/route.ts
+++ b/apps/web/src/app/api/stories/bulk/route.ts
@@ -1,6 +1,6 @@
 
 import { parseBody, bulkUpdateStorySchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -14,7 +14,7 @@ export async function PATCH(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const parsed = await parseBody(request, bulkUpdateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     if (!Array.isArray(body.items) || body.items.length === 0) {

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -1,6 +1,6 @@
 
 import { parseBody, createStorySchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { StoryService, type CreateStoryInput } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
@@ -15,7 +15,7 @@ export async function POST(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     if (!ossMode) {
       const check = await checkResourceLimit(dbClient!, me.org_id, 'max_stories', 'stories');
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);
     const pageInput = parseCursorPageInput({

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,5 @@
 import { parseBody, updateTaskSchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { TaskService } from '@/services/task';
 import { createTaskRepository, isOssMode } from '@/lib/storage/factory';
 import { handleApiError } from '@/lib/api-error';
@@ -15,7 +15,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
     const repo = await createTaskRepository(dbClient);
     const service = new TaskService(repo);
     return apiSuccess(await service.getById(id, { org_id: me.org_id, project_id: me.project_id }));
@@ -28,7 +28,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
     const parsed = await parseBody(request, updateTaskSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createTaskRepository(dbClient);
     const service = new TaskService(repo);
@@ -48,22 +48,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
           reference_id: id,
         }).catch(() => {});
       }
-      if (body.status === 'done' && before.status !== 'done' && before.story_id) {
-        (async () => {
-          const { data } = await dbClient.from('stories').select('assignee_id').eq('id', before.story_id).maybeSingle();
-          if (data?.assignee_id) {
-            await notifService.create({
-              org_id: me.org_id,
-              user_id: data.assignee_id as string,
-              type: 'task_completed',
-              title: '태스크가 완료되었습니다',
-              body: before.title ?? '',
-              reference_type: 'task',
-              reference_id: id,
-            });
-          }
-        })().catch(() => {});
-      }
     }
 
     return apiSuccess(result);
@@ -76,7 +60,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient = undefined;
     const repo = await createTaskRepository(dbClient);
     const service = new TaskService(repo);
     const existing = await service.getById(id, { org_id: me.org_id });

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -1,6 +1,6 @@
 
 import { parseBody, createTaskSchema } from '@sprintable/shared';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { TaskService, type CreateTaskInput } from '@/services/task';
 import { createTaskRepository, isOssMode } from '@/lib/storage/factory';
 import { handleApiError } from '@/lib/api-error';
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const ossMode = isOssMode();
-    const dbClient: any | undefined = ossMode ? undefined : (me.type === 'agent' ? createAdminClient() : undefined);
+    const dbClient: any | undefined = undefined;
 
     const { searchParams } = new URL(request.url);
     const storyId = searchParams.get('story_id') ?? undefined;
@@ -114,7 +114,7 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient: any = me.type === 'agent' ? createAdminClient() : undefined;
+    const dbClient: any = undefined;
 
     const parsed = await parseBody(request, createTaskSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createTaskRepository(dbClient);

--- a/apps/web/src/app/llms-baos.txt/route.ts
+++ b/apps/web/src/app/llms-baos.txt/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from 'next/server';
-import { isOssMode, createDocRepository } from '@/lib/storage/factory';
-import { createAdminClient } from '@/lib/db/admin';
+import { createDocRepository } from '@/lib/storage/factory';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,7 +8,7 @@ const DOC_SLUG = 'baos-enrollment-guide-agent';
 
 export async function GET() {
   try {
-    const db = isOssMode() ? undefined : createAdminClient();
+    const db = undefined;
     const repo = await createDocRepository(db);
     const doc = await repo.getBySlug(PROJECT_ID, DOC_SLUG);
 

--- a/apps/web/src/lib/db/admin.ts
+++ b/apps/web/src/lib/db/admin.ts
@@ -1,4 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function createAdminClient(): any {
-  return undefined;
-}

--- a/apps/web/src/lib/internal-dogfood-server.ts
+++ b/apps/web/src/lib/internal-dogfood-server.ts
@@ -1,6 +1,5 @@
 import { apiError } from '@/lib/api-response';
 import { isInternalDogfoodEnabled, readInternalDogfoodSession, resolveInternalDogfoodActor } from '@/lib/internal-dogfood';
-import { createAdminClient } from '@/lib/db/admin';
 
 export async function getInternalDogfoodContext() {
   if (!isInternalDogfoodEnabled()) {
@@ -17,5 +16,5 @@ export async function getInternalDogfoodContext() {
     return { errorResponse: apiError('FORBIDDEN', 'Internal dogfood actor not allowed', 403) };
   }
 
-  return { db: createAdminClient(), actor };
+  return { db: undefined, actor };
 }

--- a/apps/web/src/lib/llm/config.ts
+++ b/apps/web/src/lib/llm/config.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/lib/db/admin';
+
 import { z } from 'zod';
 import { githubMcpConfigSchema } from '@/lib/github-mcp';
 import { KmsError } from '@/lib/kms';
@@ -113,7 +113,7 @@ export async function resolveLLMConfig(projectId: string, overrides?: {
   timeoutMs?: number;
   maxRetries?: number;
 }) : Promise<LLMConfig | null> {
-  const serviceClient = createAdminClient();
+  const serviceClient = undefined;
 
   const { settings, integration } = await getProjectAiSettingsWithIntegration(serviceClient as never, projectId);
   const persistedProvider = settings?.provider as LLMProvider | undefined;

--- a/apps/web/src/services/agent-deployment-lifecycle.ts
+++ b/apps/web/src/services/agent-deployment-lifecycle.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { AgentExecutionLoop } from './agent-execution-loop';
 import { AgentRoutingRuleService } from './agent-routing-rule';
 import { buildAutomaticRoutingTemplate, resolveAutoRoutingPersonaRole, type AutoRoutingTemplateAgent, type AutoRoutingTemplateResult } from './agent-routing-template';
@@ -222,7 +222,7 @@ export class AgentDeploymentLifecycleService {
       }
     }
 
-    const mcpValidation = await validateProjectMcpConnections(createAdminClient() as never, {
+    const mcpValidation = await validateProjectMcpConnections(undefined as never, {
       projectId: input.projectId,
     }).catch((error) => ({
       ok: false,

--- a/apps/web/src/services/agent-tool-execution-engine.ts
+++ b/apps/web/src/services/agent-tool-execution-engine.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { githubMcpToolArgumentSchemas, isGitHubMcpToolName } from '@/lib/github-mcp';
 import { resolveMcpTokenRef } from '@/lib/mcp-secrets';
 import {
@@ -185,7 +185,7 @@ export class AgentToolExecutionEngine {
 
     let approvedServers: ExternalServerConfig[] = [];
     try {
-      approvedServers = await listProjectApprovedMcpServerConfigs(createAdminClient() as never, projectId);
+      approvedServers = await listProjectApprovedMcpServerConfigs(undefined as never, projectId);
     } catch {
       approvedServers = [];
     }
@@ -352,7 +352,7 @@ export class AgentToolExecutionEngine {
 
       if (server.auth?.token_ref) {
         const token = parseMcpVaultRef(server.auth.token_ref)
-          ? await resolveProjectMcpVaultToken(createAdminClient() as never, ctx.memo.project_id, server.auth.token_ref)
+          ? await resolveProjectMcpVaultToken(undefined as never, ctx.memo.project_id, server.auth.token_ref)
           : resolveMcpTokenRef(server.auth.token_ref);
         const headerName = server.auth.header_name ?? (server.kind === 'github' ? 'X-GitHub-Token' : 'Authorization');
         const scheme = server.auth.scheme ?? (server.kind === 'github' ? 'plain' : 'bearer');

--- a/apps/web/src/services/background-runtime.ts
+++ b/apps/web/src/services/background-runtime.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/lib/db/admin';
+
 import { DiscordGatewayRuntime } from './discord-gateway-runtime';
 import { DiscordOutboundDispatcher } from './discord-outbound-dispatcher';
 import { MemoEventDispatcher } from './memo-event-dispatcher';
@@ -195,7 +195,7 @@ export class BackgroundRuntimeWorker {
 
 export function createBackgroundRuntimeWorkerFromEnv(env: NodeJS.ProcessEnv = process.env) {
   return new BackgroundRuntimeWorker({
-    db: createAdminClient(),
+    db: undefined,
     appUrl: resolveAppUrl(env['NEXT_PUBLIC_APP_URL'], env),
     settings: resolveBackgroundRuntimeSettings(env),
   });

--- a/apps/web/src/services/inbox-item.service.ts
+++ b/apps/web/src/services/inbox-item.service.ts
@@ -9,7 +9,7 @@ import type {
   OriginNode,
   InboxOption,
 } from '@sprintable/core-storage';
-import { createAdminClient } from '@/lib/db/admin';
+
 import { isOssMode, createInboxItemRepository } from '@/lib/storage/factory';
 import { createInboxItemSchema, originChainSchema, inboxOptionsSchema } from '@sprintable/shared';
 
@@ -44,7 +44,7 @@ export class InboxItemService {
   async create(input: CreateInboxItemInput): Promise<InboxItem> {
     // Validate at single boundary point (codex tactical fix #10 — Zod at write time)
     const validated = createInboxItemSchema.parse(input);
-    const repo = await createInboxItemRepository(this.db ?? createAdminClient());
+    const repo = await createInboxItemRepository(this.db);
     return repo.create(validated);
   }
 

--- a/apps/web/src/services/persona-composer.ts
+++ b/apps/web/src/services/persona-composer.ts
@@ -1,5 +1,5 @@
 
-import { createAdminClient } from '@/lib/db/admin';
+
 import { BUILTIN_AGENT_TOOL_NAMES } from './agent-builtin-tool-names';
 import { listProjectApprovedMcpToolOptions } from './project-mcp';
 
@@ -30,7 +30,7 @@ export async function listProjectPersonaToolOptions(_db: any, projectId: string)
 
   let approvedOptions: Array<{ name: string; serverName: string; groupKind: 'mcp' | 'github' }> = [];
   try {
-    approvedOptions = await listProjectApprovedMcpToolOptions(createAdminClient() as never, projectId);
+    approvedOptions = await listProjectApprovedMcpToolOptions(undefined as never, projectId);
   } catch {
     approvedOptions = [];
   }

--- a/apps/web/src/services/project-context-loader.ts
+++ b/apps/web/src/services/project-context-loader.ts
@@ -1,4 +1,4 @@
-import { createAdminClient } from '@/lib/db/admin';
+
 import type { PromptProjectRecord, PromptTeamMemberRecord } from './agent-system-prompt';
 
 export interface ProjectContextLoaderOptions {


### PR DESCRIPTION
## C-S11: createAdminClient 완전 제거

### AC 달성

| AC | 기준 | 상태 |
|----|------|------|
| AC1 | `grep -rn "createAdminClient" apps/web/src/` → 0건 | ✅ |
| AC2 | `lib/db/admin.ts` 삭제 | ✅ |
| AC3 | `tsc --noEmit` 0 errors | ✅ |
| AC4 | 기능 회귀 없음 (undefined 고정, 서비스 분기 제거) | ✅ |

### 변경 패턴
- `ossMode ? undefined : (agent ? createAdminClient() : undefined)` → `undefined`
- `me.type === 'agent' ? createAdminClient() : undefined` → `undefined`
- 서비스 파일 직접 호출 → `undefined as never` 또는 분기 제거
- import 30개+ 전량 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)