### PR TITLE
E-MEMO-EMBED 에픽 프로모션: develop → main

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -252,6 +252,7 @@
     "latestReply": "Latest reply",
     "timeline": "Timeline",
     "noTimelineEvents": "No timeline events yet.",
+    "embeds": "Embedded entities",
     "linkedDocs": "Linked docs",
     "noLinkedDocs": "No linked docs.",
     "readBy": "Read by",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -252,6 +252,7 @@
     "latestReply": "최근 답글",
     "timeline": "타임라인",
     "noTimelineEvents": "타임라인 이벤트가 아직 없습니다.",
+    "embeds": "임베드 엔티티",
     "linkedDocs": "연결 문서",
     "noLinkedDocs": "연결된 문서가 없습니다.",
     "readBy": "읽음",

--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import Link from 'next/link';
+
+export const ENTITY_ICONS: Record<string, string> = {
+  story: '📋',
+  doc: '📄',
+  epic: '🎯',
+  task: '✅',
+};
+
+const ENTITY_COLORS: Record<string, string> = {
+  story: 'border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100',
+  doc: 'border-slate-200 bg-slate-50 text-slate-900 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100',
+  epic: 'border-purple-200 bg-purple-50 text-purple-900 dark:border-purple-800 dark:bg-purple-950 dark:text-purple-100',
+  task: 'border-emerald-200 bg-emerald-50 text-emerald-900 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-100',
+};
+
+export function getEntityHref(entityType: string, entityId: string): string | null {
+  switch (entityType) {
+    case 'story': return `/board?story=${entityId}`;
+    case 'doc': return `/docs?id=${entityId}`;
+    case 'epic': return `/epics/${entityId}`;
+    case 'task': return null;
+    default: return null;
+  }
+}
+
+export interface EmbedCardData {
+  entity_type: string;
+  entity_id: string;
+  title: string | null;
+  status: string | null;
+  position?: number;
+}
+
+export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardData) {
+  const icon = ENTITY_ICONS[entity_type] ?? '#';
+  const colorClass = ENTITY_COLORS[entity_type] ?? 'border-border bg-muted text-foreground';
+  const href = getEntityHref(entity_type, entity_id);
+  const label = title ?? entity_id;
+
+  const inner = (
+    <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
+      <span>{icon}</span>
+      <span className="font-medium">{label}</span>
+      {status ? (
+        <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+      ) : null}
+    </div>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="block transition-opacity hover:opacity-80">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}
+
+export function EntityChip({
+  entityType,
+  label,
+  href,
+}: {
+  entityType: string;
+  label: string;
+  href: string | null;
+}) {
+  const icon = ENTITY_ICONS[entityType] ?? '#';
+  const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
+
+  const inner = (
+    <span className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-xs font-medium ${colorClass}`}>
+      <span>{icon}</span>
+      <span>{label}</span>
+    </span>
+  );
+
+  if (href) {
+    return (
+      <Link href={href} className="inline-flex no-underline transition-opacity hover:opacity-80">
+        {inner}
+      </Link>
+    );
+  }
+  return inner;
+}

--- a/apps/web/src/components/memos/memo-composer.tsx
+++ b/apps/web/src/components/memos/memo-composer.tsx
@@ -20,10 +20,51 @@ function applyMention(value: string, cursorPos: number, name: string): { text: s
   return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
 }
 
+function getEntityQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  return m ? m[1] : null;
+}
+
+function applyEntity(
+  value: string,
+  cursorPos: number,
+  title: string,
+  entityType: string,
+  entityId: string,
+): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  const replacement = `[${title}](entity:${entityType}:${entityId}) `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+const ENTITY_ICONS: Record<string, string> = {
+  story: '📋',
+  doc: '📄',
+  epic: '🎯',
+  task: '✅',
+};
+
 interface MentionMember {
   id: string;
   name: string;
   role?: string | null;
+}
+
+interface EntityResult {
+  entity_type: string;
+  entity_id: string;
+  title: string;
+  status: string | null;
+}
+
+export interface EmbedItem {
+  entity_type: string;
+  entity_id: string;
+  position: number;
 }
 
 interface MemoComposerProps {
@@ -41,6 +82,8 @@ interface MemoComposerProps {
   memoId?: string;
   currentTeamMemberId?: string;
   currentTeamMemberName?: string;
+  projectId?: string;
+  onEmbedsChange?: (embeds: EmbedItem[]) => void;
 }
 
 const IMAGE_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/webp', 'image/gif', 'image/avif']);
@@ -64,6 +107,8 @@ export function MemoComposer({
   memoId,
   currentTeamMemberId,
   currentTeamMemberName,
+  projectId,
+  onEmbedsChange,
 }: MemoComposerProps) {
   const t = useTranslations('memos');
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -75,6 +120,11 @@ export function MemoComposer({
   const [mentionQuery, setMentionQuery] = useState<string | null>(null);
   const [mentionMembers, setMentionMembers] = useState<MentionMember[]>([]);
   const [mentionIndex, setMentionIndex] = useState(0);
+
+  const [entityQuery, setEntityQuery] = useState<string | null>(null);
+  const [entityResults, setEntityResults] = useState<EntityResult[]>([]);
+  const [entityIndex, setEntityIndex] = useState(0);
+  const [embeds, setEmbeds] = useState<EmbedItem[]>([]);
 
   useEffect(() => {
     valueRef.current = value;
@@ -98,6 +148,28 @@ export function MemoComposer({
       .catch(() => {});
     return () => { cancelled = true; };
   }, [mentionQuery]);
+
+  // Entity search with 200ms debounce
+  useEffect(() => {
+    let cancelled = false;
+    if (entityQuery === null || !projectId) {
+      setEntityResults([]);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const params = new URLSearchParams({ project_id: projectId });
+      if (entityQuery) params.set('q', entityQuery);
+      fetch(`/api/v2/entities/search?${params}`)
+        .then((r) => r.json())
+        .then((json: EntityResult[]) => {
+          if (cancelled) return;
+          setEntityResults(Array.isArray(json) ? json : []);
+          setEntityIndex(0);
+        })
+        .catch(() => {});
+    }, 200);
+    return () => { cancelled = true; window.clearTimeout(timer); };
+  }, [entityQuery, projectId]);
 
   const localCollaboration = useMemoPresence({
     memoId,
@@ -196,12 +268,49 @@ export function MemoComposer({
     });
   }, [onChange, value]);
 
+  const selectEntity = useCallback((entity: EntityResult) => {
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? value.length;
+    const { text, caretPos } = applyEntity(value, cursorPos, entity.title, entity.entity_type, entity.entity_id);
+    onChange(text);
+    setEntityQuery(null);
+    setEntityResults([]);
+
+    const nextEmbeds: EmbedItem[] = [
+      ...embeds,
+      { entity_type: entity.entity_type, entity_id: entity.entity_id, position: embeds.length },
+    ];
+    setEmbeds(nextEmbeds);
+    onEmbedsChange?.(nextEmbeds);
+
+    requestAnimationFrame(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(caretPos, caretPos);
+    });
+  }, [embeds, onChange, onEmbedsChange, value]);
+
   const handleChange = useCallback((nextValue: string, cursorPos: number) => {
     onChange(nextValue);
     collaboration.setTyping(Boolean(nextValue.trim()));
-    const q = getMentionQuery(nextValue, cursorPos);
-    setMentionQuery(q);
-    if (q === null) setMentionMembers([]);
+
+    const mq = getMentionQuery(nextValue, cursorPos);
+    const eq = getEntityQuery(nextValue, cursorPos);
+
+    // @ and # are mutually exclusive
+    if (mq !== null) {
+      setMentionQuery(mq);
+      setEntityQuery(null);
+      setEntityResults([]);
+    } else if (eq !== null) {
+      setEntityQuery(eq);
+      setMentionQuery(null);
+      setMentionMembers([]);
+    } else {
+      setMentionQuery(null);
+      setMentionMembers([]);
+      setEntityQuery(null);
+      setEntityResults([]);
+    }
   }, [collaboration, onChange]);
 
   const handleSubmit = useCallback(async () => {
@@ -217,6 +326,28 @@ export function MemoComposer({
   }, [collaboration, value]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (entityResults.length > 0) {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault();
+        setEntityIndex((i) => (i + 1) % entityResults.length);
+        return;
+      }
+      if (event.key === 'ArrowUp') {
+        event.preventDefault();
+        setEntityIndex((i) => (i - 1 + entityResults.length) % entityResults.length);
+        return;
+      }
+      if (event.key === 'Enter' || event.key === 'Tab') {
+        event.preventDefault();
+        selectEntity(entityResults[entityIndex]);
+        return;
+      }
+      if (event.key === 'Escape') {
+        setEntityQuery(null);
+        setEntityResults([]);
+        return;
+      }
+    }
     if (mentionMembers.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault();
@@ -243,7 +374,7 @@ export function MemoComposer({
       event.preventDefault();
       void handleSubmit();
     }
-  }, [handleSubmit, mentionMembers, mentionIndex, selectMention]);
+  }, [entityIndex, entityResults, handleSubmit, mentionMembers, mentionIndex, selectEntity, selectMention]);
 
   const presenceSummary = useMemo(() => {
     const viewers = collaboration.viewers.map((entry) => entry.name);
@@ -275,6 +406,8 @@ export function MemoComposer({
             window.setTimeout(() => {
               setMentionQuery(null);
               setMentionMembers([]);
+              setEntityQuery(null);
+              setEntityResults([]);
             }, 150);
           }}
           placeholder={placeholder}
@@ -293,6 +426,25 @@ export function MemoComposer({
                 >
                   <span className="font-medium text-primary">@</span>{member.name}
                   {member.role ? <span className="ml-2 text-xs opacity-60">{member.role}</span> : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+        {entityResults.length > 0 && (
+          <ul className="absolute bottom-full left-0 z-50 mb-1 max-h-48 w-[min(20rem,100%)] overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+            {entityResults.map((entity, idx) => (
+              <li key={`${entity.entity_type}:${entity.entity_id}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
+                  className={`w-full px-3 py-2 text-left text-sm transition ${idx === entityIndex ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                >
+                  <span className="mr-1.5">{ENTITY_ICONS[entity.entity_type] ?? '#'}</span>
+                  <span className="font-medium">{entity.title}</span>
+                  {entity.status ? (
+                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>
+                  ) : null}
                 </button>
               </li>
             ))}

--- a/apps/web/src/components/memos/memo-detail.tsx
+++ b/apps/web/src/components/memos/memo-detail.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { StatusBadge } from '@/components/ui/status-badge';
+import { EmbedCard, EntityChip, getEntityHref } from '@/components/memos/embed-card';
 import { MemoComposer } from '@/components/memos/memo-composer';
 import { useMemoPresence } from '@/components/memos/use-memo-presence';
 import type { MemoDetailState, MemoReply } from '@/components/memos/memo-state';
@@ -330,10 +331,45 @@ export function MemoDetail({
           <SectionCard>
             <SectionCardBody>
               <div className={markdownClassName}>
-                <ReactMarkdown>{memoState.content}</ReactMarkdown>
+                <ReactMarkdown
+                  components={{
+                    a: ({ href, children }) => {
+                      const m = href?.match(/^entity:(\w+):([0-9a-f-]+)$/i);
+                      if (m) {
+                        const entityType = m[1];
+                        const entityId = m[2];
+                        const entityHref = getEntityHref(entityType, entityId);
+                        return <EntityChip entityType={entityType} label={String(children)} href={entityHref} />;
+                      }
+                      return <a href={href} target="_blank" rel="noreferrer">{children}</a>;
+                    },
+                  }}
+                >
+                  {memoState.content}
+                </ReactMarkdown>
               </div>
             </SectionCardBody>
           </SectionCard>
+
+          {memoState.embeds && memoState.embeds.length > 0 ? (
+            <SectionCard>
+              <SectionCardHeader>
+                <div className="text-sm font-semibold">{t('embeds')} ({memoState.embeds.length})</div>
+              </SectionCardHeader>
+              <SectionCardBody className="space-y-2">
+                {memoState.embeds.map((embed) => (
+                  <EmbedCard
+                    key={`${embed.entity_type}:${embed.entity_id}`}
+                    entity_type={embed.entity_type}
+                    entity_id={embed.entity_id}
+                    title={embed.title}
+                    status={embed.status}
+                    position={embed.position}
+                  />
+                ))}
+              </SectionCardBody>
+            </SectionCard>
+          ) : null}
 
           <SectionCard>
             <SectionCardHeader>

--- a/apps/web/src/components/memos/memo-state.ts
+++ b/apps/web/src/components/memos/memo-state.ts
@@ -24,6 +24,14 @@ export interface MemoTimelineItem {
   by?: string | null;
 }
 
+export interface MemoEmbed {
+  entity_type: string;
+  entity_id: string;
+  title: string | null;
+  status: string | null;
+  position?: number;
+}
+
 export interface MemoDetailState {
   id: string;
   project_id?: string;
@@ -45,6 +53,7 @@ export interface MemoDetailState {
   linked_docs?: MemoLinkedDoc[];
   readers?: MemoReader[];
   supersedes_chain?: unknown[];
+  embeds?: MemoEmbed[];
 }
 
 export interface MemoSummaryState {

--- a/backend/alembic/versions/0011_add_memo_entity_links.py
+++ b/backend/alembic/versions/0011_add_memo_entity_links.py
@@ -1,0 +1,42 @@
+"""add memo_entity_links table and migrate memo_doc_links data
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-05-05
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = '0011'
+down_revision = '0010'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'memo_entity_links',
+        sa.Column('id', UUID(as_uuid=True), primary_key=True, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('memo_id', UUID(as_uuid=True), sa.ForeignKey('memos.id', ondelete='CASCADE'), nullable=False),
+        sa.Column('entity_type', sa.String(32), nullable=False),
+        sa.Column('entity_id', UUID(as_uuid=True), nullable=False),
+        sa.Column('position', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(timezone=True), nullable=False, server_default=sa.text('now()')),
+        sa.UniqueConstraint('memo_id', 'entity_type', 'entity_id', name='uq_memo_entity_links'),
+        sa.CheckConstraint("entity_type IN ('story','doc','epic','task')", name='ck_mel_entity_type'),
+    )
+    op.create_index('ix_memo_entity_links_memo_id', 'memo_entity_links', ['memo_id'])
+
+    # Migrate existing memo_doc_links data as entity_type='doc'
+    op.execute("""
+        INSERT INTO memo_entity_links (id, memo_id, entity_type, entity_id, position, created_at)
+        SELECT gen_random_uuid(), memo_id, 'doc', doc_id, 0, created_at
+        FROM memo_doc_links
+        ON CONFLICT ON CONSTRAINT uq_memo_entity_links DO NOTHING
+    """)
+
+
+def downgrade() -> None:
+    op.drop_index('ix_memo_entity_links_memo_id', 'memo_entity_links')
+    op.drop_table('memo_entity_links')

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -61,6 +61,7 @@ app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(memos.router)
+app.include_router(entities.router)
 app.include_router(notifications.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)

--- a/backend/app/models/memo.py
+++ b/backend/app/models/memo.py
@@ -38,6 +38,7 @@ class Memo(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     replies: Mapped[list["MemoReply"]] = relationship("MemoReply", back_populates="memo", lazy="select")
     assignees: Mapped[list["MemoAssignee"]] = relationship("MemoAssignee", back_populates="memo", lazy="select")
     doc_links: Mapped[list["MemoDocLink"]] = relationship("MemoDocLink", back_populates="memo", lazy="select")
+    entity_links: Mapped[list["MemoEntityLink"]] = relationship("MemoEntityLink", back_populates="memo", lazy="select", order_by="MemoEntityLink.position")
     mentions: Mapped[list["MemoMention"]] = relationship("MemoMention", back_populates="memo", lazy="select")
     reads: Mapped[list["MemoRead"]] = relationship("MemoRead", back_populates="memo", lazy="select")
 
@@ -118,6 +119,26 @@ class MemoDocLink(Base):
     )
 
     memo: Mapped[Memo] = relationship("Memo", back_populates="doc_links")
+
+
+MEMO_ENTITY_TYPES = ('story', 'doc', 'epic', 'task')
+
+
+class MemoEntityLink(Base):
+    __tablename__ = "memo_entity_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    memo_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    entity_type: Mapped[str] = mapped_column(nullable=False)
+    entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    position: Mapped[int] = mapped_column(nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    memo: Mapped[Memo] = relationship("Memo", back_populates="entity_links")
 
 
 class MemoMention(Base):

--- a/backend/app/repositories/memo.py
+++ b/backend/app/repositories/memo.py
@@ -7,8 +7,11 @@ from typing import Any
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
+from app.models.doc import Doc
+from app.models.memo import Memo, MemoDocLink, MemoEntityLink, MemoRead, MemoReply
+from app.models.pm import Epic, Story, Task
 from app.repositories.base import BaseRepository
+from app.schemas.memo import MemoEntityLinkCreate, MemoEntityLinkResponse
 
 
 class MemoRepository(BaseRepository[Memo]):
@@ -60,6 +63,87 @@ class MemoRepository(BaseRepository[Memo]):
             select(MemoDocLink).where(MemoDocLink.memo_id == id)
         )
         return list(result.scalars().all())
+
+    async def create_entity_links(
+        self, memo_id: uuid.UUID, embeds: list[MemoEntityLinkCreate]
+    ) -> None:
+        for embed in embeds:
+            self.session.add(MemoEntityLink(
+                memo_id=memo_id,
+                entity_type=embed.entity_type,
+                entity_id=embed.entity_id,
+                position=embed.position,
+            ))
+        await self.session.flush()
+
+    async def get_entity_links_resolved(
+        self, memo_id: uuid.UUID
+    ) -> list[MemoEntityLinkResponse]:
+        result = await self.session.execute(
+            select(MemoEntityLink)
+            .where(MemoEntityLink.memo_id == memo_id)
+            .order_by(MemoEntityLink.position)
+        )
+        links = list(result.scalars().all())
+        if not links:
+            return []
+
+        # Batch-resolve titles/statuses per entity_type
+        by_type: dict[str, list[uuid.UUID]] = {}
+        for lnk in links:
+            by_type.setdefault(lnk.entity_type, []).append(lnk.entity_id)
+
+        resolved: dict[uuid.UUID, tuple[str | None, str | None]] = {}
+
+        if "story" in by_type:
+            rows = await self.session.execute(
+                select(Story.id, Story.title, Story.status).where(Story.id.in_(by_type["story"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        if "doc" in by_type:
+            rows = await self.session.execute(
+                select(Doc.id, Doc.title).where(Doc.id.in_(by_type["doc"]))
+            )
+            for rid, title in rows:
+                resolved[rid] = (title, None)
+
+        if "epic" in by_type:
+            rows = await self.session.execute(
+                select(Epic.id, Epic.title, Epic.status).where(Epic.id.in_(by_type["epic"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        if "task" in by_type:
+            rows = await self.session.execute(
+                select(Task.id, Task.title, Task.status).where(Task.id.in_(by_type["task"]))
+            )
+            for rid, title, status in rows:
+                resolved[rid] = (title, status)
+
+        out = []
+        for lnk in links:
+            title, status = resolved.get(lnk.entity_id, (None, None))
+            out.append(MemoEntityLinkResponse(
+                id=lnk.id,
+                memo_id=lnk.memo_id,
+                entity_type=lnk.entity_type,
+                entity_id=lnk.entity_id,
+                position=lnk.position,
+                created_at=lnk.created_at,
+                title=title,
+                status=status,
+            ))
+        return out
+
+    async def get_entity_link_count(self, memo_id: uuid.UUID) -> int:
+        from sqlalchemy import func
+        result = await self.session.execute(
+            select(func.count()).select_from(MemoEntityLink).where(MemoEntityLink.memo_id == memo_id)
+        )
+        return result.scalar_one()
 
 
 class MemoReplyRepository:

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,0 +1,127 @@
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.doc import Doc
+from app.models.pm import Epic, Story, Task
+
+router = APIRouter(prefix="/api/v2/entities", tags=["entities"])
+
+VALID_TYPES = {"story", "doc", "epic", "task"}
+DEFAULT_LIMIT = 10
+
+
+class EntitySearchResult(BaseModel):
+    entity_type: str
+    entity_id: uuid.UUID
+    title: str
+    status: str | None = None
+    created_at: datetime
+
+
+def _get_org_id(
+    auth: AuthContext,
+    x_org_id: str | None,
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required",
+        )
+    return uuid.UUID(str(org_id_str))
+
+
+@router.get("/search", response_model=list[EntitySearchResult])
+async def search_entities(
+    project_id: uuid.UUID = Query(...),
+    q: str | None = Query(default=None),
+    types: str | None = Query(default=None, description="Comma-separated: story,doc,epic,task"),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> list[EntitySearchResult]:
+    org_id = _get_org_id(auth, x_org_id)
+
+    requested = set(types.split(",")) if types else VALID_TYPES
+    requested = requested & VALID_TYPES
+
+    search = f"%{q}%" if q else None
+    results: list[EntitySearchResult] = []
+
+    if "story" in requested:
+        stmt = (
+            select(Story.id, Story.title, Story.status, Story.created_at)
+            .where(
+                Story.org_id == org_id,
+                Story.project_id == project_id,
+                Story.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Story.title.ilike(search))
+        stmt = stmt.order_by(Story.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="story", entity_id=rid, title=title, status=st, created_at=cat))
+
+    if "doc" in requested:
+        stmt = (
+            select(Doc.id, Doc.title, Doc.created_at)
+            .where(
+                Doc.org_id == org_id,
+                Doc.project_id == project_id,
+                Doc.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Doc.title.ilike(search))
+        stmt = stmt.order_by(Doc.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, cat in rows:
+            results.append(EntitySearchResult(entity_type="doc", entity_id=rid, title=title, created_at=cat))
+
+    if "epic" in requested:
+        stmt = (
+            select(Epic.id, Epic.title, Epic.status, Epic.created_at)
+            .where(
+                Epic.org_id == org_id,
+                Epic.project_id == project_id,
+            )
+        )
+        if search:
+            stmt = stmt.where(Epic.title.ilike(search))
+        stmt = stmt.order_by(Epic.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="epic", entity_id=rid, title=title, status=st, created_at=cat))
+
+    if "task" in requested:
+        stmt = (
+            select(Task.id, Task.title, Task.status, Task.created_at)
+            .join(Story, Task.story_id == Story.id)
+            .where(
+                Task.org_id == org_id,
+                Story.project_id == project_id,
+                Task.deleted_at.is_(None),
+            )
+        )
+        if search:
+            stmt = stmt.where(Task.title.ilike(search))
+        stmt = stmt.order_by(Task.created_at.desc()).limit(DEFAULT_LIMIT)
+        rows = await db.execute(stmt)
+        for rid, title, st, cat in rows:
+            results.append(EntitySearchResult(entity_type="task", entity_id=rid, title=title, status=st, created_at=cat))
+
+    if search:
+        results.sort(key=lambda r: r.title.lower())
+    else:
+        results.sort(key=lambda r: r.created_at, reverse=True)
+
+    return results[:DEFAULT_LIMIT]

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -84,7 +84,13 @@ async def list_memos(
     if q:
         filters["q"] = q
     memos = await repo.list(**filters)
-    return [MemoListResponse.model_validate(m) for m in memos]
+    results = []
+    for m in memos:
+        count = await repo.get_entity_link_count(m.id)
+        memo_dict = {k: v for k, v in m.__dict__.items() if not k.startswith("_")}
+        memo_dict["embed_count"] = count
+        results.append(MemoListResponse.model_validate(memo_dict))
+    return results
 
 
 @router.post("", response_model=MemoListResponse, status_code=201)
@@ -104,8 +110,12 @@ async def create_memo(
         supersedes_id=body.supersedes_id,
         memo_metadata=body.memo_metadata,
     )
+    if body.embeds:
+        await repo.create_entity_links(memo.id, body.embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})
-    return MemoListResponse.model_validate(memo)
+    memo_dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
+    memo_dict["embed_count"] = len(body.embeds)
+    return MemoListResponse.model_validate(memo_dict)
 
 
 @router.get("/{id}", response_model=MemoResponse)
@@ -120,10 +130,13 @@ async def get_memo(
     reply_repo = MemoReplyRepository(db)
     replies = await reply_repo.list_by_memo(id)
     reply_items = [ReplyResponse.model_validate(r) for r in replies]
+    embeds = await repo.get_entity_links_resolved(id)
     # __dict__ 사용: 로드된 column 값만 포함, lazy-load 안 된 relationship 자동 제외
     memo_dict: dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
     memo_dict["replies"] = reply_items
     memo_dict["reply_count"] = len(reply_items)
+    memo_dict["embeds"] = embeds
+    memo_dict["embed_count"] = len(embeds)
     return MemoResponse.model_validate(memo_dict)
 
 

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -1,8 +1,25 @@
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
+
+
+class MemoEntityLinkCreate(BaseModel):
+    entity_type: Literal['story', 'doc', 'epic', 'task']
+    entity_id: uuid.UUID
+    position: int = 0
+
+
+class MemoEntityLinkResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    memo_id: uuid.UUID
+    entity_type: str
+    entity_id: uuid.UUID
+    position: int
+    created_at: datetime
 
 
 class CreateMemo(BaseModel):

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -20,6 +20,8 @@ class MemoEntityLinkResponse(BaseModel):
     entity_id: uuid.UUID
     position: int
     created_at: datetime
+    title: str | None = None
+    status: str | None = None
 
 
 class CreateMemo(BaseModel):
@@ -32,6 +34,7 @@ class CreateMemo(BaseModel):
     created_by: uuid.UUID | None = None
     supersedes_id: uuid.UUID | None = None
     memo_metadata: dict[str, Any] = {}
+    embeds: list[MemoEntityLinkCreate] = []
 
 
 class UpdateMemo(BaseModel):
@@ -61,6 +64,7 @@ class MemoListResponse(BaseModel):
     memo_metadata: dict[str, Any]
     created_at: datetime
     updated_at: datetime
+    embed_count: int = 0
 
 
 class CreateReply(BaseModel):
@@ -85,3 +89,4 @@ class MemoResponse(MemoListResponse):
     deleted_at: datetime | None = None
     replies: list[ReplyResponse] = []
     reply_count: int = 0
+    embeds: list[MemoEntityLinkResponse] = []


### PR DESCRIPTION
## Summary
- E-MEMO-EMBED 에픽 (17SP) 전량 완주, develop → main 프로모션
- ME-S1: memo_entity_links 테이블 + Alembic (#452)
- ME-S2: 메모 생성/조회 API embeds 지원 (#454)
- ME-S3: 엔티티 검색 API (#455)
- ME-S4: composer entity embed UI (#456)
- ME-S5: embed 프리뷰 카드 렌더링 (#457)
- ME-S6: 통합 검증 PASS (코드 수정 없음)

## Test plan
- [ ] dev Cloud Build 자동 배포 정상 확인
- [ ] dev smoke: 메모 embed 생성/조회/렌더링 E2E
- [ ] prod Cloud Build 배포 후 prod smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)