### PR TITLE
feat: FC-S4 stories comments/activities/backlog/bulk FastAPI 구현 + Next.js 전환

### DIFF
--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,10 +1,9 @@
-
-
-import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+import { StoryService } from '@/services/story';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,25 +13,26 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const url = new URL(request.url);
-    const limit = url.searchParams.get('limit');
-    const cursor = url.searchParams.get('cursor');
+    if (isOssMode()) {
+      const url = new URL(request.url);
+      const limit = url.searchParams.get('limit');
+      const cursor = url.searchParams.get('cursor');
+      const repo = await createStoryRepository();
+      const service = new StoryService(repo, undefined as any);
+      const activities = await service.getActivities(id, {
+        limit: limit ? parseInt(limit, 10) : 20,
+        cursor: cursor ?? undefined,
+      });
+      const hasMore = limit && activities.length > parseInt(limit, 10);
+      const data = hasMore ? activities.slice(0, -1) : activities;
+      const nextCursor = hasMore && data.length > 0 ? (data[data.length - 1] as { created_at?: string })?.created_at : null;
+      return apiSuccess(data, { nextCursor });
+    }
 
-    const repo = await createStoryRepository(dbClient);
-    const service = new StoryService(repo, dbClient as any | undefined);
-    const activities = await service.getActivities(id, {
-      limit: limit ? parseInt(limit, 10) : 20,
-      cursor: cursor ?? undefined,
-    });
-
-    const hasMore = limit && activities.length > parseInt(limit, 10);
-    const data = hasMore ? activities.slice(0, -1) : activities;
-    const nextCursor = hasMore && data.length > 0 ? (data[data.length - 1] as { created_at?: string })?.created_at : null;
-
-    return apiSuccess(data, { nextCursor });
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/activities', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,10 +1,9 @@
-
-
-import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+import { StoryService } from '@/services/story';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -14,25 +13,26 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const url = new URL(request.url);
-    const limit = url.searchParams.get('limit');
-    const cursor = url.searchParams.get('cursor');
+    if (isOssMode()) {
+      const url = new URL(request.url);
+      const limit = url.searchParams.get('limit');
+      const cursor = url.searchParams.get('cursor');
+      const repo = await createStoryRepository();
+      const service = new StoryService(repo, undefined as any);
+      const comments = await service.getComments(id, {
+        limit: limit ? parseInt(limit, 10) : 20,
+        cursor: cursor ?? undefined,
+      });
+      const hasMore = limit && comments.length > parseInt(limit, 10);
+      const data = hasMore ? comments.slice(0, -1) : comments;
+      const nextCursor = hasMore && data.length > 0 ? data[data.length - 1]?.created_at : null;
+      return apiSuccess(data, { nextCursor });
+    }
 
-    const repo = await createStoryRepository(dbClient);
-    const service = new StoryService(repo, dbClient as any | undefined);
-    const comments = await service.getComments(id, {
-      limit: limit ? parseInt(limit, 10) : 20,
-      cursor: cursor ?? undefined,
-    });
-
-    const hasMore = limit && comments.length > parseInt(limit, 10);
-    const data = hasMore ? comments.slice(0, -1) : comments;
-    const nextCursor = hasMore && data.length > 0 ? data[data.length - 1]?.created_at : null;
-
-    return apiSuccess(data, { nextCursor });
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/comments', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }
@@ -44,23 +44,20 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const body = await request.json();
-    if (!body.content || typeof body.content !== 'string') {
-      return ApiErrors.badRequest('content is required');
+    if (isOssMode()) {
+      const body = await request.json();
+      if (!body.content || typeof body.content !== 'string') return ApiErrors.badRequest('content is required');
+      const repo = await createStoryRepository();
+      const service = new StoryService(repo, undefined as any);
+      const comment = await service.addComment({ story_id: id, content: body.content, created_by: me.id });
+      return apiSuccess(comment, undefined, 201);
     }
 
-    const repo = await createStoryRepository(dbClient);
-    const service = new StoryService(repo, dbClient as any | undefined);
-    const comment = await service.addComment({
-      story_id: id,
-      content: body.content,
-      created_by: me.id,
-    });
-
-    return apiSuccess(comment, undefined, 201);
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/comments', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/stories/backlog/route.ts
+++ b/apps/web/src/app/api/stories/backlog/route.ts
@@ -1,27 +1,33 @@
-
-
-import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { StoryService } from '@/services/story';
 
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
+    if (isOssMode()) {
+      const { searchParams } = new URL(request.url);
+      const projectId = searchParams.get('project_id');
+      if (!projectId) return ApiErrors.badRequest('project_id required');
+      const repo = await createStoryRepository();
+      const service = new StoryService(repo, undefined as any);
+      const stories = await service.backlog(projectId);
+      return apiSuccess(stories);
+    }
 
-    const repo = await createStoryRepository(dbClient);
-    const service = new StoryService(repo, dbClient as any | undefined);
-    const stories = await service.backlog(projectId);
-    return apiSuccess(stories);
+    // FastAPI에서 status=backlog 필터로 처리
+    const url = new URL(request.url);
+    if (!url.searchParams.get('status')) url.searchParams.set('status', 'backlog');
+    const modified = new Request(url.toString(), request);
+    const _r = await proxyToFastapi(modified, '/api/v2/stories');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/stories/bulk/route.ts
+++ b/apps/web/src/app/api/stories/bulk/route.ts
@@ -1,11 +1,10 @@
-
 import { parseBody, bulkUpdateStorySchema } from '@sprintable/shared';
-
-import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { StoryService } from '@/services/story';
 
 // PATCH /api/stories/bulk — 벌크 수정 (칸반 드래그앤드롭용)
 export async function PATCH(request: Request) {
@@ -13,18 +12,24 @@ export async function PATCH(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const parsed = await parseBody(request, bulkUpdateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
-    if (!Array.isArray(body.items) || body.items.length === 0) {
-      return ApiErrors.badRequest('items array required');
+    if (isOssMode()) {
+      const parsed = await parseBody(request, bulkUpdateStorySchema);
+      if (!parsed.success) return parsed.response;
+      const body = parsed.data;
+      if (!Array.isArray(body.items) || body.items.length === 0) {
+        return ApiErrors.badRequest('items array required');
+      }
+      const repo = await createStoryRepository();
+      const service = new StoryService(repo, undefined as any, { isAdminContext: me.type === 'agent' });
+      const results = await service.bulkUpdate(body.items);
+      return apiSuccess(results);
     }
 
-    const repo = await createStoryRepository(dbClient);
-    const service = new StoryService(repo, dbClient as any | undefined, { isAdminContext: me.type === 'agent' });
-    const results = await service.bulkUpdate(body.items);
-    return apiSuccess(results);
+    const _r = await proxyToFastapi(request, '/api/v2/stories/bulk');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/backend/alembic/versions/0006_add_story_comments_activities.py
+++ b/backend/alembic/versions/0006_add_story_comments_activities.py
@@ -1,0 +1,58 @@
+"""add story_comments and story_activities tables
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-03
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "story_comments",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("story_id", UUID(as_uuid=True), sa.ForeignKey("stories.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("org_id", UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("content", sa.Text, nullable=False),
+        sa.Column("created_by", UUID(as_uuid=True), sa.ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_story_comments_story_id", "story_comments", ["story_id"])
+    op.create_index("ix_story_comments_org_id", "story_comments", ["org_id"])
+
+    op.create_table(
+        "story_activities",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("story_id", UUID(as_uuid=True), sa.ForeignKey("stories.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("org_id", UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("activity_type", sa.Text, nullable=False),
+        sa.Column("old_value", sa.Text, nullable=True),
+        sa.Column("new_value", sa.Text, nullable=True),
+        sa.Column("created_by", UUID(as_uuid=True), sa.ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_story_activities_story_id", "story_activities", ["story_id"])
+    op.create_index("ix_story_activities_org_id", "story_activities", ["org_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_story_activities_org_id", table_name="story_activities")
+    op.drop_index("ix_story_activities_story_id", table_name="story_activities")
+    op.drop_table("story_activities")
+    op.drop_index("ix_story_comments_org_id", table_name="story_comments")
+    op.drop_index("ix_story_comments_story_id", table_name="story_comments")
+    op.drop_table("story_comments")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date
 
-from sqlalchemy import BigInteger, Date, ForeignKey, Integer, String, Text
+from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -98,6 +98,46 @@ class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     story_points: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     story: Mapped[Story] = relationship("Story", back_populates="tasks")
+
+
+class StoryComment(Base, OrgScopedMixin):
+    __tablename__ = "story_comments"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[uuid.UUID] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class StoryActivity(Base, OrgScopedMixin):
+    __tablename__ = "story_activities"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    activity_type: Mapped[str] = mapped_column(Text, nullable=False)
+    old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    created_at: Mapped[uuid.UUID] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
 
 
 from app.models.project import Project  # noqa: E402, F401

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import date
+from datetime import date, datetime
 
 from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Text, func
 from sqlalchemy.dialects.postgresql import UUID
@@ -114,7 +114,7 @@ class StoryComment(Base, OrgScopedMixin):
     created_by: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
     )
-    created_at: Mapped[uuid.UUID] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
@@ -135,7 +135,7 @@ class StoryActivity(Base, OrgScopedMixin):
     created_by: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
     )
-    created_at: Mapped[uuid.UUID] = mapped_column(
+    created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,10 +1,14 @@
 import uuid
+from datetime import datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.pm import Story, StoryActivity, StoryComment
 from app.repositories.story import StoryRepository
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 
@@ -119,3 +123,120 @@ async def update_story_status(
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return StoryResponse.model_validate(story)
+
+
+# ─── Schemas ──────────────────────────────────────────────────────────────────
+
+class CommentResponse(BaseModel):
+    id: uuid.UUID
+    story_id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    content: str
+    created_by: uuid.UUID
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ActivityResponse(BaseModel):
+    id: uuid.UUID
+    story_id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    activity_type: str
+    old_value: str | None = None
+    new_value: str | None = None
+    created_by: uuid.UUID
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class BulkUpdateItem(BaseModel):
+    id: uuid.UUID
+    status: str | None = None
+    sprint_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    priority: str | None = None
+    position: int | None = None
+
+
+# ─── Comments ─────────────────────────────────────────────────────────────────
+
+@router.get("/{id}/comments", response_model=list[CommentResponse])
+async def list_comments(
+    id: uuid.UUID,
+    limit: int = Query(default=20, le=100),
+    cursor: str | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    _repo: StoryRepository = Depends(_get_repo),
+) -> list[CommentResponse]:
+    q = select(StoryComment).where(
+        StoryComment.story_id == id,
+        StoryComment.deleted_at.is_(None),
+    ).order_by(StoryComment.created_at.desc()).limit(limit)
+    result = await db.execute(q)
+    return [CommentResponse.model_validate(r) for r in result.scalars()]
+
+
+@router.post("/{id}/comments", response_model=CommentResponse, status_code=201)
+async def add_comment(
+    id: uuid.UUID,
+    content: str = Body(..., embed=True),
+    created_by: uuid.UUID = Body(..., embed=True),
+    db: AsyncSession = Depends(get_db),
+    repo: StoryRepository = Depends(_get_repo),
+) -> CommentResponse:
+    story = await repo.get(id)
+    if not story:
+        raise HTTPException(status_code=404, detail="Story not found")
+    comment = StoryComment(
+        story_id=id,
+        org_id=repo.org_id,
+        project_id=story.project_id,
+        content=content,
+        created_by=created_by,
+    )
+    db.add(comment)
+    await db.commit()
+    await db.refresh(comment)
+    return CommentResponse.model_validate(comment)
+
+
+# ─── Activities ───────────────────────────────────────────────────────────────
+
+@router.get("/{id}/activities", response_model=list[ActivityResponse])
+async def list_activities(
+    id: uuid.UUID,
+    limit: int = Query(default=20, le=100),
+    db: AsyncSession = Depends(get_db),
+    _repo: StoryRepository = Depends(_get_repo),
+) -> list[ActivityResponse]:
+    q = select(StoryActivity).where(
+        StoryActivity.story_id == id,
+    ).order_by(StoryActivity.created_at.desc()).limit(limit)
+    result = await db.execute(q)
+    return [ActivityResponse.model_validate(r) for r in result.scalars()]
+
+
+# ─── Bulk update ──────────────────────────────────────────────────────────────
+
+@router.patch("/bulk", response_model=list[StoryResponse])
+async def bulk_update_stories(
+    items: list[BulkUpdateItem],
+    db: AsyncSession = Depends(get_db),
+    repo: StoryRepository = Depends(_get_repo),
+) -> list[StoryResponse]:
+    results: list[StoryResponse] = []
+    for item in items:
+        q = await db.execute(select(Story).where(Story.id == item.id))
+        story = q.scalar_one_or_none()
+        if not story:
+            continue
+        update_data = item.model_dump(exclude={"id"}, exclude_none=True)
+        for k, v in update_data.items():
+            setattr(story, k, v)
+        results.append(StoryResponse.model_validate(story))
+    await db.commit()
+    return results

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -3,12 +3,13 @@ from datetime import datetime
 
 from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.pm import Story, StoryActivity, StoryComment
+from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 
@@ -174,23 +175,40 @@ async def list_comments(
 ) -> list[CommentResponse]:
     q = select(StoryComment).where(
         StoryComment.story_id == id,
-        StoryComment.deleted_at.is_(None),
     ).order_by(StoryComment.created_at.desc()).limit(limit)
     result = await db.execute(q)
     return [CommentResponse.model_validate(r) for r in result.scalars()]
+
+
+async def _resolve_team_member_id(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> uuid.UUID:
+    user_id = uuid.UUID(str(auth.user_id))
+    result = await db.execute(
+        select(TeamMember)
+        .where(
+            or_(TeamMember.user_id == user_id, TeamMember.id == user_id),
+            TeamMember.org_id == org_id,
+            TeamMember.is_active.is_(True),
+        )
+        .limit(1)
+    )
+    member = result.scalar_one_or_none()
+    if not member:
+        raise HTTPException(status_code=403, detail="Team member not found for current user")
+    return member.id
 
 
 @router.post("/{id}/comments", response_model=CommentResponse, status_code=201)
 async def add_comment(
     id: uuid.UUID,
     content: str = Body(..., embed=True),
-    created_by: uuid.UUID = Body(..., embed=True),
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
 ) -> CommentResponse:
     story = await repo.get(id)
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
+    created_by = await _resolve_team_member_id(auth, repo.org_id, db)
     comment = StoryComment(
         story_id=id,
         org_id=repo.org_id,


### PR DESCRIPTION
## Summary

### FastAPI 신규 구현
- `StoryComment` / `StoryActivity` SQLAlchemy 모델 추가 (`pm.py`)
- Alembic migration `0006`: `story_comments`, `story_activities` 테이블 생성
- `stories.py` 라우터 4개 엔드포인트 추가:
  - `GET/POST /api/v2/stories/{id}/comments`
  - `GET /api/v2/stories/{id}/activities`
  - `PATCH /api/v2/stories/bulk`
  - backlog는 기존 `GET /api/v2/stories?status=backlog` 필터 활용

### Next.js 전환
- `stories/[id]/comments/route.ts` — OSS: StoryService 유지, non-OSS: `proxyToFastapiWithParams`
- `stories/[id]/activities/route.ts` — 동일
- `stories/backlog/route.ts` — non-OSS: `?status=backlog` 쿼리로 FastAPI 전달
- `stories/bulk/route.ts` — non-OSS: `proxyToFastapi('/api/v2/stories/bulk')`

## Test plan
- [ ] 스토리 코멘트 추가/조회 정상 확인
- [ ] 스토리 활동 로그 조회 정상 확인
- [ ] 백로그 목록 조회 정상 확인
- [ ] 칸반 드래그앤드롭 벌크 업데이트 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)