### PR TITLE
fix(alembic): psycopg2-binary 추가 + asyncpg→psycopg2 URL 변환 [BF-11 블로커2]

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -16,7 +16,10 @@ target_metadata = Base.metadata
 
 
 def get_url() -> str:
-    return os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
+    url = os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
+    # alembic은 동기 실행 — asyncpg → psycopg2 변환
+    return url.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace("postgresql+asyncpg+ssl://", "postgresql+psycopg2://")
+
 
 
 def run_migrations_offline() -> None:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "alembic>=1.13.0",
+    "psycopg2-binary>=2.9.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary

- `psycopg2-binary` 의존성 추가 (pyproject.toml)
- `alembic/env.py` `get_url()`에서 `postgresql+asyncpg://` → `postgresql+psycopg2://` 자동 변환

## 배경

Alembic 0008 마이그레이션 실행 시 2차 블로커 발생:
```
sqlalchemy.exc.MissingGreenlet: greenlet_spawn has not been called
```
DB URL이 `postgresql+asyncpg://` 형태이나 alembic env.py가 동기 방식(`engine_from_config`)을 사용.
psycopg2가 미설치 상태였음.

## Test plan
- [ ] Cloud Build dev 빌드 SUCCESS
- [ ] `sprintable-migrate-dev` job 재실행 → `alembic upgrade head` 정상 완료
- [ ] `SELECT count(*) FROM team_members WHERE user_id IS NULL AND type='human'` → 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)