### PR TITLE
hotfix(bug): team-member DELETE 후 목록 잔존 + 인증 누락

### DIFF
--- a/apps/web/src/app/api/team-members/[id]/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/route.ts
@@ -31,6 +31,8 @@ export async function PATCH(request: Request, { params }: RouteParams) {
 export async function DELETE(request: Request, { params }: RouteParams) {
   try {
     const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
     const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]', { id });
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -29,7 +29,7 @@ def _get_repo(
 async def list_team_members(
     project_id: uuid.UUID | None = Query(default=None),
     type_filter: str | None = Query(default=None, alias="type"),
-    is_active: bool | None = Query(default=None),
+    is_active: bool | None = Query(default=True),
     repo: TeamMemberRepository = Depends(_get_repo),
 ) -> list[TeamMemberResponse]:
     filters: dict = {}


### PR DESCRIPTION
Bug 1: is_active 기본값 None→True (soft delete 후 비활성 멤버 목록 잔존). Bug 2: DELETE 핸들러 getAuthContext 인증 추가. 2파일 3줄 수정.