### PR TITLE
fix(bug): rehypeSanitize entity: 프로토콜 허용 — entity link 클릭 해소

### DIFF
--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { Bot, User } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -206,7 +206,7 @@ function MarkdownContent({ content, isCurrentUser }: { content: string; isCurren
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
+      rehypePlugins={[[rehypeSanitize, { ...defaultSchema, protocols: { ...defaultSchema.protocols, href: [...(defaultSchema.protocols?.href ?? []), 'entity'] } }]]}
       components={{
         p: ({ children }) => <p className={`mb-2 break-words text-[14px] leading-6 last:mb-0 ${text}`}>{children}</p>,
         h1: ({ children }) => <h1 className={`mb-2 text-lg font-bold ${text}`}>{children}</h1>,


### PR DESCRIPTION
## Summary
- `memo-thread.tsx`의 `rehypeSanitize`가 `entity:` 비표준 프로토콜을 href에서 제거
- `href=undefined` → EntityChip regex 매칭 실패 → 클릭 불가
- `defaultSchema.protocols.href`에 `'entity'` 추가로 해소
- `memo-detail.tsx`는 rehypeSanitize 미사용이라 정상이었음

## Changes (1 file, +2/-2)
```diff
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';

-rehypePlugins={[rehypeSanitize]}
+rehypePlugins={[[rehypeSanitize, { ...defaultSchema, protocols: { ...defaultSchema.protocols, href: [...(defaultSchema.protocols?.href ?? []), 'entity'] } }]]}
```

## Test plan
- [ ] 메모 스레드에서 # 엔티티 임베드 → 렌더링된 링크 클릭 → 해당 페이지 이동 확인
- [ ] 일반 URL 링크 정상 동작 확인 (regression)
- [ ] memo-detail.tsx 엔티티 링크 정상 확인 (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)