### PR TITLE
fix: save_standup org_id 422 핫픽스

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -60,7 +60,10 @@ async def upsert_standup(
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> StandupEntryResponse:
-    repo = StandupEntryRepository(session, body.org_id)
+    org_id = body.org_id or (_auth.org_id and uuid.UUID(_auth.org_id)) or None
+    if not org_id:
+        raise HTTPException(status_code=400, detail="org_id required")
+    repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
         author_id=body.author_id,

--- a/backend/app/schemas/standup.py
+++ b/backend/app/schemas/standup.py
@@ -8,7 +8,7 @@ REVIEW_TYPES = ("comment", "approve", "request_changes")
 
 class StandupUpsert(BaseModel):
     project_id: uuid.UUID
-    org_id: uuid.UUID
+    org_id: uuid.UUID | None = None
     author_id: uuid.UUID
     date: date
     sprint_id: uuid.UUID | None = None


### PR DESCRIPTION
## 원인

`StandupUpsert.org_id: uuid.UUID` 필수 필드 → MCP 핸들러에서 미전달 → 422

## 수정

- `backend/app/schemas/standup.py`: `org_id: uuid.UUID | None = None` (Optional)
- `backend/app/routers/standups.py`: `body.org_id` 없을 시 `_auth.org_id` 자동 주입

## AC 체크

- [x] AC1: MCP save_standup org_id 없이도 422 없이 정상 저장
- [x] AC2: 기존 파라미터 하위호환 유지 (org_id 있으면 그대로 사용)
- [x] AC3: `_auth.org_id`로 올바른 org_id 기록

🤖 Generated with [Claude Code](https://claude.com/claude-code)