### PR TITLE
feat(ME-S5): memo 상세 embed 프리뷰 카드 렌더링

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -252,6 +252,7 @@
     "latestReply": "Latest reply",
     "timeline": "Timeline",
     "noTimelineEvents": "No timeline events yet.",
+    "embeds": "Embedded entities",
     "linkedDocs": "Linked docs",
     "noLinkedDocs": "No linked docs.",
     "readBy": "Read by",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -252,6 +252,7 @@
     "latestReply": "최근 답글",
     "timeline": "타임라인",
     "noTimelineEvents": "타임라인 이벤트가 아직 없습니다.",
+    "embeds": "임베드 엔티티",
     "linkedDocs": "연결 문서",
     "noLinkedDocs": "연결된 문서가 없습니다.",
     "readBy": "읽음",

--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+
+export const ENTITY_ICONS: Record<string, string> = {
+  story: '📋',
+  doc: '📄',
+  epic: '🎯',
+  task: '✅',
+};
+
+const ENTITY_COLORS: Record<string, string> = {
+  story: 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100',
+  doc: 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
+  epic: 'border-purple-200 bg-purple-50 text-purple-900 dark:border-purple-800 dark:bg-purple-950 dark:text-purple-100',
+  task: 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100',
+};
+
+export function getEntityHref(entityType: string, entityId: string): string | null {
+  switch (entityType) {
+    case 'story': return `/board?story=${entityId}`;
+    case 'doc': return `/docs?id=${entityId}`;
+    case 'epic': return `/epics/${entityId}`;
+    case 'task': return null;
+    default: return null;
+  }
+}
+
+export interface EmbedCardData {
+  entity_type: string;
+  entity_id: string;
+  title: string | null;
+  status: string | null;
+  position?: number;
+}
+
+export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardData) {
+  const icon = ENTITY_ICONS[entity_type] ?? '#';
+  const colorClass = ENTITY_COLORS[entity_type] ?? 'border-border bg-muted text-foreground';
+  const href = getEntityHref(entity_type, entity_id);
+  const label = title ?? entity_id;
+
+  const inner = (
+    <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
+      <span>{icon}</span>
+      <span className="font-medium">{label}</span>
+      {status ? (
+        <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+      ) : null}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block transition-opacity hover:opacity-80">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}
+
+export function EntityChip({
+  entityType,
+  label,
+  href,
+}: {
+  entityType: string;
+  label: string;
+  href: string | null;
+}) {
+  const icon = ENTITY_ICONS[entityType] ?? '#';
+  const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
+
+  const inner = (
+    <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
+      <span>{icon}</span>
+      <span>{label}</span>
+    </span>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="inline-flex no-underline transition-opacity hover:opacity-80">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}

--- a/apps/web/src/components/memos/memo-detail.tsx
+++ b/apps/web/src/components/memos/memo-detail.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { StatusBadge } from '@/components/ui/status-badge';
+import { EmbedCard, EntityChip, getEntityHref } from '@/components/memos/embed-card';
 import { MemoComposer } from '@/components/memos/memo-composer';
 import { useMemoPresence } from '@/components/memos/use-memo-presence';
 import type { MemoDetailState, MemoReply } from '@/components/memos/memo-state';
@@ -330,10 +331,45 @@ export function MemoDetail({
           <SectionCard>
             <SectionCardBody>
               <div className={markdownClassName}>
-                <ReactMarkdown>{memoState.content}</ReactMarkdown>
+                <ReactMarkdown
+                  components={{
+                    a: ({ href, children }) => {
+                      const m = href?.match(/^entity:(\w+):([0-9a-f-]+)$/i);
+                      if (m) {
+                        const entityType = m[1];
+                        const entityId = m[2];
+                        const entityHref = getEntityHref(entityType, entityId);
+                        return <EntityChip entityType={entityType} label={String(children)} href={entityHref} />;
+                      }
+                      return <a href={href} target="_blank" rel="noreferrer">{children}</a>;
+                    },
+                  }}
+                >
+                  {memoState.content}
+                </ReactMarkdown>
               </div>
             </SectionCardBody>
           </SectionCard>
+
+          {memoState.embeds && memoState.embeds.length > 0 ? (
+            <SectionCard>
+              <SectionCardHeader>
+                <div className="text-sm font-semibold">{t('embeds')} ({memoState.embeds.length})</div>
+              </SectionCardHeader>
+              <SectionCardBody className="space-y-2">
+                {memoState.embeds.map((embed) => (
+                  <EmbedCard
+                    key={`${embed.entity_type}:${embed.entity_id}`}
+                    entity_type={embed.entity_type}
+                    entity_id={embed.entity_id}
+                    title={embed.title}
+                    status={embed.status}
+                    position={embed.position}
+                  />
+                ))}
+              </SectionCardBody>
+            </SectionCard>
+          ) : null}
 
           <SectionCard>
             <SectionCardHeader>

--- a/apps/web/src/components/memos/memo-state.ts
+++ b/apps/web/src/components/memos/memo-state.ts
@@ -24,6 +24,14 @@ export interface MemoTimelineItem {
   by?: string | null;
 }
 
+export interface MemoEmbed {
+  entity_type: string;
+  entity_id: string;
+  title: string | null;
+  status: string | null;
+  position?: number;
+}
+
 export interface MemoDetailState {
   id: string;
   project_id?: string;
@@ -45,6 +53,7 @@ export interface MemoDetailState {
   linked_docs?: MemoLinkedDoc[];
   readers?: MemoReader[];
   supersedes_chain?: unknown[];
+  embeds?: MemoEmbed[];
 }
 
 export interface MemoSummaryState {


### PR DESCRIPTION
## 스토리
- ID: `da6ed4d9`
- Epic: E-MEMO-EMBED
- SP: 3

## 변경 요약
- `embed-card.tsx` 신설 — `EmbedCard`, `EntityChip`, `getEntityHref`
- `memo-state.ts` — `MemoEmbed` 인터페이스 + `MemoDetailState.embeds?` 필드 추가
- `memo-detail.tsx` — embeds 카드 섹션 + ReactMarkdown custom a renderer
- `ko.json` / `en.json` — `embeds` i18n 키 추가

## 구현 내용
### EmbedCard
- entity_type별 아이콘(📋📄🎯✅) + 색상 (story=blue, doc=slate, epic=purple, task=emerald)
- 제목 + 상태 배지
- 클릭 시 라우팅: story→`/board?story={id}`, doc→`/docs?id={id}`, epic→`/epics/{id}`, task→null(링크 없음)

### EntityChip (인라인)
- ReactMarkdown `a` 태그 custom renderer
- `href` 패턴 `entity:type:id` 감지 → 인라인 칩으로 변환

### memo-detail.tsx
- `memoState.embeds` 배열 있을 때만 섹션 렌더링 (embeds 없는 메모 — 기존 동작 유지)
- 본문 내 `[title](entity:type:id)` 링크 → EntityChip 자동 변환

## AC 체크
- [x] AC1: embed된 엔티티 프리뷰 카드 표시 (아이콘 + 제목 + 상태)
- [x] AC2: entity_type별 색상/아이콘 시각적 구분
- [x] AC3: 카드 클릭 시 엔티티 상세 페이지 이동
- [x] AC4: 마크다운 본문 내 `entity:type:id` 링크 → 인라인 칩 렌더링
- [x] AC5: embeds 없는 메모 — 기존 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)