### PR TITLE
[SID:846f90cf] 메모 목록 N+1 쿼리 제거 — 배치 COUNT 전환

### DIFF
--- a/backend/app/repositories/memo.py
+++ b/backend/app/repositories/memo.py
@@ -145,6 +145,17 @@ class MemoRepository(BaseRepository[Memo]):
         )
         return result.scalar_one()
 
+    async def get_entity_link_counts_batch(self, memo_ids: list[uuid.UUID]) -> dict[uuid.UUID, int]:
+        from sqlalchemy import func
+        if not memo_ids:
+            return {}
+        result = await self.session.execute(
+            select(MemoEntityLink.memo_id, func.count().label("cnt"))
+            .where(MemoEntityLink.memo_id.in_(memo_ids))
+            .group_by(MemoEntityLink.memo_id)
+        )
+        return {row.memo_id: row.cnt for row in result}
+
 
 class MemoReplyRepository:
     def __init__(self, session: AsyncSession) -> None:

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -94,11 +94,11 @@ async def list_memos(
     if q:
         filters["q"] = q
     memos = await repo.list(**filters)
+    counts = await repo.get_entity_link_counts_batch([m.id for m in memos])
     results = []
     for m in memos:
-        count = await repo.get_entity_link_count(m.id)
         memo_dict = {k: v for k, v in m.__dict__.items() if not k.startswith("_")}
-        memo_dict["embed_count"] = count
+        memo_dict["embed_count"] = counts.get(m.id, 0)
         results.append(MemoListResponse.model_validate(memo_dict))
     return results
 

--- a/backend/tests/test_memos.py
+++ b/backend/tests/test_memos.py
@@ -82,9 +82,9 @@ async def test_list_memos_200():
     client, session, app = await _client()
     try:
         with patch("app.repositories.memo.MemoRepository.list", new_callable=AsyncMock) as mock_list, \
-             patch("app.repositories.memo.MemoRepository.get_entity_link_count", new_callable=AsyncMock) as mock_count:
+             patch("app.repositories.memo.MemoRepository.get_entity_link_counts_batch", new_callable=AsyncMock) as mock_count:
             mock_list.return_value = [_mock_memo()]
-            mock_count.return_value = 0
+            mock_count.return_value = {}
 
             async with client as c:
                 resp = await c.get(f"/api/v2/memos?project_id={PROJECT_ID}")


### PR DESCRIPTION
## 문제

`list_memos`에서 메모당 `get_entity_link_count()` 1회 호출 → N+1 쿼리 발생.
메모 100개 → DB 쿼리 101회.

## 수정 내용

**`backend/app/repositories/memo.py`**
`get_entity_link_counts_batch()` 추가:
```python
async def get_entity_link_counts_batch(self, memo_ids: list[uuid.UUID]) -> dict[uuid.UUID, int]:
    # GROUP BY memo_id로 배치 COUNT
    # 메모 N개 → 쿼리 1회
```

**`backend/app/routers/memos.py`**
```python
# Before: N+1
for m in memos:
    count = await repo.get_entity_link_count(m.id)

# After: 배치
counts = await repo.get_entity_link_counts_batch([m.id for m in memos])
```

**`backend/tests/test_memos.py`**
mock 대상 `get_entity_link_count` → `get_entity_link_counts_batch`로 업데이트

## 검증

```bash
cd backend && uv run pytest
# 339 passed, 0 failed
```

## AC 체크리스트

- [x] N+1 → 배치 쿼리 (메모 N개: 쿼리 2회 고정)
- [x] `memo_ids` 빈 리스트 시 early return
- [x] `embed_count` 없는 메모 → `counts.get(m.id, 0)` fallback
- [x] pytest 339/339 통과