### PR TITLE
feat(oss-stack-unify): SU-S6 OSS 잔존 참조 전량 제거 + 통합 검증

### DIFF
--- a/apps/web/env.local.example
+++ b/apps/web/env.local.example
@@ -4,15 +4,14 @@
 # Copy to apps/web/.env.local for local development.
 # See root .env.example for full variable descriptions.
 
-# [OSS required] Public URL of this deployment
-APP_BASE_URL=http://localhost:3108
+# Public URL of this deployment
+APP_BASE_URL=http://localhost:3000
 
-# [OSS required] Run in OSS mode (SQLite, no billing)
-OSS_MODE=true
-NEXT_PUBLIC_OSS_MODE=true
+# Backend (FastAPI) URL
+NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 
-# [OSS required] SQLite database path
-SQLITE_PATH=./.data/sprintable.db
+# JWT secret — minimum 32 characters
+JWT_SECRET=change-me-in-development-min-32-chars
 
-# [OSS required] Agent API key secret
+# Agent API key secret
 AGENT_API_KEY_SECRET=change-me-in-development

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -339,22 +339,23 @@ Routing rules in **Settings → Agent Routing** determine which agent handles wh
 
 ## Self-Hosting
 
-### Docker (OSS — SQLite, no external DB required)
+### Docker (PostgreSQL + FastAPI + Next.js)
 ```bash
 git clone https://github.com/moonklabs/sprintable.git
 cd sprintable
 cp .env.example .env
-docker compose -f docker-compose.oss.yml up
+docker compose up -d
 ```
 
-### Required env vars (OSS)
+### Required env vars
 ```
-APP_BASE_URL=http://localhost:3108
-OSS_MODE=true
-NEXT_PUBLIC_OSS_MODE=true
-SQLITE_PATH=./.data/sprintable.db
-AGENT_API_KEY_SECRET=<generate: openssl rand -base64 32>
-PM_API_URL=http://localhost:3108
+POSTGRES_DB=sprintable
+POSTGRES_USER=sprintable
+POSTGRES_PASSWORD=<generate: openssl rand -hex 16>
+JWT_SECRET=<generate: openssl rand -hex 32>
+SECRET_KEY=<generate: openssl rand -hex 32>
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 ```
 
 Full guide: https://github.com/moonklabs/sprintable/blob/main/docs/self-hosting.md

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -109,16 +109,8 @@ export default function SettingsPage() {
   const [memberActionMessage, setMemberActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [addingMember, setAddingMember] = useState(false);
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
-  const isOss = process.env.NEXT_PUBLIC_OSS_MODE === 'true';
-  const [isAdmin, setIsAdmin] = useState(isOss);
-  const [adminChecked, setAdminChecked] = useState(isOss);
-  const [newMemberName, setNewMemberName] = useState('');
-  const [newMemberEmail, setNewMemberEmail] = useState('');
-  const [newMemberType, setNewMemberType] = useState<'human' | 'agent'>('human');
-  const [newMemberWebhookUrl, setNewMemberWebhookUrl] = useState('');
-  const [newMemberProjectId, setNewMemberProjectId] = useState('');
-  const [addingOssMember, setAddingOssMember] = useState(false);
-  const [addMemberResult, setAddMemberResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [adminChecked, setAdminChecked] = useState(false);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
   const [projectInviteEmail, setProjectInviteEmail] = useState('');
@@ -454,36 +446,6 @@ export default function SettingsPage() {
     setRemovingMemberId(null);
   };
 
-  const handleAddOssMember = async () => {
-    if (!newMemberName.trim()) return;
-    setAddingOssMember(true);
-    setAddMemberResult(null);
-    const projectId = newMemberProjectId || memberProjectId || currentProjectId || '';
-    const body: Record<string, unknown> = {
-      name: newMemberName.trim(),
-      type: newMemberType,
-      project_id: projectId || undefined,
-    };
-    if (newMemberEmail.trim()) body.email = newMemberEmail.trim();
-    if (newMemberType === 'agent' && newMemberWebhookUrl.trim()) body.webhook_url = newMemberWebhookUrl.trim();
-    const res = await fetch('/api/team-members', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    if (res.ok) {
-      setNewMemberName('');
-      setNewMemberEmail('');
-      setNewMemberWebhookUrl('');
-      setAddMemberResult({ type: 'success', text: `${newMemberType === 'agent' ? 'Agent' : 'Member'} "${newMemberName.trim()}" added` });
-      if (projectId) await refreshMemberData(projectId);
-    } else {
-      const json = await res.json().catch(() => null);
-      setAddMemberResult({ type: 'error', text: json?.error?.message ?? 'Failed to add member' });
-    }
-    setAddingOssMember(false);
-  };
-
   // suppress unused variable warning — createdProjectMembership used in future flows
   void createdProjectMembership;
   void projectMemberships;
@@ -540,18 +502,14 @@ export default function SettingsPage() {
                   <Zap className="h-4 w-4" />
                   {t('tabIntegrations')}
                 </TabsTrigger>
-                {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' ? (
-                  <TabsTrigger value="subscription">
-                    <CreditCard className="h-4 w-4" />
-                    {t('tabSubscription')}
-                  </TabsTrigger>
-                ) : null}
-                {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' ? (
-                  <TabsTrigger value="usage">
-                    <BarChart2 className="h-4 w-4" />
-                    {t('tabUsage')}
-                  </TabsTrigger>
-                ) : null}
+                <TabsTrigger value="subscription">
+                  <CreditCard className="h-4 w-4" />
+                  {t('tabSubscription')}
+                </TabsTrigger>
+                <TabsTrigger value="usage">
+                  <BarChart2 className="h-4 w-4" />
+                  {t('tabUsage')}
+                </TabsTrigger>
               </>
             ) : null}
 
@@ -573,7 +531,7 @@ export default function SettingsPage() {
             <TabsContent value="profile">
               <div className="space-y-6">
                 <MyProfileSection />
-                {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' ? <TwoFactorSection /> : null}
+                <TwoFactorSection />
               </div>
             </TabsContent>
 
@@ -765,60 +723,6 @@ export default function SettingsPage() {
 
             <TabsContent value="members">
               <div className="space-y-6">
-                {isOss ? (
-                  <SectionCard>
-                    <SectionCardHeader>
-                      <div className="space-y-1">
-                        <h2 className="text-base font-semibold text-foreground">Add Member</h2>
-                        <p className="text-sm text-muted-foreground">Add human or agent members directly to a project</p>
-                      </div>
-                    </SectionCardHeader>
-                    <SectionCardBody className="space-y-4">
-                      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto_auto]">
-                        <OperatorInput
-                          value={newMemberName}
-                          onChange={(e) => setNewMemberName(e.target.value)}
-                          placeholder="Name (required)"
-                        />
-                        <OperatorInput
-                          value={newMemberEmail}
-                          onChange={(e) => setNewMemberEmail(e.target.value)}
-                          placeholder="Email (optional)"
-                          type="email"
-                        />
-                        <OperatorDropdownSelect
-                          value={newMemberType}
-                          onValueChange={(v) => setNewMemberType(v as 'human' | 'agent')}
-                          options={[
-                            { value: 'human', label: 'Human' },
-                            { value: 'agent', label: 'Agent' },
-                          ]}
-                        />
-                        <OperatorDropdownSelect
-                          value={newMemberProjectId || memberProjectId || currentProjectId || ''}
-                          onValueChange={(v) => setNewMemberProjectId(v)}
-                          options={projects.map((p) => ({ value: p.id, label: p.name }))}
-                        />
-                      </div>
-                      {newMemberType === 'agent' ? (
-                        <OperatorInput
-                          value={newMemberWebhookUrl}
-                          onChange={(e) => setNewMemberWebhookUrl(e.target.value)}
-                          placeholder="Webhook URL (https://...)"
-                          type="url"
-                        />
-                      ) : null}
-                      <Button variant="hero" size="lg" onClick={handleAddOssMember} disabled={!newMemberName.trim() || addingOssMember}>
-                        {addingOssMember ? '...' : 'Add Member'}
-                      </Button>
-                      {addMemberResult ? (
-                        <div className={`rounded-md border p-3 text-xs ${addMemberResult.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                          {addMemberResult.text}
-                        </div>
-                      ) : null}
-                    </SectionCardBody>
-                  </SectionCard>
-                ) : null}
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">
@@ -1092,44 +996,42 @@ export default function SettingsPage() {
               </div>
             </TabsContent>
 
-            {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' ? (
-              <TabsContent value="subscription">
-                <SectionCard>
-                  <SectionCardHeader>
-                    <div className="space-y-1">
-                      <h2 className="text-base font-semibold text-foreground">{t('manageSubscription')}</h2>
-                      <p className="text-sm text-muted-foreground">{t('subscriptionDescription')}</p>
-                    </div>
-                  </SectionCardHeader>
-                  <SectionCardBody className="space-y-3">
-                    {graceUntil && new Date(graceUntil) > new Date() ? (
-                      <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
-                        {t('gracePeriodNotice', { date: new Date(graceUntil).toLocaleDateString('ko-KR') })}
-                      </p>
-                    ) : null}
-                    <Button
-                      variant="glass"
-                      size="lg"
-                      onClick={async () => {
-                        try {
-                          const res = await fetch('/api/subscription/portal', { method: 'POST' });
-                          if (res.ok) {
-                            const json = await res.json() as { data: { portalUrl: string } };
-                            window.open(json.data.portalUrl, '_blank');
-                          }
-                        } catch {
-                          // noop
+            <TabsContent value="subscription">
+              <SectionCard>
+                <SectionCardHeader>
+                  <div className="space-y-1">
+                    <h2 className="text-base font-semibold text-foreground">{t('manageSubscription')}</h2>
+                    <p className="text-sm text-muted-foreground">{t('subscriptionDescription')}</p>
+                  </div>
+                </SectionCardHeader>
+                <SectionCardBody className="space-y-3">
+                  {graceUntil && new Date(graceUntil) > new Date() ? (
+                    <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
+                      {t('gracePeriodNotice', { date: new Date(graceUntil).toLocaleDateString('ko-KR') })}
+                    </p>
+                  ) : null}
+                  <Button
+                    variant="glass"
+                    size="lg"
+                    onClick={async () => {
+                      try {
+                        const res = await fetch('/api/subscription/portal', { method: 'POST' });
+                        if (res.ok) {
+                          const json = await res.json() as { data: { portalUrl: string } };
+                          window.open(json.data.portalUrl, '_blank');
                         }
-                      }}
-                    >
-                      {t('manageSubscriptionBtn')}
-                    </Button>
-                  </SectionCardBody>
-                </SectionCard>
-              </TabsContent>
-            ) : null}
+                      } catch {
+                        // noop
+                      }
+                    }}
+                  >
+                    {t('manageSubscriptionBtn')}
+                  </Button>
+                </SectionCardBody>
+              </SectionCard>
+            </TabsContent>
 
-            {process.env.NEXT_PUBLIC_OSS_MODE !== 'true' && adminChecked && isAdmin && orgId ? (
+            {adminChecked && isAdmin && orgId ? (
               <TabsContent value="usage">
                 <UsageDashboard
                   orgId={orgId}

--- a/apps/web/src/app/api/docs/[id]/route.test.ts
+++ b/apps/web/src/app/api/docs/[id]/route.test.ts
@@ -24,7 +24,6 @@ vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
 vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
 vi.mock('@/lib/storage/factory', () => ({
-  isOssMode: () => false,
   createDocRepository: vi.fn().mockResolvedValue({
     getById: vi.fn().mockResolvedValue({ id: 'doc-1', org_id: 'org-1', doc_type: 'page' }),
     update: vi.fn().mockResolvedValue({ id: 'doc-1', updated_at: '2026-04-09T15:21:00.000Z' }),

--- a/apps/web/src/app/api/inbox/[id]/resolve/route.test.ts
+++ b/apps/web/src/app/api/inbox/[id]/resolve/route.test.ts
@@ -5,13 +5,11 @@ const {
   createAdminClient,
   getAuthContext,
   createInboxItemRepository,
-  isOssMode,
 } = vi.hoisted(() => ({
   createDbServerClient: vi.fn(),
   createAdminClient: vi.fn(),
   getAuthContext: vi.fn(),
   createInboxItemRepository: vi.fn(),
-  isOssMode: vi.fn(() => false),
 }));
 
 vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
@@ -20,7 +18,7 @@ vi.mock('@/lib/auth-helpers', async () => {
   const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
   return { ...actual, getAuthContext };
 });
-vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository, isOssMode }));
+vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository }));
 
 import { POST } from './route';
 import { NotFoundError } from '@sprintable/core-storage';
@@ -52,7 +50,6 @@ const PARAMS = { params: Promise.resolve({ id: 'i1' }) };
 describe('POST /api/inbox/[id]/resolve', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isOssMode.mockReturnValue(false);
     createDbServerClient.mockResolvedValue({});
     getAuthContext.mockResolvedValue(ME);
   });
@@ -129,12 +126,5 @@ describe('POST /api/inbox/[id]/resolve', () => {
     expect(res.status).toBe(400);
   });
 
-  it('OSS mode passes undefined dbClient', async () => {
-    isOssMode.mockReturnValue(true);
-    const repo = { resolve: vi.fn().mockResolvedValue({ id: 'i1', state: 'resolved' }) };
-    createInboxItemRepository.mockResolvedValue(repo);
-
-    await POST(makeRequest({ choice: VALID_OPTION_ID }), PARAMS);
-    expect(createInboxItemRepository).toHaveBeenCalledWith(undefined);
-  });
 });
+

--- a/apps/web/src/app/api/inbox/route.test.ts
+++ b/apps/web/src/app/api/inbox/route.test.ts
@@ -5,14 +5,12 @@ const {
   createAdminClient,
   getAuthContext,
   createInboxItemRepository,
-  isOssMode,
   cookies,
 } = vi.hoisted(() => ({
   createDbServerClient: vi.fn(),
   createAdminClient: vi.fn(),
   getAuthContext: vi.fn(),
   createInboxItemRepository: vi.fn(),
-  isOssMode: vi.fn(() => false),
   cookies: vi.fn(),
 }));
 
@@ -22,7 +20,7 @@ vi.mock('@/lib/auth-helpers', async () => {
   const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
   return { ...actual, getAuthContext };
 });
-vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository, isOssMode }));
+vi.mock('@/lib/storage/factory', () => ({ createInboxItemRepository }));
 vi.mock('next/headers', () => ({ cookies }));
 
 import { GET } from './route';
@@ -41,7 +39,6 @@ const ME = {
 describe('GET /api/inbox', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    isOssMode.mockReturnValue(false);
     createDbServerClient.mockResolvedValue({});
     cookies.mockResolvedValue({ get: vi.fn(() => undefined) });
     getAuthContext.mockResolvedValue(ME);
@@ -122,16 +119,5 @@ describe('GET /api/inbox', () => {
     expect(repo.list).toHaveBeenCalledWith(expect.objectContaining({ project_id: 'cookie-proj' }));
   });
 
-  it('OSS mode skips dbClient and uses local repo', async () => {
-    isOssMode.mockReturnValue(true);
-    const repo = {
-      list: vi.fn().mockResolvedValue([]),
-      count: vi.fn().mockResolvedValue({ total: 0, byKind: { approval: 0, decision: 0, blocker: 0, mention: 0 } }),
-    };
-    createInboxItemRepository.mockResolvedValue(repo);
-
-    const res = await GET(new Request('http://localhost/api/inbox'));
-    expect(res.status).toBe(200);
-    expect(createInboxItemRepository).toHaveBeenCalledWith(undefined);
-  });
 });
+

--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -1,11 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, createAdminClient, getAuthContext, createTaskRepository, isOssMode } = vi.hoisted(() => ({
+const { createDbServerClient, createAdminClient, getAuthContext, createTaskRepository } = vi.hoisted(() => ({
   createDbServerClient: vi.fn(),
   createAdminClient: vi.fn(),
   getAuthContext: vi.fn(),
   createTaskRepository: vi.fn(),
-  isOssMode: vi.fn().mockReturnValue(false),
 }));
 
 const listMock = vi.fn();
@@ -13,7 +12,7 @@ const listMock = vi.fn();
 vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
 vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-vi.mock('@/lib/storage/factory', () => ({ createTaskRepository, isOssMode }));
+vi.mock('@/lib/storage/factory', () => ({ createTaskRepository }));
 vi.mock('@/services/task', () => ({ TaskService: class { list = listMock; } }));
 
 import { GET } from './route';
@@ -50,7 +49,6 @@ describe('GET /api/tasks', () => {
     createAdminClient.mockReset();
     getAuthContext.mockReset();
     createTaskRepository.mockReset();
-    isOssMode.mockReturnValue(false);
 
     const dbMock = { from: vi.fn(() => createCountBuilder()) };
     createDbServerClient.mockResolvedValue(dbMock);
@@ -83,44 +81,5 @@ describe('GET /api/tasks', () => {
     }));
   });
 
-  it('uses repository-backed counts in OSS mode', async () => {
-    isOssMode.mockReturnValue(true);
-    listMock.mockImplementation(async (filters?: { story_id?: string; status?: string; limit?: number; cursor?: string | null }) => {
-      if (filters?.story_id !== 'story-1') return [];
-      if (filters?.status === 'done') {
-        return [
-          { id: 'task-3', created_at: '2026-04-13T03:00:00.000Z', status: 'done' },
-          { id: 'task-2', created_at: '2026-04-13T02:00:00.000Z', status: 'done' },
-        ];
-      }
-      if (filters?.limit === 2) {
-        return [
-          { id: 'task-4', created_at: '2026-04-13T04:00:00.000Z', status: 'todo' },
-          { id: 'task-3', created_at: '2026-04-13T03:00:00.000Z', status: 'done' },
-          { id: 'task-2', created_at: '2026-04-13T02:00:00.000Z', status: 'done' },
-        ];
-      }
-      return [
-        { id: 'task-4', created_at: '2026-04-13T04:00:00.000Z', status: 'todo' },
-        { id: 'task-3', created_at: '2026-04-13T03:00:00.000Z', status: 'done' },
-        { id: 'task-2', created_at: '2026-04-13T02:00:00.000Z', status: 'done' },
-        { id: 'task-1', created_at: '2026-04-13T01:00:00.000Z', status: 'todo' },
-      ];
-    });
-
-    const response = await GET(new Request('http://localhost/api/tasks?story_id=story-1&limit=2'));
-    const body = await response.json();
-
-    expect(body.data).toHaveLength(2);
-    expect(body.meta).toEqual(expect.objectContaining({
-      hasMore: true,
-      nextCursor: '2026-04-13T03:00:00.000Z',
-      totalCount: 4,
-      doneCount: 2,
-    }));
-    expect(listMock).toHaveBeenCalledWith(expect.objectContaining({
-      story_id: 'story-1',
-      status: 'done',
-    }));
-  });
 });
+

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,11 +2,8 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
-
-const IS_OSS = process.env['NEXT_PUBLIC_OSS_MODE'] === 'true';
 
 const OAUTH_ERROR_MESSAGES: Record<string, string> = {
   oauth_init_failed: 'OAuth authentication failed. Please try again.',
@@ -34,22 +31,6 @@ export default function LoginPage() {
     setLoading(true);
     setError(null);
     try {
-      if (IS_OSS) {
-        const res = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ email: email.trim(), password }),
-        });
-        const json = await res.json() as { error?: { code: string; message: string } };
-        if (!res.ok) {
-          setError(json.error?.message ?? 'Login failed. Please try again.');
-          return;
-        }
-        router.push('/inbox');
-        router.refresh();
-        return;
-      }
-
       const result = await loginWithPassword(email.trim(), password, showTotp ? totpCode : undefined);
       if (result.error) {
         if (result.error.code === 'TOTP_REQUIRED') {
@@ -127,39 +108,30 @@ export default function LoginPage() {
           </button>
         </div>
 
-        {IS_OSS ? (
-          <p className="text-center text-sm text-gray-500">
-            No account?{' '}
-            <Link href="/register" className="font-medium text-blue-600 hover:underline">
-              Create one
-            </Link>
-          </p>
-        ) : (
-          <div className="space-y-3">
-            <div className="relative flex items-center">
-              <div className="flex-grow border-t border-gray-200" />
-              <span className="mx-3 flex-shrink text-xs text-gray-400">or continue with</span>
-              <div className="flex-grow border-t border-gray-200" />
-            </div>
-
-            <a href="/auth/login?provider=google" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
-              <svg className="h-5 w-5" viewBox="0 0 24 24">
-                <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
-                <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
-                <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
-                <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
-              </svg>
-              Continue with Google
-            </a>
-
-            <a href="/auth/login?provider=github" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
-              <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-                <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-              </svg>
-              Continue with GitHub
-            </a>
+        <div className="space-y-3">
+          <div className="relative flex items-center">
+            <div className="flex-grow border-t border-gray-200" />
+            <span className="mx-3 flex-shrink text-xs text-gray-400">or continue with</span>
+            <div className="flex-grow border-t border-gray-200" />
           </div>
-        )}
+
+          <a href="/auth/login?provider=google" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+              <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+              <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+              <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+            </svg>
+            Continue with Google
+          </a>
+
+          <a href="/auth/login?provider=github" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
+            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            </svg>
+            Continue with GitHub
+          </a>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/memos/use-memo-presence.ts
+++ b/apps/web/src/components/memos/use-memo-presence.ts
@@ -56,7 +56,7 @@ export function useMemoPresence({ memoId, currentTeamMemberId, currentTeamMember
   }, [memoId, currentTeamMemberId, enabled]);
 
   useEffect(() => {
-    if (!enabled || !memoId || !currentTeamMemberId || process.env['NEXT_PUBLIC_OSS_MODE'] === 'true') {
+    if (!enabled || !memoId || !currentTeamMemberId) {
       setState({ connected: false, viewers: [], typingUsers: [] });
       return;
     }

--- a/apps/web/src/hooks/use-realtime-memos.ts
+++ b/apps/web/src/hooks/use-realtime-memos.ts
@@ -45,7 +45,6 @@ export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, o
   useEffect(() => { currentTeamMemberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   useEffect(() => {
-    if (process.env['NEXT_PUBLIC_OSS_MODE'] === 'true') return;
     if (typeof EventSource === 'undefined') return;
 
     function connect() {

--- a/apps/web/src/lib/role-guard.ts
+++ b/apps/web/src/lib/role-guard.ts
@@ -22,7 +22,6 @@ export async function getCallerRole(db: any, orgId: string): Promise<string | nu
 /**
  * Assert that the caller has one of the required roles.
  * Returns an ApiErrors.forbidden() Response if not, null if allowed.
- * OSS mode always passes (isOssMode check must be done by caller before invoking).
  */
 export async function requireRole(
   db: any,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       '@sprintable/storage-api':
         specifier: workspace:*
         version: link:../../packages/storage-api
-      '@sprintable/storage-pglite':
-        specifier: workspace:*
-        version: link:../../packages/storage-pglite
       '@tiptap/core':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/pm@3.22.3)
@@ -303,22 +300,6 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
-  packages/storage-pglite:
-    dependencies:
-      '@electric-sql/pglite':
-        specifier: ^0.2.0
-        version: 0.2.17
-      '@sprintable/core-storage':
-        specifier: workspace:*
-        version: link:../core-storage
-    devDependencies:
-      '@types/node':
-        specifier: ^22
-        version: 22.19.17
-      typescript:
-        specifier: ^5.7.0
-        version: 5.9.3
-
 packages:
 
   '@alloc/quick-lru@5.2.0':
@@ -510,9 +491,6 @@ packages:
     engines: {bun: '>=1', deno: '>=2.7.10', node: '>=16'}
     peerDependencies:
       '@noble/ciphers': ^1.0.0
-
-  '@electric-sql/pglite@0.2.17':
-    resolution: {integrity: sha512-qEpKRT2oUaWDH6tjRxLHjdzMqRUGYDnGZlKrnL4dJ77JVMcP2Hpo3NYnOSPKdZdeec57B6QPprCUFg0picx5Pw==}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -5266,8 +5244,6 @@ snapshots:
   '@ecies/ciphers@0.2.6(@noble/ciphers@1.3.0)':
     dependencies:
       '@noble/ciphers': 1.3.0
-
-  '@electric-sql/pglite@0.2.17': {}
 
   '@emnapi/core@1.9.1':
     dependencies:


### PR DESCRIPTION
## Summary

전량 grep 검증 결과 발견된 OSS 잔존 참조 9개 파일에서 완전 제거.

**수정 파일:**
- `settings/page.tsx`: `isOss` + `NEXT_PUBLIC_OSS_MODE` 분기 전량 제거 (OSS Add Member 섹션 포함)
- `login/page.tsx`: `IS_OSS` 상수 + OSS fetch 분기 제거 → loginWithPassword + OAuth 단일 경로
- `use-memo-presence.ts`, `use-realtime-memos.ts`: `NEXT_PUBLIC_OSS_MODE` 체크 제거
- `role-guard.ts`: OSS 주석 정리
- `tasks/route.test.ts`, `inbox/route.test.ts`, `inbox/[id]/resolve/route.test.ts`, `docs/[id]/route.test.ts`: `isOssMode` mock 전량 제거

## AC 체크

- [x] AC1: `isOssMode|OSS_MODE|storage-pglite|@electric-sql/pglite|oss-auth|oss-retro|oss-standup` grep → **0건**
- [x] AC3: tsc PASS
- [x] AC4: `pnpm type-check` 성공
- [ ] AC2: `docker compose up -d` → QA 환경에서 검증
- [ ] AC5: SaaS 회귀 → Cloud Build SUCCESS 확인

## Test plan

- [ ] Cloud Build 통과 (SaaS 회귀 0건)
- [ ] docker compose up -d 3서비스 healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)