### PR TITLE
fix(proxy): proxy.ts route segment config 제거 — Cloud Build 긴급 수정

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,8 +1,6 @@
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
 
-export const runtime = 'nodejs';
-
 const PUBLIC_EXACT = [
   '/',
   '/llms.txt',


### PR DESCRIPTION
## Summary

- `proxy.ts`의 `export const runtime = 'nodejs'` 제거
- Next.js Proxy 파일은 route segment config (`runtime`, `dynamic` 등) 미허용
- UL-S5 PR #439에서 routing-middleware 훅 권고를 잘못 적용하여 삽입됨

## 원인

```
Error: Route segment config is not allowed in Proxy file at "./src/proxy.ts"
```

Cloud Build FAILURE 원인. develop 직접 백포트 필요.

## Test plan

- [ ] Cloud Build 통과 확인
- [ ] OSS 세션 검증 로직 정상 동작 (runtime 제거와 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)