### PR TITLE
fix(FIX-S1): Settings API Keys 탭에 Agent Webhook URL 설정 필드

### DIFF
--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -14,6 +14,7 @@ interface AgentMember {
   name: string;
   type: string;
   is_active: boolean;
+  webhook_url: string | null;
 }
 
 interface ApiKey {
@@ -85,6 +86,9 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
   const [revoking, setRevoking] = useState<string | null>(null);
   const [newAgentName, setNewAgentName] = useState('');
   const [adding, setAdding] = useState(false);
+  const [webhookUrls, setWebhookUrls] = useState<Record<string, string>>({});
+  const [webhookErrors, setWebhookErrors] = useState<Record<string, string>>({});
+  const [savingWebhook, setSavingWebhook] = useState<string | null>(null);
   const { addToast } = useToast();
 
   const fetchAgents = useCallback(async () => {
@@ -94,6 +98,14 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
       const json = await res.json() as { data: AgentMember[] };
       const agentList = (json.data ?? []).filter((m) => m.type === 'agent');
       setAgents(agentList);
+      // Seed webhook URL inputs from fetched data
+      setWebhookUrls((prev) => {
+        const next = { ...prev };
+        for (const agent of agentList) {
+          if (!(agent.id in next)) next[agent.id] = agent.webhook_url ?? '';
+        }
+        return next;
+      });
       const keyMap: Record<string, ApiKey[]> = {};
       await Promise.all(agentList.map(async (agent) => {
         const kr = await fetch(`/api/agents/${agent.id}/api-key`);
@@ -151,6 +163,33 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
       setAdding(false);
     }
   }, [newAgentName, projectId, fetchAgents, addToast]);
+
+  const handleSaveWebhook = useCallback(async (agentId: string, agentName: string) => {
+    const trimmed = (webhookUrls[agentId] ?? '').trim();
+    if (trimmed && !/^https:\/\//i.test(trimmed)) {
+      setWebhookErrors((prev) => ({ ...prev, [agentId]: 'Webhook URL must start with https://' }));
+      return;
+    }
+    setWebhookErrors((prev) => ({ ...prev, [agentId]: '' }));
+    setSavingWebhook(agentId);
+    try {
+      const res = await fetch(`/api/team-members/${agentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhook_url: trimmed || null }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({})) as { error?: { message?: string } };
+        addToast({ type: 'error', title: json.error?.message ?? 'Failed to save webhook URL' });
+        return;
+      }
+      addToast({ type: 'success', title: `Webhook URL updated for ${agentName}` });
+    } catch {
+      addToast({ type: 'error', title: 'Network error — please retry' });
+    } finally {
+      setSavingWebhook(null);
+    }
+  }, [addToast, webhookUrls]);
 
   const handleCopy = useCallback(async (text: string, label: string) => {
     try {
@@ -280,6 +319,37 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                     ⚠️ MCP Config를 사용하려면 먼저 API Key를 발급하세요.
                   </p>
                 )}
+
+                {/* Webhook URL */}
+                <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 space-y-2">
+                  <p className="text-xs font-semibold text-foreground">Webhook URL</p>
+                  <p className="text-xs text-muted-foreground">메모 배정 시 이 URL로 POST 전송됩니다. HTTPS 필수.</p>
+                  <div className="flex gap-2">
+                    <input
+                      type="url"
+                      value={webhookUrls[agent.id] ?? ''}
+                      onChange={(e) => {
+                        setWebhookUrls((prev) => ({ ...prev, [agent.id]: e.target.value }));
+                        setWebhookErrors((prev) => ({ ...prev, [agent.id]: '' }));
+                      }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') void handleSaveWebhook(agent.id, agent.name); }}
+                      placeholder="https://your-agent.example.com/webhook"
+                      className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0"
+                      disabled={savingWebhook === agent.id}
+                      onClick={() => void handleSaveWebhook(agent.id, agent.name)}
+                    >
+                      {savingWebhook === agent.id ? 'Saving...' : 'Save'}
+                    </Button>
+                  </div>
+                  {webhookErrors[agent.id] ? (
+                    <p className="text-xs text-red-600">{webhookErrors[agent.id]}</p>
+                  ) : null}
+                </div>
               </div>
             );
           })}


### PR DESCRIPTION
## 스토리
- ID: `8b63cbd3` — P0 핫픽스
- SP: 2

## 문제
Settings → API Keys 탭에 agent webhook URL 설정 UI 미노출. `AgentWebhookManager`가 구 dead code 경로에만 렌더되던 문제.

## 변경 요약
- `agent-api-keys-section.tsx` (+70)

## 구현 내용
- `AgentMember.webhook_url: string | null` 타입 추가
- `webhookUrls`, `webhookErrors`, `savingWebhook` state 추가
- `fetchAgents()` 후 `webhook_url` 초기값 주입 → 재진입 시 저장값 표시 (AC5)
- `handleSaveWebhook()`: `https://` 검증 → PATCH `/api/team-members/{id}` → 성공/실패 토스트
- 각 agent 카드 MCP Config 블록 아래 Webhook URL 입력 필드 + Save 버튼
- 빈값 저장 → `webhook_url: null` (해제)
- Enter 키 저장 지원
- 에러 메시지 인라인 표시 (AC3)

## AC 체크
- [x] AC1: Settings → API Keys에서 agent별 Webhook URL 입력 필드 표시
- [x] AC2: URL 저장 시 PATCH 호출 + 성공 토스트
- [x] AC3: https:// 미시작 → 에러 메시지 (저장 차단)
- [x] AC4: 빈값 저장 → webhook_url null (해제)
- [x] AC5: 재진입 시 저장된 webhook URL 정상 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)