### PR TITLE
[P0][SID:478c1dc8] middleware.ts 삭제 + proxy.ts config export 수정

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as default, proxyConfig as config } from './proxy';

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -143,7 +143,7 @@ export async function proxy(request: NextRequest) {
   return response;
 }
 
-export const proxyConfig = {
+export const config = {
   matcher: [
     '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
   ],


### PR DESCRIPTION
## 문제

PR #529 (middleware.ts 신설) 머지 후 Cloud Build FAILURE.

Next.js 16.2.2: `middleware.ts`와 `proxy.ts` 동시 존재 시 빌드 에러:
```
Error: Both middleware file "./src/src/middleware.ts" and proxy file "./src/src/proxy.ts" are detected.
Please use "./src/src/proxy.ts" only.
```

추가로, `proxy.ts`의 `proxyConfig` export가 Next.js에서 인식되지 않아 모든 경로에 middleware 적용 → `/_next/static/*` 도 auth 체크 → CSS 307 redirect → UI 깨짐.

## 수정 (2건)

1. `apps/web/src/middleware.ts` **삭제** (PR #529에서 추가한 파일)
2. `apps/web/src/proxy.ts`: `proxyConfig` → `config` rename → Next.js가 matcher 인식

## 검증

```bash
pnpm vitest run apps/web/src/proxy.test.ts
# 9 passed
```

## AC 체크리스트

- [x] `middleware.ts` 삭제 (빌드 에러 해소)
- [x] `proxy.ts`의 `export const proxyConfig` → `export const config` (matcher 인식)
- [x] `_next/static` 제외 matcher 정상 작동
- [x] proxy.test.ts 9/9 통과