### PR TITLE
[SID:1be0f459] /epics/[id] 상세 페이지 + 리스트 UI 개선

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1974,6 +1974,8 @@
     "description": "Description",
     "noDescription": "No description provided.",
     "editEpic": "Edit Epic",
+    "viewFull": "View Full",
+    "filterAll": "All",
     "saveChanges": "Save Changes",
     "cancel": "Cancel",
     "createEpic": "Create Epic",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1974,6 +1974,8 @@
     "description": "설명",
     "noDescription": "설명이 없습니다.",
     "editEpic": "에픽 수정",
+    "viewFull": "전체 보기",
+    "filterAll": "전체",
     "saveChanges": "변경 저장",
     "cancel": "취소",
     "createEpic": "에픽 생성",

--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { ArrowLeft, Pencil, X } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+
+type EpicStatus = 'draft' | 'active' | 'done' | 'archived';
+type EpicPriority = 'critical' | 'high' | 'medium' | 'low';
+
+interface Story {
+  id: string;
+  title: string;
+  status: string;
+  story_points?: number;
+  assignee_id?: string;
+}
+
+interface Epic {
+  id: string;
+  title: string;
+  description?: string;
+  status: EpicStatus;
+  priority: EpicPriority;
+  target_date?: string;
+  target_sp?: number;
+  created_at: string;
+  stories?: Story[];
+}
+
+function statusBadgeVariant(s: EpicStatus) {
+  if (s === 'active') return 'info' as const;
+  if (s === 'done') return 'success' as const;
+  return 'secondary' as const;
+}
+
+function priorityBadgeVariant(p: EpicPriority) {
+  if (p === 'critical') return 'destructive' as const;
+  if (p === 'high') return 'secondary' as const;
+  if (p === 'medium') return 'outline' as const;
+  return 'chip' as const;
+}
+
+function formatDate(d?: string) {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
+}
+
+function ProgressBar({ done, total }: { done: number; total: number }) {
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  return (
+    <div className="space-y-1">
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>{done} / {total}</span>
+        <span>{pct}%</span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div className="h-full rounded-full bg-primary transition-all duration-300" style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function MdBody({ content }: { content: string }) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      components={{
+        p: ({ children }) => <p className="mb-2 text-sm leading-6">{children}</p>,
+        h1: ({ children }) => <h1 className="mb-2 text-lg font-bold">{children}</h1>,
+        h2: ({ children }) => <h2 className="mb-2 text-base font-bold">{children}</h2>,
+        h3: ({ children }) => <h3 className="mb-1.5 text-sm font-bold">{children}</h3>,
+        ul: ({ children }) => <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>,
+        ol: ({ children }) => <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>,
+        li: ({ children }) => <li className="text-sm leading-6">{children}</li>,
+        code: ({ children }) => <code className="rounded px-1 py-0.5 font-mono text-[13px] bg-muted">{children}</code>,
+        strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+        em: ({ children }) => <em className="italic">{children}</em>,
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
+}
+
+function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: Epic) => void; onCancel: () => void }) {
+  const [title, setTitle] = useState(epic.title);
+  const [description, setDescription] = useState(epic.description ?? '');
+  const [status, setStatus] = useState<EpicStatus>(epic.status);
+  const [priority, setPriority] = useState<EpicPriority>(epic.priority);
+  const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
+  const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined ? String(epic.target_sp) : '');
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    if (!title.trim()) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/epics/${epic.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || undefined,
+          status,
+          priority,
+          ...(targetDate ? { target_date: targetDate } : {}),
+          ...(targetSp ? { target_sp: Number(targetSp) } : {}),
+        }),
+      });
+      if (!res.ok) throw new Error();
+      const { data } = await res.json() as { data: Epic };
+      onSaved({ ...data, stories: epic.stories });
+    } finally {
+      setSaving(false);
+    }
+  }, [title, description, status, priority, targetDate, targetSp, epic, onSaved]);
+
+  const inputCls = 'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
+
+  return (
+    <div className="space-y-4">
+      <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} placeholder="제목" />
+      <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={5} className={`${inputCls} resize-none`} placeholder="설명 (마크다운)" />
+      <div className="grid grid-cols-2 gap-3">
+        <select value={status} onChange={(e) => setStatus(e.target.value as EpicStatus)} className={inputCls}>
+          <option value="draft">Draft</option>
+          <option value="active">Active</option>
+          <option value="done">Done</option>
+          <option value="archived">Archived</option>
+        </select>
+        <select value={priority} onChange={(e) => setPriority(e.target.value as EpicPriority)} className={inputCls}>
+          <option value="critical">Critical</option>
+          <option value="high">High</option>
+          <option value="medium">Medium</option>
+          <option value="low">Low</option>
+        </select>
+        <input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} className={inputCls} />
+        <input type="number" min="0" value={targetSp} onChange={(e) => setTargetSp(e.target.value)} className={inputCls} placeholder="목표 SP" />
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button variant="ghost" size="sm" onClick={onCancel}>취소</Button>
+        <Button size="sm" disabled={saving || !title.trim()} onClick={() => void handleSave()}>
+          {saving ? '저장 중…' : '저장'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export default function EpicDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const [epic, setEpic] = useState<Epic | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isEditing, setIsEditing] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/epics/${id}`)
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((json) => setEpic((json as { data: Epic }).data))
+      .catch(() => router.replace('/epics'))
+      .finally(() => setLoading(false));
+  }, [id, router]);
+
+  if (loading) {
+    return <div className="flex h-64 items-center justify-center text-sm text-muted-foreground">불러오는 중…</div>;
+  }
+  if (!epic) return null;
+
+  const stories = epic.stories ?? [];
+  const done = stories.filter((s) => s.status === 'done').length;
+  const spDone = stories.filter((s) => s.status === 'done').reduce((a, s) => a + (s.story_points ?? 0), 0);
+  const spTotal = stories.reduce((a, s) => a + (s.story_points ?? 0), 0);
+
+  return (
+    <>
+      <TopBarSlot
+        title={
+          <div className="flex items-center gap-2">
+            <Link href="/epics" className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+              <ArrowLeft className="h-3.5 w-3.5" />
+              에픽 목록
+            </Link>
+            <span className="text-muted-foreground">/</span>
+            <span className="text-sm font-medium truncate max-w-[200px]">{epic.title}</span>
+          </div>
+        }
+      />
+
+      <div className="mx-auto max-w-3xl px-4 py-6 space-y-8">
+        {/* Header */}
+        <div className="space-y-3">
+          <div className="flex items-start justify-between gap-4">
+            <h1 className="text-xl font-bold leading-tight">{epic.title}</h1>
+            <button
+              type="button"
+              onClick={() => setIsEditing((v) => !v)}
+              className="shrink-0 flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+            >
+              {isEditing ? <X className="h-3.5 w-3.5" /> : <Pencil className="h-3.5 w-3.5" />}
+              {isEditing ? '취소' : '편집'}
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Badge variant={statusBadgeVariant(epic.status)}>{epic.status}</Badge>
+            <Badge variant={priorityBadgeVariant(epic.priority)}>{epic.priority}</Badge>
+            {epic.target_date && <span className="text-xs text-muted-foreground">마감: {formatDate(epic.target_date)}</span>}
+            {epic.target_sp != null && <span className="text-xs text-muted-foreground">목표 SP: {epic.target_sp}</span>}
+          </div>
+        </div>
+
+        {/* Edit form */}
+        {isEditing && (
+          <div className="rounded-xl border border-border bg-muted/30 p-4">
+            <EpicEditInline
+              epic={epic}
+              onSaved={(updated) => { setEpic(updated); setIsEditing(false); }}
+              onCancel={() => setIsEditing(false)}
+            />
+          </div>
+        )}
+
+        {/* Description */}
+        {!isEditing && (
+          <div className="space-y-2">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">설명</h2>
+            {epic.description?.trim() ? (
+              <MdBody content={epic.description} />
+            ) : (
+              <p className="text-sm italic text-muted-foreground">설명이 없는.</p>
+            )}
+          </div>
+        )}
+
+        {/* Progress */}
+        <div className="space-y-4">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">진행 상황</h2>
+          <div>
+            <p className="mb-1 text-xs text-muted-foreground">스토리 완료</p>
+            <ProgressBar done={done} total={stories.length} />
+          </div>
+          {spTotal > 0 && (
+            <div>
+              <p className="mb-1 text-xs text-muted-foreground">SP 진행</p>
+              <ProgressBar done={spDone} total={spTotal} />
+            </div>
+          )}
+        </div>
+
+        {/* Stories */}
+        <div className="space-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">스토리 ({stories.length})</h2>
+          {stories.length > 0 ? (
+            <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
+              {stories.map((story) => (
+                <button
+                  key={story.id}
+                  type="button"
+                  onClick={() => router.push(`/board?story=${story.id}`)}
+                  className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+                >
+                  <span className="text-sm">{story.title}</span>
+                  <div className="flex shrink-0 items-center gap-2">
+                    {story.story_points != null && (
+                      <span className="text-xs text-muted-foreground">{story.story_points} SP</span>
+                    )}
+                    <Badge variant={story.status === 'done' ? 'success' : 'secondary'} className="text-[10px]">
+                      {story.status}
+                    </Badge>
+                  </div>
+                </button>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm italic text-muted-foreground">스토리가 없는.</p>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -433,6 +433,10 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
           </div>
         </div>
 
+        {epic.description?.trim() ? (
+          <p className="text-xs text-[color:var(--operator-muted)] line-clamp-1">{epic.description.split('\n')[0]?.replace(/^#+\s*/, '')}</p>
+        ) : null}
+
         <div className="flex items-center gap-3 text-xs text-[color:var(--operator-muted)]">
           {epic.target_date ? (
             <span>{t('targetDate')}: {formatDate(epic.target_date)}</span>
@@ -510,9 +514,14 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
         </div>
         <div className="flex items-center gap-2">
           {!isEditing ? (
-            <Button size="sm" variant="outline" onClick={() => setIsEditing(true)}>
-              {t('editEpic')}
-            </Button>
+            <>
+              <Button size="sm" variant="outline" onClick={() => router.push(`/epics/${epic.id}`)}>
+                {t('viewFull')}
+              </Button>
+              <Button size="sm" variant="outline" onClick={() => setIsEditing(true)}>
+                {t('editEpic')}
+              </Button>
+            </>
           ) : null}
           <button
             type="button"
@@ -677,6 +686,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [epicsHasMore, setEpicsHasMore] = useState(false);
   const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
   const [epicsLoadingMore, setEpicsLoadingMore] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<EpicStatus | 'all'>('all');
 
   const fetchEpics = useCallback(async (cursor?: string | null) => {
     try {
@@ -719,10 +729,15 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   }, []);
 
   const handleSelectEpic = useCallback(async (epic: Epic) => {
+    // 모바일: 상세 페이지 직접 이동
+    if (typeof window !== 'undefined' && window.innerWidth < 1024) {
+      router.push(`/epics/${epic.id}`);
+      return;
+    }
     setSelectedEpic(epic);
     setMobileView('detail');
     await fetchEpicDetail(epic.id);
-  }, [fetchEpicDetail]);
+  }, [fetchEpicDetail, router]);
 
   const handleCreated = useCallback((epic: Epic) => {
     setEpics((prev) => [epic, ...prev]);
@@ -750,12 +765,32 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
     );
   }
 
+  const filteredEpics = statusFilter === 'all' ? epics : epics.filter((e) => e.status === statusFilter);
+
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[color:var(--operator-surface-soft)]/35">
 
+      {/* Status filter */}
+      <div className="flex shrink-0 gap-1 px-4 pt-3 pb-1 flex-wrap">
+        {(['all', 'draft', 'active', 'done', 'archived'] as const).map((s) => (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setStatusFilter(s)}
+            className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
+              statusFilter === s
+                ? 'border-primary/40 bg-primary/10 text-primary'
+                : 'border-[color:var(--operator-border,hsl(var(--border)))] text-[color:var(--operator-muted)] hover:bg-muted/50'
+            }`}
+          >
+            {s === 'all' ? t('filterAll') : s}
+          </button>
+        ))}
+      </div>
+
       {/* List body */}
       <div className="flex-1 overflow-y-auto p-4">
-        {epics.length === 0 ? (
+        {filteredEpics.length === 0 ? (
           <EmptyState
             title={t('noEpics')}
             description={t('noEpicsDescription')}
@@ -768,7 +803,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
           />
         ) : (
           <div className="space-y-2">
-            {epics.map((epic) => (
+            {filteredEpics.map((epic) => (
               <EpicRow
                 key={epic.id}
                 epic={epic}

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -678,6 +678,7 @@ interface EpicsClientProps {
 
 export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const t = useTranslations('epics');
+  const router = useRouter();
   const [epics, setEpics] = useState<Epic[]>([]);
   const [selectedEpic, setSelectedEpic] = useState<Epic | null>(null);
   const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## 변경 내용

### 1. /epics/[id] 상세 페이지 신설
- `apps/web/src/app/(authenticated)/epics/[id]/page.tsx` 생성
- `/api/epics/{id}` fetch → full-page 렌더
- description ReactMarkdown 렌더링
- stories 테이블 (제목/상태/SP, 클릭 시 /board?story=)
- 진행 바 (스토리 완료율 + SP 진행)
- 인라인 편집 (PATCH /api/epics/{id})

### 2. EpicDetailPanel 개선
- "전체 보기" 버튼 → `/epics/{id}` 이동

### 3. EpicRow 개선
- description 첫 줄 미리보기 표시

### 4. Status 필터
- all/draft/active/done/archived 필터 버튼

### 5. 모바일 동작
- EpicRow 탭 시 (innerWidth < 1024) → `/epics/{id}` 직접 이동

## AC 체크리스트

- [x] /epics/[id] URL 접근 시 에픽 상세 페이지 렌더
- [x] description ReactMarkdown 렌더
- [x] stories 목록 + 클릭 시 /board?story=uuid 이동
- [x] 에픽 인라인 편집
- [x] status 필터 동작
- [x] 모바일 탭 시 상세 페이지 이동
- [x] 메모 임베드 entity:epic:uuid → /epics/{id} 정상 이동 (getEntityHref 기존 처리)