### PR TITLE
fix(auth): P0 Google OAuth bracket notation 수정

### DIFF
--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { resolveAppUrl } from '@/services/app-url';
 
-const FASTAPI_BASE = process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000';
+const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);


### PR DESCRIPTION
## 문제

`auth/login/route.ts`에서 dot notation(`process.env.NEXT_PUBLIC_FASTAPI_URL`) 사용 시 webpack이 **빌드타임에 DEV URL을 인라인**하여 PROD 배포에서도 DEV 백엔드(`localhost:8000`)를 호출하는 P0 버그.

DEV 백엔드에는 OAuth v2 라우트 없음 → 404 → `oauth_init_failed` → Google 로그인 불가.

## 수정

```diff
- const FASTAPI_BASE = process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000';
+ const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
```

bracket notation은 webpack 정적 분석 대상에서 제외 → 런타임에 PROD URL 정상 읽음. (`fastapi-proxy.ts`가 이미 동일 패턴 사용 중)

## 영향 범위

- 변경: `apps/web/src/app/auth/login/route.ts` 1줄
- 리그레션 없음

## Test plan

- [ ] PROD에서 Google OAuth 로그인 정상 동작 확인
- [ ] `/api/v2/auth/oauth/google/authorize` → 200 + redirect URL 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)