### PR TITLE
[P0 Hotfix] me.py or_() regression — api_key_id claims 분기

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -19,27 +19,24 @@ async def get_me(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    uid = uuid.UUID(auth.user_id)
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+
     if member_id:
-        result = await session.execute(
-            select(TeamMember)
-            .options(joinedload(TeamMember.project))
-            .where(TeamMember.id == member_id)
-        )
-    else:
+        where_clause = TeamMember.id == member_id
+    elif is_api_key:
         # API key 인증: auth.user_id = TeamMember.id
-        # JWT 인증:     auth.user_id = user.id = TeamMember.user_id
-        uid = uuid.UUID(auth.user_id)
-        result = await session.execute(
-            select(TeamMember)
-            .options(joinedload(TeamMember.project))
-            .where(
-                or_(
-                    TeamMember.id == uid,
-                    TeamMember.user_id == uid,
-                )
-            )
-        )
-    member = result.scalar_one_or_none()
+        where_clause = TeamMember.id == uid
+    else:
+        # JWT 인증: auth.user_id = user.id = TeamMember.user_id
+        where_clause = TeamMember.user_id == uid
+
+    result = await session.execute(
+        select(TeamMember)
+        .options(joinedload(TeamMember.project))
+        .where(where_clause)
+    )
+    member = result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
     data = MeResponse.model_validate(member)

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -232,7 +232,7 @@ async def test_me_get_via_conftest(test_client, mock_session):
     """GET /api/v2/me 404 (member 없음) — 라우터 연결 확인."""
     member_id = uuid.uuid4()
     mock_result = MagicMock()
-    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.first.return_value = None
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/me?member_id={member_id}")

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -199,13 +199,50 @@ async def test_delete_organization_403_not_owner():
 
 # ── Me ────────────────────────────────────────────────────────────────────────
 
+def _mock_result(member):
+    """scalars().first() 패턴 mock 생성."""
+    r = MagicMock()
+    r.scalars.return_value.first.return_value = member
+    return r
+
+
+async def _client_api_key():
+    """API key claims (api_key_id 포함)를 가진 클라이언트."""
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(MEMBER_ID)
+    ctx.email = None
+    ctx.claims = {
+        "app_metadata": {
+            "org_id": str(ORG_ID),
+            "api_key_id": str(uuid.uuid4()),
+        }
+    }
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
 @pytest.mark.anyio
 async def test_get_me_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
 
         async with client as c:
             resp = await c.get(f"/api/v2/me?member_id={MEMBER_ID}")
@@ -218,15 +255,28 @@ async def test_get_me_200():
 
 @pytest.mark.anyio
 async def test_get_me_via_api_key_200():
-    """API key 인증: auth.user_id = member.id → or_(id, user_id) 조회로 정상 반환."""
-    client, session, app = await _client()
+    """API key 인증: auth.user_id = TeamMember.id → id 분기로 조회."""
+    client, session, app = await _client_api_key()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
 
         async with client as c:
-            # member_id 쿼리 파라미터 없이 호출 (API key 인증 경로)
+            resp = await c.get("/api/v2/me")
+
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Alice"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_me_via_jwt_no_member_id_200():
+    """JWT 인증: member_id 미전달 시 user_id 분기로 조회."""
+    client, session, app = await _client()
+    try:
+        session.execute = AsyncMock(return_value=_mock_result(_mock_member()))
+
+        async with client as c:
             resp = await c.get("/api/v2/me")
 
         assert resp.status_code == 200
@@ -239,9 +289,7 @@ async def test_get_me_via_api_key_200():
 async def test_get_me_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = AsyncMock(return_value=_mock_result(None))
 
         async with client as c:
             resp = await c.get(f"/api/v2/me?member_id={uuid.uuid4()}")


### PR DESCRIPTION
## Summary
- PR #518의 `or_(TeamMember.id, TeamMember.user_id)` + `scalar_one_or_none()`가 다중 프로젝트 JWT 사용자에서 `MultipleResultsFound` → 401 regression
- `api_key_id` claims 유무로 인증 유형 판별하여 쿼리 분기
- `scalars().first()` 전환으로 다중 멤버십 안전 처리

## Changed files
- `backend/app/routers/me.py` — get_me() 수정
- `backend/tests/test_s31.py` — JWT/API key 분기 테스트 추가
- `backend/tests/test_integration.py` — mock 패턴 동기화

## Cherry-pick
develop PR #520 (8c171786) → main cherry-pick. develop에 238건 미프로모션 변경 있어 전체 머지 대신 hotfix cherry-pick.

## Test plan
- [x] pytest 339/339 pass (PR #520)
- [x] CI Lint/TypeCheck/Build pass
- [ ] prod smoke: /api/notifications/count 200
- [ ] prod smoke: GNB 프로젝트 선택 정상