### PR TITLE
feat: FC-S6 Sprints checkin FastAPI 구현 + 전환

### DIFF
--- a/apps/web/src/app/api/sprints/[id]/checkin/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.ts
@@ -1,10 +1,8 @@
-
-
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { SprintService, NotFoundError } from '@/services/sprint';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,19 +13,15 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
-    const dbClient = undefined;
 
-    const { searchParams } = new URL(request.url);
-    const date = searchParams.get('date');
-    if (!date) return ApiErrors.badRequest('date required');
+    if (isOssMode()) {
+      return apiSuccess({ total_stories: 0, total_points: 0, done_points: 0, completion_pct: 0, missing_standups: [] });
+    }
 
-    const repo = await createSprintRepository(dbClient);
-    const service = new SprintService(repo, dbClient as any | undefined);
-    const data = await service.checkin(id, date);
-    return apiSuccess(data);
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/sprints/[id]/checkin', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
-    if (err instanceof NotFoundError) return ApiErrors.notFound(err.message);
     return handleApiError(err);
   }
 }

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -1,10 +1,15 @@
 import uuid
+from datetime import date as date_type
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.pm import Story
+from app.models.standup import StandupEntry
+from app.models.team import TeamMember
 from app.repositories.sprint import SprintRepository
 from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate
 
@@ -127,3 +132,59 @@ async def kickoff_sprint(
         raise HTTPException(status_code=404, detail="Sprint not found")
     # Notification dispatch is Phase D — return stub for Phase B
     return {"notified": 0, "sprint_id": str(id), "message": body.message}
+
+
+@router.get("/{id}/checkin")
+async def checkin_sprint(
+    id: uuid.UUID,
+    date: str = Query(..., description="YYYY-MM-DD"),
+    db: AsyncSession = Depends(get_db),
+    repo: SprintRepository = Depends(_get_repo),
+) -> dict:
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
+    try:
+        checkin_date = date_type.fromisoformat(date)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid date format, expected YYYY-MM-DD") from exc
+
+    stories_result = await db.execute(
+        select(Story.status, Story.story_points).where(Story.sprint_id == id)
+    )
+    stories = stories_result.all()
+
+    members_result = await db.execute(
+        select(TeamMember.id, TeamMember.name).where(
+            TeamMember.project_id == sprint.project_id,
+            TeamMember.is_active.is_(True),
+        )
+    )
+    members = members_result.all()
+
+    standup_result = await db.execute(
+        select(StandupEntry.author_id).where(
+            StandupEntry.project_id == sprint.project_id,
+            StandupEntry.date == checkin_date,
+        )
+    )
+    standup_author_ids = {row.author_id for row in standup_result}
+
+    total_stories = len(stories)
+    total_points = sum(s.story_points or 0 for s in stories)
+    done_points = sum(s.story_points or 0 for s in stories if s.status == "done")
+    completion_pct = round((done_points / total_points) * 100) if total_points > 0 else 0
+    missing_standups = [
+        {"id": str(m.id), "name": m.name}
+        for m in members
+        if m.id not in standup_author_ids
+    ]
+
+    return {
+        "total_stories": total_stories,
+        "total_points": total_points,
+        "done_points": done_points,
+        "completion_pct": completion_pct,
+        "missing_standups": missing_standups,
+    }


### PR DESCRIPTION
## Summary

- **Backend**: `GET /api/v2/sprints/{id}/checkin?date=YYYY-MM-DD` 엔드포인트 신규 구현
- **Frontend**: `sprints/[id]/checkin/route.ts` SprintService → proxyToFastapiWithParams 전환

## AC 검증

1. ✅ FastAPI `GET /api/v2/sprints/{id}/checkin?date=` 구현 (backend/app/routers/sprints.py)
2. ✅ SprintService 직접 사용 0건 (checkin/route.ts)
3. ✅ apiSuccess() 래핑 포함
4. ✅ pnpm build 성공

## 구현 노트

- Sprint → project_id 조회 후 stories/team_members/standup_entries 3-way 집계
- `missing_standups`: team_members - standup_entries.author_ids (당일 날짜 기준)
- OSS mode: `{ total_stories: 0, ... missing_standups: [] }` 빈 응답 반환

## Test plan

- [ ] `GET /api/v2/sprints/{id}/checkin?date=2026-05-03` — 정상 집계 확인
- [ ] date 누락 시 422 반환 확인
- [ ] 잘못된 date 포맷 시 400 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)