### PR TITLE
[SID:54c466cb] Settings admin 감지 로직 수정 — /api/me role 기반 전환

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -157,20 +157,12 @@ export default function SettingsPage() {
     const res = await fetch('/api/invitations');
     if (res.ok) {
       const json = await res.json();
-      setIsAdmin(true);
-      setAdminChecked(true);
       setInvitations(json.data ?? []);
       const statusRes = await fetch('/api/subscription/status');
       if (statusRes.ok) {
         const statusJson = await statusRes.json() as { data?: { grace_until?: string | null } };
         setGraceUntil(statusJson.data?.grace_until ?? null);
       }
-      return;
-    }
-
-    if (res.status === 403) {
-      setIsAdmin(false);
-      setAdminChecked(true);
     }
   };
 
@@ -267,6 +259,18 @@ export default function SettingsPage() {
   // Fetch org and project context
   useEffect(() => {
     async function loadContext() {
+      // admin 감지: /api/me role 기반 (invitations 응답 결과에 의존하지 않음)
+      try {
+        const meRes = await fetch('/api/me');
+        const meJson = meRes.ok ? await meRes.json() : null;
+        const role = (meJson?.data?.role ?? 'member') as string;
+        setIsAdmin(role === 'admin');
+      } catch {
+        setIsAdmin(false);
+      } finally {
+        setAdminChecked(true);
+      }
+
       // Get current project
       const projectRes = await fetch('/api/current-project');
       if (projectRes.ok) {

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -162,6 +162,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             return {
                 "org_id": str(inv.org_id),
                 "project_id": str(inv.project_id) if inv.project_id else "",
+                "role": inv.role,
             }
         return {}
 
@@ -180,6 +181,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     return {
         "org_id": str(member.org_id),
         "project_id": str(member.project_id),
+        "role": member.role,
     }
 
 

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, require_admin
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.project import OrgMember
@@ -31,6 +31,7 @@ def _get_repo(
 async def list_invitations(
     project_id: uuid.UUID | None = Query(default=None),
     repo: InvitationRepository = Depends(_get_repo),
+    _: None = Depends(require_admin),
 ) -> list[InvitationResponse]:
     items = await repo.list(project_id=project_id)
     return [InvitationResponse.model_validate(i) for i in items]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,7 +37,7 @@ def auth_ctx(org_id: uuid.UUID) -> MagicMock:
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+    ctx.claims = {"app_metadata": {"org_id": str(org_id), "role": "admin"}}
     return ctx
 
 

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -38,6 +38,10 @@ def _make_user(totp_enabled: bool = False, totp_secret: str | None = None) -> Ma
     u.is_active = True
     u.totp_enabled = totp_enabled
     u.totp_secret = totp_secret
+    u.org_id = uuid.uuid4()
+    u.project_id = uuid.uuid4()
+    u.role = "member"
+    u.user_id = None
     return u
 
 
@@ -199,6 +203,10 @@ async def test_refresh_token_rotation_200():
         stored.token_hash = hash_token(raw_refresh)
         stored.expires_at = exp
         stored.revoked_at = None
+        stored.org_id = uuid.uuid4()
+        stored.project_id = uuid.uuid4()
+        stored.role = "member"
+        stored.user_id = None
 
         def side_effect(stmt):
             r = MagicMock()

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -39,7 +39,7 @@ async def _client():
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}, "email": "new@example.com"}
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "role": "admin"}, "email": "new@example.com"}
 
     mock_session = AsyncMock()
 


### PR DESCRIPTION
## 변경 사항

member 유저가 Settings 진입 시 My Account 탭만 보이는 버그 수정.

### 근본 원인
`refreshInvitations()` 응답(200/403) 기반으로 `isAdmin`, `adminChecked`를 설정. 에러/타임아웃 시 `adminChecked=false` 유지 → nav 탭 미노출.

### 수정 내용

**Frontend (`settings/page.tsx`)**
- `loadContext()` 초반에 `GET /api/me` 호출 → `data.role === 'admin'`으로 `setIsAdmin` 설정
- `finally` 블록에서 `setAdminChecked(true)` 보장 (에러 시에도)
- `refreshInvitations()`에서 `setIsAdmin`, `setAdminChecked` 제거 (단일 책임)

**Backend (`invitations.py`)**
- `GET /api/v2/invitations`에 `require_admin` guard 추가 → member 403 반환

**Tests**
- `conftest.py`, `test_invitations.py` claims에 `"role": "admin"` 추가

## 테스트
- Next.js 빌드 PASS
- backend 353/353 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)