### PR TITLE
fix(FIX-S2): Settings 모바일 LNB 접기/펼치기 overlay

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Palette, Trash2, User, Users, Zap } from 'lucide-react';
+import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { AgentApiKeysSection } from '@/components/settings/agent-api-keys-section';
 import { AiSettingsSection } from '@/components/settings/ai-settings';
@@ -21,6 +21,7 @@ import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
 
 interface NotificationSetting {
   id: string;
@@ -70,6 +71,12 @@ export default function SettingsPage() {
   const router = useRouter();
   const searchParamsHook = useSearchParams();
   const [activeTab, setActiveTab] = useState(() => searchParamsHook.get('tab') ?? 'profile');
+  const [lnbOpen, setLnbOpen] = useState(false);
+
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    setLnbOpen(false);
+  };
 
   useEffect(() => {
     const tab = searchParamsHook.get('tab');
@@ -452,36 +459,34 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={setActiveTab} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0">
-        {/* Mobile: horizontal scrollable tab bar (< lg) */}
-        <div className="lg:hidden shrink-0 border-b overflow-x-auto">
-          <TabsList variant="line" className="flex-row w-max gap-0 px-2 py-1">
-            <TabsTrigger value="profile"><User className="h-4 w-4" />{t('tabProfile')}</TabsTrigger>
-            <TabsTrigger value="appearance"><Palette className="h-4 w-4" />{t('tabAppearance')}</TabsTrigger>
-            {currentProjectId && isAdmin ? <TabsTrigger value="api-keys"><Key className="h-4 w-4" />{t('tabApiKeys')}</TabsTrigger> : null}
-            {currentProjectId ? (
-              <>
-                <TabsTrigger value="notifications"><Bell className="h-4 w-4" />{t('tabNotifications')}</TabsTrigger>
-                <TabsTrigger value="ai"><Bot className="h-4 w-4" />{t('tabAiAgents')}</TabsTrigger>
-              </>
-            ) : null}
-            {adminChecked && isAdmin ? (
-              <>
-                <TabsTrigger value="projects"><FolderKanban className="h-4 w-4" />{t('tabProjects')}</TabsTrigger>
-                <TabsTrigger value="members"><Users className="h-4 w-4" />{t('tabMembers')}</TabsTrigger>
-                <TabsTrigger value="integrations"><Zap className="h-4 w-4" />{t('tabIntegrations')}</TabsTrigger>
-                <TabsTrigger value="subscription"><CreditCard className="h-4 w-4" />{t('tabSubscription')}</TabsTrigger>
-                <TabsTrigger value="usage"><BarChart2 className="h-4 w-4" />{t('tabUsage')}</TabsTrigger>
-              </>
-            ) : null}
-            <TabsTrigger value="danger" className="text-destructive hover:text-destructive data-active:text-destructive data-active:bg-destructive/10">
-              <Trash2 className="h-4 w-4" />{t('deleteAccount')}
-            </TabsTrigger>
-          </TabsList>
+      <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0 relative">
+        {/* Mobile: toggle bar — current tab name + hamburger (< lg) */}
+        <div className="lg:hidden flex shrink-0 items-center gap-3 border-b px-4 py-2">
+          <button
+            type="button"
+            onClick={() => setLnbOpen((v) => !v)}
+            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Toggle navigation"
+          >
+            {lnbOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+          </button>
+          <span className="text-sm font-medium truncate">{t('title')}</span>
         </div>
 
-        {/* Desktop: left vertical LNB (>= lg) */}
-        <div className="hidden lg:flex flex-col w-52 shrink-0 border-r overflow-y-auto p-4">
+        {/* Mobile backdrop */}
+        {lnbOpen && (
+          <div
+            className="fixed inset-0 z-40 bg-black/30 lg:hidden"
+            onClick={() => setLnbOpen(false)}
+          />
+        )}
+
+        {/* LNB: desktop=always shown, mobile=overlay when open */}
+        <div className={cn(
+          "w-52 shrink-0 border-r overflow-y-auto p-4 flex-col",
+          "hidden lg:flex",
+          lnbOpen && "max-lg:absolute max-lg:inset-y-0 max-lg:left-0 max-lg:z-50 max-lg:flex max-lg:bg-background max-lg:shadow-xl",
+        )}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>


### PR DESCRIPTION
## 스토리
- ID: `afa8cac5` — P0 핫픽스
- PR #470 충돌 → develop 기반 clean 재제출

## 변경 요약
- 모바일 가로 스크롤 탭 바 완전 제거
- 모바일 상단 hamburger 토글 바 (Menu/X 아이콘)
- LNB: `max-lg:absolute max-lg:inset-y-0 max-lg:z-50 max-lg:bg-background max-lg:shadow-xl` overlay
- backdrop 클릭 닫기 (fixed inset-0 z-40)
- 탭 선택 시 `handleTabChange` → 자동 LNB 닫기
- `orientation` prop 제거 (`group-data-vertical:flex-col` 간섭 방지)
- 데스크톱 (`>= lg`): `hidden lg:flex` 기존 w-52 세로 LNB 완전 유지

## AC 체크
- [x] AC1: 가로탭 제거, 세로 LNB 디자인 유지
- [x] AC2: hamburger 토글로 LNB 표시/숨김
- [x] AC3: 접힌 상태 컨텐츠 full width
- [x] AC4: 탭 선택 시 자동 접기
- [x] AC5: `max-lg:` prefix — 데스크톱 리사이즈 후 overlay 잔류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)