### PR TITLE
fix: analytics 7건 AnalyticsService(undefined) → proxyToFastapi 전환 (FC-S1)

### DIFF
--- a/apps/web/src/app/api/analytics/activity/route.ts
+++ b/apps/web/src/app/api/analytics/activity/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/activity?project_id=X&limit=N
 export async function GET(request: Request) {
@@ -9,15 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-    const limit = searchParams.get('limit');
-
-    const service = new AnalyticsService(undefined);
-    const data = await service.getRecentActivity(projectId, limit ? Number(limit) : undefined);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/activity');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/agent-stats/route.ts
+++ b/apps/web/src/app/api/analytics/agent-stats/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/agent-stats?project_id=X&agent_id=Y
 export async function GET(request: Request) {
@@ -9,18 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    const agentId = searchParams.get('agent_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-    if (!agentId) return ApiErrors.badRequest('agent_id required');
-
-    const service = new AnalyticsService(undefined);
-    const t0 = Date.now();
-    const data = await service.getAgentStats(projectId, agentId);
-    console.log(`[perf] GET /api/analytics/agent-stats agent=${agentId} ${Date.now() - t0}ms`);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/agent-stats');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/epic-progress/route.ts
+++ b/apps/web/src/app/api/analytics/epic-progress/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/epic-progress?project_id=X&epic_id=Y
 export async function GET(request: Request) {
@@ -9,16 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    const epicId = searchParams.get('epic_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-    if (!epicId) return ApiErrors.badRequest('epic_id required');
-
-    const service = new AnalyticsService(undefined);
-    const data = await service.getEpicProgress(projectId, epicId);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/epic-progress');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/health/route.ts
+++ b/apps/web/src/app/api/analytics/health/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/health?project_id=X
 export async function GET(request: Request) {
@@ -9,16 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const service = new AnalyticsService(undefined);
-    const t0 = Date.now();
-    const data = await service.getProjectHealth(projectId);
-    console.log(`[perf] GET /api/analytics/health project=${projectId} ${Date.now() - t0}ms`);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/health');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/overview/route.ts
+++ b/apps/web/src/app/api/analytics/overview/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/overview?project_id=X
 export async function GET(request: Request) {
@@ -9,16 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const service = new AnalyticsService(undefined);
-    const t0 = Date.now();
-    const data = await service.getOverview(projectId);
-    console.log(`[perf] GET /api/analytics/overview project=${projectId} ${Date.now() - t0}ms`);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/overview');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/velocity-history/route.ts
+++ b/apps/web/src/app/api/analytics/velocity-history/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/velocity-history?project_id=X
 export async function GET(request: Request) {
@@ -9,16 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const service = new AnalyticsService(undefined);
-    const t0 = Date.now();
-    const data = await service.getVelocityHistory(projectId);
-    console.log(`[perf] GET /api/analytics/velocity-history project=${projectId} ${Date.now() - t0}ms`);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/velocity-history');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/analytics/workload/route.ts
+++ b/apps/web/src/app/api/analytics/workload/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { AnalyticsService } from '@/services/analytics';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/analytics/workload?project_id=X&member_id=Y
 export async function GET(request: Request) {
@@ -9,16 +9,9 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    const memberId = searchParams.get('member_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-    if (!memberId) return ApiErrors.badRequest('member_id required');
-
-    const service = new AnalyticsService(undefined);
-    const data = await service.getMemberWorkload(projectId, memberId);
-    return apiSuccess(data);
+    const res = await proxyToFastapi(request, '/api/v2/analytics/workload');
+    if (!res.ok) return res;
+    return apiSuccess(await res.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }


### PR DESCRIPTION
## Summary
analytics/ 하위 7개 라우트에서 `AnalyticsService(undefined)` 호출 크래시 제거.

모두 FastAPI `/api/v2/analytics/*` 엔드포인트 존재 확인 후 `proxyToFastapi` + `apiSuccess()` 래핑으로 전환.

| 파일 | FastAPI 엔드포인트 |
|------|-------------------|
| `overview` | `/api/v2/analytics/overview` |
| `workload` | `/api/v2/analytics/workload` |
| `velocity-history` | `/api/v2/analytics/velocity-history` |
| `activity` | `/api/v2/analytics/activity` |
| `epic-progress` | `/api/v2/analytics/epic-progress` |
| `agent-stats` | `/api/v2/analytics/agent-stats` |
| `health` | `/api/v2/analytics/health` |

## Test plan
- [ ] 각 analytics 엔드포인트 정상 응답 확인 (200 + data)
- [ ] TS 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)