### PR TITLE
[SID:508f63b2] MCP update_story_status 잘못된 엔드포인트 수정

### DIFF
--- a/apps/web/src/app/api/stories/[id]/status/route.ts
+++ b/apps/web/src/app/api/stories/[id]/status/route.ts
@@ -1,0 +1,21 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/stories/[id]/status', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -333,7 +333,7 @@ describe('stories tools via pmApi', () => {
 
   it('update_story_status calls PATCH with status', async () => {
     stubFetch((url, init) => {
-      expect(url).toBe('http://test-pm-api/api/stories/story-alpha');
+      expect(url).toBe('http://test-pm-api/api/stories/story-alpha/status');
       const body = JSON.parse(init?.body as string);
       expect(body).toEqual({ status: 'in-progress' });
       return new Response(JSON.stringify({ data: { id: 'story-alpha', status: 'in-progress' } }), { status: 200 });

--- a/packages/mcp-server/src/tools/stories.ts
+++ b/packages/mcp-server/src/tools/stories.ts
@@ -109,7 +109,7 @@ export function registerStoriesTools(server: McpServer) {
     status: z.enum(['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done']),
   }, async ({ story_id, status }) => {
     try {
-      const data = await pmApi(`/api/stories/${encodeURIComponent(story_id)}`, {
+      const data = await pmApi(`/api/stories/${encodeURIComponent(story_id)}/status`, {
         method: 'PATCH',
         body: JSON.stringify({ status }),
       });


### PR DESCRIPTION
## 변경 사항

MCP `update_story_status` 도구가 `PATCH /api/stories/{id}` (일반 업데이트)를 호출해서 `StoryUpdate` 스키마에 `status` 필드 없음 → strip → 상태 변경 불가.

### 수정 내용
1. **`packages/mcp-server/src/tools/stories.ts`** — URL 변경
   - `/api/stories/${story_id}` → `/api/stories/${story_id}/status`

2. **`apps/web/src/app/api/stories/[id]/status/route.ts`** — PATCH 프록시 라우트 신설
   - `proxyToFastapiWithParams` → `PATCH /api/v2/stories/[id]/status`

## 빌드
- `@sprintable/mcp-server`: tsc PASS
- `web`: Next.js 빌드 PASS

## 체크리스트
- [x] 기능 구현 완료
- [x] 빌드 통과
- [x] 커밋 메시지 비즈니스 톤

🤖 Generated with [Claude Code](https://claude.com/claude-code)