### PR TITLE
fix: _build_app_metadata() id OR 조건 추가 — OAuth 후 400 근본 원인 해결 (P0)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -88,14 +88,19 @@ async def _get_user_by_id(session: AsyncSession, user_id: uuid.UUID) -> User | N
 async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     from app.models.team import TeamMember
 
-    # 1. user_id로 이미 연결된 team_member 조회
+    # 1. user_id 또는 PK(id)로 연결된 team_member 조회
     result = await session.execute(
         select(TeamMember)
-        .where(TeamMember.user_id == user.id, TeamMember.is_active.is_(True))
+        .where(
+            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+            TeamMember.is_active.is_(True),
+        )
         .order_by(TeamMember.created_at.asc())
         .limit(1)
     )
     member = result.scalar_one_or_none()
+    if member and member.user_id is None:
+        member.user_id = user.id
 
     if not member:
         # 2. user_id 미연결 human team_member 중 첫 번째에 자동 연결


### PR DESCRIPTION
## Summary
- step 1 WHERE 조건에 `or_(TeamMember.user_id == user.id, TeamMember.id == user.id)` 추가
- PK 매치 시 `member.user_id is None` 이면 `member.user_id = user.id` 자동 설정 (FK 연결)
- `from sqlalchemy import or_` 임포트 추가

## Root Cause
OAuth 신규 유저의 경우 `user.id`(User PK)와 `TeamMember.id`(PK)가 동일한 UUID인 경우 user_id FK가 미연결 상태였음. 기존 코드는 `user_id == user.id` 만 조회하여 항상 miss → JWT `org_id` 누락 → 모든 API 400.

## Test plan
- [ ] OAuth 로그인 후 `/api/v2/me` 200 + `org_id` 포함 확인
- [ ] 기존 이메일/패스워드 로그인 → 정상 유지 확인
- [ ] TeamMember.id == user.id 케이스 → user_id 자동 설정 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)