### PR TITLE
hotfix(0011): memos PK 누락 환경 — IF NOT EXISTS guard

### DIFF
--- a/backend/alembic/versions/0011_add_memo_entity_links.py
+++ b/backend/alembic/versions/0011_add_memo_entity_links.py
@@ -15,6 +15,18 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Guard: prod DB에 memos PK가 누락된 경우 복구 (FK 생성 선행 조건)
+    op.execute("""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'memos_pkey' AND contype = 'p'
+            ) THEN
+                ALTER TABLE memos ADD PRIMARY KEY (id);
+            END IF;
+        END $$;
+    """)
+
     op.create_table(
         'memo_entity_links',
         sa.Column('id', UUID(as_uuid=True), primary_key=True, server_default=sa.text('gen_random_uuid()')),


### PR DESCRIPTION
## 문제
prod DB에서 `memos.id` PK constraint 누락 시 `memo_entity_links.memo_id` FK 생성 실패:
```
psycopg2.errors.InvalidForeignKey: there is no unique constraint matching given keys for referenced table "memos"
```

## 수정
`0011` `upgrade()` 시작부에 DO $$ 블록으로 PK 존재 여부 확인 후 없을 때만 복구:
```sql
DO $$ BEGIN
    IF NOT EXISTS (
        SELECT 1 FROM pg_constraint
        WHERE conname = 'memos_pkey' AND contype = 'p'
    ) THEN
        ALTER TABLE memos ADD PRIMARY KEY (id);
    END IF;
END $$;
```
- PK가 이미 있는 환경(정상 환경) → IF 조건 false → 무시
- PK가 없는 환경(prod 이슈) → ADD PRIMARY KEY 수행 후 FK 생성 정상 진행
- `downgrade()`는 수정 없음 (PK 제거 시 다른 FK 연쇄 파괴 위험)

🤖 Generated with [Claude Code](https://claude.com/claude-code)