### PR TITLE
[SID:ec228ff6] P0 me.py or_() regression 핫픽스

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,7 +1,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import or_, select
+from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,27 +19,24 @@ async def get_me(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    uid = uuid.UUID(auth.user_id)
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+
     if member_id:
-        result = await session.execute(
-            select(TeamMember)
-            .options(joinedload(TeamMember.project))
-            .where(TeamMember.id == member_id)
-        )
-    else:
+        where_clause = TeamMember.id == member_id
+    elif is_api_key:
         # API key 인증: auth.user_id = TeamMember.id
-        # JWT 인증:     auth.user_id = user.id = TeamMember.user_id
-        uid = uuid.UUID(auth.user_id)
-        result = await session.execute(
-            select(TeamMember)
-            .options(joinedload(TeamMember.project))
-            .where(
-                or_(
-                    TeamMember.id == uid,
-                    TeamMember.user_id == uid,
-                )
-            )
-        )
-    member = result.scalar_one_or_none()
+        where_clause = TeamMember.id == uid
+    else:
+        # JWT 인증: auth.user_id = user.id = TeamMember.user_id
+        where_clause = TeamMember.user_id == uid
+
+    result = await session.execute(
+        select(TeamMember)
+        .options(joinedload(TeamMember.project))
+        .where(where_clause)
+    )
+    member = result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
     data = MeResponse.model_validate(member)

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -232,7 +232,7 @@ async def test_me_get_via_conftest(test_client, mock_session):
     """GET /api/v2/me 404 (member 없음) — 라우터 연결 확인."""
     member_id = uuid.uuid4()
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.first.return_value = None
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/me?member_id={member_id}")

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -199,13 +199,50 @@ async def test_delete_organization_403_not_owner():
 
 # ── Me ────────────────────────────────────────────────────────────────────────
 
+def _mock_result(member):
+    """scalars().first() 패턴 mock 생성."""
+    r = MagicMock()
+    r.scalars.return_value.first.return_value = member
+    return r
+
+
+async def _client_api_key():
+    """API key claims (api_key_id 포함)를 가진 클라이언트."""
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(MEMBER_ID)
+    ctx.email = None
+    ctx.claims = {
+        "app_metadata": {
+            "org_id": str(ORG_ID),
+            "api_key_id": str(uuid.uuid4()),
+        }
+    }
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
 @pytest.mark.anyio
 async def test_get_me_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
 
         async with client as c:
             resp = await c.get(f"/api/v2/me?member_id={MEMBER_ID}")
@@ -218,15 +255,28 @@ async def test_get_me_200():
 
 @pytest.mark.anyio
 async def test_get_me_via_api_key_200():
-    """API key 인증: auth.user_id = member.id → or_(id, user_id) 조회로 정상 반환."""
-    client, session, app = await _client()
+    """API key 인증: auth.user_id = TeamMember.id → id 분기로 조회."""
+    client, session, app = await _client_api_key()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
 
         async with client as c:
-            # member_id 쿼리 파라미터 없이 호출 (API key 인증 경로)
+            resp = await c.get("/api/v2/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_me_via_jwt_no_member_id_200():
+    """JWT 인증: member_id 미전달 시 user_id 분기로 조회."""
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
+
+        async with client as c:
             resp = await c.get("/api/v2/me")
 
         assert resp.status_code == 200
@@ -239,9 +289,7 @@ async def test_get_me_via_api_key_200():
 async def test_get_me_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(None))
 
         async with client as c:
             resp = await c.get(f"/api/v2/me?member_id={uuid.uuid4()}")


### PR DESCRIPTION
## 문제

PR #518의 `or_(TeamMember.id == uid, TeamMember.user_id == uid) + scalar_one_or_none()`이 다중 프로젝트 JWT 사용자에서 `MultipleResultsFound` → 500 → 프로덕션 401 regression 발생.

## 수정 내용

**`backend/app/routers/me.py`**

`or_()` 제거, `api_key_id` claims 유무로 명시적 분기:
- API key 인증 (`api_key_id` 존재): `TeamMember.id == uid`
- JWT 인증: `TeamMember.user_id == uid`
- `scalar_one_or_none()` → `scalars().first()` (다중 멤버십 환경 안전)

**`backend/tests/test_s31.py`**
- `_mock_result()` 헬퍼 추가 (`scalars().first()` 패턴)
- `_client_api_key()` fixture 추가 (api_key_id claims 포함)
- JWT 경로 테스트 `test_get_me_via_jwt_no_member_id_200` 추가

**`backend/tests/test_integration.py`**
- `test_me_get_via_conftest` mock 패턴 `scalars().first()`로 업데이트

## 주의

`/api/v2/me/memberships` 엔드포인트의 `or_()` 패턴은 의도된 것이므로 미변경.

## 검증

```bash
cd backend && uv run pytest
# 339 passed, 0 failed
```

## AC 체크리스트

- [x] API key 인증 + member_id 미전달 → 200 정상
- [x] JWT 인증 + member_id 미전달 → 200 정상 (다중 프로젝트 안전)
- [x] member_id 명시 → 200 정상 (기존 동작 유지)
- [x] member 없음 → 404
- [x] pytest 339/339 통과