### PR TITLE
promote: rehypeSanitize entity 프로토콜 허용 (develop → main)

### DIFF
--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { Bot, User } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -206,7 +206,7 @@ function MarkdownContent({ content, isCurrentUser }: { content: string; isCurren
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      rehypePlugins={[rehypeSanitize]}
+      rehypePlugins={[[rehypeSanitize, { ...defaultSchema, protocols: { ...defaultSchema.protocols, href: [...(defaultSchema.protocols?.href ?? []), 'entity'] } }]]}
       components={{
         p: ({ children }) => <p className={`mb-2 break-words text-[14px] leading-6 last:mb-0 ${text}`}>{children}</p>,
         h1: ({ children }) => <h1 className={`mb-2 text-lg font-bold ${text}`}>{children}</h1>,


### PR DESCRIPTION
## Summary
- PR #503: `rehypeSanitize`가 `entity:` 비표준 프로토콜 href 제거 → entity link 클릭 불가 해소
- `defaultSchema.protocols.href`에 `'entity'` 추가 (1파일, +2/-2)
- 까심군 QA APPROVE (AC 3/3)

## Test plan
- [ ] prod 배포 후 메모 스레드 entity link 클릭 → 페이지 이동 확인
- [ ] 일반 URL 링크 regression 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)