### PR TITLE
fix: reply_memo 웹훅 발신 + read_memo replies 미포함 2건 수정 (story 3a5c4afd)

### DIFF
--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -3,7 +3,8 @@ import { MemoService } from '@/services/memo';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { createMemoRepository, createTeamMemberRepository } from '@/lib/storage/factory';
+import { isOssMode, createMemoRepository, createTeamMemberRepository } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -27,14 +28,19 @@ export async function POST(request: Request, { params }: RouteParams) {
       );
     }
 
-    const parsed = await parseBody(request, createMemoReplySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    const dbClient = undefined;
-    const repo = await createMemoRepository(dbClient);
-    const teamMemberRepo = await createTeamMemberRepository();
-    const service = new MemoService(repo, dbClient, teamMemberRepo);
-    const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
-    const reply = await service.addReply(id, body.content, me.id, 'comment', resolvedIds);
-    return apiSuccess(reply, undefined, 201);
+    if (isOssMode()) {
+      const parsed = await parseBody(request, createMemoReplySchema);
+      if (!parsed.success) return parsed.response;
+      const body = parsed.data;
+      const repo = await createMemoRepository();
+      const teamMemberRepo = await createTeamMemberRepository();
+      const service = new MemoService(repo, undefined, teamMemberRepo);
+      const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
+      const reply = await service.addReply(id, body.content, me.id, 'comment', resolvedIds);
+      return apiSuccess(reply, undefined, 201);
+    }
+
+    return proxyToFastapiWithParams(request, '/api/v2/memos/[id]/replies', { id });
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -1,15 +1,64 @@
 import uuid
+import asyncio
+import logging
 
+import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.team import TeamMember
 from app.repositories.memo import MemoReplyRepository, MemoRepository
 from app.routers.events import publish_event
 from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResponse, ReplyResponse, UpdateMemo
 
 router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
+
+
+async def _dispatch_reply_webhooks(db: AsyncSession, memo: object, reply: object, sender_id: uuid.UUID) -> None:
+    try:
+        from app.models.memo import Memo, MemoReply  # noqa: PLC0415
+
+        m: Memo = memo  # type: ignore[assignment]
+        r: MemoReply = reply  # type: ignore[assignment]
+
+        recipient_ids = {m.assigned_to, m.created_by} - {sender_id, None}
+        if not recipient_ids:
+            return
+
+        rows = await db.execute(
+            select(TeamMember.webhook_url).where(
+                TeamMember.id.in_(recipient_ids),
+                TeamMember.is_active.is_(True),
+                TeamMember.webhook_url.isnot(None),
+            )
+        )
+        urls = [row[0] for row in rows if row[0]]
+        if not urls:
+            return
+
+        app_url = __import__("os").environ.get("NEXT_PUBLIC_APP_URL", "")
+        memo_url = f"{app_url}/memos?id={m.id}" if app_url else ""
+
+        async with httpx.AsyncClient(timeout=10) as client:
+            for url in urls:
+                try:
+                    if "discord.com/api/webhooks" in url or "discordapp.com/api/webhooks" in url:
+                        payload = {
+                            "content": f"📩 **새 답신**\n{r.content[:500]}",
+                            "embeds": [{"title": m.title or "메모 답신", "url": memo_url}] if memo_url else [],
+                        }
+                    else:
+                        payload = {"text": f"새 답신: {r.content[:200]}"}
+                    await client.post(url, json=payload)
+                except Exception:  # noqa: BLE001
+                    pass
+    except Exception:  # noqa: BLE001
+        logger.warning("reply webhook dispatch failed", exc_info=True)
 
 
 def _get_repo(
@@ -71,12 +120,18 @@ async def create_memo(
 @router.get("/{id}", response_model=MemoResponse)
 async def get_memo(
     id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
     repo: MemoRepository = Depends(_get_repo),
 ) -> MemoResponse:
     memo = await repo.get(id)
     if memo is None:
         raise HTTPException(status_code=404, detail="Memo not found")
-    return MemoResponse.model_validate(memo)
+    reply_repo = MemoReplyRepository(db)
+    replies = await reply_repo.list_by_memo(id)
+    response = MemoResponse.model_validate(memo)
+    response.replies = [ReplyResponse.model_validate(r) for r in replies]
+    response.reply_count = len(replies)
+    return response
 
 
 @router.patch("/{id}", response_model=MemoListResponse)
@@ -119,6 +174,10 @@ async def add_reply(
         memo_id=id, content=body.content, created_by=body.created_by, review_type=body.review_type
     )
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
+
+    # Discord 웹훅 발송 (비동기, 실패 무시)
+    asyncio.create_task(_dispatch_reply_webhooks(db, memo, reply, body.created_by))
+
     return ReplyResponse.model_validate(reply)
 
 

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -1,9 +1,9 @@
+import os
 import uuid
-import asyncio
 import logging
 
 import httpx
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,46 +19,33 @@ from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResp
 router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
 
 
-async def _dispatch_reply_webhooks(db: AsyncSession, memo: object, reply: object, sender_id: uuid.UUID) -> None:
-    try:
-        from app.models.memo import Memo, MemoReply  # noqa: PLC0415
-
-        m: Memo = memo  # type: ignore[assignment]
-        r: MemoReply = reply  # type: ignore[assignment]
-
-        recipient_ids = {m.assigned_to, m.created_by} - {sender_id, None}
-        if not recipient_ids:
-            return
-
-        rows = await db.execute(
-            select(TeamMember.webhook_url).where(
-                TeamMember.id.in_(recipient_ids),
-                TeamMember.is_active.is_(True),
-                TeamMember.webhook_url.isnot(None),
-            )
+async def _collect_reply_webhook_urls(
+    db: AsyncSession, assigned_to: uuid.UUID | None, created_by: uuid.UUID | None, sender_id: uuid.UUID
+) -> list[str]:
+    recipient_ids = {assigned_to, created_by} - {sender_id, None}
+    if not recipient_ids:
+        return []
+    rows = await db.execute(
+        select(TeamMember.webhook_url).where(
+            TeamMember.id.in_(recipient_ids),
+            TeamMember.is_active.is_(True),
+            TeamMember.webhook_url.isnot(None),
         )
-        urls = [row[0] for row in rows if row[0]]
-        if not urls:
-            return
+    )
+    return [row[0] for row in rows if row[0]]
 
-        app_url = __import__("os").environ.get("NEXT_PUBLIC_APP_URL", "")
-        memo_url = f"{app_url}/memos?id={m.id}" if app_url else ""
 
-        async with httpx.AsyncClient(timeout=10) as client:
-            for url in urls:
-                try:
-                    if "discord.com/api/webhooks" in url or "discordapp.com/api/webhooks" in url:
-                        payload = {
-                            "content": f"📩 **새 답신**\n{r.content[:500]}",
-                            "embeds": [{"title": m.title or "메모 답신", "url": memo_url}] if memo_url else [],
-                        }
-                    else:
-                        payload = {"text": f"새 답신: {r.content[:200]}"}
-                    await client.post(url, json=payload)
-                except Exception:  # noqa: BLE001
-                    pass
+def _fire_webhook(url: str, content: str, title: str, memo_url: str) -> None:
+    try:
+        if "discord.com/api/webhooks" in url or "discordapp.com/api/webhooks" in url:
+            payload: dict = {"content": content}
+            if memo_url:
+                payload["embeds"] = [{"title": title, "url": memo_url}]
+        else:
+            payload = {"text": content}
+        httpx.post(url, json=payload, timeout=10)
     except Exception:  # noqa: BLE001
-        logger.warning("reply webhook dispatch failed", exc_info=True)
+        logger.warning("reply webhook fire failed url=%s", url, exc_info=True)
 
 
 def _get_repo(
@@ -163,6 +150,7 @@ async def delete_memo(
 async def add_reply(
     id: uuid.UUID,
     body: CreateReply,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     repo: MemoRepository = Depends(_get_repo),
 ) -> ReplyResponse:
@@ -175,8 +163,15 @@ async def add_reply(
     )
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
 
-    # Discord 웹훅 발송 (비동기, 실패 무시)
-    asyncio.create_task(_dispatch_reply_webhooks(db, memo, reply, body.created_by))
+    # 세션이 열려 있는 지금 webhook URLs 수집 후 BackgroundTasks에 HTTP 발송 위임
+    webhook_urls = await _collect_reply_webhook_urls(db, memo.assigned_to, memo.created_by, body.created_by)
+    if webhook_urls:
+        app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
+        memo_url = f"{app_url}/memos?id={id}" if app_url else ""
+        content = f"📩 **새 답신**\n{reply.content[:500]}"
+        title = memo.title or "메모 답신"
+        for url in webhook_urls:
+            background_tasks.add_task(_fire_webhook, url, content, title, memo_url)
 
     return ReplyResponse.model_validate(reply)
 

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -48,6 +48,8 @@ class MemoListResponse(BaseModel):
 
 class MemoResponse(MemoListResponse):
     deleted_at: datetime | None = None
+    replies: list["ReplyResponse"] = []
+    reply_count: int = 0
 
 
 class CreateReply(BaseModel):


### PR DESCRIPTION
## Summary

### 버그 1: reply_memo 웹훅 무조건 스킵
- **원인**: `replies/route.ts`에서 `const dbClient = undefined` → `MemoService(repo, undefined, teamMemberRepo)` → `this.db = null` → webhook dispatch skip
- **수정**: `isOssMode()` 분기 추가
  - OSS: 기존 `MemoService.addReply()` (teamMemberRepo 기반 웹훅) 유지
  - non-OSS: `proxyToFastapiWithParams('/api/v2/memos/[id]/replies')` → FastAPI 위임
- FastAPI `add_reply()`: reply 저장 후 `_dispatch_reply_webhooks()` 비동기 실행 → `memo.assigned_to` / `memo.created_by`의 TeamMember `webhook_url` 조회 → Discord 웹훅 발송

### 버그 2: read_memo replies 미포함
- **원인**: `MemoResponse`에 `replies` / `reply_count` 필드 없음. `get_memo()`에서 reply JOIN 없음
- **수정**:
  - `MemoResponse`에 `replies: list[ReplyResponse] = []`, `reply_count: int = 0` 추가
  - `get_memo()`에서 `MemoReplyRepository.list_by_memo()` 조회 후 포함

## Test plan
- [ ] AC1: reply_memo 후 수신자 Discord 웹훅 수신 확인
- [ ] AC2: read_memo 시 replies 배열 + reply_count 정확 반환 확인
- [ ] AC3: DB 저장 + 이벤트 발행 기존 기능 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)