### PR TITLE
feat(AM-S3): 에이전트 멀티프로젝트 할당 UI (#480)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -241,7 +241,7 @@ export default function AgentDetailPage() {
       const memberJson = await memberRes.json() as { data: AgentMember };
       const newAgentId = memberJson.data.id;
 
-      const keyRes = await fetch(`/api/agents/${newAgentId}/api-key`, {
+      const keyRes = await fetch(`/api/agents/${newAgentId}/api-keys`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ scope: ['read', 'write'] }),

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { ArrowLeft, Check, Pencil, X } from 'lucide-react';
+import { ArrowLeft, Check, Pencil, Plus, X } from 'lucide-react';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
+import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { useToast } from '@/components/ui/toast';
 
@@ -38,6 +39,20 @@ interface ApiKey {
   created_at: string;
   last_used_at: string | null;
   revoked_at: string | null;
+}
+
+interface ProjectOption {
+  id: string;
+  name: string;
+}
+
+interface NewProjectResult {
+  agentId: string;
+  projectId: string;
+  projectName: string;
+  apiKey: string;
+  webhookUrl: string;
+  savingWebhook: boolean;
 }
 
 function buildMcpConfig(apiKey: string) {
@@ -79,12 +94,42 @@ export default function AgentDetailPage() {
   const [hasActiveKey, setHasActiveKey] = useState(false);
   const [mcpCopied, setMcpCopied] = useState(false);
 
+  const [projects, setProjects] = useState<ProjectOption[]>([]);
+  const [sameNameAgents, setSameNameAgents] = useState<AgentMember[]>([]);
+  const [showAddToProject, setShowAddToProject] = useState(false);
+  const [selectedAddProjectId, setSelectedAddProjectId] = useState('');
+  const [addingToProject, setAddingToProject] = useState(false);
+  const [newProjectResult, setNewProjectResult] = useState<NewProjectResult | null>(null);
+  const [orgId, setOrgId] = useState<string | null>(null);
+
   const fetchAgent = useCallback(async () => {
     const res = await fetch(`/api/team-members/${id}`);
     if (!res.ok) { router.push('/settings?tab=members'); return; }
     const json = await res.json() as { data: AgentMember };
     setAgent(json.data);
   }, [id, router]);
+
+  const fetchOrgContext = useCallback(async () => {
+    const [projectRes, contextRes] = await Promise.all([
+      fetch('/api/projects'),
+      fetch('/api/current-project'),
+    ]);
+    if (projectRes.ok) {
+      const json = await projectRes.json() as { data: ProjectOption[] };
+      setProjects((json.data ?? []).slice().sort((a, b) => a.name.localeCompare(b.name)));
+    }
+    if (contextRes.ok) {
+      const json = await contextRes.json() as { data?: { org_id?: string } };
+      setOrgId(json.data?.org_id ?? null);
+    }
+  }, []);
+
+  const fetchSameNameAgents = useCallback(async (agentName: string) => {
+    const res = await fetch('/api/team-members?type=agent&include_inactive=true');
+    if (!res.ok) return;
+    const json = await res.json() as { data: AgentMember[] };
+    setSameNameAgents((json.data ?? []).filter((a) => a.name === agentName && a.id !== id));
+  }, [id]);
 
   const fetchWebhookConfigs = useCallback(async (projectId: string) => {
     const res = await fetch(`/api/webhooks/config?project_id=${encodeURIComponent(projectId)}`);
@@ -105,14 +150,26 @@ export default function AgentDetailPage() {
 
   useEffect(() => {
     setLoading(true);
-    Promise.all([fetchAgent(), fetchActiveApiKey()])
+    Promise.all([fetchAgent(), fetchActiveApiKey(), fetchOrgContext()])
       .finally(() => setLoading(false));
-  }, [fetchAgent, fetchActiveApiKey]);
+  }, [fetchAgent, fetchActiveApiKey, fetchOrgContext]);
 
   useEffect(() => {
     if (!agent) return;
     void fetchWebhookConfigs(agent.project_id);
-  }, [agent, fetchWebhookConfigs]);
+    void fetchSameNameAgents(agent.name);
+  }, [agent, fetchWebhookConfigs, fetchSameNameAgents]);
+
+  const assignedProjectIds = useMemo(() => {
+    const ids = new Set(sameNameAgents.map((a) => a.project_id));
+    if (agent) ids.add(agent.project_id);
+    return ids;
+  }, [sameNameAgents, agent]);
+
+  const availableProjects = useMemo(
+    () => projects.filter((p) => !assignedProjectIds.has(p.id)),
+    [projects, assignedProjectIds],
+  );
 
   const handleSaveEdit = async () => {
     if (!editName.trim()) return;
@@ -164,6 +221,65 @@ export default function AgentDetailPage() {
       await fetchWebhookConfigs(agent.project_id);
     } finally {
       setSavingWebhook(false);
+    }
+  };
+
+  const handleAddToProject = async () => {
+    if (!selectedAddProjectId || !agent || !orgId) return;
+    setAddingToProject(true);
+    try {
+      const memberRes = await fetch('/api/team-members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ org_id: orgId, project_id: selectedAddProjectId, name: agent.name, type: 'agent', role: agent.role }),
+      });
+      if (!memberRes.ok) {
+        const json = await memberRes.json().catch(() => null) as { error?: { message?: string } } | null;
+        addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+        return;
+      }
+      const memberJson = await memberRes.json() as { data: AgentMember };
+      const newAgentId = memberJson.data.id;
+
+      const keyRes = await fetch(`/api/agents/${newAgentId}/api-key`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ scope: ['read', 'write'] }),
+      });
+      const rawKey = keyRes.ok
+        ? ((await keyRes.json() as { data?: { api_key?: string } }).data?.api_key ?? '')
+        : '';
+
+      const projectName = projects.find((p) => p.id === selectedAddProjectId)?.name ?? selectedAddProjectId;
+      setNewProjectResult({ agentId: newAgentId, projectId: selectedAddProjectId, projectName, apiKey: rawKey, webhookUrl: '', savingWebhook: false });
+      setSelectedAddProjectId('');
+      setShowAddToProject(false);
+      await fetchSameNameAgents(agent.name);
+    } finally {
+      setAddingToProject(false);
+    }
+  };
+
+  const handleSaveNewProjectWebhook = async () => {
+    if (!newProjectResult) return;
+    const trimmed = newProjectResult.webhookUrl.trim();
+    if (trimmed && !/^https:\/\//i.test(trimmed)) {
+      addToast({ type: 'error', title: 'Webhook URL must start with https://' });
+      return;
+    }
+    setNewProjectResult((prev) => prev ? { ...prev, savingWebhook: true } : null);
+    try {
+      if (trimmed) {
+        await fetch('/api/webhooks/config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ member_id: newProjectResult.agentId, url: trimmed, project_id: newProjectResult.projectId }),
+        });
+      }
+      addToast({ type: 'success', title: `${newProjectResult.projectName} 프로젝트 추가 완료` });
+      setNewProjectResult(null);
+    } finally {
+      setNewProjectResult((prev) => prev ? { ...prev, savingWebhook: false } : null);
     }
   };
 
@@ -307,6 +423,103 @@ export default function AgentDetailPage() {
           <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
             {buildMcpConfig(freshApiKey ?? '<YOUR_API_KEY>')}
           </pre>
+        </SectionCardBody>
+      </SectionCard>
+
+      {/* 다른 프로젝트에 추가 */}
+      <SectionCard>
+        <SectionCardHeader>
+          <div className="flex items-center justify-between w-full">
+            <div className="space-y-1">
+              <h2 className="text-base font-semibold text-foreground">다른 프로젝트에 추가</h2>
+              <p className="text-sm text-muted-foreground">
+                동일 이름으로 다른 프로젝트에 격리 배포합니다. 프로젝트별 독립 API Key와 Webhook이 발급됩니다.
+              </p>
+            </div>
+            {!showAddToProject && availableProjects.length > 0 ? (
+              <Button variant="outline" size="sm" onClick={() => setShowAddToProject(true)}>
+                <Plus className="h-3.5 w-3.5 mr-1" />
+                프로젝트 추가
+              </Button>
+            ) : null}
+          </div>
+        </SectionCardHeader>
+        <SectionCardBody className="space-y-4">
+          {/* 이미 할당된 프로젝트 목록 */}
+          {sameNameAgents.length > 0 ? (
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">할당된 프로젝트</p>
+              {sameNameAgents.map((a) => {
+                const pName = projects.find((p) => p.id === a.project_id)?.name ?? a.project_id;
+                return (
+                  <div key={a.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+                    <span className="text-foreground font-medium">{pName}</span>
+                    <div className="flex items-center gap-2">
+                      {!a.is_active ? <Badge variant="destructive">inactive</Badge> : null}
+                      <Link href={`/settings/members/agents/${a.id}`} className="text-xs text-muted-foreground hover:text-foreground underline-offset-2 hover:underline">
+                        상세
+                      </Link>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+
+          {/* 추가 폼 */}
+          {showAddToProject ? (
+            <div className="flex gap-2 items-center">
+              <OperatorDropdownSelect
+                value={selectedAddProjectId}
+                onValueChange={(v) => setSelectedAddProjectId(v)}
+                options={[
+                  { value: '', label: '프로젝트 선택' },
+                  ...availableProjects.map((p) => ({ value: p.id, label: p.name })),
+                ]}
+              />
+              <Button variant="hero" size="sm" onClick={() => void handleAddToProject()} disabled={!selectedAddProjectId || addingToProject}>
+                {addingToProject ? '...' : '추가'}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => { setShowAddToProject(false); setSelectedAddProjectId(''); }}>
+                취소
+              </Button>
+            </div>
+          ) : availableProjects.length === 0 ? (
+            <p className="text-xs text-muted-foreground">추가 가능한 프로젝트가 없습니다.</p>
+          ) : null}
+
+          {/* 신규 추가 결과: API Key + Webhook 입력 */}
+          {newProjectResult ? (
+            <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-4 space-y-3">
+              <p className="text-sm font-semibold text-emerald-500">{newProjectResult.projectName} 프로젝트 추가 완료</p>
+              {newProjectResult.apiKey ? (
+                <div className="space-y-1">
+                  <p className="text-xs font-medium text-foreground">API Key — 지금만 표시됩니다. 복사해 두세요.</p>
+                  <code className="block break-all rounded bg-background border border-border p-2 text-xs text-foreground/80 font-mono">
+                    {newProjectResult.apiKey}
+                  </code>
+                </div>
+              ) : null}
+              <div className="space-y-1">
+                <p className="text-xs font-medium text-foreground">Webhook URL (선택)</p>
+                <div className="flex gap-2">
+                  <OperatorInput
+                    type="url"
+                    value={newProjectResult.webhookUrl}
+                    onChange={(e) => setNewProjectResult((prev) => prev ? { ...prev, webhookUrl: e.target.value } : null)}
+                    placeholder="https://your-agent.example.com/webhook"
+                    className="flex-1 font-mono text-xs"
+                  />
+                  <Button variant="hero" size="sm" onClick={() => void handleSaveNewProjectWebhook()} disabled={newProjectResult.savingWebhook}>
+                    {newProjectResult.savingWebhook ? '...' : tc('save')}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setNewProjectResult(null)}>
+                    건너뛰기
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ) : null}
         </SectionCardBody>
       </SectionCard>
     </div>

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -246,9 +246,12 @@ export default function AgentDetailPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ scope: ['read', 'write'] }),
       });
-      const rawKey = keyRes.ok
-        ? ((await keyRes.json() as { data?: { api_key?: string } }).data?.api_key ?? '')
-        : '';
+      if (!keyRes.ok) {
+        addToast({ type: 'error', title: 'API Key 자동 생성 실패. 상세 페이지에서 수동으로 발급하세요.' });
+        await fetchSameNameAgents(agent.name);
+        return;
+      }
+      const rawKey = (await keyRes.json() as { data?: { api_key?: string } }).data?.api_key ?? '';
 
       const projectName = projects.find((p) => p.id === selectedAddProjectId)?.name ?? selectedAddProjectId;
       setNewProjectResult({ agentId: newAgentId, projectId: selectedAddProjectId, projectName, apiKey: rawKey, webhookUrl: '', savingWebhook: false });

--- a/apps/web/src/app/api/agents/[id]/api-keys/route.ts
+++ b/apps/web/src/app/api/agents/[id]/api-keys/route.ts
@@ -1,0 +1,30 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+/** GET /api/agents/[id]/api-keys — API Key 목록 조회 */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+/** POST /api/agents/[id]/api-keys — API Key 발급 */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapi(request, `/api/v2/agents/${id}/api-keys`);
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json(), undefined, 201);
+  } catch (err: unknown) { return handleApiError(err); }
+}


### PR DESCRIPTION
## Summary
- 에이전트 상세 페이지에 **다른 프로젝트에 추가** 섹션 신규
- 프로젝트 선택 → 동일 이름 team_member + API Key 자동 생성
- 생성 직후 API Key 1회 표시 + Webhook URL 입력 프롬프트
- 이미 할당된 프로젝트 목록 표시 + 상세 링크
- 이미 할당된 프로젝트는 선택지에서 제외 (중복 방지)

## AC Checklist
- [x] AC1: [다른 프로젝트에 추가] 버튼
- [x] AC2: 동일 이름 team_member + API Key 자동 생성
- [x] AC3: 생성 직후 webhook URL 입력 프롬프트
- [x] AC4: 동일 이름 에이전트 프로젝트별 구분 표시
- [x] AC5: 이미 할당된 프로젝트 선택지 제외

## Test plan
- [ ] 에이전트 상세 → [프로젝트 추가] 버튼 표시 확인
- [ ] 프로젝트 선택 → 추가 → API Key 표시 + Webhook 입력폼 확인
- [ ] Webhook 입력 후 저장 / 건너뛰기 확인
- [ ] 할당된 프로젝트 목록 + 상세 링크 동작 확인
- [ ] 이미 할당된 프로젝트가 드롭다운에서 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)