### PR TITLE
fix: MeResponse project_name 누락 + 사이드바 로그아웃 버튼 (P0)

### DIFF
--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -18,6 +18,7 @@ import {
   Settings,
   Users,
 } from 'lucide-react';
+import { LogoutButton } from '@/app/dashboard/logout-button';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
@@ -302,6 +303,7 @@ export function AppSidebar({
             <CircleHelp className="size-4" />
           </Link>
         </div>
+        <LogoutButton />
       </SidebarFooter>
 
       <SidebarRail />

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -2,6 +2,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
+from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
@@ -20,12 +21,16 @@ async def get_me(
 ) -> MeResponse:
     resolved_id = member_id or uuid.UUID(auth.user_id)
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == resolved_id)
+        select(TeamMember)
+        .options(joinedload(TeamMember.project))
+        .where(TeamMember.id == resolved_id)
     )
     member = result.scalar_one_or_none()
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
-    return MeResponse.model_validate(member)
+    data = MeResponse.model_validate(member)
+    data.project_name = member.project.name if member.project else None
+    return data
 
 
 @router.patch("", response_model=MeResponse)

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -16,6 +16,7 @@ class MeResponse(BaseModel):
     type: str
     role: str
     is_active: bool
+    project_name: str | None = None
 
 
 class UpdateMe(BaseModel):


### PR DESCRIPTION
## Summary
- `GET /api/v2/me` 응답에 `project_name` 누락 → ProjectSwitcher 에러 → `joinedload(TeamMember.project)` 로 조인 반환
- `MeResponse` 스키마에 `project_name: str | None = None` 추가
- `app-sidebar.tsx` SidebarFooter 하단에 `LogoutButton` 추가 → 사이드바에서 로그아웃 가능

## Test plan
- [ ] OAuth 로그인 후 사이드바 ProjectSwitcher에 프로젝트명 정상 표시 확인
- [ ] 사이드바 하단 로그아웃 버튼 클릭 → /login 리다이렉트 확인
- [ ] `/api/v2/me` 응답 JSON에 `project_name` 필드 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)