### PR TITLE
fix(docker): @sprintable/storage-pglite 의존성 추가 + lockfile [E-OSS-PGLITE 빌드 블로커]

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@sprintable/core-storage": "workspace:*",
     "@sprintable/storage-api": "workspace:*",
+    "@sprintable/storage-pglite": "workspace:*",
 "@tiptap/core": "^3.22.3",
     "@tiptap/extension-image": "^3.22.3",
     "@tiptap/extension-link": "^3.22.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@sprintable/storage-api':
         specifier: workspace:*
         version: link:../../packages/storage-api
+      '@sprintable/storage-pglite':
+        specifier: workspace:*
+        version: link:../../packages/storage-pglite
       '@tiptap/core':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/pm@3.22.3)


### PR DESCRIPTION
## Summary

- `apps/web/package.json`에 `@sprintable/storage-pglite: workspace:*` 추가
- pnpm-lock.yaml 재생성

## 배경

E-OSS-PGLITE prod Cloud Build FAILURE:
```
Module not found: Can't resolve '@electric-sql/pglite'
```
`instrumentation.ts`와 `api/current-project/route.ts`에서 `@sprintable/storage-pglite`를 dynamic import하지만 `package.json`에 의존성 미선언 → `pnpm install --filter web...` 시 `@electric-sql/pglite` 미설치.

## Test plan
- [ ] Cloud Build prod 빌드 SUCCESS
- [ ] /login 200, /api/health 200, /api/v2/health db:ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)