### PR TITLE
fix(memberships): OR 조건 추가 — user_id NULL 레코드 포함 [BF-10]

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,7 +42,10 @@ async def get_my_memberships(
         select(TeamMember)
         .options(joinedload(TeamMember.project))
         .where(
-            TeamMember.user_id == uuid.UUID(auth.user_id),
+            or_(
+                TeamMember.id == uuid.UUID(auth.user_id),
+                TeamMember.user_id == uuid.UUID(auth.user_id),
+            ),
             TeamMember.is_active.is_(True),
             TeamMember.type == "human",
         )


### PR DESCRIPTION
## Summary
- `GET /api/v2/me/memberships` 쿼리에 `or_(TeamMember.id, TeamMember.user_id)` 조건 적용
- Supabase→Cloud SQL 마이그레이션 시 user_id FK가 전량 NULL인 레코드를 id PK 매칭으로 포함
- PR #381 `_build_app_metadata()` 동일 패턴

## Story
BF-10 `cdf4cd0d` (Critical, 1SP)

## Test plan
- [ ] dev Cloud Build SUCCESS
- [ ] dev smoke: GET /api/v2/me/memberships → 장사왕 프로젝트 포함 확인
- [ ] 까심군 QA APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)