### PR TITLE
feat(oss-unlimited): UL-S5 OSS 멀티유저 인증 기초 (E-OSS-UNLIMITED 전량 완주)

### DIFF
--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { isOssMode } from '@/lib/storage/factory';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -15,6 +16,30 @@ export async function POST(request: Request) {
   if (csrfError) return csrfError;
 
   const body = await request.json() as { email: string; password: string; totp_code?: string | null };
+
+  if (isOssMode()) {
+    const { getDb } = await import('@sprintable/storage-pglite');
+    const { verifyPassword, signOssSession, ossSessionCookieOptions, OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
+    const db = await getDb();
+
+    if (!body.email?.trim() || !body.password) {
+      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'Email and password required' } }, { status: 400 });
+    }
+
+    const user = (await db.query(
+      'SELECT id, email, name, password_hash FROM oss_users WHERE email = $1 LIMIT 1',
+      [body.email.trim().toLowerCase()]
+    )).rows[0] as { id: string; email: string; name: string; password_hash: string } | undefined;
+
+    if (!user || !verifyPassword(body.password, user.password_hash)) {
+      return NextResponse.json({ error: { code: 'AUTH_FAILED', message: 'Invalid email or password' } }, { status: 401 });
+    }
+
+    const token = await signOssSession(user.id);
+    const res = NextResponse.json({ data: { ok: true } });
+    res.cookies.set(OSS_SESSION_COOKIE, token, ossSessionCookieOptions());
+    return res;
+  }
 
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/token`, {
     method: 'POST',

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { isOssMode } from '@/lib/storage/factory';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -9,6 +10,13 @@ const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://loca
 export async function POST(request: Request) {
   const csrfError = verifyCsrfOrigin(request);
   if (csrfError) return csrfError;
+
+  if (isOssMode()) {
+    const { OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
+    const res = NextResponse.json({ data: { ok: true } });
+    res.cookies.set(OSS_SESSION_COOKIE, '', { httpOnly: true, secure: process.env['NODE_ENV'] === 'production', sameSite: 'lax', path: '/', maxAge: 0 });
+    return res;
+  }
 
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get(SP_RT_COOKIE)?.value ?? '';

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+import { isOssMode } from '@/lib/storage/factory';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -14,7 +15,62 @@ export async function POST(request: Request) {
   const csrfError = verifyCsrfOrigin(request);
   if (csrfError) return csrfError;
 
-  const body = await request.json() as { email: string; password: string };
+  const body = await request.json() as { email: string; password: string; name?: string };
+
+  if (isOssMode()) {
+    const { getDb, OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
+    const { hashPassword, signOssSession, ossSessionCookieOptions, OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
+    const { randomUUID } = await import('node:crypto');
+    const db = await getDb();
+
+    const email = body.email?.trim().toLowerCase();
+    const name = (body.name?.trim()) || email.split('@')[0] || 'User';
+    const password = body.password;
+
+    if (!email || !password) {
+      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'email and password are required' } }, { status: 400 });
+    }
+    if (password.length < 8) {
+      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'Password must be at least 8 characters' } }, { status: 400 });
+    }
+
+    const existing = (await db.query('SELECT id FROM oss_users WHERE email = $1 LIMIT 1', [email])).rows[0];
+    if (existing) {
+      return NextResponse.json({ error: { code: 'CONFLICT', message: 'Email already registered' } }, { status: 409 });
+    }
+
+    const now = new Date().toISOString();
+    const userId = randomUUID();
+    const passwordHash = hashPassword(password);
+
+    await db.query(
+      'INSERT INTO oss_users (id, email, password_hash, name, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$5)',
+      [userId, email, passwordHash, name, now]
+    );
+
+    // Count after insert to determine role (1 = first user → owner).
+    const countRow = (await db.query('SELECT COUNT(*) as cnt FROM oss_users')).rows[0] as { cnt: string | number };
+    const isFirst = Number(countRow.cnt) <= 1;
+    const role = isFirst ? 'owner' : 'member';
+
+    const projects = (await db.query(
+      'SELECT id, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC'
+    )).rows as Array<{ id: string; org_id: string }>;
+    const targetProjects = projects.length > 0 ? projects : [{ id: OSS_PROJECT_ID, org_id: OSS_ORG_ID }];
+
+    for (const project of targetProjects) {
+      const memberId = randomUUID();
+      await db.query(
+        'INSERT INTO team_members (id, org_id, project_id, user_id, name, email, role, type, is_active, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,1,$9,$9)',
+        [memberId, project.org_id, project.id, userId, name, email, role, 'human', now]
+      );
+    }
+
+    const token = await signOssSession(userId);
+    const res = NextResponse.json({ data: { ok: true } }, { status: 201 });
+    res.cookies.set(OSS_SESSION_COOKIE, token, ossSessionCookieOptions());
+    return res;
+  }
 
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/register`, {
     method: 'POST',

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,8 +2,11 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
+
+const IS_OSS = process.env['NEXT_PUBLIC_OSS_MODE'] === 'true';
 
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   oauth_init_failed: 'OAuth authentication failed. Please try again.',
@@ -31,6 +34,22 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
+      if (IS_OSS) {
+        const res = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email: email.trim(), password }),
+        });
+        const json = await res.json() as { error?: { code: string; message: string } };
+        if (!res.ok) {
+          setError(json.error?.message ?? 'Login failed. Please try again.');
+          return;
+        }
+        router.push('/inbox');
+        router.refresh();
+        return;
+      }
+
       const result = await loginWithPassword(email.trim(), password, showTotp ? totpCode : undefined);
       if (result.error) {
         if (result.error.code === 'TOTP_REQUIRED') {
@@ -108,30 +127,39 @@ export default function LoginPage() {
           </button>
         </div>
 
-        <div className="space-y-3">
-          <div className="relative flex items-center">
-            <div className="flex-grow border-t border-gray-200" />
-            <span className="mx-3 flex-shrink text-xs text-gray-400">or continue with</span>
-            <div className="flex-grow border-t border-gray-200" />
+        {IS_OSS ? (
+          <p className="text-center text-sm text-gray-500">
+            No account?{' '}
+            <Link href="/register" className="font-medium text-blue-600 hover:underline">
+              Create one
+            </Link>
+          </p>
+        ) : (
+          <div className="space-y-3">
+            <div className="relative flex items-center">
+              <div className="flex-grow border-t border-gray-200" />
+              <span className="mx-3 flex-shrink text-xs text-gray-400">or continue with</span>
+              <div className="flex-grow border-t border-gray-200" />
+            </div>
+
+            <a href="/auth/login?provider=google" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
+              <svg className="h-5 w-5" viewBox="0 0 24 24">
+                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+              </svg>
+              Continue with Google
+            </a>
+
+            <a href="/auth/login?provider=github" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
+              <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+              </svg>
+              Continue with GitHub
+            </a>
           </div>
-
-          <a href="/auth/login?provider=google" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
-            <svg className="h-5 w-5" viewBox="0 0 24 24">
-              <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
-              <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-              <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-              <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-            </svg>
-            Continue with Google
-          </a>
-
-          <a href="/auth/login?provider=github" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
-            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-            </svg>
-            Continue with GitHub
-          </a>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from 'next/navigation';
+import { isOssMode } from '@/lib/storage/factory';
+import { RegisterFormClient } from './register-form-client';
+
+export default function RegisterPage() {
+  if (!isOssMode()) redirect('/login');
+  return <RegisterFormClient />;
+}

--- a/apps/web/src/app/register/register-form-client.tsx
+++ b/apps/web/src/app/register/register-form-client.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export function RegisterFormClient() {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleRegister = async () => {
+    if (!name.trim() || !email.trim() || password.length < 8) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), email: email.trim(), password }),
+      });
+      const json = await res.json() as { error?: { code: string; message: string } };
+      if (!res.ok) {
+        setError(json.error?.message ?? 'Registration failed. Please try again.');
+        return;
+      }
+      router.push('/inbox');
+      router.refresh();
+    } catch {
+      setError('Registration failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo
+            variant="stacked"
+            className="text-gray-900"
+            markClassName="h-14"
+            wordmarkClassName="h-5"
+          />
+          <p className="text-sm text-gray-500">Create your account</p>
+        </div>
+
+        <div className="space-y-3">
+          <input
+            type="text"
+            placeholder="Name"
+            autoComplete="name"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
+          <input
+            type="email"
+            placeholder="Email"
+            autoComplete="email"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
+          <input
+            type="password"
+            placeholder="Password (min 8 characters)"
+            autoComplete="new-password"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            onClick={handleRegister}
+            disabled={loading || !name.trim() || !email.trim() || password.length < 8}
+            className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Creating account...' : 'Create account'}
+          </button>
+        </div>
+
+        <p className="text-center text-sm text-gray-500">
+          Already have an account?{' '}
+          <Link href="/login" className="font-medium text-blue-600 hover:underline">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/auth-helpers.ts
+++ b/apps/web/src/lib/auth-helpers.ts
@@ -90,7 +90,14 @@ function toPos(q: string, p: (string|number|boolean|null)[]): [string, (string|n
 
 export async function getOssUserContext(): Promise<MembershipContext> {
   const { getDb } = await import('@sprintable/storage-pglite');
+  const { OSS_SESSION_COOKIE, verifyOssSession } = await import('@/lib/oss-auth');
   const db = await getDb();
+
+  // Resolve current user from session cookie.
+  const cookieStore = await cookies();
+  const sessionToken = cookieStore.get(OSS_SESSION_COOKIE)?.value ?? null;
+  const session = sessionToken ? await verifyOssSession(sessionToken) : null;
+  const userId = session?.userId ?? null;
 
   const projects = (await db.query(
     'SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC'
@@ -101,10 +108,28 @@ export async function getOssUserContext(): Promise<MembershipContext> {
   const cookieProjectId = await getCurrentProjectIdCookie();
   const currentProject = projects.find((p) => p.id === cookieProjectId) ?? projects[0]!;
 
-  const memberRow = (await db.query(
-    `SELECT id, org_id, project_id FROM team_members WHERE project_id = $1 AND is_active = 1 AND type = 'human' ORDER BY created_at ASC LIMIT 1`,
-    [currentProject.id]
-  )).rows[0] as { id: string; org_id: string; project_id: string } | undefined;
+  // Resolve team_member for the authenticated user in the current project.
+  let memberRow: { id: string; org_id: string; project_id: string } | undefined;
+  if (userId) {
+    memberRow = (await db.query(
+      `SELECT id, org_id, project_id FROM team_members WHERE user_id = $1 AND project_id = $2 AND is_active = 1 LIMIT 1`,
+      [userId, currentProject.id]
+    )).rows[0] as { id: string; org_id: string; project_id: string } | undefined;
+
+    // Fallback: any project the user belongs to if not in the current project.
+    if (!memberRow) {
+      memberRow = (await db.query(
+        `SELECT id, org_id, project_id FROM team_members WHERE user_id = $1 AND is_active = 1 ORDER BY created_at ASC LIMIT 1`,
+        [userId]
+      )).rows[0] as { id: string; org_id: string; project_id: string } | undefined;
+    }
+  } else {
+    // No session: fall back to any human member (single-user legacy / first boot).
+    memberRow = (await db.query(
+      `SELECT id, org_id, project_id FROM team_members WHERE project_id = $1 AND is_active = 1 AND type = 'human' ORDER BY created_at ASC LIMIT 1`,
+      [currentProject.id]
+    )).rows[0] as { id: string; org_id: string; project_id: string } | undefined;
+  }
 
   const memberships: ProjectMembership[] = projects.map((p) => ({
     id: memberRow?.id ?? '',
@@ -114,7 +139,7 @@ export async function getOssUserContext(): Promise<MembershipContext> {
   }));
 
   const me = memberRow
-    ? { id: memberRow.id, org_id: memberRow.org_id, project_id: currentProject.id, project_name: currentProject.name }
+    ? { id: memberRow.id, org_id: memberRow.org_id, project_id: memberRow.project_id, project_name: currentProject.name }
     : null;
 
   return { me, memberships };

--- a/apps/web/src/lib/oss-auth.ts
+++ b/apps/web/src/lib/oss-auth.ts
@@ -1,0 +1,50 @@
+import { scryptSync, randomBytes, timingSafeEqual } from 'node:crypto';
+import { SignJWT, jwtVerify } from 'jose';
+
+export const OSS_SESSION_COOKIE = 'sp_oss_at';
+const SESSION_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+function getSecret(): Uint8Array {
+  const s = process.env['OSS_SESSION_SECRET'] ?? 'sprintable-oss-dev-secret-change-in-prod';
+  return new TextEncoder().encode(s);
+}
+
+export function hashPassword(password: string): string {
+  const salt = randomBytes(16).toString('hex');
+  const hash = scryptSync(password, salt, 64).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, stored: string): boolean {
+  const [salt, hash] = stored.split(':');
+  if (!salt || !hash) return false;
+  try {
+    const derived = scryptSync(password, salt, 64);
+    return timingSafeEqual(derived, Buffer.from(hash, 'hex'));
+  } catch { return false; }
+}
+
+export async function signOssSession(userId: string): Promise<string> {
+  return new SignJWT({ sub: userId, type: 'oss_access' })
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime(`${SESSION_TTL_SECONDS}s`)
+    .sign(getSecret());
+}
+
+export async function verifyOssSession(token: string): Promise<{ userId: string } | null> {
+  try {
+    const { payload } = await jwtVerify(token, getSecret());
+    if (payload['type'] !== 'oss_access' || !payload.sub) return null;
+    return { userId: payload.sub };
+  } catch { return null; }
+}
+
+export function ossSessionCookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env['NODE_ENV'] === 'production',
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: SESSION_TTL_SECONDS,
+  };
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,6 +1,8 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
 
+export const runtime = 'nodejs';
+
 const PUBLIC_EXACT = [
   '/',
   '/llms.txt',
@@ -24,6 +26,21 @@ export const SP_RT_COOKIE = 'sp_rt';
 
 function isOssMode(): boolean {
   return process.env['OSS_MODE'] === 'true';
+}
+
+const OSS_SESSION_COOKIE = 'sp_oss_at';
+const OSS_PUBLIC_PREFIXES = ['/login', '/register', '/api/', '/_next/', '/favicon', '/icon'];
+
+function getOssSecretBytes(): Uint8Array {
+  const s = process.env['OSS_SESSION_SECRET'] ?? 'sprintable-oss-dev-secret-change-in-prod';
+  return new TextEncoder().encode(s);
+}
+
+async function verifyOssSessionToken(token: string): Promise<boolean> {
+  try {
+    const { payload } = await jwtVerify(token, getOssSecretBytes());
+    return payload['type'] === 'oss_access' && !!payload.sub;
+  } catch { return false; }
 }
 
 function getJwtSecretBytes(): Uint8Array {
@@ -83,17 +100,33 @@ export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
   if (isOssMode()) {
+    const isOssPublic = OSS_PUBLIC_PREFIXES.some((p) => pathname.startsWith(p));
+    const sessionToken = request.cookies.get(OSS_SESSION_COOKIE)?.value;
+    const isAuthenticated = sessionToken ? await verifyOssSessionToken(sessionToken) : false;
+
+    if (isOssPublic) {
+      // Redirect authenticated users away from login/register to app.
+      if (isAuthenticated && (pathname === '/login' || pathname === '/register')) {
+        const url = request.nextUrl.clone();
+        url.pathname = '/inbox';
+        url.search = '';
+        return NextResponse.redirect(url);
+      }
+      return NextResponse.next({ request });
+    }
+
+    if (!isAuthenticated) {
+      const url = request.nextUrl.clone();
+      url.pathname = '/login';
+      return NextResponse.redirect(url);
+    }
+
     if (pathname === '/') {
       const url = request.nextUrl.clone();
       url.pathname = '/inbox';
       return NextResponse.redirect(url);
     }
-    if (pathname === '/login' || pathname.startsWith('/auth/callback')) {
-      const url = request.nextUrl.clone();
-      url.pathname = '/inbox';
-      url.search = '';
-      return NextResponse.redirect(url);
-    }
+
     return NextResponse.next({ request });
   }
 
@@ -162,7 +195,7 @@ export async function proxy(request: NextRequest) {
   return response;
 }
 
-export const config = {
+export const proxyConfig = {
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],

--- a/packages/storage-pglite/src/db.ts
+++ b/packages/storage-pglite/src/db.ts
@@ -311,6 +311,16 @@ async function _initSchema(db: PGlite): Promise<void> {
       scope TEXT DEFAULT '["read","write"]'
     );
 
+    CREATE TABLE IF NOT EXISTS oss_users (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      password_hash TEXT NOT NULL,
+      name TEXT NOT NULL,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      UNIQUE(email)
+    );
+
     CREATE TABLE IF NOT EXISTS agent_personas (
       id TEXT PRIMARY KEY,
       org_id TEXT NOT NULL,
@@ -396,6 +406,7 @@ async function _initSchema(db: PGlite): Promise<void> {
     CREATE INDEX IF NOT EXISTS idx_agent_runs_created_at ON agent_runs(created_at);
     CREATE INDEX IF NOT EXISTS idx_agent_api_keys_team_member ON agent_api_keys(team_member_id);
     CREATE INDEX IF NOT EXISTS idx_agent_personas_project ON agent_personas(project_id);
+    CREATE INDEX IF NOT EXISTS idx_oss_users_email ON oss_users(email);
     CREATE INDEX IF NOT EXISTS idx_retro_sessions_project ON retro_sessions(project_id);
     CREATE INDEX IF NOT EXISTS idx_retro_items_session ON retro_items(session_id);
     CREATE INDEX IF NOT EXISTS idx_retro_actions_session ON retro_actions(session_id);


### PR DESCRIPTION
## Summary

- **UL-S5**: OSS 셀프호스팅 환경 이메일+패스워드 로컬 인증 + 멀티유저 기초 (3SP)
- E-OSS-UNLIMITED 에픽 마지막 스토리 — UL-S1~S5 전량 완주 (19SP)

## 변경 내용

### 새 파일
- `packages/storage-pglite/src/db.ts` — `oss_users` 테이블 DDL (email/password_hash/name/unique)
- `apps/web/src/lib/oss-auth.ts` — `scrypt` 패스워드 해싱 + `jose` JWT 세션 발급/검증 헬퍼
- `apps/web/src/app/register/page.tsx` + `register-form-client.tsx` — OSS 전용 가입 폼 (서버 guard + 클라이언트 폼)

### 수정 파일
- `proxy.ts` — OSS 모드: `sp_oss_at` 세션 쿠키 검증, 미인증 → `/login` 리다이렉트 (Next.js 16 `proxyConfig` + Node.js runtime)
- `auth-helpers.ts` — `getOssUserContext()`: 세션 쿠키 `sp_oss_at` → `user_id` → `team_members` 동적 매핑
- `/api/auth/login` — OSS 경로: `oss_users` 인증 + `sp_oss_at` httpOnly 쿠키 발급
- `/api/auth/register` — OSS 경로: 가입 + 모든 프로젝트에 `team_members` 자동 등록 (첫 가입자 owner)
- `/api/auth/logout` — OSS 경로: `sp_oss_at` 쿠키 삭제
- `login/page.tsx` — OSS 모드: OAuth 버튼 숨김, `/register` 링크 표시

## AC 체크

- [x] AC1: 이메일+패스워드 로컬 인증 (`oss_users` PGLite)
- [x] AC2: 회원가입 플로우 (OSS 전용, `/register`)
- [x] AC3: 사용자별 멤버십 분리 (`user_id` → `team_members.user_id`)
- [x] AC4: `getAuthContext()` OSS 경로: 세션 쿠키 → `user_id` 추출
- [x] AC5: JWT 세션 토큰 발급/검증 (`jose` HS256, 7일 만료)

## Test plan

- [ ] OSS 모드(`NEXT_PUBLIC_OSS_MODE=true`)에서 `/register` 접근 → 가입 폼 표시
- [ ] 이름/이메일/비밀번호(8자+) 입력 후 가입 → `/inbox` 리다이렉트, `sp_oss_at` 쿠키 설정
- [ ] 로그아웃 후 `/inbox` 접근 → `/login` 리다이렉트
- [ ] 재로그인 → 동일 계정 복원
- [ ] 두 번째 가입자는 `member` 역할 (첫 가입자는 `owner`)
- [ ] SaaS 모드: `/register` → `/login` 리다이렉트, 기존 OAuth 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)