### PR TITLE
hotfix(types): storage-api utils.ts TS2322 해소 — res.json() 타입 캐스트

### DIFF
--- a/packages/storage-api/src/utils.ts
+++ b/packages/storage-api/src/utils.ts
@@ -49,7 +49,7 @@ export async function fastapiCall<T>(
 
   if (!res.ok) {
     let errBody: { error?: { code?: string; message?: string } } = {};
-    try { errBody = await res.json(); } catch { /* ignore parse error */ }
+    try { errBody = await res.json() as typeof errBody; } catch { /* ignore parse error */ }
     throw mapApiError(res.status, errBody);
   }
 


### PR DESCRIPTION
P0. packages/storage-api/src/utils.ts:52 res.json() unknown → as typeof errBody 캐스트 추가. 1줄 수정, 로직 변경 없음. npx tsc --noEmit -p packages/storage-api/tsconfig.json 0 errors 확인.