### PR TITLE
[SID:369adfff] Settings member 권한 — Members/Projects 탭 + 에이전트 생성 접근 허용

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -907,6 +907,7 @@ export default function SettingsPage() {
                                     {!agent.is_active ? <Badge variant="destructive">inactive</Badge> : null}
                                   </div>
                                 </div>
+                                {isAdmin ? (
                                 <Button
                                   variant="glass"
                                   size="sm"
@@ -915,6 +916,7 @@ export default function SettingsPage() {
                                 >
                                   {deactivatingAgentId === agent.id ? '...' : agent.is_active ? t('deactivateAgent') : t('activateAgent')}
                                 </Button>
+                                ) : null}
                               </div>
                             );
                           })}
@@ -1222,6 +1224,7 @@ export default function SettingsPage() {
               )}
             </TabsContent>
 
+            {adminChecked && isAdmin ? (
             <TabsContent value="integrations">
               <div className="space-y-6">
                 <SlackIntegrationSettingsSection />
@@ -1282,7 +1285,9 @@ export default function SettingsPage() {
                 </SectionCard>
               </div>
             </TabsContent>
+            ) : null}
 
+            {adminChecked && isAdmin ? (
             <TabsContent value="subscription">
               <SectionCard>
                 <SectionCardHeader>
@@ -1317,6 +1322,7 @@ export default function SettingsPage() {
                 </SectionCardBody>
               </SectionCard>
             </TabsContent>
+            ) : null}
 
             {adminChecked && isAdmin && orgId ? (
               <TabsContent value="usage">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -302,14 +302,14 @@ export default function SettingsPage() {
   }, [currentProjectId, orgId]);
 
   useEffect(() => {
-    if (!isAdmin || !memberProjectId) return;
+    if (!memberProjectId) return;
     void refreshMemberData(memberProjectId).catch(() => {});
-  }, [isAdmin, memberProjectId]);
+  }, [memberProjectId]);
 
   useEffect(() => {
-    if (!isAdmin) return;
     void refreshOrgAgents().catch(() => {});
-  }, [isAdmin]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // api-keys 탭 접근 시 Members > Agents로 자동 전환 (레거시 리다이렉트)
   useEffect(() => {
@@ -595,7 +595,7 @@ export default function SettingsPage() {
               </>
             ) : null}
 
-            {adminChecked && isAdmin ? (
+            {adminChecked ? (
               <>
                 <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('organizationSettings')}</span>
                 <TabsTrigger value="projects">
@@ -606,18 +606,22 @@ export default function SettingsPage() {
                   <Users className="h-4 w-4" />
                   {t('tabMembers')}
                 </TabsTrigger>
-                <TabsTrigger value="integrations">
-                  <Zap className="h-4 w-4" />
-                  {t('tabIntegrations')}
-                </TabsTrigger>
-                <TabsTrigger value="subscription">
-                  <CreditCard className="h-4 w-4" />
-                  {t('tabSubscription')}
-                </TabsTrigger>
-                <TabsTrigger value="usage">
-                  <BarChart2 className="h-4 w-4" />
-                  {t('tabUsage')}
-                </TabsTrigger>
+                {isAdmin ? (
+                  <>
+                    <TabsTrigger value="integrations">
+                      <Zap className="h-4 w-4" />
+                      {t('tabIntegrations')}
+                    </TabsTrigger>
+                    <TabsTrigger value="subscription">
+                      <CreditCard className="h-4 w-4" />
+                      {t('tabSubscription')}
+                    </TabsTrigger>
+                    <TabsTrigger value="usage">
+                      <BarChart2 className="h-4 w-4" />
+                      {t('tabUsage')}
+                    </TabsTrigger>
+                  </>
+                ) : null}
               </>
             ) : null}
 
@@ -922,36 +926,35 @@ export default function SettingsPage() {
                         </div>
                       )}
 
-                      {isAdmin ? (
-                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
-                          <OperatorInput
-                            value={newAgentName}
-                            onChange={(e) => setNewAgentName(e.target.value)}
-                            placeholder={t('agentNamePlaceholder')}
-                          />
-                          <OperatorDropdownSelect
-                            value={newAgentProjectId}
-                            onValueChange={(v) => setNewAgentProjectId(v)}
-                            options={[
-                              { value: '', label: t('selectProject') },
-                              ...projects.map((p) => ({ value: p.id, label: p.name })),
-                            ]}
-                          />
-                          <Button
-                            variant="hero"
-                            size="lg"
-                            onClick={() => void handleAddAgent()}
-                            disabled={!newAgentName.trim() || !newAgentProjectId || addingAgent}
-                          >
-                            {addingAgent ? '...' : t('addAgent')}
-                          </Button>
-                        </div>
-                      ) : null}
+                      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
+                        <OperatorInput
+                          value={newAgentName}
+                          onChange={(e) => setNewAgentName(e.target.value)}
+                          placeholder={t('agentNamePlaceholder')}
+                        />
+                        <OperatorDropdownSelect
+                          value={newAgentProjectId}
+                          onValueChange={(v) => setNewAgentProjectId(v)}
+                          options={[
+                            { value: '', label: t('selectProject') },
+                            ...projects.map((p) => ({ value: p.id, label: p.name })),
+                          ]}
+                        />
+                        <Button
+                          variant="hero"
+                          size="lg"
+                          onClick={() => void handleAddAgent()}
+                          disabled={!newAgentName.trim() || !newAgentProjectId || addingAgent}
+                        >
+                          {addingAgent ? '...' : t('addAgent')}
+                        </Button>
+                      </div>
                     </SectionCardBody>
                   </SectionCard>
                 </div>
               ) : (
               <div className="space-y-6">
+                {isAdmin ? (
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">
@@ -1058,7 +1061,9 @@ export default function SettingsPage() {
                     ) : null}
                   </SectionCardBody>
                 </SectionCard>
+                ) : null}
 
+                {isAdmin ? (
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">
@@ -1098,6 +1103,7 @@ export default function SettingsPage() {
                     ) : null}
                   </SectionCardBody>
                 </SectionCard>
+                ) : null}
 
                 <SectionCard>
                   <SectionCardHeader>
@@ -1107,6 +1113,7 @@ export default function SettingsPage() {
                     </div>
                   </SectionCardHeader>
                   <SectionCardBody className="space-y-4">
+                    {isAdmin ? (
                     <div className="grid gap-3 md:grid-cols-[220px_minmax(0,1fr)_auto]">
                       <OperatorDropdownSelect
                         value={memberProjectId}
@@ -1129,6 +1136,7 @@ export default function SettingsPage() {
                         {addingMember ? '...' : t('addToProject')}
                       </Button>
                     </div>
+                    ) : null}
 
                     {memberActionMessage ? (
                       <div className={`rounded-md border p-3 text-xs ${memberActionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
@@ -1152,9 +1160,11 @@ export default function SettingsPage() {
                                   <Badge variant="outline">{member.role}</Badge>
                                 </div>
                               </div>
+                              {isAdmin ? (
                               <Button variant="glass" size="sm" onClick={() => handleRemoveProjectMember(member.id)} disabled={removingMemberId === member.id}>
                                 {removingMemberId === member.id ? '...' : t('removeFromProject')}
                               </Button>
+                              ) : null}
                             </div>
                             {/* Webhook URL */}
                             <div className="flex items-center gap-2">

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;


### PR DESCRIPTION
## 변경 사항

member 권한 유저가 Settings에서 Members/Projects 탭에 접근 불가하던 문제 수정.

### 수정 내용 (`settings/page.tsx`)

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| Nav: Members/Projects 탭 | `adminChecked && isAdmin` | `adminChecked` |
| Nav: Integrations/Subscription/Usage | `adminChecked && isAdmin` | `isAdmin` (유지) |
| 데이터 로딩: refreshMemberData | `isAdmin && memberProjectId` | `memberProjectId` |
| 데이터 로딩: refreshOrgAgents | `isAdmin` | 제거 (항상 로드) |
| Agent 생성 폼 | `isAdmin` 조건 | 조건 제거 (member 접근 가능) |
| Invite Members SectionCard | 노출 (admin 탭이라 접근 불가) | `isAdmin` 조건부 |
| Project Invite SectionCard | 노출 | `isAdmin` 조건부 |
| Member Management Add 폼 | 노출 | `isAdmin` 조건부 |
| Remove 버튼 | 노출 | `isAdmin` 조건부 |

## 빌드
- Next.js 빌드 PASS

## 체크리스트
- [x] 기능 구현 완료
- [x] 빌드 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)