### PR TITLE
fix(proxy): Next.js 16 proxy.ts 단독 패턴 — middleware.ts 충돌 제거 + CSS 307 수정

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as default, proxyConfig as config } from './proxy';

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,3 +1,5 @@
+export const runtime = 'nodejs';
+
 import { jwtVerify } from 'jose';
 import { NextResponse, type NextRequest } from 'next/server';
 
@@ -143,7 +145,9 @@ export async function proxy(request: NextRequest) {
   return response;
 }
 
-export const proxyConfig = {
+export default proxy;
+
+export const config = {
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],


### PR DESCRIPTION
## Summary

- `apps/web/src/middleware.ts` 삭제 (proxy.ts와 충돌 원인)
- `proxy.ts`에 `export const runtime = 'nodejs'` 추가 (Next.js 16 Node.js runtime)
- `proxy.ts`에 `export default proxy` 추가 (Next.js middleware 함수 인식)
- `proxyConfig` → `config` rename (Next.js가 matcher 인식)

## 배경

Next.js 16.2.2는 `proxy.ts`를 공식 middleware 파일로 인식.  
PR #529에서 `middleware.ts`를 추가했는데 `proxy.ts`와 동시 존재 → 빌드 에러 발생.

```
Error: Both middleware file "./src/src/middleware.ts" and proxy file "./src/src/proxy.ts" are detected.
Please use "./src/src/proxy.ts" only.
```

동시에 `proxyConfig`가 `config`로 rename되어 Next.js가 `_next/static` 제외 matcher를 인식 → CSS 307 리다이렉트 문제도 함께 해소.

## Test plan

- [ ] Cloud Build develop SUCCEED (step 0 "build-frontend" 통과)
- [ ] `/_next/static/css/e1905ddb5d1e4c94.css` → 200 OK
- [ ] dev `/login` 페이지 Google/GitHub 버튼 아이콘 정상 렌더
- [ ] Smoke Test 7/7 PASS