### PR TITLE
fix: P0 GET /api/v2/standups/feedback 엔드포인트 추가

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -2,10 +2,12 @@ import uuid
 from datetime import date
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.standup import StandupEntry, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
 from app.schemas.standup import (
     FeedbackCreate,
@@ -79,6 +81,32 @@ async def get_missing_standups(
     repo: StandupEntryRepository = Depends(_get_repo),
 ) -> list[uuid.UUID]:
     return await repo.get_missing(project_id, date_filter)
+
+
+@router.get("/feedback", response_model=list[FeedbackResponse])
+async def list_feedback(
+    project_id: uuid.UUID = Query(...),
+    date_filter: date = Query(..., alias="date"),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> list[FeedbackResponse]:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    org_id = uuid.UUID(str(org_id_str))
+
+    q = (
+        select(StandupFeedback)
+        .join(StandupEntry, StandupFeedback.standup_entry_id == StandupEntry.id)
+        .where(
+            StandupFeedback.project_id == project_id,
+            StandupFeedback.org_id == org_id,
+            StandupEntry.date == date_filter,
+        )
+    )
+    result = await db.execute(q)
+    return [FeedbackResponse.model_validate(f) for f in result.scalars()]
 
 
 @router.get("/{id}", response_model=StandupEntryResponse)


### PR DESCRIPTION
## 문제

`GET /api/v2/standups/feedback` 호출 시 `/{id}` 패턴에 매칭 → `id="feedback"` UUID 검증 실패 → 422 → 스탠드업 페이지 전체 에러.

## 수정

- `GET /feedback`을 `GET /{id}` **앞에** 등록 (라우트 순서 충돌 방지)
- `StandupEntry` JOIN으로 `date` 필터링 (`StandupFeedback`에 `date` 컬럼 없음)
- Query params: `project_id` (UUID, required), `date` (YYYY-MM-DD, required)
- org_id JWT `app_metadata` / `X-Org-Id` 헤더 스코핑 적용

## Test plan

- [ ] `GET /api/v2/standups/feedback?project_id=X&date=2026-05-03` → 200 + list 반환
- [ ] date 누락 시 422
- [ ] 스탠드업 페이지 정상 로드 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)