### PR TITLE
fix: proxyToFastapi apiSuccess() 래핑 통일 49건 (FC-S7)

### DIFF
--- a/apps/web/src/app/api/account/delete/route.ts
+++ b/apps/web/src/app/api/account/delete/route.ts
@@ -1,6 +1,10 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** POST — 계정 탈퇴 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/account/delete');
+  const _r = await proxyToFastapi(request, '/api/v2/account/delete');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/agent-runs/[id]/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -6,5 +7,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 // PATCH /api/agent-runs/[id]
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/agent-runs/route.ts
+++ b/apps/web/src/app/api/agent-runs/route.ts
@@ -1,12 +1,19 @@
+import { apiSuccess } from '@/lib/api-response';
 
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // POST /api/agent-runs
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-runs');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 // GET /api/agent-runs?project_id=X&limit=N
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-runs');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/api-keys/[id]/logs/route.ts
+++ b/apps/web/src/app/api/api-keys/[id]/logs/route.ts
@@ -8,5 +8,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function GET(request: Request, { params }: RouteParams) {
   if (isOssMode()) return apiSuccess([]);
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/api-keys/${id}/logs`);
+const _r = await proxyToFastapi(request, `/api/v2/api-keys/${id}/logs`);
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }

--- a/apps/web/src/app/api/api-keys/rotate/route.ts
+++ b/apps/web/src/app/api/api-keys/rotate/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /**
@@ -6,5 +7,8 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
  * Body: { api_key_id: string }
  */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/api-keys/rotate');
+  const _r = await proxyToFastapi(request, '/api/v2/api-keys/rotate');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/auth/2fa/disable/route.ts
+++ b/apps/web/src/app/api/auth/2fa/disable/route.ts
@@ -1,6 +1,10 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** POST /api/auth/2fa/disable — TOTP 비활성화 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/auth/2fa/disable');
+  const _r = await proxyToFastapi(request, '/api/v2/auth/2fa/disable');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/cron/agent-session-recovery/route.ts
+++ b/apps/web/src/app/api/cron/agent-session-recovery/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/cron/agent-session-recovery');
+  const _r = await proxyToFastapi(request, '/api/v2/cron/agent-session-recovery');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/cron/anonymize/route.ts
+++ b/apps/web/src/app/api/cron/anonymize/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/cron/anonymize');
+  const _r = await proxyToFastapi(request, '/api/v2/cron/anonymize');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/cron/hitl-timeouts/route.ts
+++ b/apps/web/src/app/api/cron/hitl-timeouts/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/cron/hitl-timeouts');
+  const _r = await proxyToFastapi(request, '/api/v2/cron/hitl-timeouts');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/cron/inbox-outbox/route.ts
+++ b/apps/web/src/app/api/cron/inbox-outbox/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/cron/inbox-outbox');
+  const _r = await proxyToFastapi(request, '/api/v2/cron/inbox-outbox');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/cron/retry-agent-runs/route.ts
+++ b/apps/web/src/app/api/cron/retry-agent-runs/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/cron/retry-agent-runs');
+  const _r = await proxyToFastapi(request, '/api/v2/cron/retry-agent-runs');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/dashboard/route.ts
+++ b/apps/web/src/app/api/dashboard/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
@@ -16,7 +16,10 @@ export async function GET(request: Request) {
       return apiSuccess({ my_stories: [], assigned_stories: [], my_tasks: [], open_memos: [] });
     }
 
-    return proxyToFastapi(request, '/api/v2/dashboard');
+const _r = await proxyToFastapi(request, '/api/v2/dashboard');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/integrations/mcp/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/mcp/github/callback/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/integrations/mcp/github/callback', { public: true });
+  const _r = await proxyToFastapi(request, '/api/v2/integrations/mcp/github/callback', { public: true });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/invitations/[id]/resend/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/resend/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,5 +6,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** POST /api/invitations/[id]/resend */
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/invitations/[id]/resend', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/invitations/[id]/resend', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/invitations/[id]/route.ts
+++ b/apps/web/src/app/api/invitations/[id]/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,5 +6,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** DELETE /api/invitations/[id] */
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/invitations/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/invitations/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/invitations/accept/route.ts
+++ b/apps/web/src/app/api/invitations/accept/route.ts
@@ -1,6 +1,10 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** POST — 초대 수락 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/invitations/accept');
+  const _r = await proxyToFastapi(request, '/api/v2/invitations/accept');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/invitations/route.ts
+++ b/apps/web/src/app/api/invitations/route.ts
@@ -1,11 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 초대 목록 */
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/invitations');
+  const _r = await proxyToFastapi(request, '/api/v2/invitations');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** POST — 초대 생성 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/invitations');
+  const _r = await proxyToFastapi(request, '/api/v2/invitations');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/mcp/mockups/route.ts
+++ b/apps/web/src/app/api/mcp/mockups/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/mcp/mockups');
+  const _r = await proxyToFastapi(request, '/api/v2/mcp/mockups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -39,7 +39,10 @@ export async function PATCH(request: Request) {
       const updated = await repo.update(OSS_MEMBER_ID, { name: name.trim() });
       return apiSuccess({ ...updated, email: null });
     }
-    return proxyToFastapi(request, '/api/v2/me');
+const _r = await proxyToFastapi(request, '/api/v2/me');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/memos/attachments/route.ts
+++ b/apps/web/src/app/api/memos/attachments/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/memos/attachments');
+  const _r = await proxyToFastapi(request, '/api/v2/memos/attachments');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/memos/convert/route.ts
+++ b/apps/web/src/app/api/memos/convert/route.ts
@@ -1,6 +1,10 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** POST — 메모를 스토리로 전환 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/memos/convert');
+  const _r = await proxyToFastapi(request, '/api/v2/memos/convert');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/mockups/[id]/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,17 +6,26 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** GET — 목업 상세 (컴포넌트 포함) */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** PUT — 목업 수정 (컴포넌트 트리 일괄 교체) */
 export async function PUT(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** DELETE — 목업 소프트 삭제 */
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/scenarios/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,23 +6,35 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** GET — 시나리오 목록 */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** POST — 시나리오 생성 */
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** PATCH — 시나리오 수정 */
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** DELETE — 시나리오 삭제 (default 불가) */
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/scenarios', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/mockups/[id]/versions/route.ts
+++ b/apps/web/src/app/api/mockups/[id]/versions/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,11 +6,17 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** GET — 버전 히스토리 */
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** POST — 버전 복원 */
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/mockups/[id]/versions', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/mockups/route.ts
+++ b/apps/web/src/app/api/mockups/route.ts
@@ -1,11 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 목업 목록 (페이지네이션) */
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/mockups');
+  const _r = await proxyToFastapi(request, '/api/v2/mockups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** POST — 목업 생성 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/mockups');
+  const _r = await proxyToFastapi(request, '/api/v2/mockups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/organizations/[id]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -5,5 +6,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 /** DELETE /api/organizations/[id] */
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/organizations/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/organizations/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/organizations/route.ts
+++ b/apps/web/src/app/api/organizations/route.ts
@@ -1,6 +1,10 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // POST /api/organizations
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/organizations');
+  const _r = await proxyToFastapi(request, '/api/v2/organizations');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/projects/[id]/ai-settings/route.ts
+++ b/apps/web/src/app/api/projects/[id]/ai-settings/route.ts
@@ -1,18 +1,28 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET — OSS 모드에서는 null 반환 */
 export async function GET(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/ai-settings');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/ai-settings');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** PUT */
 export async function PUT(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/ai-settings');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/ai-settings');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 /** DELETE */
 export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/ai-settings');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/ai-settings');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/projects/[id]/invitations/route.ts
+++ b/apps/web/src/app/api/projects/[id]/invitations/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** POST /api/projects/:id/invitations */
 export async function POST(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/invitations');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/invitations');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.ts
@@ -1,11 +1,18 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; serverKey: string }> };
 
 export async function PUT(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function DELETE(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+  const _r = await proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/projects/[id]/mcp-connections/route.ts
+++ b/apps/web/src/app/api/projects/[id]/mcp-connections/route.ts
@@ -14,5 +14,8 @@ export async function GET(_request: Request, { params }: RouteParams) {
 }
 
 export async function POST(request: Request, _ctx: RouteParams) {
-  return proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+const _r = await proxyToFastapi(request, '/api/v2/projects/mcp-connections');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -12,7 +12,10 @@ export async function GET(request: Request) {
       const project = await repo.getById(OSS_PROJECT_ID);
       return apiSuccess(project ? [{ id: project.id, name: project.name, description: null, org_id: OSS_ORG_ID }] : []);
     }
-    return proxyToFastapi(request, '/api/v2/projects');
+const _r = await proxyToFastapi(request, '/api/v2/projects');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -20,5 +23,8 @@ export async function GET(request: Request) {
 
 /** POST — 프로젝트 생성 */
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/projects');
+const _r = await proxyToFastapi(request, '/api/v2/projects');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -19,7 +19,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -45,7 +48,10 @@ export async function POST(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/export/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
@@ -13,7 +13,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id });
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/export', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
@@ -24,7 +24,10 @@ export async function POST(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items/[item_id]/vote', { id, item_id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items/[item_id]/vote', { id, item_id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     const e = err as Error & { code?: string };
     if (e.code === 'CONFLICT') return apiError('CONFLICT', e.message, 409);

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -16,7 +16,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -41,7 +44,10 @@ export async function POST(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -30,7 +30,10 @@ export async function GET(request: Request, { params }: RouteParams) {
       return apiSuccess({ session, items, actions });
     }
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -55,7 +58,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       return apiSuccess(data);
     }
 
-    return proxyToFastapiWithParams(request, '/api/v2/retros/[id]/phase', { id });
+const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/phase', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/retro-sessions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
@@ -20,7 +20,10 @@ export async function GET(request: Request) {
       return apiSuccess(await listOssRetroSessions(projectId));
     }
 
-    return proxyToFastapi(request, '/api/v2/retros');
+const _r = await proxyToFastapi(request, '/api/v2/retros');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -48,7 +51,10 @@ export async function POST(request: Request) {
       return apiSuccess(data, undefined, 201);
     }
 
-    return proxyToFastapi(request, '/api/v2/retros');
+const _r = await proxyToFastapi(request, '/api/v2/retros');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/rewards/leaderboard/route.ts
+++ b/apps/web/src/app/api/rewards/leaderboard/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -19,6 +19,9 @@ export async function GET(request: Request) {
       return ApiErrors.badRequest('period must be one of: daily, weekly, monthly, all');
     }
 
-    return proxyToFastapi(request, '/api/v2/rewards/leaderboard');
+    const _r = await proxyToFastapi(request, '/api/v2/rewards/leaderboard');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/rewards/route.ts
+++ b/apps/web/src/app/api/rewards/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -8,7 +8,10 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    return proxyToFastapi(request, '/api/v2/rewards');
+    const _r = await proxyToFastapi(request, '/api/v2/rewards');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -20,6 +23,9 @@ export async function POST(request: Request) {
     if (me.type === 'agent' && !me.scope?.includes('admin')) {
       return ApiErrors.insufficientScope('admin');
     }
-    return proxyToFastapi(request, '/api/v2/rewards');
+    const _r = await proxyToFastapi(request, '/api/v2/rewards');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/sprints/[id]/summary/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/summary/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -6,5 +7,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 // GET /api/sprints/:id/summary — story count+points by status
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/sprints/${id}/summary`);
+  const _r = await proxyToFastapi(request, `/api/v2/sprints/${id}/summary`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/sprints/[id]/velocity/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/velocity/route.ts
@@ -1,3 +1,4 @@
+import { apiSuccess } from '@/lib/api-response';
 
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -6,5 +7,8 @@ type RouteParams = { params: Promise<{ id: string }> };
 // GET /api/sprints/:id/velocity — sprint velocity + title + status
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/sprints/${id}/velocity`);
+  const _r = await proxyToFastapi(request, `/api/v2/sprints/${id}/velocity`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/standup/feedback/[id]/route.ts
+++ b/apps/web/src/app/api/standup/feedback/[id]/route.ts
@@ -25,7 +25,10 @@ export async function GET(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -44,7 +47,10 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -62,7 +68,10 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     }
 
     const { id } = await params;
-    return proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/feedback/route.ts
+++ b/apps/web/src/app/api/standup/feedback/route.ts
@@ -22,7 +22,10 @@ export async function GET(request: Request) {
       return apiSuccess(await listOssStandupFeedbackByDate(projectId, date));
     }
 
-    return proxyToFastapi(request, '/api/v2/standups/feedback');
+const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -50,7 +53,10 @@ export async function POST(request: Request) {
       return apiSuccess(feedback, undefined, 201);
     }
 
-    return proxyToFastapi(request, '/api/v2/standups/feedback');
+const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -23,7 +23,10 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupHistory(projectId, limit));
     }
 
-    return proxyToFastapi(request, '/api/v2/standups');
+const _r = await proxyToFastapi(request, '/api/v2/standups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -24,7 +24,10 @@ export async function GET(request: Request) {
       return apiSuccess(await getOssStandupMissing(projectId, date));
     }
 
-    return proxyToFastapi(request, '/api/v2/standups/missing');
+const _r = await proxyToFastapi(request, '/api/v2/standups/missing');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/standup/route.ts
+++ b/apps/web/src/app/api/standup/route.ts
@@ -27,7 +27,10 @@ export async function GET(request: Request) {
       return apiSuccess(await listOssStandupEntries(projectId, date));
     }
 
-    return proxyToFastapi(request, '/api/v2/standups');
+const _r = await proxyToFastapi(request, '/api/v2/standups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -70,7 +73,10 @@ export async function POST(request: Request) {
       return apiSuccess(entry);
     }
 
-    return proxyToFastapi(request, '/api/v2/standups');
+const _r = await proxyToFastapi(request, '/api/v2/standups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -108,7 +114,10 @@ export async function PUT(request: Request) {
       return apiSuccess(entry);
     }
 
-    return proxyToFastapi(request, '/api/v2/standups');
+const _r = await proxyToFastapi(request, '/api/v2/standups');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,13 +1,20 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -30,7 +30,12 @@ export async function POST(request: Request) {
     const parsed = await parseBody(request, createTeamMemberSchema);
     if (!parsed.success) return parsed.response;
     const body = parsed.data;
-    if (body.type !== 'agent') return proxyToFastapi(request, '/api/v2/team-members');
+    if (body.type !== 'agent') {
+      const _r = await proxyToFastapi(request, '/api/v2/team-members');
+      if (!_r.ok) return _r;
+      if (_r.status === 204) return apiSuccess({ ok: true });
+      return apiSuccess(await _r.json());
+    }
     if (!body.name) return ApiErrors.badRequest('name required for agent');
     if (isOssMode()) {
       const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-sqlite');
@@ -44,7 +49,10 @@ export async function POST(request: Request) {
       });
       return apiSuccess(member, undefined, 201);
     }
-    return proxyToFastapi(request, '/api/v2/team-members');
+const _r = await proxyToFastapi(request, '/api/v2/team-members');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json())
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/v1/agent-deployments/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/[id]/route.ts
@@ -1,18 +1,28 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-deployments/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-deployments/[id]/verification/route.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/[id]/verification/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-deployments/${id}/verification`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-deployments/${id}/verification`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-deployments/preflight/route.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/preflight/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-deployments/preflight');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-deployments/preflight');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-deployments/route.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/route.ts
@@ -1,9 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-deployments');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-deployments');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-deployments');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-deployments');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-personas/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-personas/[id]/route.ts
@@ -1,18 +1,28 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function GET(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-personas/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-personas/route.ts
+++ b/apps/web/src/app/api/v1/agent-personas/route.ts
@@ -1,9 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-personas');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-personas');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-routing-rules/route.ts
+++ b/apps/web/src/app/api/v1/agent-routing-rules/route.ts
@@ -1,21 +1,37 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-routing-rules');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-routing-rules');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-routing-rules');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-routing-rules');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PATCH(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-routing-rules');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-routing-rules');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PUT(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-routing-rules');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-routing-rules');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function DELETE(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-routing-rules');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-routing-rules');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-runs/[id]/retry/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/retry/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-runs/${id}/retry`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}/retry`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
@@ -17,11 +17,17 @@ export async function GET(request: Request, { params }: RouteParams) {
     } catch (error) { return handleApiError(error); }
   }
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   if (isOssMode()) return ApiErrors.badRequest('Not available in OSS mode');
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }

--- a/apps/web/src/app/api/v1/agent-runs/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.ts
@@ -26,10 +26,16 @@ export async function GET(request: Request) {
       return apiSuccess(enriched, { nextCursor: result.nextCursor, hasMore: result.hasMore, limit });
     } catch (error) { return handleApiError(error); }
   }
-  return proxyToFastapi(request, '/api/v2/agent-runs');
+const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }
 
 export async function POST(request: Request) {
   if (isOssMode()) return ApiErrors.badRequest('Not available in OSS mode');
-  return proxyToFastapi(request, '/api/v2/agent-runs');
+const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json())
 }

--- a/apps/web/src/app/api/v1/agent-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-sessions/[id]/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/agent-sessions/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/agent-sessions/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/agent-sessions/route.ts
+++ b/apps/web/src/app/api/v1/agent-sessions/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/agent-sessions');
+  const _r = await proxyToFastapi(request, '/api/v2/agent-sessions');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/hitl-policy/route.ts
+++ b/apps/web/src/app/api/v1/hitl-policy/route.ts
@@ -1,9 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/hitl/policy');
+  const _r = await proxyToFastapi(request, '/api/v2/hitl/policy');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function PATCH(request: Request) {
-  return proxyToFastapi(request, '/api/v2/hitl/policy');
+  const _r = await proxyToFastapi(request, '/api/v2/hitl/policy');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/hitl-requests/[id]/route.ts
+++ b/apps/web/src/app/api/v1/hitl-requests/[id]/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/hitl/requests/${id}`);
+  const _r = await proxyToFastapi(request, `/api/v2/hitl/requests/${id}`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/hitl-requests/route.ts
+++ b/apps/web/src/app/api/v1/hitl-requests/route.ts
@@ -1,5 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/hitl/requests');
+  const _r = await proxyToFastapi(request, '/api/v2/hitl/requests');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/workflow-versions/[id]/rollback/route.ts
+++ b/apps/web/src/app/api/v1/workflow-versions/[id]/rollback/route.ts
@@ -1,8 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function POST(request: Request, { params }: RouteParams) {
   const { id } = await params;
-  return proxyToFastapi(request, `/api/v2/workflow-versions/${id}/rollback`);
+  const _r = await proxyToFastapi(request, `/api/v2/workflow-versions/${id}/rollback`);
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/v1/workflow-versions/route.ts
+++ b/apps/web/src/app/api/v1/workflow-versions/route.ts
@@ -1,9 +1,16 @@
+import { apiSuccess } from '@/lib/api-response';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/workflow-versions');
+  const _r = await proxyToFastapi(request, '/api/v2/workflow-versions');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }
 
 export async function POST(request: Request) {
-  return proxyToFastapi(request, '/api/v2/workflow-versions');
+  const _r = await proxyToFastapi(request, '/api/v2/workflow-versions');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }

--- a/apps/web/src/app/api/webhooks/agent-runtime/route.ts
+++ b/apps/web/src/app/api/webhooks/agent-runtime/route.ts
@@ -1,8 +1,11 @@
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
-import { apiError } from '@/lib/api-response';
+import { apiSuccess, apiError } from '@/lib/api-response';
 import { isOssMode } from '@/lib/storage/factory';
 
 export async function POST(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
-  return proxyToFastapi(request, '/api/v2/webhooks/agent-runtime');
+  const _r = await proxyToFastapi(request, '/api/v2/webhooks/agent-runtime');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
 }


### PR DESCRIPTION
## Summary
`proxyToFastapi` / `proxyToFastapiWithParams` 사용 라우트 49건에서 FastAPI raw JSON을 클라이언트가 기대하는 `{data, error, meta}` 형식으로 통일.

**변환 패턴**:
```
// Before
return proxyToFastapi(request, '/api/v2/...');

// After
const _r = await proxyToFastapi(request, '/api/v2/...');
if (!_r.ok) return _r;
if (_r.status === 204) return apiSuccess({ ok: true });
return apiSuccess(await _r.json());
```

Python 스크립트로 49파일 일괄 처리. `apiSuccess` import 자동 추가.

## Test plan
- [ ] 주요 엔드포인트 200 응답 + `{data, ...}` 형식 확인
- [ ] DELETE 등 204 응답 케이스 `{data: {ok: true}}` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)