### PR TITLE
fix: MemoThread memberMap 타입 불일치 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memos-feed-client.tsx
@@ -93,6 +93,11 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
     [members],
   );
 
+  const memberInfoMap = useMemo(
+    () => Object.fromEntries(members.map((m) => [m.id, { name: m.name, type: m.type }])),
+    [members],
+  );
+
   const humanMembers = useMemo(() => members.filter((m) => m.type !== 'agent'), [members]);
   const agentMembers = useMemo(() => members.filter((m) => m.type === 'agent'), [members]);
 
@@ -398,7 +403,7 @@ export function MemosFeedClient({ currentTeamMemberId, projectId }: MemosFeedCli
       currentUserId={currentTeamMemberId}
       onReply={handleReply}
       onResolve={handleResolve}
-      memberMap={memberMap}
+      memberMap={memberInfoMap}
     />
   ) : (
     <div className="flex h-full items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- `memberMap`이 `Record<string, string>`으로 생성돼 `MemoThread`(`Record<string, MemberInfo>`) 전달 시 TypeScript 빌드 에러 발생
- `memberInfoMap`(`{ name, type }`) 을 별도 생성하여 `MemoThread`에 전달
- `MemoFeed`는 기존 `memberMap`(`string`) 그대로 유지

## Test plan
- [ ] Cloud Build 통과 확인
- [ ] memos 페이지 로드 및 thread 렌더링 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)