### PR TITLE
fix(docker): alembic.ini + alembic/ backend 이미지 포함 [BF-11 블로커]

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,8 @@ RUN uv sync --no-dev
 # 소스 복사
 COPY app/ app/
 COPY ee/ ee/
+COPY alembic.ini .
+COPY alembic/ alembic/
 
 ENV PATH="/app/.venv/bin:$PATH"
 


### PR DESCRIPTION
## Summary

- backend/Dockerfile에 `alembic.ini` + `alembic/` 복사 구문 추가

## 배경

BF-11 Alembic 0008 마이그레이션 실행 시도 중 Cloud Run Job 실패:
```
FAILED: No 'script_location' key found in configuration.
```
Dockerfile이 `app/`, `ee/` 만 복사하고 `alembic.ini`, `alembic/`를 누락한 것이 원인.

## 변경

```dockerfile
COPY alembic.ini .
COPY alembic/ alembic/
```

## Test plan
- [ ] Cloud Build dev 빌드 SUCCESS
- [ ] `sprintable-migrate-dev` job 재실행 → `alembic upgrade head` 정상 완료
- [ ] `SELECT count(*) FROM team_members WHERE user_id IS NULL AND type='human'` → 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)