### PR TITLE
feat(oss-stack-unify): SU-S3 Route Handler isOssMode() 분기 전량 제거

### DIFF
--- a/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/[keyId]/route.ts
@@ -1,21 +1,13 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createAgentApiKeyRepository } from '@/lib/storage/factory';
+import { createAgentApiKeyRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string; keyId: string }> };
 
 /** DELETE /api/agents/[id]/api-key/[keyId] — API Key revoke */
 export async function DELETE(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { keyId } = await params;
-      const repo = await createAgentApiKeyRepository();
-      await repo.revoke(keyId);
-      return apiSuccess({ message: 'API key revoked' });
-    } catch (err: unknown) { return handleApiError(err); }
-  }
   try {
     const { id, keyId } = await params;
     const me = await getAuthContext(request);

--- a/apps/web/src/app/api/agents/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-key/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createAgentApiKeyRepository } from '@/lib/storage/factory';
+import { createAgentApiKeyRepository } from '@/lib/storage/factory';
 import { generateApiKey } from '@/lib/auth-api-key';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -9,13 +9,6 @@ type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET /api/agents/[id]/api-key — API Key 목록 조회 */
 export async function GET(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { id: teamMemberId } = await params;
-      const repo = await createAgentApiKeyRepository();
-      return apiSuccess(await repo.list(teamMemberId));
-    } catch (err: unknown) { return handleApiError(err); }
-  }
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
@@ -28,19 +21,6 @@ export async function GET(request: Request, { params }: RouteParams) {
 
 /** POST /api/agents/[id]/api-key — API Key 발급 */
 export async function POST(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { id: teamMemberId } = await params;
-      const body = await request.json().catch(() => ({})) as { expires_at?: string; scope?: string[] };
-      const { apiKey, keyPrefix, keyHash } = generateApiKey();
-      const defaultExpiry = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString();
-      const expiresAt = body.expires_at ?? defaultExpiry;
-      const scope = body.scope ?? ['read', 'write'];
-      const repo = await createAgentApiKeyRepository();
-      const row = await repo.create({ teamMemberId, keyPrefix, keyHash, expiresAt, scope });
-      return apiSuccess({ ...row, api_key: apiKey }, undefined, 201);
-    } catch (err: unknown) { return handleApiError(err); }
-  }
   try {
     const { id } = await params;
     const me = await getAuthContext(request);
@@ -53,16 +33,6 @@ export async function POST(request: Request, { params }: RouteParams) {
 
 /** DELETE /api/agents/[id]/api-key?key_id={key_id} — API Key 폐기 */
 export async function DELETE(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { searchParams } = new URL(request.url);
-      const keyId = searchParams.get('key_id');
-      if (!keyId) return ApiErrors.badRequest('key_id required');
-      const repo = await createAgentApiKeyRepository();
-      await repo.revoke(keyId);
-      return apiSuccess({ ok: true });
-    } catch (err: unknown) { return handleApiError(err); }
-  }
   try {
     const { id } = await params;
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/agents/personas/route.ts
+++ b/apps/web/src/app/api/agents/personas/route.ts
@@ -1,22 +1,11 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors, apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const db = await getDb();
-      const personas = (await db.query(
-        'SELECT * FROM agent_personas WHERE project_id = $1 ORDER BY created_at ASC',
-        [me.project_id]
-      )).rows;
-      return apiSuccess(personas);
-    }
     const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());
@@ -25,28 +14,6 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      let body: unknown;
-      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON', 400); }
-      const b = (body as Record<string, unknown>) ?? {};
-      if (typeof b.name !== 'string' || !b.name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
-      if (typeof b.agent_id !== 'string' || !b.agent_id.trim()) return apiError('VALIDATION_ERROR', 'agent_id is required', 400);
-
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const { randomUUID } = await import('node:crypto');
-      const db = await getDb();
-      const id = randomUUID();
-      const now = new Date().toISOString();
-      const slug = (b.name as string).trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-      await db.query(
-        'INSERT INTO agent_personas (id, org_id, project_id, agent_id, name, slug, description, system_prompt, style_prompt, model, config, is_builtin, is_default, created_by, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$15)',
-        [id, me.org_id, me.project_id, b.agent_id, (b.name as string).trim(), slug, b.description ?? null, b.system_prompt ?? '', b.style_prompt ?? null, b.model ?? null, JSON.stringify(b.config ?? {}), 0, 0, me.id, now]
-      );
-      const persona = (await db.query('SELECT * FROM agent_personas WHERE id = $1', [id])).rows[0];
-      return apiSuccess(persona, undefined, 201);
-    }
     const _r = await proxyToFastapi(request, '/api/v2/agent-personas');
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/api/api-keys/[id]/logs/route.ts
+++ b/apps/web/src/app/api/api-keys/[id]/logs/route.ts
@@ -1,12 +1,11 @@
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { apiSuccess } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 /** GET /api/api-keys/[id]/logs — 키별 사용 이력 (admin/owner only) */
 export async function GET(request: Request, { params }: RouteParams) {
-  if (isOssMode()) return apiSuccess([]);
   const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/api-keys/${id}/logs`);
   if (!_r.ok) return _r;

--- a/apps/web/src/app/api/auth/login/route.ts
+++ b/apps/web/src/app/api/auth/login/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -16,30 +16,6 @@ export async function POST(request: Request) {
   if (csrfError) return csrfError;
 
   const body = await request.json() as { email: string; password: string; totp_code?: string | null };
-
-  if (isOssMode()) {
-    const { getDb } = await import('@sprintable/storage-pglite');
-    const { verifyPassword, signOssSession, ossSessionCookieOptions, OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
-    const db = await getDb();
-
-    if (!body.email?.trim() || !body.password) {
-      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'Email and password required' } }, { status: 400 });
-    }
-
-    const user = (await db.query(
-      'SELECT id, email, name, password_hash FROM oss_users WHERE email = $1 LIMIT 1',
-      [body.email.trim().toLowerCase()]
-    )).rows[0] as { id: string; email: string; name: string; password_hash: string } | undefined;
-
-    if (!user || !verifyPassword(body.password, user.password_hash)) {
-      return NextResponse.json({ error: { code: 'AUTH_FAILED', message: 'Invalid email or password' } }, { status: 401 });
-    }
-
-    const token = await signOssSession(user.id);
-    const res = NextResponse.json({ data: { ok: true } });
-    res.cookies.set(OSS_SESSION_COOKIE, token, ossSessionCookieOptions());
-    return res;
-  }
 
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/token`, {
     method: 'POST',

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -10,13 +10,6 @@ const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://loca
 export async function POST(request: Request) {
   const csrfError = verifyCsrfOrigin(request);
   if (csrfError) return csrfError;
-
-  if (isOssMode()) {
-    const { OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
-    const res = NextResponse.json({ data: { ok: true } });
-    res.cookies.set(OSS_SESSION_COOKIE, '', { httpOnly: true, secure: process.env['NODE_ENV'] === 'production', sameSite: 'lax', path: '/', maxAge: 0 });
-    return res;
-  }
 
   const cookieStore = await cookies();
   const refreshToken = cookieStore.get(SP_RT_COOKIE)?.value ?? '';

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE } from '@/lib/db/server';
 import { verifyCsrfOrigin } from '@/lib/auth/csrf';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
@@ -16,61 +16,6 @@ export async function POST(request: Request) {
   if (csrfError) return csrfError;
 
   const body = await request.json() as { email: string; password: string; name?: string };
-
-  if (isOssMode()) {
-    const { getDb, OSS_ORG_ID, OSS_PROJECT_ID } = await import('@sprintable/storage-pglite');
-    const { hashPassword, signOssSession, ossSessionCookieOptions, OSS_SESSION_COOKIE } = await import('@/lib/oss-auth');
-    const { randomUUID } = await import('node:crypto');
-    const db = await getDb();
-
-    const email = body.email?.trim().toLowerCase();
-    const name = (body.name?.trim()) || email.split('@')[0] || 'User';
-    const password = body.password;
-
-    if (!email || !password) {
-      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'email and password are required' } }, { status: 400 });
-    }
-    if (password.length < 8) {
-      return NextResponse.json({ error: { code: 'VALIDATION_ERROR', message: 'Password must be at least 8 characters' } }, { status: 400 });
-    }
-
-    const existing = (await db.query('SELECT id FROM oss_users WHERE email = $1 LIMIT 1', [email])).rows[0];
-    if (existing) {
-      return NextResponse.json({ error: { code: 'CONFLICT', message: 'Email already registered' } }, { status: 409 });
-    }
-
-    const now = new Date().toISOString();
-    const userId = randomUUID();
-    const passwordHash = hashPassword(password);
-
-    await db.query(
-      'INSERT INTO oss_users (id, email, password_hash, name, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$5)',
-      [userId, email, passwordHash, name, now]
-    );
-
-    // Count after insert to determine role (1 = first user → owner).
-    const countRow = (await db.query('SELECT COUNT(*) as cnt FROM oss_users')).rows[0] as { cnt: string | number };
-    const isFirst = Number(countRow.cnt) <= 1;
-    const role = isFirst ? 'owner' : 'member';
-
-    const projects = (await db.query(
-      'SELECT id, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC'
-    )).rows as Array<{ id: string; org_id: string }>;
-    const targetProjects = projects.length > 0 ? projects : [{ id: OSS_PROJECT_ID, org_id: OSS_ORG_ID }];
-
-    for (const project of targetProjects) {
-      const memberId = randomUUID();
-      await db.query(
-        'INSERT INTO team_members (id, org_id, project_id, user_id, name, email, role, type, is_active, created_at, updated_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,1,$9,$9)',
-        [memberId, project.org_id, project.id, userId, name, email, role, 'human', now]
-      );
-    }
-
-    const token = await signOssSession(userId);
-    const res = NextResponse.json({ data: { ok: true } }, { status: 201 });
-    res.cookies.set(OSS_SESSION_COOKIE, token, ossSessionCookieOptions());
-    return res;
-  }
 
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/register`, {
     method: 'POST',

--- a/apps/web/src/app/api/current-project/route.ts
+++ b/apps/web/src/app/api/current-project/route.ts
@@ -3,26 +3,10 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { CURRENT_PROJECT_COOKIE, getAuthContext } from '@/lib/auth-helpers';
 import { parseBody, setCurrentProjectSchema } from '@sprintable/shared';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const db = await getDb();
-      const projects = (await db.query('SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC')).rows as Array<{ id: string; name: string; org_id: string }>;
-      const cookieStore = await cookies();
-      const cookieProjectId = cookieStore.get(CURRENT_PROJECT_COOKIE)?.value;
-      const current = projects.find((p) => p.id === cookieProjectId) ?? projects[0];
-      if (!current) return apiError('NOT_FOUND', 'No projects found', 404);
-      return apiSuccess({
-        project_id: current.id,
-        project_name: current.name,
-        org_id: current.org_id,
-        projects: projects.map((p) => ({ id: p.id, name: p.name, org_id: p.org_id })),
-      });
-    }
-
     // 비-OSS: getAuthContext → me에 org_id, project_id 포함
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
@@ -55,16 +39,6 @@ export async function POST(request: Request) {
     const parsed = await parseBody(request, setCurrentProjectSchema);
     if (!parsed.success) return parsed.response;
     const { project_id: projectId } = parsed.data;
-
-    if (isOssMode()) {
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const db = await getDb();
-      const projectRow = (await db.query('SELECT id, name FROM projects WHERE id = $1 AND deleted_at IS NULL LIMIT 1', [projectId])).rows[0] as { id: string; name: string } | undefined;
-      if (!projectRow) return ApiErrors.forbidden('Project not found');
-      const cookieStore = await cookies();
-      cookieStore.set(CURRENT_PROJECT_COOKIE, projectId, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
-      return apiSuccess({ project_id: projectId, project_name: projectRow.name });
-    }
 
     // 비-OSS: 쿠키에 project_id 저장 + fastapiCall로 프로젝트 정보 조회
     const cookieStore = await cookies();

--- a/apps/web/src/app/api/dashboard/route.ts
+++ b/apps/web/src/app/api/dashboard/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/dashboard?member_id=X[&project_id=X]
@@ -10,11 +10,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { apiSuccess } = await import('@/lib/api-response');
-      return apiSuccess({ my_stories: [], assigned_stories: [], my_tasks: [], open_memos: [] });
-    }
 
 const _r = await proxyToFastapi(request, '/api/v2/dashboard');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/docs/[id]/comments/route.ts
+++ b/apps/web/src/app/api/docs/[id]/comments/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -12,8 +12,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) return apiSuccess([]);
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/docs/[id]/comments', { id });
     if (!_r.ok) return _r;
@@ -27,7 +25,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/docs/[id]/comments', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/docs/[id]/revisions/route.ts
+++ b/apps/web/src/app/api/docs/[id]/revisions/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -12,8 +12,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) return apiSuccess([]);
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/docs/[id]/revisions', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/docs/[id]/route.ts
+++ b/apps/web/src/app/api/docs/[id]/route.ts
@@ -3,7 +3,7 @@ import { DocsService } from '@/services/docs';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { createDocRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -17,12 +17,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const parsed = await parseBody(request, updateDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createDocRepository(dbClient);
     const service = new DocsService(repo, dbClient);
-
-    if (isOssMode()) {
-      const existing = await repo.getById(id);
-      const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
-      if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents are read-only', 403);
-    }
 
     const doc = await service.updateDoc(id, {
       ...body,
@@ -62,12 +56,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
     const dbClient = undefined;
     const repo = await createDocRepository(dbClient);
-
-    if (isOssMode()) {
-      const existing = await repo.getById(id);
-      const docType = (existing as unknown as { doc_type?: string }).doc_type ?? 'page';
-      if (docType === 'sprint_report') return apiError('FORBIDDEN', 'sprint_report documents cannot be deleted', 403);
-    }
 
     const service = new DocsService(repo, dbClient);
     await service.deleteDoc(id);

--- a/apps/web/src/app/api/docs/preview/route.ts
+++ b/apps/web/src/app/api/docs/preview/route.ts
@@ -1,7 +1,7 @@
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { createDocRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /**
@@ -17,20 +17,6 @@ export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
     const q = searchParams.get('q')?.trim();
     if (!q) return ApiErrors.badRequest('q is required');
-
-    if (isOssMode()) {
-      const repo = await createDocRepository();
-      const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(q);
-      try {
-        const doc = isUuid
-          ? await repo.getById(q)
-          : await (repo as unknown as { getBySlug: (p: string, s: string) => Promise<{ id: string; title: string; icon: string | null; slug: string; content: string }> }).getBySlug(me.project_id, q);
-        if (!doc) return ApiErrors.notFound('Document not found');
-        return apiSuccess({ id: doc.id, title: doc.title, icon: doc.icon ?? null, slug: doc.slug, embedChain: [] });
-      } catch {
-        return ApiErrors.notFound('Document not found');
-      }
-    }
 
     const _r = await proxyToFastapi(request, '/api/v2/docs/preview');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/docs/route.ts
+++ b/apps/web/src/app/api/docs/route.ts
@@ -5,7 +5,7 @@ import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { checkResourceLimit } from '@/lib/check-feature';
-import { isOssMode, createDocRepository } from '@/lib/storage/factory';
+import { createDocRepository } from '@/lib/storage/factory';
 
 export async function GET(request: Request) {
   try {
@@ -49,12 +49,9 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
-    if (!ossMode) {
-      const check = await checkResourceLimit(dbClient, me.org_id, 'max_docs', 'docs');
-      if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Document limit reached. Upgrade to Team.', 403);
-    }
+    const check = await checkResourceLimit(dbClient, me.org_id, 'max_docs', 'docs');
+    if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Document limit reached. Upgrade to Team.', 403);
     const parsed = await parseBody(request, createDocSchema); if (!parsed.success) return parsed.response; const body = parsed.data;
     const repo = await createDocRepository(dbClient);
     const service = new DocsService(repo, dbClient);

--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -4,7 +4,7 @@ import { EpicService } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { createEpicRepository, isOssMode } from '@/lib/storage/factory';
+import { createEpicRepository } from '@/lib/storage/factory';
 import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -55,7 +55,7 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (!isOssMode() && me.type !== 'agent') {
+    if (me.type !== 'agent') {
       const denied = await requireRole(undefined, me.org_id, ADMIN_ROLES, 'Epic deletion requires admin or owner role');
       if (denied) return denied;
     }

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -6,7 +6,7 @@ import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createEpicRepository } from '@/lib/storage/factory';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
 
 export async function GET(request: Request) {
@@ -41,7 +41,7 @@ export async function POST(request: Request) {
     const dbClient = undefined;
 
     // 권한 체크: agent 또는 admin/owner만 에픽 생성 가능
-    if (!isOssMode() && me.type !== 'agent') {
+    if (me.type !== 'agent') {
       const role = await getEpicActorRole(dbClient, me.id);
       if (!role || !hasEpicRole(role, 'admin')) {
         return apiError('FORBIDDEN', 'Epic creation requires admin or owner role', 403);

--- a/apps/web/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { apiError, ApiErrors } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { buildSlackConnectUrl } from '@/services/slack-channel-mapping';
 
 export async function GET() {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const db: any = null;
   const me = await getMyTeamMember(db, null as any);

--- a/apps/web/src/app/api/me/route.ts
+++ b/apps/web/src/app/api/me/route.ts
@@ -1,21 +1,11 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createTeamMemberRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-
-      const repo = await createTeamMemberRepository();
-      const members = await repo.list({ org_id: me.org_id });
-      const member = members.find((m) => m.id === me.id);
-      if (!member) return ApiErrors.notFound('Member not found');
-      return apiSuccess({ ...member, email: null });
-    }
     const res = await proxyToFastapi(request, '/api/v2/me');
     if (!res.ok) return res;
     const data: unknown = await res.json();
@@ -27,18 +17,6 @@ export async function GET(request: Request) {
 
 export async function PATCH(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      let body: unknown;
-      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
-      const { name } = (body as Record<string, unknown>) ?? {};
-      if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
-
-      const repo = await createTeamMemberRepository();
-      const updated = await repo.update(me.id, { name: name.trim() });
-      return apiSuccess({ ...updated, email: null });
-    }
 const _r = await proxyToFastapi(request, '/api/v2/me');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/meetings/[id]/recording/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/recording/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -12,7 +12,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/recording', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -13,8 +13,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
     if (!_r.ok) return _r;
@@ -30,8 +28,6 @@ export async function PUT(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
-
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
     if (!_r.ok) return _r;
     return apiSuccess(await _r.json());
@@ -45,8 +41,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) return ApiErrors.notFound('Meeting not found');
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/summarize/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summarize/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -14,7 +14,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summarize', { id });
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/meetings/[id]/summary/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/summary/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -14,7 +14,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/summary', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
+++ b/apps/web/src/app/api/meetings/[id]/transcribe/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 export const maxDuration = 60;
@@ -14,7 +14,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     return proxyToFastapiWithParams(request, '/api/v2/meetings/[id]/transcribe', { id });
   } catch (err: unknown) { return handleApiError(err); }

--- a/apps/web/src/app/api/meetings/route.ts
+++ b/apps/web/src/app/api/meetings/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { checkResourceLimit } from '@/lib/check-feature';
 
@@ -11,8 +11,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) return apiSuccess([]);
 
     const _r = await proxyToFastapi(request, '/api/v2/meetings');
     if (!_r.ok) return _r;
@@ -26,7 +24,6 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     // AC8: Feature gating (SaaS only)
     const check = await checkResourceLimit(undefined, me.org_id, 'max_meetings', 'meetings');

--- a/apps/web/src/app/api/members/route.ts
+++ b/apps/web/src/app/api/members/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createTeamMemberRepository } from '@/lib/storage/factory';
 
 // GET /api/members?project_id=X
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/memos/[id]/archive/route.ts
+++ b/apps/web/src/app/api/memos/[id]/archive/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { createMemoRepository, isOssMode } from '@/lib/storage/factory';
+import { createMemoRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -12,7 +12,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
 
     const dbClient = undefined;
     const repo = await createMemoRepository(dbClient);

--- a/apps/web/src/app/api/memos/[id]/replies/route.ts
+++ b/apps/web/src/app/api/memos/[id]/replies/route.ts
@@ -3,7 +3,7 @@ import { MemoService } from '@/services/memo';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { isOssMode, createMemoRepository, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createMemoRepository, createTeamMemberRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -25,18 +25,6 @@ export async function POST(request: Request, { params }: RouteParams) {
           },
         }
       );
-    }
-
-    if (isOssMode()) {
-      const parsed = await parseBody(request, createMemoReplySchema);
-      if (!parsed.success) return parsed.response;
-      const body = parsed.data;
-      const repo = await createMemoRepository();
-      const teamMemberRepo = await createTeamMemberRepository();
-      const service = new MemoService(repo, undefined, teamMemberRepo);
-      const resolvedIds = body.assigned_to_ids ?? (body.assigned_to ? [body.assigned_to] : undefined);
-      const reply = await service.addReply(id, body.content, me.id, 'comment', resolvedIds);
-      return apiSuccess(reply, undefined, 201);
     }
 
     // non-OSS: body 파싱 후 created_by(me.id) 주입해서 FastAPI 호출

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -3,7 +3,7 @@ import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { attachNotificationHrefs } from '@/services/notification-navigation';
 import { parseBody, updateNotificationSchema } from '@sprintable/shared';
-import { isOssMode, createNotificationRepository } from '@/lib/storage/factory';
+import { createNotificationRepository } from '@/lib/storage/factory';
 
 /** GET — 알림 목록 (안읽음 우선, 최신순) */
 export async function GET(request: Request) {

--- a/apps/web/src/app/api/oss/seed/route.ts
+++ b/apps/web/src/app/api/oss/seed/route.ts
@@ -1,4 +1,4 @@
-import { isOssMode, createStoryRepository, createProjectRepository } from '@/lib/storage/factory';
+import { createStoryRepository, createProjectRepository } from '@/lib/storage/factory';
 import { apiSuccess, apiError } from '@/lib/api-response';
 
 const SAMPLE_STORIES = [
@@ -8,10 +8,6 @@ const SAMPLE_STORIES = [
 ];
 
 export async function POST() {
-  if (!isOssMode()) {
-    return apiError('NOT_AVAILABLE', 'Seed is only available in OSS mode', 403);
-  }
-
   try {
     const { getOssUserContext } = await import('@/lib/auth-helpers');
     const { me } = await getOssUserContext();

--- a/apps/web/src/app/api/oss/webhook-status/route.ts
+++ b/apps/web/src/app/api/oss/webhook-status/route.ts
@@ -1,10 +1,6 @@
-import { isOssMode } from '@/lib/storage/factory';
-import { apiSuccess, apiError } from '@/lib/api-response';
+import { apiSuccess } from '@/lib/api-response';
 
 export async function GET() {
-  if (!isOssMode()) {
-    return apiError('NOT_AVAILABLE', 'Only available in OSS mode', 403);
-  }
   const connected = !!process.env['GITHUB_WEBHOOK_SECRET'];
   return apiSuccess({ connected });
 }

--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,18 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { isOssMode, createProjectRepository, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createProjectRepository, createTeamMemberRepository } from '@/lib/storage/factory';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 조직 프로젝트 목록 */
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const db = await getDb();
-      const projects = (await db.query('SELECT id, name, org_id FROM projects WHERE deleted_at IS NULL ORDER BY created_at ASC')).rows as Array<{ id: string; name: string; org_id: string }>;
-      return apiSuccess(projects.map((p) => ({ id: p.id, name: p.name, description: null, org_id: p.org_id })));
-    }
 const _r = await proxyToFastapi(request, '/api/v2/projects');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
@@ -25,35 +19,6 @@ const _r = await proxyToFastapi(request, '/api/v2/projects');
 /** POST — 프로젝트 생성 */
 export async function POST(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-
-      let body: unknown;
-      try { body = await request.json(); } catch { return apiError('BAD_REQUEST', 'Invalid JSON body', 400); }
-      const { name, description } = (body as Record<string, unknown>) ?? {};
-      if (typeof name !== 'string' || !name.trim()) return apiError('VALIDATION_ERROR', 'name is required', 400);
-
-      const projectRepo = await createProjectRepository();
-      const project = await projectRepo.create({
-        org_id: me.org_id,
-        name: name.trim(),
-        description: typeof description === 'string' ? description || null : null,
-        created_by: me.id,
-      });
-
-      const memberRepo = await createTeamMemberRepository();
-      await memberRepo.create({
-        org_id: me.org_id,
-        project_id: project.id,
-        name: 'Admin',
-        role: 'owner',
-        type: 'human',
-        is_active: true,
-      });
-
-      return apiSuccess(project, undefined, 201);
-    }
     const _r = await proxyToFastapi(request, '/api/v2/projects');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/actions/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { addOssRetroAction } from '@/lib/oss-retro';
 
@@ -42,11 +42,6 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     const body = await request.json() as { title?: string; assignee_id?: string | null };
     if (!body.title) return ApiErrors.badRequest('title required');
-
-    if (isOssMode()) {
-      const data = await addOssRetroAction({ session_id: id, project_id: projectId, title: body.title, assignee_id: body.assignee_id ?? null });
-      return apiSuccess(data);
-    }
 
 const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/actions', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/[item_id]/vote/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { voteOssRetroItem } from '@/lib/oss-retro';
 
@@ -14,15 +14,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      if (!projectId) return ApiErrors.badRequest('project_id required');
-      const body = await request.json().catch(() => ({})) as { voter_id?: string };
-      const data = await voteOssRetroItem(item_id, body.voter_id ?? me.id, projectId);
-      return apiSuccess(data);
-    }
 
 const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items/[item_id]/vote', { id, item_id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/items/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { addOssRetroItem } from '@/lib/oss-retro';
 import type { RetroCategory } from '@/lib/oss-retro';
@@ -32,17 +32,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      if (!projectId) return ApiErrors.badRequest('project_id required');
-      const body = await request.json() as { category?: string; text?: string; author_id?: string };
-      if (!body.category) return ApiErrors.badRequest('category required');
-      if (!body.text) return ApiErrors.badRequest('text required');
-      const data = await addOssRetroItem({ session_id: id, project_id: projectId, category: body.category as RetroCategory, text: body.text, author_id: body.author_id ?? me.id });
-      return apiSuccess(data);
-    }
 
 const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/items', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/retro-sessions/[id]/route.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { getOssRetroSession, listOssRetroItems, listOssRetroActions, advanceOssRetroPhase } from '@/lib/oss-retro';
 import type { RetroPhase } from '@/lib/oss-retro';
@@ -19,16 +19,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    if (isOssMode()) {
-      const session = await getOssRetroSession(id, projectId);
-      if (!session) return ApiErrors.notFound('Session not found');
-      const [items, actions] = await Promise.all([
-        listOssRetroItems(id, projectId),
-        listOssRetroActions(id, projectId),
-      ]);
-      return apiSuccess({ session, items, actions });
-    }
 
 const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]', { id });
     if (!_r.ok) return _r;
@@ -50,13 +40,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const { searchParams } = new URL(request.url);
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    if (isOssMode()) {
-      const body = await request.json() as { phase?: string };
-      if (!body.phase) return ApiErrors.badRequest('phase required');
-      const data = await advanceOssRetroPhase(id, projectId, body.phase as RetroPhase);
-      return apiSuccess(data);
-    }
 
 const _r = await proxyToFastapiWithParams(request, '/api/v2/retros/[id]/phase', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/retro-sessions/route.ts
+++ b/apps/web/src/app/api/retro-sessions/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/retro-sessions?project_id=X
@@ -10,15 +10,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { apiSuccess } = await import('@/lib/api-response');
-      const { listOssRetroSessions } = await import('@/lib/oss-retro');
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      if (!projectId) return ApiErrors.badRequest('project_id required');
-      return apiSuccess(await listOssRetroSessions(projectId));
-    }
 
 const _r = await proxyToFastapi(request, '/api/v2/retros');
     if (!_r.ok) return _r;
@@ -35,21 +26,6 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { apiSuccess } = await import('@/lib/api-response');
-      const { createOssRetroSession } = await import('@/lib/oss-retro');
-      const body = await request.json() as {
-        project_id?: string; org_id?: string; title?: string;
-        sprint_id?: string | null; created_by?: string;
-      };
-      if (!body.project_id) return ApiErrors.badRequest('project_id required');
-      if (!body.org_id) return ApiErrors.badRequest('org_id required');
-      if (!body.title) return ApiErrors.badRequest('title required');
-      if (!body.created_by) return ApiErrors.badRequest('created_by required');
-      const data = await createOssRetroSession({ org_id: body.org_id, project_id: body.project_id, title: body.title, sprint_id: body.sprint_id ?? null, created_by: body.created_by });
-      return apiSuccess(data, undefined, 201);
-    }
 
 const _r = await proxyToFastapi(request, '/api/v2/retros');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/sprints/[id]/activate/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/activate/route.ts
@@ -4,7 +4,7 @@ import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,7 +15,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);

--- a/apps/web/src/app/api/sprints/[id]/burndown/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/burndown/route.ts
@@ -4,7 +4,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { SprintService, NotFoundError } from '@/services/sprint';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,7 +15,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);

--- a/apps/web/src/app/api/sprints/[id]/checkin/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/checkin/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -13,10 +13,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      return apiSuccess({ total_stories: 0, total_points: 0, done_points: 0, completion_pct: 0, missing_standups: [] });
-    }
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/sprints/[id]/checkin', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/sprints/[id]/close/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/close/route.ts
@@ -4,7 +4,7 @@ import { SprintService } from '@/services/sprint';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createSprintRepository, createDocRepository } from '@/lib/storage/factory';
+import { createSprintRepository, createDocRepository } from '@/lib/storage/factory';
 import { NotificationService } from '@/services/notification.service';
 import { DocsService } from '@/services/docs';
 import { requireRole, EDIT_ROLES } from '@/lib/role-guard';
@@ -18,10 +18,9 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
-    if (!ossMode && dbClient && me.type !== 'agent') {
+    if (dbClient && me.type !== 'agent') {
       const denied = await requireRole(dbClient, me.org_id, EDIT_ROLES, 'Admin or PO access required to close sprint');
       if (denied) return denied;
     }
@@ -29,118 +28,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const repo = await createSprintRepository(dbClient);
     const service = new SprintService(repo, dbClient as any | undefined);
     const sprint = await service.close(id);
-
-    if (!ossMode && dbClient) {
-      const db = dbClient as any;
-
-      // 알림 발송 (fire-and-forget)
-      const notifService = new NotificationService(db);
-      (async () => {
-        const { data: members } = await db.from('team_members').select('id').eq('project_id', sprint.project_id).eq('is_active', true);
-        for (const member of (members ?? []) as Array<{ id: string }>) {
-          await notifService.create({ org_id: sprint.org_id, user_id: member.id, type: 'sprint_closed', title: `${sprint.title ?? '스프린트'} 종료`, reference_type: 'sprint', reference_id: sprint.id });
-        }
-      })().catch(() => {});
-
-      // 자동 sprint report 생성 (fire-and-forget)
-      (async () => {
-        const { data: stories } = await db.from('stories').select('id, title, status, story_points, assignee_id').eq('sprint_id', id);
-        const allStories = (stories ?? []) as Array<{ id: string; title: string; status: string; story_points: number | null; assignee_id: string | null }>;
-        const doneStories = allStories.filter((s) => s.status === 'done');
-        const carriedOver = allStories.filter((s) => s.status !== 'done');
-        const totalSp = allStories.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
-        const doneSp = doneStories.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
-        const completionPct = totalSp > 0 ? Math.round((doneSp / totalSp) * 100) : 0;
-        const duration = (sprint.duration as number | undefined) ?? 14;
-        const velocityPerDay = duration > 0 ? Math.round((doneSp / duration) * 10) / 10 : 0;
-
-        const reportContent = [
-          `# Sprint Report: ${sprint.title ?? id}`,
-          ``,
-          `**기간:** ${sprint.start_date ?? ''} ~ ${sprint.end_date ?? ''}  `,
-          `**Duration:** ${duration}일`,
-          ``,
-          `## 결과 요약`,
-          `| 항목 | 수치 |`,
-          `|---|---|`,
-          `| 완료율 | ${completionPct}% |`,
-          `| 완료 SP | ${doneSp} / ${totalSp} |`,
-          `| 속도 | ${velocityPerDay} SP/일 |`,
-          `| 완료 스토리 | ${doneStories.length} / ${allStories.length} |`,
-          ``,
-          `## 완료 스토리`,
-          ...doneStories.map((s) => `- [x] ${s.title} (${s.story_points ?? 0} SP)`),
-          ``,
-          `## 이월 스토리`,
-          carriedOver.length === 0 ? '_없음_' : '',
-          ...carriedOver.map((s) => `- [ ] ${s.title} (${s.story_points ?? 0} SP)`),
-        ].join('\n');
-
-        const slug = `sprint-report-${id.slice(0, 8)}-${Date.now()}`;
-        const docRepo = await createDocRepository(db);
-        const docsService = new DocsService(docRepo, db);
-        const doc = await docsService.createDoc({
-          org_id: sprint.org_id as string,
-          project_id: sprint.project_id as string,
-          title: `Sprint Report: ${sprint.title ?? id}`,
-          slug,
-          content: reportContent,
-          content_format: 'markdown',
-          doc_type: 'sprint_report',
-          created_by: me.id,
-        });
-
-        // sprint에 report_doc_id 기록
-        const sprintRepo = await createSprintRepository(db);
-        await sprintRepo.update(id, { report_doc_id: doc.id });
-      })().catch(() => {});
-
-      // 미완료 회고 액션 이월 (fire-and-forget)
-      (async () => {
-        // 1. 현재 스프린트 retro session 조회
-        const { data: closedSession } = await db
-          .from('retro_sessions')
-          .select('id')
-          .eq('sprint_id', id)
-          .maybeSingle();
-        if (!closedSession) return;
-
-        // 2. 미완료 액션 조회
-        const { data: openActions } = await db
-          .from('retro_actions')
-          .select('title, assignee_id')
-          .eq('session_id', closedSession.id)
-          .neq('status', 'done');
-        if (!openActions?.length) return;
-
-        // 3. 다음 active 스프린트 조회
-        const { data: nextSprint } = await db
-          .from('sprints')
-          .select('id')
-          .eq('project_id', sprint.project_id)
-          .eq('status', 'active')
-          .maybeSingle();
-        if (!nextSprint) return;
-
-        // 4. 다음 스프린트 retro session 조회
-        const { data: nextSession } = await db
-          .from('retro_sessions')
-          .select('id')
-          .eq('sprint_id', nextSprint.id)
-          .maybeSingle();
-        if (!nextSession) return;
-
-        // 5. 이월 INSERT
-        await db.from('retro_actions').insert(
-          openActions.map((a) => ({
-            session_id: nextSession.id,
-            title: `[이월] ${a.title}`,
-            assignee_id: a.assignee_id,
-            status: 'open',
-          })),
-        );
-      })().catch(() => {});
-    }
 
     return apiSuccess(sprint);
   } catch (err: unknown) {

--- a/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/kickoff/route.ts
@@ -4,7 +4,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { SprintService, NotFoundError } from '@/services/sprint';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -15,7 +15,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const body = await request.json().catch(() => ({})) as { message?: string };

--- a/apps/web/src/app/api/sprints/[id]/route.ts
+++ b/apps/web/src/app/api/sprints/[id]/route.ts
@@ -5,7 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { parseBody, updateSprintSchema } from '@sprintable/shared';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { createSprintRepository } from '@/lib/storage/factory';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -16,7 +16,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);
@@ -35,7 +34,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const parsed = await parseBody(request, updateSprintSchema);
@@ -56,7 +54,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createSprintRepository(dbClient);

--- a/apps/web/src/app/api/sprints/route.ts
+++ b/apps/web/src/app/api/sprints/route.ts
@@ -5,7 +5,7 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { createSprintSchema } from '@sprintable/shared';
-import { isOssMode, createSprintRepository } from '@/lib/storage/factory';
+import { createSprintRepository } from '@/lib/storage/factory';
 
 // POST /api/sprints — 생성
 export async function POST(request: Request) {
@@ -13,7 +13,6 @@ export async function POST(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     let rawBody: unknown;
@@ -39,7 +38,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/standup/feedback/[id]/route.ts
+++ b/apps/web/src/app/api/standup/feedback/[id]/route.ts
@@ -3,7 +3,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import {
   deleteOssStandupFeedback,
   listOssStandupFeedbackForEntry,
@@ -16,14 +16,6 @@ type RouteParams = { params: Promise<{ id: string }> };
 // GET /api/standup/feedback/:entry_id — list all feedback for a standup entry
 export async function GET(request: Request, { params }: RouteParams) {
   try {
-    if (isOssMode()) {
-      const { id: entryId } = await params;
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-      return apiSuccess(await listOssStandupFeedbackForEntry(entryId));
-    }
-
     const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
     if (!_r.ok) return _r;
@@ -36,16 +28,6 @@ const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
 
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
-    if (isOssMode()) {
-      const { id } = await params;
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-      const parsed = await parseBody(request, updateStandupFeedbackSchema);
-      if (!parsed.success) return parsed.response;
-      return apiSuccess(await updateOssStandupFeedback(id, parsed.data, me.id));
-    }
-
     const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
     if (!_r.ok) return _r;
@@ -58,15 +40,6 @@ const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
 
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
-    if (isOssMode()) {
-      const { id } = await params;
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-      await deleteOssStandupFeedback(id, me.id);
-      return apiSuccess({ ok: true });
-    }
-
     const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/standups/feedback/${id}`);
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/standup/feedback/route.ts
+++ b/apps/web/src/app/api/standup/feedback/route.ts
@@ -3,25 +3,12 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { createOssStandupFeedback, listOssStandupFeedbackByDate } from '@/lib/oss-standup';
 import { parseBody, createStandupFeedbackSchema } from '@sprintable/shared';
 
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      const date = searchParams.get('date');
-      if (!projectId || !date) return ApiErrors.badRequest('project_id and date required');
-
-      return apiSuccess(await listOssStandupFeedbackByDate(projectId, date));
-    }
-
 const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
@@ -33,26 +20,6 @@ const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
 
 export async function POST(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-      const parsed = await parseBody(request, createStandupFeedbackSchema);
-      if (!parsed.success) return parsed.response;
-      const body = parsed.data;
-
-      const feedback = await createOssStandupFeedback({
-        project_id: me.project_id,
-        org_id: me.org_id,
-        standup_entry_id: body.standup_entry_id,
-        feedback_by_id: me.id,
-        review_type: body.review_type ?? 'comment',
-        feedback_text: body.feedback_text,
-      });
-      return apiSuccess(feedback, undefined, 201);
-    }
-
 const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/standup/history/route.ts
+++ b/apps/web/src/app/api/standup/history/route.ts
@@ -3,7 +3,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { getOssStandupHistory } from '@/lib/oss-standup';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
@@ -18,10 +18,6 @@ export async function GET(request: Request) {
     const projectId = searchParams.get('project_id');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     const limit = searchParams.get('limit') ? Number(searchParams.get('limit')) : 50;
-
-    if (isOssMode()) {
-      return apiSuccess(await getOssStandupHistory(projectId, limit));
-    }
 
 const _r = await proxyToFastapi(request, '/api/v2/standups');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/standup/missing/route.ts
+++ b/apps/web/src/app/api/standup/missing/route.ts
@@ -3,7 +3,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { getOssStandupMissing } from '@/lib/oss-standup';
 
@@ -19,10 +19,6 @@ export async function GET(request: Request) {
     const date = searchParams.get('date');
     if (!projectId) return ApiErrors.badRequest('project_id required');
     if (!date) return ApiErrors.badRequest('date required');
-
-    if (isOssMode()) {
-      return apiSuccess(await getOssStandupMissing(projectId, date));
-    }
 
 const _r = await proxyToFastapi(request, '/api/v2/standups/missing');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/standup/route.ts
+++ b/apps/web/src/app/api/standup/route.ts
@@ -1,6 +1,6 @@
 
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { handleApiError } from '@/lib/api-error';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
@@ -10,23 +10,6 @@ import { getOssStandupEntryForUser, listOssStandupEntries, saveOssStandupEntry }
 // GET /api/standup?project_id=...&date=YYYY-MM-DD[&member_id=...]
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      const date = searchParams.get('date');
-      const memberId = searchParams.get('member_id');
-      if (!projectId || !date) return ApiErrors.badRequest('project_id and date required');
-
-      if (memberId) {
-        return apiSuccess(await getOssStandupEntryForUser(projectId, memberId, date));
-      }
-      return apiSuccess(await listOssStandupEntries(projectId, date));
-    }
-
 const _r = await proxyToFastapi(request, '/api/v2/standups');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
@@ -39,40 +22,6 @@ const _r = await proxyToFastapi(request, '/api/v2/standups');
 // POST /api/standup — supports Dual Auth; agent may pass author_id in body
 export async function POST(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-      let rawBody: unknown;
-      try { rawBody = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
-
-      const authorId: string =
-        me.type === 'agent' && typeof (rawBody as Record<string, unknown>).author_id === 'string'
-          ? (rawBody as Record<string, unknown>).author_id as string
-          : me.id;
-
-      const parsed = saveStandupSchema.safeParse(rawBody);
-      if (!parsed.success) {
-        const issues = parsed.error.issues.map((i) => ({ path: i.path.join('.'), message: i.message }));
-        return ApiErrors.validationFailed(issues);
-      }
-      const body = parsed.data;
-
-      const entry = await saveOssStandupEntry({
-        project_id: me.project_id,
-        org_id: me.org_id,
-        author_id: authorId,
-        date: body.date || new Date().toISOString().slice(0, 10),
-        done: body.done ?? null,
-        plan: body.plan ?? null,
-        blockers: body.blockers ?? null,
-        sprint_id: body.sprint_id ?? null,
-        plan_story_ids: body.plan_story_ids ?? [],
-      });
-      return apiSuccess(entry);
-    }
-
 const _r = await proxyToFastapi(request, '/api/v2/standups');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
@@ -85,35 +34,6 @@ const _r = await proxyToFastapi(request, '/api/v2/standups');
 // PUT /api/standup — kept for backwards compatibility (human auth only)
 export async function PUT(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-      let rawBody: unknown;
-      try { rawBody = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
-
-      const parsed = saveStandupSchema.safeParse(rawBody);
-      if (!parsed.success) {
-        const issues = parsed.error.issues.map((i) => ({ path: i.path.join('.'), message: i.message }));
-        return ApiErrors.validationFailed(issues);
-      }
-      const body = parsed.data;
-
-      const entry = await saveOssStandupEntry({
-        project_id: me.project_id,
-        org_id: me.org_id,
-        author_id: me.id,
-        date: body.date || new Date().toISOString().slice(0, 10),
-        done: body.done ?? null,
-        plan: body.plan ?? null,
-        blockers: body.blockers ?? null,
-        sprint_id: body.sprint_id ?? null,
-        plan_story_ids: body.plan_story_ids ?? [],
-      });
-      return apiSuccess(entry);
-    }
-
 const _r = await proxyToFastapi(request, '/api/v2/standups');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/stories/[id]/activities/route.ts
+++ b/apps/web/src/app/api/stories/[id]/activities/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { StoryService } from '@/services/story';
 
@@ -13,22 +13,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const url = new URL(request.url);
-      const limit = url.searchParams.get('limit');
-      const cursor = url.searchParams.get('cursor');
-      const repo = await createStoryRepository();
-      const service = new StoryService(repo, undefined as any);
-      const activities = await service.getActivities(id, {
-        limit: limit ? parseInt(limit, 10) : 20,
-        cursor: cursor ?? undefined,
-      });
-      const hasMore = limit && activities.length > parseInt(limit, 10);
-      const data = hasMore ? activities.slice(0, -1) : activities;
-      const nextCursor = hasMore && data.length > 0 ? (data[data.length - 1] as { created_at?: string })?.created_at : null;
-      return apiSuccess(data, { nextCursor });
-    }
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/activities', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/stories/[id]/comments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/comments/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { StoryService } from '@/services/story';
 
@@ -13,22 +13,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const url = new URL(request.url);
-      const limit = url.searchParams.get('limit');
-      const cursor = url.searchParams.get('cursor');
-      const repo = await createStoryRepository();
-      const service = new StoryService(repo, undefined as any);
-      const comments = await service.getComments(id, {
-        limit: limit ? parseInt(limit, 10) : 20,
-        cursor: cursor ?? undefined,
-      });
-      const hasMore = limit && comments.length > parseInt(limit, 10);
-      const data = hasMore ? comments.slice(0, -1) : comments;
-      const nextCursor = hasMore && data.length > 0 ? data[data.length - 1]?.created_at : null;
-      return apiSuccess(data, { nextCursor });
-    }
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/comments', { id });
     if (!_r.ok) return _r;
@@ -44,15 +28,6 @@ export async function POST(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const body = await request.json();
-      if (!body.content || typeof body.content !== 'string') return ApiErrors.badRequest('content is required');
-      const repo = await createStoryRepository();
-      const service = new StoryService(repo, undefined as any);
-      const comment = await service.addComment({ story_id: id, content: body.content, created_by: me.id });
-      return apiSuccess(comment, undefined, 201);
-    }
 
     const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/comments', { id });
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/stories/[id]/route.ts
+++ b/apps/web/src/app/api/stories/[id]/route.ts
@@ -5,7 +5,7 @@ import { StoryService } from '@/services/story';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 import { NotificationService } from '@/services/notification.service';
 
 type RouteParams = { params: Promise<{ id: string }> };
@@ -16,7 +16,6 @@ export async function GET(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createStoryRepository(dbClient);
@@ -40,7 +39,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const parsed = await parseBody(request, updateStorySchema); if (!parsed.success) return parsed.response; const body = parsed.data;
@@ -58,7 +56,7 @@ export async function PATCH(request: Request, { params }: RouteParams) {
       const newAssigneeId = body.assignee_id as string | null;
       const oldAssigneeId = before.assignee_id as string | null;
 
-      if (!ossMode && dbClient) {
+      if (dbClient) {
         const notifService = new NotificationService(dbClient as any);
         if (newAssigneeId && newAssigneeId !== actorId) {
           notifService.create({ org_id: orgId, user_id: newAssigneeId, type: 'story_assigned', title: '스토리가 배정되었습니다', body: before.title ?? '', reference_type: 'story', reference_id: id }).catch(() => {});
@@ -93,7 +91,6 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const repo = await createStoryRepository(dbClient);

--- a/apps/web/src/app/api/stories/backlog/route.ts
+++ b/apps/web/src/app/api/stories/backlog/route.ts
@@ -1,7 +1,7 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { StoryService } from '@/services/story';
 
@@ -10,16 +10,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id');
-      if (!projectId) return ApiErrors.badRequest('project_id required');
-      const repo = await createStoryRepository();
-      const service = new StoryService(repo, undefined as any);
-      const stories = await service.backlog(projectId);
-      return apiSuccess(stories);
-    }
 
     // FastAPI에서 status=backlog 필터로 처리
     const url = new URL(request.url);

--- a/apps/web/src/app/api/stories/bulk/route.ts
+++ b/apps/web/src/app/api/stories/bulk/route.ts
@@ -2,7 +2,7 @@ import { parseBody, bulkUpdateStorySchema } from '@sprintable/shared';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { StoryService } from '@/services/story';
 
@@ -12,33 +12,6 @@ export async function PATCH(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    if (isOssMode()) {
-      const parsed = await parseBody(request, bulkUpdateStorySchema);
-      if (!parsed.success) return parsed.response;
-      const body = parsed.data;
-      if (!Array.isArray(body.items) || body.items.length === 0) {
-        return ApiErrors.badRequest('items array required');
-      }
-      const repo = await createStoryRepository();
-      const service = new StoryService(repo, undefined as any, { isAdminContext: me.type === 'agent' });
-
-      // activity log를 위해 변경 전 상태 수집
-      const befores = await Promise.all(body.items.map((item) => service.getById(item.id).catch(() => null)));
-
-      const results = await service.bulkUpdate(body.items);
-
-      // status 변경 activity log
-      for (let i = 0; i < body.items.length; i++) {
-        const item = body.items[i]!;
-        const before = befores[i];
-        if (item.status && before && item.status !== before.status) {
-          service.logActivity({ story_id: item.id, org_id: me.org_id, actor_id: me.id, action_type: 'status_changed', old_value: before.status as string, new_value: item.status }).catch(() => {});
-        }
-      }
-
-      return apiSuccess(results);
-    }
 
     const _r = await proxyToFastapi(request, '/api/v2/stories/bulk');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -7,20 +7,17 @@ import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { checkResourceLimit } from '@/lib/check-feature';
 import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
-import { isOssMode, createStoryRepository } from '@/lib/storage/factory';
+import { createStoryRepository } from '@/lib/storage/factory';
 
 export async function POST(request: Request) {
   try {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
-    if (!ossMode) {
-      const check = await checkResourceLimit(dbClient!, me.org_id, 'max_stories', 'stories');
-      if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Story limit reached. Upgrade to Team.', 403);
-    }
+    const check = await checkResourceLimit(dbClient!, me.org_id, 'max_stories', 'stories');
+    if (!check.allowed) return apiError('UPGRADE_REQUIRED', check.reason ?? 'Story limit reached. Upgrade to Team.', 403);
 
     const rawBody = await request.json();
     if (!rawBody.project_id) rawBody.project_id = me.project_id;
@@ -41,7 +38,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient = undefined;
 
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/tasks/[id]/route.ts
+++ b/apps/web/src/app/api/tasks/[id]/route.ts
@@ -1,7 +1,7 @@
 import { parseBody, updateTaskSchema } from '@sprintable/shared';
 
 import { TaskService } from '@/services/task';
-import { createTaskRepository, isOssMode } from '@/lib/storage/factory';
+import { createTaskRepository } from '@/lib/storage/factory';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -35,19 +35,17 @@ export async function PATCH(request: Request, { params }: RouteParams) {
     const before = await service.getById(id, { org_id: me.org_id, project_id: me.project_id });
     const result = await service.update(id, body);
 
-    if (!isOssMode()) {
-      const notifService = new NotificationService(dbClient);
-      if (body.assignee_id && body.assignee_id !== before.assignee_id) {
-        notifService.create({
-          org_id: me.org_id,
-          user_id: body.assignee_id,
-          type: 'task_assigned',
-          title: '태스크가 배정되었습니다',
-          body: before.title ?? '',
-          reference_type: 'task',
-          reference_id: id,
-        }).catch(() => {});
-      }
+    const notifService = new NotificationService(dbClient);
+    if (body.assignee_id && body.assignee_id !== before.assignee_id) {
+      notifService.create({
+        org_id: me.org_id,
+        user_id: body.assignee_id,
+        type: 'task_assigned',
+        title: '태스크가 배정되었습니다',
+        body: before.title ?? '',
+        reference_type: 'task',
+        reference_id: id,
+      }).catch(() => {});
     }
 
     return apiSuccess(result);

--- a/apps/web/src/app/api/tasks/route.ts
+++ b/apps/web/src/app/api/tasks/route.ts
@@ -2,7 +2,7 @@
 import { parseBody, createTaskSchema } from '@sprintable/shared';
 
 import { TaskService, type CreateTaskInput } from '@/services/task';
-import { createTaskRepository, isOssMode } from '@/lib/storage/factory';
+import { createTaskRepository } from '@/lib/storage/factory';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -12,9 +12,8 @@ async function getStoryTaskCounts(
   service: TaskService,
   storyId: string,
   dbClient: any | undefined,
-  ossMode: boolean,
 ) {
-  if (ossMode || !dbClient) {
+  if (!dbClient) {
     const [allTasks, doneTasks] = await Promise.all([
       service.list({ story_id: storyId }),
       service.list({ story_id: storyId, status: 'done' }),
@@ -45,7 +44,6 @@ export async function GET(request: Request) {
     const me = await getAuthContext(request);
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-    const ossMode = isOssMode();
     const dbClient: any | undefined = undefined;
 
     const { searchParams } = new URL(request.url);
@@ -74,7 +72,7 @@ export async function GET(request: Request) {
         if (error) throw error;
         return apiSuccess(data ?? []);
       }
-      // OSS: fallback to per-story serial fetch
+      // fallback to per-story serial fetch
       const all: unknown[] = [];
       for (const sid of storyIds) {
         const items = await service.list({ story_id: sid, status });
@@ -99,7 +97,7 @@ export async function GET(request: Request) {
       return apiSuccess(page, meta);
     }
 
-    const counts = await getStoryTaskCounts(service, storyId, dbClient, ossMode);
+    const counts = await getStoryTaskCounts(service, storyId, dbClient);
 
     return apiSuccess(page, {
       ...meta,

--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -1,5 +1,5 @@
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createTeamMemberRepository } from '@/lib/storage/factory';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
 import { handleApiError } from '@/lib/api-error';
@@ -9,21 +9,6 @@ type RouteParams = { params: Promise<{ id: string }> };
 export async function PATCH(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      let body: unknown;
-      try { body = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
-      const { name, webhook_url, role, is_active } = (body as Record<string, unknown>) ?? {};
-      const repo = await createTeamMemberRepository();
-      const updated = await repo.update(id, {
-        ...(typeof name === 'string' ? { name: name.trim() } : {}),
-        ...(webhook_url !== undefined ? { webhook_url: typeof webhook_url === 'string' ? webhook_url : null } : {}),
-        ...(typeof role === 'string' ? { role } : {}),
-        ...(typeof is_active === 'boolean' ? { is_active } : {}),
-      });
-      return apiSuccess(updated);
-    }
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
@@ -34,13 +19,6 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      const repo = await createTeamMemberRepository();
-      await repo.update(id, { is_active: false });
-      return apiSuccess({ id });
-    }
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -1,23 +1,12 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { parseBody, createTeamMemberSchema } from '@sprintable/shared';
-import { isOssMode, createTeamMemberRepository } from '@/lib/storage/factory';
+import { createTeamMemberRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { getAuthContext } from '@/lib/auth-helpers';
 
 export async function GET(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      const { searchParams } = new URL(request.url);
-      const projectId = searchParams.get('project_id') ?? me.project_id;
-      const type = searchParams.get('type') as 'human' | 'agent' | null;
-      const repo = await createTeamMemberRepository();
-      const includeInactive = searchParams.get('include_inactive') === 'true';
-      const members = await repo.list({ org_id: me.org_id, project_id: projectId, ...(type ? { type } : {}), ...(includeInactive ? {} : { is_active: true }) });
-      return apiSuccess(members);
-    }
     const res = await proxyToFastapi(request, '/api/v2/team-members');
     if (!res.ok) return res;
     const data: unknown = await res.json();
@@ -30,31 +19,6 @@ export async function GET(request: Request) {
 /** POST — 프로젝트 멤버 추가/재활성화 */
 export async function POST(request: Request) {
   try {
-    if (isOssMode()) {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-
-      let body: unknown;
-      try { body = await request.json(); } catch { return ApiErrors.badRequest('Invalid JSON body'); }
-      const { name, type, role, project_id, webhook_url, email } = (body as Record<string, unknown>) ?? {};
-      const memberType = (type as string) === 'agent' ? 'agent' : 'human';
-      if (!name || typeof name !== 'string' || !name.trim()) return ApiErrors.badRequest('name is required');
-
-      const repo = await createTeamMemberRepository();
-      const member = await repo.create({
-        org_id: me.org_id,
-        project_id: typeof project_id === 'string' ? project_id : me.project_id,
-        name: name.trim(),
-        type: memberType,
-        role: typeof role === 'string' ? role : 'member',
-        email: typeof email === 'string' ? email : undefined,
-      });
-      if (typeof webhook_url === 'string' && webhook_url) {
-        await repo.update(member.id, { webhook_url } as Parameters<typeof repo.update>[1]);
-      }
-      return apiSuccess(member, undefined, 201);
-    }
-
     const parsed = await parseBody(request, createTeamMemberSchema);
     if (!parsed.success) return parsed.response;
     const body = parsed.data;

--- a/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/[id]/route.ts
@@ -1,23 +1,12 @@
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import { isOssMode, createAgentRunRepository } from '@/lib/storage/factory';
+import { createAgentRunRepository } from '@/lib/storage/factory';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { getAuthContext } from '@/lib/auth-helpers';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
 export async function GET(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { id } = await params;
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      const repo = await createAgentRunRepository();
-      const run = await repo.getById(id, me.org_id, me.project_id);
-      if (!run) return ApiErrors.notFound('Agent run not found');
-      return apiSuccess({ ...run, agent_name: null, tool_audit_trail: [], continuity_debug: null });
-    } catch (error) { return handleApiError(error); }
-  }
   const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
   if (!_r.ok) return _r;
@@ -26,28 +15,6 @@ const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
 }
 
 export async function PATCH(request: Request, { params }: RouteParams) {
-  if (isOssMode()) {
-    try {
-      const { id } = await params;
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      let body: unknown;
-      try { body = await request.json(); } catch { body = {}; }
-      const b = (body as Record<string, unknown>) ?? {};
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const db = await getDb();
-      const sets: string[] = [];
-      const vals: unknown[] = [];
-      const allowed = ['status','result_summary','error_message','started_at','finished_at','duration_ms','input_tokens','output_tokens'] as const;
-      for (const k of allowed) {
-        if (k in b) { sets.push(`${k} = $${sets.length + 1}`); vals.push(b[k] ?? null); }
-      }
-      if (sets.length) await db.query(`UPDATE agent_runs SET ${sets.join(', ')} WHERE id = $${sets.length + 1} AND org_id = $${sets.length + 2}`, [...vals, id, me.org_id]);
-      const run = (await db.query('SELECT * FROM agent_runs WHERE id = $1', [id])).rows[0];
-      if (!run) return ApiErrors.notFound('Agent run not found');
-      return apiSuccess(run);
-    } catch (error) { return handleApiError(error); }
-  }
   const { id } = await params;
 const _r = await proxyToFastapi(request, `/api/v2/agent-runs/${id}`);
   if (!_r.ok) return _r;

--- a/apps/web/src/app/api/v1/agent-runs/route.ts
+++ b/apps/web/src/app/api/v1/agent-runs/route.ts
@@ -1,6 +1,6 @@
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
 import { handleApiError } from '@/lib/api-error';
-import { isOssMode, createAgentRunRepository } from '@/lib/storage/factory';
+import { createAgentRunRepository } from '@/lib/storage/factory';
 import { normalizeRunStatusFilter } from '@/services/agent-run-history';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { getAuthContext } from '@/lib/auth-helpers';
@@ -8,26 +8,6 @@ import { getAuthContext } from '@/lib/auth-helpers';
 const PAGE_SIZE = 20;
 
 export async function GET(request: Request) {
-  if (isOssMode()) {
-    try {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      const repo = await createAgentRunRepository();
-      const url = new URL(request.url);
-      const limit = Math.min(Number(url.searchParams.get('limit') ?? PAGE_SIZE), 50);
-      const result = await repo.list({
-        orgId: me.org_id,
-        projectId: me.project_id,
-        status: normalizeRunStatusFilter(url.searchParams.get('status')),
-        from: url.searchParams.get('from'),
-        to: url.searchParams.get('to'),
-        cursor: url.searchParams.get('cursor'),
-        limit,
-      });
-      const enriched = result.items.map((r) => ({ ...r, agent_name: null }));
-      return apiSuccess(enriched, { nextCursor: result.nextCursor, hasMore: result.hasMore, limit });
-    } catch (error) { return handleApiError(error); }
-  }
 const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess({ ok: true });
@@ -35,26 +15,6 @@ const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
 }
 
 export async function POST(request: Request) {
-  if (isOssMode()) {
-    try {
-      const me = await getAuthContext(request);
-      if (!me) return ApiErrors.unauthorized();
-      let body: unknown;
-      try { body = await request.json(); } catch { body = {}; }
-      const b = (body as Record<string, unknown>) ?? {};
-      const { getDb } = await import('@sprintable/storage-pglite');
-      const { randomUUID } = await import('node:crypto');
-      const db = await getDb();
-      const id = randomUUID();
-      const now = new Date().toISOString();
-      await db.query(
-        'INSERT INTO agent_runs (id, org_id, project_id, agent_id, session_id, memo_id, story_id, trigger, status, created_at) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)',
-        [id, me.org_id, me.project_id, b.agent_id ?? null, b.session_id ?? null, b.memo_id ?? null, b.story_id ?? null, b.trigger ?? null, 'pending', now]
-      );
-      const run = (await db.query('SELECT * FROM agent_runs WHERE id = $1', [id])).rows[0];
-      return apiSuccess(run, undefined, 201);
-    } catch (error) { return handleApiError(error); }
-  }
 const _r = await proxyToFastapi(request, '/api/v2/agent-runs');
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/v1/bridge/slack/events/route.ts
+++ b/apps/web/src/app/api/v1/bridge/slack/events/route.ts
@@ -1,10 +1,9 @@
 import { apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 export async function POST(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
 
   const rawBody = await request.text();
   const headers: Record<string, string> = {

--- a/apps/web/src/app/api/v1/bridge/slack/interactions/route.ts
+++ b/apps/web/src/app/api/v1/bridge/slack/interactions/route.ts
@@ -1,10 +1,9 @@
 import { apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 export async function POST(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
 
   const rawBody = await request.text();
   const headers: Record<string, string> = {

--- a/apps/web/src/app/api/v1/bridge/teams/events/route.ts
+++ b/apps/web/src/app/api/v1/bridge/teams/events/route.ts
@@ -1,10 +1,9 @@
 import { apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 export async function POST(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
 
   const rawBody = await request.text();
   const headers: Record<string, string> = {

--- a/apps/web/src/app/api/webhooks/agent-runtime/route.ts
+++ b/apps/web/src/app/api/webhooks/agent-runtime/route.ts
@@ -1,9 +1,8 @@
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { apiSuccess, apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 export async function POST(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   const _r = await proxyToFastapi(request, '/api/v2/webhooks/agent-runtime');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/apps/web/src/app/api/webhooks/config/route.ts
+++ b/apps/web/src/app/api/webhooks/config/route.ts
@@ -1,11 +1,10 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 내 웹훅 설정 목록 */
 export async function GET(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;
@@ -15,7 +14,6 @@ export async function GET(request: Request) {
 
 /** PUT — 웹훅 설정 upsert */
 export async function PUT(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;
@@ -25,7 +23,6 @@ export async function PUT(request: Request) {
 
 /** DELETE — 웹훅 설정 삭제 */
 export async function DELETE(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     const _r = await proxyToFastapi(request, '/api/v2/webhooks/config');
     if (!_r.ok) return _r;

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -2,10 +2,9 @@ import { handleApiError } from '@/lib/api-error';
 import { getMyTeamMember } from '@/lib/auth-helpers';
 import { requireOrgAdmin } from '@/lib/admin-check';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
-import { isOssMode } from '@/lib/storage/factory';
+;
 
 export async function GET(request: Request) {
-  if (isOssMode()) return apiError('NOT_AVAILABLE', 'Not available in OSS mode.', 503);
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const db: any = null;


### PR DESCRIPTION
## Summary

- **66개 Route Handler 파일**에서 `isOssMode()` if 블록 + 관련 import 전량 제거
- `proxyToFastapi` / SaaS 경로 코드만 유지
- `-970 lines, +88 lines` (882줄 순삭)

## 처리 패턴

| 패턴 | 처리 방법 |
|---|---|
| `if (isOssMode()) return X;` | 라인 제거 |
| `if (isOssMode()) { ... }` | 블록 전체 제거 |
| `const ossMode = isOssMode()` | 라인 제거 + 사용처 정리 |
| `if (!isOssMode()) { ... }` | 조건문 제거, 내용 유지 |
| `if (!ossMode && cond)` | `if (cond)` |
| import `isOssMode` | 제거 |

## 주요 파일

- `tasks/route.ts` — `getStoryTaskCounts(ossMode)` 파라미터 제거
- `oss/seed`, `oss/webhook-status` — OSS-only 가드 제거
- sprints, stories, docs, epics — `ossMode` 변수 패턴 전량 정리

## 범위 외 (후속 스토리)

- `factory.ts` 삭제 → SU-S2
- `storage-pglite` 패키지 삭제 → SU-S2
- `auth-helpers.ts` OSS 경로 → SU-S4
- `proxy.ts` OSS 세션 로직 → SU-S4

## Test plan

- [x] `pnpm type-check` PASS
- [ ] Cloud Build 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)