### PR TITLE
[SID:0e581a29] MCP URL 하드코딩 제거 — NEXT_PUBLIC_FASTAPI_URL 동적 적용

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -13,7 +13,7 @@ import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
 
 interface AgentMember {
   id: string;

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -13,7 +13,7 @@ import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
 
 interface AgentMember {
   id: string;

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
-const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
 const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
 

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -6,8 +6,8 @@ import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
-const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
+const LLMS_PROMPT = `Read this document and complete onboarding: ${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/llms.txt`;
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
 
 function buildMcpConfig(apiKey: string) {

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -6,8 +6,8 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
-const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
+const LLMS_PROMPT = `Read this document and complete onboarding: ${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/llms.txt`;
 
 interface AgentMember {
   id: string;

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -6,7 +6,7 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';
+const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
 const LLMS_PROMPT = 'Read this document and complete onboarding: https://app.sprintable.ai/llms.txt';
 
 interface AgentMember {


### PR DESCRIPTION
## 문제

3개 파일에 `https://app.sprintable.ai/api/v2/mcp` 하드코딩 → 셀프호스팅 유저 에이전트 MCP 연결 불가.

## 수정 파일

| 파일 | 변경 |
|------|------|
| `settings/members/agents/[id]/page.tsx` | `MCP_SERVER_URL` 동적화 |
| `onboarding/onboarding-form.tsx` | `MCP_SERVER_URL` 동적화 |
| `components/settings/agent-api-keys-section.tsx` | `MCP_SERVER_URL` 동적화 |

## 변경 내용

```typescript
// Before
const MCP_SERVER_URL = 'https://app.sprintable.ai/api/v2/mcp';

// After
const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
```

- `NEXT_PUBLIC_FASTAPI_URL` 미설정 시 기존 URL로 fallback (하위 호환)
- 셀프호스팅 환경: `env.local`의 `NEXT_PUBLIC_FASTAPI_URL` 설정으로 자동 적용

## 검증

```bash
grep -rn "app.sprintable.ai/api/v2/mcp" apps/web/src
# (출력 없음 — 하드코딩 0건)
```

## AC 체크리스트

- [x] 3개 파일 전량 동적 URL 교체
- [x] 하드코딩 잔존 0건 확인
- [x] fallback으로 기존 URL 유지 (하위 호환)