### PR TITLE
E-ONBOARD-AGENT: 에이전트 연결 중심 온보딩 (14SP)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -304,7 +304,21 @@
     "createProjectAction": "Create Project",
     "projectDescPlaceholder": "Project description...",
     "createProjectFailed": "Failed to create project",
-    "unknownUser": "Unknown"
+    "unknownUser": "Unknown",
+    "createAgent": "Add AI Agent",
+    "agentSubtitle": "Connect an AI agent to automatically manage sprints, memos, and standups.",
+    "agentName": "Agent Name",
+    "agentNamePlaceholder": "e.g. My Agent",
+    "agentRole": "Role",
+    "createAgentAction": "Create Agent + Issue API Key",
+    "connectAgent": "Connect Agent",
+    "connectSubtitle": "Paste the MCP config below into your agent settings.",
+    "mcpConfigTitle": "MCP Config",
+    "promptTitle": "Onboarding Prompt",
+    "finish": "Finish → Dashboard",
+    "skip": "Skip",
+    "stepOf": "{current} / {total}",
+    "createOrgFailed": "Failed to create organization"
   },
   "settings": {
     "title": "Settings",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -100,7 +100,13 @@
     "blocked": "Blocked",
     "openStories": "Open Stories",
     "assignedToMe": "Assigned to Me",
-    "noAssignedStories": "No assigned stories"
+    "noAssignedStories": "No assigned stories",
+    "startSprint": "Start a sprint",
+    "writeMemo": "Write first memo",
+    "viewBoard": "View board",
+    "writeDocs": "Write a doc",
+    "noAgentBanner": "Connect an AI agent to delegate more work automatically",
+    "noAgentBannerCta": "Connect agent"
   },
   "board": {
     "title": "Kanban Board",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -100,7 +100,13 @@
     "blocked": "차단됨",
     "openStories": "전체 열림",
     "assignedToMe": "나에게 할당됨",
-    "noAssignedStories": "할당된 스토리가 없습니다"
+    "noAssignedStories": "할당된 스토리가 없습니다",
+    "startSprint": "스프린트 시작하기",
+    "writeMemo": "첫 메모 작성",
+    "viewBoard": "보드 보기",
+    "writeDocs": "문서 작성",
+    "noAgentBanner": "AI 에이전트를 연결하면 더 많은 일을 위임할 수 있어요",
+    "noAgentBannerCta": "에이전트 연결"
   },
   "board": {
     "title": "칸반 보드",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -304,7 +304,21 @@
     "createProjectAction": "프로젝트 만들기",
     "projectDescPlaceholder": "프로젝트 설명...",
     "createProjectFailed": "프로젝트 생성에 실패했습니다",
-    "unknownUser": "알 수 없음"
+    "unknownUser": "알 수 없음",
+    "createAgent": "AI 에이전트 추가",
+    "agentSubtitle": "AI 에이전트를 프로젝트에 연결하면 스프린트, 메모, 스탠드업을 자동으로 관리합니다.",
+    "agentName": "에이전트 이름",
+    "agentNamePlaceholder": "예: My Agent",
+    "agentRole": "역할",
+    "createAgentAction": "에이전트 생성 + API 키 발급",
+    "connectAgent": "에이전트 연결",
+    "connectSubtitle": "아래 MCP config를 에이전트 설정에 붙여넣으세요.",
+    "mcpConfigTitle": "MCP Config",
+    "promptTitle": "온보딩 프롬프트",
+    "finish": "완료 → 대시보드",
+    "skip": "건너뛰기",
+    "stepOf": "{current} / {total}",
+    "createOrgFailed": "조직 생성에 실패했습니다"
   },
   "settings": {
     "title": "설정",

--- a/apps/web/public/llms-baos.txt
+++ b/apps/web/public/llms-baos.txt
@@ -1,0 +1,146 @@
+# Sprintable for 장사왕 (BAOS)
+
+Commerce AI Agent Integration Guide.
+
+장사왕(BAOS) is a commerce automation AI. This guide explains how to connect BAOS to Sprintable so it can receive work via memo delegation and report back through the memo thread.
+
+---
+
+## Connect BAOS in 4 Steps
+
+### Step 1 — Get an API key
+
+In Sprintable: Settings → API Keys → New Agent (name: "BAOS" or "장사왕") → Copy API Key
+
+### Step 2 — Add the MCP server to your BAOS agent config
+
+```json
+{
+  "mcpServers": {
+    "sprintable": {
+      "type": "streamable-http",
+      "url": "https://app.sprintable.ai/api/v2/mcp",
+      "headers": {
+        "Authorization": "Bearer YOUR_AGENT_API_KEY"
+      }
+    }
+  }
+}
+```
+
+For self-hosted: replace the URL with your Sprintable instance (e.g. `http://localhost:3000/api/v2/mcp`).
+
+### Step 3 — Set a webhook URL
+
+In Sprintable: Settings → API Keys → [BAOS agent] → Webhook URL
+
+Sprintable will POST to this URL whenever a memo is assigned to BAOS.
+
+Webhook POST body:
+```json
+{
+  "event": "memo.assigned",
+  "memo_id": "uuid",
+  "assigned_to": "baos-team-member-id",
+  "content": "memo content preview...",
+  "thread_id": "parent-memo-id or null"
+}
+```
+
+BAOS should call `read_memo(memo_id)` for the full thread, complete the task, then `reply_memo(memo_id, content)`.
+
+### Step 4 — Send the first memo
+
+Assign a memo to BAOS from the Sprintable UI, or via MCP:
+
+```
+send_memo(
+  content="오늘 매출 리포트 작성해줘",
+  assigned_to_ids=["<baos-team-member-id>"]
+)
+```
+
+---
+
+## MCP Tools for BAOS
+
+BAOS uses Sprintable's standard MCP tools. Key tools for commerce workflows:
+
+### Memo (delegation core)
+- `send_memo` — assign work to BAOS or another agent
+- `reply_memo` — report results back (triggers next agent if routing rules set)
+- `read_memo` — read full memo thread with context
+- `list_my_memos` — BAOS's open assignments
+
+### Story / Kanban (task tracking)
+- `add_story` — create a story for a commerce task (e.g. "재고 발주 처리")
+- `update_story_status` — move story: `todo` → `in_progress` → `done`
+- `list_stories` — query stories by sprint, status, or assignee
+- `my_dashboard` — BAOS's assigned stories, tasks, and open memos
+
+### Docs (report storage)
+- `create_doc` — save a generated report as a Sprintable doc
+- `update_doc` — append data to an existing report doc
+- `get_doc` — retrieve report content
+
+### Standup (daily summary)
+- `save_standup` — post daily commerce summary (done, plan, blockers)
+- `get_standup` — read today's standup for any member
+
+---
+
+## BAOS Domain Workflow Examples
+
+### Example 1 — 일일 매출 리포트 자동 작성
+
+```
+[Scheduler / PO agent, every morning]
+  → send_memo(
+      content="어제 매출 집계 후 리포트 작성해줘. 전일 대비 증감, 채널별 분류 포함.",
+      assigned_to_ids=[baos_id]
+    )
+
+[BAOS agent wakes up via webhook]
+  → read_memo(memo_id)                     # read full spec
+  → [fetches sales data from commerce API]
+  → create_doc(title="2026-05-05 매출 리포트", content="...")   # save report
+  → reply_memo(memo_id,
+      "[BAOS] 리포트 작성 완료.\n총 매출: 12,430,000원 (+8.3% vs 전일)\n채널: 스마트스토어 62%, 쿠팡 28%, 기타 10%\n문서: /docs?id=..."
+    )
+
+[Routing rule → notifies PO agent]
+```
+
+### Example 2 — 재고 부족 감지 → 발주 메모 생성
+
+```
+[BAOS agent, triggered by inventory monitor]
+  → [detects stock level < threshold for SKU-001]
+  → add_story(title="SKU-001 발주 처리", project_id=..., story_points=1)
+  → send_memo(
+      content="SKU-001 재고 부족 (현재 12개, 기준 50개). 공급업체 발주 필요.",
+      assigned_to_ids=[ops_agent_id],
+      memo_type="memo"
+    )
+  → save_standup(done="재고 모니터링 완료", blockers="SKU-001 발주 대기")
+```
+
+---
+
+## Multi-Agent Chain with BAOS
+
+```
+PO agent
+  → send_memo("오늘 프로모션 결과 분석 요청", assigned_to=[baos_id])
+      ↓ webhook → BAOS wakes up
+BAOS
+  → read_memo → fetch data → create_doc (analysis report)
+  → reply_memo("[BAOS] 분석 완료. 전환율 3.2%, 매출 기여 18%. 상세: /docs?id=...")
+      ↓ routing rule → PO agent notified
+PO agent
+  → reads report, decides next action
+```
+
+---
+
+Full Sprintable MCP reference: https://app.sprintable.ai/llms-full.txt

--- a/apps/web/public/llms-full.txt
+++ b/apps/web/public/llms-full.txt
@@ -64,6 +64,31 @@ Sprintable (SSoT)
 
 ---
 
+## Authentication Model
+
+Sprintable uses **Agent API Keys** (`sk_live_...`) for MCP and HTTP API access.
+
+### API Key Scope
+- Issued per agent team member (`type: 'agent'`)
+- Grants access to **all MCP tools** across the entire org (all projects the agent is a member of)
+- **Cannot** access UI routes (e.g. `/dashboard`, `/board`) — those require browser session auth
+- Passed as `Authorization: Bearer <api_key>` header on every MCP or REST request
+
+### How to obtain
+Settings → API Keys → select agent → Issue New Key (shown once — copy immediately)
+
+### Error Codes
+
+| HTTP | Meaning | Common cause |
+|---|---|---|
+| 401 | Unauthenticated | Missing or invalid `Authorization` header |
+| 403 | Forbidden | UI-only route accessed via API key; or wrong org scope |
+| 422 | Validation error | Missing required field or type mismatch in request body |
+| 429 | Rate limited | Too many requests — back off and retry with exponential delay |
+| 500 | Server error | Sprintable internal error — report via memo to the ops agent |
+
+---
+
 ## MCP Tool Reference
 
 All tools are available at `POST /mcp` with `Authorization: Bearer <api_key>`.
@@ -324,6 +349,29 @@ All tools are available at `POST /mcp` with `Authorization: Bearer <api_key>`.
 ### QA Reply Convention
 - Approve: `[QA][APPROVE]` prefix in reply content
 - Request changes: `[QA][RC]` prefix in reply content
+
+### Multi-Agent Routing: PO → DEV → QA Chain
+
+```
+PO agent
+  → send_memo(type="kickoff", content="Implement login AC...", assigned_to_ids=[dev_id])
+      ↓ Sprintable fires webhook → DEV agent wakes up
+DEV agent
+  → read_memo(memo_id) — reads full spec
+  → [does work: writes code, opens PR]
+  → reply_memo(memo_id, "[DEV][PR] https://github.com/.../pull/42")
+      ↓ Routing rule: reply from dev → forward to QA agent webhook
+QA agent
+  → read_memo(memo_id) — reads PR link from thread
+  → [reviews PR]
+  → reply_memo(memo_id, "[QA][APPROVE] All AC pass. PR ready to merge.")
+      ↓ Routing rule: QA APPROVE → notify PO agent
+PO agent
+  → read_memo(memo_id) — sees QA approval
+  → merge PR, update_story_status(story_id, "done")
+```
+
+**Key rule:** Each agent only calls `reply_memo` — Sprintable's routing engine determines who wakes up next. Agents never call each other directly.
 
 ---
 

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -28,8 +28,8 @@ In Sprintable: Settings → Agents → New Agent → Copy API Key
 {
   "mcpServers": {
     "sprintable": {
-      "type": "http",
-      "url": "http://localhost:3108/mcp",
+      "type": "streamable-http",
+      "url": "https://app.sprintable.ai/api/v2/mcp",
       "headers": {
         "Authorization": "Bearer YOUR_AGENT_API_KEY"
       }
@@ -38,13 +38,26 @@ In Sprintable: Settings → Agents → New Agent → Copy API Key
 }
 ```
 
-Replace `localhost:3108` with your Sprintable deployment URL.
+For self-hosted deployments, replace the URL with your instance (e.g. `http://localhost:3000/api/v2/mcp`).
 
 ### Step 3 — Set a webhook URL
 
 In Sprintable: Settings → Agents → [Your Agent] → Webhook URL
 
 Enter the URL where Sprintable will POST when a memo is assigned to this agent. The agent must serve HTTP at this URL to receive assignments.
+
+Webhook POST body example:
+```json
+{
+  "event": "memo.assigned",
+  "memo_id": "uuid",
+  "assigned_to": "agent-team-member-id",
+  "content": "memo content preview...",
+  "thread_id": "parent-memo-id or null"
+}
+```
+
+Your agent should call `read_memo(memo_id)` to fetch the full thread, then `reply_memo(memo_id, content)` when done.
 
 ### Step 4 — Send the first memo
 

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -34,6 +34,13 @@ export default async function DashboardPage() {
   const projectId = me.project_id;
   const teamMemberId = me.id;
 
+  // Agent connection banner: check if any active agent exists
+  const agentsData = await fastapiCall<Array<{ id: string; is_active: boolean; type: string }>>(
+    'GET', '/api/v2/members', session.access_token,
+    { query: { project_id: projectId, member_type: 'agent' } },
+  ).catch(() => null);
+  const hasActiveAgent = (agentsData ?? []).some((a) => a.is_active);
+
   interface DashboardData {
     my_stories: Array<{ id: string; title: string; status: string; story_points: number | null }>;
     my_tasks: Array<{ id: string; title: string; status: string }>;
@@ -73,6 +80,16 @@ export default async function DashboardPage() {
             </div>
           }
         />
+
+        {/* Agent connection banner — shown only when no active agents */}
+        {!hasActiveAgent && (
+          <div className="flex items-center justify-between gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-950">
+            <p className="text-sm text-blue-900 dark:text-blue-100">{t('noAgentBanner')}</p>
+            <Button asChild size="sm" variant="outline" className="shrink-0 border-blue-300 text-blue-800 hover:bg-blue-100 dark:border-blue-700 dark:text-blue-200 dark:hover:bg-blue-900">
+              <Link href="/settings?tab=api-keys">{t('noAgentBannerCta')}</Link>
+            </Button>
+          </div>
+        )}
 
         <div className="grid gap-4 md:grid-cols-3">
           <SectionCard className="col-span-full">
@@ -142,9 +159,10 @@ export default async function DashboardPage() {
                   </div>
                 </div>
               ) : (
-                <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-center">
-                  <div className="text-sm text-muted-foreground">{t('noAssignedStories')}</div>
-                </div>
+                <EmptyState
+                  title={t('noAssignedStories')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/board">{t('viewBoard')}</Link></Button>}
+                />
               )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
@@ -163,7 +181,13 @@ export default async function DashboardPage() {
                   <div className="mt-1 text-xs text-muted-foreground">{formatLocaleDateOnly(s.start_date, locale)} ~ {formatLocaleDateOnly(s.end_date, locale)}</div>
                   <div className="mt-2"><StatusBadge status={s.status} label={getSprintStatusLabel(s.status)} /></div>
                 </Link>
-              )) : <EmptyState title={t('noActiveSprints')} description={t('noActiveSprintsDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noActiveSprints')}
+                  description={t('noActiveSprintsDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/sprints">{t('startSprint')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
@@ -176,7 +200,13 @@ export default async function DashboardPage() {
                   <div className="font-medium text-foreground">{doc.title}</div>
                   <div className="text-xs text-muted-foreground">/{doc.slug}</div>
                 </div>
-              )) : <EmptyState title={t('noDocsYet')} description={t('noDocsYetDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noDocsYet')}
+                  description={t('noDocsYetDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/docs">{t('writeDocs')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
@@ -207,7 +237,13 @@ export default async function DashboardPage() {
                   <div className="font-medium text-foreground">{memo.title ?? memo.content.slice(0, 60)}</div>
                   <div className="text-xs text-muted-foreground">{formatLocaleDateTime(memo.created_at, locale)}</div>
                 </div>
-              )) : <EmptyState title={t('noOpenMemos')} description={t('noOpenMemosDescription')} />}
+              )) : (
+                <EmptyState
+                  title={t('noOpenMemos')}
+                  description={t('noOpenMemosDescription')}
+                  action={<Button asChild size="sm" variant="outline"><Link href="/memos">{t('writeMemo')}</Link></Button>}
+                />
+              )}
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -5,7 +5,28 @@ import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
-type Step = 'org' | 'project';
+const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
+const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
+
+function buildMcpConfig(apiKey: string) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        sprintable: {
+          type: 'streamable-http',
+          url: MCP_SERVER_URL,
+          headers: { Authorization: `Bearer ${apiKey}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+type Step = 'org' | 'project' | 'agent' | 'connect';
+const STEPS: Step[] = ['org', 'project', 'agent', 'connect'];
 
 export function OnboardingForm() {
   const router = useRouter();
@@ -17,10 +38,17 @@ export function OnboardingForm() {
   const [projectName, setProjectName] = useState('');
   const [projectDesc, setProjectDesc] = useState('');
   const [orgId, setOrgId] = useState<string | null>(null);
+  const [projectId, setProjectId] = useState<string | null>(null);
+  const [agentName, setAgentName] = useState('My Agent');
+  const [agentRole, setAgentRole] = useState('developer');
+  const [newApiKey, setNewApiKey] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [showUpgrade, setShowUpgrade] = useState(false);
   const [upgradeReason, setUpgradeReason] = useState('');
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const stepIndex = STEPS.indexOf(step);
 
   const handleOrgNameChange = (name: string) => {
     setOrgName(name);
@@ -31,6 +59,16 @@ export function OnboardingForm() {
         .replace(/\s+/g, '-')
         .slice(0, 50),
     );
+  };
+
+  const handleCopy = async (text: string, key: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(key);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      // ignore
+    }
   };
 
   const handleCreateOrg = async () => {
@@ -61,7 +99,6 @@ export function OnboardingForm() {
     setLoading(true);
     setError('');
 
-    // 서버 API 경유 프로젝트 생성 (Feature Gating: max_projects 서버 enforcement)
     const res = await fetch('/api/projects', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -88,6 +125,8 @@ export function OnboardingForm() {
       return;
     }
 
+    setProjectId(project.id);
+
     // team_member 자동 생성 (type=human)
     const meRes = await fetch('/api/me');
     if (meRes.ok) {
@@ -112,6 +151,53 @@ export function OnboardingForm() {
       body: JSON.stringify({ project_id: project.id }),
     }).catch(() => null);
 
+    setStep('agent');
+    setLoading(false);
+  };
+
+  const handleCreateAgent = async () => {
+    if (!agentName.trim() || !projectId || !orgId) return;
+    setLoading(true);
+    setError('');
+
+    // 에이전트 팀원 생성
+    const memberRes = await fetch('/api/team-members', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        org_id: orgId,
+        project_id: projectId,
+        type: 'agent',
+        name: agentName.trim(),
+        role: agentRole,
+      }),
+    });
+    const memberJson = await memberRes.json() as { data?: { id: string }; error?: { message?: string } };
+    if (!memberRes.ok) {
+      setError(memberJson?.error?.message ?? 'Failed to create agent');
+      setLoading(false);
+      return;
+    }
+
+    const agentId = memberJson.data?.id;
+    if (!agentId) {
+      setError('Failed to create agent');
+      setLoading(false);
+      return;
+    }
+
+    // API 키 자동 발급
+    const keyRes = await fetch(`/api/agents/${agentId}/api-key`, { method: 'POST' });
+    const keyJson = await keyRes.json() as { data?: { api_key: string } };
+    if (keyRes.ok && keyJson.data?.api_key) {
+      setNewApiKey(keyJson.data.api_key);
+    }
+
+    setStep('connect');
+    setLoading(false);
+  };
+
+  const handleFinish = () => {
     router.push('/dashboard');
     router.refresh();
   };
@@ -119,14 +205,31 @@ export function OnboardingForm() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
       <div className="w-full max-w-md space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        {/* Progress bar */}
+        <div className="space-y-1">
+          <div className="flex justify-between text-xs text-gray-400">
+            <span>{t('stepOf', { current: stepIndex + 1, total: STEPS.length })}</span>
+          </div>
+          <div className="h-1.5 w-full rounded-full bg-gray-100">
+            <div
+              className="h-1.5 rounded-full bg-blue-600 transition-all duration-300"
+              style={{ width: `${((stepIndex + 1) / STEPS.length) * 100}%` }}
+            />
+          </div>
+        </div>
+
         <div className="text-center">
           <h1 className="text-2xl font-bold text-gray-900">
-            {step === 'org' ? t('createOrg') : t('createProject')}
+            {step === 'org' && t('createOrg')}
+            {step === 'project' && t('createProject')}
+            {step === 'agent' && t('createAgent')}
+            {step === 'connect' && t('connectAgent')}
           </h1>
           <p className="mt-2 text-sm text-gray-500">
-            {step === 'org'
-              ? t('welcome')
-              : t('projectSubtitle', { orgName })}
+            {step === 'org' && t('welcome')}
+            {step === 'project' && t('projectSubtitle', { orgName })}
+            {step === 'agent' && t('agentSubtitle')}
+            {step === 'connect' && t('connectSubtitle')}
           </p>
         </div>
 
@@ -136,12 +239,10 @@ export function OnboardingForm() {
           </div>
         )}
 
-        {step === 'org' ? (
+        {step === 'org' && (
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('orgName')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('orgName')}</label>
               <input
                 type="text"
                 value={orgName}
@@ -151,9 +252,7 @@ export function OnboardingForm() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('slug')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('slug')}</label>
               <input
                 type="text"
                 value={orgSlug}
@@ -161,9 +260,7 @@ export function OnboardingForm() {
                 placeholder={t('slugPlaceholder')}
                 className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
               />
-              <p className="mt-1 text-xs text-gray-400">
-                sprintable.app/{orgSlug || '...'}
-              </p>
+              <p className="mt-1 text-xs text-gray-400">sprintable.app/{orgSlug || '...'}</p>
             </div>
             <button
               onClick={handleCreateOrg}
@@ -173,12 +270,12 @@ export function OnboardingForm() {
               {loading ? t('creating') : t('createOrg')}
             </button>
           </div>
-        ) : (
+        )}
+
+        {step === 'project' && (
           <div className="space-y-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('projectName')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('projectName')}</label>
               <input
                 type="text"
                 value={projectName}
@@ -188,9 +285,7 @@ export function OnboardingForm() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700">
-                {t('projectDesc')}
-              </label>
+              <label className="block text-sm font-medium text-gray-700">{t('projectDesc')}</label>
               <textarea
                 value={projectDesc}
                 onChange={(e) => setProjectDesc(e.target.value)}
@@ -205,6 +300,95 @@ export function OnboardingForm() {
               className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
             >
               {loading ? t('creating') : t('createProjectAction')}
+            </button>
+          </div>
+        )}
+
+        {step === 'agent' && (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700">{t('agentName')}</label>
+              <input
+                type="text"
+                value={agentName}
+                onChange={(e) => setAgentName(e.target.value)}
+                placeholder={t('agentNamePlaceholder')}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700">{t('agentRole')}</label>
+              <select
+                value={agentRole}
+                onChange={(e) => setAgentRole(e.target.value)}
+                className="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                {AGENT_ROLES.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </div>
+            <button
+              onClick={handleCreateAgent}
+              disabled={!agentName.trim() || loading}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? t('creating') : t('createAgentAction')}
+            </button>
+            <button
+              onClick={handleFinish}
+              className="w-full rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50"
+            >
+              {t('skip')}
+            </button>
+          </div>
+        )}
+
+        {step === 'connect' && (
+          <div className="space-y-4">
+            {newApiKey ? (
+              <>
+                <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="text-xs font-semibold text-gray-700">{t('mcpConfigTitle')}</p>
+                    <button
+                      onClick={() => void handleCopy(buildMcpConfig(newApiKey), 'mcp')}
+                      className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
+                    >
+                      {copied === 'mcp' ? '✓ Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <pre className="overflow-x-auto rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
+                    {buildMcpConfig(newApiKey)}
+                  </pre>
+                </div>
+              </>
+            ) : (
+              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+                API Key 발급에 실패했습니다. Settings → API Keys에서 수동으로 발급하세요.
+              </div>
+            )}
+
+            <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-xs font-semibold text-gray-700">{t('promptTitle')}</p>
+                <button
+                  onClick={() => void handleCopy(LLMS_PROMPT, 'prompt')}
+                  className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
+                >
+                  {copied === 'prompt' ? '✓ Copied' : 'Copy'}
+                </button>
+              </div>
+              <p className="break-all rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
+                {LLMS_PROMPT}
+              </p>
+            </div>
+
+            <button
+              onClick={handleFinish}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              {t('finish')}
             </button>
           </div>
         )}

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -6,6 +6,9 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
 
+const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
+
 interface AgentMember {
   id: string;
   name: string;
@@ -26,6 +29,51 @@ interface NewKeyResult {
   key_prefix: string;
   api_key: string;
   created_at: string;
+}
+
+function buildMcpConfig(apiKey: string) {
+  return JSON.stringify(
+    {
+      mcpServers: {
+        sprintable: {
+          type: 'streamable-http',
+          url: MCP_SERVER_URL,
+          headers: { Authorization: `Bearer ${apiKey}` },
+        },
+      },
+    },
+    null,
+    2,
+  );
+}
+
+function McpConfigBlock({
+  apiKey,
+  agentName,
+  onCopy,
+}: {
+  apiKey: string;
+  agentName: string;
+  onCopy: (text: string, label: string) => void;
+}) {
+  const config = buildMcpConfig(apiKey);
+
+  return (
+    <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <p className="text-xs font-semibold text-foreground">MCP Config — {agentName}</p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-6 text-xs"
+          onClick={() => onCopy(config, 'MCP Config')}
+        >
+          Copy
+        </Button>
+      </div>
+      <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-foreground/80">{config}</pre>
+    </div>
+  );
 }
 
 export function AgentApiKeysSection({ projectId }: { projectId: string }) {
@@ -104,103 +152,165 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
     }
   }, [newAgentName, projectId, fetchAgents, addToast]);
 
+  const handleCopy = useCallback(async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      addToast({ type: 'success', title: `${label} 복사됨` });
+    } catch {
+      addToast({ type: 'error', title: '복사 실패', body: '클립보드 접근 권한을 확인하세요.' });
+    }
+  }, [addToast]);
+
   if (loading) return <div className="text-sm text-muted-foreground">Loading...</div>;
 
   return (
-    <SectionCard>
-      <SectionCardHeader>
-        <div className="space-y-1">
-          <h2 className="text-base font-semibold">🔑 Agent API Keys</h2>
-          <p className="text-sm text-muted-foreground">에이전트 팀원의 API Key를 관리하는. MCP/HTTP API 전용 — UI 로그인 불가.</p>
-        </div>
-      </SectionCardHeader>
-      <SectionCardBody>
-        <div className="mb-6 flex gap-2">
-          <input
-            type="text"
-            value={newAgentName}
-            onChange={(e) => setNewAgentName(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') void handleAddAgent(); }}
-            placeholder="에이전트 이름"
-            className="flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-          />
-          <Button
-            size="sm"
-            variant="outline"
-            disabled={!newAgentName.trim() || adding}
-            onClick={() => void handleAddAgent()}
-          >
-            {adding ? '추가 중...' : '+ 에이전트 추가'}
-          </Button>
-        </div>
-        {agents.length === 0 && (
-          <p className="text-sm text-muted-foreground">No agent team members in this project.</p>
-        )}
-        {agents.map((agent) => (
-          <div key={agent.id} className="mb-6">
-            <div className="mb-2 flex items-center gap-2">
-              <span className="font-medium text-sm">{agent.name}</span>
-              <Badge variant={agent.is_active ? 'default' : 'secondary'}>
-                {agent.is_active ? 'active' : 'inactive'}
-              </Badge>
-            </div>
-
-            {newKey?.agentId === agent.id && (
-              <div className="mb-3 rounded-md border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-700 dark:bg-yellow-950">
-                <p className="mb-1 text-xs font-semibold text-yellow-800 dark:text-yellow-200">
-                  새 API Key — 지금만 표시됩니다. 복사해 두세요.
-                </p>
-                <code className="block break-all text-xs text-yellow-900 dark:text-yellow-100">
-                  {newKey.result.api_key}
-                </code>
-              </div>
-            )}
-
-            <div className="space-y-1">
-              {(keys[agent.id] ?? []).map((k) => (
-                <div key={k.id} className="flex items-center justify-between rounded border px-3 py-2 text-xs">
-                  <div className="flex items-center gap-3">
-                    <code className="font-mono">{k.key_prefix}…</code>
-                    <span className="text-muted-foreground">
-                      발급: {new Date(k.created_at).toLocaleDateString()}
-                    </span>
-                    {k.last_used_at && (
-                      <span className="text-muted-foreground">
-                        최근 사용: {new Date(k.last_used_at).toLocaleDateString()}
-                      </span>
-                    )}
-                    {k.revoked_at && <Badge variant="destructive">revoked</Badge>}
-                  </div>
-                  {!k.revoked_at && (
-                    <Button
-                      size="sm"
-                      variant="ghost"
-                      className="h-6 text-xs text-destructive hover:text-destructive"
-                      disabled={revoking === k.id}
-                      onClick={() => void handleRevoke(agent.id, k.id)}
-                    >
-                      {revoking === k.id ? 'Revoking...' : 'Revoke'}
-                    </Button>
-                  )}
-                </div>
-              ))}
-              {(keys[agent.id] ?? []).length === 0 && (
-                <p className="text-xs text-muted-foreground">발급된 API Key 없음.</p>
-              )}
-            </div>
-
+    <div className="space-y-4">
+      <SectionCard>
+        <SectionCardHeader>
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold">🔑 Agent API Keys</h2>
+            <p className="text-sm text-muted-foreground">에이전트 팀원의 API Key를 관리하는. MCP/HTTP API 전용 — UI 로그인 불가.</p>
+          </div>
+        </SectionCardHeader>
+        <SectionCardBody>
+          <div className="mb-6 flex gap-2">
+            <input
+              type="text"
+              value={newAgentName}
+              onChange={(e) => setNewAgentName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') void handleAddAgent(); }}
+              placeholder="에이전트 이름"
+              className="flex-1 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
             <Button
               size="sm"
               variant="outline"
-              className="mt-2"
-              disabled={issuing === agent.id}
-              onClick={() => void handleIssue(agent.id)}
+              disabled={!newAgentName.trim() || adding}
+              onClick={() => void handleAddAgent()}
             >
-              {issuing === agent.id ? 'Issuing...' : '+ 새 API Key 발급'}
+              {adding ? '추가 중...' : '+ 에이전트 추가'}
             </Button>
           </div>
-        ))}
-      </SectionCardBody>
-    </SectionCard>
+          {agents.length === 0 && (
+            <p className="text-sm text-muted-foreground">No agent team members in this project.</p>
+          )}
+          {agents.map((agent) => {
+            const agentKeys = keys[agent.id] ?? [];
+            const activeKeys = agentKeys.filter((k) => !k.revoked_at);
+            const freshKey = newKey?.agentId === agent.id ? newKey.result : null;
+
+            return (
+              <div key={agent.id} className="mb-6">
+                <div className="mb-2 flex items-center gap-2">
+                  <span className="font-medium text-sm">{agent.name}</span>
+                  <Badge variant={agent.is_active ? 'default' : 'secondary'}>
+                    {agent.is_active ? 'active' : 'inactive'}
+                  </Badge>
+                </div>
+
+                {freshKey ? (
+                  <div className="mb-3 rounded-md border border-yellow-300 bg-yellow-50 p-3 dark:border-yellow-700 dark:bg-yellow-950">
+                    <p className="mb-1 text-xs font-semibold text-yellow-800 dark:text-yellow-200">
+                      새 API Key — 지금만 표시됩니다. 복사해 두세요.
+                    </p>
+                    <code className="block break-all text-xs text-yellow-900 dark:text-yellow-100">
+                      {freshKey.api_key}
+                    </code>
+                  </div>
+                ) : null}
+
+                <div className="space-y-1">
+                  {agentKeys.map((k) => (
+                    <div key={k.id} className="flex items-center justify-between rounded border px-3 py-2 text-xs">
+                      <div className="flex items-center gap-3">
+                        <code className="font-mono">{k.key_prefix}…</code>
+                        <span className="text-muted-foreground">
+                          발급: {new Date(k.created_at).toLocaleDateString()}
+                        </span>
+                        {k.last_used_at && (
+                          <span className="text-muted-foreground">
+                            최근 사용: {new Date(k.last_used_at).toLocaleDateString()}
+                          </span>
+                        )}
+                        {k.revoked_at && <Badge variant="destructive">revoked</Badge>}
+                      </div>
+                      {!k.revoked_at && (
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          className="h-6 text-xs text-destructive hover:text-destructive"
+                          disabled={revoking === k.id}
+                          onClick={() => void handleRevoke(agent.id, k.id)}
+                        >
+                          {revoking === k.id ? 'Revoking...' : 'Revoke'}
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                  {agentKeys.length === 0 && (
+                    <p className="text-xs text-muted-foreground">발급된 API Key 없음.</p>
+                  )}
+                </div>
+
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="mt-2"
+                  disabled={issuing === agent.id}
+                  onClick={() => void handleIssue(agent.id)}
+                >
+                  {issuing === agent.id ? 'Issuing...' : '+ 새 API Key 발급'}
+                </Button>
+
+                {/* MCP Config block */}
+                {freshKey ? (
+                  <McpConfigBlock
+                    apiKey={freshKey.api_key}
+                    agentName={agent.name}
+                    onCopy={handleCopy}
+                  />
+                ) : activeKeys.length > 0 ? (
+                  <McpConfigBlock
+                    apiKey={`${activeKeys[0].key_prefix}...`}
+                    agentName={agent.name}
+                    onCopy={handleCopy}
+                  />
+                ) : (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    ⚠️ MCP Config를 사용하려면 먼저 API Key를 발급하세요.
+                  </p>
+                )}
+              </div>
+            );
+          })}
+        </SectionCardBody>
+      </SectionCard>
+
+      {/* Agent onboarding prompt */}
+      <SectionCard>
+        <SectionCardHeader>
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold">🤖 에이전트 온보딩 프롬프트</h2>
+            <p className="text-sm text-muted-foreground">에이전트에게 아래 문구를 전달하면 Sprintable 사용법을 자동으로 학습합니다.</p>
+          </div>
+        </SectionCardHeader>
+        <SectionCardBody>
+          <div className="rounded-md border border-border bg-muted/20 p-3 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs font-semibold text-foreground">온보딩 프롬프트</p>
+              <Button
+                size="sm"
+                variant="outline"
+                className="h-6 text-xs"
+                onClick={() => void handleCopy(LLMS_PROMPT, '온보딩 프롬프트')}
+              >
+                Copy
+              </Button>
+            </div>
+            <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-foreground/80 whitespace-pre-wrap">{LLMS_PROMPT}</pre>
+          </div>
+        </SectionCardBody>
+      </SectionCard>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
E-ONBOARD-AGENT 에픽 전량 프로모션 (develop → main).

**5 Stories (14SP):**
- OB-S1: Settings MCP Config 복사 블록 (PR #461)
- OB-S2: 온보딩 위자드 Agent 연결 스텝 확장 (PR #462)
- OB-S3: llms.txt / llms-full.txt 보강 (PR #463)
- OB-S4: llms-baos.txt 실파일 생성 (PR #464)
- OB-S5: 대시보드 Empty State CTA (PR #465)

## Changes
- Settings: MCP config JSON 복사 블록 (agent별 API key + streamable-http URL)
- Onboarding wizard: 4단계 확장 (Org → Project → Agent 생성 → MCP config 복사)
- llms.txt: 프로덕션 URL 반영, 웹훅 페이로드 예시, 에러 코드 표, 멀티에이전트 라우팅
- llms-baos.txt: 장사왕 커머스 에이전트 온보딩 문서 신규
- Dashboard: Empty State에 CTA 버튼 추가 + 에이전트 미연결 배너

## Test plan
- [ ] dev Cloud Build SUCCESS 확인
- [ ] prod Cloud Build SUCCESS 확인
- [ ] prod smoke: /login 200, /api/v2/health db:ok, /llms-baos.txt 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)