### PR TITLE
[P0] Standup feedback POST 405 수정 — standup_entry_id URL 경로 포함

### DIFF
--- a/apps/web/src/app/api/standup/feedback/route.ts
+++ b/apps/web/src/app/api/standup/feedback/route.ts
@@ -16,7 +16,17 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const _r = await proxyToFastapi(request, '/api/v2/standups/feedback');
+    const body = await request.json() as { standup_entry_id?: string; [key: string]: unknown };
+    const { standup_entry_id, ...rest } = body;
+    if (!standup_entry_id) {
+      return new Response(JSON.stringify({ error: 'standup_entry_id required' }), { status: 400 });
+    }
+    const newRequest = new Request(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify(rest),
+    });
+    const _r = await proxyToFastapi(newRequest, `/api/v2/standups/${standup_entry_id}/feedback`);
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());


### PR DESCRIPTION
## Summary
`POST /api/standup/feedback` → 405 핫픽스. body의 `standup_entry_id`를 추출해 `/api/v2/standups/{id}/feedback`로 올바르게 프록시.

## 원인
기존: `proxyToFastapi(request, '/api/v2/standups/feedback')` → 해당 경로 없음 → 405
수정: body에서 `standup_entry_id` 추출 → `/api/v2/standups/${standup_entry_id}/feedback`

## Test plan
- [ ] 스탠드업 피드백 작성 → 201 정상 응답
- [ ] `standup_entry_id` 누락 시 400 반환
- [ ] TypeScript 빌드 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)