### PR TITLE
feat(E-AGENT-MEMBER AM-S5): 레거시 정리 — api-keys 리다이렉트 + webhook_url deprecation

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -379,6 +379,11 @@ export default function AgentDetailPage() {
           <div className="space-y-1">
             <h2 className="text-base font-semibold text-foreground">Webhook URL</h2>
             <p className="text-sm text-muted-foreground">이 에이전트로 이벤트가 발생할 때 POST로 전송됩니다. HTTPS 필수.</p>
+            {agent.webhook_url && webhookConfigs.length === 0 ? (
+              <p className="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
+                기존 webhook URL(<code className="font-mono">{agent.webhook_url}</code>)이 레거시 필드에 저장되어 있습니다. 아래에 다시 입력해 저장하면 새 webhook_configs 방식으로 마이그레이션됩니다.
+              </p>
+            ) : null}
           </div>
         </SectionCardHeader>
         <SectionCardBody className="space-y-3">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -308,6 +308,14 @@ export default function SettingsPage() {
     void refreshOrgAgents().catch(() => {});
   }, [isAdmin]);
 
+  // api-keys 탭 접근 시 Members > Agents로 자동 전환 (레거시 리다이렉트)
+  useEffect(() => {
+    if (activeTab === 'api-keys') {
+      setActiveTab('members');
+      setMembersSubTab('agents');
+    }
+  }, [activeTab]);
+
   const toggleSetting = async (eventType: string, currentEnabled: boolean) => {
     const newEnabled = !currentEnabled;
     await fetch('/api/notification-settings', {
@@ -619,9 +627,20 @@ export default function SettingsPage() {
             </TabsContent>
 
             <TabsContent value="api-keys">
-              {currentProjectId && isAdmin ? (
-                <AgentApiKeysSection projectId={currentProjectId} />
-              ) : null}
+              <SectionCard>
+                <SectionCardBody>
+                  <p className="text-sm text-muted-foreground">
+                    에이전트 API Key 관리는 <strong>Members → Agents</strong> 탭으로 이관됐습니다.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => { setActiveTab('members'); setMembersSubTab('agents'); }}
+                    className="mt-3 rounded-md border border-border px-3 py-1.5 text-sm text-foreground hover:bg-muted transition-colors"
+                  >
+                    Members → Agents로 이동
+                  </button>
+                </SectionCardBody>
+              </SectionCard>
             </TabsContent>
 
             <TabsContent value="notifications">

--- a/apps/web/src/components/agents/agent-webhook-manager.tsx
+++ b/apps/web/src/components/agents/agent-webhook-manager.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+// @deprecated: team_members.webhook_url 직접 수정 방식. webhook_configs 테이블 기반 AM-S2 구현으로 대체됨.
+// 에이전트 상세 페이지(/settings/members/agents/[id]) Webhook 섹션 사용 권장.
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Button } from '@/components/ui/button';

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -320,7 +320,7 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                   </p>
                 )}
 
-                {/* Webhook URL */}
+                {/* @deprecated: team_members.webhook_url — webhook_configs 테이블로 이관 예정 (AM-S2). 신규 에이전트는 상세 페이지 Webhook 섹션 사용. */}
                 <div className="mt-3 rounded-md border border-border bg-muted/20 p-3 space-y-2">
                   <p className="text-xs font-semibold text-foreground">Webhook URL</p>
                   <p className="text-xs text-muted-foreground">메모 배정 시 이 URL로 POST 전송됩니다. HTTPS 필수.</p>


### PR DESCRIPTION
## Summary
- **api-keys 탭 자동 전환**: `?tab=api-keys` 접근 시 Members > Agents 탭으로 자동 전환 (useEffect)
- **api-keys TabsContent**: `AgentApiKeysSection` 제거 → "Members → Agents로 이동" 안내 UI
- **@deprecated 주석**: `agent-api-keys-section.tsx` webhook_url 섹션, `agent-webhook-manager.tsx` 파일 레벨
- **마이그레이션 안내**: 에이전트 상세 페이지에서 `agent.webhook_url` 있고 `webhook_configs` 없을 때 amber 배너 표시

## AC Checklist
- [x] AC1: api-keys 탭 접근 시 Members > Agents 탭으로 자동 전환
- [x] AC2: Settings 레거시 API Key 관리 UI 제거 (AgentApiKeysSection 삭제)
- [x] AC3: team_members.webhook_url 사용 코드 @deprecated 처리
- [x] AC4: 에이전트 상세에서 레거시 webhook_url 마이그레이션 안내 배너

## Test plan
- [ ] `/settings?tab=api-keys` 접근 → Members > Agents 탭으로 자동 전환 확인
- [ ] Settings > Members > Agents 탭 정상 표시 확인
- [ ] 기존 webhook_url 있는 에이전트 상세 → amber 배너 표시 확인
- [ ] TypeScript 빌드 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)