### PR TITLE
fix: read_memo __dict__ 패턴 — ORM 속성명 불일치 해소

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -116,9 +116,8 @@ async def get_memo(
     reply_repo = MemoReplyRepository(db)
     replies = await reply_repo.list_by_memo(id)
     reply_items = [ReplyResponse.model_validate(r) for r in replies]
-    # column 속성만 추출하여 ORM relationship lazy-load 완전 우회
-    col_keys = [c.key for c in memo.__table__.columns]
-    memo_dict: dict = {k: getattr(memo, k) for k in col_keys}
+    # __dict__ 사용: 로드된 column 값만 포함, lazy-load 안 된 relationship 자동 제외
+    memo_dict: dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
     memo_dict["replies"] = reply_items
     memo_dict["reply_count"] = len(reply_items)
     return MemoResponse.model_validate(memo_dict)


### PR DESCRIPTION
## Summary
- `__table__.columns c.key` → `memo.__dict__` 패턴으로 교체
- `c.key`는 DB 컬럼명("metadata")을 반환하여 Python 속성명("memo_metadata")과 불일치 → Pydantic validation 실패
- `__dict__`는 로드된 Python 속성만 포함, lazy-load relationship 자동 제외

## Context
- PR #392 머지 후 동일 브랜치에 추가 수정 (commit 30b5c62)
- 까심군 QA APPROVE: codex session `019de93b-f31d-7313-bd61-a195212375cc`
- AC 전항목 PASS 확인

## Test plan
- [x] 까심군 codex QA PASS (session 019de93b)
- [x] `.venv/bin/python` 실제 실행 PASS
- [ ] 배포 후 read_memo MCP 실호출 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)