### PR TITLE
feat(memo-embed): ME-S1 memo_entity_links 테이블 + Alembic 마이그레이션

### DIFF
--- a/backend/alembic/versions/0011_add_memo_entity_links.py
+++ b/backend/alembic/versions/0011_add_memo_entity_links.py
@@ -1,0 +1,41 @@
+"""add memo_entity_links table and migrate memo_doc_links data
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-05-05
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = '0011'
+down_revision = '0010'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'memo_entity_links',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('memo_id', UUID(as_uuid=True), sa.ForeignKey('memos.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('entity_type', sa.String(32), nullable=False),
+        sa.Column('entity_id', UUID(as_uuid=True), nullable=False),
+        sa.Column('position', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.UniqueConstraint('memo_id', 'entity_type', 'entity_id', name='uq_memo_entity_links'),
+    )
+    op.create_index('ix_memo_entity_links_memo_id', 'memo_entity_links', ['memo_id'])
+
+    # Migrate existing memo_doc_links data as entity_type='doc'
+    op.execute("""
+        INSERT INTO memo_entity_links (id, memo_id, entity_type, entity_id, position, created_at)
+        SELECT gen_random_uuid(), memo_id, 'doc', doc_id, 0, created_at
+        FROM memo_doc_links
+        ON CONFLICT ON CONSTRAINT uq_memo_entity_links DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_memo_entity_links_memo_id', 'memo_entity_links')
+    op.drop_table('memo_entity_links')

--- a/backend/alembic/versions/0011_add_memo_entity_links.py
+++ b/backend/alembic/versions/0011_add_memo_entity_links.py
@@ -24,6 +24,7 @@ def upgrade() -> None:
         sa.Column('position', sa.Integer(), nullable=False, server_default='0'),
         sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
         sa.UniqueConstraint('memo_id', 'entity_type', 'entity_id', name='uq_memo_entity_links'),
+        sa.CheckConstraint("entity_type IN ('story','doc','epic','task')", name='ck_mel_entity_type'),
     )
     op.create_index('ix_memo_entity_links_memo_id', 'memo_entity_links', ['memo_id'])
 

--- a/backend/app/models/memo.py
+++ b/backend/app/models/memo.py
@@ -38,6 +38,7 @@ class Memo(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     replies: Mapped[list["MemoReply"]] = relationship("MemoReply", back_populates="memo", lazy="select")
     assignees: Mapped[list["MemoAssignee"]] = relationship("MemoAssignee", back_populates="memo", lazy="select")
     doc_links: Mapped[list["MemoDocLink"]] = relationship("MemoDocLink", back_populates="memo", lazy="select")
+    entity_links: Mapped[list["MemoEntityLink"]] = relationship("MemoEntityLink", back_populates="memo", lazy="select", order_by="MemoEntityLink.position")
     mentions: Mapped[list["MemoMention"]] = relationship("MemoMention", back_populates="memo", lazy="select")
     reads: Mapped[list["MemoRead"]] = relationship("MemoRead", back_populates="memo", lazy="select")
 
@@ -118,6 +119,26 @@ class MemoDocLink(Base):
     )
 
     memo: Mapped[Memo] = relationship("Memo", back_populates="doc_links")
+
+
+MEMO_ENTITY_TYPES = ('story', 'doc', 'epic', 'task')
+
+
+class MemoEntityLink(Base):
+    __tablename__ = "memo_entity_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    entity_type: Mapped[str] = mapped_column(nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    position: Mapped[int] = mapped_column(nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="entity_links")
 
 
 class MemoMention(Base):

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
 
 class MemoEntityLinkCreate(BaseModel):
-    entity_type: str
+    entity_type: Literal['story', 'doc', 'epic', 'task']
     entity_id: uuid.UUID
     position: int = 0
 

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -5,6 +5,23 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict
 
 
+class MemoEntityLinkCreate(BaseModel):
+    entity_type: str
+    entity_id: uuid.UUID
+    position: int = 0
+
+
+class MemoEntityLinkResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    memo_id: uuid.UUID
+    entity_type: str
+    entity_id: uuid.UUID
+    position: int
+    created_at: datetime
+
+
 class CreateMemo(BaseModel):
     project_id: uuid.UUID
     org_id: uuid.UUID


### PR DESCRIPTION
## Summary

E-MEMO-EMBED 에픽 첫 스토리 — `memo_entity_links` 테이블 신설 및 기존 `memo_doc_links` 데이터 마이그레이션.

## 변경 내용

### `backend/alembic/versions/0011_add_memo_entity_links.py`
- `memo_entity_links` 테이블 생성
  - `id`, `memo_id` (FK → memos, CASCADE), `entity_type` (story/doc/epic/task), `entity_id`, `position` (default 0), `created_at`
  - UNIQUE(`memo_id`, `entity_type`, `entity_id`)
  - 인덱스: `ix_memo_entity_links_memo_id`
- 데이터 마이그레이션: `memo_doc_links` → `memo_entity_links` (`entity_type='doc'`)

### `backend/app/models/memo.py`
- `MemoEntityLink` SQLAlchemy 모델 추가
- `Memo.entity_links` relationship 추가 (position 순 정렬)

### `backend/app/schemas/memo.py`
- `MemoEntityLinkCreate`, `MemoEntityLinkResponse` Pydantic 스키마 추가

## AC 체크

- [x] AC1: `alembic upgrade head` → memo_entity_links 테이블 생성
- [x] AC2: 기존 memo_doc_links 데이터 → memo_entity_links (entity_type='doc') 복사
- [x] AC3: `Memo.entity_links` relationship 접근 가능
- [x] AC4: entity_type story/doc/epic/task 4종 지원 구조

`MemoDocLink` 테이블/모델 유지 (하위호환, ME-S2에서 전환 예정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)