### PR TITLE
feat(oss-pglite): PG-S2 12개 Repository PGLite async 전환 [E-OSS-PGLITE]

### DIFF
--- a/apps/web/src/lib/storage/factory.ts
+++ b/apps/web/src/lib/storage/factory.ts
@@ -38,8 +38,8 @@ async function getSpAt(): Promise<string> {
 
 export async function createEpicRepository(db?: unknown): Promise<IEpicRepository> {
   if (isOssMode()) {
-    const { SqliteEpicRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteEpicRepository(getDb());
+    const { PgliteEpicRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteEpicRepository(await getDb());
   }
   const { ApiEpicRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,8 +48,8 @@ export async function createEpicRepository(db?: unknown): Promise<IEpicRepositor
 
 export async function createStoryRepository(db?: unknown): Promise<IStoryRepository> {
   if (isOssMode()) {
-    const { SqliteStoryRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteStoryRepository(getDb());
+    const { PgliteStoryRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteStoryRepository(await getDb());
   }
   const { ApiStoryRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -58,8 +58,8 @@ export async function createStoryRepository(db?: unknown): Promise<IStoryReposit
 
 export async function createTaskRepository(db?: unknown): Promise<ITaskRepository> {
   if (isOssMode()) {
-    const { SqliteTaskRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteTaskRepository(getDb());
+    const { PgliteTaskRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteTaskRepository(await getDb());
   }
   const { ApiTaskRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -68,8 +68,8 @@ export async function createTaskRepository(db?: unknown): Promise<ITaskRepositor
 
 export async function createMemoRepository(db?: unknown): Promise<IMemoRepository> {
   if (isOssMode()) {
-    const { SqliteMemoRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteMemoRepository(getDb());
+    const { PgliteMemoRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteMemoRepository(await getDb());
   }
   const { ApiMemoRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -78,8 +78,8 @@ export async function createMemoRepository(db?: unknown): Promise<IMemoRepositor
 
 export async function createDocRepository(db?: unknown): Promise<IDocRepository> {
   if (isOssMode()) {
-    const { SqliteDocRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteDocRepository(getDb());
+    const { PgliteDocRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteDocRepository(await getDb());
   }
   const { ApiDocRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -88,8 +88,8 @@ export async function createDocRepository(db?: unknown): Promise<IDocRepository>
 
 export async function createProjectRepository(db?: unknown): Promise<IProjectRepository> {
   if (isOssMode()) {
-    const { SqliteProjectRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteProjectRepository(getDb());
+    const { PgliteProjectRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteProjectRepository(await getDb());
   }
   const { ApiProjectRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -98,8 +98,8 @@ export async function createProjectRepository(db?: unknown): Promise<IProjectRep
 
 export async function createSprintRepository(db?: unknown): Promise<ISprintRepository> {
   if (isOssMode()) {
-    const { SqliteSprintRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteSprintRepository(getDb());
+    const { PgliteSprintRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteSprintRepository(await getDb());
   }
   const { ApiSprintRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -108,8 +108,8 @@ export async function createSprintRepository(db?: unknown): Promise<ISprintRepos
 
 export async function createNotificationRepository(db?: unknown): Promise<INotificationRepository> {
   if (isOssMode()) {
-    const { SqliteNotificationRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteNotificationRepository(getDb());
+    const { PgliteNotificationRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteNotificationRepository(await getDb());
   }
   const { ApiNotificationRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -118,8 +118,8 @@ export async function createNotificationRepository(db?: unknown): Promise<INotif
 
 export async function createTeamMemberRepository(db?: unknown): Promise<ITeamMemberRepository> {
   if (isOssMode()) {
-    const { SqliteTeamMemberRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteTeamMemberRepository(getDb());
+    const { PgliteTeamMemberRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteTeamMemberRepository(await getDb());
   }
   const { ApiTeamMemberRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -128,8 +128,8 @@ export async function createTeamMemberRepository(db?: unknown): Promise<ITeamMem
 
 export async function createInboxItemRepository(db?: unknown): Promise<IInboxItemRepository> {
   if (isOssMode()) {
-    const { SqliteInboxItemRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteInboxItemRepository(getDb());
+    const { PgliteInboxItemRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteInboxItemRepository(await getDb());
   }
   const { ApiInboxItemRepository } = await import('@sprintable/storage-api');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -176,16 +176,16 @@ export async function createAgentRunBillingRepository(db?: unknown): Promise<IAg
 
 export async function createAgentRunRepository(): Promise<IAgentRunRepository> {
   if (isOssMode()) {
-    const { SqliteAgentRunRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteAgentRunRepository(getDb());
+    const { PgliteAgentRunRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteAgentRunRepository(await getDb());
   }
   throw new Error('AgentRunRepository is only available in OSS mode');
 }
 
 export async function createAgentApiKeyRepository(): Promise<IAgentApiKeyRepository> {
   if (isOssMode()) {
-    const { SqliteAgentApiKeyRepository, getDb } = await import('@sprintable/storage-sqlite');
-    return new SqliteAgentApiKeyRepository(getDb());
+    const { PgliteAgentApiKeyRepository, getDb } = await import('@sprintable/storage-pglite');
+    return new PgliteAgentApiKeyRepository(await getDb());
   }
   throw new Error('AgentApiKeyRepository is only available in OSS mode');
 }

--- a/packages/storage-pglite/src/PgliteAgentApiKeyRepository.ts
+++ b/packages/storage-pglite/src/PgliteAgentApiKeyRepository.ts
@@ -1,0 +1,48 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  IAgentApiKeyRepository,
+  AgentApiKey,
+  CreateAgentApiKeyInput,
+} from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteAgentApiKeyRepository implements IAgentApiKeyRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateAgentApiKeyInput): Promise<Pick<AgentApiKey, 'id' | 'key_prefix' | 'created_at'>> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const expiresAt = input.expiresAt ?? null;
+    const scope = JSON.stringify(input.scope ?? ['read', 'write']);
+    await this.db.query(...toPos(
+      'INSERT INTO agent_api_keys (id, team_member_id, key_prefix, key_hash, created_at, expires_at, scope) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [id, input.teamMemberId, input.keyPrefix, input.keyHash, now, expiresAt, scope]
+    ));
+    return { id, key_prefix: input.keyPrefix, created_at: now };
+  }
+
+  async list(teamMemberId: string): Promise<AgentApiKey[]> {
+    const rows = (await this.db.query(...toPos(
+      'SELECT * FROM agent_api_keys WHERE team_member_id = ? ORDER BY created_at DESC',
+      [teamMemberId]
+    ))).rows as Array<Record<string, unknown>>;
+    return rows.map((row) => ({
+      ...row,
+      scope: row.scope ? JSON.parse(row.scope as string) as string[] : ['read', 'write'],
+    })) as unknown as AgentApiKey[];
+  }
+
+  async revoke(keyId: string): Promise<void> {
+    await this.db.query(...toPos(
+      'UPDATE agent_api_keys SET revoked_at = ? WHERE id = ?',
+      [new Date().toISOString(), keyId]
+    ));
+  }
+}

--- a/packages/storage-pglite/src/PgliteAgentRunRepository.ts
+++ b/packages/storage-pglite/src/PgliteAgentRunRepository.ts
@@ -1,0 +1,60 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  IAgentRunRepository,
+  AgentRun,
+  AgentRunListFilters,
+  AgentRunListResult,
+} from '@sprintable/core-storage';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteAgentRunRepository implements IAgentRunRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async list(filters: AgentRunListFilters): Promise<AgentRunListResult> {
+    let query = 'SELECT * FROM agent_runs WHERE org_id = ? AND project_id = ?';
+    const params: SqlParam[] = [filters.orgId, filters.projectId];
+
+    if (filters.status) {
+      query += ' AND status = ?';
+      params.push(filters.status);
+    }
+
+    const fromDate = filters.from ?? new Date(Date.now() - 7 * 86400000).toISOString();
+    query += ' AND created_at >= ?';
+    params.push(fromDate);
+
+    if (filters.to) {
+      query += ' AND created_at <= ?';
+      params.push(filters.to);
+    }
+
+    if (filters.cursor) {
+      query += ' AND created_at < ?';
+      params.push(filters.cursor);
+    }
+
+    query += ' ORDER BY created_at DESC LIMIT ?';
+    params.push(filters.limit + 1);
+
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as AgentRun[];
+    const hasMore = rows.length > filters.limit;
+    const items = hasMore ? rows.slice(0, filters.limit) : rows;
+    const nextCursor = hasMore && items.length > 0 ? (items[items.length - 1]!.created_at) : null;
+
+    return { items, nextCursor, hasMore, limit: filters.limit };
+  }
+
+  async getById(id: string, orgId: string, projectId: string): Promise<AgentRun | null> {
+    const row = (await this.db.query(...toPos(
+      'SELECT * FROM agent_runs WHERE id = ? AND org_id = ? AND project_id = ?',
+      [id, orgId, projectId]
+    ))).rows[0] as AgentRun | undefined;
+    return row ?? null;
+  }
+}

--- a/packages/storage-pglite/src/PgliteDocRepository.ts
+++ b/packages/storage-pglite/src/PgliteDocRepository.ts
@@ -1,0 +1,104 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  IDocRepository,
+  Doc,
+  DocSummary,
+  CreateDocInput,
+  UpdateDocInput,
+  DocListFilters,
+  RepositoryScopeContext,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+interface DocRow extends Omit<Doc, 'tags' | 'is_folder'> {
+  tags: string | null;
+  is_folder: number;
+}
+
+function hydrateDoc(row: DocRow): Doc {
+  return {
+    ...row,
+    tags: row.tags ? JSON.parse(row.tags) : [],
+    is_folder: Boolean(row.is_folder),
+  };
+}
+
+export class PgliteDocRepository implements IDocRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async list(filters: DocListFilters): Promise<DocSummary[]> {
+    let query = 'SELECT id, parent_id, title, slug, icon, sort_order, is_folder, updated_at FROM docs WHERE project_id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [filters.project_id];
+    if (filters.cursor) { query += ' AND updated_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY updated_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as Array<Omit<DocSummary, 'is_folder'> & { is_folder: number }>;
+    return rows.map((r) => ({ ...r, is_folder: Boolean(r.is_folder) }));
+  }
+
+  async getTree(projectId: string): Promise<DocSummary[]> {
+    const rows = (await this.db.query(...toPos('SELECT id, parent_id, title, slug, icon, sort_order, is_folder, updated_at FROM docs WHERE project_id = ? AND deleted_at IS NULL ORDER BY sort_order', [projectId]))).rows as unknown as Array<Omit<DocSummary, 'is_folder'> & { is_folder: number }>;
+    return rows.map((r) => ({ ...r, is_folder: Boolean(r.is_folder) }));
+  }
+
+  async getBySlug(projectId: string, slug: string): Promise<Doc> {
+    const row = (await this.db.query(...toPos('SELECT * FROM docs WHERE project_id = ? AND slug = ? AND deleted_at IS NULL', [projectId, slug]))).rows[0] as DocRow | undefined;
+    if (!row) throw new NotFoundError('Doc not found');
+    return hydrateDoc(row);
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Doc> {
+    let query = 'SELECT * FROM docs WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    if (scope?.project_id) { query += ' AND project_id = ?'; params.push(scope.project_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as DocRow | undefined;
+    if (!row) throw new NotFoundError('Doc not found');
+    return hydrateDoc(row);
+  }
+
+  async create(input: CreateDocInput): Promise<Doc> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO docs (id, org_id, project_id, parent_id, title, slug, content, content_format, icon, tags, sort_order, is_folder, created_by, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `, [
+      id, input.org_id, input.project_id, input.parent_id ?? null, input.title, input.slug,
+      input.content ?? null, input.content_format ?? 'markdown', input.icon ?? null,
+      JSON.stringify(input.tags ?? []), input.sort_order ?? 0, input.is_folder ? 1 : 0,
+      input.created_by, now, now,
+    ]));
+    return this.getById(id);
+  }
+
+  async update(id: string, input: UpdateDocInput): Promise<Doc> {
+    const ALLOWED: (keyof UpdateDocInput)[] = ['title', 'content', 'content_format', 'icon', 'tags', 'sort_order', 'parent_id'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) {
+        sets.push(`${key} = ?`);
+        const val = input[key];
+        params.push(key === 'tags' && val != null ? JSON.stringify(val) : (val as SqlParam));
+      }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE docs SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, _orgId: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE docs SET deleted_at = ? WHERE id = ?', [new Date().toISOString(), id]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteEpicRepository.ts
+++ b/packages/storage-pglite/src/PgliteEpicRepository.ts
@@ -1,0 +1,72 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { IEpicRepository, Epic, CreateEpicInput, UpdateEpicInput, EpicListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteEpicRepository implements IEpicRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateEpicInput): Promise<Epic> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO epics (id, org_id, project_id, title, status, priority, description, objective, success_criteria, target_sp, target_date, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `, [id, input.org_id, input.project_id, input.title.trim(), input.status ?? 'active', input.priority ?? 'medium', input.description ?? null, input.objective ?? null, input.success_criteria ?? null, input.target_sp ?? null, input.target_date ?? null, now, now]));
+    return this.getById(id);
+  }
+
+  async list(filters: EpicListFilters): Promise<Epic[]> {
+    let query = 'SELECT * FROM epics WHERE deleted_at IS NULL';
+    const params: SqlParam[] = [];
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit) { query += ` LIMIT ${filters.limit + 1}`; }
+    return (await this.db.query(...toPos(query, params))).rows as unknown as Epic[];
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Epic> {
+    let query = 'SELECT * FROM epics WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    if (scope?.project_id) { query += ' AND project_id = ?'; params.push(scope.project_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as Epic | undefined;
+    if (!row) throw new NotFoundError('Epic not found');
+    return row;
+  }
+
+  async getByIdWithStories(id: string, scope?: RepositoryScopeContext): Promise<Epic & { stories: unknown[] }> {
+    const epic = await this.getById(id, scope);
+    const stories = (await this.db.query(...toPos('SELECT * FROM stories WHERE epic_id = ? AND deleted_at IS NULL ORDER BY created_at DESC', [id]))).rows;
+    return { ...epic, stories };
+  }
+
+  async update(id: string, input: UpdateEpicInput): Promise<Epic> {
+    const ALLOWED: (keyof UpdateEpicInput)[] = ['title', 'status', 'priority', 'description', 'objective', 'success_criteria', 'target_sp', 'target_date'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) { sets.push(`${key} = ?`); params.push(input[key] as SqlParam); }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?');
+    params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE epics SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, _orgId: string): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.query(...toPos('UPDATE stories SET epic_id = NULL WHERE epic_id = ?', [id]));
+    await this.db.query(...toPos('UPDATE epics SET deleted_at = ? WHERE id = ?', [now, id]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteInboxItemRepository.ts
+++ b/packages/storage-pglite/src/PgliteInboxItemRepository.ts
@@ -1,0 +1,322 @@
+import type { PGlite } from '@electric-sql/pglite';
+import { randomUUID } from 'node:crypto';
+import type {
+  IInboxItemRepository,
+  InboxItem,
+  CreateInboxItemInput,
+  InboxListFilters,
+  ResolveInboxItemInput,
+  DismissInboxItemInput,
+  ReassignInboxItemInput,
+  InboxItemCount,
+  InboxKind,
+  OriginNode,
+  InboxOption,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+interface InboxItemRow {
+  id: string;
+  org_id: string;
+  project_id: string;
+  assignee_member_id: string;
+  kind: InboxKind;
+  title: string;
+  context: string | null;
+  agent_summary: string | null;
+  origin_chain: string;     // JSON-encoded
+  options: string;          // JSON-encoded
+  after_decision: string | null;
+  from_agent_id: string | null;
+  story_id: string | null;
+  memo_id: string | null;
+  priority: 'high' | 'normal';
+  state: 'pending' | 'resolved' | 'dismissed';
+  resolved_by: string | null;
+  resolved_option_id: string | null;
+  resolved_note: string | null;
+  source_type: InboxItem['source_type'];
+  source_id: string;
+  waiting_since: string;
+  created_at: string;
+  resolved_at: string | null;
+}
+
+function hydrate(row: InboxItemRow): InboxItem {
+  return {
+    ...row,
+    origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+    options: parseJsonArray<InboxOption>(row.options),
+  };
+}
+
+function parseJsonArray<T>(text: string | null | undefined): T[] {
+  if (!text) return [];
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+export class PgliteInboxItemRepository implements IInboxItemRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateInboxItemInput): Promise<InboxItem> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+
+    // Idempotency: same (org, source_type, source_id, kind) returns existing row
+    const existing = (await this.db.query(...toPos(
+      'SELECT * FROM inbox_items WHERE org_id = ? AND source_type = ? AND source_id = ? AND kind = ?',
+      [input.org_id, input.source_type, input.source_id, input.kind]
+    ))).rows[0] as InboxItemRow | undefined;
+    if (existing) return hydrate(existing);
+
+    await this.db.query(...toPos(`
+      INSERT INTO inbox_items (
+        id, org_id, project_id, assignee_member_id, kind, title, context, agent_summary,
+        origin_chain, options, after_decision, from_agent_id, story_id, memo_id,
+        priority, state, source_type, source_id, waiting_since, created_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?, ?, ?)
+    `, [
+      id, input.org_id, input.project_id, input.assignee_member_id, input.kind,
+      input.title, input.context ?? null, input.agent_summary ?? null,
+      JSON.stringify(input.origin_chain ?? []),
+      JSON.stringify(input.options ?? []),
+      input.after_decision ?? null, input.from_agent_id ?? null,
+      input.story_id ?? null, input.memo_id ?? null,
+      input.priority ?? 'normal',
+      input.source_type, input.source_id, now, now,
+    ]));
+
+    return this.requireById(id, input.org_id);
+  }
+
+  async list(filters: InboxListFilters): Promise<InboxItem[]> {
+    let query = 'SELECT * FROM inbox_items WHERE org_id = ?';
+    const params: SqlParam[] = [filters.org_id];
+
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.assignee_member_id) { query += ' AND assignee_member_id = ?'; params.push(filters.assignee_member_id); }
+    if (filters.kind) { query += ' AND kind = ?'; params.push(filters.kind); }
+    if (filters.state) { query += ' AND state = ?'; params.push(filters.state); }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit); }
+
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as InboxItemRow[];
+    return rows.map(hydrate);
+  }
+
+  async get(id: string, orgId: string): Promise<InboxItem | null> {
+    const row = (await this.db.query(...toPos(
+      'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?',
+      [id, orgId]
+    ))).rows[0] as InboxItemRow | undefined;
+    return row ? hydrate(row) : null;
+  }
+
+  async count(filters: Omit<InboxListFilters, 'limit' | 'cursor'>): Promise<InboxItemCount> {
+    let query = 'SELECT kind, COUNT(*) as n FROM inbox_items WHERE org_id = ?';
+    const params: SqlParam[] = [filters.org_id];
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.assignee_member_id) { query += ' AND assignee_member_id = ?'; params.push(filters.assignee_member_id); }
+    if (filters.state) { query += ' AND state = ?'; params.push(filters.state); }
+    query += ' GROUP BY kind';
+
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as Array<{ kind: InboxKind; n: number }>;
+    const byKind: Record<InboxKind, number> = { approval: 0, decision: 0, blocker: 0, mention: 0 };
+    let total = 0;
+    for (const r of rows) {
+      byKind[r.kind] = r.n;
+      total += r.n;
+    }
+    return { total, byKind };
+  }
+
+  async resolve(id: string, orgId: string, input: ResolveInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    await this.db.query('BEGIN');
+    try {
+      const row = (await this.db.query(...toPos(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?',
+        [id, orgId]
+      ))).rows[0] as InboxItemRow | undefined;
+      if (!row) {
+        await this.db.query('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+      if (row.state !== 'pending') {
+        await this.db.query('ROLLBACK');
+        throw new Error(`Inbox item already ${row.state}`);
+      }
+
+      // Verify resolved_option_id exists in options
+      const options = parseJsonArray<InboxOption>(row.options);
+      if (!options.some((opt) => opt.id === input.resolved_option_id)) {
+        await this.db.query('ROLLBACK');
+        throw new Error(`Option id ${input.resolved_option_id} not found in inbox item options`);
+      }
+
+      await this.db.query(...toPos(`
+        UPDATE inbox_items
+        SET state = 'resolved', resolved_by = ?, resolved_option_id = ?, resolved_note = ?, resolved_at = ?
+        WHERE id = ? AND org_id = ?
+      `, [input.resolved_by, input.resolved_option_id, input.resolved_note ?? null, now, id, orgId]));
+
+      await this.enqueueOutbox(orgId, id, 'resolved', {
+        inbox_item_id: id,
+        event_type: 'resolved',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options,
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_choice: input.resolved_option_id,
+        resolved_note: input.resolved_note ?? null,
+        resolved_by: input.resolved_by,
+        ts: now,
+      });
+
+      await this.db.query('COMMIT');
+    } catch (e) {
+      try { await this.db.query('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  async dismiss(id: string, orgId: string, input: DismissInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    await this.db.query('BEGIN');
+    try {
+      const row = (await this.db.query(...toPos(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?',
+        [id, orgId]
+      ))).rows[0] as InboxItemRow | undefined;
+      if (!row) {
+        await this.db.query('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+      if (row.state !== 'pending') {
+        await this.db.query('ROLLBACK');
+        throw new Error(`Inbox item already ${row.state}`);
+      }
+
+      await this.db.query(...toPos(`
+        UPDATE inbox_items
+        SET state = 'dismissed', resolved_by = ?, resolved_note = ?, resolved_at = ?
+        WHERE id = ? AND org_id = ?
+      `, [input.resolved_by, input.resolved_note ?? null, now, id, orgId]));
+
+      await this.enqueueOutbox(orgId, id, 'dismissed', {
+        inbox_item_id: id,
+        event_type: 'dismissed',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options: parseJsonArray<InboxOption>(row.options),
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_note: input.resolved_note ?? null,
+        resolved_by: input.resolved_by,
+        ts: now,
+      });
+
+      await this.db.query('COMMIT');
+    } catch (e) {
+      try { await this.db.query('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  async reassign(id: string, orgId: string, input: ReassignInboxItemInput): Promise<InboxItem> {
+    const now = new Date().toISOString();
+
+    await this.db.query('BEGIN');
+    try {
+      const row = (await this.db.query(...toPos(
+        'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?',
+        [id, orgId]
+      ))).rows[0] as InboxItemRow | undefined;
+      if (!row) {
+        await this.db.query('ROLLBACK');
+        throw new NotFoundError(`Inbox item not found: ${id}`);
+      }
+
+      await this.db.query(...toPos(`
+        UPDATE inbox_items
+        SET assignee_member_id = ?
+        WHERE id = ? AND org_id = ?
+      `, [input.new_assignee_member_id, id, orgId]));
+
+      await this.enqueueOutbox(orgId, id, 'reassigned', {
+        inbox_item_id: id,
+        event_type: 'reassigned',
+        inbox_item_snapshot: {
+          title: row.title,
+          kind: row.kind,
+          project_id: row.project_id,
+          org_id: row.org_id,
+          options: parseJsonArray<InboxOption>(row.options),
+          origin_chain: parseJsonArray<OriginNode>(row.origin_chain),
+        },
+        resolved_by: input.reassigned_by,
+        ts: now,
+      });
+
+      await this.db.query('COMMIT');
+    } catch (e) {
+      try { await this.db.query('ROLLBACK'); } catch { /* already rolled back */ }
+      throw e;
+    }
+
+    return this.requireById(id, orgId);
+  }
+
+  // ──────────────────────────────────────────────
+  // Internal helpers
+  // ──────────────────────────────────────────────
+
+  private async requireById(id: string, orgId: string): Promise<InboxItem> {
+    const row = (await this.db.query(...toPos(
+      'SELECT * FROM inbox_items WHERE id = ? AND org_id = ?',
+      [id, orgId]
+    ))).rows[0] as InboxItemRow | undefined;
+    if (!row) throw new NotFoundError(`Inbox item not found after upsert: ${id}`);
+    return hydrate(row);
+  }
+
+  private async enqueueOutbox(orgId: string, inboxItemId: string, eventType: 'resolved' | 'dismissed' | 'reassigned', payload: unknown): Promise<void> {
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO inbox_outbox (
+        id, org_id, inbox_item_id, event_type, payload,
+        webhook_url, status, attempt_count, next_attempt_at, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, NULL, 'pending', 0, ?, ?, ?)
+    `, [
+      randomUUID(), orgId, inboxItemId, eventType, JSON.stringify(payload),
+      now, now, now,
+    ]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteMemoRepository.ts
+++ b/packages/storage-pglite/src/PgliteMemoRepository.ts
@@ -1,0 +1,119 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  IMemoRepository,
+  Memo,
+  CreateMemoInput,
+  UpdateMemoInput,
+  MemoReply,
+  MemoListFilters,
+  RepositoryScopeContext,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+interface MemoRow extends Omit<Memo, 'metadata'> {
+  metadata: string | null;
+}
+
+function hydrateMemo(row: MemoRow): Memo {
+  return { ...row, metadata: row.metadata ? JSON.parse(row.metadata) : null };
+}
+
+export class PgliteMemoRepository implements IMemoRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateMemoInput): Promise<Memo> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO memos (id, org_id, project_id, title, content, status, memo_type, assigned_to, supersedes_id, created_by, metadata, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
+    `, [
+      id, input.org_id, input.project_id, input.title ?? null, input.content.trim(),
+      input.memo_type ?? 'memo', input.assigned_to ?? null, input.supersedes_id ?? null,
+      input.created_by, JSON.stringify(input.metadata ?? {}), now, now,
+    ]));
+    return this.getById(id);
+  }
+
+  async list(filters: MemoListFilters): Promise<Memo[]> {
+    let query = 'SELECT * FROM memos WHERE deleted_at IS NULL';
+    const params: SqlParam[] = [];
+    if (filters.org_id && !filters.project_id) { query += ' AND org_id = ?'; params.push(filters.org_id); }
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.assigned_to) { query += ' AND assigned_to = ?'; params.push(filters.assigned_to); }
+    if (filters.created_by) { query += ' AND created_by = ?'; params.push(filters.created_by); }
+    if (filters.status) { query += ' AND status = ?'; params.push(filters.status); }
+    if (filters.q?.trim()) {
+      query += ' AND (title LIKE ? OR content LIKE ?)';
+      const q = `%${filters.q.trim()}%`;
+      params.push(q, q);
+    }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as MemoRow[];
+    return rows.map(hydrateMemo);
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Memo> {
+    let query = 'SELECT * FROM memos WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    if (scope?.project_id) { query += ' AND project_id = ?'; params.push(scope.project_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as MemoRow | undefined;
+    if (!row) throw new NotFoundError('Memo not found');
+    return hydrateMemo(row);
+  }
+
+  async update(id: string, input: UpdateMemoInput): Promise<Memo> {
+    const ALLOWED: (keyof UpdateMemoInput)[] = ['title', 'content', 'status', 'assigned_to', 'metadata'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) {
+        sets.push(`${key} = ?`);
+        const val = input[key];
+        params.push(key === 'metadata' && val != null ? JSON.stringify(val) : (val as SqlParam));
+      }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE memos SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async resolve(id: string, resolvedBy: string): Promise<Memo> {
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`UPDATE memos SET status = 'resolved', resolved_by = ?, resolved_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL`, [resolvedBy, now, now, id]));
+    return this.getById(id);
+  }
+
+  async archive(id: string, archivedAt: string | null): Promise<Memo> {
+    const now = new Date().toISOString();
+    await this.db.query(...toPos('UPDATE memos SET archived_at = ?, updated_at = ? WHERE id = ? AND deleted_at IS NULL', [archivedAt, now, id]));
+    return this.getById(id);
+  }
+
+  async addReply(input: { memo_id: string; content: string; created_by: string; review_type?: string }): Promise<MemoReply> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO memo_replies (id, memo_id, content, created_by, review_type, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `, [id, input.memo_id, input.content.trim(), input.created_by, input.review_type ?? 'comment', now]));
+    return (await this.db.query(...toPos('SELECT * FROM memo_replies WHERE id = ?', [id]))).rows[0] as unknown as MemoReply;
+  }
+
+  async getReplies(memoId: string): Promise<MemoReply[]> {
+    return (await this.db.query(...toPos('SELECT * FROM memo_replies WHERE memo_id = ? ORDER BY created_at ASC', [memoId]))).rows as unknown as MemoReply[];
+  }
+}

--- a/packages/storage-pglite/src/PgliteNotificationRepository.ts
+++ b/packages/storage-pglite/src/PgliteNotificationRepository.ts
@@ -1,0 +1,66 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  INotificationRepository,
+  Notification,
+  CreateNotificationInput,
+  NotificationListFilters,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+interface NotificationRow extends Omit<Notification, 'is_read'> {
+  is_read: number;
+}
+
+function hydrate(row: NotificationRow): Notification {
+  return { ...row, is_read: Boolean(row.is_read) };
+}
+
+export class PgliteNotificationRepository implements INotificationRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateNotificationInput): Promise<Notification> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO notifications (id, org_id, user_id, type, title, body, is_read, reference_type, reference_id, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)
+    `, [
+      id, input.org_id, input.user_id, input.type ?? 'info', input.title,
+      input.body ?? null, input.reference_type ?? null, input.reference_id ?? null, now,
+    ]));
+    const row = (await this.db.query(...toPos('SELECT * FROM notifications WHERE id = ?', [id]))).rows[0] as NotificationRow | undefined;
+    if (!row) throw new NotFoundError('Notification not found after insert');
+    return hydrate(row);
+  }
+
+  async list(filters: NotificationListFilters): Promise<Notification[]> {
+    let query = 'SELECT * FROM notifications WHERE user_id = ?';
+    const params: SqlParam[] = [filters.user_id];
+    if (filters.is_read != null) { query += ' AND is_read = ?'; params.push(filters.is_read ? 1 : 0); }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as NotificationRow[];
+    return rows.map(hydrate);
+  }
+
+  async markRead(id: string, userId: string): Promise<Notification> {
+    await this.db.query(...toPos('UPDATE notifications SET is_read = 1 WHERE id = ? AND user_id = ?', [id, userId]));
+    const row = (await this.db.query(...toPos('SELECT * FROM notifications WHERE id = ? AND user_id = ?', [id, userId]))).rows[0] as NotificationRow | undefined;
+    if (!row) throw new NotFoundError('Notification not found');
+    return hydrate(row);
+  }
+
+  async markAllRead(userId: string): Promise<number> {
+    const result = await this.db.query(...toPos('UPDATE notifications SET is_read = 1 WHERE user_id = ? AND is_read = 0', [userId]));
+    return Number((result as unknown as { affectedRows?: number }).affectedRows ?? 0);
+  }
+}

--- a/packages/storage-pglite/src/PgliteProjectRepository.ts
+++ b/packages/storage-pglite/src/PgliteProjectRepository.ts
@@ -1,0 +1,68 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  IProjectRepository,
+  Project,
+  CreateProjectInput,
+  UpdateProjectInput,
+  ProjectListFilters,
+  RepositoryScopeContext,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteProjectRepository implements IProjectRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async list(filters: ProjectListFilters): Promise<Project[]> {
+    let query = 'SELECT * FROM projects WHERE org_id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [filters.org_id];
+    if (filters.cursor) { query += ' AND created_at > ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at ASC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    return (await this.db.query(...toPos(query, params))).rows as unknown as Project[];
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Project> {
+    let query = 'SELECT * FROM projects WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as Project | undefined;
+    if (!row) throw new NotFoundError('Project not found');
+    return row;
+  }
+
+  async create(input: CreateProjectInput): Promise<Project> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO projects (id, org_id, name, description, created_by, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `, [id, input.org_id, input.name.trim(), input.description ?? null, input.created_by ?? null, now, now]));
+    return this.getById(id);
+  }
+
+  async update(id: string, input: UpdateProjectInput): Promise<Project> {
+    const ALLOWED: (keyof UpdateProjectInput)[] = ['name', 'description'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) { sets.push(`${key} = ?`); params.push(input[key] as SqlParam); }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE projects SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, orgId: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE projects SET deleted_at = ? WHERE id = ? AND org_id = ?', [new Date().toISOString(), id, orgId]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteSprintRepository.ts
+++ b/packages/storage-pglite/src/PgliteSprintRepository.ts
@@ -1,0 +1,71 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  ISprintRepository,
+  Sprint,
+  CreateSprintInput,
+  UpdateSprintInput,
+  SprintListFilters,
+  RepositoryScopeContext,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteSprintRepository implements ISprintRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateSprintInput): Promise<Sprint> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO sprints (id, org_id, project_id, title, status, start_date, end_date, team_size, created_at, updated_at)
+      VALUES (?, ?, ?, ?, 'planning', ?, ?, ?, ?, ?)
+    `, [id, input.org_id, input.project_id, input.title.trim(), input.start_date, input.end_date, input.team_size ?? null, now, now]));
+    return this.getById(id);
+  }
+
+  async list(filters: SprintListFilters): Promise<Sprint[]> {
+    let query = 'SELECT * FROM sprints WHERE deleted_at IS NULL';
+    const params: SqlParam[] = [];
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.status) { query += ' AND status = ?'; params.push(filters.status); }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    return (await this.db.query(...toPos(query, params))).rows as unknown as Sprint[];
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Sprint> {
+    let query = 'SELECT * FROM sprints WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    if (scope?.project_id) { query += ' AND project_id = ?'; params.push(scope.project_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as Sprint | undefined;
+    if (!row) throw new NotFoundError('Sprint not found');
+    return row;
+  }
+
+  async update(id: string, input: UpdateSprintInput): Promise<Sprint> {
+    const ALLOWED: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'status', 'velocity'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) { sets.push(`${key} = ?`); params.push(input[key] as SqlParam); }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE sprints SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, orgId: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE sprints SET deleted_at = ? WHERE id = ? AND org_id = ?', [new Date().toISOString(), id, orgId]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteStoryRepository.ts
+++ b/packages/storage-pglite/src/PgliteStoryRepository.ts
@@ -1,0 +1,114 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { IStoryRepository, Story, CreateStoryInput, UpdateStoryInput, BulkUpdateItem, StoryComment, StoryListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
+import type { PaginationOptions } from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteStoryRepository implements IStoryRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateStoryInput): Promise<Story> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO stories (id, org_id, project_id, epic_id, sprint_id, assignee_id, title, status, priority, story_points, description, acceptance_criteria, meeting_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `, [id, input.org_id, input.project_id, input.epic_id ?? null, input.sprint_id ?? null, input.assignee_id ?? null, input.title.trim(), input.status ?? 'backlog', input.priority ?? 'medium', input.story_points ?? null, input.description ?? null, input.acceptance_criteria ?? null, input.meeting_id ?? null, now, now]));
+    return this.getById(id);
+  }
+
+  async list(filters: StoryListFilters): Promise<Story[]> {
+    let query = 'SELECT * FROM stories WHERE deleted_at IS NULL';
+    const params: SqlParam[] = [];
+    if (filters.sprint_id) { query += ' AND sprint_id = ?'; params.push(filters.sprint_id); }
+    if (filters.epic_id) { query += ' AND epic_id = ?'; params.push(filters.epic_id); }
+    if (filters.assignee_id) { query += ' AND assignee_id = ?'; params.push(filters.assignee_id); }
+    if (filters.status) { query += ' AND status = ?'; params.push(filters.status); }
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.unassigned) { query += ' AND assignee_id IS NULL'; }
+    if (filters.q) { query += ' AND title LIKE ?'; params.push(`%${filters.q}%`); }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit) { query += ` LIMIT ${filters.limit + 1}`; }
+    return (await this.db.query(...toPos(query, params))).rows as unknown as Story[];
+  }
+
+  async backlog(projectId: string): Promise<Story[]> {
+    return (await this.db.query(...toPos('SELECT * FROM stories WHERE project_id = ? AND sprint_id IS NULL AND deleted_at IS NULL ORDER BY created_at DESC', [projectId]))).rows as unknown as Story[];
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Story> {
+    let query = 'SELECT * FROM stories WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    if (scope?.project_id) { query += ' AND project_id = ?'; params.push(scope.project_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as Story | undefined;
+    if (!row) throw new NotFoundError('Story not found');
+    return row;
+  }
+
+  async getByIdWithDetails(id: string, scope?: RepositoryScopeContext): Promise<Story & { tasks: unknown[] }> {
+    const story = await this.getById(id, scope);
+    const tasks = (await this.db.query(...toPos('SELECT * FROM tasks WHERE story_id = ? ORDER BY created_at ASC', [id]))).rows;
+    return { ...story, tasks };
+  }
+
+  async update(id: string, input: UpdateStoryInput): Promise<Story> {
+    const ALLOWED: (keyof UpdateStoryInput)[] = ['title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria', 'epic_id', 'sprint_id', 'assignee_id', 'position'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) { sets.push(`${key} = ?`); params.push(input[key] as SqlParam); }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?');
+    params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE stories SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE stories SET deleted_at = ? WHERE id = ?', [new Date().toISOString(), id]));
+  }
+
+  async bulkUpdate(items: BulkUpdateItem[]): Promise<Story[]> {
+    return Promise.all(items.map(({ id, ...patch }) => this.update(id, patch)));
+  }
+
+  async addComment(input: { story_id: string; content: string; created_by: string }): Promise<StoryComment> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos('INSERT INTO story_comments (id, story_id, content, created_by, created_at) VALUES (?, ?, ?, ?, ?)', [id, input.story_id, input.content, input.created_by, now]));
+    return (await this.db.query(...toPos('SELECT * FROM story_comments WHERE id = ?', [id]))).rows[0] as unknown as StoryComment;
+  }
+
+  async getComments(storyId: string, options?: PaginationOptions): Promise<StoryComment[]> {
+    let query = 'SELECT * FROM story_comments WHERE story_id = ?';
+    const params: SqlParam[] = [storyId];
+    if (options?.cursor) { query += ' AND created_at > ?'; params.push(options.cursor); }
+    query += ' ORDER BY created_at ASC';
+    if (options?.limit) { query += ` LIMIT ${options.limit}`; }
+    return (await this.db.query(...toPos(query, params))).rows as unknown as StoryComment[];
+  }
+
+  async getActivities(storyId: string, options?: PaginationOptions): Promise<unknown[]> {
+    let query = 'SELECT * FROM story_activities WHERE story_id = ?';
+    const params: SqlParam[] = [storyId];
+    if (options?.cursor) { query += ' AND created_at < ?'; params.push(options.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (options?.limit) { query += ` LIMIT ${options.limit}`; }
+    return (await this.db.query(...toPos(query, params))).rows;
+  }
+
+  async addActivity(_input: { story_id: string; org_id: string; actor_id: string; action_type: string; old_value?: string | null; new_value?: string | null }): Promise<void> {
+    // OSS PGlite mode: activity logs not persisted
+  }
+}

--- a/packages/storage-pglite/src/PgliteTaskRepository.ts
+++ b/packages/storage-pglite/src/PgliteTaskRepository.ts
@@ -1,0 +1,84 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type { ITaskRepository, Task, CreateTaskInput, UpdateTaskInput, TaskListFilters, RepositoryScopeContext } from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+export class PgliteTaskRepository implements ITaskRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async create(input: CreateTaskInput): Promise<Task> {
+    const story = (await this.db.query(...toPos('SELECT org_id FROM stories WHERE id = ? AND deleted_at IS NULL', [input.story_id]))).rows[0] as { org_id: string } | undefined;
+    if (!story) throw new NotFoundError('Parent story not found');
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO tasks (id, org_id, story_id, title, status, assignee_id, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `, [id, story.org_id, input.story_id, input.title.trim(), input.status ?? 'todo', input.assignee_id ?? null, now, now]));
+    return this.getById(id);
+  }
+
+  async list(filters: TaskListFilters): Promise<Task[]> {
+    let query = 'SELECT * FROM tasks WHERE deleted_at IS NULL';
+    const params: SqlParam[] = [];
+    if (filters.story_id) { query += ' AND story_id = ?'; params.push(filters.story_id); }
+    if (filters.assignee_id) { query += ' AND assignee_id = ?'; params.push(filters.assignee_id); }
+    if (filters.status) { query += ' AND status = ?'; params.push(filters.status); }
+    if (filters.status_ne) { query += ' AND status != ?'; params.push(filters.status_ne); }
+    if (filters.days_since != null) {
+      const since = new Date(Date.now() - filters.days_since * 24 * 60 * 60 * 1000).toISOString();
+      query += ' AND created_at >= ?'; params.push(since);
+    }
+    if (filters.cursor) { query += ' AND created_at < ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at DESC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    let results = (await this.db.query(...toPos(query, params))).rows as unknown as Task[];
+
+    if (filters.project_id && results.length > 0) {
+      const storyIds = [...new Set(results.map((t) => t.story_id))];
+      const placeholders = storyIds.map(() => '?').join(',');
+      const stories = (await this.db.query(...toPos(`SELECT id FROM stories WHERE project_id = ? AND id IN (${placeholders})`, [filters.project_id, ...storyIds]))).rows as Array<{ id: string }>;
+      const validIds = new Set(stories.map((s) => s.id));
+      results = results.filter((t) => validIds.has(t.story_id));
+    }
+    return results;
+  }
+
+  async getById(id: string, scope?: RepositoryScopeContext): Promise<Task> {
+    let query = 'SELECT * FROM tasks WHERE id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [id];
+    if (scope?.org_id) { query += ' AND org_id = ?'; params.push(scope.org_id); }
+    const row = (await this.db.query(...toPos(query, params))).rows[0] as Task | undefined;
+    if (!row) throw new NotFoundError('Task not found');
+    if (scope?.project_id) {
+      const story = (await this.db.query(...toPos('SELECT project_id FROM stories WHERE id = ?', [row.story_id]))).rows[0] as { project_id: string } | undefined;
+      if (!story || story.project_id !== scope.project_id) throw new NotFoundError('Task not found');
+    }
+    return row;
+  }
+
+  async update(id: string, input: UpdateTaskInput): Promise<Task> {
+    const ALLOWED: (keyof UpdateTaskInput)[] = ['title', 'status', 'assignee_id'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) { sets.push(`${key} = ?`); params.push(input[key] as SqlParam); }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, _orgId: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE tasks SET deleted_at = ? WHERE id = ?', [new Date().toISOString(), id]));
+  }
+}

--- a/packages/storage-pglite/src/PgliteTeamMemberRepository.ts
+++ b/packages/storage-pglite/src/PgliteTeamMemberRepository.ts
@@ -1,0 +1,94 @@
+import type { PGlite } from '@electric-sql/pglite';
+import type {
+  ITeamMemberRepository,
+  TeamMember,
+  CreateTeamMemberInput,
+  UpdateTeamMemberInput,
+  TeamMemberListFilters,
+} from '@sprintable/core-storage';
+import { NotFoundError } from '@sprintable/core-storage';
+import { randomUUID } from 'node:crypto';
+
+type SqlParam = string | number | boolean | null;
+
+function toPos(query: string, params: SqlParam[]): [string, SqlParam[]] {
+  let i = 0;
+  return [query.replace(/\?/g, () => `$${++i}`), params];
+}
+
+interface TeamMemberRow extends Omit<TeamMember, 'is_active' | 'type'> {
+  is_active: number;
+  type: string;
+}
+
+function hydrate(row: TeamMemberRow): TeamMember {
+  return {
+    ...row,
+    is_active: Boolean(row.is_active),
+    type: row.type as 'human' | 'agent',
+  };
+}
+
+export class PgliteTeamMemberRepository implements ITeamMemberRepository {
+  constructor(private readonly db: PGlite) {}
+
+  async list(filters: TeamMemberListFilters): Promise<TeamMember[]> {
+    let query = 'SELECT * FROM team_members WHERE org_id = ? AND deleted_at IS NULL';
+    const params: SqlParam[] = [filters.org_id];
+    if (filters.project_id) { query += ' AND project_id = ?'; params.push(filters.project_id); }
+    if (filters.type) { query += ' AND type = ?'; params.push(filters.type); }
+    if (filters.is_active != null) { query += ' AND is_active = ?'; params.push(filters.is_active ? 1 : 0); }
+    if (filters.cursor) { query += ' AND created_at > ?'; params.push(filters.cursor); }
+    query += ' ORDER BY created_at ASC';
+    if (filters.limit != null) { query += ' LIMIT ?'; params.push(filters.limit + 1); }
+    const rows = (await this.db.query(...toPos(query, params))).rows as unknown as TeamMemberRow[];
+    return rows.map(hydrate);
+  }
+
+  async getById(id: string): Promise<TeamMember> {
+    const row = (await this.db.query(...toPos('SELECT * FROM team_members WHERE id = ? AND deleted_at IS NULL', [id]))).rows[0] as TeamMemberRow | undefined;
+    if (!row) throw new NotFoundError('Team member not found');
+    return hydrate(row);
+  }
+
+  async getByUserId(userId: string, orgId: string): Promise<TeamMember | null> {
+    const row = (await this.db.query(...toPos('SELECT * FROM team_members WHERE user_id = ? AND org_id = ? AND deleted_at IS NULL', [userId, orgId]))).rows[0] as TeamMemberRow | undefined;
+    return row ? hydrate(row) : null;
+  }
+
+  async create(input: CreateTeamMemberInput): Promise<TeamMember> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    await this.db.query(...toPos(`
+      INSERT INTO team_members (id, org_id, project_id, user_id, name, email, role, type, is_active, webhook_url, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `, [
+      id, input.org_id, input.project_id, input.user_id ?? null, input.name, input.email ?? null,
+      input.role ?? 'member', input.type ?? 'human', (input.is_active ?? true) ? 1 : 0,
+      (input as { webhook_url?: string | null }).webhook_url ?? null, now, now,
+    ]));
+    return this.getById(id);
+  }
+
+  async update(id: string, input: UpdateTeamMemberInput): Promise<TeamMember> {
+    const ALLOWED: (keyof UpdateTeamMemberInput)[] = ['name', 'email', 'role', 'is_active', 'webhook_url'];
+    const sets: string[] = [];
+    const params: SqlParam[] = [];
+    for (const key of ALLOWED) {
+      if (key in input) {
+        sets.push(`${key} = ?`);
+        const val = input[key];
+        params.push(key === 'is_active' ? (val ? 1 : 0) : (val as SqlParam));
+      }
+    }
+    if (sets.length === 0) throw new Error('No valid fields to update');
+    sets.push('updated_at = ?'); params.push(new Date().toISOString());
+    params.push(id);
+    await this.db.query(...toPos(`UPDATE team_members SET ${sets.join(', ')} WHERE id = ? AND deleted_at IS NULL`, params));
+    return this.getById(id);
+  }
+
+  async delete(id: string, orgId: string): Promise<void> {
+    await this.db.query(...toPos('UPDATE team_members SET deleted_at = ? WHERE id = ? AND org_id = ?', [new Date().toISOString(), id, orgId]));
+  }
+}

--- a/packages/storage-pglite/src/db.ts
+++ b/packages/storage-pglite/src/db.ts
@@ -110,6 +110,7 @@ async function _initSchema(db: PGlite): Promise<void> {
       created_by TEXT NOT NULL,
       resolved_by TEXT,
       resolved_at TEXT,
+      archived_at TEXT,
       metadata TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,

--- a/packages/storage-pglite/src/index.ts
+++ b/packages/storage-pglite/src/index.ts
@@ -1,1 +1,13 @@
 export { getDb, OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } from './db';
+export { PgliteEpicRepository } from './PgliteEpicRepository';
+export { PgliteStoryRepository } from './PgliteStoryRepository';
+export { PgliteTaskRepository } from './PgliteTaskRepository';
+export { PgliteMemoRepository } from './PgliteMemoRepository';
+export { PgliteDocRepository } from './PgliteDocRepository';
+export { PgliteProjectRepository } from './PgliteProjectRepository';
+export { PgliteSprintRepository } from './PgliteSprintRepository';
+export { PgliteNotificationRepository } from './PgliteNotificationRepository';
+export { PgliteTeamMemberRepository } from './PgliteTeamMemberRepository';
+export { PgliteAgentRunRepository } from './PgliteAgentRunRepository';
+export { PgliteAgentApiKeyRepository } from './PgliteAgentApiKeyRepository';
+export { PgliteInboxItemRepository } from './PgliteInboxItemRepository';


### PR DESCRIPTION
## Summary

12개 SqliteXxxRepository → PgliteXxxRepository 전환. DatabaseSync sync API → PGlite async API 전환.

## Changes

### packages/storage-pglite/src/Pglite*Repository.ts (12개 신규)

| 파일 | 기존 |
|------|------|
| PgliteEpicRepository | SqliteEpicRepository |
| PgliteStoryRepository | SqliteStoryRepository |
| PgliteTaskRepository | SqliteTaskRepository |
| PgliteMemoRepository | SqliteMemoRepository |
| PgliteDocRepository | SqliteDocRepository |
| PgliteProjectRepository | SqliteProjectRepository |
| PgliteSprintRepository | SqliteSprintRepository |
| PgliteNotificationRepository | SqliteNotificationRepository |
| PgliteTeamMemberRepository | SqliteTeamMemberRepository |
| PgliteAgentRunRepository | SqliteAgentRunRepository |
| PgliteAgentApiKeyRepository | SqliteAgentApiKeyRepository |
| PgliteInboxItemRepository | SqliteInboxItemRepository |

**변환 내용:**
- `DatabaseSync` → `PGlite` (async)
- `?` 파라미터 → `$1,$2,...` (toPos() 헬퍼)
- `.prepare().run(...params)` → `await .query(...toPos(q, params))`
- `.prepare().all(...params)` → `(await .query(...)).rows`
- `.prepare().get(...params)` → `(await .query(...)).rows[0]`

### apps/web/src/lib/storage/factory.ts
- `@sprintable/storage-sqlite` → `@sprintable/storage-pglite`
- `getDb()` → `await getDb()` (async 싱글톤)

## Validation
- `tsc --noEmit`: CLEAN (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)