### PR TITLE
fix: 로그인 안정성 — 401만 redirect + fetchWithAuth 인터셉터 (FC-S8)

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -32,25 +32,29 @@ export default async function AuthenticatedLayout({
     );
   }
 
-  try {
-    const session = await getServerSession();
-    if (!session) redirect('/login');
+  const session = await getServerSession();
+  if (!session) redirect('/login');
 
-    const me = await fastapiCall<MemberContext | null>('GET', '/api/v2/me', session.access_token).catch(() => null);
-    if (!me) redirect('/login');
+  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+  const meRes = await fetch(`${fastapiUrl}/api/v2/me`, {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    cache: 'no-store',
+  }).catch(() => null);
 
-    return (
-      <DashboardShell
-        currentTeamMemberId={me.id}
-        orgId={me.org_id}
-        projectId={me.project_id}
-        projectName={me.project_name}
-        projectMemberships={[{ projectId: me.project_id, projectName: me.project_name }]}
-      >
-        {children}
-      </DashboardShell>
-    );
-  } catch {
-    redirect('/login');
-  }
+  // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
+  if (!meRes || meRes.status === 401) redirect('/login');
+
+  const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+
+  return (
+    <DashboardShell
+      currentTeamMemberId={me?.id}
+      orgId={me?.org_id}
+      projectId={me?.project_id}
+      projectName={me?.project_name ?? undefined}
+      projectMemberships={me ? [{ projectId: me.project_id, projectName: me.project_name }] : []}
+    >
+      {children}
+    </DashboardShell>
+  );
 }

--- a/apps/web/src/lib/db/client.ts
+++ b/apps/web/src/lib/db/client.ts
@@ -50,6 +50,32 @@ export async function refreshAuthTokens(): Promise<AuthResult> {
   return callAuthRoute('/api/auth/refresh', {});
 }
 
+// ─── 401 인터셉터 fetch 래퍼 ─────────────────────────────────────────────────
+
+let _refreshing: Promise<AuthResult> | null = null;
+
+export async function fetchWithAuth(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
+  const res = await fetch(input, init);
+  if (res.status !== 401) return res;
+
+  // 중복 refresh 방지: 동시 호출 시 하나만 실행
+  if (!_refreshing) {
+    _refreshing = refreshAuthTokens().finally(() => { _refreshing = null; });
+  }
+  try {
+    await _refreshing;
+  } catch {
+    if (typeof window !== 'undefined') window.location.href = '/login';
+    return res;
+  }
+
+  const retried = await fetch(input, init);
+  if (retried.status === 401 && typeof window !== 'undefined') {
+    window.location.href = '/login';
+  }
+  return retried;
+}
+
 // ─── Rate-limited fetch helper ────────────────────────────────────────────────
 
 const rateLimitBlockedUntil = new Map<string, number>();


### PR DESCRIPTION
## Summary

### 수정 1: `(authenticated)/layout.tsx` 에러 핸들링
- **Before**: `catch { redirect('/login') }` → 모든 에러(500 포함)에서 로그인 풀림
- **After**: `fastapiCall` → 직접 `fetch`로 교체. `meRes.status === 401`만 `/login` 리다이렉트. 500 등 다른 에러는 me=null로 처리, children 렌더링 유지

### 수정 2: `lib/db/client.ts` `fetchWithAuth` 401 인터셉터
```typescript
export async function fetchWithAuth(input, init?): Promise<Response>
```
- 401 응답 시 `refreshAuthTokens()` 자동 시도 (중복 refresh 방지)
- refresh 성공 → 원 요청 재시도
- refresh 실패 또는 재시도 401 → `window.location.href = '/login'`

## Test plan
- [ ] AC1: API 500 에러 발생 시 /login 리다이렉트 없이 화면 유지 확인
- [ ] AC2: 클라이언트 401 시 refresh 시도 확인
- [ ] AC3: refresh 실패 시만 /login 리다이렉트 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)