### PR TITLE
feat(ME-S3): GET /api/v2/entities/search 엔드포인트 신설

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -61,6 +61,7 @@ app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(memos.router)
+app.include_router(entities.router)
 app.include_router(notifications.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Literal
+from datetime import datetime
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from pydantic import BaseModel
@@ -22,6 +22,7 @@ class EntitySearchResult(BaseModel):
     entity_id: uuid.UUID
     title: str
     status: str | None = None
+    created_at: datetime
 
 
 def _get_org_id(
@@ -56,7 +57,7 @@ async def search_entities(
 
     if "story" in requested:
         stmt = (
-            select(Story.id, Story.title, Story.status)
+            select(Story.id, Story.title, Story.status, Story.created_at)
             .where(
                 Story.org_id == org_id,
                 Story.project_id == project_id,
@@ -67,12 +68,12 @@ async def search_entities(
             stmt = stmt.where(Story.title.ilike(search))
         stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
         rows = await db.execute(stmt)
-        for rid, title, st in rows:
-            results.append(EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st))
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st, created_at=cat))
 
     if "doc" in requested:
         stmt = (
-            select(Doc.id, Doc.title)
+            select(Doc.id, Doc.title, Doc.created_at)
             .where(
                 Doc.org_id == org_id,
                 Doc.project_id == project_id,
@@ -83,12 +84,12 @@ async def search_entities(
             stmt = stmt.where(Doc.title.ilike(search))
         stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
         rows = await db.execute(stmt)
-        for rid, title in rows:
-            results.append(EntitySearchResult(entity_type="doc", entity_id=rid, title=title))
+        for rid, title, cat in rows:
+            results.append(EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat))
 
     if "epic" in requested:
         stmt = (
-            select(Epic.id, Epic.title, Epic.status)
+            select(Epic.id, Epic.title, Epic.status, Epic.created_at)
             .where(
                 Epic.org_id == org_id,
                 Epic.project_id == project_id,
@@ -98,12 +99,12 @@ async def search_entities(
             stmt = stmt.where(Epic.title.ilike(search))
         stmt = stmt.order_by(Epic.created_at.desc()).limit(DEFAULT_LIMIT)
         rows = await db.execute(stmt)
-        for rid, title, st in rows:
-            results.append(EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st))
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st, created_at=cat))
 
     if "task" in requested:
         stmt = (
-            select(Task.id, Task.title, Task.status)
+            select(Task.id, Task.title, Task.status, Task.created_at)
             .join(Story, Task.story_id == Story.id)
             .where(
                 Task.org_id == org_id,
@@ -115,11 +116,12 @@ async def search_entities(
             stmt = stmt.where(Task.title.ilike(search))
         stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
         rows = await db.execute(stmt)
-        for rid, title, st in rows:
-            results.append(EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st))
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st, created_at=cat))
 
-    # Sort by title when searching, by created_at (already DESC per type) otherwise
     if search:
         results.sort(key=lambda r: r.title.lower())
+    else:
+        results.sort(key=lambda r: r.created_at, reverse=True)
 
     return results[:DEFAULT_LIMIT]

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,0 +1,125 @@
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.doc import Doc
+from app.models.pm import Epic, Story, Task
+
+router = APIRouter(prefix="/api/v2/entities", tags=["entities"])
+
+VALID_TYPES = {"story", "doc", "epic", "task"}
+DEFAULT_LIMIT = 10
+
+
+class EntitySearchResult(BaseModel):
+    entity_type: str
+    entity_id: uuid.UUID
+    title: str
+    status: str | None = None
+
+
+def _get_org_id(
+    auth: AuthContext,
+    x_org_id: str | None,
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required",
+        )
+    return uuid.UUID(str(org_id_str))
+
+
+@router.get("/search", response_model=list[EntitySearchResult])
+async def search_entities(
+    project_id: uuid.UUID = Query(...),
+    q: str | None = Query(default=None),
+    types: str | None = Query(default=None, description="Comma-separated: story,doc,epic,task"),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> list[EntitySearchResult]:
+    org_id = _get_org_id(auth, x_org_id)
+
+    requested = set(types.split(",")) if types else VALID_TYPES
+    requested = requested & VALID_TYPES
+
+    search = f"%{q}%" if q else None
+    results: list[EntitySearchResult] = []
+
+    if "story" in requested:
+        stmt = (
+            select(Story.id, Story.title, Story.status)
+            .where(
+                Story.org_id == org_id,
+                Story.project_id == project_id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Story.title.ilike(search))
+        stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st in rows:
+            results.append(EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st))
+
+    if "doc" in requested:
+        stmt = (
+            select(Doc.id, Doc.title)
+            .where(
+                Doc.org_id == org_id,
+                Doc.project_id == project_id,
+                Doc.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Doc.title.ilike(search))
+        stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title in rows:
+            results.append(EntitySearchResult(entity_type="doc", entity_id=rid, title=title))
+
+    if "epic" in requested:
+        stmt = (
+            select(Epic.id, Epic.title, Epic.status)
+            .where(
+                Epic.org_id == org_id,
+                Epic.project_id == project_id,
+            )
+        )
+        if search:
+            stmt = stmt.where(Epic.title.ilike(search))
+        stmt = stmt.order_by(Epic.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st in rows:
+            results.append(EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st))
+
+    if "task" in requested:
+        stmt = (
+            select(Task.id, Task.title, Task.status)
+            .join(Story, Task.story_id == Story.id)
+            .where(
+                Task.org_id == org_id,
+                Story.project_id == project_id,
+                Task.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Task.title.ilike(search))
+        stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st in rows:
+            results.append(EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st))
+
+    # Sort by title when searching, by created_at (already DESC per type) otherwise
+    if search:
+        results.sort(key=lambda r: r.title.lower())
+
+    return results[:DEFAULT_LIMIT]


### PR DESCRIPTION
## 스토리
- ID: `4a5a4a9a-48c6-48d5-b8bc-a23b5a2ecda0`
- Epic: E-MEMO-EMBED
- SP: 2

## 변경 요약
- `backend/app/routers/entities.py` 신설
- `GET /api/v2/entities/search` 엔드포인트
- `backend/app/main.py` — entities 라우터 등록

## 동작
- `project_id` (필수), `q` (검색어), `types` (comma-sep: story,doc,epic,task)
- q 빈값 → 최근 생성 10건 반환
- q 있음 → 타입별 title ILIKE 검색, 알파벳 정렬 후 상위 10건
- Task: story_id→Story 조인으로 project_id 스코프 적용 (Task에 project_id 없음)
- org_id 기반 접근 제어 — 타 org 엔티티 미노출
- SoftDeleteMixin 모델(Story/Task/Doc): deleted_at.is_(None) 필터

## AC 체크
- [x] AC1: q 검색 시 매칭 엔티티 반환
- [x] AC2: types 파라미터로 특정 타입만 필터
- [x] AC3: org_id + project_id 스코프 — 외부 엔티티 미노출
- [x] AC4: 빈 q 시 최근 생성 엔티티 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)