### PR TITLE
hotfix: Alembic 0011 memos PK 복구 (prod 배포 블로커)

### DIFF
--- a/backend/alembic/versions/0011_add_memo_entity_links.py
+++ b/backend/alembic/versions/0011_add_memo_entity_links.py
@@ -15,6 +15,18 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Guard: prod DB에 memos PK가 누락된 경우 복구 (FK 생성 선행 조건)
+    op.execute("""
+        DO $$ BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'memos_pkey' AND contype = 'p'
+            ) THEN
+                ALTER TABLE memos ADD PRIMARY KEY (id);
+            END IF;
+        END $$;
+    """)
+
     op.create_table(
         'memo_entity_links',
         sa.Column('id', UUID(as_uuid=True), primary_key=True, server_default=sa.text('gen_random_uuid()')),


### PR DESCRIPTION
## Summary
- prod Alembic 0011 실행 시 memos 테이블 PK 누락으로 FK 생성 실패
- DO $$ 가드로 PK 없을 때만 조건부 ADD PRIMARY KEY
- idempotent, PK 있는 환경에서 무영향

## Test plan
- [ ] 담롱군 prod Alembic 0011 재실행 → SUCCESS
- [ ] prod smoke PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)