### PR TITLE
FIX-S2 RC2: Settings 모바일 LNB 접기/펼치기 overlay (#468 후속)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -452,9 +452,36 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 gap-0">
-        {/* Left nav */}
-        <div className="w-52 shrink-0 border-r overflow-y-auto p-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
+        {/* Mobile: horizontal scrollable tab bar (< lg) */}
+        <div className="lg:hidden shrink-0 border-b overflow-x-auto">
+          <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">
+            <TabsTrigger value="profile"><User className="h-4 w-4" />{t('tabProfile')}</TabsTrigger>
+            <TabsTrigger value="appearance"><Palette className="h-4 w-4" />{t('tabAppearance')}</TabsTrigger>
+            {currentProjectId && isAdmin ? <TabsTrigger value="api-keys"><Key className="h-4 w-4" />{t('tabApiKeys')}</TabsTrigger> : null}
+            {currentProjectId ? (
+              <>
+                <TabsTrigger value="notifications"><Bell className="h-4 w-4" />{t('tabNotifications')}</TabsTrigger>
+                <TabsTrigger value="ai"><Bot className="h-4 w-4" />{t('tabAiAgents')}</TabsTrigger>
+              </>
+            ) : null}
+            {adminChecked && isAdmin ? (
+              <>
+                <TabsTrigger value="projects"><FolderKanban className="h-4 w-4" />{t('tabProjects')}</TabsTrigger>
+                <TabsTrigger value="members"><Users className="h-4 w-4" />{t('tabMembers')}</TabsTrigger>
+                <TabsTrigger value="integrations"><Zap className="h-4 w-4" />{t('tabIntegrations')}</TabsTrigger>
+                <TabsTrigger value="subscription"><CreditCard className="h-4 w-4" />{t('tabSubscription')}</TabsTrigger>
+                <TabsTrigger value="usage"><BarChart2 className="h-4 w-4" />{t('tabUsage')}</TabsTrigger>
+              </>
+            ) : null}
+            <TabsTrigger value="danger" className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10">
+              <Trash2 className="h-4 w-4" />{t('deleteAccount')}
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* Desktop: left vertical LNB (>= lg) */}
+        <div className="hidden lg:flex flex-col w-52 shrink-0 border-r overflow-y-auto p-4">
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Palette, Trash2, User, Users, Zap } from 'lucide-react';
+import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { AgentApiKeysSection } from '@/components/settings/agent-api-keys-section';
 import { AiSettingsSection } from '@/components/settings/ai-settings';
@@ -21,6 +21,7 @@ import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 
 interface NotificationSetting {
   id: string;
@@ -70,6 +71,12 @@ export default function SettingsPage() {
   const router = useRouter();
   const searchParamsHook = useSearchParams();
   const [activeTab, setActiveTab] = useState(() => searchParamsHook.get('tab') ?? 'profile');
+  const [lnbOpen, setLnbOpen] = useState(false);
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    setLnbOpen(false);
+  };
 
   useEffect(() => {
     const tab = searchParamsHook.get('tab');
@@ -452,36 +459,34 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
-        {/* Mobile: horizontal scrollable tab bar (< lg) */}
-        <div className="lg:hidden shrink-0 border-b overflow-x-auto">
-          <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">
-            <TabsTrigger value="profile"><User className="h-4 w-4" />{t('tabProfile')}</TabsTrigger>
-            <TabsTrigger value="appearance"><Palette className="h-4 w-4" />{t('tabAppearance')}</TabsTrigger>
-            {currentProjectId && isAdmin ? <TabsTrigger value="api-keys"><Key className="h-4 w-4" />{t('tabApiKeys')}</TabsTrigger> : null}
-            {currentProjectId ? (
-              <>
-                <TabsTrigger value="notifications"><Bell className="h-4 w-4" />{t('tabNotifications')}</TabsTrigger>
-                <TabsTrigger value="ai"><Bot className="h-4 w-4" />{t('tabAiAgents')}</TabsTrigger>
-              </>
-            ) : null}
-            {adminChecked && isAdmin ? (
-              <>
-                <TabsTrigger value="projects"><FolderKanban className="h-4 w-4" />{t('tabProjects')}</TabsTrigger>
-                <TabsTrigger value="members"><Users className="h-4 w-4" />{t('tabMembers')}</TabsTrigger>
-                <TabsTrigger value="integrations"><Zap className="h-4 w-4" />{t('tabIntegrations')}</TabsTrigger>
-                <TabsTrigger value="subscription"><CreditCard className="h-4 w-4" />{t('tabSubscription')}</TabsTrigger>
-                <TabsTrigger value="usage"><BarChart2 className="h-4 w-4" />{t('tabUsage')}</TabsTrigger>
-              </>
-            ) : null}
-            <TabsTrigger value="danger" className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10">
-              <Trash2 className="h-4 w-4" />{t('deleteAccount')}
-            </TabsTrigger>
-          </TabsList>
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0 relative">
+        {/* Mobile: toggle bar — current tab name + hamburger (< lg) */}
+        <div className="lg:hidden flex shrink-0 items-center gap-3 border-b px-4 py-2">
+          <button
+            type="button"
+            onClick={() => setLnbOpen((v) => !v)}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Toggle navigation"
+          >
+            {lnbOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+          <span className="text-sm font-medium truncate">{t('title')}</span>
         </div>
 
-        {/* Desktop: left vertical LNB (>= lg) */}
-        <div className="hidden lg:flex flex-col w-52 shrink-0 border-r overflow-y-auto p-4">
+        {/* Mobile backdrop */}
+        {lnbOpen && (
+          <div
+            className="fixed inset-0 z-40 bg-black/30 lg:hidden"
+            onClick={() => setLnbOpen(false)}
+          />
+        )}
+
+        {/* LNB: desktop=always shown, mobile=overlay when open */}
+        <div className={cn(
+          "w-52 shrink-0 border-r overflow-y-auto p-4 flex-col",
+          "hidden lg:flex",
+          lnbOpen && "absolute inset-y-0 left-0 z-50 flex bg-background shadow-xl",
+        )}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -485,7 +485,7 @@ export default function SettingsPage() {
         <div className={cn(
           "w-52 shrink-0 border-r overflow-y-auto p-4 flex-col",
           "hidden lg:flex",
-          lnbOpen && "absolute inset-y-0 left-0 z-50 flex bg-background shadow-xl",
+          lnbOpen && "max-lg:absolute max-lg:inset-y-0 max-lg:left-0 max-lg:z-50 max-lg:flex max-lg:bg-background max-lg:shadow-xl",
         )}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -452,7 +452,7 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} orientation="vertical" className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
         {/* Mobile: horizontal scrollable tab bar (< lg) */}
         <div className="lg:hidden shrink-0 border-b overflow-x-auto">
           <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">


### PR DESCRIPTION
## Summary
선생님 피드백 반영: 가로탭 전환 → 세로 LNB 접기/펼치기 overlay로 변경.

- 가로 스크롤 TabsList 완전 제거
- 모바일 상단: hamburger 토글 + 타이틀
- LNB: absolute overlay (z-50) + backdrop (z-40)
- 탭 선택 시 자동 닫기
- 데스크톱 기존 동작 유지

## Test plan
- [ ] 모바일에서 hamburger 클릭 → LNB overlay 표시
- [ ] 탭 선택 시 자동 닫기 + 컨텐츠 전환
- [ ] 데스크톱 좌측 세로 LNB 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)