### PR TITLE
fix: proxyToFastapi {id} 파라미터 누락 7파일 수정 (P1 Stage 4)

### DIFF
--- a/apps/web/src/app/api/invitations/[id]/resend/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/resend/route.ts
@@ -1,8 +1,9 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** POST /api/invitations/[id]/resend */
-export async function POST(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/invitations/resend');
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/invitations/[id]/resend', { id });
 }

--- a/apps/web/src/app/api/invitations/[id]/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/route.ts
@@ -1,8 +1,9 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** DELETE /api/invitations/[id] */
-export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/invitations');
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/invitations/[id]', { id });
 }

--- a/apps/web/src/app/api/mockups/[id]/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/route.ts
@@ -1,18 +1,21 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 목업 상세 (컴포넌트 포함) */
-export async function GET(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups');
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
 }
 
 /** PUT — 목업 수정 (컴포넌트 트리 일괄 교체) */
-export async function PUT(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups');
+export async function PUT(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
 }
 
 /** DELETE — 목업 소프트 삭제 */
-export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups');
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
 }

--- a/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
@@ -1,23 +1,27 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 시나리오 목록 */
-export async function GET(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/scenarios');
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
 }
 
 /** POST — 시나리오 생성 */
-export async function POST(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/scenarios');
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
 }
 
 /** PATCH — 시나리오 수정 */
-export async function PATCH(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/scenarios');
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
 }
 
 /** DELETE — 시나리오 삭제 (default 불가) */
-export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/scenarios');
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
 }

--- a/apps/web/src/app/api/mockups/[id]/versions/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/versions/route.ts
@@ -1,13 +1,15 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — 버전 히스토리 */
-export async function GET(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/versions');
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
 }
 
 /** POST — 버전 복원 */
-export async function POST(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/mockups/versions');
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
 }

--- a/apps/web/src/app/api/organizations/[id]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/route.ts
@@ -1,6 +1,9 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
 
 /** DELETE /api/organizations/[id] */
-export async function DELETE(request: Request) {
-  return proxyToFastapi(request, '/api/v2/organizations');
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/organizations/[id]', { id });
 }

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,11 +1,13 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/team-members');
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
 }
 
-export async function PATCH(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/team-members');
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
 }


### PR DESCRIPTION
## Summary
동적 경로 핸들러에서 `proxyToFastapi(request, '/api/v2/xxx')` 호출 시 `[id]` 파라미터가 FastAPI 경로에 누락되는 버그 수정.

**수정 패턴**: `proxyToFastapi` → `proxyToFastapiWithParams` + `const { id } = await params`

**수정 파일 (7개, 15핸들러)**
| 파일 | 이전 경로 | 이후 경로 |
|------|-----------|-----------|
| `organizations/[id]/route.ts` | `/api/v2/organizations` | `/api/v2/organizations/[id]` |
| `team-members/[id]/route.ts` (DELETE/PATCH) | `/api/v2/team-members` | `/api/v2/team-members/[id]` |
| `invitations/[id]/route.ts` | `/api/v2/invitations` | `/api/v2/invitations/[id]` |
| `invitations/[id]/resend/route.ts` | `/api/v2/invitations/resend` | `/api/v2/invitations/[id]/resend` |
| `mockups/[id]/route.ts` (GET/PUT/DELETE) | `/api/v2/mockups` | `/api/v2/mockups/[id]` |
| `mockups/[id]/versions/route.ts` (GET/POST) | `/api/v2/mockups/versions` | `/api/v2/mockups/[id]/versions` |
| `mockups/[id]/scenarios/route.ts` (GET/POST/PATCH/DELETE) | `/api/v2/mockups/scenarios` | `/api/v2/mockups/[id]/scenarios` |

## Test plan
- [ ] 조직 삭제 정상 작동 확인
- [ ] 팀 멤버 삭제/수정 정상 확인
- [ ] 초대 취소/재발송 정상 확인
- [ ] 목업 상세/수정/삭제 + 버전/시나리오 CRUD 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)