### PR TITLE
[SID:77ccd62d] 메모 웹훅 payload에 memo_id/reply_id 평문 포함

### DIFF
--- a/apps/web/src/services/memo-assignment-dispatch.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.ts
@@ -32,8 +32,8 @@ export async function dispatchMemoAssignmentImmediately(memo: DispatchableMemo) 
 
     const isDiscord = member.webhook_url.includes('discord.com') || member.webhook_url.includes('discordapp.com');
     const body = isDiscord
-      ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}` })
-      : JSON.stringify({ text: `*${title}*\n${description}` });
+      ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}\n\nmemo_id: ${memo.id}` })
+      : JSON.stringify({ text: `*${title}*\n${description}\n\nmemo_id: ${memo.id}` });
 
     await fetch(member.webhook_url, {
       method: 'POST',

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -188,15 +188,19 @@ async function postWebhook(
   webhook: ResolvedWebhook,
   title: string,
   description: string,
+  ids?: { memo_id: string; reply_id?: string },
 ) {
+  const idsSuffix = ids
+    ? `\n\nmemo_id: ${ids.memo_id}${ids.reply_id ? `\nreply_id: ${ids.reply_id}` : ''}`
+    : '';
   const format = webhook.channel ?? detectWebhookFormat(webhook.url);
   const body = format === 'discord'
     ? JSON.stringify({
-        content: `${title}\n${description.substring(0, 500)}`,
+        content: `${title}\n${description.substring(0, 500)}${idsSuffix}`,
         embeds: [{ title, description, color: 0x3B82F6 }],
       })
     : format === 'google' || format === 'slack'
-      ? JSON.stringify({ text: `*${title}*\n${description}` })
+      ? JSON.stringify({ text: `*${title}*\n${description}${idsSuffix}` })
       : JSON.stringify({ title, description });
 
   const headers: Record<string, string> = {
@@ -284,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;
@@ -297,7 +301,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
     if (!webhook) continue;
 
     try {
-      const sent = await postWebhook(db, fetchFn, memo.org_id, webhook, title, description);
+      const sent = await postWebhook(db, fetchFn, memo.org_id, webhook, title, description, { memo_id: memo.id, reply_id: reply.id });
       if (sent) {
         sentCount += 1;
       } else {

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -281,10 +281,10 @@ export async function dispatchWorkflowMemoReplyWebhooks(
 
   const authorName = memberById.get(reply.created_by)?.name?.trim() || reply.created_by;
   const preview = buildPreview(reply.content);
-  const memoLabel = memo.title?.trim() ? `“${memo.title.trim()}”` : `#${memo.id}`;
+  const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -704,8 +704,8 @@ export class MemoService {
       try {
         const format = this.detectWebhookFormat(member.webhook_url);
         const body = format === 'discord'
-          ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}`, embeds: [{ title, description, color: 0x3B82F6 }] })
-          : JSON.stringify({ text: `*${title}*\n${description}` });
+          ? JSON.stringify({ content: `${title}\n${description.substring(0, 500)}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`, embeds: [{ title, description, color: 0x3B82F6 }] })
+          : JSON.stringify({ text: `*${title}*\n${description}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}` });
 
         await fetch(member.webhook_url, {
           method: 'POST',

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -49,14 +49,17 @@ async def _collect_reply_webhook_urls(
     return [row[0] for row in rows if row[0]]
 
 
-def _fire_webhook(url: str, content: str, title: str, memo_url: str) -> None:
+def _fire_webhook(url: str, content: str, title: str, memo_url: str, memo_id: str = "") -> None:
     try:
+        full_content = content
+        if memo_id:
+            full_content = f"{content}\n\nmemo_id: {memo_id}"
         if "discord.com/api/webhooks" in url or "discordapp.com/api/webhooks" in url:
-            payload: dict = {"content": content}
+            payload: dict = {"content": full_content}
             if memo_url:
                 payload["embeds"] = [{"title": title, "url": memo_url}]
         else:
-            payload = {"text": content}
+            payload = {"text": full_content}
         httpx.post(url, json=payload, timeout=10)
     except Exception:  # noqa: BLE001
         logger.warning("reply webhook fire failed url=%s", url, exc_info=True)
@@ -202,10 +205,10 @@ async def add_reply(
     if webhook_urls:
         app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
         memo_url = f"{app_url}/memos?id={id}" if app_url else ""
-        content = f"📩 **새 답신**\n{reply.content[:500]}"
+        content = f"📩 **새 답신**\n{reply.content[:500]}\n\nreply_id: {reply.id}"
         title = memo.title or "메모 답신"
         for url in webhook_urls:
-            background_tasks.add_task(_fire_webhook, url, content, title, memo_url)
+            background_tasks.add_task(_fire_webhook, url, content, title, memo_url, str(id))
 
     return ReplyResponse.model_validate(reply)
 


### PR DESCRIPTION
## Summary
메모 웹훅 Discord content에 `memo_id` (+ reply의 경우 `reply_id`)를 평문으로 포함. 수신 에이전트가 `read_memo(memo_id)`로 원문/thread를 즉시 조회 가능.

## 수정 파일
- `backend/app/routers/memos.py` — `_fire_webhook`에 `memo_id` 파라미터 추가, reply 웹훅 호출 시 `reply_id`도 content에 포함
- `apps/web/src/services/memo-assignment-dispatch.ts` — assignment content 하단에 `memo_id: {uuid}` 추가
- `apps/web/src/services/memo-reply-webhook-dispatch.ts` — description 하단에 `memo_id: {uuid}\nreply_id: {uuid}` 추가
- `apps/web/src/services/memo.ts` — OSS 모드 reply 웹훅 content에 `memo_id + reply_id` 추가

## 포맷
**send_memo:**
```
📋 메모 배정: "제목"
{본문}

memo_id: {uuid}
```
**reply_memo:**
```
📩 새 답신
{본문}

memo_id: {uuid}
reply_id: {uuid}
```

## Test plan
- [ ] 메모 배정 웹훅 content에 `memo_id:` 줄 포함 확인
- [ ] 메모 답신 웹훅 content에 `memo_id:` + `reply_id:` 줄 포함 확인
- [ ] 기존 이모지/제목/본문/링크 포맷 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)