### PR TITLE
feat(oss-unlimited): UL-S4 OSS 차단 기능 해제 [E-OSS-UNLIMITED]

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/personas/new/oss-persona-form-client.tsx
+++ b/apps/web/src/app/(authenticated)/agents/personas/new/oss-persona-form-client.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+export function OssPersonaFormClient({ agents }: { agents: Array<{ id: string; name: string }> }) {
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        const res = await fetch('/api/agents/personas', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: fd.get('name'),
+            agent_id: fd.get('agent_id'),
+            system_prompt: fd.get('system_prompt'),
+            description: fd.get('description'),
+          }),
+        });
+        if (res.ok) window.location.href = '/agents';
+      }}
+    >
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Agent</label>
+        <select name="agent_id" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
+          {agents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Persona Name</label>
+        <input name="name" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="e.g. Helpful Assistant" required />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">System Prompt</label>
+        <textarea name="system_prompt" rows={5} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="You are a helpful assistant..." />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Description (optional)</label>
+        <input name="description" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="Brief description" />
+      </div>
+      <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90">
+        Create Persona
+      </button>
+    </form>
+  );
+}

--- a/apps/web/src/app/(authenticated)/agents/personas/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/personas/new/page.tsx
@@ -12,6 +12,7 @@ import { buttonVariants } from '@/components/ui/button';
 import { AgentPersonaService, MANAGED_SAFETY_LAYER_NOTICE } from '@/services/agent-persona';
 import { listProjectPersonaToolOptions } from '@/services/persona-composer';
 import { isOssMode } from '@/lib/storage/factory';
+import { OssPersonaFormClient } from './oss-persona-form-client';
 
 export default async function NewAgentPersonaPage() {
   if (isOssMode()) {
@@ -43,51 +44,3 @@ function OssPersonaForm({ agents }: { agents: Array<{ id: string; name: string }
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function OssPersonaFormClient({ agents }: { agents: any[] }) {
-  'use client';
-  return (
-    <form
-      action="/api/agents/personas"
-      method="POST"
-      className="space-y-4"
-      onSubmit={async (e) => {
-        e.preventDefault();
-        const fd = new FormData(e.currentTarget);
-        const res = await fetch('/api/agents/personas', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: fd.get('name'),
-            agent_id: fd.get('agent_id'),
-            system_prompt: fd.get('system_prompt'),
-            description: fd.get('description'),
-          }),
-        });
-        if (res.ok) window.location.href = '/agents';
-      }}
-    >
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Agent</label>
-        <select name="agent_id" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
-          {agents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
-        </select>
-      </div>
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Persona Name</label>
-        <input name="name" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="e.g. Helpful Assistant" required />
-      </div>
-      <div className="space-y-2">
-        <label className="text-sm font-medium">System Prompt</label>
-        <textarea name="system_prompt" rows={5} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="You are a helpful assistant..." />
-      </div>
-      <div className="space-y-2">
-        <label className="text-sm font-medium">Description (optional)</label>
-        <input name="description" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="Brief description" />
-      </div>
-      <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90">
-        Create Persona
-      </button>
-    </form>
-  );
-}

--- a/apps/web/src/app/(authenticated)/agents/personas/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/personas/new/page.tsx
@@ -15,16 +15,79 @@ import { isOssMode } from '@/lib/storage/factory';
 
 export default async function NewAgentPersonaPage() {
   if (isOssMode()) {
-    return (
-      <div className="flex h-64 items-center justify-center p-6 text-center">
-        <div>
-          <h2 className="text-base font-semibold text-foreground">OSS 버전 미제공 기능인.</h2>
-          <p className="mt-1 text-sm text-muted-foreground">에이전트 배포 관리는 SaaS 버전에서 이용 가능한.</p>
-        </div>
-      </div>
-    );
+    const { getOssUserContext } = await import('@/lib/auth-helpers');
+    const { me } = await getOssUserContext();
+    const { createTeamMemberRepository } = await import('@/lib/storage/factory');
+    const agents = me ? await (await createTeamMemberRepository()).list({ org_id: me.org_id, project_id: me.project_id, type: 'agent', is_active: true }) : [];
+    return <OssPersonaForm agents={agents} />;
   }
   // SaaS-only path — not reached in OSS mode
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return null as any;
+}
+
+// Minimal OSS persona creation form
+function OssPersonaForm({ agents }: { agents: Array<{ id: string; name: string }> }) {
+  return (
+    <div className="p-6 max-w-xl space-y-6">
+      <div>
+        <h2 className="text-base font-semibold text-foreground">New Agent Persona</h2>
+        <p className="mt-1 text-sm text-muted-foreground">Create a persona for an agent in this project</p>
+      </div>
+      {agents.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No agents in this project. Add an agent member first.</p>
+      ) : (
+        <OssPersonaFormClient agents={agents} />
+      )}
+    </div>
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function OssPersonaFormClient({ agents }: { agents: any[] }) {
+  'use client';
+  return (
+    <form
+      action="/api/agents/personas"
+      method="POST"
+      className="space-y-4"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        const fd = new FormData(e.currentTarget);
+        const res = await fetch('/api/agents/personas', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            name: fd.get('name'),
+            agent_id: fd.get('agent_id'),
+            system_prompt: fd.get('system_prompt'),
+            description: fd.get('description'),
+          }),
+        });
+        if (res.ok) window.location.href = '/agents';
+      }}
+    >
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Agent</label>
+        <select name="agent_id" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
+          {agents.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Persona Name</label>
+        <input name="name" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="e.g. Helpful Assistant" required />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">System Prompt</label>
+        <textarea name="system_prompt" rows={5} className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="You are a helpful assistant..." />
+      </div>
+      <div className="space-y-2">
+        <label className="text-sm font-medium">Description (optional)</label>
+        <input name="description" className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm" placeholder="Brief description" />
+      </div>
+      <button type="submit" className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90">
+        Create Persona
+      </button>
+    </form>
+  );
 }

--- a/apps/web/src/app/api/agents/personas/route.ts
+++ b/apps/web/src/app/api/agents/personas/route.ts
@@ -1,0 +1,54 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors, apiError } from '@/lib/api-response';
+import { isOssMode } from '@/lib/storage/factory';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  try {
+    if (isOssMode()) {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const db = await getDb();
+      const personas = (await db.query(
+        'SELECT * FROM agent_personas WHERE project_id = $1 ORDER BY created_at ASC',
+        [me.project_id]
+      )).rows;
+      return apiSuccess(personas);
+    }
+    const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+export async function POST(request: Request) {
+  try {
+    if (isOssMode()) {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      let body: unknown;
+      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON', 400); }
+      const b = (body as Record<string, unknown>) ?? {};
+      if (typeof b.name !== 'string' || !b.name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
+      if (typeof b.agent_id !== 'string' || !b.agent_id.trim()) return apiError('VALIDATION_ERROR', 'agent_id is required', 400);
+
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const { randomUUID } = await import('node:crypto');
+      const db = await getDb();
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      const slug = (b.name as string).trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      await db.query(
+        'INSERT INTO agent_personas (id, org_id, project_id, agent_id, name, slug, description, system_prompt, style_prompt, model, config, is_builtin, is_default, created_by, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$15)',
+        [id, me.org_id, me.project_id, b.agent_id, (b.name as string).trim(), slug, b.description ?? null, b.system_prompt ?? '', b.style_prompt ?? null, b.model ?? null, JSON.stringify(b.config ?? {}), 0, 0, me.id, now]
+      );
+      const persona = (await db.query('SELECT * FROM agent_personas WHERE id = $1', [id])).rows[0];
+      return apiSuccess(persona, undefined, 201);
+    }
+    const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/app/api/docs/[id]/comments/route.ts
+++ b/apps/web/src/app/api/docs/[id]/comments/route.ts
@@ -28,7 +28,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('Comments not supported in OSS mode');
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/docs/[id]/comments', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/recording/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/recording/route.ts
@@ -13,7 +13,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('Recording not supported in OSS mode');
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/recording', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/summarize/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summarize/route.ts
@@ -15,7 +15,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('AI summarization not supported in OSS mode');
 
     return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summarize', { id });
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/meetings/[id]/summary/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summary/route.ts
@@ -15,7 +15,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('AI summary not supported in OSS mode');
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summary', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
@@ -15,7 +15,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('Transcription not supported in OSS mode');
 
     return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/transcribe', { id });
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/meetings/route.ts
+++ b/apps/web/src/app/api/meetings/route.ts
@@ -27,7 +27,6 @@ export async function POST(request: Request) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.badRequest('Meetings not supported in OSS mode');
 
     // AC8: Feature gating (SaaS only)
     const check = await checkResourceLimit(undefined, me.org_id, 'max_meetings', 'meetings');

--- a/apps/web/src/app/api/memos/[id]/archive/route.ts
+++ b/apps/web/src/app/api/memos/[id]/archive/route.ts
@@ -13,7 +13,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.notFound('Archive not supported in OSS mode');
 
     const dbClient = undefined;
     const repo = await createMemoRepository(dbClient);

--- a/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
@@ -26,7 +26,28 @@ const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
-  if (isOssMode()) return ApiErrors.badRequest('Not available in OSS mode');
+  if (isOssMode()) {
+    try {
+      const { id } = await params;
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      let body: unknown;
+      try { body = await request.json(); } catch { body = {}; }
+      const b = (body as Record<string, unknown>) ?? {};
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const db = await getDb();
+      const sets: string[] = [];
+      const vals: unknown[] = [];
+      const allowed = ['status','result_summary','error_message','started_at','finished_at','duration_ms','input_tokens','output_tokens'] as const;
+      for (const k of allowed) {
+        if (k in b) { sets.push(`${k} = $${sets.length + 1}`); vals.push(b[k] ?? null); }
+      }
+      if (sets.length) await db.query(`UPDATE agent_runs SET ${sets.join(', ')} WHERE id = $${sets.length + 1} AND org_id = $${sets.length + 2}`, [...vals, id, me.org_id]);
+      const run = (await db.query('SELECT * FROM agent_runs WHERE id = $1', [id])).rows[0];
+      if (!run) return ApiErrors.notFound('Agent run not found');
+      return apiSuccess(run);
+    } catch (error) { return handleApiError(error); }
+  }
   const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
   if (!_r.ok) return _r;

--- a/apps/web/src/app/api/v1/agent-runs/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.ts
@@ -35,7 +35,26 @@ const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
 }
 
 export async function POST(request: Request) {
-  if (isOssMode()) return ApiErrors.badRequest('Not available in OSS mode');
+  if (isOssMode()) {
+    try {
+      const me = await getAuthContext(request);
+      if (!me) return ApiErrors.unauthorized();
+      let body: unknown;
+      try { body = await request.json(); } catch { body = {}; }
+      const b = (body as Record<string, unknown>) ?? {};
+      const { getDb } = await import('@sprintable/storage-pglite');
+      const { randomUUID } = await import('node:crypto');
+      const db = await getDb();
+      const id = randomUUID();
+      const now = new Date().toISOString();
+      await db.query(
+        'INSERT INTO agent_runs (id, org_id, project_id, agent_id, session_id, memo_id, story_id, trigger, status, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)',
+        [id, me.org_id, me.project_id, b.agent_id ?? null, b.session_id ?? null, b.memo_id ?? null, b.story_id ?? null, b.trigger ?? null, 'pending', now]
+      );
+      const run = (await db.query('SELECT * FROM agent_runs WHERE id = $1', [id])).rows[0];
+      return apiSuccess(run, undefined, 201);
+    } catch (error) { return handleApiError(error); }
+  }
 const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess({ ok: true });

--- a/packages/storage-pglite/src/db.ts
+++ b/packages/storage-pglite/src/db.ts
@@ -311,6 +311,25 @@ async function _initSchema(db: PGlite): Promise<void> {
       scope TEXT DEFAULT '["read","write"]'
     );
 
+    CREATE TABLE IF NOT EXISTS agent_personas (
+      id TEXT PRIMARY KEY,
+      org_id TEXT NOT NULL,
+      project_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      name TEXT NOT NULL,
+      slug TEXT NOT NULL,
+      description TEXT,
+      system_prompt TEXT NOT NULL DEFAULT '',
+      style_prompt TEXT,
+      model TEXT,
+      config TEXT NOT NULL DEFAULT '{}',
+      is_builtin INTEGER NOT NULL DEFAULT 0,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      created_by TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS retro_sessions (
       id TEXT PRIMARY KEY,
       org_id TEXT NOT NULL,
@@ -376,6 +395,7 @@ async function _initSchema(db: PGlite): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_agent_runs_org_project ON agent_runs(org_id, project_id);
     CREATE INDEX IF NOT EXISTS idx_agent_runs_created_at ON agent_runs(created_at);
     CREATE INDEX IF NOT EXISTS idx_agent_api_keys_team_member ON agent_api_keys(team_member_id);
+    CREATE INDEX IF NOT EXISTS idx_agent_personas_project ON agent_personas(project_id);
     CREATE INDEX IF NOT EXISTS idx_retro_sessions_project ON retro_sessions(project_id);
     CREATE INDEX IF NOT EXISTS idx_retro_items_session ON retro_items(session_id);
     CREATE INDEX IF NOT EXISTS idx_retro_actions_session ON retro_actions(session_id);


### PR DESCRIPTION
## Summary

OSS "not available" 플레이스홀더/차단 전량 제거. managed agents(deploy/hitl/workflow)는 SaaS 전용 유지.

## Changes

### API 차단 해제 (isOssMode 얼리 리턴 제거)
| 파일 | 변경 |
|------|------|
| `v1/agent-runs/route.ts` POST | OSS PGLite INSERT 핸들러 추가 |
| `v1/agent-runs/[id]/route.ts` PATCH | OSS PGLite UPDATE 핸들러 추가 |
| `memos/[id]/archive/route.ts` | OSS 차단 제거 |
| `docs/[id]/comments/route.ts` | OSS 차단 제거 |
| `meetings/route.ts` POST | OSS 차단 제거 |
| `meetings/[id]/recording|transcribe|summarize|summary` | OSS 차단 제거 |

### 신규
- `api/agents/personas/route.ts`: OSS GET/POST — PGLite `agent_personas` 테이블 CRUD
- `storage-pglite/db.ts`: `agent_personas` 테이블 + 인덱스 추가
- `agents/personas/new/page.tsx`: OSS 블록 메시지 제거 → 간단한 페르소나 생성 폼 (agent 선택 + name + system_prompt)

### 유지 (SaaS 전용 차단 유지)
- Slack/Teams 브리지, Slack integration settings
- `webhooks/config`, `webhooks/agent-runtime`
- `agents/deploy`, `agents/hitl`, `agents/workflow`

## AC

- [x] AC1: agent-runs POST OSS 허용
- [x] AC2: agents/personas/new OSS 접근 허용 + 페르소나 생성 UI
- [x] AC3: Settings > Projects (UL-S2에서 구현 완료)
- [x] AC4: meetings, doc comments, memos archive 차단 해제
- [x] AC5: managed agents (deploy/hitl/workflow) SaaS 전용 유지
- [x] tsc CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)