### PR TITLE
[SID:66d43ced] P0 온보딩 파손 — 회원가입 시 초대 org 연결 실패 수정

### DIFF
--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -141,14 +141,23 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
                 .on_conflict_do_nothing(constraint="uq_org_members_org_user")
             )
             if inv.project_id:
-                new_member = TeamMember(
-                    org_id=inv.org_id,
-                    project_id=inv.project_id,
-                    user_id=user.id,
-                    type="human",
-                    role=inv.role,
+                existing_tm = await session.execute(
+                    select(TeamMember).where(
+                        TeamMember.project_id == inv.project_id,
+                        TeamMember.user_id == user.id,
+                        TeamMember.is_active.is_(True),
+                    )
                 )
-                session.add(new_member)
+                if not existing_tm.scalar_one_or_none():
+                    new_member = TeamMember(
+                        org_id=inv.org_id,
+                        project_id=inv.project_id,
+                        user_id=user.id,
+                        type="human",
+                        name=inv.email.split("@")[0],
+                        role=inv.role,
+                    )
+                    session.add(new_member)
             await session.flush()
             return {
                 "org_id": str(inv.org_id),

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -30,6 +30,9 @@ from app.core.security import (
 )
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.invitation import Invitation
+from app.models.project import OrgMember
+from app.models.team import TeamMember
 from app.models.user import RefreshToken, User
 
 from datetime import timedelta
@@ -119,9 +122,41 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             member.user_id = user.id
 
     if not member:
+        # 3. 이메일로 pending 초대 조회 → 자동 수락 + org_member + team_member 생성
+        inv_result = await session.execute(
+            select(Invitation).where(
+                Invitation.email == user.email,
+                Invitation.status == "pending",
+                Invitation.expires_at > datetime.now(timezone.utc),
+            ).order_by(Invitation.created_at.asc()).limit(1)
+        )
+        inv = inv_result.scalar_one_or_none()
+        if inv:
+            inv.status = "accepted"
+            inv.accepted_at = datetime.now(timezone.utc)
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+            await session.execute(
+                pg_insert(OrgMember)
+                .values(org_id=inv.org_id, user_id=user.id, role=inv.role)
+                .on_conflict_do_nothing(constraint="uq_org_members_org_user")
+            )
+            if inv.project_id:
+                new_member = TeamMember(
+                    org_id=inv.org_id,
+                    project_id=inv.project_id,
+                    user_id=user.id,
+                    type="human",
+                    role=inv.role,
+                )
+                session.add(new_member)
+            await session.flush()
+            return {
+                "org_id": str(inv.org_id),
+                "project_id": str(inv.project_id) if inv.project_id else "",
+            }
         return {}
 
-    # 3. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
+    # 4. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
     await session.execute(
         update(TeamMember)
         .where(

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -98,14 +98,23 @@ async def accept_invitation(
     )
 
     if inv.project_id:
-        new_member = TeamMember(
-            org_id=inv.org_id,
-            project_id=inv.project_id,
-            user_id=user_id,
-            type="human",
-            role=inv.role,
+        existing_tm = await session.execute(
+            select(TeamMember).where(
+                TeamMember.project_id == inv.project_id,
+                TeamMember.user_id == user_id,
+                TeamMember.is_active.is_(True),
+            )
         )
-        session.add(new_member)
+        if not existing_tm.scalar_one_or_none():
+            new_member = TeamMember(
+                org_id=inv.org_id,
+                project_id=inv.project_id,
+                user_id=user_id,
+                type="human",
+                name=inv.email.split("@")[0],
+                role=inv.role,
+            )
+            session.add(new_member)
 
     await session.flush()
     return {"ok": True, "org_id": str(inv.org_id), "project_id": str(inv.project_id) if inv.project_id else None}

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -1,10 +1,15 @@
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.invitation import Invitation
+from app.models.project import OrgMember
+from app.models.team import TeamMember
 from app.repositories.invitation import InvitationRepository
 from app.schemas.invitation import AcceptInvitation, CreateInvitation, InvitationResponse
 
@@ -70,10 +75,37 @@ async def resend_invitation(
 @router.post("/accept", status_code=200)
 async def accept_invitation(
     body: AcceptInvitation,
-    repo: InvitationRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    inv = await repo.accept(body.token)
-    if inv is None:
+    result = await session.execute(
+        select(Invitation).where(Invitation.token == body.token)
+    )
+    inv = result.scalar_one_or_none()
+    if inv is None or inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="Invalid, expired, or already used token")
-    # Phase D: org_member + team_member 생성은 Supabase RPC(accept_invitation) 위임
+
+    inv.status = "accepted"
+    inv.accepted_at = datetime.now(timezone.utc)
+
+    user_id = uuid.UUID(auth.user_id)
+
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    await session.execute(
+        pg_insert(OrgMember)
+        .values(org_id=inv.org_id, user_id=user_id, role=inv.role)
+        .on_conflict_do_nothing(constraint="uq_org_members_org_user")
+    )
+
+    if inv.project_id:
+        new_member = TeamMember(
+            org_id=inv.org_id,
+            project_id=inv.project_id,
+            user_id=user_id,
+            type="human",
+            role=inv.role,
+        )
+        session.add(new_member)
+
+    await session.flush()
     return {"ok": True, "org_id": str(inv.org_id), "project_id": str(inv.project_id) if inv.project_id else None}

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -85,6 +85,10 @@ async def accept_invitation(
     if inv is None or inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
         raise HTTPException(status_code=400, detail="Invalid, expired, or already used token")
 
+    caller_email = auth.claims.get("email", "")
+    if inv.email.lower() != caller_email.lower():
+        raise HTTPException(status_code=403, detail="Invitation was issued to a different email")
+
     inv.status = "accepted"
     inv.accepted_at = datetime.now(timezone.utc)
 

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -39,7 +39,7 @@ async def _client():
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}, "email": "new@example.com"}
 
     mock_session = AsyncMock()
 
@@ -242,5 +242,24 @@ async def test_accept_invitation_creates_org_and_team_member():
         # TeamMember session.add 호출 확인
         assert session.add.called
         assert session.flush.called
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_accept_invitation_403_email_mismatch():
+    """다른 이메일로 발행된 초대 토큰 수락 시 403 반환 (권한 상승 방지)."""
+    client, session, app = await _client()
+    try:
+        inv = _mock_invitation("pending")
+        inv.email = "other@example.com"  # 로그인 유저(new@example.com)와 불일치
+        inv_result = MagicMock()
+        inv_result.scalar_one_or_none.return_value = inv
+        session.execute = AsyncMock(return_value=inv_result)
+
+        async with client as c:
+            resp = await c.post("/api/v2/invitations/accept", json={"token": TOKEN})
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -182,15 +182,20 @@ async def test_resend_invitation_404_when_revoked():
 async def test_accept_invitation_200():
     client, session, app = await _client()
     try:
-        accepted = _mock_invitation("accepted")
-        with patch("app.repositories.invitation.InvitationRepository.accept", new_callable=AsyncMock) as mock_accept:
-            mock_accept.return_value = accepted
+        inv = _mock_invitation("pending")
+        inv_result = MagicMock()
+        inv_result.scalar_one_or_none.return_value = inv
+        tm_result = MagicMock()
+        tm_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(side_effect=[inv_result, MagicMock(), tm_result])
+        session.flush = AsyncMock()
 
-            async with client as c:
-                resp = await c.post("/api/v2/invitations/accept", json={"token": TOKEN})
+        async with client as c:
+            resp = await c.post("/api/v2/invitations/accept", json={"token": TOKEN})
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
+        assert resp.json()["org_id"] == str(ORG_ID)
     finally:
         app.dependency_overrides.clear()
 
@@ -199,12 +204,43 @@ async def test_accept_invitation_200():
 async def test_accept_invitation_400_invalid_token():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.invitation.InvitationRepository.accept", new_callable=AsyncMock) as mock_accept:
-            mock_accept.return_value = None
+        inv_result = MagicMock()
+        inv_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=inv_result)
 
-            async with client as c:
-                resp = await c.post("/api/v2/invitations/accept", json={"token": "badtoken"})
+        async with client as c:
+            resp = await c.post("/api/v2/invitations/accept", json={"token": "badtoken"})
 
         assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_accept_invitation_creates_org_and_team_member():
+    """직접 생성 경로: OrgMember + TeamMember 생성 호출 검증."""
+    client, session, app = await _client()
+    try:
+        inv = _mock_invitation("pending")
+        inv_result = MagicMock()
+        inv_result.scalar_one_or_none.return_value = inv
+        tm_result = MagicMock()
+        tm_result.scalar_one_or_none.return_value = None  # 중복 없음
+        org_exec_result = MagicMock()
+        session.execute = AsyncMock(side_effect=[inv_result, org_exec_result, tm_result])
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+
+        async with client as c:
+            resp = await c.post("/api/v2/invitations/accept", json={"token": TOKEN})
+
+        assert resp.status_code == 200
+        assert resp.json()["org_id"] == str(ORG_ID)
+        assert resp.json()["project_id"] == str(PROJECT_ID)
+        # OrgMember INSERT + TeamMember 중복체크 실행 확인
+        assert session.execute.call_count == 3
+        # TeamMember session.add 호출 확인
+        assert session.add.called
+        assert session.flush.called
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 문제

선생님이 직접 회원가입 테스트 중 발견. 초대 링크로 가입한 신규 유저가 org에 자동 연결되지 않아 온보딩 완전 파손.

## 원인

1. `_build_app_metadata()` — team_member 못 찾으면 `{}` 반환. 초대받은 email이어도 invitation 수락 로직 없음.
2. `accept_invitation()` — `"Supabase RPC 위임"` 주석만 있고 실제 org_member / team_member 생성 로직 미구현.

## 수정

### `backend/app/routers/auth.py` — `_build_app_metadata()`

team_member 미연결 시 user.email로 pending invitation 조회:
- 있으면 `invitation.status = 'accepted'` + `OrgMember` 생성 (`on_conflict_do_nothing`) + `TeamMember` 생성 + `org_id/project_id` 반환

### `backend/app/routers/invitations.py` — `accept_invitation()`

- Supabase RPC 위임 주석 제거
- `_get_repo` 의존성 제거 (org_id 없는 신규 유저도 호출 가능하도록)
- `session` + `auth` 직접 의존
- token 조회 → `OrgMember` + `TeamMember` 직접 생성

## AC 체크리스트

- [ ] 초대받은 이메일로 회원가입 시 org 자동 연결
- [ ] 초대 수락 후 JWT app_metadata에 org_id 포함
- [ ] 기존 유저 `accept_invitation` 정상 동작
- [ ] 중복 org_member INSERT 시 오류 없음 (on_conflict_do_nothing)
- [ ] project_id 없는 초대(org-only)도 정상 처리

## 테스트 방법

1. 초대 이메일 발송
2. 해당 이메일로 신규 회원가입
3. 로그인 후 JWT 확인 → `app_metadata.org_id` 포함 여부
4. `/board` 정상 접근 확인

## 수정 파일

- `backend/app/routers/auth.py`
- `backend/app/routers/invitations.py`