### PR TITLE
Hotfix: Settings webhook URL + mobile LNB responsive

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -452,9 +452,36 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 gap-0">
-        {/* Left nav */}
-        <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
+        {/* Mobile: horizontal scrollable tab bar (< lg) */}
+        <div className="lg:hidden shrink-0 border-b overflow-x-auto">
+          <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">
+            <TabsTrigger value="profile"><User className="h-4 w-4" />{t('tabProfile')}</TabsTrigger>
+            <TabsTrigger value="appearance"><Palette className="h-4 w-4" />{t('tabAppearance')}</TabsTrigger>
+            {currentProjectId && isAdmin ? <TabsTrigger value="api-keys"><Key className="h-4 w-4" />{t('tabApiKeys')}</TabsTrigger> : null}
+            {currentProjectId ? (
+              <>
+                <TabsTrigger value="notifications"><Bell className="h-4 w-4" />{t('tabNotifications')}</TabsTrigger>
+                <TabsTrigger value="ai"><Bot className="h-4 w-4" />{t('tabAiAgents')}</TabsTrigger>
+              </>
+            ) : null}
+            {adminChecked && isAdmin ? (
+              <>
+                <TabsTrigger value="projects"><FolderKanban className="h-4 w-4" />{t('tabProjects')}</TabsTrigger>
+                <TabsTrigger value="members"><Users className="h-4 w-4" />{t('tabMembers')}</TabsTrigger>
+                <TabsTrigger value="integrations"><Zap className="h-4 w-4" />{t('tabIntegrations')}</TabsTrigger>
+                <TabsTrigger value="subscription"><CreditCard className="h-4 w-4" />{t('tabSubscription')}</TabsTrigger>
+                <TabsTrigger value="usage"><BarChart2 className="h-4 w-4" />{t('tabUsage')}</TabsTrigger>
+              </>
+            ) : null}
+            <TabsTrigger value="danger" className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10">
+              <Trash2 className="h-4 w-4" />{t('deleteAccount')}
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* Desktop: left vertical LNB (>= lg) */}
+        <div className="hidden lg:flex flex-col w-52 shrink-0 border-r overflow-y-auto p-4">
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -14,6 +14,7 @@ interface AgentMember {
   name: string;
   type: string;
   is_active: boolean;
+  webhook_url: string | null;
 }
 
 interface ApiKey {
@@ -85,6 +86,9 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
   const [revoking, setRevoking] = useState<string | null>(null);
   const [newAgentName, setNewAgentName] = useState('');
   const [adding, setAdding] = useState(false);
+  const [webhookUrls, setWebhookUrls] = useState<Record<string, string>>({});
+  const [webhookErrors, setWebhookErrors] = useState<Record<string, string>>({});
+  const [savingWebhook, setSavingWebhook] = useState<string | null>(null);
   const { addToast } = useToast();
 
   const fetchAgents = useCallback(async () => {
@@ -94,6 +98,14 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
       const json = await res.json() as { data: AgentMember[] };
       const agentList = (json.data ?? []).filter((m) => m.type === 'agent');
       setAgents(agentList);
+      // Seed webhook URL inputs from fetched data
+      setWebhookUrls((prev) => {
+        const next = { ...prev };
+        for (const agent of agentList) {
+          if (!(agent.id in next)) next[agent.id] = agent.webhook_url ?? '';
+        }
+        return next;
+      });
       const keyMap: Record<string, ApiKey[]> = {};
       await Promise.all(agentList.map(async (agent) => {
         const kr = await fetch(`/api/agents/${agent.id}/api-key`);
@@ -151,6 +163,33 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
       setAdding(false);
     }
   }, [newAgentName, projectId, fetchAgents, addToast]);
+
+  const handleSaveWebhook = useCallback(async (agentId: string, agentName: string) => {
+    const trimmed = (webhookUrls[agentId] ?? '').trim();
+    if (trimmed && !/^https:\/\//i.test(trimmed)) {
+      setWebhookErrors((prev) => ({ ...prev, [agentId]: 'Webhook URL must start with https://' }));
+      return;
+    }
+    setWebhookErrors((prev) => ({ ...prev, [agentId]: '' }));
+    setSavingWebhook(agentId);
+    try {
+      const res = await fetch(`/api/team-members/${agentId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ webhook_url: trimmed || null }),
+      });
+      if (!res.ok) {
+        const json = await res.json().catch(() => ({})) as { error?: { message?: string } };
+        addToast({ type: 'error', title: json.error?.message ?? 'Failed to save webhook URL' });
+        return;
+      }
+      addToast({ type: 'success', title: `Webhook URL updated for ${agentName}` });
+    } catch {
+      addToast({ type: 'error', title: 'Network error — please retry' });
+    } finally {
+      setSavingWebhook(null);
+    }
+  }, [addToast, webhookUrls]);
 
   const handleCopy = useCallback(async (text: string, label: string) => {
     try {
@@ -280,6 +319,37 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                     ⚠️ MCP Config를 사용하려면 먼저 API Key를 발급하세요.
                   </p>
                 )}
+
+                {/* Webhook URL */}
+                <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 space-y-2">
+                  <p className="text-xs font-semibold text-foreground">Webhook URL</p>
+                  <p className="text-xs text-muted-foreground">메모 배정 시 이 URL로 POST 전송됩니다. HTTPS 필수.</p>
+                  <div className="flex gap-2">
+                    <input
+                      type="url"
+                      value={webhookUrls[agent.id] ?? ''}
+                      onChange={(e) => {
+                        setWebhookUrls((prev) => ({ ...prev, [agent.id]: e.target.value }));
+                        setWebhookErrors((prev) => ({ ...prev, [agent.id]: '' }));
+                      }}
+                      onKeyDown={(e) => { if (e.key === 'Enter') void handleSaveWebhook(agent.id, agent.name); }}
+                      placeholder="https://your-agent.example.com/webhook"
+                      className="flex-1 rounded-md border border-border bg-background px-3 py-1.5 font-mono text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    />
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="shrink-0"
+                      disabled={savingWebhook === agent.id}
+                      onClick={() => void handleSaveWebhook(agent.id, agent.name)}
+                    >
+                      {savingWebhook === agent.id ? 'Saving...' : 'Save'}
+                    </Button>
+                  </div>
+                  {webhookErrors[agent.id] ? (
+                    <p className="text-xs text-red-600">{webhookErrors[agent.id]}</p>
+                  ) : null}
+                </div>
               </div>
             );
           })}


### PR DESCRIPTION
## Summary
선생님 지적 2건 핫픽스.

- **PR #467**: Settings API Keys 탭에 agent별 Webhook URL 입력 필드 추가
- **PR #468**: Settings 모바일 LNB 반응형 (w-52 고정 → lg breakpoint 가로 탭 전환)

## Test plan
- [ ] dev Cloud Build SUCCESS
- [ ] prod Cloud Build SUCCESS
- [ ] prod smoke: /login 200, /api/v2/health db:ok
- [ ] 모바일에서 Settings 진입 시 LNB 가로 탭 바 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)