### PR TITLE
[SID:3d5a17ae] 로그인 페이지 회원가입 링크 + register 페이지 구현

### DIFF
--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 import { loginWithPassword } from '@/lib/db/client';
 
@@ -132,6 +133,13 @@ export default function LoginPage() {
             Continue with GitHub
           </a>
         </div>
+
+        <p className="text-center text-sm text-gray-500">
+          Don&apos;t have an account?{' '}
+          <Link href="/register" className="font-medium text-blue-600 hover:text-blue-700">
+            Sign up
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -1,5 +1,92 @@
-import { redirect } from 'next/navigation';
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
 
 export default function RegisterPage() {
-  redirect('/login');
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleRegister = async () => {
+    if (!email.trim() || !password.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim(), password }),
+      });
+      const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
+      if (!res.ok || !json.data?.ok) {
+        setError(json.error?.message ?? 'Registration failed. Please try again.');
+        return;
+      }
+      router.push('/inbox');
+      router.refresh();
+    } catch {
+      setError('Registration failed. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo
+            variant="stacked"
+            className="text-gray-900"
+            markClassName="h-14"
+            wordmarkClassName="h-5"
+          />
+          <p className="text-sm text-gray-500">Create your account</p>
+        </div>
+
+        <div className="space-y-3">
+          <input
+            type="email"
+            placeholder="Email"
+            autoComplete="email"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
+          <input
+            type="password"
+            placeholder="Password"
+            autoComplete="new-password"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
+          {error && <p className="text-sm text-red-600">{error}</p>}
+          <button
+            onClick={handleRegister}
+            disabled={loading || !email.trim() || !password.trim()}
+            className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+          >
+            {loading ? 'Creating account...' : 'Sign up'}
+          </button>
+        </div>
+
+        <p className="text-center text-sm text-gray-500">
+          Already have an account?{' '}
+          <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -12,6 +12,7 @@ const PUBLIC_PREFIX = [
   '/api/',
   '/login',
   '/signup',
+  '/register',
   '/forgot-password',
   '/auth/callback',
   '/auth/login',


### PR DESCRIPTION
## 변경 내용

**`apps/web/src/app/login/page.tsx`**
- OAuth 버튼 하단에 "Don't have an account? Sign up" + `/register` Link 추가

**`apps/web/src/app/register/page.tsx`**
- `redirect('/login')` 제거 → 실제 회원가입 폼 구현
- email + password 입력 → `/api/auth/register` POST
- 성공 시 `/inbox` 이동
- "Already have an account? Sign in" + `/login` 복귀 링크

**`apps/web/src/proxy.ts`**
- `/register`를 `PUBLIC_PREFIX`에 추가 (미인증 사용자 접근 허용)

## 검증

```bash
pnpm vitest run apps/web/src/proxy.test.ts
# 9 passed
```

## AC 체크리스트

- [x] `/login` 하단 "Don't have an account? Sign up" + `/register` 링크
- [x] `/register` 실제 회원가입 폼 (email + password)
- [x] `/register` → "Already have an account? Sign in" + `/login` 복귀 링크
- [x] `/register` PUBLIC_PREFIX 추가 (미인증 접근 가능)
- [x] proxy.test.ts 9/9 통과