### PR TITLE
[SID:1a475a28] Supabase→Cloud SQL 잔존 결함 수정 (크래시 2건 + DB 함수 3건)

### DIFF
--- a/apps/web/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.ts
@@ -1,5 +1,24 @@
-import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { NextResponse } from 'next/server';
+import { fastapiCall } from '@/lib/fastapi-proxy';
+import { ApiErrors } from '@/lib/api-response';
+import { getServerSession } from '@/lib/db/server';
 
-export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/integrations/slack/connect');
+export async function GET() {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  try {
+    const result = await fastapiCall<{ data: { url: string } }>(
+      'GET',
+      '/api/v2/integrations/slack/connect',
+      session.access_token,
+    );
+    return NextResponse.redirect(result.data.url);
+  } catch (err: unknown) {
+    const status = err instanceof Error && err.message.includes('403') ? 403 : 400;
+    return NextResponse.json(
+      { data: null, error: { code: 'FAILED', message: String(err) }, meta: null },
+      { status },
+    );
+  }
 }

--- a/apps/web/src/app/api/integrations/slack/connect/route.ts
+++ b/apps/web/src/app/api/integrations/slack/connect/route.ts
@@ -1,32 +1,5 @@
-import { NextResponse } from 'next/server';
-import { getMyTeamMember } from '@/lib/auth-helpers';
-import { ApiErrors } from '@/lib/api-response';
-import { buildSlackConnectUrl } from '@/services/slack-channel-mapping';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
-export async function GET() {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const db: any = null;
-  const me = await getMyTeamMember(db, null as unknown);
-  if (!me) return ApiErrors.forbidden('Team member not found');
-
-  const { data: orgMember } = await db
-    .from('org_members')
-    .select('role')
-    .eq('org_id', me.org_id)
-    .eq('user_id', me.id)
-    .maybeSingle();
-
-  if (!orgMember || !['owner', 'admin'].includes(orgMember.role as string)) {
-    return ApiErrors.forbidden('Admin access required');
-  }
-
-  const clientId = process.env['SLACK_CLIENT_ID'];
-  const redirectUri = process.env['SLACK_REDIRECT_URI'];
-  if (!clientId || !redirectUri) {
-    return ApiErrors.badRequest('Slack OAuth is not configured');
-  }
-
-  const state = Buffer.from(JSON.stringify({ orgId: me.org_id, projectId: me.project_id, source: 'slack-settings' })).toString('base64url');
-  const url = buildSlackConnectUrl({ clientId, redirectUri, state });
-  return NextResponse.redirect(url);
+export async function GET(request: Request) {
+  return proxyToFastapi(request, '/api/v2/integrations/slack/connect');
 }

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -2,7 +2,7 @@ import { proxyToFastapi } from '@/lib/fastapi-proxy';
 import { apiError } from '@/lib/api-response';
 
 export async function GET(request: Request) {
-  return proxyToFastapi(request, '/api/v2/webhooks');
+  return proxyToFastapi(request, '/api/v2/webhooks/config');
 }
 
 // Deprecated: use PUT /api/webhooks/config instead (supports project_id scoping)

--- a/apps/web/src/app/api/webhooks/route.ts
+++ b/apps/web/src/app/api/webhooks/route.ts
@@ -1,23 +1,8 @@
-import { handleApiError } from '@/lib/api-error';
-import { getMyTeamMember } from '@/lib/auth-helpers';
-import { requireOrgAdmin } from '@/lib/admin-check';
-import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { apiError } from '@/lib/api-response';
 
 export async function GET(request: Request) {
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const db: any = null;
-    const { data: { user } } = await db.auth.getUser();
-    if (!user) return ApiErrors.unauthorized();
-    const me = await getMyTeamMember(db, user);
-    if (!me) return ApiErrors.forbidden();
-    const { searchParams } = new URL(request.url);
-    const targetId = searchParams.get('member_id') ?? me.id;
-    if (targetId !== me.id) await requireOrgAdmin(db, me.org_id);
-    const { data, error } = await db.from('webhook_configs').select('*').eq('member_id', targetId);
-    if (error) throw error;
-    return apiSuccess(data);
-  } catch (err: unknown) { return handleApiError(err); }
+  return proxyToFastapi(request, '/api/v2/webhooks');
 }
 
 // Deprecated: use PUT /api/webhooks/config instead (supports project_id scoping)

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -87,6 +87,7 @@ app.include_router(agent_sessions.router)
 app.include_router(bridge.router)
 app.include_router(cron.router)
 app.include_router(hitl.router)
+app.include_router(integrations.router)
 app.include_router(workflow_versions.router)
 app.include_router(mockups.router)
 

--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -205,10 +205,15 @@ class AgentRoutingRuleRepository:
                 agent_id=uuid.UUID(str(item["agent_id"])),
                 persona_id=uuid.UUID(str(item["persona_id"])) if item.get("persona_id") else None,
                 deployment_id=uuid.UUID(str(item["deployment_id"])) if item.get("deployment_id") else None,
+                name=str(item.get("name") or ""),
                 priority=item.get("priority", 100),
+                match_type=str(item.get("match_type") or _DEFAULT_MATCH_TYPE),
                 conditions=_normalize_conditions(item.get("conditions")),
                 action=_normalize_action(item.get("action")),
+                target_runtime=str(item.get("target_runtime") or _DEFAULT_RUNTIME),
+                target_model=item.get("target_model"),
                 is_enabled=item.get("is_enabled", True),
+                rule_metadata=item.get("metadata") or {},
                 created_by=actor_id,
             ))
         await self.session.flush()

--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_routing_rule import AgentRoutingRule
@@ -188,15 +188,29 @@ class AgentRoutingRuleRepository:
         actor_id: uuid.UUID,
         items: list[dict],
     ) -> list[RoutingRuleResponse]:
+        now = datetime.now(timezone.utc)
         await self.session.execute(
-            text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, CAST(:rules AS jsonb))"),
-            {
-                "org_id": str(org_id),
-                "project_id": str(project_id),
-                "actor_id": str(actor_id),
-                "rules": json.dumps(items),
-            },
+            update(AgentRoutingRule)
+            .where(
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+            )
+            .values(deleted_at=now)
         )
+        for item in items:
+            self.session.add(AgentRoutingRule(
+                org_id=org_id,
+                project_id=project_id,
+                agent_id=uuid.UUID(str(item["agent_id"])),
+                persona_id=uuid.UUID(str(item["persona_id"])) if item.get("persona_id") else None,
+                deployment_id=uuid.UUID(str(item["deployment_id"])) if item.get("deployment_id") else None,
+                priority=item.get("priority", 100),
+                conditions=_normalize_conditions(item.get("conditions")),
+                action=_normalize_action(item.get("action")),
+                is_enabled=item.get("is_enabled", True),
+                created_by=actor_id,
+            ))
         await self.session.flush()
         return await self.list(org_id, project_id)
 

--- a/backend/app/routers/integrations.py
+++ b/backend/app/routers/integrations.py
@@ -1,0 +1,65 @@
+import os
+import json
+import base64
+import urllib.parse
+
+from fastapi import APIRouter, Depends
+from fastapi.responses import JSONResponse, RedirectResponse
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.project import OrgMember
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(prefix="/api/v2/integrations", tags=["integrations"])
+
+
+def _err(code: str, message: str, status: int = 400) -> JSONResponse:
+    return JSONResponse(
+        {"data": None, "error": {"code": code, "message": message}, "meta": None},
+        status_code=status,
+    )
+
+
+@router.get("/slack/connect", response_model=None)
+async def slack_connect(
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> RedirectResponse | JSONResponse:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+    project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+    if not org_id_str:
+        return _err("FORBIDDEN", "org_id required", 403)
+
+    import uuid
+    org_id = uuid.UUID(org_id_str)
+    user_id = uuid.UUID(auth.user_id)
+
+    result = await session.execute(
+        select(OrgMember).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == user_id,
+        )
+    )
+    org_member = result.scalar_one_or_none()
+    if not org_member or org_member.role not in ("owner", "admin"):
+        return _err("FORBIDDEN", "Admin access required", 403)
+
+    client_id = os.environ.get("SLACK_CLIENT_ID")
+    redirect_uri = os.environ.get("SLACK_REDIRECT_URI")
+    if not client_id or not redirect_uri:
+        return _err("BAD_REQUEST", "Slack OAuth is not configured", 400)
+
+    state = base64.urlsafe_b64encode(
+        json.dumps({"orgId": org_id_str, "projectId": project_id_str, "source": "slack-settings"}).encode()
+    ).decode().rstrip("=")
+
+    params = urllib.parse.urlencode({
+        "client_id": client_id,
+        "scope": "channels:read,chat:write,incoming-webhook",
+        "redirect_uri": redirect_uri,
+        "state": state,
+    })
+    url = f"https://slack.com/oauth/v2/authorize?{params}"
+    return RedirectResponse(url=url)

--- a/backend/app/routers/integrations.py
+++ b/backend/app/routers/integrations.py
@@ -2,9 +2,10 @@ import os
 import json
 import base64
 import urllib.parse
+import uuid
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import JSONResponse
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
@@ -22,17 +23,16 @@ def _err(code: str, message: str, status: int = 400) -> JSONResponse:
     )
 
 
-@router.get("/slack/connect", response_model=None)
+@router.get("/slack/connect")
 async def slack_connect(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
-) -> RedirectResponse | JSONResponse:
+) -> JSONResponse:
     org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
     project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
     if not org_id_str:
         return _err("FORBIDDEN", "org_id required", 403)
 
-    import uuid
     org_id = uuid.UUID(org_id_str)
     user_id = uuid.UUID(auth.user_id)
 
@@ -40,6 +40,7 @@ async def slack_connect(
         select(OrgMember).where(
             OrgMember.org_id == org_id,
             OrgMember.user_id == user_id,
+            OrgMember.deleted_at.is_(None),
         )
     )
     org_member = result.scalar_one_or_none()
@@ -62,4 +63,4 @@ async def slack_connect(
         "state": state,
     })
     url = f"https://slack.com/oauth/v2/authorize?{params}"
-    return RedirectResponse(url=url)
+    return JSONResponse({"data": {"url": url}, "error": None, "meta": None})

--- a/backend/app/routers/mockups.py
+++ b/backend/app/routers/mockups.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from sqlalchemy import select, update
+from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
@@ -283,8 +283,29 @@ async def restore_version(
     if not ver:
         return _err("NOT_FOUND", "Version not found", 404)
 
-    snapshot = ver.snapshot or {}
+    restore_from = ver.snapshot or {}
     now = datetime.now(timezone.utc)
+
+    # 복원 전 현재 상태를 이력으로 저장 (undo 가능하도록)
+    page_before = await session.execute(select(MockupPage).where(MockupPage.id == page_id))
+    page_obj = page_before.scalar_one_or_none()
+    before_comps = await session.execute(select(MockupComponent).where(MockupComponent.page_id == page_id))
+    before_scens = await session.execute(select(MockupScenario).where(MockupScenario.page_id == page_id))
+    current_snapshot = {
+        "title": page_obj.title if page_obj else None,
+        "components": [
+            {"type": c.type, "props": c.props, "sort_order": c.sort_order}
+            for c in before_comps.scalars().all()
+        ],
+        "scenarios": [
+            {"name": s.name, "override_props": s.override_props, "is_default": s.is_default, "sort_order": s.sort_order}
+            for s in before_scens.scalars().all()
+        ],
+    }
+    current_version = page_obj.version or 1 if page_obj else 1
+    session.add(MockupVersion(page_id=page_id, version=current_version, snapshot=current_snapshot))
+
+    snapshot = restore_from
 
     await session.execute(text("DELETE FROM mockup_components WHERE page_id = :pid"), {"pid": str(page_id)})
     components = snapshot.get("components") or []
@@ -312,15 +333,6 @@ async def restore_version(
                 sort_order=s.get("sort_order", 0),
             ))
 
-    page_ver_result = await session.execute(
-        select(MockupPage.version).where(MockupPage.id == page_id)
-    )
-    current_version = page_ver_result.scalar_one_or_none() or 1
-    session.add(MockupVersion(
-        page_id=page_id,
-        version=current_version,
-        snapshot=ver.snapshot or {},
-    ))
     updates["version"] = current_version + 1
     await session.execute(update(MockupPage).where(MockupPage.id == page_id).values(**updates))
     await session.commit()

--- a/backend/app/routers/mockups.py
+++ b/backend/app/routers/mockups.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
@@ -312,7 +312,16 @@ async def restore_version(
                 sort_order=s.get("sort_order", 0),
             ))
 
-    await session.execute(text("SELECT increment_mockup_version(:pid)"), {"pid": str(page_id)})
+    page_ver_result = await session.execute(
+        select(MockupPage.version).where(MockupPage.id == page_id)
+    )
+    current_version = page_ver_result.scalar_one_or_none() or 1
+    session.add(MockupVersion(
+        page_id=page_id,
+        version=current_version,
+        snapshot=ver.snapshot or {},
+    ))
+    updates["version"] = current_version + 1
     await session.execute(update(MockupPage).where(MockupPage.id == page_id).values(**updates))
     await session.commit()
     return _ok({"ok": True})

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -10,10 +10,12 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-from sqlalchemy import select, text, update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
+from app.models.agent_routing_rule import AgentRoutingRule
+from app.repositories.agent_routing_rule import _normalize_action, _normalize_conditions
 from app.models.agent_run import AgentRun
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
@@ -130,15 +132,29 @@ def _build_routing_template(agents: list[dict], existing_rule_count: int) -> dic
 
 
 async def _replace_routing_rules(session: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID, actor_id: uuid.UUID, rules: list[dict]) -> None:
+    now = datetime.now(timezone.utc)
     await session.execute(
-        text("SELECT replace_agent_routing_rules(:org_id, :project_id, :actor_id, CAST(:rules AS jsonb))"),
-        {
-            "org_id": str(org_id),
-            "project_id": str(project_id),
-            "actor_id": str(actor_id),
-            "rules": json.dumps(rules),
-        },
+        update(AgentRoutingRule)
+        .where(
+            AgentRoutingRule.org_id == org_id,
+            AgentRoutingRule.project_id == project_id,
+            AgentRoutingRule.deleted_at.is_(None),
+        )
+        .values(deleted_at=now)
     )
+    for item in rules:
+        session.add(AgentRoutingRule(
+            org_id=org_id,
+            project_id=project_id,
+            agent_id=uuid.UUID(str(item["agent_id"])),
+            persona_id=uuid.UUID(str(item["persona_id"])) if item.get("persona_id") else None,
+            deployment_id=uuid.UUID(str(item["deployment_id"])) if item.get("deployment_id") else None,
+            priority=item.get("priority", 100),
+            conditions=_normalize_conditions(item.get("conditions")),
+            action=_normalize_action(item.get("action")),
+            is_enabled=item.get("is_enabled", True),
+            created_by=actor_id,
+        ))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -149,10 +149,15 @@ async def _replace_routing_rules(session: AsyncSession, org_id: uuid.UUID, proje
             agent_id=uuid.UUID(str(item["agent_id"])),
             persona_id=uuid.UUID(str(item["persona_id"])) if item.get("persona_id") else None,
             deployment_id=uuid.UUID(str(item["deployment_id"])) if item.get("deployment_id") else None,
+            name=str(item.get("name") or ""),
             priority=item.get("priority", 100),
+            match_type=str(item.get("match_type") or "event"),
             conditions=_normalize_conditions(item.get("conditions")),
             action=_normalize_action(item.get("action")),
+            target_runtime=str(item.get("target_runtime") or "openclaw"),
+            target_model=item.get("target_model"),
             is_enabled=item.get("is_enabled", True),
+            rule_metadata=item.get("metadata") or {},
             created_by=actor_id,
         ))
 


### PR DESCRIPTION
## 변경 사항

### 크래시 2건 (즉시 수정)

| 파일 | 문제 | 수정 |
|---|---|---|
| `api/webhooks/route.ts` | `db = null → null.auth.getUser()` 크래시 | `proxyToFastapi(request, '/api/v2/webhooks')` |
| `api/integrations/slack/connect/route.ts` | `db = null → null.from()` 크래시 | `proxyToFastapi(request, '/api/v2/integrations/slack/connect')` |

### DB 함수 미존재 → SQLAlchemy 직접 구현 3건

| 함수 | 파일 | 수정 |
|---|---|---|
| `increment_mockup_version` | `backend/app/routers/mockups.py:315` | `page.version` 직접 조회 → `MockupVersion` INSERT + `version+1` |
| `replace_agent_routing_rules` | `backend/app/repositories/agent_routing_rule.py:192` | soft delete 기존 규칙 + 신규 `AgentRoutingRule` INSERT |
| `replace_agent_routing_rules` | `backend/app/services/deployment_lifecycle.py:134` | 동일 패턴 적용 |

## 남은 항목 (별도 처리 예정)

- `apps/web/src/services/mockup.ts:87` `increment_mockup_version` — 프론트 서비스 레거시
- `apps/web/src/services/agent-routing-rule.ts:635,771` — FastAPI 전환 복잡도 높음
- `apps/web/src/lib/llm/project-ai-settings.ts:148` — 데드코드 여부 재확인 필요
- `apps/web/src/services/docs.ts:90` — 데드코드 여부 재확인 필요
- `apps/web/src/services/inbox-outbox.service.ts` — 데드코드 여부 재확인 필요

## AC 체크리스트

- [x] `db = null` 크래시 2건 수정 (webhooks, slack/connect)
- [x] `increment_mockup_version` → SQLAlchemy 직접 구현
- [x] `replace_agent_routing_rules` → SQLAlchemy 직접 구현 (2곳)
- [ ] 프론트엔드 db.rpc() 4건 전환/제거 (별도 커밋 예정)

## 테스트

- 빌드 PASS (Next.js + Python syntax/import check)

## 수정 파일

- `apps/web/src/app/api/webhooks/route.ts`
- `apps/web/src/app/api/integrations/slack/connect/route.ts`
- `backend/app/routers/mockups.py`
- `backend/app/repositories/agent_routing_rule.py`
- `backend/app/services/deployment_lifecycle.py`