### PR TITLE
[SID:63fc8d6d] EntityChip 인라인 엔티티 모달 프리뷰 적용

### DIFF
--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -148,13 +148,16 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
 
 export function EntityChip({
   entityType,
+  entityId,
   label,
   href,
 }: {
   entityType: string;
+  entityId?: string;
   label: string;
   href: string | null;
 }) {
+  const [showModal, setShowModal] = useState(false);
   const icon = ENTITY_ICONS[entityType] ?? '#';
   const colorClass = ENTITY_COLORS[entityType] ?? 'border-border bg-muted text-foreground';
 
@@ -164,6 +167,30 @@ export function EntityChip({
       <span>{label}</span>
     </span>
   );
+
+  if (entityId) {
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => setShowModal(true)}
+          className="inline-flex no-underline transition-opacity hover:opacity-80"
+        >
+          {inner}
+        </button>
+        {showModal && (
+          <EntityPreviewModal
+            entityType={entityType}
+            entityId={entityId}
+            title={label}
+            status={null}
+            href={href}
+            onClose={() => setShowModal(false)}
+          />
+        )}
+      </>
+    );
+  }
 
   if (href) {
     return (

--- a/apps/web/src/components/memos/memo-detail.tsx
+++ b/apps/web/src/components/memos/memo-detail.tsx
@@ -339,7 +339,7 @@ export function MemoDetail({
                         const entityType = m[1];
                         const entityId = m[2];
                         const entityHref = getEntityHref(entityType, entityId);
-                        return <EntityChip entityType={entityType} label={String(children)} href={entityHref} />;
+                        return <EntityChip entityType={entityType} entityId={entityId} label={String(children)} href={entityHref} />;
                       }
                       return <a href={href} target="_blank" rel="noreferrer">{children}</a>;
                     },

--- a/apps/web/src/components/memos/memo-thread.tsx
+++ b/apps/web/src/components/memos/memo-thread.tsx
@@ -223,7 +223,7 @@ function MarkdownContent({ content, isCurrentUser }: { content: string; isCurren
             const entityType = m[1];
             const entityId = m[2];
             const entityHref = getEntityHref(entityType, entityId);
-            return <EntityChip entityType={entityType} label={String(children)} href={entityHref} />;
+            return <EntityChip entityType={entityType} entityId={entityId} label={String(children)} href={entityHref} />;
           }
           return <a href={href} target="_blank" rel="noopener noreferrer" className="underline underline-offset-2">{children}</a>;
         },


### PR DESCRIPTION
## 문제

PR #527에서 `EmbedCard`(하단 임베드 섹션)에만 모달 적용. 실제 메모 본문의 인라인 `EntityChip` 클릭 시 바로 페이지 이동.

## 수정 내용

**`embed-card.tsx`**
- `EntityChip`에 `entityId?: string` prop 추가
- `entityId` 전달 시 button 클릭 → `EntityPreviewModal` 오픈
- `entityId` 미전달 시 기존 Link/span 동작 유지

**`memo-detail.tsx`**, **`memo-thread.tsx`**
- `entity:type:id` 링크 렌더링 시 `entityId={entityId}` 추가 전달

## AC 체크리스트

- [x] 본문 내 인라인 엔티티 클릭 → 모달 오픈
- [x] ESC / 외부 클릭 닫기 (EntityPreviewModal 기존 동작)
- [x] "전체 보기" 링크로 실제 페이지 이동
- [x] vitest 6/6 통과