### PR TITLE
feat(E-AGENT-MEMBER AM-S4): 온보딩 위자드 에이전트 스텝 리뉴얼

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -318,13 +318,15 @@
     "agentRole": "Role",
     "createAgentAction": "Create Agent + Issue API Key",
     "connectAgent": "Connect Agent",
-    "connectSubtitle": "Paste the MCP config below into your agent settings.",
+    "connectSubtitle": "Paste the MCP config into your agent to connect. Manage additional agents under Settings > Members > Agents.",
     "mcpConfigTitle": "MCP Config",
     "promptTitle": "Onboarding Prompt",
     "finish": "Finish → Dashboard",
     "skip": "Skip",
     "stepOf": "{current} / {total}",
-    "createOrgFailed": "Failed to create organization"
+    "createOrgFailed": "Failed to create organization",
+    "apiKeyFailedMembers": "API key generation failed. Go to Settings > Members > Agents to issue one manually.",
+    "goToMembersAgents": "Manage in Members > Agents"
   },
   "settings": {
     "title": "Settings",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -318,13 +318,15 @@
     "agentRole": "역할",
     "createAgentAction": "에이전트 생성 + API 키 발급",
     "connectAgent": "에이전트 연결",
-    "connectSubtitle": "아래 MCP config를 에이전트 설정에 붙여넣으세요.",
+    "connectSubtitle": "MCP config를 에이전트에 붙여넣어 연결하세요. 추가 에이전트는 Settings > Members > Agents에서 관리합니다.",
     "mcpConfigTitle": "MCP Config",
     "promptTitle": "온보딩 프롬프트",
     "finish": "완료 → 대시보드",
     "skip": "건너뛰기",
     "stepOf": "{current} / {total}",
-    "createOrgFailed": "조직 생성에 실패했습니다"
+    "createOrgFailed": "조직 생성에 실패했습니다",
+    "apiKeyFailedMembers": "API Key 발급에 실패했습니다. Settings > Members > Agents에서 수동으로 발급하세요.",
+    "goToMembersAgents": "Members > Agents에서 관리하기"
   },
   "settings": {
     "title": "설정",

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
@@ -347,25 +348,29 @@ export function OnboardingForm() {
         {step === 'connect' && (
           <div className="space-y-4">
             {newApiKey ? (
-              <>
-                <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="text-xs font-semibold text-gray-700">{t('mcpConfigTitle')}</p>
-                    <button
-                      onClick={() => void handleCopy(buildMcpConfig(newApiKey), 'mcp')}
-                      className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
-                    >
-                      {copied === 'mcp' ? '✓ Copied' : 'Copy'}
-                    </button>
-                  </div>
-                  <pre className="overflow-x-auto rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
-                    {buildMcpConfig(newApiKey)}
-                  </pre>
+              <div className="rounded-md border border-gray-200 bg-gray-50 p-3 space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs font-semibold text-gray-700">{t('mcpConfigTitle')}</p>
+                  <button
+                    onClick={() => void handleCopy(buildMcpConfig(newApiKey), 'mcp')}
+                    className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
+                  >
+                    {copied === 'mcp' ? '✓ Copied' : 'Copy'}
+                  </button>
                 </div>
-              </>
+                <pre className="overflow-x-auto rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
+                  {buildMcpConfig(newApiKey)}
+                </pre>
+              </div>
             ) : (
-              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
-                API Key 발급에 실패했습니다. Settings → API Keys에서 수동으로 발급하세요.
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 space-y-2">
+                <p className="text-sm text-amber-800">{t('apiKeyFailedMembers')}</p>
+                <Link
+                  href="/settings?tab=members"
+                  className="inline-block rounded border border-amber-400 bg-white px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50 transition"
+                >
+                  {t('goToMembersAgents')} →
+                </Link>
               </div>
             )}
 
@@ -382,6 +387,14 @@ export function OnboardingForm() {
               <p className="break-all rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
                 {LLMS_PROMPT}
               </p>
+            </div>
+
+            {/* Members > Agents 경로 안내 */}
+            <div className="rounded-md border border-gray-100 bg-gray-50 px-3 py-2 text-xs text-gray-500">
+              에이전트 추가 및 API Key 관리:{' '}
+              <Link href="/settings?tab=members" className="font-medium text-blue-600 hover:underline">
+                Settings → Members → Agents
+              </Link>
             </div>
 
             <button


### PR DESCRIPTION
## Summary
- 온보딩 위자드 `connect` 스텝에서 **"Settings → API Keys"** 문구/링크 전량 제거
- API Key 발급 실패 시: amber 박스 + **Members > Agents 직접 이동 CTA** (`/settings?tab=members`)
- connect 스텝 하단: **Settings → Members → Agents 경로 안내 링크** 상시 표시
- `connectSubtitle` i18n 수정: Members > Agents 경유 안내 추가
- ko/en 2키 추가 (`apiKeyFailedMembers`, `goToMembersAgents`)

## AC Checklist
- [x] AC1: "에이전트 연결" 스텝 → Organization > Members > Agents 경로 안내
- [x] AC2: [에이전트 추가] CTA → `/settings?tab=members` (Agents 탭) 이동
- [x] AC3: 에이전트 1개 이상(newApiKey 있을 때) MCP Config 복사 블록 인라인 표시
- [x] AC4: "Settings > API Keys" 문구/링크 전량 제거, Members 경유 대체

## Test plan
- [ ] 온보딩 위자드 전체 플로우 완주 → connect 스텝 진입
- [ ] API Key 정상 발급 시: MCP Config 블록 표시 + 하단 Members > Agents 링크 확인
- [ ] 에이전트 스텝 skip 후 connect 스텝: amber 박스 + CTA 표시 확인
- [ ] CTA 클릭 → `/settings?tab=members` (Agents 탭) 이동 확인
- [ ] "Settings → API Keys" 문구 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)