### PR TITLE
fix: createBrowserClient 스텁 크래시 8파일 전량 제거 (P1 Stage 3)

### DIFF
--- a/apps/web/src/app/invite/page.tsx
+++ b/apps/web/src/app/invite/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { createBrowserClient } from '@/lib/db/client';
 
 export default function InvitePage() {
   const t = useTranslations('invite');
@@ -20,9 +19,8 @@ export default function InvitePage() {
       return;
     }
 
-    const db = createBrowserClient();
-    db.auth.getUser().then(({ data: { user } }) => {
-      if (user) {
+    fetch('/api/me').then((res) => {
+      if (res.ok) {
         void acceptInvite(token);
       } else {
         setStatus('login-required');

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { createBrowserClient } from '@/lib/db/client';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
@@ -10,7 +9,6 @@ type Step = 'org' | 'project';
 
 export function OnboardingForm() {
   const router = useRouter();
-  const db = createBrowserClient();
   const t = useTranslations('onboarding');
 
   const [step, setStep] = useState<Step>('org');
@@ -91,34 +89,21 @@ export function OnboardingForm() {
     }
 
     // team_member 자동 생성 (type=human)
-    const { data: { user } } = await db.auth.getUser();
-    if (user) {
-      const name = user.user_metadata?.name
-        || user.user_metadata?.full_name
-        || user.email
-        || t('unknownUser');
-
-      // 중복 방지: 이미 존재하면 스킵
-      const { data: existingMember } = await db
-        .from('team_members')
-        .select('id')
-        .eq('user_id', user.id)
-        .eq('project_id', project.id)
-        .eq('type', 'human')
-        .maybeSingle();
-
-      if (!existingMember) {
-        await db
-          .from('team_members')
-          .insert({
-            org_id: orgId,
-            project_id: project.id,
-            type: 'human',
-            user_id: user.id,
-            name,
-            role: 'member',
-          });
-      }
+    const meRes = await fetch('/api/me');
+    if (meRes.ok) {
+      const meJson = await meRes.json() as { data?: { name?: string } };
+      const memberName = meJson.data?.name ?? t('unknownUser');
+      await fetch('/api/team-members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          org_id: orgId,
+          project_id: project.id,
+          type: 'human',
+          name: memberName,
+          role: 'member',
+        }),
+      }).catch(() => null);
     }
 
     await fetch('/api/current-project', {

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -16,7 +16,6 @@ import { AgentDeploymentVerificationStep } from '@/components/agents/agent-deplo
 import { ANTHROPIC_MODELS, GOOGLE_MODELS, GROQ_MODELS, LLMProvider, OPENAI_MODELS } from '@/lib/llm/types';
 import type { ManagedAgentDeploymentVerification } from '@/lib/managed-agent-contract';
 import { buildAutomaticRoutingTemplate, resolveAutoRoutingPersonaRole, type AutoRoutingPersonaRole } from '@/services/agent-routing-template';
-import { createBrowserClient } from '@/lib/db/client';
 
 export interface WizardAgent {
   id: string;
@@ -159,12 +158,6 @@ export function AgentDeploymentWizard({
   const [failureMessage, setFailureMessage] = useState<string | null>(null);
   const [overwriteRoutingRules, setOverwriteRoutingRules] = useState(false);
 
-  const getAuthHeaders = async (): Promise<Record<string, string>> => {
-    const db = createBrowserClient();
-    const { data: { session } } = await db.auth.getSession();
-    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
-  };
-
   const builtinPersonas = personas.filter((persona) => persona.is_builtin);
   const customPersonas = personas.filter((persona) => !persona.is_builtin);
   const selectedPersona = personas.find((persona) => persona.id === selectedPersonaId) ?? null;
@@ -283,8 +276,7 @@ export function AgentDeploymentWizard({
     if (!deploymentId || !deploying) return;
     let cancelled = false;
     const timer = setInterval(async () => {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}`, { cache: 'no-store', headers: authHeaders });
+      const response = await fetch(`/api/v1/agent-deployments/${deploymentId}`, { cache: 'no-store' });
       const json = await response.json();
       if (!response.ok) {
         if (!cancelled) {
@@ -346,10 +338,9 @@ export function AgentDeploymentWizard({
     setPreflightRunning(true);
     setFailureMessage(null);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/agent-deployments/preflight', {
+      const response = await fetch('/api/v1/agent-deployments/preflight', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(deploymentPayload),
       });
 
@@ -379,10 +370,9 @@ export function AgentDeploymentWizard({
     setFailureMessage(null);
     setDeploymentStatus('DEPLOYING');
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/agent-deployments', {
+      const response = await fetch('/api/v1/agent-deployments', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(deploymentPayload),
       });
 
@@ -425,10 +415,8 @@ export function AgentDeploymentWizard({
     if (!deploymentId) return;
     setVerificationSubmitting(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch(`/api/v2/agent-deployments/${deploymentId}/verification`, {
+      const response = await fetch(`/api/v1/agent-deployments/${deploymentId}/verification`, {
         method: 'POST',
-        headers: authHeaders,
       });
       const json = await response.json();
       if (!response.ok) {

--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { createBrowserClient } from '@/lib/db/client';
 import { AlertTriangle, CheckCircle2, Clock3, ShieldAlert } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -31,20 +30,11 @@ export function AgentHitlPolicyEditor() {
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
-  const getAuthHeaders = async (): Promise<Record<string, string>> => {
-    const db = createBrowserClient();
-    const { data: { session } } = await db.auth.getSession();
-    const headers: Record<string, string> = {};
-    if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
-    return headers;
-  };
-
   const fetchPolicy = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/hitl/policy', { headers: authHeaders });
+      const response = await fetch('/api/v1/hitl-policy');
       if (!response.ok) throw new Error(t('policyLoadFailed'));
       const json = await response.json() as { data?: HitlPolicySnapshot };
       if (!json.data) throw new Error(t('policyLoadFailed'));
@@ -92,10 +82,9 @@ export function AgentHitlPolicyEditor() {
     setSaving(true);
     setError(null);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/hitl/policy', {
+      const response = await fetch('/api/v1/hitl-policy', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           approval_rules: policy.approval_rules,
           timeout_classes: policy.timeout_classes,

--- a/apps/web/src/components/agents/agent-hitl-requests-list.tsx
+++ b/apps/web/src/components/agents/agent-hitl-requests-list.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ArrowLeft, Bot, Clock3, RefreshCw, TriangleAlert, User } from 'lucide-react';
-import { createBrowserClient } from '@/lib/db/client';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -63,12 +62,7 @@ export function AgentHitlRequestsList() {
     else setLoading(true);
 
     try {
-      const db = createBrowserClient();
-      const { data: { session } } = await db.auth.getSession();
-      const headers: Record<string, string> = {};
-      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
-
-      const res = await fetch('/api/v2/hitl/requests?status=pending', { headers });
+      const res = await fetch('/api/v1/hitl-requests?status=pending');
       if (!res.ok) return;
       const json = await res.json() as { data?: HitlRequestItem[] };
       setRequests(json.data ?? []);

--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -11,7 +11,6 @@ import { OperatorInput, OperatorSelect, OperatorTextarea } from '@/components/ui
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import type { PersonaToolOption } from '@/services/persona-composer';
 import { estimatePromptTokens } from '@/services/persona-composer';
-import { createBrowserClient } from '@/lib/db/client';
 
 export interface PersonaComposerAgent {
   id: string;
@@ -144,13 +143,9 @@ export function AgentPersonaComposer({
     setCreatedPersona(null);
 
     try {
-      const db = createBrowserClient();
-      const { data: { session } } = await db.auth.getSession();
-      const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-      if (session?.access_token) headers['Authorization'] = `Bearer ${session.access_token}`;
-      const response = await fetch('/api/v2/agent-personas', {
+      const response = await fetch('/api/v1/agent-personas', {
         method: 'POST',
-        headers,
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           agent_id: selectedAgentId,
           name: name.trim(),

--- a/apps/web/src/components/agents/agent-workflow-editor.tsx
+++ b/apps/web/src/components/agents/agent-workflow-editor.tsx
@@ -31,7 +31,6 @@ import { PageHeader } from '@/components/ui/page-header';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { getRollbackSnapshotFromRules, type RoutingRuleSummary, type WorkflowVersionSummary } from '@/services/agent-routing-rule';
-import { createBrowserClient } from '@/lib/db/client';
 import {
   WORKFLOW_MEMO_TYPE_OPTIONS,
   WORKFLOW_ORIGINAL_ASSIGNEE_ID,
@@ -554,22 +553,15 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
 
   // ─── API actions ───────────────────────────────────────────────────────────
 
-  const getAuthHeaders = async (): Promise<Record<string, string>> => {
-    const db = createBrowserClient();
-    const { data: { session } } = await db.auth.getSession();
-    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
-  };
-
   const saveWorkflow = useCallback(async () => {
     setSaving(true);
     try {
       if (!draftWorkflow.rules) throw new Error(draftWorkflow.error ?? t('workflowSaveErrorBody'));
 
       const desired = draftWorkflow.rules;
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/agent-routing-rules', {
+      const response = await fetch('/api/v1/agent-routing-rules', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           items: desired.map((rule) => ({
             id: rule.id,
@@ -612,10 +604,9 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
     if (!rollbackSnapshot?.items.length) return;
     setSaving(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/agent-routing-rules', {
+      const response = await fetch('/api/v1/agent-routing-rules', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ items: rollbackSnapshot.items }),
       });
       const json = await response.json().catch(() => null) as ApiResponse<RoutingRuleSummary[]> | null;
@@ -634,8 +625,7 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
   useEffect(() => {
     void (async () => {
       try {
-        const authHeaders = await getAuthHeaders();
-        const r = await fetch('/api/v2/workflow-versions', { headers: authHeaders });
+        const r = await fetch('/api/v1/workflow-versions');
         const json = await r.json() as { data?: WorkflowVersionSummary[] };
         if (Array.isArray(json.data)) setVersions(json.data);
       } catch {
@@ -647,8 +637,7 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
   const rollbackToVersion = useCallback(async (versionId: string) => {
     setSaving(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch(`/api/v2/workflow-versions/${versionId}/rollback`, { method: 'POST', headers: authHeaders });
+      const response = await fetch(`/api/v1/workflow-versions/${versionId}/rollback`, { method: 'POST' });
       const json = await response.json().catch(() => null) as { data?: RoutingRuleSummary[] } | null;
       if (!response.ok || !json?.data || !Array.isArray(json.data)) throw new Error(t('workflowRollbackErrorBody'));
       setSavedRules(json.data);
@@ -667,10 +656,9 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
     if (savedRules.length === 0) return;
     setSaving(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const response = await fetch('/api/v2/agent-routing-rules', {
+      const response = await fetch('/api/v1/agent-routing-rules', {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ disable_all: true }),
       });
       const json = await response.json().catch(() => null) as ApiResponse<RoutingRuleSummary[]> | null;

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -18,7 +18,6 @@ import {
 } from '@/components/ui/dialog';
 import { getDeploymentHealthState, getDeploymentRecoveryCueKeys, hasActiveFailureSignal } from '@/services/agent-deployment-console';
 import { getTriggerMemoHref } from '@/services/agent-run-history';
-import { createBrowserClient } from '@/lib/db/client';
 
 export interface AgentDeploymentCard {
   id: string;
@@ -151,18 +150,11 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
     }
   }, [addToast]);
 
-  const getAuthHeaders = async (): Promise<Record<string, string>> => {
-    const db = createBrowserClient();
-    const { data: { session } } = await db.auth.getSession();
-    return session?.access_token ? { Authorization: `Bearer ${session.access_token}` } : {};
-  };
-
   // Auto-refresh polling
   const fetchDeployments = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const res = await fetch('/api/v2/agent-deployments', { headers: authHeaders });
+      const res = await fetch('/api/v1/agent-deployments');
       if (!res.ok) return;
       const json = await res.json() as { data: AgentDeploymentCard[] | null };
       if (json.data) {
@@ -211,10 +203,9 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
     if (!pendingAction) return;
     setTransitioning(true);
     try {
-      const authHeaders = await getAuthHeaders();
-      const res = await fetch(`/api/v2/agent-deployments/${pendingAction.deploymentId}`, {
+      const res = await fetch(`/api/v1/agent-deployments/${pendingAction.deploymentId}`, {
         method: 'PATCH',
-        headers: { 'Content-Type': 'application/json', ...authHeaders },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ status: pendingAction.targetStatus }),
       });
       if (!res.ok) {


### PR DESCRIPTION
## Summary
`createBrowserClient()` → `undefined` 반환으로 인한 8개 컴포넌트 크래시 전량 해소.

**수정 패턴**: `getAuthHeaders()` (createBrowserClient → db.auth.getSession → access_token 추출) 제거 → `/api/v1/*` 쿠키 자동 전달 fetch로 대체

**수정 파일 (8개)**
| 파일 | 이전 | 이후 |
|------|------|------|
| `agents-dashboard.tsx` | `/api/v2/agent-deployments` + Bearer | `/api/v1/agent-deployments` (쿠키) |
| `agent-persona-composer.tsx` | `/api/v2/agent-personas` + Bearer | `/api/v1/agent-personas` |
| `agent-hitl-policy-editor.tsx` | `/api/v2/hitl/policy` + Bearer | `/api/v1/hitl-policy` |
| `agent-hitl-requests-list.tsx` | `/api/v2/hitl/requests` + Bearer | `/api/v1/hitl-requests` |
| `agent-deployment-wizard.tsx` | `/api/v2/agent-deployments/*` + Bearer | `/api/v1/agent-deployments/*` |
| `agent-workflow-editor.tsx` | `/api/v2/agent-routing-rules`, `/api/v2/workflow-versions` + Bearer | `/api/v1/agent-routing-rules`, `/api/v1/workflow-versions` |
| `invite/page.tsx` | `db.auth.getUser()` | `fetch('/api/me')` 응답 여부로 인증 확인 |
| `onboarding-form.tsx` | `db.auth.getUser()` + `db.from('team_members')` 직접 | `/api/me` + `/api/team-members` POST |

## Test plan
- [ ] `/agents` — 에이전트 대시보드 렌더링 + 배포 상태 조회 정상 확인
- [ ] `/agents` HITL 요청 목록 + 정책 편집 정상 확인
- [ ] 에이전트 배포 위저드 전체 플로우 확인
- [ ] 워크플로우 에디터 저장/롤백 정상 확인
- [ ] `/invite?token=X` — 로그인 사용자 초대 수락 정상 확인
- [ ] `/onboarding` — org/project 생성 + team_member 자동 생성 확인
- [ ] pnpm build 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)