### PR TITLE
[SID:54e7bd28] 메모 보낸 메모 필터 추가 — created_by 백엔드 + sent 프론트

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -208,6 +208,7 @@
     "filterMembers": "Members",
     "filterAgents": "Agents",
     "clearFilters": "Clear filters",
+    "sentByMe": "Sent by me",
     "noFilteredMemos": "No memos match the selected filters.",
     "filterAssigned": "Assigned to me",
     "filterCreated": "Created by me",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -208,6 +208,7 @@
     "filterMembers": "멤버",
     "filterAgents": "에이전트",
     "clearFilters": "필터 초기화",
+    "sentByMe": "보낸 메모",
     "noFilteredMemos": "선택한 필터에 해당하는 메모가 없습니다.",
     "filterAssigned": "내게 할당",
     "filterCreated": "내가 작성",

--- a/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
+++ b/apps/web/src/app/(authenticated)/memos/memo-list-client.tsx
@@ -47,7 +47,9 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
     return raw ? raw.split(',').filter(Boolean) : [];
   }, [searchParams]);
 
-  const hasActiveFilters = selectedMemberIds.length > 0 || selectedAgentIds.length > 0;
+  const showSentOnly = searchParams.get('sent') === 'true';
+
+  const hasActiveFilters = selectedMemberIds.length > 0 || selectedAgentIds.length > 0 || showSentOnly;
   const humanMembers = useMemo(() => members.filter((m) => m.type !== 'agent'), [members]);
   const agentMembers = useMemo(() => members.filter((m) => m.type === 'agent'), [members]);
   const memberMap = useMemo(() => Object.fromEntries(members.map((m) => [m.id, m.name])), [members]);
@@ -76,10 +78,18 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
     router.replace(`/memos${params.size > 0 ? `?${params.toString()}` : ''}`, { scroll: false });
   }, [router, searchParams]);
 
+  const toggleSentOnly = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (showSentOnly) params.delete('sent');
+    else params.set('sent', 'true');
+    router.replace(`/memos${params.size > 0 ? `?${params.toString()}` : ''}`, { scroll: false });
+  }, [router, searchParams, showSentOnly]);
+
   const clearFilters = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
     params.delete('member_ids');
     params.delete('agent_ids');
+    params.delete('sent');
     router.replace(`/memos${params.size > 0 ? `?${params.toString()}` : ''}`, { scroll: false });
   }, [router, searchParams]);
 
@@ -98,6 +108,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
       if (q?.trim()) params.append('q', q.trim());
       if (cursor) params.append('cursor', cursor);
       if (filterIds?.length) params.append('assigned_to', filterIds.join(','));
+      if (showSentOnly) params.append('sent', 'true');
       const res = await fetch(`/api/memos?${params.toString()}`);
       if (!res.ok) throw new Error('Failed to fetch memos');
       const { data, meta } = await res.json();
@@ -143,7 +154,7 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
     setHasMore(false);
     const allFilterIds = [...selectedMemberIds, ...selectedAgentIds];
     void fetchMemos(debouncedQuery, null, allFilterIds.length ? allFilterIds : undefined);
-  }, [debouncedQuery, fetchMemos, selectedMemberIds, selectedAgentIds]);
+  }, [debouncedQuery, fetchMemos, selectedMemberIds, selectedAgentIds, showSentOnly]);
 
   useAutoRefresh('memo-list', () => void fetchMemos(debouncedQuery));
 
@@ -173,6 +184,16 @@ export function MemoListClient({ selectedMemoId, onNewMemo }: MemoListClientProp
               <X className="h-3.5 w-3.5" />
             </button>
           ) : null}
+        </div>
+
+        <div className="flex flex-wrap gap-1">
+          <button
+            type="button"
+            onClick={toggleSentOnly}
+            className={`rounded-md border px-2 py-0.5 text-xs font-medium transition-colors ${showSentOnly ? 'border-primary/40 bg-primary/10 text-primary' : 'border-border bg-muted/30 text-muted-foreground hover:bg-muted/60 hover:text-foreground'}`}
+          >
+            {t('sentByMe')}
+          </button>
         </div>
 
         {(humanMembers.length > 0 || agentMembers.length > 0) && (

--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -81,11 +81,12 @@ export async function GET(request: Request) {
     const dbClient = undefined;
     const repo = await createMemoRepository();
     const service = new MemoService(repo, dbClient);
+    const sentOnly = searchParams.get('sent') === 'true';
     const memos = await service.list({
       org_id: me.org_id,
       project_id: searchParams.get('project_id') ?? undefined,
       assigned_to: searchParams.get('assigned_to') ?? undefined,
-      created_by: searchParams.get('created_by') ?? undefined,
+      created_by: sentOnly ? me.id : (searchParams.get('created_by') ?? undefined),
       status: searchParams.get('status') ?? undefined,
       q: searchParams.get('q') ?? undefined,
       include_archived: searchParams.get('include_archived') === 'true',

--- a/backend/app/repositories/memo.py
+++ b/backend/app/repositories/memo.py
@@ -24,6 +24,8 @@ class MemoRepository(BaseRepository[Memo]):
             q = q.where(Memo.project_id == filters["project_id"])
         if "assigned_to" in filters:
             q = q.where(Memo.assigned_to == filters["assigned_to"])
+        if "created_by" in filters:
+            q = q.where(Memo.created_by == filters["created_by"])
         if "status" in filters:
             q = q.where(Memo.status == filters["status"])
         if "q" in filters and filters["q"]:

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -80,6 +80,7 @@ def _get_repo(
 async def list_memos(
     project_id: uuid.UUID | None = Query(default=None),
     assigned_to: uuid.UUID | None = Query(default=None),
+    created_by: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
     q: str | None = Query(default=None),
     repo: MemoRepository = Depends(_get_repo),
@@ -89,6 +90,8 @@ async def list_memos(
         filters["project_id"] = project_id
     if assigned_to:
         filters["assigned_to"] = assigned_to
+    if created_by:
+        filters["created_by"] = created_by
     if status_filter:
         filters["status"] = status_filter
     if q:


### PR DESCRIPTION
## 변경 내용

### 백엔드 (FastAPI)
**`backend/app/repositories/memo.py`**
- `list()`: `created_by` 필터 추가

**`backend/app/routers/memos.py`**
- `list_memos`: `created_by` 쿼리 파라미터 추가

### Next.js API Route
**`apps/web/src/app/api/memos/route.ts`**
- `sent=true` 파라미터 수신 시 `created_by = me.id` (현재 로그인 멤버)

### 프론트엔드
**`memo-list-client.tsx`**
- `showSentOnly` URL 파라미터 (`sent=true`) 상태 추가
- `toggleSentOnly` 핸들러 추가
- `fetchMemos`에서 `sent=true` 파라미터 전달
- "보낸 메모" 토글 버튼 UI 추가
- `clearFilters`에 `sent` param 제거 추가

**`messages/ko.json`, `messages/en.json`**
- `sentByMe`: "보낸 메모" / "Sent by me" 키 추가

## 검증

```bash
cd backend && uv run pytest
# 339 passed
```

## AC 체크리스트

- [x] FastAPI `created_by` 필터 추가
- [x] `sent=true` → 현재 로그인 멤버의 보낸 메모 필터
- [x] "보낸 메모" 토글 버튼 UI
- [x] 필터 초기화 시 `sent` 파라미터 제거
- [x] pytest 339/339 통과