### PR TITLE
[SID:cb979c03] P0 /agents C.map 크래시 수정 — apiSuccess 이중 래핑 제거

### DIFF
--- a/apps/web/src/app/api/v1/agent-deployments/route.test.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/route.test.ts
@@ -1,237 +1,78 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-const {
-  createDbServerClient,
-  getMyTeamMember,
-  requireOrgAdmin,
-  buildDeploymentCards,
-  createDeployment,
-  requireAgentOrchestration,
-  getProjectAiSettingsWithIntegrationMock,
-} = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getMyTeamMember: vi.fn(),
-  requireOrgAdmin: vi.fn(),
-  buildDeploymentCards: vi.fn(),
-  createDeployment: vi.fn(),
-  requireAgentOrchestration: vi.fn(),
-  getProjectAiSettingsWithIntegrationMock: vi.fn(),
+const { proxyToFastapi } = vi.hoisted(() => ({
+  proxyToFastapi: vi.fn(),
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/auth-helpers', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
-  return { ...actual, getMyTeamMember };
-});
-vi.mock('@/lib/admin-check', () => ({ requireOrgAdmin }));
-vi.mock('@/services/agent-dashboard', () => ({ buildDeploymentCards }));
-vi.mock('@/lib/require-agent-orchestration', () => ({ requireAgentOrchestration }));
-vi.mock('@/lib/llm/project-ai-settings', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/llm/project-ai-settings')>('@/lib/llm/project-ai-settings');
-  return { ...actual, getProjectAiSettingsWithIntegration: getProjectAiSettingsWithIntegrationMock };
-});
-vi.mock('@/services/agent-deployment-lifecycle', () => ({
-  DeploymentLifecycleError: class DeploymentLifecycleError extends Error {
-    constructor(public code: string, public status: number, message: string, public details?: Record<string, unknown>) {
-      super(message);
-      this.name = 'DeploymentLifecycleError';
-    }
-  },
-  AgentDeploymentLifecycleService: class {
-    createDeployment = createDeployment;
-  },
-}));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET, POST } from './route';
 
-describe('/api/v1/agent-deployments', () => {
-  beforeEach(() => {
-    createDbServerClient.mockReset();
-    getMyTeamMember.mockReset();
-    requireOrgAdmin.mockReset();
-    buildDeploymentCards.mockReset();
-    createDeployment.mockReset();
-    requireAgentOrchestration.mockReset();
-    getProjectAiSettingsWithIntegrationMock.mockReset();
-
-    createDbServerClient.mockResolvedValue({
-      auth: {
-        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
-      },
-    });
-    getMyTeamMember.mockResolvedValue({
-      id: 'member-1',
-      org_id: 'org-1',
-      project_id: 'project-1',
-    });
-    requireAgentOrchestration.mockResolvedValue(null);
-    getProjectAiSettingsWithIntegrationMock.mockResolvedValue({ settings: null, integration: null });
+function fastapiOk(data: unknown, status = 200) {
+  return new Response(JSON.stringify({ data, error: null, meta: null }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
   });
+}
 
-  it('lists deployment cards when agent orchestration is enabled', async () => {
-    buildDeploymentCards.mockResolvedValue([{ id: 'dep-1', name: 'Reviewer' }]);
+function fastapiErr(status: number, code: string, message: string) {
+  return new Response(JSON.stringify({ data: null, error: { code, message }, meta: null }), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
-    const response = await GET(new Request('http://test'));
+describe('/api/v1/agent-deployments', () => {
+  it('GET — deployment 목록을 data 배열로 반환', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk([{ id: 'dep-1', name: 'Reviewer' }]));
 
-    expect(response.status).toBe(200);
-    expect(requireAgentOrchestration).toHaveBeenCalledWith(expect.anything(), 'org-1');
-    await expect(response.json()).resolves.toMatchObject({
+    const resp = await GET(new Request('http://test'));
+
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({
       data: [{ id: 'dep-1', name: 'Reviewer' }],
     });
   });
 
-  it('blocks deployment dashboard API access when upgrade is required', async () => {
-    requireAgentOrchestration.mockResolvedValue(new Response(JSON.stringify({
-      code: 'UPGRADE_REQUIRED',
-      error: { code: 'UPGRADE_REQUIRED', message: 'Upgrade required' },
-    }), { status: 403, headers: { 'Content-Type': 'application/json' } }));
+  it('GET — FastAPI 오류 응답을 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(403, 'FORBIDDEN', 'org_id required'));
 
-    const response = await GET(new Request('http://test'));
+    const resp = await GET(new Request('http://test'));
 
-    expect(response.status).toBe(403);
-    expect(buildDeploymentCards).not.toHaveBeenCalled();
+    expect(resp.status).toBe(403);
   });
 
-  it('creates a deployment inside the current org/project scope', async () => {
-    createDeployment.mockResolvedValue({ id: 'dep-1', status: 'DEPLOYING' });
+  it('GET — 204 응답 시 { ok: true } 반환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
 
-    const response = await POST(new Request('http://localhost/api/v1/agent-deployments', {
-      method: 'POST',
-      body: JSON.stringify({
-        agent_id: '11111111-1111-4111-8111-111111111111',
-        name: 'Reviewer',
-        persona_id: '22222222-2222-4222-8222-222222222222',
-        config: {
-          schema_version: 1,
-          llm_mode: 'managed',
-          provider: 'openai',
-          scope_mode: 'projects',
-          project_ids: ['33333333-3333-4333-8333-333333333333'],
-        },
-      }),
-    }));
+    const resp = await GET(new Request('http://test'));
 
-    expect(response.status).toBe(202);
-    expect(createDeployment).toHaveBeenCalledWith(expect.objectContaining({
-      orgId: 'org-1',
-      projectId: 'project-1',
-      actorId: 'member-1',
-      agentId: '11111111-1111-4111-8111-111111111111',
-      name: 'Reviewer',
-      personaId: '22222222-2222-4222-8222-222222222222',
-      config: expect.objectContaining({
-        llm_mode: 'managed',
-        provider: 'openai',
-      }),
-    }));
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
   });
 
-  it('rejects BYOM deployment creation when the stored project credential provider does not match', async () => {
-    getProjectAiSettingsWithIntegrationMock.mockResolvedValue({
-      settings: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        llm_config: { model: 'gpt-4o-mini' },
-      },
-      integration: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        integration_type: 'byom_api_key',
-        provider: 'openai',
-        secret_last4: '1234',
-        encrypted_secret: 'encrypted',
-      },
-    });
+  it('POST — 배포 생성 성공 시 202 + data 반환', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ id: 'dep-1', status: 'DEPLOYING' }, 202));
 
-    const response = await POST(new Request('http://localhost/api/v1/agent-deployments', {
+    const resp = await POST(new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({
-        agent_id: '11111111-1111-4111-8111-111111111111',
-        name: 'Reviewer',
-        config: {
-          schema_version: 1,
-          llm_mode: 'byom',
-          provider: 'anthropic',
-          scope_mode: 'projects',
-          project_ids: ['33333333-3333-4333-8333-333333333333'],
-        },
-      }),
+      body: JSON.stringify({ agent_id: 'a', name: 'Reviewer' }),
     }));
 
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toMatchObject({
-      error: {
-        code: 'BYOM_PROVIDER_MISMATCH',
-      },
-    });
-    expect(createDeployment).not.toHaveBeenCalled();
-  });
-
-  it('returns structured preflight details when creation is blocked server-side', async () => {
-    const { DeploymentLifecycleError } = await import('@/services/agent-deployment-lifecycle');
-    createDeployment.mockRejectedValue(new DeploymentLifecycleError(
-      'DEPLOYMENT_PREFLIGHT_FAILED',
-      409,
-      'Resolve preflight issues before deploying',
-      {
-        preflight: {
-          ok: false,
-          blocking_reasons: ['Managed deployment validation failed for one or more MCP connections'],
-        },
-      },
-    ));
-
-    const response = await POST(new Request('http://localhost/api/v1/agent-deployments', {
-      method: 'POST',
-      body: JSON.stringify({
-        agent_id: '11111111-1111-4111-8111-111111111111',
-        name: 'Reviewer',
-        config: {
-          schema_version: 1,
-          llm_mode: 'managed',
-          provider: 'openai',
-          scope_mode: 'projects',
-          project_ids: ['33333333-3333-4333-8333-333333333333'],
-        },
-      }),
-    }));
-
-    expect(response.status).toBe(409);
-    await expect(response.json()).resolves.toMatchObject({
-      error: {
-        code: 'DEPLOYMENT_PREFLIGHT_FAILED',
-        details: {
-          preflight: {
-            ok: false,
-          },
-        },
-      },
+    expect(resp.status).toBe(202);
+    await expect(resp.json()).resolves.toMatchObject({
+      data: { id: 'dep-1', status: 'DEPLOYING' },
     });
   });
 
-  it('rejects deployment creation bypass when upgrade is required', async () => {
-    requireAgentOrchestration.mockResolvedValue(new Response(JSON.stringify({
-      code: 'UPGRADE_REQUIRED',
-      error: { code: 'UPGRADE_REQUIRED', message: 'Upgrade required' },
-    }), { status: 403, headers: { 'Content-Type': 'application/json' } }));
+  it('POST — FastAPI 오류 응답을 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(409, 'CONFLICT', 'Deployment already exists'));
 
-    const response = await POST(new Request('http://localhost/api/v1/agent-deployments', {
+    const resp = await POST(new Request('http://test', {
       method: 'POST',
-      body: JSON.stringify({
-        agent_id: '11111111-1111-4111-8111-111111111111',
-        name: 'Reviewer',
-        config: {
-          schema_version: 1,
-          llm_mode: 'managed',
-          provider: 'openai',
-          scope_mode: 'projects',
-          project_ids: ['33333333-3333-4333-8333-333333333333'],
-        },
-      }),
+      body: JSON.stringify({ agent_id: 'a' }),
     }));
 
-    expect(response.status).toBe(403);
-    expect(createDeployment).not.toHaveBeenCalled();
+    expect(resp.status).toBe(409);
   });
 });

--- a/apps/web/src/app/api/v1/agent-deployments/route.ts
+++ b/apps/web/src/app/api/v1/agent-deployments/route.ts
@@ -3,14 +3,16 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 export async function GET(request: Request) {
   const _r = await proxyToFastapi(request, '/api/v2/agent-deployments');
-    if (!_r.ok) return _r;
-    if (_r.status === 204) return apiSuccess({ ok: true });
-    return apiSuccess(await _r.json());
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  const json = await _r.json();
+  return apiSuccess(json.data, json.meta ?? undefined);
 }
 
 export async function POST(request: Request) {
   const _r = await proxyToFastapi(request, '/api/v2/agent-deployments');
-    if (!_r.ok) return _r;
-    if (_r.status === 204) return apiSuccess({ ok: true });
-    return apiSuccess(await _r.json());
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  const json = await _r.json();
+  return apiSuccess(json.data, json.meta ?? undefined, _r.status);
 }


### PR DESCRIPTION
## 문제

`/agents` 페이지에서 `C.map is not a function` 크래시 발생.

**원인:** `agent-deployments/route.ts`에서 FastAPI 응답(`{ data: [...], error: null, meta: null }`)을 `apiSuccess()`로 다시 감싸 이중 래핑 발생.
- FastAPI 응답: `{ data: [...] }`
- route.ts 반환: `{ data: { data: [...], error: null, meta: null }, error: null, meta: null }`
- 프론트엔드 `json.data` → 배열이 아닌 객체 → `.map()` 크래시

## 수정 내용

**`apps/web/src/app/api/v1/agent-deployments/route.ts`**
- `apiSuccess(await _r.json())` → `apiSuccess(json.data, json.meta ?? undefined)`
- POST: `_r.status` 전달로 202 응답 코드 유지

**`apps/web/src/app/api/v1/agent-deployments/route.test.ts`**
- 기존 `buildDeploymentCards` 기반 테스트 (6 failed) 제거
- `proxyToFastapi` mock 기반으로 전면 재작성 (5개 케이스)

## 검증

```bash
pnpm vitest run apps/web/src/app/api/v1/agent-deployments/route.test.ts
# 5 passed
```
수정 전 전체 118 failed → 수정 후 112 failed (regression 없음)

## AC 체크리스트

- [x] `json.data` 추출 후 `apiSuccess` 전달 — 이중 래핑 제거
- [x] POST 202 status 유지
- [x] route.test.ts 5/5 통과
- [x] 기존 테스트 대비 regression 없음