### PR TITLE
fix: proxy.ts JWT 만료 시 자동 refresh — 15분 로그아웃 해결 (P0)

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -128,19 +128,19 @@ export async function proxy(request: NextRequest) {
     return response;
   }
 
-  let claims: { exp?: number } | null;
-  try {
-    claims = await verifyAccessToken(accessToken);
-  } catch {
-    const url = request.nextUrl.clone();
-    url.pathname = '/login';
-    return NextResponse.redirect(url);
-  }
+  const claims = await verifyAccessToken(accessToken);
 
   if (!claims) {
-    const url = request.nextUrl.clone();
-    url.pathname = '/login';
-    return NextResponse.redirect(url);
+    // access token invalid/expired — try refresh before redirecting
+    const tokens = await tryRefreshViaFastapi(request);
+    if (!tokens) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+    const response = NextResponse.next({ request });
+    applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
+    return response;
   }
 
   // Proactive refresh if expiring within 5 minutes


### PR DESCRIPTION
## Summary
- 기존: access token이 만료되면 바로 `/login` 리다이렉트 (refresh 시도 없음)
- 수정: `claims === null` (만료/유효하지 않은 토큰) 시 `tryRefreshViaFastapi()` 먼저 시도 → 성공 시 새 쿠키 설정 후 계속, 실패 시 `/login` 리다이렉트

## Root Cause
`proxy.ts`의 `verifyAccessToken()` 실패 케이스에 refresh 로직이 없어 15분 만료 주기마다 강제 로그아웃 발생.

## Test plan
- [ ] 15분 경과 후 페이지 접근 → 자동 토큰 갱신 + 페이지 정상 표시 확인
- [ ] refresh token도 만료 시 `/login` 리다이렉트 확인
- [ ] 신규 로그인 → 정상 작동 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)