### PR TITLE
[SID:478c1dc8] middleware.ts 신설 — 정적파일 차단 수정

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,0 +1,1 @@
+export { proxy as default, proxyConfig as config } from './proxy';


### PR DESCRIPTION
## 문제

`proxy.ts`의 `proxyConfig`가 `proxyConfig`라는 이름으로만 export되어 있어 Next.js가 matcher를 인식하지 못함.

Next.js는 `middleware.ts`에서 `export const config = { matcher: [...] }` 형태를 기대하는데:
- `middleware.ts` 파일 자체가 없음
- `proxyConfig`라는 이름은 Next.js가 인식하지 않음

결과: 기본 matcher(모든 경로) 적용 → `/_next/static/css` 포함 정적 파일도 auth middleware 통과 → `/login` 307 리다이렉트 → CSS 미로드 → UI 깨짐

## 수정 내용

**`apps/web/src/middleware.ts` (신규)**
```typescript
export { proxy as default, proxyConfig as config } from './proxy';
```

- `proxy` 함수를 Next.js middleware default export로 등록
- `proxyConfig`를 `config`로 export → Next.js가 matcher 인식
- 기존 matcher에 `_next/static`, `_next/image` 제외 패턴 유지

## 검증

```bash
pnpm vitest run apps/web/src/proxy.test.ts
# 9 passed
```

## AC 체크리스트

- [x] `middleware.ts` 생성으로 Next.js middleware 올바르게 등록
- [x] `proxyConfig` → `config` export로 matcher 인식
- [x] `_next/static`, `_next/image` matcher 제외 유지
- [x] proxy.test.ts 9/9 통과