### PR TITLE
[SID:280187b6] Dockerfile builder stage root package.json 복사 추가 — pnpm 버전 크래시 수정

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -17,6 +17,7 @@ RUN pnpm install --frozen-lockfile --filter web...
 # ─── 빌드 ────────────────────────────────────────────────────────────────────
 FROM base AS builder
 WORKDIR /app
+COPY package.json ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/web/node_modules ./apps/web/node_modules
 COPY --from=deps /app/packages ./packages


### PR DESCRIPTION
## Summary
`apps/web/Dockerfile` builder stage에 `COPY package.json ./` 1줄 추가.

## 원인
- `deps` stage: root `package.json` 복사 (Corepack이 `packageManager: "pnpm@9.15.0"` 인식)
- `builder` stage: root `package.json` 미복사 → Corepack이 버전 불명으로 pnpm@latest(11.0.8) 다운로드
- pnpm 11은 Node.js 22.13+ 필수, Dockerfile은 `node:20-alpine`
- → `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` 크래시 → Cloud Build 5연속 실패

## 수정
```dockerfile
FROM base AS builder
WORKDIR /app
COPY package.json ./          # ← 추가
COPY --from=deps /app/node_modules ./node_modules
```

## Test plan
- [ ] Cloud Build 성공 확인 (dev 배포 복구)
- [ ] `pnpm@9.15.0` 고정 사용 확인 (pnpm 11 다운로드 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)