### PR TITLE
fix: replies/route.ts — API key 헤더 우선 토큰 (reply_memo 401 수정)

### DIFF
--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -45,9 +45,12 @@ export async function POST(request: Request, { params }: RouteParams) {
     const body = parsed.data;
 
     const { fastapiCall } = await import('@sprintable/storage-api');
+    const xApiKey = request.headers.get('x-api-key');
+    const authHeader = request.headers.get('authorization');
+    const rawApiKey = xApiKey ?? (authHeader?.startsWith('Bearer sk_live_') ? authHeader.slice(7) : null);
     const { getServerSession } = await import('@/lib/db/server');
     const session = await getServerSession();
-    const token = session?.access_token ?? '';
+    const token = rawApiKey ?? session?.access_token ?? '';
 
     const reply = await fastapiCall<unknown>(
       'POST', `/api/v2/memos/${id}/replies`, token,


### PR DESCRIPTION
## Summary

`replies/route.ts` non-OSS 경로에서 `getServerSession()?.access_token`만 사용하여 API key 요청 시 빈 토큰 → FastAPI 401 반환.

Fix: `x-api-key` / `Authorization: Bearer sk_live_*` 헤더 감지 → rawApiKey 우선 사용, OAuth 세션 fallback.

`factory.ts` `getSpAt()` (PR #367) 과 동일 패턴.

🤖 Generated with [Claude Code](https://claude.com/claude-code)