### PR TITLE
fix(P0): current-project node:sqlite 크래시 — isOssMode() 분기 추가

### DIFF
--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -1,19 +1,45 @@
 import { cookies } from 'next/headers';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
+import { CURRENT_PROJECT_COOKIE, getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, setCurrentProjectSchema } from '@sprintable/shared';
-import { createProjectRepository } from '@/lib/storage/factory';
+import { isOssMode } from '@/lib/storage/factory';
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const repo = await createProjectRepository();
-    const project = await repo.getById(OSS_PROJECT_ID);
+    if (isOssMode()) {
+      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+      const { createProjectRepository } = await import('@/lib/storage/factory');
+      const repo = await createProjectRepository();
+      const project = await repo.getById(OSS_PROJECT_ID);
+      return apiSuccess({
+        project_id: OSS_PROJECT_ID,
+        project_name: project?.name ?? 'My Project',
+        org_id: OSS_ORG_ID,
+      });
+    }
+
+    // 비-OSS: getAuthContext → me에 org_id, project_id 포함
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+
+    const { fastapiCall } = await import('@sprintable/storage-api');
+    const { getServerSession } = await import('@/lib/db/server');
+    const session = await getServerSession();
+    const token = session?.access_token ?? '';
+
+    let projectName = 'My Project';
+    try {
+      const proj = await fastapiCall<{ name?: string; id?: string }>(
+        'GET', `/api/v2/projects/${me.project_id}`, token,
+      );
+      projectName = proj?.name ?? 'My Project';
+    } catch { /* fallback to default */ }
+
     return apiSuccess({
-      project_id: OSS_PROJECT_ID,
-      project_name: project?.name ?? 'My Project',
-      org_id: OSS_ORG_ID,
+      project_id: me.project_id,
+      project_name: projectName,
+      org_id: me.org_id,
     });
   } catch (err: unknown) {
     return handleApiError(err);
@@ -22,13 +48,31 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
-    const { OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
     const parsed = await parseBody(request, setCurrentProjectSchema);
     if (!parsed.success) return parsed.response;
     const { project_id: projectId } = parsed.data;
 
-    if (projectId !== OSS_PROJECT_ID) return ApiErrors.forbidden('Project membership not found');
+    if (isOssMode()) {
+      const { OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
+      if (projectId !== OSS_PROJECT_ID) return ApiErrors.forbidden('Project membership not found');
 
+      const cookieStore = await cookies();
+      cookieStore.set(CURRENT_PROJECT_COOKIE, projectId, {
+        path: '/',
+        sameSite: 'lax',
+        maxAge: 60 * 60 * 24 * 365,
+      });
+
+      const { createProjectRepository } = await import('@/lib/storage/factory');
+      const repo = await createProjectRepository();
+      const project = await repo.getById(OSS_PROJECT_ID);
+      return apiSuccess({
+        project_id: projectId,
+        project_name: project?.name ?? 'My Project',
+      });
+    }
+
+    // 비-OSS: 쿠키에 project_id 저장 + fastapiCall로 프로젝트 정보 조회
     const cookieStore = await cookies();
     cookieStore.set(CURRENT_PROJECT_COOKIE, projectId, {
       path: '/',
@@ -36,11 +80,22 @@ export async function POST(request: Request) {
       maxAge: 60 * 60 * 24 * 365,
     });
 
-    const repo = await createProjectRepository();
-    const project = await repo.getById(OSS_PROJECT_ID);
+    const { fastapiCall } = await import('@sprintable/storage-api');
+    const { getServerSession } = await import('@/lib/db/server');
+    const session = await getServerSession();
+    const token = session?.access_token ?? '';
+
+    let projectName = 'My Project';
+    try {
+      const proj = await fastapiCall<{ name?: string; id?: string }>(
+        'GET', `/api/v2/projects/${projectId}`, token,
+      );
+      projectName = proj?.name ?? 'My Project';
+    } catch { /* fallback to default */ }
+
     return apiSuccess({
       project_id: projectId,
-      project_name: project?.name ?? 'My Project',
+      project_name: projectName,
     });
   } catch (err: unknown) {
     return handleApiError(err);


### PR DESCRIPTION
## P0 크래시 수정

**원인:** GET/POST 모두 `@sprintable/storage-sqlite` 무조건 import → Cloud Run에 `node:sqlite` 없어서 크래시

**수정:** `isOssMode()` 분기 추가
- **OSS mode (true):** 기존 SQLite 경로 유지
- **비-OSS (Cloud Run):** `fastapiCall GET /api/v2/projects/{id}` 경유, `CURRENT_PROJECT_COOKIE` 저장

tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)