### PR TITLE
fix(bug): entity embed # 검색 401 — route handler 추가 + URL 변경

### DIFF
--- a/apps/web/src/app/api/entities/search/route.ts
+++ b/apps/web/src/app/api/entities/search/route.ts
@@ -1,0 +1,17 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const res = await proxyToFastapi(request, '/api/v2/entities/search');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/memos/memo-composer.tsx
+++ b/apps/web/src/components/memos/memo-composer.tsx
@@ -159,7 +159,7 @@ export function MemoComposer({
     const timer = window.setTimeout(() => {
       const params = new URLSearchParams({ project_id: projectId });
       if (entityQuery) params.set('q', entityQuery);
-      fetch(`/api/v2/entities/search?${params}`)
+      fetch(`/api/entities/search?${params}`)
         .then((r) => r.json())
         .then((json: EntityResult[]) => {
           if (cancelled) return;


### PR DESCRIPTION
/api/v2/entities/search 직행 → Bearer 없어서 401. /api/entities/search/route.ts 신설(getAuthContext+proxyToFastapi). memo-composer fetch URL 수정. 2파일.