### PR TITLE
fix(FIX-S2): Settings 모바일 LNB 반응형 — lg breakpoint 분기

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -452,9 +452,36 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 gap-0">
-        {/* Left nav */}
-        <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
+        {/* Mobile: horizontal scrollable tab bar (< lg) */}
+        <div className="lg:hidden shrink-0 border-b overflow-x-auto">
+          <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">
+            <TabsTrigger value="profile"><User className="h-4 w-4" />{t('tabProfile')}</TabsTrigger>
+            <TabsTrigger value="appearance"><Palette className="h-4 w-4" />{t('tabAppearance')}</TabsTrigger>
+            {currentProjectId && isAdmin ? <TabsTrigger value="api-keys"><Key className="h-4 w-4" />{t('tabApiKeys')}</TabsTrigger> : null}
+            {currentProjectId ? (
+              <>
+                <TabsTrigger value="notifications"><Bell className="h-4 w-4" />{t('tabNotifications')}</TabsTrigger>
+                <TabsTrigger value="ai"><Bot className="h-4 w-4" />{t('tabAiAgents')}</TabsTrigger>
+              </>
+            ) : null}
+            {adminChecked && isAdmin ? (
+              <>
+                <TabsTrigger value="projects"><FolderKanban className="h-4 w-4" />{t('tabProjects')}</TabsTrigger>
+                <TabsTrigger value="members"><Users className="h-4 w-4" />{t('tabMembers')}</TabsTrigger>
+                <TabsTrigger value="integrations"><Zap className="h-4 w-4" />{t('tabIntegrations')}</TabsTrigger>
+                <TabsTrigger value="subscription"><CreditCard className="h-4 w-4" />{t('tabSubscription')}</TabsTrigger>
+                <TabsTrigger value="usage"><BarChart2 className="h-4 w-4" />{t('tabUsage')}</TabsTrigger>
+              </>
+            ) : null}
+            <TabsTrigger value="danger" className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10">
+              <Trash2 className="h-4 w-4" />{t('deleteAccount')}
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* Desktop: left vertical LNB (>= lg) */}
+        <div className="hidden lg:flex flex-col w-52 shrink-0 border-r overflow-y-auto p-4">
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -452,7 +452,7 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
         {/* Mobile: horizontal scrollable tab bar (< lg) */}
         <div className="lg:hidden shrink-0 border-b overflow-x-auto">
           <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">


### PR DESCRIPTION
## 스토리
- ID: `afa8cac5` — P0 핫픽스
- SP: 2

## 문제
`w-52 shrink-0` 고정 LNB가 모바일에서 축소 안 돼 화면 절반 이상 차지.

## 변경 요약
- `settings/page.tsx` (+30/-3)

## 구현
- **모바일 (`< lg`)**: `lg:hidden` — 상단 가로 스크롤 탭 바 (`overflow-x-auto`, `w-max`)
- **데스크톱 (`>= lg`)**: `hidden lg:flex` — 기존 w-52 세로 LNB 유지
- `Tabs`: `flex-col lg:flex-row` 방향 전환
- 두 TabsList 모두 `activeTab` 상태 공유 → 완전 동기화
- breakpoint `lg` (1024px) — GNB `lg:hidden`과 일치

## AC 체크
- [x] AC1: 모바일에서 LNB 화면 절반 이상 차지 안 함
- [x] AC2: 모바일 탭 전환 정상 (모든 탭 접근 가능)
- [x] AC3: 데스크톱 기존 좌측 세로 LNB 유지
- [x] AC4: breakpoint lg — GNB와 일치
- [x] AC5: 탭 전환 URL 파라미터 연동 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)