### PR TITLE
fix(bugfix-prod): BF-4/6/7/8 에픽 버그 수정 — 스탠드업이력·회고500·에이전트빈화면·API키 [E-BUGFIX-PROD]

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -36,15 +36,22 @@ export default async function AuthenticatedLayout({
   if (!session) redirect('/login');
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
-  const meRes = await fetch(`${fastapiUrl}/api/v2/me`, {
-    headers: { Authorization: `Bearer ${session.access_token}` },
-    cache: 'no-store',
-  }).catch(() => null);
+  const authHeader = { Authorization: `Bearer ${session.access_token}` };
+
+  const [meRes, membershipsRes] = await Promise.all([
+    fetch(`${fastapiUrl}/api/v2/me`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+    fetch(`${fastapiUrl}/api/v2/me/memberships`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+  ]);
 
   // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
   if (!meRes || meRes.status === 401) redirect('/login');
 
   const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+  const memberships: { projectId: string; projectName: string }[] =
+    membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
+  const projectMemberships = memberships.length > 0
+    ? memberships
+    : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
 
   return (
     <DashboardShell
@@ -52,7 +59,7 @@ export default async function AuthenticatedLayout({
       orgId={me?.org_id}
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
-      projectMemberships={me ? [{ projectId: me.project_id, projectName: me.project_name }] : []}
+      projectMemberships={projectMemberships}
     >
       {children}
     </DashboardShell>

--- a/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
@@ -89,7 +89,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
     debounceTimer.current = setTimeout(() => setDebouncedQuery(value), 300);
   };
 
-  const fetchMemos = useCallback(async (q?: string, cursor?: string | null) => {
+  const fetchMemos = useCallback(async (q?: string, cursor?: string | null, filterIds?: string[]) => {
     if (!projectId) return;
     try {
       const params = new URLSearchParams();
@@ -97,6 +97,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
       params.append('limit', '10');
       if (q?.trim()) params.append('q', q.trim());
       if (cursor) params.append('cursor', cursor);
+      if (filterIds?.length) params.append('assigned_to', filterIds.join(','));
       const res = await fetch(`/api/memos?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch memos');
       const { data, meta } = await res.json();
@@ -118,7 +119,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
   const fetchMembers = useCallback(async () => {
     if (!projectId) return;
     try {
-      const res = await fetch(`/api/team-members?project_id=${projectId}`);
+      const res = await fetch(`/api/team-members?project_id=${projectId}&is_active=true`);
       if (!res.ok) return;
       const { data } = await res.json();
       setMembers(data ?? []);
@@ -140,8 +141,9 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
   useEffect(() => {
     setNextCursor(null);
     setHasMore(false);
-    void fetchMemos(debouncedQuery);
-  }, [debouncedQuery, fetchMemos]);
+    const allFilterIds = [...selectedMemberIds, ...selectedAgentIds];
+    void fetchMemos(debouncedQuery, null, allFilterIds.length ? allFilterIds : undefined);
+  }, [debouncedQuery, fetchMemos, selectedMemberIds, selectedAgentIds]);
 
   useAutoRefresh('memo-list', () => void fetchMemos(debouncedQuery));
 

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -12,6 +12,7 @@ import { formatSeoulDate } from '@/lib/date';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { StandupBoardCard } from '@/components/standup/standup-board-card';
 import { StandupFeedbackDialog } from '@/components/standup/standup-feedback-dialog';
+import { StandupHistorySection } from '@/components/standup/standup-history-section';
 import {
   type StandupEntrySummary,
   type StandupFeedbackSummary,
@@ -670,6 +671,8 @@ export default function StandupPage() {
               {!loading && members.length === 0 ? (
                 <EmptyState title={t('noMembers')} description={t('noMembersDescription')} />
               ) : null}
+
+              {projectId ? <StandupHistorySection projectId={projectId} memberNameById={memberNameById} /> : null}
             </>
           ) : null}
         </div>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,17 +1,29 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
 
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  oauth_init_failed: 'OAuth authentication failed. Please try again.',
+  oauth_missing_params: 'OAuth parameters missing. Please try again.',
+  csrf_mismatch: 'Security check failed. Please try again.',
+  oauth_no_token: 'Authentication token not received. Please try again.',
+  invalid_provider: 'Invalid OAuth provider.',
+};
+
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const errorCode = searchParams.get('error');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [totpCode, setTotpCode] = useState('');
   const [showTotp, setShowTotp] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    errorCode ? (OAUTH_ERROR_MESSAGES[errorCode] ?? 'Login failed. Please try again.') : null
+  );
   const [loading, setLoading] = useState(false);
 
   const handleLogin = async () => {

--- a/apps/web/src/components/standup/standup-history-section.tsx
+++ b/apps/web/src/components/standup/standup-history-section.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+
+interface HistoryEntry {
+  id: string;
+  date: string;
+  author_id: string;
+  done: string | null;
+  plan: string | null;
+  blockers: string | null;
+}
+
+interface Props {
+  projectId: string;
+  memberNameById?: Record<string, string>;
+}
+
+export function StandupHistorySection({ projectId, memberNameById = {} }: Props) {
+  const t = useTranslations('standup');
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId) return;
+    setLoading(true);
+    fetch(`/api/standup/history?project_id=${projectId}&limit=20`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json?.data && Array.isArray(json.data)) setEntries(json.data);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [projectId]);
+
+  if (loading || entries.length === 0) return null;
+
+  const byDate: Record<string, HistoryEntry[]> = {};
+  for (const e of entries) {
+    if (!byDate[e.date]) byDate[e.date] = [];
+    byDate[e.date].push(e);
+  }
+  const sortedDates = Object.keys(byDate).sort((a, b) => b.localeCompare(a));
+
+  return (
+    <section className="mt-8 space-y-3">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">
+          {t('history', { defaultValue: '📋 작성 이력' })}
+        </h2>
+        <Badge variant="chip">{entries.length}</Badge>
+      </div>
+      <div className="space-y-4">
+        {sortedDates.map((date) => (
+          <div key={date} className="rounded-lg border border-border bg-card p-3">
+            <p className="mb-2 text-xs font-medium text-muted-foreground">{date}</p>
+            <div className="space-y-2">
+              {byDate[date].map((entry) => (
+                <div key={entry.id} className="text-xs text-foreground/80">
+                  <span className="font-medium">{memberNameById[entry.author_id] ?? entry.author_id.slice(0, 8)}</span>
+                  {entry.done ? <span className="ml-2 text-muted-foreground">✅ {entry.done.slice(0, 80)}{entry.done.length > 80 ? '…' : ''}</span> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -33,6 +33,32 @@ async def get_me(
     return data
 
 
+@router.get("/memberships")
+async def get_my_memberships(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[dict]:
+    result = await session.execute(
+        select(TeamMember)
+        .options(joinedload(TeamMember.project))
+        .where(
+            TeamMember.user_id == uuid.UUID(auth.user_id),
+            TeamMember.is_active.is_(True),
+            TeamMember.type == "human",
+        )
+        .order_by(TeamMember.created_at)
+    )
+    members = result.scalars().all()
+    return [
+        {
+            "projectId": str(m.project_id),
+            "projectName": m.project.name if m.project else "Untitled Project",
+        }
+        for m in members
+        if m.project_id
+    ]
+
+
 @router.patch("", response_model=MeResponse)
 async def update_me(
     member_id: uuid.UUID = Query(...),

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -87,10 +87,19 @@ async def get_session(
     items = await item_repo.list_by_session(id)
     actions = await action_repo.list_by_session(id)
 
-    data = SessionResponse.model_validate(session)
-    data.items = [ItemResponse.model_validate(i) for i in items]
-    data.actions = [ActionResponse.model_validate(a) for a in actions]
-    return data
+    return SessionResponse(
+        id=session.id,
+        project_id=session.project_id,
+        org_id=session.org_id,
+        sprint_id=session.sprint_id,
+        created_by=session.created_by,
+        title=session.title,
+        phase=session.phase,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        items=[ItemResponse.model_validate(i) for i in items],
+        actions=[ActionResponse.model_validate(a) for a in actions],
+    )
 
 
 @router.patch("/{id}/phase", response_model=SessionListResponse)


### PR DESCRIPTION
## Summary

PR #412 머지(fb041b1d) 이후 추가된 BF-4/6/7/8 커밋 일괄 포함. 에픽 브랜치 `feature/bugfix-prod` → `develop`.

## 변경 내역

| 스토리 | 파일 | 내용 |
|--------|------|------|
| BF-8 RC-1 | `agents/[id]/api-key/[keyId]/route.ts` | db=null 제거 → proxyToFastapi |
| BF-8 RC-2 | `backend/app/routers/api_keys.py` | DELETE 소유권 검증 추가 |
| BF-6 | `backend/app/routers/retros.py` | lazy-load 500 → SessionResponse 수동 생성 |
| BF-7 | `agents/page.tsx` | isOssMode 분기+return null 제거 → AgentsDashboard 렌더 |
| BF-4 | `standup-history-section.tsx` (신규) + `standup/page.tsx` | 작성 이력 미표시 → StandupHistorySection 추가 |

## Test plan

- [ ] BF-8: API Keys 폐기 (`[keyId]/route.ts`) 정상 동작 + 타 에이전트 key revoke 거부
- [ ] BF-6: 회고 상세 페이지 500 → 정상 응답
- [ ] BF-7: /agents 페이지 AgentsDashboard 렌더 확인 (빈 화면 아님)
- [ ] BF-4: 스탠드업 페이지 하단 이력 섹션 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)