### PR TITLE
feat: FC-S3 Meetings FastAPI 구현 + 전환 (에픽 마지막)

### DIFF
--- a/apps/web/src/app/api/meetings/[id]/recording/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/recording/route.ts
@@ -1,60 +1,22 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { checkFeatureLimit } from '@/lib/check-feature';
-import { uploadToGcs, GCS_RECORDINGS_BUCKET } from '@/lib/gcs';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
-const ALLOWED_MIME_TYPES = new Set([
-  'audio/webm',
-  'audio/wav',
-  'audio/mp4',
-  'audio/mpeg',
-  'audio/ogg',
-]);
-
-/** POST — 녹음 파일 업로드 (multipart/form-data). STT 사용량은 /transcribe에서만 적재. */
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    // AC9: Feature gating — 녹음 기능 티어 검증
-    const featureCheck = await checkFeatureLimit(dbClient, me.org_id, 'stt_recording');
-    if (!featureCheck.allowed) {
-      return ApiErrors.forbidden(featureCheck.reason ?? 'Recording not available on your plan');
-    }
+    if (isOssMode()) return ApiErrors.badRequest('Recording not supported in OSS mode');
 
-    const formData = await request.formData();
-    const file = formData.get('audio') as File | null;
-    if (!file) return ApiErrors.badRequest('audio file required');
-
-    // AC8: 파일 크기 검증
-    if (file.size > MAX_FILE_SIZE) {
-      return ApiErrors.badRequest(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB.`);
-    }
-
-    // AC8: MIME 타입 검증
-    if (!ALLOWED_MIME_TYPES.has(file.type)) {
-      return ApiErrors.badRequest(
-        `Unsupported audio format: ${file.type}. Supported: ${[...ALLOWED_MIME_TYPES].join(', ')}`,
-      );
-    }
-
-    const ext = file.type.includes('webm') ? 'webm'
-      : file.type.includes('wav') ? 'wav'
-      : file.type.includes('mp4') ? 'mp4'
-      : file.type.includes('mpeg') ? 'mp3'
-      : 'ogg';
-    const path = `meetings/${id}/${Date.now()}.${ext}`;
-
-    const publicUrl = await uploadToGcs(GCS_RECORDINGS_BUCKET, path, file);
-
-    return apiSuccess({ path, publicUrl });
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/recording', { id });
+    if (!_r.ok) return _r;
+    return _r;
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/meetings/[id]/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/route.ts
@@ -1,8 +1,8 @@
-import { parseBody, updateMeetingSchema } from '@sprintable/shared';
-import { MeetingService } from '@/services/meeting';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -13,11 +13,12 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const service = new MeetingService(dbClient);
-    const meeting = await service.getById(id);
-    return apiSuccess(meeting);
+    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -28,28 +29,27 @@ export async function PUT(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const parsed = await parseBody(request, updateMeetingSchema);
-    if (!parsed.success) return parsed.response;
+    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
 
-    const service = new MeetingService(dbClient);
-    const meeting = await service.update(id, parsed.data);
-    return apiSuccess(meeting);
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
-/** DELETE — 회의록 삭제 (soft) */
+/** DELETE — 회의록 삭제 */
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const service = new MeetingService(dbClient);
-    await service.delete(id);
-    return apiSuccess({ ok: true });
+    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/meetings/[id]/summarize/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summarize/route.ts
@@ -1,142 +1,22 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiUpgradeRequired, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { checkUsage, incrementUsage, getThresholdAlert } from '@/lib/usage-check';
-import { NotificationService } from '@/services/notification.service';
-import {
-  createLLMClient,
-  LLMAuthError,
-  LLMTimeoutError,
-  LLMTokenLimitError,
-  resolveLLMConfig,
-  type LLMProvider,
-} from '@/lib/llm';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-const SYSTEM_PROMPT = `You are a meeting note structurer. Given a raw meeting transcript, extract:
-1. A concise summary (2-4 paragraphs)
-2. Key decisions made (with owner if mentioned)
-3. Action items (with assignee and due date if mentioned)
-
-Respond in valid JSON:
-{
-  "summary": "...",
-  "decisions": [{"id": "d1", "text": "...", "owner": "..."}],
-  "action_items": [{"id": "a1", "text": "...", "assignee": "...", "due_date": "...", "status": "todo"}]
-}
-
-Use the same language as the transcript. Be concise and accurate.`;
-
-/**
- * POST /api/meetings/:id/summarize
- *
- * 기존 직접 OpenAI/Anthropic 호출을 LLM 추상화 레이어로 교체.
- * 응답 형식은 기존 프론트 훅과 호환되도록 SSE 유지.
- */
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const usageCheck = await checkUsage(dbClient, me.org_id, 'ai_calls');
-    if (!usageCheck.allowed) {
-      return apiUpgradeRequired(
-        `AI calls limit reached (${usageCheck.currentValue}/${usageCheck.limitValue})`,
-        'ai_calls',
-      );
-    }
+    if (isOssMode()) return ApiErrors.badRequest('AI summarization not supported in OSS mode');
 
-    const body = await request.json().catch(() => ({})) as {
-      provider?: LLMProvider;
-      apiKey?: string;
-      model?: string;
-      baseUrl?: string;
-      timeoutMs?: number;
-      maxRetries?: number;
-      projectId?: string;
-      rawTranscript?: string;
-    };
-
-    const projectId = body.projectId ?? me.project_id;
-    const rawTranscript = body.rawTranscript;
-    if (!rawTranscript) return ApiErrors.badRequest('NO_TRANSCRIPT');
-
-    const llmConfig = await resolveLLMConfig(projectId, body);
-    if (!llmConfig) return ApiErrors.badRequest('NO_API_KEY');
-
-    const llm = createLLMClient(llmConfig);
-
-    const encoder = new TextEncoder();
-    const stream = new ReadableStream({
-      async start(controller) {
-        try {
-          const response = await llm.generate([
-            { role: 'system', content: SYSTEM_PROMPT },
-            { role: 'user', content: `Meeting transcript:\n\n${rawTranscript}` },
-          ], { responseFormat: 'json_object' });
-
-          if (response.text) {
-            controller.enqueue(encoder.encode(`data: ${JSON.stringify({ text: response.text })}\n\n`));
-          }
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ usage: response.usage })}\n\n`));
-
-          let parsed: { summary?: string; decisions?: unknown[]; action_items?: unknown[] } = {};
-          try {
-            parsed = JSON.parse(response.text);
-          } catch {
-            parsed = { summary: response.text, decisions: [], action_items: [] };
-          }
-
-          await incrementUsage(dbClient, me.org_id, 'ai_calls');
-          const postUsage = await checkUsage(dbClient, me.org_id, 'ai_calls');
-          const alert = getThresholdAlert(postUsage.percentage);
-          if (alert) {
-            new NotificationService(dbClient).create({
-              org_id: me.org_id,
-              user_id: me.id,
-              type: 'warning',
-              title: alert === 'limit_reached' ? 'AI calls limit reached' : `AI calls at ${postUsage.percentage}%`,
-              body: `${postUsage.currentValue}/${postUsage.limitValue} used`,
-              reference_type: 'usage',
-            }).catch(() => {});
-          }
-
-          controller.enqueue(encoder.encode(
-            `data: ${JSON.stringify({
-              done: true,
-              meetingId: id,
-              summary: parsed.summary ?? response.text,
-              decisions: parsed.decisions ?? [],
-              action_items: parsed.action_items ?? [],
-            })}\n\n`,
-          ));
-        } catch (error) {
-          let message = 'AI structuring failed';
-          if (error instanceof LLMAuthError) message = 'LLMAuthError';
-          else if (error instanceof LLMTimeoutError) message = 'LLMTimeoutError';
-          else if (error instanceof LLMTokenLimitError) message = 'LLMTokenLimitError';
-          else if (error instanceof Error) message = error.message;
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify({ error: message })}\n\n`));
-        } finally {
-          controller.close();
-        }
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
-      },
-    });
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+    return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summarize', { id });
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/meetings/[id]/summary/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summary/route.ts
@@ -1,75 +1,24 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { checkUsage, incrementUsage } from '@/lib/usage-check';
-import { createLLMClient, resolveLLMConfig, type LLMProvider } from '@/lib/llm';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-const SYSTEM_PROMPT = `You are a meeting note structurer. Given a raw meeting transcript, extract:
-1. A concise summary (2-4 paragraphs)
-2. Key decisions made (with owner if mentioned)
-3. Action items (with assignee and due date if mentioned)
-
-Respond in valid JSON:
-{
-  "summary": "...",
-  "decisions": [{"id": "d1", "text": "...", "owner": "..."}],
-  "action_items": [{"id": "a1", "text": "...", "assignee": "...", "due_date": "...", "status": "todo"}]
-}
-
-Use the same language as the transcript. Be concise and accurate.`;
-
-// POST /api/meetings/:id/summary — JSON response (agent-facing, non-SSE)
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const usageCheck = await checkUsage(dbClient, me.org_id, 'ai_calls');
-    if (!usageCheck.allowed) return ApiErrors.badRequest(`AI calls limit reached (${usageCheck.currentValue}/${usageCheck.limitValue})`);
+    if (isOssMode()) return ApiErrors.badRequest('AI summary not supported in OSS mode');
 
-    const body = await request.json().catch(() => ({})) as {
-      provider?: LLMProvider;
-      apiKey?: string;
-      model?: string;
-      baseUrl?: string;
-      timeoutMs?: number;
-      maxRetries?: number;
-      projectId?: string;
-      rawTranscript?: string;
-    };
-
-    const projectId = body.projectId ?? me.project_id;
-    const rawTranscript = body.rawTranscript;
-    if (!rawTranscript) return ApiErrors.badRequest('No transcript available');
-
-    const llmConfig = await resolveLLMConfig(projectId, body);
-    if (!llmConfig) return ApiErrors.badRequest('No AI API key configured');
-
-    const llm = createLLMClient(llmConfig);
-    const response = await llm.generate([
-      { role: 'system', content: SYSTEM_PROMPT },
-      { role: 'user', content: `Meeting transcript:\n\n${rawTranscript}` },
-    ], { responseFormat: 'json_object' });
-
-    let parsed: { summary?: string; decisions?: unknown[]; action_items?: unknown[] } = {};
-    try { parsed = JSON.parse(response.text); } catch { parsed = { summary: response.text, decisions: [], action_items: [] }; }
-
-    await incrementUsage(dbClient, me.org_id, 'ai_calls');
-
-    return apiSuccess({
-      meeting_id: id,
-      summary: parsed.summary ?? response.text,
-      decisions: parsed.decisions ?? [],
-      action_items: parsed.action_items ?? [],
-    });
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summary', { id });
+    if (!_r.ok) return _r;
+    return _r;
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
@@ -1,108 +1,22 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiUpgradeRequired, ApiErrors } from '@/lib/api-response';
+import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { checkFeatureLimit } from '@/lib/check-feature';
-import { checkUsage, incrementUsage, getThresholdAlert } from '@/lib/usage-check';
-import { NotificationService } from '@/services/notification.service';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-const MAX_FILE_SIZE = 50 * 1024 * 1024;
-const ALLOWED_MIME_TYPES = new Set(['audio/webm', 'audio/wav', 'audio/mp4', 'audio/mpeg', 'audio/ogg']);
-
-/**
- * POST /api/meetings/:id/transcribe
- *
- * AC4+AC6: 서버 사이드 STT — 업로드 파일을 Whisper API로 전사
- * Web Speech API는 마이크 전용이므로, 파일 업로드 STT는 서버 경유 필수
- *
- * env: OPENAI_API_KEY (서버 관리형) 또는 request body의 apiKey (BYOM)
- */
 export async function POST(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    // AC2+AC3: usage meter 체크 (통합 게이팅+쿼오타 체크)
-    const usageCheck = await checkUsage(dbClient, me.org_id, 'stt_minutes');
-    if (!usageCheck.allowed) {
-      return apiUpgradeRequired(
-        `STT limit reached (${usageCheck.currentValue}/${usageCheck.limitValue} min)`,
-        'stt_minutes',
-      );
-    }
+    if (isOssMode()) return ApiErrors.badRequest('Transcription not supported in OSS mode');
 
-    // AC9: STT minute quota — checkFeatureLimit 경유 (SaaS overlay에서 org_subscriptions 기반 검증)
-    const quotaCheck = await checkFeatureLimit(dbClient, me.org_id, 'max_stt_minutes');
-    if (!quotaCheck.allowed) {
-      return apiUpgradeRequired(`Monthly STT limit reached`, 'stt_minutes');
-    }
-
-    const formData = await request.formData();
-    const file = formData.get('audio') as File | null;
-    if (!file) return ApiErrors.badRequest('audio file required');
-
-    if (file.size > MAX_FILE_SIZE) {
-      return ApiErrors.badRequest(`File too large. Maximum size is ${MAX_FILE_SIZE / 1024 / 1024}MB.`);
-    }
-    if (!ALLOWED_MIME_TYPES.has(file.type)) {
-      return ApiErrors.badRequest(`Unsupported format: ${file.type}`);
-    }
-
-    // BYOM: 클라이언트가 API key를 보내면 사용, 아니면 서버 env
-    const byomKey = formData.get('apiKey') as string | null;
-    const apiKey = byomKey || process.env.OPENAI_API_KEY;
-    if (!apiKey) {
-      return ApiErrors.badRequest('No STT API key configured. Set OPENAI_API_KEY or provide apiKey.');
-    }
-
-    // Whisper API 호출
-    const whisperForm = new FormData();
-    whisperForm.append('file', file, 'recording.webm');
-    whisperForm.append('model', 'whisper-1');
-    const lang = (formData.get('language') as string | null) ?? 'ko';
-    whisperForm.append('language', lang.split('-')[0]);
-
-    const whisperRes = await fetch('https://api.openai.com/v1/audio/transcriptions', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${apiKey}` },
-      body: whisperForm,
-    });
-
-    if (!whisperRes.ok) {
-      const errBody = await whisperRes.json().catch(() => ({}));
-      const msg = (errBody as { error?: { message?: string } })?.error?.message ?? `Whisper API error: ${whisperRes.status}`;
-      return ApiErrors.badRequest(msg);
-    }
-
-    const result = (await whisperRes.json()) as { text: string; duration?: number };
-
-    const durationSec = result.duration ? Math.ceil(result.duration) : Math.max(60, Math.ceil(file.size / (1024 * 1024)) * 60);
-
-    // AC2: usage meter 증가 + AC6: threshold 알림
-    await incrementUsage(dbClient, me.org_id, 'stt_minutes', Math.ceil(durationSec / 60));
-    const postUsage = await checkUsage(dbClient, me.org_id, 'stt_minutes');
-    const alert = getThresholdAlert(postUsage.percentage);
-    if (alert) {
-      new NotificationService(dbClient).create({
-        org_id: me.org_id,
-        user_id: me.id,
-        type: 'warning',
-        title: alert === 'limit_reached' ? 'STT limit reached' : `STT usage at ${postUsage.percentage}%`,
-        body: `${postUsage.currentValue}/${postUsage.limitValue} min used`,
-        reference_type: 'usage',
-      }).catch(() => {});
-    }
-
-    return apiSuccess({
-      meetingId: id,
-      text: result.text,
-      duration_sec: durationSec,
-    });
+    return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/transcribe', { id });
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/meetings/route.ts
+++ b/apps/web/src/app/api/meetings/route.ts
@@ -1,8 +1,8 @@
-import { parseBody, createMeetingSchema } from '@sprintable/shared';
-import { MeetingService } from '@/services/meeting';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
+import { isOssMode } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { checkResourceLimit } from '@/lib/check-feature';
 
 /** GET — 회의록 목록 */
@@ -11,15 +11,12 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    const { searchParams } = new URL(request.url);
-    const page = Number(searchParams.get('page') ?? '1');
-    const limit = Number(searchParams.get('limit') ?? '20');
+    if (isOssMode()) return apiSuccess([]);
 
-    const service = new MeetingService(dbClient);
-    const result = await service.list(me.project_id, page, limit);
-    return apiSuccess(result.items, { total: result.total, page, limit });
+    const _r = await proxyToFastapi(request, '/api/v2/meetings');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -29,21 +26,15 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const dbClient = undefined;
 
-    // AC8: Feature gating
-    const check = await checkResourceLimit(dbClient, me.org_id, 'max_meetings', 'meetings');
+    if (isOssMode()) return ApiErrors.badRequest('Meetings not supported in OSS mode');
+
+    // AC8: Feature gating (SaaS only)
+    const check = await checkResourceLimit(undefined, me.org_id, 'max_meetings', 'meetings');
     if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Meeting limit reached', 403);
 
-    const parsed = await parseBody(request, createMeetingSchema);
-    if (!parsed.success) return parsed.response;
-
-    const service = new MeetingService(dbClient);
-    const meeting = await service.create({
-      project_id: me.project_id,
-      ...parsed.data,
-      created_by: me.id,
-    });
-    return apiSuccess(meeting, undefined, 201);
+    const _r = await proxyToFastapi(request, '/api/v2/meetings');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json(), undefined, 201);
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
@@ -12,11 +12,17 @@ router = APIRouter(prefix="/api/v2/meetings", tags=["meetings"])
 
 
 def _get_repo(
-    project_id: uuid.UUID = Query(...),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    project_id_q: uuid.UUID | None = Query(default=None, alias="project_id"),
 ) -> MeetingRepository:
-    return MeetingRepository(session, project_id)
+    pid = (str(project_id_q) if project_id_q else None) or auth.claims.get("app_metadata", {}).get("project_id")
+    if not pid:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="project_id required (query param or JWT app_metadata)",
+        )
+    return MeetingRepository(session, uuid.UUID(str(pid)))
 
 
 @router.get("", response_model=list[MeetingResponse])
@@ -46,11 +52,8 @@ async def create_meeting(
 @router.get("/{id}", response_model=MeetingResponse)
 async def get_meeting(
     id: uuid.UUID,
-    project_id: uuid.UUID = Query(...),
-    session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    repo: MeetingRepository = Depends(_get_repo),
 ) -> MeetingResponse:
-    repo = MeetingRepository(session, project_id)
     meeting = await repo.get(id)
     if meeting is None:
         raise HTTPException(status_code=404, detail="Meeting not found")
@@ -61,11 +64,21 @@ async def get_meeting(
 async def update_meeting(
     id: uuid.UUID,
     body: MeetingUpdate,
-    project_id: uuid.UUID = Query(...),
-    session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    repo: MeetingRepository = Depends(_get_repo),
 ) -> MeetingResponse:
-    repo = MeetingRepository(session, project_id)
+    data = body.model_dump(exclude_unset=True)
+    meeting = await repo.update(id, **data)
+    if meeting is None:
+        raise HTTPException(status_code=404, detail="Meeting not found")
+    return MeetingResponse.model_validate(meeting)
+
+
+@router.put("/{id}", response_model=MeetingResponse)
+async def put_meeting(
+    id: uuid.UUID,
+    body: MeetingUpdate,
+    repo: MeetingRepository = Depends(_get_repo),
+) -> MeetingResponse:
     data = body.model_dump(exclude_unset=True)
     meeting = await repo.update(id, **data)
     if meeting is None:
@@ -76,12 +89,43 @@ async def update_meeting(
 @router.delete("/{id}", status_code=200)
 async def delete_meeting(
     id: uuid.UUID,
-    project_id: uuid.UUID = Query(...),
-    session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    repo: MeetingRepository = Depends(_get_repo),
 ) -> dict:
-    repo = MeetingRepository(session, project_id)
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Meeting not found")
     return {"ok": True}
+
+
+# ─── AI / Storage 스텁 (EE 기능, 후속 에픽에서 구현) ──────────────────────────
+
+@router.post("/{id}/recording", status_code=501)
+async def upload_recording(
+    id: uuid.UUID,
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    raise HTTPException(status_code=501, detail="Recording upload not yet implemented in this environment")
+
+
+@router.post("/{id}/transcribe", status_code=501)
+async def transcribe_meeting(
+    id: uuid.UUID,
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    raise HTTPException(status_code=501, detail="Transcription not yet implemented in this environment")
+
+
+@router.post("/{id}/summarize", status_code=501)
+async def summarize_meeting(
+    id: uuid.UUID,
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    raise HTTPException(status_code=501, detail="AI summarization not yet implemented in this environment")
+
+
+@router.post("/{id}/summary", status_code=501)
+async def create_summary(
+    id: uuid.UUID,
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    raise HTTPException(status_code=501, detail="AI summary not yet implemented in this environment")


### PR DESCRIPTION
## Summary

- **Backend**: meetings.py `_get_repo` JWT fallback 방식으로 수정 + `PUT /{id}` alias 추가 + AI/Storage 스텁 4개 (501)
- **Frontend**: 6파일 전량 MeetingService 제거 → proxyToFastapi/proxyToFastapiWithParams 전환

## AC 검증

1. ✅ meetings/route.ts + [id]/route.ts MeetingService 제거, proxyToFastapi 전환
2. ✅ recording/summarize/summary/transcribe isOssMode() 분기 + non-OSS proxyToFastapiWithParams
3. ✅ MeetingService 호출처 0건 (`grep` 확인)
4. ✅ pnpm build 성공 (122 pages, 에러 0건)

## 구현 노트

- meetings.py `_get_repo`: `project_id` Query param Optional → JWT `app_metadata.project_id` 우선 fallback
- `PUT /{id}` FastAPI 엔드포인트 추가: 기존 프론트 `PUT` method 호환
- recording/summarize/summary/transcribe: OSS 미지원(badRequest), non-OSS FastAPI 스텁(501) — AI/Storage는 EE 기능, 후속 에픽에서 구현

## Test plan

- [ ] `GET /api/v2/meetings?project_id=` 목록 조회
- [ ] `POST /api/v2/meetings` 생성
- [ ] `GET /api/v2/meetings/{id}` 상세
- [ ] `PUT /api/v2/meetings/{id}` 수정
- [ ] `DELETE /api/v2/meetings/{id}` 삭제
- [ ] recording/summarize/summary/transcribe → 501 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)