### PR TITLE
Promote: Settings 모바일 SidebarTrigger + GNB 접근 (develop→main)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -21,6 +21,7 @@ import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { SidebarTrigger } from '@/components/ui/sidebar';
 
 interface NotificationSetting {
   id: string;
@@ -534,6 +535,7 @@ export default function SettingsPage() {
         <div className="flex-1 min-w-0 overflow-y-auto">
           {/* Mobile toggle button */}
           <div className="lg:hidden flex items-center gap-2 border-b px-4 py-2">
+            <SidebarTrigger className="mr-1" />
             <button
               type="button"
               onClick={() => setLnbOpen((v) => !v)}


### PR DESCRIPTION
## Summary
- FIX-S2 후속: Settings 모바일 토글 바에 SidebarTrigger 추가
- 모바일에서 GNB 사이드바 열기 가능 → Settings 탈출 경로 보장
- PR #476 (2줄, QA: RC4 본체 APPROVE 기반)

🤖 Generated with [Claude Code](https://claude.com/claude-code)