### PR TITLE
feat(OAuth): Google/GitHub OAuth 로그인 구현 (Story 68be2e4c)

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
+import { resolveAppUrl } from '@/services/app-url';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+function cookieBase() {
+  const domain = process.env['NEXT_PUBLIC_COOKIE_DOMAIN'];
+  return { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax' as const, path: '/', ...(domain ? { domain } : {}) };
+}
+
+type RouteParams = { params: Promise<{ provider: string }> };
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { provider } = await params;
+  const { searchParams } = new URL(request.url);
+  const code = searchParams.get('code');
+  const state = searchParams.get('state');
+  const origin = resolveAppUrl(null);
+
+  if (!['google', 'github'].includes(provider)) {
+    return NextResponse.redirect(`${origin}/login?error=invalid_provider`);
+  }
+
+  if (!code || !state) {
+    return NextResponse.redirect(`${origin}/login?error=oauth_missing_params`);
+  }
+
+  // CSRF state 검증
+  const cookieStore = await cookies();
+  const storedState = cookieStore.get(`oauth_state_${provider}`)?.value;
+  cookieStore.delete(`oauth_state_${provider}`);
+
+  if (!storedState || storedState !== state) {
+    return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
+  }
+
+  // FastAPI OAuth callback
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/callback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ provider, code, state }),
+  }).catch(() => null);
+
+  if (!fastapiRes?.ok) {
+    const errBody = await fastapiRes?.json().catch(() => null) as { error?: { code?: string } } | null;
+    const errCode = errBody?.error?.code ?? 'oauth_failed';
+    return NextResponse.redirect(`${origin}/login?error=${errCode}`);
+  }
+
+  const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string } };
+  const { access_token, refresh_token } = json.data ?? {};
+
+  if (!access_token || !refresh_token) {
+    return NextResponse.redirect(`${origin}/login?error=oauth_no_token`);
+  }
+
+  const res = NextResponse.redirect(`${origin}/inbox`);
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  return res;
+}

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -1,7 +1,39 @@
 import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
 import { resolveAppUrl } from '@/services/app-url';
 
-export async function GET(_request: Request) {
+const FASTAPI_BASE = process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const provider = searchParams.get('provider');
   const origin = resolveAppUrl(null);
-  return NextResponse.redirect(`${origin}/login`);
+
+  if (!provider || !['google', 'github'].includes(provider)) {
+    return NextResponse.redirect(`${origin}/login`);
+  }
+
+  const res = await fetch(`${FASTAPI_BASE}/api/v2/auth/oauth/${provider}/authorize`).catch(() => null);
+  if (!res?.ok) {
+    return NextResponse.redirect(`${origin}/login?error=oauth_init_failed`);
+  }
+
+  const json = await res.json() as { data?: { url?: string; state?: string } };
+  const url = json.data?.url;
+  const state = json.data?.state;
+
+  if (!url || !state) {
+    return NextResponse.redirect(`${origin}/login?error=oauth_init_failed`);
+  }
+
+  const cookieStore = await cookies();
+  cookieStore.set(`oauth_state_${provider}`, state, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: 300,
+    path: '/',
+  });
+
+  return NextResponse.redirect(url);
 }

--- a/backend/alembic/versions/0005_add_oauth_fields.py
+++ b/backend/alembic/versions/0005_add_oauth_fields.py
@@ -1,0 +1,34 @@
+"""add oauth fields to users
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-05-02
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("google_id", sa.Text(), nullable=True))
+    op.add_column("users", sa.Column("github_id", sa.Text(), nullable=True))
+    op.create_unique_constraint("uq_users_google_id", "users", ["google_id"])
+    op.create_unique_constraint("uq_users_github_id", "users", ["github_id"])
+    op.create_index("ix_users_google_id", "users", ["google_id"])
+    op.create_index("ix_users_github_id", "users", ["github_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_github_id", table_name="users")
+    op.drop_index("ix_users_google_id", table_name="users")
+    op.drop_constraint("uq_users_github_id", "users", type_="unique")
+    op.drop_constraint("uq_users_google_id", "users", type_="unique")
+    op.drop_column("users", "github_id")
+    op.drop_column("users", "google_id")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -29,6 +29,14 @@ class Settings(BaseSettings):
     app_env: str = "development"
     debug: bool = True
 
+    # OAuth — Google / GitHub
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    github_client_id: str = ""
+    github_client_secret: str = ""
+    # Next.js 프론트엔드 URL (OAuth redirect_uri 조합용)
+    app_url: str = "http://localhost:3000"
+
     # EE / SaaS gating
     license_consent: str = ""
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -17,6 +17,8 @@ class User(Base):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     totp_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
+    github_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import secrets
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import urlencode
 
+import httpx
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
 
 from app.core.security import (
     create_tokens,
@@ -263,3 +268,168 @@ async def totp_verify(
     )
     await session.commit()
     return _ok({"totp_enabled": True})
+
+
+# ─── OAuth ────────────────────────────────────────────────────────────────────
+
+_OAUTH_CONFIGS: dict[str, dict] = {
+    "google": {
+        "authorize_url": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_url": "https://oauth2.googleapis.com/token",
+        "userinfo_url": "https://www.googleapis.com/oauth2/v3/userinfo",
+        "scope": "openid email profile",
+        "id_field": "sub",
+        "email_field": "email",
+    },
+    "github": {
+        "authorize_url": "https://github.com/login/oauth/authorize",
+        "token_url": "https://github.com/login/oauth/access_token",
+        "userinfo_url": "https://api.github.com/user",
+        "scope": "read:user user:email",
+        "id_field": "id",
+        "email_field": "email",
+    },
+}
+
+
+def _redirect_uri(provider: str) -> str:
+    return f"{settings.app_url}/api/auth/callback/{provider}"
+
+
+def _client_id(provider: str) -> str:
+    return settings.google_client_id if provider == "google" else settings.github_client_id
+
+
+def _client_secret(provider: str) -> str:
+    return settings.google_client_secret if provider == "google" else settings.github_client_secret
+
+
+class OAuthCallbackRequest(BaseModel):
+    provider: str
+    code: str
+    state: str
+
+
+@router.get("/oauth/{provider}/authorize")
+async def oauth_authorize(provider: str) -> JSONResponse:
+    if provider not in _OAUTH_CONFIGS:
+        return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
+    cfg = _OAUTH_CONFIGS[provider]
+    state = secrets.token_urlsafe(32)
+    params = {
+        "client_id": _client_id(provider),
+        "redirect_uri": _redirect_uri(provider),
+        "response_type": "code",
+        "scope": cfg["scope"],
+        "state": state,
+    }
+    if provider == "google":
+        params["access_type"] = "offline"
+        params["prompt"] = "select_account"
+    url = f"{cfg['authorize_url']}?{urlencode(params)}"
+    return _ok({"url": url, "state": state})
+
+
+@router.post("/oauth/callback")
+async def oauth_callback(
+    body: OAuthCallbackRequest,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    provider = body.provider
+    if provider not in _OAUTH_CONFIGS:
+        return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
+    cfg = _OAUTH_CONFIGS[provider]
+
+    async with httpx.AsyncClient(timeout=15) as client:
+        # 1. code → access_token 교환
+        token_resp = await client.post(
+            cfg["token_url"],
+            data={
+                "client_id": _client_id(provider),
+                "client_secret": _client_secret(provider),
+                "code": body.code,
+                "redirect_uri": _redirect_uri(provider),
+                "grant_type": "authorization_code",
+            },
+            headers={"Accept": "application/json"},
+        )
+        if token_resp.status_code != 200:
+            return _err("OAUTH_TOKEN_EXCHANGE_FAILED", "Failed to exchange code for token", 400)
+        token_data = token_resp.json()
+        access_token = token_data.get("access_token")
+        if not access_token:
+            return _err("OAUTH_NO_TOKEN", "No access_token in response", 400)
+
+        # 2. userinfo 조회
+        userinfo_resp = await client.get(
+            cfg["userinfo_url"],
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if userinfo_resp.status_code != 200:
+            return _err("OAUTH_USERINFO_FAILED", "Failed to fetch user info", 400)
+        userinfo = userinfo_resp.json()
+
+        # GitHub email이 null인 경우 /user/emails로 추가 조회
+        if provider == "github" and not userinfo.get("email"):
+            emails_resp = await client.get(
+                "https://api.github.com/user/emails",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if emails_resp.status_code == 200:
+                emails = emails_resp.json()
+                primary = next((e["email"] for e in emails if e.get("primary") and e.get("verified")), None)
+                if primary:
+                    userinfo["email"] = primary
+
+    oauth_id = str(userinfo.get(cfg["id_field"], ""))
+    email = (userinfo.get(cfg["email_field"]) or "").lower().strip()
+
+    if not oauth_id or not email:
+        return _err("OAUTH_MISSING_INFO", "Missing id or email from provider", 400)
+
+    # 3. 기존 유저 조회 (oauth_id 기준 → email 기준 순)
+    id_col = User.google_id if provider == "google" else User.github_id
+    result = await session.execute(select(User).where(id_col == oauth_id, User.is_active.is_(True)))
+    user = result.scalar_one_or_none()
+
+    if not user:
+        # 동일 이메일 유저가 있으면 OAuth ID 연결
+        result = await session.execute(select(User).where(User.email == email, User.is_active.is_(True)))
+        user = result.scalar_one_or_none()
+        if user:
+            await session.execute(
+                update(User).where(User.id == user.id).values(**{f"{provider}_id": oauth_id})
+            )
+            await session.commit()
+            await session.refresh(user)
+        else:
+            # 신규 유저 생성 (비밀번호 없음 — OAuth 전용)
+            user = User(
+                email=email,
+                hashed_password="",
+                is_active=True,
+                **{f"{provider}_id": oauth_id},
+            )
+            session.add(user)
+            try:
+                await session.commit()
+                await session.refresh(user)
+            except IntegrityError:
+                await session.rollback()
+                return _err("EMAIL_CONFLICT", "Email already registered", 409)
+
+    # 4. JWT 발급
+    from datetime import timedelta
+    from app.core.security import ACCESS_TOKEN_EXPIRE_MINUTES, REFRESH_TOKEN_EXPIRE_DAYS
+
+    tokens = create_tokens(str(user.id), user.email, _build_app_metadata(user))
+    raw_refresh = tokens["refresh_token"]
+    expires_at = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    await _store_refresh_token(session, user, raw_refresh, expires_at)
+
+    return _ok({
+        "access_token": tokens["access_token"],
+        "refresh_token": raw_refresh,
+        "token_type": "bearer",
+        "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
+    })


### PR DESCRIPTION
## Google / GitHub OAuth 로그인

### 구현 내용

**Backend (FastAPI)**
| 파일 | 변경 |
|------|------|
| `config.py` | GOOGLE_CLIENT_ID/SECRET, GITHUB_CLIENT_ID/SECRET, APP_URL 추가 |
| `models/user.py` | `google_id`, `github_id` nullable unique 컬럼 추가 |
| `alembic/0005_add_oauth_fields.py` | DDL migration |
| `routers/auth.py` | `GET /api/v2/auth/oauth/{provider}/authorize` + `POST /api/v2/auth/oauth/callback` |

**Frontend (Next.js)**
| 파일 | 변경 |
|------|------|
| `auth/login/route.ts` | `?provider=google/github` → state 생성 → OAuth URL redirect |
| `api/auth/callback/[provider]/route.ts` | CSRF state 검증 → FastAPI callback → sp_at/sp_rt 쿠키 설정 → /inbox redirect |

### OAuth 흐름

```
/auth/login?provider=google
  → FastAPI GET /oauth/google/authorize (state 생성)
  → oauth_state_google 쿠키 저장
  → Google 인증 페이지 redirect

Google → /api/auth/callback/google?code=xxx&state=xxx
  → CSRF state 검증 (쿠키 vs query 비교)
  → FastAPI POST /oauth/callback (code exchange → userinfo)
  → 동일 이메일 유저 매핑 or 신규 생성
  → JWT (sp_at/sp_rt 쿠키)
  → /inbox redirect
```

### AC 달성
- ✅ Google/GitHub OAuth 로그인 → 대시보드 도달
- ✅ 동일 이메일 유저 매핑 (google_id/github_id 연결)
- ✅ 신규 유저 자동 생성
- ✅ tsc 0 errors
- ✅ CSRF state 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)