### PR TITLE
promote: P0 에이전트 인증 수정 + CI 정상화 (develop → main)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,12 +23,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -41,7 +35,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            moonklabs/sprintable
             ghcr.io/moonklabs/sprintable
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -26,10 +26,18 @@ async def get_me(
             .where(TeamMember.id == member_id)
         )
     else:
+        # API key 인증: auth.user_id = TeamMember.id
+        # JWT 인증:     auth.user_id = user.id = TeamMember.user_id
+        uid = uuid.UUID(auth.user_id)
         result = await session.execute(
             select(TeamMember)
             .options(joinedload(TeamMember.project))
-            .where(TeamMember.user_id == uuid.UUID(auth.user_id))
+            .where(
+                or_(
+                    TeamMember.id == uid,
+                    TeamMember.user_id == uid,
+                )
+            )
         )
     member = result.scalar_one_or_none()
     if member is None:

--- a/backend/tests/test_memos.py
+++ b/backend/tests/test_memos.py
@@ -30,6 +30,7 @@ def _mock_memo(status: str = "open") -> MagicMock:
     m.deleted_at = None
     m.memo_metadata = {}
     m.search_vector = None
+    m.embed_count = 0
     m.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
     return m
@@ -80,8 +81,10 @@ async def _client():
 async def test_list_memos_200():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.memo.MemoRepository.list", new_callable=AsyncMock) as mock_list:
+        with patch("app.repositories.memo.MemoRepository.list", new_callable=AsyncMock) as mock_list, \
+             patch("app.repositories.memo.MemoRepository.get_entity_link_count", new_callable=AsyncMock) as mock_count:
             mock_list.return_value = [_mock_memo()]
+            mock_count.return_value = 0
 
             async with client as c:
                 resp = await c.get(f"/api/v2/memos?project_id={PROJECT_ID}")

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -39,6 +39,10 @@ def _mock_org() -> MagicMock:
 def _mock_member() -> MagicMock:
     m = MagicMock()
     m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.project_name = None
+    m.project = None
     m.name = "Alice"
     m.type = "human"
     m.role = "admin"

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -217,6 +217,25 @@ async def test_get_me_200():
 
 
 @pytest.mark.anyio
+async def test_get_me_via_api_key_200():
+    """API key 인증: auth.user_id = member.id → or_(id, user_id) 조회로 정상 반환."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = _mock_member()
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            # member_id 쿼리 파라미터 없이 호출 (API key 인증 경로)
+            resp = await c.get("/api/v2/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_me_404():
     client, session, app = await _client()
     try:


### PR DESCRIPTION
## Summary
- P0: /api/v2/me 에이전트 API key 인증 수정 — or_(id, user_id) 분기
- pytest mock 수정 2건 (337/337 전량 통과)
- Docker Publish GHCR 단독 전환 (Docker Hub 의존성 제거)

## Test plan
- [x] CI: Backend pytest pass, Lint/TypeCheck/Build pass
- [x] Cloud Build (GCP) develop SUCCESS
- [ ] prod Cloud Build 자동 트리거 확인
- [ ] /api/v2/me 에이전트 API key 인증 검증
- [ ] MCP send_memo 웹훅 자동 발송 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)