### PR TITLE
feat(oss-unlimited): UL-S3 OSS 멤버 CRUD + Settings 통합 [E-OSS-UNLIMITED]

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
@@ -3,33 +3,11 @@ import { getMyTeamMember } from '@/lib/auth-helpers';
 import { requireOrgAdmin } from '@/lib/admin-check';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { AgentWebhookManager } from '@/components/agents/agent-webhook-manager';
-import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { isOssMode } from '@/lib/storage/factory';
 
 export default async function ApiKeysPage() {
   if (isOssMode()) {
-    const { getOssUserContext } = await import('@/lib/auth-helpers');
-    const { me } = await getOssUserContext();
-    if (!me) return <div>No project</div>;
-    const repo = await createTeamMemberRepository();
-    const agents = await repo.list({ org_id: me.org_id, project_id: me.project_id });
-    const agentMembers = agents.filter((m) => m.type === 'agent' && m.is_active);
-    return (
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6 space-y-6">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">Agent API Keys</h2>
-          <p className="mt-1 text-sm text-muted-foreground">Manage API keys for agent authentication</p>
-        </div>
-        {agentMembers.length === 0 ? (
-          <p className="text-muted-foreground">No agents found in this project</p>
-        ) : (
-          <div className="space-y-6">
-            {agentMembers.map((agent) => (
-              <AgentApiKeyManager key={agent.id} agentId={agent.id} agentName={agent.name} />
-            ))}
-          </div>
-        )}
-      </div>
-    );
+    redirect('/settings#members');
   }
   const db = null as any;
   const { data: { user } } = { data: { user: null } };

--- a/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
@@ -7,7 +7,7 @@ import { isOssMode } from '@/lib/storage/factory';
 
 export default async function ApiKeysPage() {
   if (isOssMode()) {
-    redirect('/settings#members');
+    redirect('/settings?tab=members');
   }
   const db = null as any;
   const { data: { user } } = { data: { user: null } };

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Palette, Trash2, User, Users, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
@@ -68,6 +68,13 @@ export default function SettingsPage() {
   const t = useTranslations('settings');
   const tc = useTranslations('common');
   const router = useRouter();
+  const searchParamsHook = useSearchParams();
+  const [activeTab, setActiveTab] = useState(() => searchParamsHook.get('tab') ?? 'profile');
+
+  useEffect(() => {
+    const tab = searchParamsHook.get('tab');
+    if (tab) setActiveTab(tab);
+  }, [searchParamsHook]);
 
   const [orgId, setOrgId] = useState<string | null>(null);
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
@@ -483,7 +490,7 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs defaultValue="profile" orientation="vertical" className="flex-1 min-h-0 gap-0">
+      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 gap-0">
         {/* Left nav */}
         <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -105,6 +105,13 @@ export default function SettingsPage() {
   const isOss = process.env.NEXT_PUBLIC_OSS_MODE === 'true';
   const [isAdmin, setIsAdmin] = useState(isOss);
   const [adminChecked, setAdminChecked] = useState(isOss);
+  const [newMemberName, setNewMemberName] = useState('');
+  const [newMemberEmail, setNewMemberEmail] = useState('');
+  const [newMemberType, setNewMemberType] = useState<'human' | 'agent'>('human');
+  const [newMemberWebhookUrl, setNewMemberWebhookUrl] = useState('');
+  const [newMemberProjectId, setNewMemberProjectId] = useState('');
+  const [addingOssMember, setAddingOssMember] = useState(false);
+  const [addMemberResult, setAddMemberResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
   const [projectInviteEmail, setProjectInviteEmail] = useState('');
@@ -440,6 +447,36 @@ export default function SettingsPage() {
     setRemovingMemberId(null);
   };
 
+  const handleAddOssMember = async () => {
+    if (!newMemberName.trim()) return;
+    setAddingOssMember(true);
+    setAddMemberResult(null);
+    const projectId = newMemberProjectId || memberProjectId || currentProjectId || '';
+    const body: Record<string, unknown> = {
+      name: newMemberName.trim(),
+      type: newMemberType,
+      project_id: projectId || undefined,
+    };
+    if (newMemberEmail.trim()) body.email = newMemberEmail.trim();
+    if (newMemberType === 'agent' && newMemberWebhookUrl.trim()) body.webhook_url = newMemberWebhookUrl.trim();
+    const res = await fetch('/api/team-members', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      setNewMemberName('');
+      setNewMemberEmail('');
+      setNewMemberWebhookUrl('');
+      setAddMemberResult({ type: 'success', text: `${newMemberType === 'agent' ? 'Agent' : 'Member'} "${newMemberName.trim()}" added` });
+      if (projectId) await refreshMemberData(projectId);
+    } else {
+      const json = await res.json().catch(() => null);
+      setAddMemberResult({ type: 'error', text: json?.error?.message ?? 'Failed to add member' });
+    }
+    setAddingOssMember(false);
+  };
+
   // suppress unused variable warning — createdProjectMembership used in future flows
   void createdProjectMembership;
   void projectMemberships;
@@ -721,6 +758,60 @@ export default function SettingsPage() {
 
             <TabsContent value="members">
               <div className="space-y-6">
+                {isOss ? (
+                  <SectionCard>
+                    <SectionCardHeader>
+                      <div className="space-y-1">
+                        <h2 className="text-base font-semibold text-foreground">Add Member</h2>
+                        <p className="text-sm text-muted-foreground">Add human or agent members directly to a project</p>
+                      </div>
+                    </SectionCardHeader>
+                    <SectionCardBody className="space-y-4">
+                      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto]">
+                        <OperatorInput
+                          value={newMemberName}
+                          onChange={(e) => setNewMemberName(e.target.value)}
+                          placeholder="Name (required)"
+                        />
+                        <OperatorInput
+                          value={newMemberEmail}
+                          onChange={(e) => setNewMemberEmail(e.target.value)}
+                          placeholder="Email (optional)"
+                          type="email"
+                        />
+                        <OperatorDropdownSelect
+                          value={newMemberType}
+                          onValueChange={(v) => setNewMemberType(v as 'human' | 'agent')}
+                          options={[
+                            { value: 'human', label: 'Human' },
+                            { value: 'agent', label: 'Agent' },
+                          ]}
+                        />
+                        <OperatorDropdownSelect
+                          value={newMemberProjectId || memberProjectId || currentProjectId || ''}
+                          onValueChange={(v) => setNewMemberProjectId(v)}
+                          options={projects.map((p) => ({ value: p.id, label: p.name }))}
+                        />
+                      </div>
+                      {newMemberType === 'agent' ? (
+                        <OperatorInput
+                          value={newMemberWebhookUrl}
+                          onChange={(e) => setNewMemberWebhookUrl(e.target.value)}
+                          placeholder="Webhook URL (https://...)"
+                          type="url"
+                        />
+                      ) : null}
+                      <Button variant="hero" size="lg" onClick={handleAddOssMember} disabled={!newMemberName.trim() || addingOssMember}>
+                        {addingOssMember ? '...' : 'Add Member'}
+                      </Button>
+                      {addMemberResult ? (
+                        <div className={`rounded-md border p-3 text-xs ${addMemberResult.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
+                          {addMemberResult.text}
+                        </div>
+                      ) : null}
+                    </SectionCardBody>
+                  </SectionCard>
+                ) : null}
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,20 +1,49 @@
-import { apiSuccess } from '@/lib/api-response';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+import { handleApiError } from '@/lib/api-error';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
-export async function DELETE(request: Request, { params }: RouteParams) {
-  const { id } = await params;
-  const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    if (isOssMode()) {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      let body: unknown;
+      try { body = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
+      const { name, webhook_url, role, is_active } = (body as Record<string, unknown>) ?? {};
+      const repo = await createTeamMemberRepository();
+      const updated = await repo.update(id, {
+        ...(typeof name === 'string' ? { name: name.trim() } : {}),
+        ...(webhook_url !== undefined ? { webhook_url: typeof webhook_url === 'string' ? webhook_url : null } : {}),
+        ...(typeof role === 'string' ? { role } : {}),
+        ...(typeof is_active === 'boolean' ? { is_active } : {}),
+      });
+      return apiSuccess(updated);
+    }
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
 }
 
-export async function PATCH(request: Request, { params }: RouteParams) {
-  const { id } = await params;
-  const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    if (isOssMode()) {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      const repo = await createTeamMemberRepository();
+      await repo.update(id, { is_active: false });
+      return apiSuccess({ id });
+    }
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -29,33 +29,39 @@ export async function GET(request: Request) {
 /** POST — 프로젝트 멤버 추가/재활성화 */
 export async function POST(request: Request) {
   try {
-    const parsed = await parseBody(request, createTeamMemberSchema);
-    if (!parsed.success) return parsed.response;
-    const body = parsed.data;
-    if (body.type !== 'agent') {
-      const _r = await proxyToFastapi(request, '/api/v2/team-members');
-      if (!_r.ok) return _r;
-      if (_r.status === 204) return apiSuccess({ ok: true });
-      return apiSuccess(await _r.json());
-    }
-    if (!body.name) return ApiErrors.badRequest('name required for agent');
     if (isOssMode()) {
       const me = await getAuthContext(request);
       if (!me) return ApiErrors.unauthorized();
+
+      let body: unknown;
+      try { body = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
+      const { name, type, role, project_id, webhook_url, email } = (body as Record<string, unknown>) ?? {};
+      const memberType = (type as string) === 'agent' ? 'agent' : 'human';
+      if (!name || typeof name !== 'string' || !name.trim()) return ApiErrors.badRequest('name is required');
+
       const repo = await createTeamMemberRepository();
       const member = await repo.create({
         org_id: me.org_id,
-        project_id: body.project_id ?? me.project_id,
-        name: body.name,
-        type: 'agent',
-        role: body.role ?? 'member',
+        project_id: typeof project_id === 'string' ? project_id : me.project_id,
+        name: name.trim(),
+        type: memberType,
+        role: typeof role === 'string' ? role : 'member',
+        email: typeof email === 'string' ? email : undefined,
       });
+      if (typeof webhook_url === 'string' && webhook_url) {
+        await repo.update(member.id, { webhook_url } as Parameters<typeof repo.update>[1]);
+      }
       return apiSuccess(member, undefined, 201);
     }
-const _r = await proxyToFastapi(request, '/api/v2/team-members');
+
+    const parsed = await parseBody(request, createTeamMemberSchema);
+    if (!parsed.success) return parsed.response;
+    const body = parsed.data;
+    if (!body.name) return ApiErrors.badRequest('name required for agent');
+    const _r = await proxyToFastapi(request, '/api/v2/team-members');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
-    return apiSuccess(await _r.json())
+    return apiSuccess(await _r.json());
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -14,7 +14,8 @@ export async function GET(request: Request) {
       const projectId = searchParams.get('project_id') ?? me.project_id;
       const type = searchParams.get('type') as 'human' | 'agent' | null;
       const repo = await createTeamMemberRepository();
-      const members = await repo.list({ org_id: me.org_id, project_id: projectId, ...(type ? { type } : {}) });
+      const includeInactive = searchParams.get('include_inactive') === 'true';
+      const members = await repo.list({ org_id: me.org_id, project_id: projectId, ...(type ? { type } : {}), ...(includeInactive ? {} : { is_active: true }) });
       return apiSuccess(members);
     }
     const res = await proxyToFastapi(request, '/api/v2/team-members');


### PR DESCRIPTION
## Summary

human + agent 멤버를 Settings > Members에서 통합 관리. OSS 멤버 N명 추가/관리.

## Changes

### `apps/web/src/app/api/team-members/route.ts` POST
- OSS 경로: human/agent 모두 허용 (기존: agent only → SaaS proxy)
- name(필수), email(선택), type, project_id, webhook_url(agent 전용) 지원
- webhook_url: create 후 별도 update로 적용

### `apps/web/src/app/api/team-members/[id]/route.ts`
- OSS PATCH: name/webhook_url/role/is_active 업데이트
- OSS DELETE: `is_active = false` soft deactivate

### `apps/web/src/app/(authenticated)/settings/page.tsx`
- OSS 모드 시 Members 탭 상단에 "Add Member" 섹션 표시
- 폼: 이름, 이메일(opt), type(human/agent), 프로젝트 선택, webhook_url(agent)
- 제출 → POST `/api/team-members` → 멤버 목록 자동 갱신

### `apps/web/src/app/(authenticated)/agents/api-keys/page.tsx`
- OSS 모드 시 `/settings#members`로 리다이렉트 (하위 호환)

## AC

- [x] AC1: POST OSS human 멤버 추가
- [x] AC2: Add Member 다이얼로그 — type 선택 (human/agent)
- [x] AC3: Agent 추가 시 webhook_url 설정
- [x] AC4: Agent Member API Key — AgentApiKeyManager 기존 컴포넌트 (Settings#members 경유)
- [x] AC5: agents/api-keys → Settings#members 리다이렉트
- [x] tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)