### PR TITLE
fix(P0): storage-sqlite 전량 isOssMode() 분기 내부로 이동

### DIFF
--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -1,19 +1,23 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { createTeamMemberRepository } from '@/lib/storage/factory';
+import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    const { OSS_MEMBER_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const me = await getAuthContext(request);
-    if (!me) return ApiErrors.unauthorized();
+    if (isOssMode()) {
+      const { OSS_MEMBER_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
 
-    const repo = await createTeamMemberRepository();
-    const members = await repo.list({ org_id: OSS_ORG_ID });
-    const member = members.find((m) => m.id === (me.id ?? OSS_MEMBER_ID));
-    if (!member) return ApiErrors.notFound('Member not found');
-    return apiSuccess({ ...member, email: null });
+      const repo = await createTeamMemberRepository();
+      const members = await repo.list({ org_id: OSS_ORG_ID });
+      const member = members.find((m) => m.id === (me.id ?? OSS_MEMBER_ID));
+      if (!member) return ApiErrors.notFound('Member not found');
+      return apiSuccess({ ...member, email: null });
+    }
+    return proxyToFastapi(request, '/api/v2/me');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -21,16 +25,18 @@ export async function GET(request: Request) {
 
 export async function PATCH(request: Request) {
   try {
-    const { OSS_MEMBER_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    let body: unknown;
-    try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
-    const { name } = (body as Record<string, unknown>) ?? {};
-    if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
+    if (isOssMode()) {
+      const { OSS_MEMBER_ID } = await import('@sprintable/storage-sqlite');
+      let body: unknown;
+      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
+      const { name } = (body as Record<string, unknown>) ?? {};
+      if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
 
-    const repo = await createTeamMemberRepository();
-    void OSS_ORG_ID;
-    const updated = await repo.update(OSS_MEMBER_ID, { name: name.trim() });
-    return apiSuccess({ ...updated, email: null });
+      const repo = await createTeamMemberRepository();
+      const updated = await repo.update(OSS_MEMBER_ID, { name: name.trim() });
+      return apiSuccess({ ...updated, email: null });
+    }
+    return proxyToFastapi(request, '/api/v2/me');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/members/route.ts
+++ b/apps/web/src/app/api/members/route.ts
@@ -15,8 +15,7 @@ export async function GET(request: Request) {
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
     const repo = await createTeamMemberRepository();
-    const { OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId });
+    const members = await repo.list({ org_id: me.org_id, project_id: projectId });
     const active = members.filter((m) => m.is_active);
     return apiSuccess(active);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/projects/[id]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { createProjectRepository } from '@/lib/storage/factory';
+import { isOssMode, createProjectRepository } from '@/lib/storage/factory';
 import { z } from 'zod/v4';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -69,12 +69,19 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+    let orgId: string;
+    if (isOssMode()) {
+      const { OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+      orgId = OSS_ORG_ID;
+    } else {
+      orgId = me.org_id;
+    }
+
     const repo = await createProjectRepository();
     const existing = await repo.getById(id);
     if (!existing) return ApiErrors.notFound('Project not found');
 
-    await repo.delete(id, OSS_ORG_ID);
+    await repo.delete(id, orgId);
     return apiSuccess({ id });
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,15 +1,18 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess } from '@/lib/api-response';
-import { createProjectRepository } from '@/lib/storage/factory';
+import { isOssMode, createProjectRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 조직 프로젝트 목록 */
-export async function GET(_request: Request) {
+export async function GET(request: Request) {
   try {
-    const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
-    const repo = await createProjectRepository();
-    const project = await repo.getById(OSS_PROJECT_ID);
-    return apiSuccess(project ? [{ id: project.id, name: project.name, description: null, org_id: OSS_ORG_ID }] : []);
+    if (isOssMode()) {
+      const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-sqlite');
+      const repo = await createProjectRepository();
+      const project = await repo.getById(OSS_PROJECT_ID);
+      return apiSuccess(project ? [{ id: project.id, name: project.name, description: null, org_id: OSS_ORG_ID }] : []);
+    }
+    return proxyToFastapi(request, '/api/v2/projects');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -1,18 +1,21 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { parseBody, createTeamMemberSchema } from '@sprintable/shared';
-import { createTeamMemberRepository } from '@/lib/storage/factory';
+import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id') ?? OSS_PROJECT_ID;
-    const type = searchParams.get('type') as 'human' | 'agent' | null;
-    const repo = await createTeamMemberRepository();
-    const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId, ...(type ? { type } : {}) });
-    return apiSuccess(members);
+    if (isOssMode()) {
+      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+      const { searchParams } = new URL(request.url);
+      const projectId = searchParams.get('project_id') ?? OSS_PROJECT_ID;
+      const type = searchParams.get('type') as 'human' | 'agent' | null;
+      const repo = await createTeamMemberRepository();
+      const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId, ...(type ? { type } : {}) });
+      return apiSuccess(members);
+    }
+    return proxyToFastapi(request, '/api/v2/team-members');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -26,16 +29,19 @@ export async function POST(request: Request) {
     const body = parsed.data;
     if (body.type !== 'agent') return proxyToFastapi(request, '/api/v2/team-members');
     if (!body.name) return ApiErrors.badRequest('name required for agent');
-    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
-    const repo = await createTeamMemberRepository();
-    const member = await repo.create({
-      org_id: OSS_ORG_ID,
-      project_id: body.project_id ?? OSS_PROJECT_ID,
-      name: body.name,
-      type: 'agent',
-      role: body.role ?? 'member',
-    });
-    return apiSuccess(member, undefined, 201);
+    if (isOssMode()) {
+      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
+      const repo = await createTeamMemberRepository();
+      const member = await repo.create({
+        org_id: OSS_ORG_ID,
+        project_id: body.project_id ?? OSS_PROJECT_ID,
+        name: body.name,
+        type: 'agent',
+        role: body.role ?? 'member',
+      });
+      return apiSuccess(member, undefined, 201);
+    }
+    return proxyToFastapi(request, '/api/v2/team-members');
   } catch (err: unknown) {
     return handleApiError(err);
   }


### PR DESCRIPTION
## P0 일괄 수정

**원인:** 5개 라우트가 isOssMode() 가드 없이 `@sprintable/storage-sqlite` import → Cloud Run에서 node:sqlite 크래시

**수정 파일 (5개):**
- `team-members/route.ts` GET/POST → isOssMode() ? SQLite : proxyToFastapi
- `projects/route.ts` GET → isOssMode() ? SQLite : proxyToFastapi
- `projects/[id]/route.ts` DELETE → OSS_ORG_ID를 조건부 사용 (비-OSS: me.org_id)
- `me/route.ts` GET/PATCH → isOssMode() ? SQLite : proxyToFastapi
- `members/route.ts` → OSS_ORG_ID import 제거, me.org_id 사용

tsc 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)