### PR TITLE
fix(migration): MV-S1 survey + MV-S2 Supabase UID 매핑 교정 [E-MIGRATION-VERIFY]

### DIFF
--- a/backend/alembic/versions/0009_fix_supabase_uid_mapping.py
+++ b/backend/alembic/versions/0009_fix_supabase_uid_mapping.py
@@ -1,0 +1,57 @@
+"""Fix Supabase UID mapping: replace stale Supabase auth.users UUIDs with Cloud SQL users.id
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-05-04
+
+MV-S2: Supabase→Cloud SQL 마이그레이션 시 team_members.user_id 및 org_members.user_id에
+Supabase auth.users UUID가 그대로 유입됨. 등록된 2명의 매핑 정보를 기반으로 Cloud SQL users.id로
+UPDATE.
+
+매핑 출처: backend/scripts/fk_null_survey_result.json (registered_users_mapping)
+  - 송윤재: a306ae71-58ad-468b-84c0-667850d28fb1 → aac01791-5a99-4f5c-99c1-29f35c84cc61
+  - 윤도선: cccaed24-e082-4b7b-ae82-eae588a64f58 → fb474687-aeef-4f4e-a5e9-c97c0cb427f3
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+_MAPPINGS = [
+    (
+        "a306ae71-58ad-468b-84c0-667850d28fb1",
+        "aac01791-5a99-4f5c-99c1-29f35c84cc61",
+    ),
+    (
+        "cccaed24-e082-4b7b-ae82-eae588a64f58",
+        "fb474687-aeef-4f4e-a5e9-c97c0cb427f3",
+    ),
+]
+
+
+def upgrade() -> None:
+    for supabase_uid, cloud_sql_uid in _MAPPINGS:
+        op.execute(
+            f"UPDATE team_members SET user_id = '{cloud_sql_uid}' "
+            f"WHERE user_id = '{supabase_uid}'"
+        )
+        op.execute(
+            f"UPDATE org_members SET user_id = '{cloud_sql_uid}' "
+            f"WHERE user_id = '{supabase_uid}'"
+        )
+
+
+def downgrade() -> None:
+    for supabase_uid, cloud_sql_uid in _MAPPINGS:
+        op.execute(
+            f"UPDATE team_members SET user_id = '{supabase_uid}' "
+            f"WHERE user_id = '{cloud_sql_uid}'"
+        )
+        op.execute(
+            f"UPDATE org_members SET user_id = '{supabase_uid}' "
+            f"WHERE user_id = '{cloud_sql_uid}'"
+        )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -119,30 +119,9 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             member.user_id = user.id
 
     if not member:
-        # 3. stale Supabase UID 감지: user_id가 users 테이블에 존재하지 않는 레코드
-        # (Supabase→Cloud SQL 마이그레이션 잔존 — 미등록 유저 최초 로그인 시 자동 교정)
-        stale_exists = (
-            select(User.id).where(User.id == TeamMember.user_id).correlates(TeamMember).exists()
-        )
-        result3 = await session.execute(
-            select(TeamMember)
-            .where(
-                TeamMember.user_id.is_not(None),
-                TeamMember.is_active.is_(True),
-                TeamMember.type == "human",
-                ~stale_exists,
-            )
-            .order_by(TeamMember.created_at.asc())
-            .limit(1)
-        )
-        member = result3.scalar_one_or_none()
-        if member:
-            member.user_id = user.id
-
-    if not member:
         return {}
 
-    # 4. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
+    # 3. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
     await session.execute(
         update(TeamMember)
         .where(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -103,7 +103,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member.user_id = user.id
 
     if not member:
-        # 2. user_id 미연결 human team_member 중 첫 번째에 자동 연결
+        # 2. user_id NULL human team_member 중 첫 번째에 자동 연결
         result2 = await session.execute(
             select(TeamMember)
             .where(
@@ -119,9 +119,30 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             member.user_id = user.id
 
     if not member:
+        # 3. stale Supabase UID 감지: user_id가 users 테이블에 존재하지 않는 레코드
+        # (Supabase→Cloud SQL 마이그레이션 잔존 — 미등록 유저 최초 로그인 시 자동 교정)
+        stale_exists = (
+            select(User.id).where(User.id == TeamMember.user_id).correlates(TeamMember).exists()
+        )
+        result3 = await session.execute(
+            select(TeamMember)
+            .where(
+                TeamMember.user_id.is_not(None),
+                TeamMember.is_active.is_(True),
+                TeamMember.type == "human",
+                ~stale_exists,
+            )
+            .order_by(TeamMember.created_at.asc())
+            .limit(1)
+        )
+        member = result3.scalar_one_or_none()
+        if member:
+            member.user_id = user.id
+
+    if not member:
         return {}
 
-    # 3. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
+    # 4. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
     await session.execute(
         update(TeamMember)
         .where(

--- a/backend/scripts/fk_null_survey_result.json
+++ b/backend/scripts/fk_null_survey_result.json
@@ -1,0 +1,68 @@
+{
+  "survey_date": "2026-05-04T07:18:00Z",
+  "surveyed_by": "ortega-po",
+  "connection": "public-ip-34.22.111.69:5432/sprintable",
+
+  "root_cause_discovery": {
+    "issue": "team_members.user_id and org_members.user_id contain Supabase auth.users UUIDs, not Cloud SQL users.id UUIDs",
+    "impact": "Auth flow WHERE user_id = cloud_sql_uid fails for cross-project memberships (장사왕 GNB)",
+    "sprintable_workaround": "tm.id = users.id PK coincidence (legacy pattern)",
+    "affected_records": {
+      "team_members_human_invalid_user_id": 17,
+      "org_members_invalid_user_id": 10
+    },
+    "registered_users_mapping": [
+      {
+        "name": "송윤재",
+        "email": "iamyoonjae@moonklabs.com",
+        "cloud_sql_id": "aac01791-5a99-4f5c-99c1-29f35c84cc61",
+        "supabase_auth_uid": "a306ae71-58ad-468b-84c0-667850d28fb1"
+      },
+      {
+        "name": "윤도선",
+        "email": "dosunyun@moonklabs.com",
+        "cloud_sql_id": "fb474687-aeef-4f4e-a5e9-c97c0cb427f3",
+        "supabase_auth_uid": "cccaed24-e082-4b7b-ae82-eae588a64f58"
+      }
+    ],
+    "unregistered_supabase_uids": [
+      {"name": "신이삭", "supabase_uid": "df196f2e-78bb-413f-ad1e-333419874482"},
+      {"name": "신이삭 (sellerking)", "supabase_uid": "c7ab5124-be42-47f2-bed5-c93a73a5d5fa"},
+      {"name": "차봉희", "supabase_uid": "62d433c1-e245-404b-a8c2-d492074b2acb"},
+      {"name": "최하록", "supabase_uid": "ab3dd4af-454c-4f96-b0e7-9b85f9a96c3a"},
+      {"name": "윤희선", "supabase_uid": "cb1bb777-fb2b-4788-8768-11c926ea2c93"},
+      {"name": "이수민", "supabase_uid": "e3df5abb-eeee-4a5d-9e0d-6e99e389e5fc"},
+      {"name": "지창훈", "supabase_uid": "77503b80-eb10-4fef-baf5-44d415d18b95"},
+      {"name": "sellerking@moonklabs.com", "supabase_uid": "7efeaad6-c91e-4e44-815d-63c18b85ba81"},
+      {"name": "Integritics", "supabase_uid": "7673bded-05af-480a-9683-aa3fb9e65606"}
+    ]
+  },
+
+  "fk_null_survey": {
+    "critical": [
+      {"table": "agent_personas", "column": "created_by", "total": 40, "null_count": 40, "null_pct": 100.0}
+    ],
+    "high": [
+      {"table": "docs", "column": "created_by", "total": 346, "null_count": 237, "null_pct": 68.5}
+    ],
+    "low": [
+      {"table": "doc_revisions", "column": "created_by", "total": 141, "null_count": 3, "null_pct": 2.1}
+    ],
+    "clean": [
+      {"table": "team_members", "column": "user_id", "note": "0 human NULL, 10 agent NULL (by design)"},
+      {"table": "agent_deployments", "total": 0},
+      {"table": "agent_sessions", "column": "created_by", "total": 3, "null_count": 0},
+      {"table": "agent_routing_rules", "column": "created_by", "total": 24, "null_count": 0},
+      {"table": "meetings", "total": 0},
+      {"table": "policy_documents", "total": 0},
+      {"table": "workflow_versions", "column": "created_by", "total": 3, "null_count": 0},
+      {"table": "standup_entries", "column": "author_id", "total": 125, "null_count": 0},
+      {"table": "webhook_configs", "column": "member_id", "total": 3, "null_count": 0},
+      {"table": "notifications", "column": "user_id", "total": 1159, "null_count": 0},
+      {"table": "memos", "column": "created_by", "total": 1955, "null_count": 0},
+      {"table": "stories", "column": "project_id", "total": 921, "null_count": 0},
+      {"table": "retro_sessions", "column": "created_by", "total": 1, "null_count": 0},
+      {"table": "reward_ledger", "column": "member_id", "total": 3, "null_count": 0}
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- MV-S1: FK NULL 서베이 결과 커밋 (`backend/scripts/fk_null_survey_result.json`)
- MV-S2: Supabase auth.users UID → Cloud SQL users.id 매핑 Alembic 마이그레이션 (0009)
- MV-S2: `_build_app_metadata()` Step 3 신규 — stale Supabase UID 자동 감지 및 교정

## Changes

### `backend/scripts/fk_null_survey_result.json` (신규)
MV-S1 서베이 결과. 오르테가군 직접 실행 (2026-05-04).
- **CRITICAL**: `agent_personas.created_by` 100% NULL (40/40)
- **HIGH**: `docs.created_by` 68.5% NULL (237/346)
- **LOW**: `doc_revisions.created_by` 2.1% NULL (3/141)
- 나머지 13개 테이블 clean
- **Root cause**: `team_members.user_id` = Supabase UID (NULL 아님) — Cloud SQL UID 불일치

### `backend/alembic/versions/0009_fix_supabase_uid_mapping.py` (신규)
등록된 2명의 Supabase UID를 Cloud SQL UID로 교정:
| 이름 | Supabase UID | Cloud SQL UID |
|------|-------------|---------------|
| 송윤재 | a306ae71-58ad-... | aac01791-5a99-... |
| 윤도선 | cccaed24-e082-... | fb474687-aeef-... |

`team_members` + `org_members` 양쪽 모두 UPDATE. downgrade 포함.

### `backend/app/routers/auth.py`
`_build_app_metadata()` Step 3 신규 추가:
- 기존 Step 1 (user_id/PK 매칭), Step 2 (NULL user_id) 실패 시
- Step 3: `user_id`가 `users` 테이블에 존재하지 않는 레코드 탐지 (stale Supabase UID)
- 탐지 시 `user_id = user.id`로 자동 교정 → 미등록 유저 최초 로그인 시 team_member 자동 연결

## AC

- [x] AC1: `fk_null_survey_result.json` 커밋 — severity별 분류 완료
- [x] AC2: CRITICAL/HIGH 항목 테이블+컬럼+건수 기록
- [x] AC3: Alembic 0009 — 등록된 2명 UID 매핑 교정 (team_members + org_members)
- [x] AC4: `_build_app_metadata()` stale UID 감지 + 자동 교정 로직 추가
- [ ] AC5: dev 환경에서 마이그레이션 실행 후 `team_members WHERE user_id = 'a306ae71-...'` = 0건 확인 (담롱군 수행)

## Test Plan
- Alembic migration 코드 검토 (UUID 매핑 정합성)
- auth.py Step 3 로직 검토 (stale exists 서브쿼리 정확성)
- dev 배포 후 담롱군이 마이그레이션 실행 + 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)