### PR TITLE
[SID:a202e49c] Board 필터 Sprint/Epic 관리 페이지 진입점 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -152,6 +152,8 @@
     "filterAgents": "Agents",
     "sprints": "Sprints",
     "epics": "Epics",
+    "manageSprints": "Manage sprints →",
+    "manageEpics": "Manage epics →",
     "assignees": "Assignees",
     "assignee": "Assignee",
     "unassigned": "Unassigned",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -152,6 +152,8 @@
     "filterAgents": "에이전트",
     "sprints": "스프린트",
     "epics": "에픽",
+    "manageSprints": "스프린트 관리 →",
+    "manageEpics": "에픽 관리 →",
     "assignees": "담당자",
     "assignee": "담당자",
     "unassigned": "담당자 없음",

--- a/apps/web/src/components/kanban/board-sidebar-filters.tsx
+++ b/apps/web/src/components/kanban/board-sidebar-filters.tsx
@@ -102,6 +102,10 @@ export function BoardSidebarFilters({ projectId }: BoardSidebarFiltersProps) {
                     {s.id === sprintId && <Check className="size-3.5 text-primary" />}
                   </DropdownMenuItem>
                 ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => router.push('/sprints')}>
+                  <span className="flex-1 text-muted-foreground">{t('manageSprints')}</span>
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </SidebarMenuItem>
@@ -131,6 +135,10 @@ export function BoardSidebarFilters({ projectId }: BoardSidebarFiltersProps) {
                     {e.id === epicId && <Check className="size-3.5 text-primary" />}
                   </DropdownMenuItem>
                 ))}
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => router.push('/epics')}>
+                  <span className="flex-1 text-muted-foreground">{t('manageEpics')}</span>
+                </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
           </SidebarMenuItem>


### PR DESCRIPTION
## Summary
- Sprint 드롭다운 하단 — `DropdownMenuSeparator` + "스프린트 관리 →" 클릭 시 `/sprints` 이동
- Epic 드롭다운 하단 — `DropdownMenuSeparator` + "에픽 관리 →" 클릭 시 `/epics` 이동
- `ko.json` / `en.json` — `board.manageSprints`, `board.manageEpics` 번역키 추가

## 배경
GNB 1depth에서 Sprint/Epic 제외 후 Board 필터 드롭다운이 유일한 진입점. Linear 패턴 참조.

## Test plan
- [ ] Board 페이지 → Sprint 드롭다운 열기 → "스프린트 관리 →" 클릭 → /sprints 이동 확인
- [ ] Board 페이지 → Epic 드롭다운 열기 → "에픽 관리 →" 클릭 → /epics 이동 확인
- [ ] 기존 Sprint/Epic 필터 동작 영향 없음
- [ ] TypeScript 빌드 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)