### PR TITLE
feat(ux): MemoComposer @ 멘션 / # 임베드 힌트 텍스트 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -269,6 +269,8 @@
     "uploadingImage": "Uploading image...",
     "uploadFailed": "Image upload failed.",
     "composerShortcut": "Ctrl/⌘+Enter to send",
+    "composerMentionHint": "@ mention members",
+    "composerEmbedHint": "# embed entities",
     "realtimeConnected": "Realtime connected",
     "docLinkTools": "Doc linking",
     "hideCreateDoc": "Hide create form",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -269,6 +269,8 @@
     "uploadingImage": "이미지 업로드 중...",
     "uploadFailed": "이미지 업로드에 실패했습니다.",
     "composerShortcut": "Ctrl/⌘+Enter로 전송",
+    "composerMentionHint": "@ 멤버 멘션",
+    "composerEmbedHint": "# 엔티티 삽입",
     "realtimeConnected": "실시간 연결됨",
     "docLinkTools": "문서 연결",
     "hideCreateDoc": "생성 폼 숨기기",

--- a/apps/web/src/components/memos/memo-composer.tsx
+++ b/apps/web/src/components/memos/memo-composer.tsx
@@ -482,7 +482,11 @@ export function MemoComposer({
             </button>
           ) : null}
         </div>
-        <div className="text-xs text-muted-foreground">{t('composerShortcut')}</div>
+        <div className="flex flex-wrap gap-x-3 gap-y-0.5 text-xs text-muted-foreground">
+          <span>{t('composerShortcut')}</span>
+          <span>{t('composerMentionHint')}</span>
+          <span>{t('composerEmbedHint')}</span>
+        </div>
       </div>
 
       {uploadError ? <p className="text-xs text-red-600">{uploadError}</p> : null}


### PR DESCRIPTION
composerShortcut 영역에 @ 멘션 + # 임베드 힌트 flex 배열. ko.json/en.json 번역 추가. 3파일 +9/-1.