### PR TITLE
[SID:f8bd45f0] Board 필터 드롭다운 검색 + Assignee 그룹화

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -160,7 +160,11 @@
     "save": "Save",
     "cancel": "Cancel",
     "edit": "Edit",
-    "addDescription": "Add description"
+    "addDescription": "Add description",
+    "searchSprints": "Search sprints...",
+    "searchEpics": "Search epics...",
+    "searchAssignees": "Search assignees...",
+    "noResults": "No results"
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -160,7 +160,11 @@
     "save": "저장",
     "cancel": "취소",
     "edit": "편집",
-    "addDescription": "설명 추가"
+    "addDescription": "설명 추가",
+    "searchSprints": "스프린트 검색...",
+    "searchEpics": "에픽 검색...",
+    "searchAssignees": "담당자 검색...",
+    "noResults": "결과 없음"
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -94,6 +94,9 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [showSearch, setShowSearch] = useState(false);
   const [assigneeTypeFilter, setAssigneeTypeFilter] = useState<'' | 'human' | 'agent'>('');
   const [viewMode, setViewMode] = useState<'board' | 'list'>('board');
+  const [sprintSearch, setSprintSearch] = useState('');
+  const [epicSearch, setEpicSearch] = useState('');
+  const [assigneeSearch, setAssigneeSearch] = useState('');
 
   const updateFilter = useCallback((key: string, value: string) => {
     const params = new URLSearchParams(searchParams.toString());
@@ -566,7 +569,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           <div className="mx-1 h-4 w-px bg-border/60" />
 
           {/* Sprint chip */}
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={(open) => { if (!open) setSprintSearch(''); }}>
             <DropdownMenuTrigger
               render={
                 <button
@@ -584,21 +587,40 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                 </button>
               }
             />
-            <DropdownMenuContent align="start" className="w-56 max-h-[60vh] overflow-y-auto">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground">{t('sprints')}</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => updateFilter('sprint_id', '')}>
-                  <span className="flex-1">{t('allSprints')}</span>
-                  {!selectedSprintId && <Check className="size-3.5 text-primary" />}
-                </DropdownMenuItem>
-                {sprints.map((s) => (
-                  <DropdownMenuItem key={s.id} onClick={() => updateFilter('sprint_id', s.id)}>
-                    <span className="flex-1 truncate">{s.title}</span>
-                    {s.id === selectedSprintId && <Check className="size-3.5 text-primary" />}
+            <DropdownMenuContent align="start" className="w-56">
+              <div className="p-1">
+                <Input
+                  autoFocus
+                  value={sprintSearch}
+                  onChange={(e) => setSprintSearch(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  placeholder={t('searchSprints')}
+                  className="h-7 text-xs"
+                />
+              </div>
+              <DropdownMenuSeparator />
+              <div className="max-h-[50vh] overflow-y-auto">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={() => updateFilter('sprint_id', '')}>
+                    <span className="flex-1">{t('allSprints')}</span>
+                    {!selectedSprintId && <Check className="size-3.5 text-primary" />}
                   </DropdownMenuItem>
-                ))}
-                <DropdownMenuSeparator />
+                  {(() => {
+                    const filtered = sprints.filter((s) => s.title.toLowerCase().includes(sprintSearch.toLowerCase()));
+                    if (filtered.length === 0) {
+                      return <div className="px-2 py-1.5 text-xs text-muted-foreground">{t('noResults')}</div>;
+                    }
+                    return filtered.map((s) => (
+                      <DropdownMenuItem key={s.id} onClick={() => updateFilter('sprint_id', s.id)}>
+                        <span className="flex-1 truncate">{s.title}</span>
+                        {s.id === selectedSprintId && <Check className="size-3.5 text-primary" />}
+                      </DropdownMenuItem>
+                    ));
+                  })()}
+                </DropdownMenuGroup>
+              </div>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
                 <DropdownMenuItem onClick={() => router.push('/sprints')}>
                   <span className="flex-1 text-xs text-muted-foreground">{t('manageSprints')}</span>
                 </DropdownMenuItem>
@@ -607,7 +629,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           </DropdownMenu>
 
           {/* Epic chip */}
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={(open) => { if (!open) setEpicSearch(''); }}>
             <DropdownMenuTrigger
               render={
                 <button
@@ -625,21 +647,40 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                 </button>
               }
             />
-            <DropdownMenuContent align="start" className="w-56 max-h-[60vh] overflow-y-auto">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground">{t('epics')}</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => updateFilter('epic_id', '')}>
-                  <span className="flex-1">{t('allEpics')}</span>
-                  {!selectedEpicId && <Check className="size-3.5 text-primary" />}
-                </DropdownMenuItem>
-                {epics.map((e) => (
-                  <DropdownMenuItem key={e.id} onClick={() => updateFilter('epic_id', e.id)}>
-                    <span className="flex-1 truncate">{e.title}</span>
-                    {e.id === selectedEpicId && <Check className="size-3.5 text-primary" />}
+            <DropdownMenuContent align="start" className="w-56">
+              <div className="p-1">
+                <Input
+                  autoFocus
+                  value={epicSearch}
+                  onChange={(e) => setEpicSearch(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  placeholder={t('searchEpics')}
+                  className="h-7 text-xs"
+                />
+              </div>
+              <DropdownMenuSeparator />
+              <div className="max-h-[50vh] overflow-y-auto">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={() => updateFilter('epic_id', '')}>
+                    <span className="flex-1">{t('allEpics')}</span>
+                    {!selectedEpicId && <Check className="size-3.5 text-primary" />}
                   </DropdownMenuItem>
-                ))}
-                <DropdownMenuSeparator />
+                  {(() => {
+                    const filtered = epics.filter((e) => e.title.toLowerCase().includes(epicSearch.toLowerCase()));
+                    if (filtered.length === 0) {
+                      return <div className="px-2 py-1.5 text-xs text-muted-foreground">{t('noResults')}</div>;
+                    }
+                    return filtered.map((e) => (
+                      <DropdownMenuItem key={e.id} onClick={() => updateFilter('epic_id', e.id)}>
+                        <span className="flex-1 truncate">{e.title}</span>
+                        {e.id === selectedEpicId && <Check className="size-3.5 text-primary" />}
+                      </DropdownMenuItem>
+                    ));
+                  })()}
+                </DropdownMenuGroup>
+              </div>
+              <DropdownMenuSeparator />
+              <DropdownMenuGroup>
                 <DropdownMenuItem onClick={() => router.push('/epics')}>
                   <span className="flex-1 text-xs text-muted-foreground">{t('manageEpics')}</span>
                 </DropdownMenuItem>
@@ -648,7 +689,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           </DropdownMenu>
 
           {/* Assignee chip */}
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={(open) => { if (!open) setAssigneeSearch(''); }}>
             <DropdownMenuTrigger
               render={
                 <button
@@ -666,21 +707,63 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                 </button>
               }
             />
-            <DropdownMenuContent align="start" className="w-56 max-h-[60vh] overflow-y-auto">
-              <DropdownMenuGroup>
-                <DropdownMenuLabel className="text-xs text-muted-foreground">{t('assignees')}</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={() => updateFilter('assignee_id', '')}>
-                  <span className="flex-1">{t('allAssignees')}</span>
-                  {!selectedAssigneeId && <Check className="size-3.5 text-primary" />}
-                </DropdownMenuItem>
-                {members.map((m) => (
-                  <DropdownMenuItem key={m.id} onClick={() => updateFilter('assignee_id', m.id)}>
-                    <span className="flex-1 truncate">{m.name}</span>
-                    {m.id === selectedAssigneeId && <Check className="size-3.5 text-primary" />}
+            <DropdownMenuContent align="start" className="w-56">
+              <div className="p-1">
+                <Input
+                  autoFocus
+                  value={assigneeSearch}
+                  onChange={(e) => setAssigneeSearch(e.target.value)}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  placeholder={t('searchAssignees')}
+                  className="h-7 text-xs"
+                />
+              </div>
+              <DropdownMenuSeparator />
+              <div className="max-h-[50vh] overflow-y-auto">
+                <DropdownMenuGroup>
+                  <DropdownMenuItem onClick={() => updateFilter('assignee_id', '')}>
+                    <span className="flex-1">{t('allAssignees')}</span>
+                    {!selectedAssigneeId && <Check className="size-3.5 text-primary" />}
                   </DropdownMenuItem>
-                ))}
-              </DropdownMenuGroup>
+                </DropdownMenuGroup>
+                {(() => {
+                  const q = assigneeSearch.toLowerCase();
+                  const humans = members.filter((m) => m.type !== 'agent' && m.name.toLowerCase().includes(q));
+                  const agents = members.filter((m) => m.type === 'agent' && m.name.toLowerCase().includes(q));
+                  const hasResults = humans.length > 0 || agents.length > 0;
+                  if (!hasResults) {
+                    return <div className="px-2 py-1.5 text-xs text-muted-foreground">{t('noResults')}</div>;
+                  }
+                  return (
+                    <>
+                      {humans.length > 0 && (
+                        <DropdownMenuGroup>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel className="text-xs text-muted-foreground">{t('filterMembers')}</DropdownMenuLabel>
+                          {humans.map((m) => (
+                            <DropdownMenuItem key={m.id} onClick={() => updateFilter('assignee_id', m.id)}>
+                              <span className="flex-1 truncate">{m.name}</span>
+                              {m.id === selectedAssigneeId && <Check className="size-3.5 text-primary" />}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuGroup>
+                      )}
+                      {agents.length > 0 && (
+                        <DropdownMenuGroup>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuLabel className="text-xs text-muted-foreground">{t('filterAgents')}</DropdownMenuLabel>
+                          {agents.map((m) => (
+                            <DropdownMenuItem key={m.id} onClick={() => updateFilter('assignee_id', m.id)}>
+                              <span className="flex-1 truncate">{m.name}</span>
+                              {m.id === selectedAssigneeId && <Check className="size-3.5 text-primary" />}
+                            </DropdownMenuItem>
+                          ))}
+                        </DropdownMenuGroup>
+                      )}
+                    </>
+                  );
+                })()}
+              </div>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;


### PR DESCRIPTION
## 변경 사항

- Sprint/Epic/Assignee 드롭다운 상단에 검색 인풋 추가 (키워드 필터링)
- 검색 결과 없을 시 "결과 없음" 텍스트 표시
- Assignee 드롭다운: Human(팀원) / Agent 그룹 분리 (`DropdownMenuGroup` + `DropdownMenuLabel`)
- 검색 인풋 `onKeyDown stopPropagation` — 타이핑 시 드롭다운 닫힘 방지
- `onOpenChange` — 드롭다운 닫힐 때 검색어 자동 초기화
- i18n: `searchSprints` / `searchEpics` / `searchAssignees` / `noResults` (ko + en)

## AC 체크리스트

- [x] Sprint 드롭다운 상단에 검색 인풋 추가
- [x] Epic 드롭다운 상단에 검색 인풋 추가
- [x] Assignee 드롭다운: Human / Agent 그룹 분리 표시
- [x] 검색 인풋 포커스 시 드롭다운 닫히지 않음
- [x] 빈 검색 결과 시 "결과 없음" 표시
- [x] 기존 필터 URL 파라미터 동작 유지
- [x] 모바일 레이아웃 깨지지 않음 (flex-wrap 유지, w-56 고정)

## 테스트 방법

1. `/board` 진입
2. Sprint 칩 클릭 → 드롭다운 상단에 검색 인풋 확인
3. 검색어 입력 → 스프린트 목록 필터링 확인
4. 없는 이름 입력 → "결과 없음" 표시 확인
5. Assignee 칩 클릭 → Human / Agent 그룹 분리 확인
6. URL 파라미터 변경 정상 동작 확인

## 수정 파일

- `apps/web/src/components/kanban/kanban-board.tsx`
- `apps/web/messages/ko.json`
- `apps/web/messages/en.json`