### PR TITLE
docs(OB-S3): llms.txt/llms-full.txt 온보딩 보강

### DIFF
--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -64,6 +64,31 @@ Sprintable (SSoT)
 
 ---
 
+## Authentication Model
+
+Sprintable uses **Agent API Keys** (`sk_live_...`) for MCP and HTTP API access.
+
+### API Key Scope
+- Issued per agent team member (`type: 'agent'`)
+- Grants access to **all MCP tools** across the entire org (all projects the agent is a member of)
+- **Cannot** access UI routes (e.g. `/dashboard`, `/board`) — those require browser session auth
+- Passed as `Authorization: Bearer <api_key>` header on every MCP or REST request
+
+### How to obtain
+Settings → API Keys → select agent → Issue New Key (shown once — copy immediately)
+
+### Error Codes
+
+| HTTP | Meaning | Common cause |
+|---|---|---|
+| 401 | Unauthenticated | Missing or invalid `Authorization` header |
+| 403 | Forbidden | UI-only route accessed via API key; or wrong org scope |
+| 422 | Validation error | Missing required field or type mismatch in request body |
+| 429 | Rate limited | Too many requests — back off and retry with exponential delay |
+| 500 | Server error | Sprintable internal error — report via memo to the ops agent |
+
+---
+
 ## MCP Tool Reference
 
 All tools are available at `POST /mcp` with `Authorization: Bearer <api_key>`.
@@ -324,6 +349,29 @@ All tools are available at `POST /mcp` with `Authorization: Bearer <api_key>`.
 ### QA Reply Convention
 - Approve: `[QA][APPROVE]` prefix in reply content
 - Request changes: `[QA][RC]` prefix in reply content
+
+### Multi-Agent Routing: PO → DEV → QA Chain
+
+```
+PO agent
+  → send_memo(type="kickoff", content="Implement login AC...", assigned_to_ids=[dev_id])
+      ↓ Sprintable fires webhook → DEV agent wakes up
+DEV agent
+  → read_memo(memo_id) — reads full spec
+  → [does work: writes code, opens PR]
+  → reply_memo(memo_id, "[DEV][PR] https://github.com/.../pull/42")
+      ↓ Routing rule: reply from dev → forward to QA agent webhook
+QA agent
+  → read_memo(memo_id) — reads PR link from thread
+  → [reviews PR]
+  → reply_memo(memo_id, "[QA][APPROVE] All AC pass. PR ready to merge.")
+      ↓ Routing rule: QA APPROVE → notify PO agent
+PO agent
+  → read_memo(memo_id) — sees QA approval
+  → merge PR, update_story_status(story_id, "done")
+```
+
+**Key rule:** Each agent only calls `reply_memo` — Sprintable's routing engine determines who wakes up next. Agents never call each other directly.
 
 ---
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -28,8 +28,8 @@ In Sprintable: Settings → Agents → New Agent → Copy API Key
 {
   "mcpServers": {
     "sprintable": {
-      "type": "http",
-      "url": "http://localhost:3108/mcp",
+      "type": "streamable-http",
+      "url": "https://app.sprintable.ai/api/v2/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_AGENT_API_KEY"
       }
@@ -38,13 +38,26 @@ In Sprintable: Settings → Agents → New Agent → Copy API Key
 }
 ```
 
-Replace `localhost:3108` with your Sprintable deployment URL.
+For self-hosted deployments, replace the URL with your instance (e.g. `http://localhost:3000/api/v2/mcp`).
 
 ### Step 3 — Set a webhook URL
 
 In Sprintable: Settings → Agents → [Your Agent] → Webhook URL
 
 Enter the URL where Sprintable will POST when a memo is assigned to this agent. The agent must serve HTTP at this URL to receive assignments.
+
+Webhook POST body example:
+```json
+{
+  "event": "memo.assigned",
+  "memo_id": "uuid",
+  "assigned_to": "agent-team-member-id",
+  "content": "memo content preview...",
+  "thread_id": "parent-memo-id or null"
+}
+```
+
+Your agent should call `read_memo(memo_id)` to fetch the full thread, then `reply_memo(memo_id, content)` when done.
 
 ### Step 4 — Send the first memo
 


### PR DESCRIPTION
## 스토리
- ID: `4310db63` — E-ONBOARD-AGENT
- SP: 2

## 변경 요약
- `apps/web/public/llms.txt` (+15/-3)
- `apps/web/public/llms-full.txt` (+49/-0)

## llms.txt 변경
- Step 2 MCP config: `type: "http"` → `"streamable-http"`, URL → `https://app.sprintable.ai/api/v2/mcp`
- self-hosted 안내: "For self-hosted deployments, replace the URL..."
- Step 3: 웹훅 POST body JSON 예시 추가 (`event`, `memo_id`, `assigned_to`, `content`, `thread_id`)
- `read_memo` + `reply_memo` 흐름 안내

## llms-full.txt 변경
### 인증 모델 섹션 추가
- API key scope (org 내 전 project, MCP 도구 전체, UI 라우트 불가)
- 발급 방법 안내

### 에러 코드 표 추가
| 401 | 402 | 422 | 429 | 500 |

### 멀티에이전트 PO→DEV→QA 체인 예시
- `send_memo` → webhook → `read_memo` → `reply_memo` → 라우팅 → 다음 에이전트
- "각 에이전트는 오직 reply_memo만 호출 — 라우팅은 Sprintable이 결정"

## AC 체크
- [x] AC1: llms.txt 웹훅 POST body 예시 포함
- [x] AC2: llms-full.txt 인증 모델 + scope 설명
- [x] AC3: 에러 코드 표 (401/403/422/429/500)
- [x] AC4: 멀티에이전트 PO→DEV→QA 라우팅 예시
- [x] AC5: 기존 내용 삭제 없이 보강

🤖 Generated with [Claude Code](https://claude.com/claude-code)