### PR TITLE
feat(oss-unlimited): UL-S1 OSS 동적 컨텍스트 + 프로젝트 선택기 [E-OSS-UNLIMITED]

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
@@ -7,9 +7,11 @@ import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
 
 export default async function ApiKeysPage() {
   if (isOssMode()) {
-    const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
+    const { getOssUserContext } = await import('@/lib/auth-helpers');
+    const { me } = await getOssUserContext();
+    if (!me) return <div>No project</div>;
     const repo = await createTeamMemberRepository();
-    const agents = await repo.list({ org_id: OSS_ORG_ID, project_id: OSS_PROJECT_ID });
+    const agents = await repo.list({ org_id: me.org_id, project_id: me.project_id });
     const agentMembers = agents.filter((m) => m.type === 'agent' && m.is_active);
     return (
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6 space-y-6">

--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -1,6 +1,6 @@
 import { cookies } from 'next/headers';
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { CURRENT_PROJECT_COOKIE, getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, setCurrentProjectSchema } from '@sprintable/shared';
 import { isOssMode } from '@/lib/storage/factory';
@@ -8,15 +8,14 @@ import { isOssMode } from '@/lib/storage/factory';
 export async function GET(request: Request) {
   try {
     if (isOssMode()) {
-      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-pglite');
-      const { createProjectRepository } = await import('@/lib/storage/factory');
-      const repo = await createProjectRepository();
-      const project = await repo.getById(OSS_PROJECT_ID);
-      return apiSuccess({
-        project_id: OSS_PROJECT_ID,
-        project_name: project?.name ?? 'My Project',
-        org_id: OSS_ORG_ID,
-      });
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const db = await getDb();
+      const projects = (await db.query('SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC')).rows as Array<{ id: string; name: string; org_id: string }>;
+      const cookieStore = await cookies();
+      const cookieProjectId = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value;
+      const current = projects.find((p) => p.id === cookieProjectId) ?? projects[0];
+      if (!current) return apiError('NOT_FOUND', 'No projects found', 404);
+      return apiSuccess({ project_id: current.id, project_name: current.name, org_id: current.org_id });
     }
 
     // 비-OSS: getAuthContext → me에 org_id, project_id 포함
@@ -53,23 +52,13 @@ export async function POST(request: Request) {
     const { project_id: projectId } = parsed.data;
 
     if (isOssMode()) {
-      const { OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
-      if (projectId !== OSS_PROJECT_ID) return ApiErrors.forbidden('Project membership not found');
-
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const db = await getDb();
+      const projectRow = (await db.query('SELECT id, name FROM projects WHERE id = $1 AND deleted_at IS NULL LIMIT 1', [projectId])).rows[0] as { id: string; name: string } | undefined;
+      if (!projectRow) return ApiErrors.forbidden('Project not found');
       const cookieStore = await cookies();
-      cookieStore.set(CURRENT_PROJECT_COOKIE, projectId, {
-        path: '/',
-        sameSite: 'lax',
-        maxAge: 60 * 60 * 24 * 365,
-      });
-
-      const { createProjectRepository } = await import('@/lib/storage/factory');
-      const repo = await createProjectRepository();
-      const project = await repo.getById(OSS_PROJECT_ID);
-      return apiSuccess({
-        project_id: projectId,
-        project_name: project?.name ?? 'My Project',
-      });
+      cookieStore.set(CURRENT_PROJECT_COOKIE, projectId, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
+      return apiSuccess({ project_id: projectId, project_name: projectRow.name });
     }
 
     // 비-OSS: 쿠키에 project_id 저장 + fastapiCall로 프로젝트 정보 조회

--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -15,7 +15,12 @@ export async function GET(request: Request) {
       const cookieProjectId = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value;
       const current = projects.find((p) => p.id === cookieProjectId) ?? projects[0];
       if (!current) return apiError('NOT_FOUND', 'No projects found', 404);
-      return apiSuccess({ project_id: current.id, project_name: current.name, org_id: current.org_id });
+      return apiSuccess({
+        project_id: current.id,
+        project_name: current.name,
+        org_id: current.org_id,
+        projects: projects.map((p) => ({ id: p.id, name: p.name, org_id: p.org_id })),
+      });
     }
 
     // 비-OSS: getAuthContext → me에 org_id, project_id 포함

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -7,13 +7,12 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 export async function GET(request: Request) {
   try {
     if (isOssMode()) {
-      const { OSS_MEMBER_ID, OSS_ORG_ID } = await import('@sprintable/storage-pglite');
       const me = await getAuthContext(request);
       if (!me) return ApiErrors.unauthorized();
 
       const repo = await createTeamMemberRepository();
-      const members = await repo.list({ org_id: OSS_ORG_ID });
-      const member = members.find((m) => m.id === (me.id ?? OSS_MEMBER_ID));
+      const members = await repo.list({ org_id: me.org_id });
+      const member = members.find((m) => m.id === me.id);
       if (!member) return ApiErrors.notFound('Member not found');
       return apiSuccess({ ...member, email: null });
     }
@@ -29,14 +28,15 @@ export async function GET(request: Request) {
 export async function PATCH(request: Request) {
   try {
     if (isOssMode()) {
-      const { OSS_MEMBER_ID } = await import('@sprintable/storage-pglite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
       let body: unknown;
       try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
       const { name } = (body as Record<string, unknown>) ?? {};
       if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
 
       const repo = await createTeamMemberRepository();
-      const updated = await repo.update(OSS_MEMBER_ID, { name: name.trim() });
+      const updated = await repo.update(me.id, { name: name.trim() });
       return apiSuccess({ ...updated, email: null });
     }
 const _r = await proxyToFastapi(request, '/api/v2/me');

--- a/apps/web/src/app/api/oss/seed/route.ts
+++ b/apps/web/src/app/api/oss/seed/route.ts
@@ -13,7 +13,11 @@ export async function POST() {
   }
 
   try {
-    const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-pglite');
+    const { getOssUserContext } = await import('@/lib/auth-helpers');
+    const { me } = await getOssUserContext();
+    if (!me) return apiError('NOT_AVAILABLE', 'No project context', 503);
+    const { project_id: OSS_PROJECT_ID, org_id: OSS_ORG_ID } = me;
+
     const storyRepo = await createStoryRepository();
     const existing = await storyRepo.list({ project_id: OSS_PROJECT_ID, limit: 1 });
 

--- a/apps/web/src/app/api/projects/[id]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createProjectRepository } from '@/lib/storage/factory';
+import { createProjectRepository } from '@/lib/storage/factory';
 import { z } from 'zod/v4';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -69,13 +69,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    let orgId: string;
-    if (isOssMode()) {
-      const { OSS_ORG_ID } = await import('@sprintable/storage-pglite');
-      orgId = OSS_ORG_ID;
-    } else {
-      orgId = me.org_id;
-    }
+    const orgId = me.org_id;
 
     const repo = await createProjectRepository();
     const existing = await repo.getById(id);

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,16 +1,16 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess } from '@/lib/api-response';
-import { isOssMode, createProjectRepository } from '@/lib/storage/factory';
+import { isOssMode } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 조직 프로젝트 목록 */
 export async function GET(request: Request) {
   try {
     if (isOssMode()) {
-      const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
-      const repo = await createProjectRepository();
-      const project = await repo.getById(OSS_PROJECT_ID);
-      return apiSuccess(project ? [{ id: project.id, name: project.name, description: null, org_id: OSS_ORG_ID }] : []);
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const db = await getDb();
+      const projects = (await db.query('SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC')).rows as Array<{ id: string; name: string; org_id: string }>;
+      return apiSuccess(projects.map((p) => ({ id: p.id, name: p.name, description: null, org_id: p.org_id })));
     }
 const _r = await proxyToFastapi(request, '/api/v2/projects');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -3,16 +3,18 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { parseBody, createTeamMemberSchema } from '@sprintable/shared';
 import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { getAuthContext } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
     if (isOssMode()) {
-      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-pglite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
       const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id') ?? OSS_PROJECT_ID;
+      const projectId = searchParams.get('project_id') ?? me.project_id;
       const type = searchParams.get('type') as 'human' | 'agent' | null;
       const repo = await createTeamMemberRepository();
-      const members = await repo.list({ org_id: OSS_ORG_ID, project_id: projectId, ...(type ? { type } : {}) });
+      const members = await repo.list({ org_id: me.org_id, project_id: projectId, ...(type ? { type } : {}) });
       return apiSuccess(members);
     }
     const res = await proxyToFastapi(request, '/api/v2/team-members');
@@ -38,11 +40,12 @@ export async function POST(request: Request) {
     }
     if (!body.name) return ApiErrors.badRequest('name required for agent');
     if (isOssMode()) {
-      const { OSS_PROJECT_ID, OSS_ORG_ID } = await import('@sprintable/storage-pglite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
       const repo = await createTeamMemberRepository();
       const member = await repo.create({
-        org_id: OSS_ORG_ID,
-        project_id: body.project_id ?? OSS_PROJECT_ID,
+        org_id: me.org_id,
+        project_id: body.project_id ?? me.project_id,
         name: body.name,
         type: 'agent',
         role: body.role ?? 'member',

--- a/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
@@ -2,6 +2,7 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
 import { isOssMode, createAgentRunRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { getAuthContext } from '@/lib/auth-helpers';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -9,9 +10,10 @@ export async function GET(request: Request, { params }: RouteParams) {
   if (isOssMode()) {
     try {
       const { id } = await params;
-      const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
       const repo = await createAgentRunRepository();
-      const run = await repo.getById(id, OSS_ORG_ID, OSS_PROJECT_ID);
+      const run = await repo.getById(id, me.org_id, me.project_id);
       if (!run) return ApiErrors.notFound('Agent run not found');
       return apiSuccess({ ...run, agent_name: null, tool_audit_trail: [], continuity_debug: null });
     } catch (error) { return handleApiError(error); }

--- a/apps/web/src/app/api/v1/agent-runs/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.ts
@@ -3,19 +3,21 @@ import { handleApiError } from '@/lib/api-error';
 import { isOssMode, createAgentRunRepository } from '@/lib/storage/factory';
 import { normalizeRunStatusFilter } from '@/services/agent-run-history';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { getAuthContext } from '@/lib/auth-helpers';
 
 const PAGE_SIZE = 20;
 
 export async function GET(request: Request) {
   if (isOssMode()) {
     try {
-      const { OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
       const repo = await createAgentRunRepository();
       const url = new URL(request.url);
       const limit = Math.min(Number(url.searchParams.get('limit') ?? PAGE_SIZE), 50);
       const result = await repo.list({
-        orgId: OSS_ORG_ID,
-        projectId: OSS_PROJECT_ID,
+        orgId: me.org_id,
+        projectId: me.project_id,
         status: normalizeRunStatusFilter(url.searchParams.get('status')),
         from: url.searchParams.get('from'),
         to: url.searchParams.get('to'),

--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -89,17 +89,35 @@ function toPos(q: string, p: (string|number|boolean|null)[]): [string, (string|n
 }
 
 export async function getOssUserContext(): Promise<MembershipContext> {
-  const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID } = await import('@sprintable/storage-pglite');
-  const me = {
-    id: OSS_MEMBER_ID,
-    org_id: OSS_ORG_ID,
-    project_id: OSS_PROJECT_ID,
-    project_name: 'My Project',
-  };
-  return {
-    me,
-    memberships: [{ id: OSS_MEMBER_ID, org_id: OSS_ORG_ID, project_id: OSS_PROJECT_ID, project_name: 'My Project' }],
-  };
+  const { getDb } = await import('@sprintable/storage-pglite');
+  const db = await getDb();
+
+  const projects = (await db.query(
+    'SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC'
+  )).rows as Array<{ id: string; name: string; org_id: string }>;
+
+  if (projects.length === 0) return { me: null, memberships: [] };
+
+  const cookieProjectId = await getCurrentProjectIdCookie();
+  const currentProject = projects.find((p) => p.id === cookieProjectId) ?? projects[0]!;
+
+  const memberRow = (await db.query(
+    `SELECT id, org_id, project_id FROM team_members WHERE project_id = $1 AND is_active = 1 AND type = 'human' ORDER BY created_at ASC LIMIT 1`,
+    [currentProject.id]
+  )).rows[0] as { id: string; org_id: string; project_id: string } | undefined;
+
+  const memberships: ProjectMembership[] = projects.map((p) => ({
+    id: memberRow?.id ?? '',
+    org_id: p.org_id,
+    project_id: p.id,
+    project_name: p.name,
+  }));
+
+  const me = memberRow
+    ? { id: memberRow.id, org_id: memberRow.org_id, project_id: currentProject.id, project_name: currentProject.name }
+    : null;
+
+  return { me, memberships };
 }
 
 /**
@@ -213,7 +231,7 @@ export const getAuthContext = cache(async (
 } | null> => {
   // 1. OSS_MODE — DB 없이 PGLite 기반 인증
   if (isOssMode()) {
-    const { OSS_ORG_ID, OSS_PROJECT_ID, OSS_MEMBER_ID, getDb } = await import('@sprintable/storage-pglite');
+    const { getDb } = await import('@sprintable/storage-pglite');
 
     const authHeader = request.headers.get('Authorization');
     const xApiKey = request.headers.get('x-api-key');
@@ -249,14 +267,10 @@ export const getAuthContext = cache(async (
       }
     }
 
-    // API Key 없거나 인증 실패 시 고정 human 반환 (하위 호환)
-    return {
-      id: OSS_MEMBER_ID,
-      org_id: OSS_ORG_ID,
-      project_id: OSS_PROJECT_ID,
-      project_name: 'My Project',
-      type: 'human',
-    };
+    // API Key 없거나 인증 실패 시 PGLite에서 동적으로 조회
+    const ossCtx = await getOssUserContext();
+    if (!ossCtx.me) return null;
+    return { id: ossCtx.me.id, org_id: ossCtx.me.org_id, project_id: ossCtx.me.project_id, project_name: ossCtx.me.project_name, type: 'human' };
   }
 
   // 2. API Key 인증 — FastAPI /api/v2/me에 rawApiKey를 Bearer 토큰으로 전달


### PR DESCRIPTION
## Summary

OSS 무제한 에픽 첫 스토리. 하드코딩 `OSS_ORG_ID`/`OSS_PROJECT_ID`/`OSS_MEMBER_ID` 전량 제거. 동적 PGLite 컨텍스트 + 쿠키 기반 프로젝트 전환 지원.

## Changes

### `apps/web/src/lib/auth-helpers.ts`
- `getOssUserContext()`: PGLite에서 전체 프로젝트 조회 + 쿠키(`sprintable_current_project_id`) 기반 현재 프로젝트 동적 선택. 쿠키 없으면 첫 번째 프로젝트 fallback.
- `getAuthContext()` OSS fallback: 고정 ID 반환 → `getOssUserContext()` 호출로 전환

### Route 변경 (10개)
| 파일 | 변경 |
|------|------|
| `current-project/route.ts` GET | 전체 프로젝트 목록 + 쿠키 기반 현재 프로젝트 |
| `current-project/route.ts` POST | DB 존재 확인 (하드코딩 check 제거) |
| `projects/route.ts` GET | 전체 프로젝트 동적 반환 |
| `me/route.ts` GET/PATCH | `getAuthContext(request)` 사용 |
| `team-members/route.ts` GET/POST | `me.org_id`/`me.project_id` 사용 |
| `v1/agent-runs/route.ts` | `me.org_id`/`me.project_id` |
| `v1/agent-runs/[id]/route.ts` | `me.org_id`/`me.project_id` |
| `oss/seed/route.ts` | `getOssUserContext()` |
| `agents/api-keys/page.tsx` | `getOssUserContext()` |
| `projects/[id]/route.ts` | `me.org_id` |

## AC 달성
- [x] AC1: `getOssUserContext()` PGLite 동적 조회 전환
- [x] AC2: `_seedOssDefaults()` ON CONFLICT DO NOTHING (기존 유지)
- [x] AC3: `current-project/route.ts` 전체 프로젝트 목록 반환 + 프로젝트 전환 지원
- [x] AC4: Layout이 `getOssUserContext()` 사용 → 프로젝트 선택기 실제 데이터 표시
- [x] AC5: OSS_*_ID 직접 import 10건 → authContext 사용으로 전환
- [x] AC6: 쿠키 `sprintable_current_project_id` 기반 현재 프로젝트 유지
- [x] tsc CLEAN (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)