### PR TITLE
feat(ci): Cloud Build 파이프라인 v2 — develop→main promotion

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -44,8 +44,10 @@ jobs:
         run: |
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             echo "target=prod" >> "$GITHUB_OUTPUT"
+            echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
+            echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -53,6 +55,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}" \
             --suppress-logs \
             .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -8,8 +8,8 @@
 substitutions:
   _AR_REGION: asia-northeast3
   _AR_REPO: sprintable
-  _DEPLOY_ENV: dev  # main push 시 prod로 오버라이드됨
-  _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app  # 트리거별 오버라이드
+  _DEPLOY_ENV: dev
+  _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -53,11 +53,47 @@ steps:
     env:
       - DOCKER_BUILDKIT=1
 
-images:
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:${COMMIT_SHA}
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
-  - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:latest-${_DEPLOY_ENV}
+  # ─── Push images ──────────────────────────────────────────────────────────
+  - id: push-frontend
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - --all-tags
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend
+    waitFor: [build-frontend]
+
+  - id: push-backend
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - --all-tags
+      - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend
+    waitFor: [build-backend]
+
+  # ─── Deploy to Cloud Run ───────────────────────────────────────────────────
+  - id: deploy-frontend
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - sprintable-frontend-${_DEPLOY_ENV}
+      - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:${COMMIT_SHA}
+      - --region=${_AR_REGION}
+      - --quiet
+    waitFor: [push-frontend]
+
+  - id: deploy-backend
+    name: gcr.io/google.com/cloudsdktool/cloud-sdk
+    entrypoint: gcloud
+    args:
+      - run
+      - deploy
+      - sprintable-backend-${_DEPLOY_ENV}
+      - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
+      - --region=${_AR_REGION}
+      - --quiet
+    waitFor: [push-backend]
 
 options:
   machineType: E2_HIGHCPU_8


### PR DESCRIPTION
## Summary
- PR #409 (Cloud Build v2 파이프라인) develop → main promotion
- `_FASTAPI_URL` 환경별 자동 분기 (develop=dev URL, main=prod URL)
- `cloudbuild.yaml`: build → push → deploy 자동화 (Cloud Run 자동 배포)
- GitHub Actions WIF 인증 + SA 권한 전량 설정 완료

## Verified on dev
- Cloud Build `77413f49` SUCCESS (6/6 steps)
- dev Cloud Run 자동 배포 확인: frontend-dev-00004-gg4, backend-dev-00004-zmz
- dev smoke: /api/v2/health db:ok, /login 200, OAuth /authorize 200

## Test plan
- [ ] main 머지 후 Cloud Build prod 자동 트리거 확인
- [ ] prod Cloud Run 자동 배포 확인
- [ ] prod smoke: /api/v2/health, /login, OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)