### PR TITLE
[SID:63fc8d6d] 메모 엔티티 임베드 모달 프리뷰

### DIFF
--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { ExternalLink, X } from 'lucide-react';
 
 export const ENTITY_ICONS: Record<string, string> = {
   story: '📋',
@@ -34,7 +36,78 @@ export interface EmbedCardData {
   position?: number;
 }
 
+function EntityPreviewModal({
+  entityType,
+  entityId,
+  title,
+  status,
+  href,
+  onClose,
+}: {
+  entityType: string;
+  entityId: string;
+  title: string | null;
+  status: string | null;
+  href: string | null;
+  onClose: () => void;
+}) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const handleOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === overlayRef.current) onClose();
+  }, [onClose]);
+
+  const icon = ENTITY_ICONS[entityType] ?? '#';
+  const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
+  const label = title ?? entityId;
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={handleOverlayClick}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+    >
+      <div className="relative w-full max-w-sm rounded-xl border border-border bg-popover p-5 shadow-xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute right-3 top-3 text-muted-foreground hover:text-foreground"
+          aria-label="닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass} mb-4`}>
+          <span>{icon}</span>
+          <span className="font-medium">{label}</span>
+          {status ? (
+            <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
+          ) : null}
+        </div>
+        {href ? (
+          <Link
+            href={href}
+            onClick={onClose}
+            className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+          >
+            <ExternalLink className="h-3.5 w-3.5" />
+            전체 보기
+          </Link>
+        ) : (
+          <p className="text-xs text-muted-foreground">이 엔티티는 별도 페이지가 없는.</p>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardData) {
+  const [showModal, setShowModal] = useState(false);
   const icon = ENTITY_ICONS[entity_type] ?? '#';
   const colorClass = ENTITY_COLORS[entity_type] ?? 'border-border bg-muted text-foreground';
   const href = getEntityHref(entity_type, entity_id);
@@ -50,14 +123,27 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
     </div>
   );
 
-  if (href) {
-    return (
-      <Link href={href} className="block transition-opacity hover:opacity-80">
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className="block w-full text-left transition-opacity hover:opacity-80"
+      >
         {inner}
-      </Link>
-    );
-  }
-  return inner;
+      </button>
+      {showModal && (
+        <EntityPreviewModal
+          entityType={entity_type}
+          entityId={entity_id}
+          title={title}
+          status={status}
+          href={href}
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
+  );
 }
 
 export function EntityChip({


### PR DESCRIPTION
## 변경 내용

**`src/components/memos/embed-card.tsx`**

`EmbedCard` 컴포넌트:
- `Link` 직접 이동 → `button` 클릭 시 `EntityPreviewModal` 오픈
- 모달 내: 엔티티 카드 프리뷰 + "전체 보기" 링크

`EntityPreviewModal` 신규 추가:
- ESC 키 / overlay 클릭으로 닫기
- "전체 보기" Link로 실제 페이지 이동
- href 없는 엔티티(task 등)는 안내 문구

## 검증

memo component vitest: 6/6 통과

## AC 체크리스트

- [x] 엔티티 임베드 클릭 → 페이지 이동 없이 모달 오픈
- [x] ESC 닫기
- [x] 외부 클릭(overlay) 닫기
- [x] "전체 보기" 버튼으로 실제 페이지 이동
- [x] vitest 6/6 통과