### PR TITLE
fix: 보드/스탠드업/대시보드/프로필 크래시 4건 해소 (P0 Stage 1)

### DIFF
--- a/apps/web/src/app/api/dashboard/route.ts
+++ b/apps/web/src/app/api/dashboard/route.ts
@@ -1,6 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/dashboard?member_id=X[&project_id=X]
 export async function GET(request: Request) {
@@ -9,16 +11,12 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const memberId = searchParams.get('member_id');
-    if (!memberId) return ApiErrors.badRequest('member_id required');
+    if (isOssMode()) {
+      const { apiSuccess } = await import('@/lib/api-response');
+      return apiSuccess({ my_stories: [], assigned_stories: [], my_tasks: [], open_memos: [] });
+    }
 
-    return apiSuccess({
-      my_stories: [],
-      assigned_stories: [],
-      my_tasks: [],
-      open_memos: [],
-    });
+    return proxyToFastapi(request, '/api/v2/dashboard');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -17,7 +17,10 @@ export async function GET(request: Request) {
       if (!member) return ApiErrors.notFound('Member not found');
       return apiSuccess({ ...member, email: null });
     }
-    return proxyToFastapi(request, '/api/v2/me');
+    const res = await proxyToFastapi(request, '/api/v2/me');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/feedback/[id]/route.ts
+++ b/apps/web/src/app/api/standup/feedback/[id]/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standup/feedback/${id}`);
+    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -44,7 +44,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standup/feedback/${id}`);
+    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -62,7 +62,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standup/feedback/${id}`);
+    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/feedback/route.ts
+++ b/apps/web/src/app/api/standup/feedback/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: Request) {
       return apiSuccess(await listOssStandupFeedbackByDate(projectId, date));
     }
 
-    return proxyToFastapi(request, '/api/v2/standup/feedback');
+    return proxyToFastapi(request, '/api/v2/standups/feedback');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
       return apiSuccess(feedback, undefined, 201);
     }
 
-    return proxyToFastapi(request, '/api/v2/standup/feedback');
+    return proxyToFastapi(request, '/api/v2/standups/feedback');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/route.ts
+++ b/apps/web/src/app/api/standup/route.ts
@@ -27,7 +27,7 @@ export async function GET(request: Request) {
       return apiSuccess(await listOssStandupEntries(projectId, date));
     }
 
-    return proxyToFastapi(request, '/api/v2/standup');
+    return proxyToFastapi(request, '/api/v2/standups');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -70,7 +70,7 @@ export async function POST(request: Request) {
       return apiSuccess(entry);
     }
 
-    return proxyToFastapi(request, '/api/v2/standup');
+    return proxyToFastapi(request, '/api/v2/standups');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -108,7 +108,7 @@ export async function PUT(request: Request) {
       return apiSuccess(entry);
     }
 
-    return proxyToFastapi(request, '/api/v2/standup');
+    return proxyToFastapi(request, '/api/v2/standups');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -15,7 +15,10 @@ export async function GET(request: Request) {
       const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId, ...(type ? { type } : {}) });
       return apiSuccess(members);
     }
-    return proxyToFastapi(request, '/api/v2/team-members');
+    const res = await proxyToFastapi(request, '/api/v2/team-members');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);
   }


### PR DESCRIPTION
## Summary
1. **team-members GET** — FastAPI raw list → `apiSuccess()` 래핑 (`json.data` 접근 정상화)
2. **me GET** — FastAPI raw object → `apiSuccess()` 래핑
3. **dashboard GET** — 빈 배열 하드코딩 → `proxyToFastapi('/api/v2/dashboard')` 전환 (OSS mode fallback 유지)
4. **standup 경로 수정 (3파일)** — `/api/v2/standup` → `/api/v2/standups` (FastAPI prefix 일치)
   - `standup/route.ts` (GET/POST/PUT)
   - `standup/feedback/route.ts` (GET/POST)
   - `standup/feedback/[id]/route.ts` (GET/PATCH/DELETE)

## Test plan
- [ ] 보드(/board) 팀 멤버 목록 정상 로드 확인
- [ ] 스탠드업(/standup) 항목 조회/저장 정상 작동 확인
- [ ] 대시보드(/dashboard) 데이터 정상 표시 확인
- [ ] 설정 > 프로필 이름 조회/수정 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)