### PR TITLE
fix(bug): rehypeSanitize entity: 프로토콜 허용 — entity link 클릭 가능

### DIFF
--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
 import type { MemoDetailState } from './memo-state';
 import { MemoComposer } from './memo-composer';
+import { EntityChip, getEntityHref } from '@/components/memos/embed-card';
 
 interface MemberInfo {
   name: string;
@@ -217,7 +218,16 @@ function MarkdownContent({ content, isCurrentUser }: { content: string; isCurren
         pre: ({ children }) => <pre className={`mb-2 overflow-x-auto rounded-lg p-3 text-[13px] ${codeBg}`}>{children}</pre>,
         code: ({ children }) => <code className={`rounded px-1 py-0.5 font-mono text-[13px] ${codeBg}`}>{children}</code>,
         blockquote: ({ children }) => <blockquote className={`mb-2 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
-        a: ({ href, children }) => <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">{children}</a>,
+        a: ({ href, children }) => {
+          const m = href?.match(/^entity:(\w+):([0-9a-f-]+)$/i);
+          if (m) {
+            const entityType = m[1];
+            const entityId = m[2];
+            const entityHref = getEntityHref(entityType, entityId);
+            return <EntityChip entityType={entityType} label={String(children)} href={entityHref} />;
+          }
+          return <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">{children}</a>;
+        },
         strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
         em: ({ children }) => <em className={`italic ${text}`}>{children}</em>,
         hr: () => <hr className={`my-2 ${border}`} />,

--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { Bot, User } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -206,7 +206,7 @@ function MarkdownContent({ content, isCurrentUser }: { content: string; isCurren
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
+      rehypePlugins={[[rehypeSanitize, { ...defaultSchema, protocols: { ...defaultSchema.protocols, href: [...(defaultSchema.protocols?.href ?? []), 'entity'] } }]]}
       components={{
         p: ({ children }) => <p className={`mb-2 break-words text-[14px] leading-6 last:mb-0 ${text}`}>{children}</p>,
         h1: ({ children }) => <h1 className={`mb-2 text-lg font-bold ${text}`}>{children}</h1>,


### PR DESCRIPTION
## Summary
- `memo-thread.tsx`의 `rehypeSanitize`가 `entity:` 비표준 프로토콜을 href에서 제거 → EntityChip 매칭 실패 → 클릭 불가
- `defaultSchema.protocols.href`에 `'entity'` 추가로 해소
- `memo-detail.tsx`는 rehypeSanitize 미사용이라 영향 없었음

## Changes
- `import rehypeSanitize` → `import rehypeSanitize, { defaultSchema }`
- `rehypePlugins={[rehypeSanitize]}` → `rehypePlugins={[[rehypeSanitize, { ...defaultSchema, protocols: { ...defaultSchema.protocols, href: [...(defaultSchema.protocols?.href ?? []), 'entity'] } }]]}` 

## Test plan
- [ ] 메모 스레드에서 `#` 엔티티 임베드 → 렌더링된 링크 클릭 → 해당 페이지 이동 확인
- [ ] 일반 URL 링크 정상 동작 확인
- [ ] memo-detail.tsx 엔티티 링크 regression 없음 확인

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>