### PR TITLE
[SID:63fc8d6d] EntityPreviewModal 마크다운 스타일 수정 — prose 제거

### DIFF
--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeSanitize from 'rehype-sanitize';
 import { ExternalLink, X } from 'lucide-react';
 
 export const ENTITY_ICONS: Record<string, string> = {
@@ -52,11 +51,25 @@ const MdBadge = ({ label }: { label: string }) => (
 );
 
 const MdBody = ({ content }: { content: string }) => (
-  <div className="prose prose-sm dark:prose-invert max-w-none text-sm leading-relaxed">
-    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
-      {content}
-    </ReactMarkdown>
-  </div>
+  <ReactMarkdown
+    remarkPlugins={[remarkGfm]}
+    components={{
+      p: ({ children }) => <p className="mb-2 text-sm leading-6">{children}</p>,
+      h1: ({ children }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
+      h2: ({ children }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
+      h3: ({ children }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
+      ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
+      ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
+      li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
+      pre: ({ children }) => <pre className="mb-2 overflow-x-auto rounded-lg p-3 text-[13px] bg-muted">{children}</pre>,
+      code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
+      blockquote: ({ children }) => <blockquote className="mb-2 border-l-2 pl-3 border-border text-muted-foreground">{children}</blockquote>,
+      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+      em: ({ children }) => <em className="italic">{children}</em>,
+    }}
+  >
+    {content}
+  </ReactMarkdown>
 );
 
 function EntityDetail({ entityType, detail }: { entityType: string; detail: Record<string, unknown> }) {


### PR DESCRIPTION
prose 클래스 제거, components prop으로 직접 스타일 지정. memo-thread.tsx MarkdownContent 동일 패턴.