### PR TITLE
feat(ME-S2): memo 생성/조회 API embeds 지원

### DIFF
--- a/backend/app/repositories/memo.py
+++ b/backend/app/repositories/memo.py
@@ -7,8 +7,11 @@ from typing import Any
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
+from app.models.doc import Doc
+from app.models.memo import Memo, MemoDocLink, MemoEntityLink, MemoRead, MemoReply
+from app.models.pm import Epic, Story, Task
 from app.repositories.base import BaseRepository
+from app.schemas.memo import MemoEntityLinkCreate, MemoEntityLinkResponse
 
 
 class MemoRepository(BaseRepository[Memo]):
@@ -60,6 +63,87 @@ class MemoRepository(BaseRepository[Memo]):
             select(MemoDocLink).where(MemoDocLink.memo_id == id)
         )
         return list(result.scalars().all())
+
+    async def create_entity_links(
+        self, memo_id: uuid.UUID, embeds: list[MemoEntityLinkCreate]
+    ) -> None:
+        for embed in embeds:
+            self.session.add(MemoEntityLink(
+                memo_id=memo_id,
+                entity_type=embed.entity_type,
+                entity_id=embed.entity_id,
+                position=embed.position,
+            ))
+        await self.session.flush()
+
+    async def get_entity_links_resolved(
+        self, memo_id: uuid.UUID
+    ) -> list[MemoEntityLinkResponse]:
+        result = await self.session.execute(
+            select(MemoEntityLink)
+            .where(MemoEntityLink.memo_id == memo_id)
+            .order_by(MemoEntityLink.position)
+        )
+        links = list(result.scalars().all())
+        if not links:
+            return []
+
+        # Batch-resolve titles/statuses per entity_type
+        by_type: dict[str, list[uuid.UUID]] = {}
+        for lnk in links:
+            by_type.setdefault(lnk.entity_type, []).append(lnk.entity_id)
+
+        resolved: dict[uuid.UUID, tuple[str | None, str | None]] = {}
+
+        if "story" in by_type:
+            rows = await self.session.execute(
+                select(Story.id, Story.title, Story.status).where(Story.id.in_(by_type["story"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        if "doc" in by_type:
+            rows = await self.session.execute(
+                select(Doc.id, Doc.title).where(Doc.id.in_(by_type["doc"]))
+            )
+            for rid, title in rows:
+                resolved[rid] = (title, None)
+
+        if "epic" in by_type:
+            rows = await self.session.execute(
+                select(Epic.id, Epic.title, Epic.status).where(Epic.id.in_(by_type["epic"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        if "task" in by_type:
+            rows = await self.session.execute(
+                select(Task.id, Task.title, Task.status).where(Task.id.in_(by_type["task"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        out = []
+        for lnk in links:
+            title, status = resolved.get(lnk.entity_id, (None, None))
+            out.append(MemoEntityLinkResponse(
+                id=lnk.id,
+                memo_id=lnk.memo_id,
+                entity_type=lnk.entity_type,
+                entity_id=lnk.entity_id,
+                position=lnk.position,
+                created_at=lnk.created_at,
+                title=title,
+                status=status,
+            ))
+        return out
+
+    async def get_entity_link_count(self, memo_id: uuid.UUID) -> int:
+        from sqlalchemy import func
+        result = await self.session.execute(
+            select(func.count()).select_from(MemoEntityLink).where(MemoEntityLink.memo_id == memo_id)
+        )
+        return result.scalar_one()
 
 
 class MemoReplyRepository:

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -84,7 +84,13 @@ async def list_memos(
     if q:
         filters["q"] = q
     memos = await repo.list(**filters)
-    return [MemoListResponse.model_validate(m) for m in memos]
+    results = []
+    for m in memos:
+        count = await repo.get_entity_link_count(m.id)
+        memo_dict = {k: v for k, v in m.__dict__.items() if not k.startswith("_")}
+        memo_dict["embed_count"] = count
+        results.append(MemoListResponse.model_validate(memo_dict))
+    return results
 
 
 @router.post("", response_model=MemoListResponse, status_code=201)
@@ -104,8 +110,12 @@ async def create_memo(
         supersedes_id=body.supersedes_id,
         memo_metadata=body.memo_metadata,
     )
+    if body.embeds:
+        await repo.create_entity_links(memo.id, body.embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})
-    return MemoListResponse.model_validate(memo)
+    memo_dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
+    memo_dict["embed_count"] = len(body.embeds)
+    return MemoListResponse.model_validate(memo_dict)
 
 
 @router.get("/{id}", response_model=MemoResponse)
@@ -120,10 +130,13 @@ async def get_memo(
     reply_repo = MemoReplyRepository(db)
     replies = await reply_repo.list_by_memo(id)
     reply_items = [ReplyResponse.model_validate(r) for r in replies]
+    embeds = await repo.get_entity_links_resolved(id)
     # __dict__ 사용: 로드된 column 값만 포함, lazy-load 안 된 relationship 자동 제외
     memo_dict: dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
     memo_dict["replies"] = reply_items
     memo_dict["reply_count"] = len(reply_items)
+    memo_dict["embeds"] = embeds
+    memo_dict["embed_count"] = len(embeds)
     return MemoResponse.model_validate(memo_dict)
 
 

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -20,6 +20,8 @@ class MemoEntityLinkResponse(BaseModel):
     entity_id: uuid.UUID
     position: int
     created_at: datetime
+    title: str | None = None
+    status: str | None = None
 
 
 class CreateMemo(BaseModel):
@@ -32,6 +34,7 @@ class CreateMemo(BaseModel):
     created_by: uuid.UUID | None = None
     supersedes_id: uuid.UUID | None = None
     memo_metadata: dict[str, Any] = {}
+    embeds: list[MemoEntityLinkCreate] = []
 
 
 class UpdateMemo(BaseModel):
@@ -61,6 +64,7 @@ class MemoListResponse(BaseModel):
     memo_metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime
+    embed_count: int = 0
 
 
 class CreateReply(BaseModel):
@@ -85,3 +89,4 @@ class MemoResponse(MemoListResponse):
     deleted_at: datetime | None = None
     replies: list[ReplyResponse] = []
     reply_count: int = 0
+    embeds: list[MemoEntityLinkResponse] = []


### PR DESCRIPTION
## 스토리
- ID: `47ce8e14-d8bb-45a8-8667-9e90624f28b1`
- Epic: E-MEMO-EMBED
- SP: 3

## 변경 요약
- `CreateMemo.embeds`: `MemoEntityLinkCreate[]` 배열 추가 (Optional, default=[])
- `POST /api/v2/memos`: embeds 전달 시 `memo_entity_links` 레코드 자동 생성
- `GET /api/v2/memos/{id}`: `embeds` 배열 반환 — entity별 `title`/`status` batch-resolve
- `GET /api/v2/memos` (목록): `embed_count` 포함
- `MemoEntityLinkResponse`: `title`, `status` 필드 추가
- `MemoListResponse`: `embed_count` 필드 추가 (기본값 0, 하위호환)

## entity resolve 로직
- `story` → `stories.title`, `stories.status`
- `doc` → `docs.title` (status=null)
- `epic` → `epics.title`, `epics.status`
- `task` → `tasks.title`, `tasks.status`
- entity_type별 batch IN 쿼리 (N+1 없음)
- 존재하지 않는 entity_id → `title=null, status=null` (무시, 메모 생성 허용)

## AC 체크
- [x] AC1: 메모 생성 시 embeds 배열 전달 → memo_entity_links 레코드 생성
- [x] AC2: 메모 조회 시 embeds 배열 반환 (entity_type, entity_id, title, status)
- [x] AC3: embeds 없이 메모 생성 → 기존 동작 유지 (하위호환)
- [x] AC4: 존재하지 않는 entity_id → title/status=null 반환 (무시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)