### PR TITLE
feat(oss-unlimited): UL-S2 OSS 프로젝트 CRUD + Settings 관리 화면 [E-OSS-UNLIMITED]

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -102,8 +102,9 @@ export default function SettingsPage() {
   const [memberActionMessage, setMemberActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [addingMember, setAddingMember] = useState(false);
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
-  const [isAdmin, setIsAdmin] = useState(false);
-  const [adminChecked, setAdminChecked] = useState(false);
+  const isOss = process.env.NEXT_PUBLIC_OSS_MODE === 'true';
+  const [isAdmin, setIsAdmin] = useState(isOss);
+  const [adminChecked, setAdminChecked] = useState(isOss);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
   const [projectInviteEmail, setProjectInviteEmail] = useState('');

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,6 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createProjectRepository, createTeamMemberRepository } from '@/lib/storage/factory';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 조직 프로젝트 목록 */
@@ -23,8 +24,41 @@ const _r = await proxyToFastapi(request, '/api/v2/projects');
 
 /** POST — 프로젝트 생성 */
 export async function POST(request: Request) {
-const _r = await proxyToFastapi(request, '/api/v2/projects');
-  if (!_r.ok) return _r;
-  if (_r.status === 204) return apiSuccess({ ok: true });
-  return apiSuccess(await _r.json())
+  try {
+    if (isOssMode()) {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+
+      let body: unknown;
+      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
+      const { name, description } = (body as Record<string, unknown>) ?? {};
+      if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
+
+      const projectRepo = await createProjectRepository();
+      const project = await projectRepo.create({
+        org_id: me.org_id,
+        name: name.trim(),
+        description: typeof description === 'string' ? description || null : null,
+        created_by: me.id,
+      });
+
+      const memberRepo = await createTeamMemberRepository();
+      await memberRepo.create({
+        org_id: me.org_id,
+        project_id: project.id,
+        name: 'Admin',
+        role: 'owner',
+        type: 'human',
+        is_active: true,
+      });
+
+      return apiSuccess(project, undefined, 201);
+    }
+    const _r = await proxyToFastapi(request, '/api/v2/projects');
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
 }


### PR DESCRIPTION
## Summary

OSS 사용자가 프로젝트를 N개 생성/수정/삭제 가능하게. UL-S1 기반.

## Changes

### `apps/web/src/app/api/projects/route.ts` — POST OSS 분기 추가
- `getAuthContext(request)` → `me.org_id` 사용
- PGLite `projectRepo.create()` + 생성자를 owner human 멤버로 `memberRepo.create()` 자동 등록
- 201 응답

### `apps/web/src/app/(authenticated)/settings/page.tsx`
- OSS 모드 시 `isAdmin`/`adminChecked` 초기값 `true` → Projects 탭 자동 노출 (기존 SaaS UI 재활용)
- 기존 프로젝트 생성/편집/삭제 UI 그대로 동작

### `apps/web/src/app/api/projects/[id]/route.ts` PATCH/DELETE
- 이미 `factory → PgliteProjectRepository` 경유로 동작 (별도 변경 불필요)

## AC

- [x] AC1: `projects/route.ts` POST — OSS 프로젝트 생성 + owner 멤버 자동 등록
- [x] AC2: `projects/[id]/route.ts` PATCH/DELETE — 이미 factory 경유 동작
- [x] AC3: Settings > Projects 탭 — OSS 모드 자동 표시, 기존 CRUD UI 재활용
- [x] AC4: 생성자 owner 멤버 자동 team_members INSERT
- [x] tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)