### PR TITLE
fix(FIX-S2 RC4+): Settings 모바일 GNB 접근 + LNB flex push (#475)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -21,7 +21,6 @@ import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
-import { cn } from '@/lib/utils';
 
 interface NotificationSetting {
   id: string;
@@ -75,7 +74,7 @@ export default function SettingsPage() {
 
   const handleTabChange = (tab: string) => {
     setActiveTab(tab);
-    setLnbOpen(false);
+    setLnbOpen(false); // 모바일에서 탭 선택 시 LNB 자동 접기
   };
 
   useEffect(() => {
@@ -459,34 +458,9 @@ export default function SettingsPage() {
 
   return (
     <>
-      <Tabs value={activeTab} onValueChange={handleTabChange} className="flex-1 min-h-0 flex flex-col lg:flex-row gap-0 relative">
-        {/* Mobile: toggle bar — current tab name + hamburger (< lg) */}
-        <div className="lg:hidden flex shrink-0 items-center gap-3 border-b px-4 py-2">
-          <button
-            type="button"
-            onClick={() => setLnbOpen((v) => !v)}
-            className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
-            aria-label="Toggle navigation"
-          >
-            {lnbOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
-          </button>
-          <span className="text-sm font-medium truncate">{t('title')}</span>
-        </div>
-
-        {/* Mobile backdrop */}
-        {lnbOpen && (
-          <div
-            className="fixed inset-0 z-40 bg-black/30 lg:hidden"
-            onClick={() => setLnbOpen(false)}
-          />
-        )}
-
-        {/* LNB: desktop=always shown, mobile=overlay when open */}
-        <div className={cn(
-          "w-52 shrink-0 border-r overflow-y-auto p-4 flex-col",
-          "hidden lg:flex",
-          lnbOpen && "max-lg:absolute max-lg:inset-y-0 max-lg:left-0 max-lg:z-50 max-lg:flex max-lg:bg-background max-lg:shadow-xl",
-        )}>
+      <Tabs value={activeTab} onValueChange={handleTabChange} orientation="vertical" className="flex-1 min-h-0 gap-0">
+        {/* Left nav: desktop=always visible, mobile=toggle via lnbOpen */}
+        <div className={`shrink-0 border-r overflow-y-auto p-4 flex-col w-52 ${lnbOpen ? 'flex' : 'hidden'} lg:flex`}>
           <h1 className="mb-4 px-2 text-sm font-semibold">{t('title')}</h1>
           <TabsList variant="line" className="w-full flex-col items-stretch">
             <span className="px-2 pb-1 pt-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('myAccount')}</span>
@@ -558,6 +532,18 @@ export default function SettingsPage() {
 
         {/* Right content */}
         <div className="flex-1 min-w-0 overflow-y-auto">
+          {/* Mobile toggle button */}
+          <div className="lg:hidden flex items-center gap-2 border-b px-4 py-2">
+            <button
+              type="button"
+              onClick={() => setLnbOpen((v) => !v)}
+              className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+              aria-label="Toggle navigation"
+            >
+              {lnbOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+            </button>
+            <span className="text-sm font-medium">{t('title')}</span>
+          </div>
           <div className="w-full max-w-3xl mx-auto p-6">
 
             <TabsContent value="profile">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { BarChart2, Bell, Bot, CreditCard, FolderKanban, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { AgentApiKeysSection } from '@/components/settings/agent-api-keys-section';
 import { AiSettingsSection } from '@/components/settings/ai-settings';
@@ -534,6 +535,7 @@ export default function SettingsPage() {
         <div className="flex-1 min-w-0 overflow-y-auto">
           {/* Mobile toggle button */}
           <div className="lg:hidden flex items-center gap-2 border-b px-4 py-2">
+            <SidebarTrigger className="mr-1" />
             <button
               type="button"
               onClick={() => setLnbOpen((v) => !v)}


### PR DESCRIPTION
## Summary
- RC4 전체 변경사항 + SidebarTrigger 추가 통합
- 모바일 Settings에서 GNB 열기 불가 문제 해결 (SidebarTrigger 배치)
- overlay 전량 제거, 원본 레이아웃 복원, flex push 접기/펴기

## Changes
- `SidebarTrigger` import + 모바일 토글 바에 배치
- RC3 overlay/backdrop/z-index 전량 제거
- 원본 `orientation="vertical"` + `w-52` 복원
- 모바일: `lnbOpen` 토글로 LNB show/hide (flex push)
- 탭 선택 시 자동 접기

## Test plan
- [ ] 모바일: SidebarTrigger 클릭 → GNB 사이드바 열림
- [ ] 모바일: LNB 햄버거 클릭 → LNB 토글 정상
- [ ] 모바일: 탭 선택 → LNB 자동 접기
- [ ] 데스크톱: 기존과 100% 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)