### PR TITLE
fix(P0): auth.py/me.py OR 조건 복원 — BF-11 regression [BF-12]

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -10,7 +10,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -88,11 +88,11 @@ async def _get_user_by_id(session: AsyncSession, user_id: uuid.UUID) -> User | N
 async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     from app.models.team import TeamMember
 
-    # 1. user_id로 연결된 team_member 조회
+    # 1. user_id 또는 PK(id)로 연결된 team_member 조회
     result = await session.execute(
         select(TeamMember)
         .where(
-            TeamMember.user_id == user.id,
+            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
             TeamMember.is_active.is_(True),
         )
         .order_by(TeamMember.created_at.asc())

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -42,7 +42,10 @@ async def get_my_memberships(
         select(TeamMember)
         .options(joinedload(TeamMember.project))
         .where(
-            TeamMember.user_id == uuid.UUID(auth.user_id),
+            or_(
+                TeamMember.id == uuid.UUID(auth.user_id),
+                TeamMember.user_id == uuid.UUID(auth.user_id),
+            ),
             TeamMember.is_active.is_(True),
             TeamMember.type == "human",
         )


### PR DESCRIPTION
## Summary
- BF-11에서 제거한 or_(user_id, id) 조건 복원
- Alembic 0008 백필 불완전(10/27 잔여 NULL) 상태에서 OR 제거로 regression 발생
- auth.py _build_app_metadata() + me.py GET /memberships 양쪽 복원

## Story
BF-12 `9b385138` (P0 Critical, 1SP)

## Test plan
- [ ] 까심군 QA APPROVE
- [ ] dev Cloud Build SUCCESS
- [ ] prod 프로모션 → 선생님 재로그인 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)