### PR TITLE
E-BUGFIX-PROD: 프로덕션 버그 10건 일괄 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/page.tsx
@@ -1,17 +1,5 @@
-import { redirect } from 'next/navigation';
-import { getMyTeamMember } from '@/lib/auth-helpers';
-import { requireOrgAdmin } from '@/lib/admin-check';
-import { checkFeatureLimit } from '@/lib/check-feature';
 import { AgentsDashboard } from '@/components/agents/agents-dashboard';
-import { buildDeploymentCards } from '@/services/agent-dashboard';
-import { AgentOrchestrationUpgradeState } from '@/components/agents/agent-orchestration-gate';
-import { isOssMode } from '@/lib/storage/factory';
 
 export default async function AgentsPage() {
-  if (isOssMode()) {
-    return <AgentsDashboard deployments={[]} />;
-  }
-  // SaaS-only path — not reached in OSS mode
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return null as any;
+  return <AgentsDashboard deployments={[]} />;
 }

--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -36,15 +36,22 @@ export default async function AuthenticatedLayout({
   if (!session) redirect('/login');
 
   const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
-  const meRes = await fetch(`${fastapiUrl}/api/v2/me`, {
-    headers: { Authorization: `Bearer ${session.access_token}` },
-    cache: 'no-store',
-  }).catch(() => null);
+  const authHeader = { Authorization: `Bearer ${session.access_token}` };
+
+  const [meRes, membershipsRes] = await Promise.all([
+    fetch(`${fastapiUrl}/api/v2/me`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+    fetch(`${fastapiUrl}/api/v2/me/memberships`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+  ]);
 
   // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
   if (!meRes || meRes.status === 401) redirect('/login');
 
   const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+  const memberships: { projectId: string; projectName: string }[] =
+    membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
+  const projectMemberships = memberships.length > 0
+    ? memberships
+    : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
 
   return (
     <DashboardShell
@@ -52,7 +59,7 @@ export default async function AuthenticatedLayout({
       orgId={me?.org_id}
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
-      projectMemberships={me ? [{ projectId: me.project_id, projectName: me.project_name }] : []}
+      projectMemberships={projectMemberships}
     >
       {children}
     </DashboardShell>

--- a/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
@@ -89,7 +89,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
     debounceTimer.current = setTimeout(() => setDebouncedQuery(value), 300);
   };
 
-  const fetchMemos = useCallback(async (q?: string, cursor?: string | null) => {
+  const fetchMemos = useCallback(async (q?: string, cursor?: string | null, filterIds?: string[]) => {
     if (!projectId) return;
     try {
       const params = new URLSearchParams();
@@ -97,6 +97,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
       params.append('limit', '10');
       if (q?.trim()) params.append('q', q.trim());
       if (cursor) params.append('cursor', cursor);
+      if (filterIds?.length) params.append('assigned_to', filterIds.join(','));
       const res = await fetch(`/api/memos?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch memos');
       const { data, meta } = await res.json();
@@ -118,7 +119,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
   const fetchMembers = useCallback(async () => {
     if (!projectId) return;
     try {
-      const res = await fetch(`/api/team-members?project_id=${projectId}`);
+      const res = await fetch(`/api/team-members?project_id=${projectId}&is_active=true`);
       if (!res.ok) return;
       const { data } = await res.json();
       setMembers(data ?? []);
@@ -140,8 +141,9 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
   useEffect(() => {
     setNextCursor(null);
     setHasMore(false);
-    void fetchMemos(debouncedQuery);
-  }, [debouncedQuery, fetchMemos]);
+    const allFilterIds = [...selectedMemberIds, ...selectedAgentIds];
+    void fetchMemos(debouncedQuery, null, allFilterIds.length ? allFilterIds : undefined);
+  }, [debouncedQuery, fetchMemos, selectedMemberIds, selectedAgentIds]);
 
   useAutoRefresh('memo-list', () => void fetchMemos(debouncedQuery));
 

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -12,6 +12,7 @@ import { formatSeoulDate } from '@/lib/date';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { StandupBoardCard } from '@/components/standup/standup-board-card';
 import { StandupFeedbackDialog } from '@/components/standup/standup-feedback-dialog';
+import { StandupHistorySection } from '@/components/standup/standup-history-section';
 import {
   type StandupEntrySummary,
   type StandupFeedbackSummary,
@@ -670,6 +671,8 @@ export default function StandupPage() {
               {!loading && members.length === 0 ? (
                 <EmptyState title={t('noMembers')} description={t('noMembersDescription')} />
               ) : null}
+
+              {projectId ? <StandupHistorySection projectId={projectId} memberNameById={memberNameById} /> : null}
             </>
           ) : null}
         </div>

--- a/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
@@ -1,16 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
-import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { isOssMode, createAgentApiKeyRepository } from '@/lib/storage/factory';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; keyId: string }> };
 
-/**
- * DELETE /api/agents/[id]/api-key/[keyId]
- * API Key revoke (취소)
- *
- * Admin만 가능
- */
+/** DELETE /api/agents/[id]/api-key/[keyId] — API Key revoke */
 export async function DELETE(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
@@ -21,53 +17,11 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     } catch (err: unknown) { return handleApiError(err); }
   }
   try {
-    const { keyId } = await params;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
+    const { id, keyId } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
-
-    // Admin 권한 확인
-    const { data: myMember } = await db
-      .from('team_members')
-      .select('role, org_id')
-      .eq('id', me.id)
-      .single();
-
-    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
-      return ApiErrors.forbidden('Admin only');
-    }
-
-    // API Key 조회 (org 확인용)
-    const { data: apiKeyRow } = await db
-      .from('agent_api_keys')
-      .select('id, team_member_id, team_members(org_id)')
-      .eq('id', keyId)
-      .single();
-
-    if (!apiKeyRow) {
-      return ApiErrors.notFound('API key not found');
-    }
-
-    const teamMember = Array.isArray(apiKeyRow.team_members)
-      ? apiKeyRow.team_members[0]
-      : apiKeyRow.team_members;
-
-    // 같은 org인지 확인
-    if ((teamMember as { org_id: string } | null)?.org_id !== me.org_id) {
-      return ApiErrors.forbidden('Cannot revoke API key from different org');
-    }
-
-    // Revoke (revoked_at 설정)
-    const { error: updateError } = await db
-      .from('agent_api_keys')
-      .update({ revoked_at: new Date().toISOString() })
-      .eq('id', keyId);
-
-    if (updateError) throw updateError;
-
-    return apiSuccess({ message: 'API key revoked' });
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys/${keyId}`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -1,17 +1,32 @@
 import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { generateApiKey } from '@/lib/auth-api-key';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { isOssMode, createAgentApiKeyRepository } from '@/lib/storage/factory';
+import { generateApiKey } from '@/lib/auth-api-key';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-/**
- * POST /api/agents/[id]/api-key
- * 에이전트에게 API Key 발급
- *
- * Admin만 가능
- */
+/** GET /api/agents/[id]/api-key — API Key 목록 조회 */
+export async function GET(request: Request, { params }: RouteParams) {
+  if (isOssMode()) {
+    try {
+      const { id: teamMemberId } = await params;
+      const repo = await createAgentApiKeyRepository();
+      return apiSuccess(await repo.list(teamMemberId));
+    } catch (err: unknown) { return handleApiError(err); }
+  }
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+/** POST /api/agents/[id]/api-key — API Key 발급 */
 export async function POST(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
@@ -27,123 +42,36 @@ export async function POST(request: Request, { params }: RouteParams) {
     } catch (err: unknown) { return handleApiError(err); }
   }
   try {
-    const { id: teamMemberId } = await params;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
+    const { id } = await params;
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
-
-    // AC4: API Key로 접근 시 admin scope 필요
-    if (me.type === 'agent' && !me.scope?.includes('admin')) {
-      return ApiErrors.insufficientScope('admin');
-    }
-
-    // Admin 권한 확인
-    const { data: myMember } = await db
-      .from('team_members')
-      .select('role')
-      .eq('id', me.id)
-      .single();
-
-    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
-      return ApiErrors.forbidden('Admin only');
-    }
-
-    // 대상 team_member가 agent인지 확인
-    const { data: targetMember } = await db
-      .from('team_members')
-      .select('id, name, type, org_id')
-      .eq('id', teamMemberId)
-      .eq('type', 'agent')
-      .single();
-
-    if (!targetMember) {
-      return ApiErrors.notFound('Agent not found');
-    }
-
-    // 같은 org인지 확인
-    if (targetMember.org_id !== me.org_id) {
-      return ApiErrors.forbidden('Cannot issue API key for agent in different org');
-    }
-
-    // API Key 생성
-    const body = await request.json().catch(() => ({})) as { expires_at?: string; scope?: string[] };
-    const { apiKey, keyPrefix, keyHash } = generateApiKey();
-    const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
-    const expiresAt = body.expires_at ?? defaultExpiry;
-    const scope = body.scope ?? ['read', 'write'];
-
-    // DB에 저장
-    const { data: apiKeyRow, error: insertError } = await db
-      .from('agent_api_keys')
-      .insert({
-        team_member_id: teamMemberId,
-        key_prefix: keyPrefix,
-        key_hash: keyHash,
-        expires_at: expiresAt,
-        scope,
-      })
-      .select('id, key_prefix, created_at, expires_at, scope')
-      .single();
-
-    if (insertError || !apiKeyRow) {
-      throw insertError || new Error('Failed to create API key');
-    }
-
-    // 평문 API Key는 1회만 반환
-    return apiSuccess({
-      id: apiKeyRow.id,
-      key_prefix: apiKeyRow.key_prefix,
-      created_at: apiKeyRow.created_at,
-      api_key: apiKey, // ⚠️ 평문 키 (1회만 표시)
-    }, undefined, 201);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json(), undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
 }
 
-/**
- * GET /api/agents/[id]/api-key
- * 에이전트의 API Key 목록 조회
- *
- * Admin만 가능
- */
-export async function GET(request: Request, { params }: RouteParams) {
+/** DELETE /api/agents/[id]/api-key?key_id={key_id} — API Key 폐기 */
+export async function DELETE(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
-      const { id: teamMemberId } = await params;
+      const { searchParams } = new URL(request.url);
+      const keyId = searchParams.get('key_id');
+      if (!keyId) return ApiErrors.badRequest('key_id required');
       const repo = await createAgentApiKeyRepository();
-      return apiSuccess(await repo.list(teamMemberId));
+      await repo.revoke(keyId);
+      return apiSuccess({ ok: true });
     } catch (err: unknown) { return handleApiError(err); }
   }
   try {
-    const { id: teamMemberId } = await params;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
+    const { id } = await params;
+    const { searchParams } = new URL(request.url);
+    const keyId = searchParams.get('key_id');
+    if (!keyId) return ApiErrors.badRequest('key_id required');
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
-
-    // Admin 권한 확인
-    const { data: myMember } = await db
-      .from('team_members')
-      .select('role, org_id')
-      .eq('id', me.id)
-      .single();
-
-    if (!myMember || !['owner', 'admin'].includes(myMember.role)) {
-      return ApiErrors.forbidden('Admin only');
-    }
-
-    // API Key 목록 조회
-    const { data: keys, error } = await db
-      .from('agent_api_keys')
-      .select('id, team_member_id, key_prefix, created_at, revoked_at, last_used_at, expires_at')
-      .eq('team_member_id', teamMemberId);
-
-    if (error) throw error;
-
-    return apiSuccess(keys ?? []);
-  } catch (err: unknown) {
-    return handleApiError(err);
-  }
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys/${keyId}`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,5 +1,5 @@
 import { handleApiError } from '@/lib/api-error';
-import { ApiErrors } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -13,10 +13,12 @@ export async function GET(request: Request) {
     const url = new URL(request.url);
     url.searchParams.set('assignee_member_id', me.id);
 
-    return proxyToFastapi(
+    const _r = await proxyToFastapi(
       new Request(url.toString(), { method: 'GET', headers: request.headers }),
       '/api/v2/inbox',
     );
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/inbox/route.ts
+++ b/apps/web/src/app/api/inbox/route.ts
@@ -1,58 +1,22 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext, CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-import { cookies } from 'next/headers';
-import { createInboxItemRepository } from '@/lib/storage/factory';
-import { INBOX_KINDS, INBOX_STATES } from '@sprintable/shared';
-import type { InboxKind, InboxState } from '@sprintable/core-storage';
+import { ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
-/** GET — inbox 목록 (현재 project + 본인 assignee 기준, state=pending 기본) */
+/** GET — inbox 목록 (/api/v2/inbox proxy, assignee_member_id 자동 주입) */
 export async function GET(request: Request) {
   try {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    const { searchParams } = new URL(request.url);
-    const kindParam = searchParams.get('kind');
-    const stateParam = searchParams.get('state') ?? 'pending';
-    const cursor = searchParams.get('cursor') ?? undefined;
-    const limit = Math.min(Math.max(parseInt(searchParams.get('limit') ?? '50', 10) || 50, 1), 100);
+    const url = new URL(request.url);
+    url.searchParams.set('assignee_member_id', me.id);
 
-    if (kindParam && !INBOX_KINDS.includes(kindParam as InboxKind)) {
-      return ApiErrors.badRequest(`Invalid kind: ${kindParam}`);
-    }
-    if (!INBOX_STATES.includes(stateParam as InboxState)) {
-      return ApiErrors.badRequest(`Invalid state: ${stateParam}`);
-    }
-
-    const cookieStore = await cookies();
-    const projectIdFromCookie = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value;
-    const projectId = searchParams.get('project_id') ?? projectIdFromCookie ?? me.project_id;
-
-    const repo = await createInboxItemRepository(undefined);
-    const items = await repo.list({
-      org_id: me.org_id,
-      project_id: projectId,
-      assignee_member_id: me.id,
-      kind: kindParam ? (kindParam as InboxKind) : undefined,
-      state: stateParam as InboxState,
-      cursor,
-      limit,
-    });
-
-    const counts = await repo.count({
-      org_id: me.org_id,
-      project_id: projectId,
-      assignee_member_id: me.id,
-      state: 'pending',
-    });
-
-    return apiSuccess(items, {
-      pendingCount: counts.total,
-      countsByKind: counts.byKind,
-      nextCursor: items.length === limit ? items[items.length - 1]!.created_at : null,
-    });
+    return proxyToFastapi(
+      new Request(url.toString(), { method: 'GET', headers: request.headers }),
+      '/api/v2/inbox',
+    );
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -52,6 +52,7 @@ export async function POST(request: Request, { params }: RouteParams) {
     const session = await getServerSession();
     const token = rawApiKey ?? session?.access_token ?? '';
 
+    const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
     const reply = await fastapiCall<unknown>(
       'POST', `/api/v2/memos/${id}/replies`, token,
       {
@@ -59,6 +60,7 @@ export async function POST(request: Request, { params }: RouteParams) {
           content: body.content,
           created_by: me.id,
           review_type: 'comment',
+          ...(resolvedIds ? { assigned_to_ids: resolvedIds } : {}),
         },
       },
     );

--- a/apps/web/src/app/api/v2/events/memos/route.ts
+++ b/apps/web/src/app/api/v2/events/memos/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function GET(request: NextRequest) {
+  const session = await getServerSession();
+  if (!session?.access_token) {
+    return NextResponse.json(
+      { data: null, error: { code: 'UNAUTHORIZED', message: 'Authentication required' }, meta: null },
+      { status: 401 },
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const upstream = await fetch(
+    `${FASTAPI_URL()}/api/v2/events/memos?${searchParams.toString()}`,
+    {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+    },
+  );
+
+  if (!upstream.ok) {
+    let errBody: { detail?: string; error?: { code?: string; message?: string } } = {};
+    try { errBody = await upstream.json(); } catch { /* ignore */ }
+    const message = errBody.error?.message ?? errBody.detail ?? `HTTP ${upstream.status}`;
+    const code = errBody.error?.code ?? 'UPSTREAM_ERROR';
+    return NextResponse.json(
+      { data: null, error: { code, message }, meta: null },
+      { status: upstream.status },
+    );
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      'Connection': 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -1,17 +1,29 @@
 'use client';
 
 import { useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
 
+const OAUTH_ERROR_MESSAGES: Record<string, string> = {
+  oauth_init_failed: 'OAuth authentication failed. Please try again.',
+  oauth_missing_params: 'OAuth parameters missing. Please try again.',
+  csrf_mismatch: 'Security check failed. Please try again.',
+  oauth_no_token: 'Authentication token not received. Please try again.',
+  invalid_provider: 'Invalid OAuth provider.',
+};
+
 export default function LoginPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const errorCode = searchParams.get('error');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [totpCode, setTotpCode] = useState('');
   const [showTotp, setShowTotp] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(
+    errorCode ? (OAUTH_ERROR_MESSAGES[errorCode] ?? 'Login failed. Please try again.') : null
+  );
   const [loading, setLoading] = useState(false);
 
   const handleLogin = async () => {

--- a/apps/web/src/components/standup/standup-history-section.tsx
+++ b/apps/web/src/components/standup/standup-history-section.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+
+interface HistoryEntry {
+  id: string;
+  date: string;
+  author_id: string;
+  done: string | null;
+  plan: string | null;
+  blockers: string | null;
+}
+
+interface Props {
+  projectId: string;
+  memberNameById?: Record<string, string>;
+}
+
+export function StandupHistorySection({ projectId, memberNameById = {} }: Props) {
+  const t = useTranslations('standup');
+  const [entries, setEntries] = useState<HistoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId) return;
+    setLoading(true);
+    fetch(`/api/standup/history?project_id=${projectId}&limit=20`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (json?.data && Array.isArray(json.data)) setEntries(json.data);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [projectId]);
+
+  if (loading || entries.length === 0) return null;
+
+  const byDate: Record<string, HistoryEntry[]> = {};
+  for (const e of entries) {
+    if (!byDate[e.date]) byDate[e.date] = [];
+    byDate[e.date].push(e);
+  }
+  const sortedDates = Object.keys(byDate).sort((a, b) => b.localeCompare(a));
+
+  return (
+    <section className="mt-8 space-y-3">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">
+          {t('history', { defaultValue: '📋 작성 이력' })}
+        </h2>
+        <Badge variant="chip">{entries.length}</Badge>
+      </div>
+      <div className="space-y-4">
+        {sortedDates.map((date) => (
+          <div key={date} className="rounded-lg border border-border bg-card p-3">
+            <p className="mb-2 text-xs font-medium text-muted-foreground">{date}</p>
+            <div className="space-y-2">
+              {byDate[date].map((entry) => (
+                <div key={entry.id} className="text-xs text-foreground/80">
+                  <span className="font-medium">{memberNameById[entry.author_id] ?? entry.author_id.slice(0, 8)}</span>
+                  {entry.done ? <span className="ml-2 text-muted-foreground">✅ {entry.done.slice(0, 80)}{entry.done.length > 80 ? '…' : ''}</span> : null}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,8 @@
 import os
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.core.config import settings
 from app.core.logging_config import configure_logging
@@ -16,6 +17,25 @@ app = FastAPI(
     docs_url="/api/v2/_swagger" if settings.debug else None,
     redoc_url=None,
 )
+
+_HTTP_CODE_MAP: dict[int, str] = {
+    400: "BAD_REQUEST",
+    401: "UNAUTHORIZED",
+    403: "FORBIDDEN",
+    404: "NOT_FOUND",
+    409: "CONFLICT",
+    422: "UNPROCESSABLE_ENTITY",
+}
+
+
+@app.exception_handler(HTTPException)
+async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
+    code = _HTTP_CODE_MAP.get(exc.status_code, f"HTTP_{exc.status_code}")
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"data": None, "error": {"code": code, "message": str(exc.detail)}, "meta": None},
+    )
+
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -81,6 +81,9 @@ async def revoke_agent_api_key(
     _auth: AuthContext = Depends(get_current_user),
     repo: ApiKeyRepository = Depends(_get_repo),
 ) -> dict:
+    key = await repo.get(key_id)
+    if key is None or key.team_member_id != agent_id:
+        raise HTTPException(status_code=404, detail="API key not found for this agent")
     result = await repo.revoke(key_id)
     if result is None:
         raise HTTPException(status_code=404, detail="API key not found")

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -72,3 +72,16 @@ async def create_agent_api_key(
     )
     data = ApiKeyResponse.model_validate(key)
     return ApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
+
+
+@router.delete("/agents/{agent_id}/api-keys/{key_id}", status_code=200)
+async def revoke_agent_api_key(
+    agent_id: uuid.UUID,
+    key_id: uuid.UUID,
+    _auth: AuthContext = Depends(get_current_user),
+    repo: ApiKeyRepository = Depends(_get_repo),
+) -> dict:
+    result = await repo.revoke(key_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+    return {"ok": True}

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -33,6 +33,32 @@ async def get_me(
     return data
 
 
+@router.get("/memberships")
+async def get_my_memberships(
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[dict]:
+    result = await session.execute(
+        select(TeamMember)
+        .options(joinedload(TeamMember.project))
+        .where(
+            TeamMember.user_id == uuid.UUID(auth.user_id),
+            TeamMember.is_active.is_(True),
+            TeamMember.type == "human",
+        )
+        .order_by(TeamMember.created_at)
+    )
+    members = result.scalars().all()
+    return [
+        {
+            "projectId": str(m.project_id),
+            "projectName": m.project.name if m.project else "Untitled Project",
+        }
+        for m in members
+        if m.project_id
+    ]
+
+
 @router.patch("", response_model=MeResponse)
 async def update_me(
     member_id: uuid.UUID = Query(...),

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -20,9 +20,13 @@ router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
 
 
 async def _collect_reply_webhook_urls(
-    db: AsyncSession, assigned_to: uuid.UUID | None, created_by: uuid.UUID | None, sender_id: uuid.UUID
+    db: AsyncSession,
+    assigned_to: uuid.UUID | None,
+    created_by: uuid.UUID | None,
+    sender_id: uuid.UUID,
+    extra_ids: list[uuid.UUID] | None = None,
 ) -> list[str]:
-    recipient_ids = {assigned_to, created_by} - {sender_id, None}
+    recipient_ids = ({assigned_to, created_by} | set(extra_ids or [])) - {sender_id, None}
     if not recipient_ids:
         return []
     rows = await db.execute(
@@ -166,7 +170,9 @@ async def add_reply(
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
 
     # 세션이 열려 있는 지금 webhook URLs 수집 후 BackgroundTasks에 HTTP 발송 위임
-    webhook_urls = await _collect_reply_webhook_urls(db, memo.assigned_to, memo.created_by, body.created_by)
+    webhook_urls = await _collect_reply_webhook_urls(
+        db, memo.assigned_to, memo.created_by, body.created_by, body.assigned_to_ids
+    )
     if webhook_urls:
         app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
         memo_url = f"{app_url}/memos?id={id}" if app_url else ""

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -87,10 +87,19 @@ async def get_session(
     items = await item_repo.list_by_session(id)
     actions = await action_repo.list_by_session(id)
 
-    data = SessionResponse.model_validate(session)
-    data.items = [ItemResponse.model_validate(i) for i in items]
-    data.actions = [ActionResponse.model_validate(a) for a in actions]
-    return data
+    return SessionResponse(
+        id=session.id,
+        project_id=session.project_id,
+        org_id=session.org_id,
+        sprint_id=session.sprint_id,
+        created_by=session.created_by,
+        title=session.title,
+        phase=session.phase,
+        created_at=session.created_at,
+        updated_at=session.updated_at,
+        items=[ItemResponse.model_validate(i) for i in items],
+        actions=[ActionResponse.model_validate(a) for a in actions],
+    )
 
 
 @router.patch("/{id}/phase", response_model=SessionListResponse)

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -50,6 +50,7 @@ class CreateReply(BaseModel):
     content: str
     created_by: uuid.UUID
     review_type: str = "comment"
+    assigned_to_ids: list[uuid.UUID] | None = None
 
 
 class ReplyResponse(BaseModel):


### PR DESCRIPTION
## Summary
- E-BUGFIX-PROD 에픽 전량 완주 (10건, 31SP)
- BF-0: reply_memo 웹훅 미발송 수정
- BF-1: events/memos 401 + 에러 JSON 규격 통일
- BF-2: /api/inbox 400 해소 (proxyToFastapi 전환)
- BF-3: 메모 멤버 필터 미작동 + 비활성 멤버 노출 수정
- BF-4: 스탠드업 작성 이력 표시 (StandupHistorySection 신규)
- BF-5: 장사왕 프로젝트 GNB 멀티 프로젝트 표시 (/api/v2/me/memberships 신규)
- BF-6: 회고 상세 500 해소 (Pydantic model_validate → 수동 생성)
- BF-7: 에이전트 메뉴 빈화면 해소 (isOssMode 분기 제거)
- BF-8: API Keys 400 null.from 해소 (proxyToFastapi + 소유권 검증)
- BF-9: 로그인 에러 메시지 표시 (OAuth 에러 코드 매핑)

## Dev 검증
- Cloud Build ebdce162 + 40bf4fce SUCCESS
- Dev smoke: frontend 200, backend db:ok

## PR Chain
- PR #411 (BF-0/1) → PR #412 (BF-2/7/8) → PR #413 (BF-3/4/5/6/9)
- 까심군 QA: 전량 APPROVE (codex 019df0f7, 019df112, 019df118, 019df127)