### PR TITLE
BF-11: user_id 백필 + OR 반창고 제거 + Dockerfile alembic — prod 프로모션

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,6 +12,8 @@ RUN uv sync --no-dev
 # 소스 복사
 COPY app/ app/
 COPY ee/ ee/
+COPY alembic.ini .
+COPY alembic/ alembic/
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -16,7 +16,10 @@ target_metadata = Base.metadata
 
 
 def get_url() -> str:
-    return os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
+    url = os.environ.get("DATABASE_URL", config.get_main_option("sqlalchemy.url", ""))
+    # alembic은 동기 실행 — asyncpg → psycopg2 변환
+    return url.replace("postgresql+asyncpg://", "postgresql+psycopg2://").replace("postgresql+asyncpg+ssl://", "postgresql+psycopg2://")
+
 
 
 def run_migrations_offline() -> None:

--- a/backend/alembic/versions/0008_backfill_team_members_user_id.py
+++ b/backend/alembic/versions/0008_backfill_team_members_user_id.py
@@ -1,0 +1,47 @@
+"""backfill team_members.user_id from users and invitations
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-05-04
+
+Supabase→Cloud SQL 마이그레이션 시 team_members.user_id FK가 전량 NULL.
+두 경로로 백필:
+  1. team_members.id == users.id (Supabase에서 PK 동일 패턴)
+  2. invitations.email → users.email 매핑 (초대 기반 교차 프로젝트 멤버십)
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Step 1: team_members.id == users.id 케이스 (Supabase PK 동일 패턴)
+    op.execute("""
+        UPDATE team_members
+        SET user_id = id
+        WHERE user_id IS NULL
+          AND type = 'human'
+          AND id IN (SELECT id FROM users)
+    """)
+
+    # Step 2: invitations 테이블 경유 email 매핑
+    # invitations.team_member_id → invitations.email → users.id
+    op.execute("""
+        UPDATE team_members tm
+        SET user_id = u.id
+        FROM invitations inv
+        JOIN users u ON u.email = inv.email
+        WHERE tm.user_id IS NULL
+          AND tm.type = 'human'
+          AND inv.team_member_id = tm.id
+    """)
+
+
+def downgrade() -> None:
+    # 백필된 user_id를 NULL로 되돌리는 것은 데이터 손실 위험이 있어 no-op
+    pass

--- a/backend/alembic/versions/0008_backfill_team_members_user_id.py
+++ b/backend/alembic/versions/0008_backfill_team_members_user_id.py
@@ -21,24 +21,14 @@ depends_on = None
 
 def upgrade() -> None:
     # Step 1: team_members.id == users.id 케이스 (Supabase PK 동일 패턴)
+    # invitations 테이블에 team_member_id 컬럼 없어 email 경유 교차 프로젝트 매핑 불가.
+    # 잔여 NULL 레코드는 _build_app_metadata() Step 2 로그인 시 자동 백필.
     op.execute("""
         UPDATE team_members
         SET user_id = id
         WHERE user_id IS NULL
           AND type = 'human'
           AND id IN (SELECT id FROM users)
-    """)
-
-    # Step 2: invitations 테이블 경유 email 매핑
-    # invitations.team_member_id → invitations.email → users.id
-    op.execute("""
-        UPDATE team_members tm
-        SET user_id = u.id
-        FROM invitations inv
-        JOIN users u ON u.email = inv.email
-        WHERE tm.user_id IS NULL
-          AND tm.type = 'human'
-          AND inv.team_member_id = tm.id
     """)
 
 

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import or_, select, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -88,11 +88,11 @@ async def _get_user_by_id(session: AsyncSession, user_id: uuid.UUID) -> User | N
 async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     from app.models.team import TeamMember
 
-    # 1. user_id 또는 PK(id)로 연결된 team_member 조회
+    # 1. user_id로 연결된 team_member 조회
     result = await session.execute(
         select(TeamMember)
         .where(
-            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+            TeamMember.user_id == user.id,
             TeamMember.is_active.is_(True),
         )
         .order_by(TeamMember.created_at.asc())

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,10 +42,7 @@ async def get_my_memberships(
         select(TeamMember)
         .options(joinedload(TeamMember.project))
         .where(
-            or_(
-                TeamMember.id == uuid.UUID(auth.user_id),
-                TeamMember.user_id == uuid.UUID(auth.user_id),
-            ),
+            TeamMember.user_id == uuid.UUID(auth.user_id),
             TeamMember.is_active.is_(True),
             TeamMember.type == "human",
         )

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.27.0",
     "alembic>=1.13.0",
+    "psycopg2-binary>=2.9.0",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## Summary
- PR #417: Alembic 0008 user_id 백필 마이그레이션 + auth.py/me.py OR 반창고 제거
- PR #418: Dockerfile alembic.ini + alembic/ 포함
- PR #419: alembic env.py asyncpg→psycopg2 동기 드라이버 변환

## Stories
- BF-11 `d8143425` (Critical, 3SP)

## QA
- 까심군 codex 019df14d APPROVE
- dev Alembic 0008 실행 완료, alembic current: 0008 (head)

## Test plan
- [ ] prod Cloud Build SUCCESS
- [ ] 담롱군 prod Alembic 0008 실행
- [ ] 선생님 재로그인 → 장사왕 프로젝트 GNB 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)