### PR TITLE
feat(OB-S2): 온보딩 위자드 4단계 확장 — Agent 생성 + MCP config

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -304,7 +304,21 @@
     "createProjectAction": "Create Project",
     "projectDescPlaceholder": "Project description...",
     "createProjectFailed": "Failed to create project",
-    "unknownUser": "Unknown"
+    "unknownUser": "Unknown",
+    "createAgent": "Add AI Agent",
+    "agentSubtitle": "Connect an AI agent to automatically manage sprints, memos, and standups.",
+    "agentName": "Agent Name",
+    "agentNamePlaceholder": "e.g. My Agent",
+    "agentRole": "Role",
+    "createAgentAction": "Create Agent + Issue API Key",
+    "connectAgent": "Connect Agent",
+    "connectSubtitle": "Paste the MCP config below into your agent settings.",
+    "mcpConfigTitle": "MCP Config",
+    "promptTitle": "Onboarding Prompt",
+    "finish": "Finish → Dashboard",
+    "skip": "Skip",
+    "stepOf": "{current} / {total}",
+    "createOrgFailed": "Failed to create organization"
   },
   "settings": {
     "title": "Settings",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -304,7 +304,21 @@
     "createProjectAction": "프로젝트 만들기",
     "projectDescPlaceholder": "프로젝트 설명...",
     "createProjectFailed": "프로젝트 생성에 실패했습니다",
-    "unknownUser": "알 수 없음"
+    "unknownUser": "알 수 없음",
+    "createAgent": "AI 에이전트 추가",
+    "agentSubtitle": "AI 에이전트를 프로젝트에 연결하면 스프린트, 메모, 스탠드업을 자동으로 관리합니다.",
+    "agentName": "에이전트 이름",
+    "agentNamePlaceholder": "예: My Agent",
+    "agentRole": "역할",
+    "createAgentAction": "에이전트 생성 + API 키 발급",
+    "connectAgent": "에이전트 연결",
+    "connectSubtitle": "아래 MCP config를 에이전트 설정에 붙여넣으세요.",
+    "mcpConfigTitle": "MCP Config",
+    "promptTitle": "온보딩 프롬프트",
+    "finish": "완료 → 대시보드",
+    "skip": "건너뛰기",
+    "stepOf": "{current} / {total}",
+    "createOrgFailed": "조직 생성에 실패했습니다"
   },
   "settings": {
     "title": "설정",

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -5,7 +5,28 @@ import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
-type Step = 'org' | 'project';
+const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
+const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
+
+function buildMcpConfig(apiKey: string) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        sprintable: {
+          type: 'streamable-http',
+          url: MCP_SERVER_URL,
+          headers: { Authorization: `Bearer ${apiKey}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+type Step = 'org' | 'project' | 'agent' | 'connect';
+const STEPS: Step[] = ['org', 'project', 'agent', 'connect'];
 
 export function OnboardingForm() {
   const router = useRouter();
@@ -17,10 +38,17 @@ export function OnboardingForm() {
   const [projectName, setProjectName] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [orgId, setOrgId] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [agentName, setAgentName] = useState('My Agent');
+  const [agentRole, setAgentRole] = useState('developer');
+  const [newApiKey, setNewApiKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showUpgrade, setShowUpgrade] = useState(false);
   const [upgradeReason, setUpgradeReason] = useState('');
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const stepIndex = STEPS.indexOf(step);
 
   const handleOrgNameChange = (name: string) => {
     setOrgName(name);
@@ -31,6 +59,16 @@ export function OnboardingForm() {
         .replace(/\s+/g, '-')
         .slice(0, 50),
     );
+  };
+
+  const handleCopy = async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      // ignore
+    }
   };
 
   const handleCreateOrg = async () => {
@@ -61,7 +99,6 @@ export function OnboardingForm() {
     setLoading(true);
     setError('');
 
-    // 서버 API 경유 프로젝트 생성 (Feature Gating: max_projects 서버 enforcement)
     const res = await fetch('/api/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -88,6 +125,8 @@ export function OnboardingForm() {
       return;
     }
 
+    setProjectId(project.id);
+
     // team_member 자동 생성 (type=human)
     const meRes = await fetch('/api/me');
     if (meRes.ok) {
@@ -112,6 +151,53 @@ export function OnboardingForm() {
       body: JSON.stringify({ project_id: project.id }),
     }).catch(() => null);
 
+    setStep('agent');
+    setLoading(false);
+  };
+
+  const handleCreateAgent = async () => {
+    if (!agentName.trim() || !projectId || !orgId) return;
+    setLoading(true);
+    setError('');
+
+    // 에이전트 팀원 생성
+    const memberRes = await fetch('/api/team-members', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        org_id: orgId,
+        project_id: projectId,
+        type: 'agent',
+        name: agentName.trim(),
+        role: agentRole,
+      }),
+    });
+    const memberJson = await memberRes.json() as { data?: { id: string }; error?: { message?: string } };
+    if (!memberRes.ok) {
+      setError(memberJson?.error?.message ?? 'Failed to create agent');
+      setLoading(false);
+      return;
+    }
+
+    const agentId = memberJson.data?.id;
+    if (!agentId) {
+      setError('Failed to create agent');
+      setLoading(false);
+      return;
+    }
+
+    // API 키 자동 발급
+    const keyRes = await fetch(`/api/agents/${agentId}/api-key`, { method: 'POST' });
+    const keyJson = await keyRes.json() as { data?: { api_key: string } };
+    if (keyRes.ok && keyJson.data?.api_key) {
+      setNewApiKey(keyJson.data.api_key);
+    }
+
+    setStep('connect');
+    setLoading(false);
+  };
+
+  const handleFinish = () => {
     router.push('/dashboard');
     router.refresh();
   };
@@ -119,14 +205,31 @@ export function OnboardingForm() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        {/* Progress bar */}
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-gray-400">
+            <span>{t('stepOf', { current: stepIndex + 1, total: STEPS.length })}</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-gray-100">
+            <div
+              className="h-1.5 rounded-full bg-blue-600 transition-all duration-300"
+              style={{ width: `${((stepIndex + 1) / STEPS.length) * 100}%` }}
+            />
+          </div>
+        </div>
+
         <div className="text-center">
           <h1 className="text-2xl font-bold text-gray-900">
-            {step === 'org' ? t('createOrg') : t('createProject')}
+            {step === 'org' && t('createOrg')}
+            {step === 'project' && t('createProject')}
+            {step === 'agent' && t('createAgent')}
+            {step === 'connect' && t('connectAgent')}
           </h1>
           <p className="mt-2 text-sm text-gray-500">
-            {step === 'org'
-              ? t('welcome')
-              : t('projectSubtitle', { orgName })}
+            {step === 'org' && t('welcome')}
+            {step === 'project' && t('projectSubtitle', { orgName })}
+            {step === 'agent' && t('agentSubtitle')}
+            {step === 'connect' && t('connectSubtitle')}
           </p>
         </div>
 
@@ -136,12 +239,10 @@ export function OnboardingForm() {
           </div>
         )}
 
-        {step === 'org' ? (
+        {step === 'org' && (
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('orgName')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('orgName')}</label>
               <input
                 type="text"
                 value={orgName}
@@ -151,9 +252,7 @@ export function OnboardingForm() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('slug')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('slug')}</label>
               <input
                 type="text"
                 value={orgSlug}
@@ -161,9 +260,7 @@ export function OnboardingForm() {
                 placeholder={t('slugPlaceholder')}
                 className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               />
-              <p className="mt-1 text-xs text-gray-400">
-                sprintable.app/{orgSlug || '...'}
-              </p>
+              <p className="mt-1 text-xs text-gray-400">sprintable.app/{orgSlug || '...'}</p>
             </div>
             <button
               onClick={handleCreateOrg}
@@ -173,12 +270,12 @@ export function OnboardingForm() {
               {loading ? t('creating') : t('createOrg')}
             </button>
           </div>
-        ) : (
+        )}
+
+        {step === 'project' && (
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('projectName')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('projectName')}</label>
               <input
                 type="text"
                 value={projectName}
@@ -188,9 +285,7 @@ export function OnboardingForm() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('projectDesc')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('projectDesc')}</label>
               <textarea
                 value={projectDesc}
                 onChange={(e) => setProjectDesc(e.target.value)}
@@ -205,6 +300,95 @@ export function OnboardingForm() {
               className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
             >
               {loading ? t('creating') : t('createProjectAction')}
+            </button>
+          </div>
+        )}
+
+        {step === 'agent' && (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">{t('agentName')}</label>
+              <input
+                type="text"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder={t('agentNamePlaceholder')}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">{t('agentRole')}</label>
+              <select
+                value={agentRole}
+                onChange={(e) => setAgentRole(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {AGENT_ROLES.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleCreateAgent}
+              disabled={!agentName.trim() || loading}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? t('creating') : t('createAgentAction')}
+            </button>
+            <button
+              onClick={handleFinish}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
+            >
+              {t('skip')}
+            </button>
+          </div>
+        )}
+
+        {step === 'connect' && (
+          <div className="space-y-4">
+            {newApiKey ? (
+              <>
+                <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs font-semibold text-gray-700">{t('mcpConfigTitle')}</p>
+                    <button
+                      onClick={() => void handleCopy(buildMcpConfig(newApiKey), 'mcp')}
+                      className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
+                    >
+                      {copied === 'mcp' ? '✓ Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <pre className="overflow-x-auto rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
+                    {buildMcpConfig(newApiKey)}
+                  </pre>
+                </div>
+              </>
+            ) : (
+              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+                API Key 발급에 실패했습니다. Settings → API Keys에서 수동으로 발급하세요.
+              </div>
+            )}
+
+            <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-gray-700">{t('promptTitle')}</p>
+                <button
+                  onClick={() => void handleCopy(LLMS_PROMPT, 'prompt')}
+                  className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
+                >
+                  {copied === 'prompt' ? '✓ Copied' : 'Copy'}
+                </button>
+              </div>
+              <p className="break-all rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
+                {LLMS_PROMPT}
+              </p>
+            </div>
+
+            <button
+              onClick={handleFinish}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              {t('finish')}
             </button>
           </div>
         )}


### PR DESCRIPTION
## 스토리
- ID: `cd2090dd` — E-ONBOARD-AGENT
- SP: 5

## 변경 요약
- `onboarding-form.tsx` 2스텝 → 4스텝 확장 (+212/-25)
- `ko.json` / `en.json` 온보딩 i18n 키 추가

## 구현 내용
### 진행 표시 바
- `STEPS: ['org', 'project', 'agent', 'connect']`
- 1/4 ~ 4/4 텍스트 + 블루 프로그레스 바

### Step 3: AI 에이전트 추가
- agent 이름 입력 (기본: "My Agent")
- 역할 select (developer/designer/pm/qa/devops, 기본: developer)
- 생성: `POST /api/team-members` (type: 'agent')
- API Key 자동 발급: `POST /api/agents/{id}/api-key`
- Skip 버튼 → 대시보드

### Step 4: 에이전트 연결
- MCP Config JSON Copy 버튼 (2초 후 "✓ Copied" → 원복)
- llms.txt 프롬프트 Copy 버튼
- API Key 발급 실패 시 안내 메시지
- 완료 → 대시보드

## AC 체크
- [x] AC1: 3-4단계 추가 + 진행 표시 바
- [x] AC2: Step 3 — agent 생성 + API 키 자동 발급
- [x] AC3: Step 4 — MCP config + llms.txt 복사
- [x] AC4: Skip 버튼 → 대시보드
- [x] AC5: 기존 Step 1-2 동작 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)