### PR TITLE
feat(OB-S5): 대시보드 Empty State CTA + 에이전트 미연결 배너

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -100,7 +100,13 @@
     "blocked": "Blocked",
     "openStories": "Open Stories",
     "assignedToMe": "Assigned to Me",
-    "noAssignedStories": "No assigned stories"
+    "noAssignedStories": "No assigned stories",
+    "startSprint": "Start a sprint",
+    "writeMemo": "Write first memo",
+    "viewBoard": "View board",
+    "writeDocs": "Write a doc",
+    "noAgentBanner": "Connect an AI agent to delegate more work automatically",
+    "noAgentBannerCta": "Connect agent"
   },
   "board": {
     "title": "Kanban Board",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -100,7 +100,13 @@
     "blocked": "차단됨",
     "openStories": "전체 열림",
     "assignedToMe": "나에게 할당됨",
-    "noAssignedStories": "할당된 스토리가 없습니다"
+    "noAssignedStories": "할당된 스토리가 없습니다",
+    "startSprint": "스프린트 시작하기",
+    "writeMemo": "첫 메모 작성",
+    "viewBoard": "보드 보기",
+    "writeDocs": "문서 작성",
+    "noAgentBanner": "AI 에이전트를 연결하면 더 많은 일을 위임할 수 있어요",
+    "noAgentBannerCta": "에이전트 연결"
   },
   "board": {
     "title": "칸반 보드",

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -34,6 +34,13 @@ export default async function DashboardPage() {
   const projectId = me.project_id;
   const teamMemberId = me.id;
 
+  // Agent connection banner: check if any active agent exists
+  const agentsData = await fastapiCall<Array<{ id: string; is_active: boolean; type: string }>>(
+    'GET', '/api/v2/members', session.access_token,
+    { query: { project_id: projectId, member_type: 'agent' } },
+  ).catch(() => null);
+  const hasActiveAgent = (agentsData ?? []).some((a) => a.is_active);
+
   interface DashboardData {
     my_stories: Array<{ id: string; title: string; status: string; story_points: number | null }>;
     my_tasks: Array<{ id: string; title: string; status: string }>;
@@ -73,6 +80,16 @@ export default async function DashboardPage() {
             </div>
           }
         />
+
+        {/* Agent connection banner — shown only when no active agents */}
+        {!hasActiveAgent && (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-950">
+            <p className="text-sm text-blue-900 dark:text-blue-100">{t('noAgentBanner')}</p>
+            <Button asChild size="sm" variant="outline" className="shrink-0 border-blue-300 text-blue-800 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-200 dark:hover:bg-blue-900">
+              <Link href="/settings?tab=api-keys">{t('noAgentBannerCta')}</Link>
+            </Button>
+          </div>
+        )}
 
         <div className="grid gap-4 md:grid-cols-3">
           <SectionCard className="col-span-full">
@@ -142,9 +159,10 @@ export default async function DashboardPage() {
                   </div>
                 </div>
               ) : (
-                <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-center">
-                  <div className="text-sm text-muted-foreground">{t('noAssignedStories')}</div>
-                </div>
+                <EmptyState
+                  title={t('noAssignedStories')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/board">{t('viewBoard')}</Link></Button>}
+                />
               )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
@@ -163,7 +181,13 @@ export default async function DashboardPage() {
                   <div className="mt-1 text-xs text-muted-foreground">{formatLocaleDateOnly(s.start_date, locale)} ~ {formatLocaleDateOnly(s.end_date, locale)}</div>
                   <div className="mt-2"><StatusBadge status={s.status} label={getSprintStatusLabel(s.status)} /></div>
                 </Link>
-              )) : <EmptyState title={t('noActiveSprints')} description={t('noActiveSprintsDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noActiveSprints')}
+                  description={t('noActiveSprintsDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/sprints">{t('startSprint')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
@@ -176,7 +200,13 @@ export default async function DashboardPage() {
                   <div className="font-medium text-foreground">{doc.title}</div>
                   <div className="text-xs text-muted-foreground">/{doc.slug}</div>
                 </div>
-              )) : <EmptyState title={t('noDocsYet')} description={t('noDocsYetDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noDocsYet')}
+                  description={t('noDocsYetDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/docs">{t('writeDocs')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
@@ -207,7 +237,13 @@ export default async function DashboardPage() {
                   <div className="font-medium text-foreground">{memo.title ?? memo.content.slice(0, 60)}</div>
                   <div className="text-xs text-muted-foreground">{formatLocaleDateTime(memo.created_at, locale)}</div>
                 </div>
-              )) : <EmptyState title={t('noOpenMemos')} description={t('noOpenMemosDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noOpenMemos')}
+                  description={t('noOpenMemosDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/memos">{t('writeMemo')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>


### PR DESCRIPTION
## 스토리
- ID: `08be6b28` — E-ONBOARD-AGENT (마지막 스토리)
- SP: 3

## 변경 요약
- `dashboard/page.tsx` (+48/-8)
- `ko.json` / `en.json` (+6 keys each)

## 구현 내용

### 에이전트 미연결 배너
- `GET /api/v2/members?project_id=...&member_type=agent` 서버 조회
- active agent 0명 → 블루 배너 표시: "AI 에이전트를 연결하면 더 많은 일을 위임할 수 있어요"
- CTA: "에이전트 연결" → `/settings?tab=api-keys`
- active agent 1명 이상 → 배너 미표시 (AC4)

### EmptyState CTA 버튼 (기존 `action` prop 활용)
| 섹션 | CTA | 링크 |
|---|---|---|
| No active sprints | 스프린트 시작하기 | /sprints |
| No assigned stories | 보드 보기 | /board |
| No docs yet | 문서 작성 | /docs |
| No open memos | 첫 메모 작성 | /memos |

## AC 체크
- [x] AC1: 대시보드 빈 섹션에 액션 버튼 표시
- [x] AC2: 각 버튼 클릭 시 해당 페이지로 이동
- [x] AC3: 에이전트 미연결 시 상단 안내 배너 표시
- [x] AC4: 에이전트 연결 후 배너 미표시
- [x] AC5: 기존 EmptyState `action` prop 활용 (인터페이스 변경 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)