### PR TITLE
fix: retro/standup-history/rewards/notification-settings 크래시 해소 (P1 Stage 2)

### DIFF
--- a/apps/web/src/app/api/notification-settings/route.ts
+++ b/apps/web/src/app/api/notification-settings/route.ts
@@ -1,9 +1,21 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/notification-settings');
+  try {
+    const res = await proxyToFastapi(request, '/api/v2/notification-settings');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
+  } catch (err: unknown) { return handleApiError(err); }
 }
 
 export async function PUT(request: Request) {
-  return proxyToFastapi(request, '/api/v2/notification-settings');
+  try {
+    const res = await proxyToFastapi(request, '/api/v2/notification-settings');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -1,8 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
 import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { addOssRetroAction } from '@/lib/oss-retro';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -19,10 +19,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.listActions(id, projectId);
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -48,10 +45,7 @@ export async function POST(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.addAction({ session_id: id, project_id: projectId, title: body.title, assignee_id: body.assignee_id ?? null });
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -13,14 +13,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.exportSession(id, projectId);
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
@@ -1,8 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
 import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { voteOssRetroItem } from '@/lib/oss-retro';
 
 type RouteParams = { params: Promise<{ id: string; item_id: string }> };
@@ -10,27 +10,21 @@ type RouteParams = { params: Promise<{ id: string; item_id: string }> };
 // POST /api/retro-sessions/:id/items/:item_id/vote
 export async function POST(request: Request, { params }: RouteParams) {
   try {
-    const { item_id } = await params;
+    const { id, item_id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const body = await request.json().catch(() => ({})) as { voter_id?: string };
-    const voterId = body.voter_id ?? me.id;
-
     if (isOssMode()) {
-      const data = await voteOssRetroItem(item_id, voterId, projectId);
+      const { searchParams } = new URL(request.url);
+      const projectId = searchParams.get('project_id');
+      if (!projectId) return ApiErrors.badRequest('project_id required');
+      const body = await request.json().catch(() => ({})) as { voter_id?: string };
+      const data = await voteOssRetroItem(item_id, body.voter_id ?? me.id, projectId);
       return apiSuccess(data);
     }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.voteItem(item_id, voterId, projectId);
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items/[item_id]/vote', { id, item_id });
   } catch (err: unknown) {
     const e = err as Error & { code?: string };
     if (e.code === 'CONFLICT') return apiError('CONFLICT', e.message, 409);

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -1,9 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
-import type { RetroItemCategory } from '@/services/retro-session';
 import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { addOssRetroItem } from '@/lib/oss-retro';
 import type { RetroCategory } from '@/lib/oss-retro';
 
@@ -17,14 +16,7 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.listItems(id, projectId);
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -38,24 +30,18 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const body = await request.json() as { category?: RetroItemCategory; text?: string; author_id?: string };
-    if (!body.category) return ApiErrors.badRequest('category required');
-    if (!body.text) return ApiErrors.badRequest('text required');
-    const author_id = body.author_id ?? me.id;
-
     if (isOssMode()) {
-      const data = await addOssRetroItem({ session_id: id, project_id: projectId, category: body.category as RetroCategory, text: body.text!, author_id });
+      const { searchParams } = new URL(request.url);
+      const projectId = searchParams.get('project_id');
+      if (!projectId) return ApiErrors.badRequest('project_id required');
+      const body = await request.json() as { category?: string; text?: string; author_id?: string };
+      if (!body.category) return ApiErrors.badRequest('category required');
+      if (!body.text) return ApiErrors.badRequest('text required');
+      const data = await addOssRetroItem({ session_id: id, project_id: projectId, category: body.category as RetroCategory, text: body.text, author_id: body.author_id ?? me.id });
       return apiSuccess(data);
     }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.addItem({ session_id: id, project_id: projectId, category: body.category, text: body.text, author_id });
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -1,9 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
-import type { RetroSessionPhase } from '@/services/retro-session';
 import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { getOssRetroSession, listOssRetroItems, listOssRetroActions, advanceOssRetroPhase } from '@/lib/oss-retro';
 import type { RetroPhase } from '@/lib/oss-retro';
 
@@ -31,15 +30,7 @@ export async function GET(request: Request, { params }: RouteParams) {
       return apiSuccess({ session, items, actions });
     }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.getSession(id, projectId);
-    if (!data) return ApiErrors.notFound('Session not found');
-    const [items, actions] = await Promise.all([
-      service.listItems(id, projectId),
-      service.listActions(id, projectId),
-    ]);
-    return apiSuccess({ session: data, items, actions });
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -57,7 +48,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
-    const body = await request.json() as { phase?: RetroSessionPhase };
+    const body = await request.json() as { phase?: string };
     if (!body.phase) return ApiErrors.badRequest('phase required');
 
     if (isOssMode()) {
@@ -65,10 +56,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.changePhase(id, projectId, body.phase);
-    return apiSuccess(data);
+    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/phase', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -48,10 +48,9 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
-    const body = await request.json() as { phase?: string };
-    if (!body.phase) return ApiErrors.badRequest('phase required');
-
     if (isOssMode()) {
+      const body = await request.json() as { phase?: string };
+      if (!body.phase) return ApiErrors.badRequest('phase required');
       const data = await advanceOssRetroPhase(id, projectId, body.phase as RetroPhase);
       return apiSuccess(data);
     }

--- a/apps/web/src/app/api/retro-sessions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/route.ts
@@ -1,7 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { RetroSessionService } from '@/services/retro-session';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/retro-sessions?project_id=X
 export async function GET(request: Request) {
@@ -10,14 +11,16 @@ export async function GET(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
+    if (isOssMode()) {
+      const { apiSuccess } = await import('@/lib/api-response');
+      const { listOssRetroSessions } = await import('@/lib/oss-retro');
+      const { searchParams } = new URL(request.url);
+      const projectId = searchParams.get('project_id');
+      if (!projectId) return ApiErrors.badRequest('project_id required');
+      return apiSuccess(await listOssRetroSessions(projectId));
+    }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.listSessions(projectId);
-    return apiSuccess(data);
+    return proxyToFastapi(request, '/api/v2/retros');
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -30,28 +33,22 @@ export async function POST(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const body = await request.json() as {
-      project_id?: string;
-      org_id?: string;
-      title?: string;
-      sprint_id?: string | null;
-      created_by?: string;
-    };
-    if (!body.project_id) return ApiErrors.badRequest('project_id required');
-    if (!body.org_id) return ApiErrors.badRequest('org_id required');
-    if (!body.title) return ApiErrors.badRequest('title required');
-    if (!body.created_by) return ApiErrors.badRequest('created_by required');
+    if (isOssMode()) {
+      const { apiSuccess } = await import('@/lib/api-response');
+      const { createOssRetroSession } = await import('@/lib/oss-retro');
+      const body = await request.json() as {
+        project_id?: string; org_id?: string; title?: string;
+        sprint_id?: string | null; created_by?: string;
+      };
+      if (!body.project_id) return ApiErrors.badRequest('project_id required');
+      if (!body.org_id) return ApiErrors.badRequest('org_id required');
+      if (!body.title) return ApiErrors.badRequest('title required');
+      if (!body.created_by) return ApiErrors.badRequest('created_by required');
+      const data = await createOssRetroSession({ org_id: body.org_id, project_id: body.project_id, title: body.title, sprint_id: body.sprint_id ?? null, created_by: body.created_by });
+      return apiSuccess(data, undefined, 201);
+    }
 
-    const dbClient = undefined;
-    const service = new RetroSessionService(dbClient);
-    const data = await service.createSession({
-      org_id: body.org_id,
-      project_id: body.project_id,
-      title: body.title,
-      sprint_id: body.sprint_id ?? null,
-      created_by: body.created_by,
-    });
-    return apiSuccess(data);
+    return proxyToFastapi(request, '/api/v2/retros');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/rewards/leaderboard/route.ts
+++ b/apps/web/src/app/api/rewards/leaderboard/route.ts
@@ -1,7 +1,7 @@
-import { RewardsService } from '@/services/rewards';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET /api/rewards/leaderboard?project_id=X&period=daily|weekly|monthly|all&limit=N&cursor=X */
 export async function GET(request: Request) {
@@ -19,11 +19,6 @@ export async function GET(request: Request) {
       return ApiErrors.badRequest('period must be one of: daily, weekly, monthly, all');
     }
 
-    const limit = Math.min(Number(searchParams.get('limit') ?? '50'), 100);
-    const cursor = searchParams.get('cursor') ?? undefined;
-
-    const service = new RewardsService(undefined);
-    const data = await service.getLeaderboardByPeriod(projectId, period, limit, cursor);
-    return apiSuccess(data);
+    return proxyToFastapi(request, '/api/v2/rewards/leaderboard');
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/rewards/route.ts
+++ b/apps/web/src/app/api/rewards/route.ts
@@ -1,23 +1,14 @@
-import { parseBody, createRewardSchema } from '@sprintable/shared';
-import { RewardsService } from '@/services/rewards';
 import { handleApiError } from '@/lib/api-error';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const { searchParams } = new URL(request.url);
-    const projectId = me.type === 'agent' ? me.project_id : searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-    const service = new RewardsService(undefined);
-    const type = searchParams.get('type');
-    if (type === 'leaderboard') return apiSuccess(await service.getLeaderboard(projectId));
-    const memberId = searchParams.get('member_id');
-    if (memberId && searchParams.get('balance') === 'true') return apiSuccess(await service.getBalance(projectId, memberId));
-    return apiSuccess(await service.getLedger(projectId, memberId ?? undefined));
+    return proxyToFastapi(request, '/api/v2/rewards');
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -29,14 +20,6 @@ export async function POST(request: Request) {
     if (me.type === 'agent' && !me.scope?.includes('admin')) {
       return ApiErrors.insufficientScope('admin');
     }
-    const parsed = await parseBody(request, createRewardSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const service = new RewardsService(undefined);
-    const entry = await service.grant({
-      org_id: me.org_id, project_id: me.project_id,
-      member_id: body.member_id, amount: body.amount,
-      reason: body.reason, granted_by: me.id,
-      reference_type: body.reference_type, reference_id: body.reference_id,
-    });
-    return apiSuccess(entry, undefined, 201);
+    return proxyToFastapi(request, '/api/v2/rewards');
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -1,11 +1,11 @@
 
 
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
 import { getOssStandupHistory } from '@/lib/oss-standup';
-import { StandupService } from '@/services/standup';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/standup/history?project_id=X[&limit=N]
 export async function GET(request: Request) {
@@ -23,10 +23,7 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupHistory(projectId, limit));
     }
 
-    const dbClient: any = undefined;
-    const service = new StandupService(dbClient);
-    const data = await service.getHistory(projectId, limit);
-    return apiSuccess(data);
+    return proxyToFastapi(request, '/api/v2/standups');
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -1,7 +1,7 @@
 
 
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
 import { getOssStandupHistory } from '@/lib/oss-standup';

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -4,8 +4,8 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { getOssStandupMissing } from '@/lib/oss-standup';
-import { StandupService } from '@/services/standup';
 
 // GET /api/standup/missing?project_id=X&date=YYYY-MM-DD
 export async function GET(request: Request) {
@@ -24,10 +24,7 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupMissing(projectId, date));
     }
 
-    const dbClient: any = undefined;
-    const service = new StandupService(dbClient);
-    const data = await service.getMissing(projectId, date);
-    return apiSuccess(data);
+    return proxyToFastapi(request, '/api/v2/standups/missing');
   } catch (err: unknown) {
     return handleApiError(err);
   }


### PR DESCRIPTION
## Summary
`dbClient = undefined; const service = new XxxService(dbClient)` 패턴 전량 `proxyToFastapi()` 전환.

**수정 파일 (11개)**
- `retro-sessions/route.ts` — GET/POST → `/api/v2/retros` (OSS mode oss-retro 함수 사용)
- `retro-sessions/[id]/route.ts` — GET → `/api/v2/retros/[id]`, PATCH → `/api/v2/retros/[id]/phase`
- `retro-sessions/[id]/actions/route.ts` — GET/POST → `/api/v2/retros/[id]/actions`
- `retro-sessions/[id]/export/route.ts` — GET → `/api/v2/retros/[id]/export`
- `retro-sessions/[id]/items/route.ts` — GET/POST → `/api/v2/retros/[id]/items`
- `retro-sessions/[id]/items/[item_id]/vote/route.ts` — POST → `/api/v2/retros/[id]/items/[item_id]/vote`
- `standup/history/route.ts` — non-OSS → `/api/v2/standups` (history 전용 엔드포인트 없음)
- `standup/missing/route.ts` — non-OSS → `/api/v2/standups/missing`
- `rewards/route.ts` — GET/POST → `/api/v2/rewards`
- `rewards/leaderboard/route.ts` — GET → `/api/v2/rewards/leaderboard`
- `notification-settings/route.ts` — GET/PUT `apiSuccess()` 래핑 추가

## Test plan
- [ ] 레트로 세션 목록/생성/조회/phase 변경 정상 작동 확인
- [ ] 스탠드업 missing/history 정상 응답 확인
- [ ] 리워드 목록/포인트 지급/리더보드 정상 확인
- [ ] 알림 설정 조회/수정 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)