### PR TITLE
fix(P0): 장사왕 GNB + webhooks null + notification-settings 422 [BF-13]

### DIFF
--- a/apps/web/src/app/api/notification-settings/route.ts
+++ b/apps/web/src/app/api/notification-settings/route.ts
@@ -1,21 +1,30 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+function withMemberId(request: Request, memberId: string): Request {
+  const url = new URL(request.url);
+  url.searchParams.set('member_id', memberId);
+  return new Request(url.toString(), { method: request.method, headers: request.headers, body: request.method !== 'GET' ? request.body : undefined });
+}
 
 export async function GET(request: Request) {
   try {
-    const res = await proxyToFastapi(request, '/api/v2/notification-settings');
-    if (!res.ok) return res;
-    const data: unknown = await res.json();
-    return apiSuccess(data);
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(withMemberId(request, me.id), '/api/v2/notification-settings');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
 export async function PUT(request: Request) {
   try {
-    const res = await proxyToFastapi(request, '/api/v2/notification-settings');
-    if (!res.ok) return res;
-    const data: unknown = await res.json();
-    return apiSuccess(data);
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(withMemberId(request, me.id), '/api/v2/notification-settings');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/webhooks/config/route.ts
+++ b/apps/web/src/app/api/webhooks/config/route.ts
@@ -7,7 +7,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 export async function GET(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
@@ -17,7 +17,7 @@ export async function GET(request: Request) {
 export async function PUT(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
@@ -27,7 +27,7 @@ export async function PUT(request: Request) {
 export async function DELETE(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/webhooks/config/route.ts
+++ b/apps/web/src/app/api/webhooks/config/route.ts
@@ -1,29 +1,15 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError } from '@/lib/api-response';
 import { isOssMode } from '@/lib/storage/factory';
-import { getMyTeamMember } from '@/lib/auth-helpers';
-import { requireOrgAdmin } from '@/lib/admin-check';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 내 웹훅 설정 목록 */
-export async function GET() {
+export async function GET(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
-    const { data: { user } } = await db.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
-
-    const me = await getMyTeamMember(db, user);
-    if (!me) return ApiErrors.forbidden('Team member not found');
-
-    const { data, error } = await db
-      .from('webhook_configs')
-      .select('*, projects(name)')
-      .eq('member_id', me.id)
-      .order('created_at');
-
-    if (error) throw error;
-    return apiSuccess(data);
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
@@ -31,83 +17,18 @@ export async function GET() {
 export async function PUT(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
-    const { data: { user } } = await db.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
-
-    const me = await getMyTeamMember(db, user);
-    if (!me) return ApiErrors.forbidden('Team member not found');
-
-    const body = await request.json();
-    if (!body.url?.trim()) return ApiErrors.badRequest('url required');
-
-    // project_id 기반 upsert
-    const projectId = body.project_id ?? null;
-
-    // 기존 설정 확인
-    let query = db
-      .from('webhook_configs')
-      .select('id')
-      .eq('member_id', me.id)
-      .eq('org_id', me.org_id);
-
-    if (projectId) {
-      query = query.eq('project_id', projectId);
-    } else {
-      query = query.is('project_id', null);
-    }
-
-    const { data: existing } = await query.maybeSingle();
-
-    if (existing) {
-      const { error } = await db
-        .from('webhook_configs')
-        .update({ url: body.url.trim(), events: body.events ?? ['*'], is_active: body.is_active ?? true })
-        .eq('id', existing.id);
-      if (error) throw error;
-    } else {
-      const { error } = await db
-        .from('webhook_configs')
-        .insert({
-          org_id: me.org_id,
-          member_id: me.id,
-          project_id: projectId,
-          url: body.url.trim(),
-          events: body.events ?? ['*'],
-        });
-      if (error) throw error;
-    }
-
-    return apiSuccess({ ok: true });
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }
 
-/** DELETE — 웹훅 설정 삭제 (admin만) */
+/** DELETE — 웹훅 설정 삭제 */
 export async function DELETE(request: Request) {
   if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
-    const { data: { user } } = await db.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
-
-    const me = await getMyTeamMember(db, user);
-    if (!me) return ApiErrors.forbidden('Team member not found');
-
-    await requireOrgAdmin(db, me.org_id);
-
-    const { searchParams } = new URL(request.url);
-    const id = searchParams.get('id');
-    if (!id) return ApiErrors.badRequest('id required');
-
-    const { error } = await db
-      .from('webhook_configs')
-      .delete()
-      .eq('id', id)
-      .eq('org_id', me.org_id);
-
-    if (error) throw error;
-    return apiSuccess({ ok: true });
+    const _r = await proxyToFastapi(request, '/api/v2/webhooks');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -121,6 +121,18 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     if not member:
         return {}
 
+    # 3. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
+    await session.execute(
+        update(TeamMember)
+        .where(
+            TeamMember.user_id.is_(None),
+            TeamMember.is_active.is_(True),
+            TeamMember.type == "human",
+            TeamMember.org_id == member.org_id,
+        )
+        .values(user_id=user.id)
+    )
+
     return {
         "org_id": str(member.org_id),
         "project_id": str(member.project_id),


### PR DESCRIPTION
## Summary
- auth.py: _build_app_metadata() Step 3 추가 — 같은 org user_id NULL 전량 백필
- webhooks/config: db=null 스텁 → proxyToFastapi 전환
- notification-settings: member_id query param 주입

## Story
BF-13 `e50ce8aa` (P0 Critical, 3SP)

## Test plan
- [ ] 까심군 QA APPROVE
- [ ] dev+prod Cloud Build SUCCESS
- [ ] 선생님 재로그인 → 장사왕 GNB 표시 + 400/422 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)