### PR TITLE
[SID:a1645ac3] Docs D&D 계층 이동 수정 — drop 위치 기반 자식/reorder 분기

### DIFF
--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -236,27 +236,48 @@ export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMov
     const overDoc = docs.find((d) => d.id === over.id);
     if (!activeDoc || !overDoc) return;
 
-    if (activeDoc.parent_id !== overDoc.parent_id) {
-      // Cross-parent move: prevent circular (dragging a node into its own subtree)
+    // Drop position 기반으로 reorder vs 자식 이동 구분:
+    // over 항목의 상단 25% / 하단 25% → same-level reorder
+    // 중앙 50% → overDoc을 부모로 이동
+    const overRect = over.rect;
+    const activeTranslated = active.rect.current.translated;
+    const activeCenterY = activeTranslated
+      ? activeTranslated.top + activeTranslated.height / 2
+      : overRect.top + overRect.height / 2;
+    const relativeY = (activeCenterY - overRect.top) / overRect.height;
+    const dropIntoParent = relativeY > 0.25 && relativeY < 0.75;
+
+    if (dropIntoParent) {
+      // 자식으로 이동 (overDoc이 새 부모)
+      if (activeDoc.parent_id === overDoc.id) return; // 이미 자식
       if (isDescendant(docs, activeDoc.id, overDoc.id)) {
         onMoveDenied?.('circular');
         return;
       }
-
-      // Require onMove to be wired for cross-parent moves
       if (!onMove) {
         onMoveDenied?.('no-permission');
         return;
       }
-
-      // Place activeDoc as a child of overDoc (overDoc becomes the new parent)
-      const newParentId = overDoc.id;
-      await onMove(activeDoc.id, newParentId, overDoc.sort_order);
+      await onMove(activeDoc.id, overDoc.id, overDoc.sort_order);
       return;
     }
 
-    // Same-parent reorder (existing behaviour)
+    // Same-level reorder (상단/하단 25% 드롭)
     if (!onReorder) return;
+    if (activeDoc.parent_id !== overDoc.parent_id) {
+      // Cross-parent reorder: overDoc과 같은 레벨로 이동
+      if (isDescendant(docs, activeDoc.id, overDoc.id)) {
+        onMoveDenied?.('circular');
+        return;
+      }
+      if (!onMove) {
+        onMoveDenied?.('no-permission');
+        return;
+      }
+      await onMove(activeDoc.id, overDoc.parent_id, overDoc.sort_order);
+      return;
+    }
+
     const siblings = docs.filter((d) => d.parent_id === activeDoc.parent_id).sort((a, b) => a.sort_order - b.sort_order);
     const oldIndex = siblings.findIndex((d) => d.id === active.id);
     const newIndex = siblings.findIndex((d) => d.id === over.id);


### PR DESCRIPTION
## 문제

루트 A, 루트 B 간 D&D 시 `activeDoc.parent_id === overDoc.parent_id (=null)` 조건으로 reorder만 발생. 자식 이동 불가.

## 수정 내용

**`src/components/docs/doc-tree.tsx`**

`handleDragEnd`에서 drop 위치(over 항목 내 상대 Y 좌표)로 분기:
- `relativeY 0.25~0.75` (중앙 50%): `overDoc.id`를 부모로 이동 (자식 이동)
- 그 외 상단/하단 25%: 기존 same-level reorder 유지

```typescript
const relativeY = (activeCenterY - overRect.top) / overRect.height;
const dropIntoParent = relativeY > 0.25 && relativeY < 0.75;
```

추가:
- cross-parent reorder 시 `onMove(activeDoc.id, overDoc.parent_id, overDoc.sort_order)` 처리
- 이미 overDoc의 자식인 경우 no-op

## AC 체크리스트

- [x] 문서를 다른 문서 중앙 위로 D&D → 자식으로 이동
- [x] 같은 레벨 내 상단/하단 D&D → reorder 유지
- [x] circular 이동 방지
- [x] doc-tree.test.ts 12/12 통과