### PR TITLE
develop → main: PR #562 프로덕션 프로모션 (#563)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -302,14 +302,14 @@ export default function SettingsPage() {
   }, [currentProjectId, orgId]);
 
   useEffect(() => {
-    if (!isAdmin || !memberProjectId) return;
+    if (!memberProjectId) return;
     void refreshMemberData(memberProjectId).catch(() => {});
-  }, [isAdmin, memberProjectId]);
+  }, [memberProjectId]);
 
   useEffect(() => {
-    if (!isAdmin) return;
     void refreshOrgAgents().catch(() => {});
-  }, [isAdmin]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // api-keys 탭 접근 시 Members > Agents로 자동 전환 (레거시 리다이렉트)
   useEffect(() => {
@@ -595,7 +595,7 @@ export default function SettingsPage() {
               </>
             ) : null}
 
-            {adminChecked && isAdmin ? (
+            {adminChecked ? (
               <>
                 <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('organizationSettings')}</span>
                 <TabsTrigger value="projects">
@@ -606,18 +606,22 @@ export default function SettingsPage() {
                   <Users className="h-4 w-4" />
                   {t('tabMembers')}
                 </TabsTrigger>
-                <TabsTrigger value="integrations">
-                  <Zap className="h-4 w-4" />
-                  {t('tabIntegrations')}
-                </TabsTrigger>
-                <TabsTrigger value="subscription">
-                  <CreditCard className="h-4 w-4" />
-                  {t('tabSubscription')}
-                </TabsTrigger>
-                <TabsTrigger value="usage">
-                  <BarChart2 className="h-4 w-4" />
-                  {t('tabUsage')}
-                </TabsTrigger>
+                {isAdmin ? (
+                  <>
+                    <TabsTrigger value="integrations">
+                      <Zap className="h-4 w-4" />
+                      {t('tabIntegrations')}
+                    </TabsTrigger>
+                    <TabsTrigger value="subscription">
+                      <CreditCard className="h-4 w-4" />
+                      {t('tabSubscription')}
+                    </TabsTrigger>
+                    <TabsTrigger value="usage">
+                      <BarChart2 className="h-4 w-4" />
+                      {t('tabUsage')}
+                    </TabsTrigger>
+                  </>
+                ) : null}
               </>
             ) : null}
 
@@ -903,6 +907,7 @@ export default function SettingsPage() {
                                     {!agent.is_active ? <Badge variant="destructive">inactive</Badge> : null}
                                   </div>
                                 </div>
+                                {isAdmin ? (
                                 <Button
                                   variant="glass"
                                   size="sm"
@@ -911,6 +916,7 @@ export default function SettingsPage() {
                                 >
                                   {deactivatingAgentId === agent.id ? '...' : agent.is_active ? t('deactivateAgent') : t('activateAgent')}
                                 </Button>
+                                ) : null}
                               </div>
                             );
                           })}
@@ -922,36 +928,35 @@ export default function SettingsPage() {
                         </div>
                       )}
 
-                      {isAdmin ? (
-                        <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
-                          <OperatorInput
-                            value={newAgentName}
-                            onChange={(e) => setNewAgentName(e.target.value)}
-                            placeholder={t('agentNamePlaceholder')}
-                          />
-                          <OperatorDropdownSelect
-                            value={newAgentProjectId}
-                            onValueChange={(v) => setNewAgentProjectId(v)}
-                            options={[
-                              { value: '', label: t('selectProject') },
-                              ...projects.map((p) => ({ value: p.id, label: p.name })),
-                            ]}
-                          />
-                          <Button
-                            variant="hero"
-                            size="lg"
-                            onClick={() => void handleAddAgent()}
-                            disabled={!newAgentName.trim() || !newAgentProjectId || addingAgent}
-                          >
-                            {addingAgent ? '...' : t('addAgent')}
-                          </Button>
-                        </div>
-                      ) : null}
+                      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
+                        <OperatorInput
+                          value={newAgentName}
+                          onChange={(e) => setNewAgentName(e.target.value)}
+                          placeholder={t('agentNamePlaceholder')}
+                        />
+                        <OperatorDropdownSelect
+                          value={newAgentProjectId}
+                          onValueChange={(v) => setNewAgentProjectId(v)}
+                          options={[
+                            { value: '', label: t('selectProject') },
+                            ...projects.map((p) => ({ value: p.id, label: p.name })),
+                          ]}
+                        />
+                        <Button
+                          variant="hero"
+                          size="lg"
+                          onClick={() => void handleAddAgent()}
+                          disabled={!newAgentName.trim() || !newAgentProjectId || addingAgent}
+                        >
+                          {addingAgent ? '...' : t('addAgent')}
+                        </Button>
+                      </div>
                     </SectionCardBody>
                   </SectionCard>
                 </div>
               ) : (
               <div className="space-y-6">
+                {isAdmin ? (
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">
@@ -1058,7 +1063,9 @@ export default function SettingsPage() {
                     ) : null}
                   </SectionCardBody>
                 </SectionCard>
+                ) : null}
 
+                {isAdmin ? (
                 <SectionCard>
                   <SectionCardHeader>
                     <div className="space-y-1">
@@ -1098,6 +1105,7 @@ export default function SettingsPage() {
                     ) : null}
                   </SectionCardBody>
                 </SectionCard>
+                ) : null}
 
                 <SectionCard>
                   <SectionCardHeader>
@@ -1107,6 +1115,7 @@ export default function SettingsPage() {
                     </div>
                   </SectionCardHeader>
                   <SectionCardBody className="space-y-4">
+                    {isAdmin ? (
                     <div className="grid gap-3 md:grid-cols-[220px_minmax(0,1fr)_auto]">
                       <OperatorDropdownSelect
                         value={memberProjectId}
@@ -1129,6 +1138,7 @@ export default function SettingsPage() {
                         {addingMember ? '...' : t('addToProject')}
                       </Button>
                     </div>
+                    ) : null}
 
                     {memberActionMessage ? (
                       <div className={`rounded-md border p-3 text-xs ${memberActionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
@@ -1152,9 +1162,11 @@ export default function SettingsPage() {
                                   <Badge variant="outline">{member.role}</Badge>
                                 </div>
                               </div>
+                              {isAdmin ? (
                               <Button variant="glass" size="sm" onClick={() => handleRemoveProjectMember(member.id)} disabled={removingMemberId === member.id}>
                                 {removingMemberId === member.id ? '...' : t('removeFromProject')}
                               </Button>
+                              ) : null}
                             </div>
                             {/* Webhook URL */}
                             <div className="flex items-center gap-2">
@@ -1212,6 +1224,7 @@ export default function SettingsPage() {
               )}
             </TabsContent>
 
+            {adminChecked && isAdmin ? (
             <TabsContent value="integrations">
               <div className="space-y-6">
                 <SlackIntegrationSettingsSection />
@@ -1272,7 +1285,9 @@ export default function SettingsPage() {
                 </SectionCard>
               </div>
             </TabsContent>
+            ) : null}
 
+            {adminChecked && isAdmin ? (
             <TabsContent value="subscription">
               <SectionCard>
                 <SectionCardHeader>
@@ -1307,6 +1322,7 @@ export default function SettingsPage() {
                 </SectionCardBody>
               </SectionCard>
             </TabsContent>
+            ) : null}
 
             {adminChecked && isAdmin && orgId ? (
               <TabsContent value="usage">

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -157,20 +157,12 @@ export default function SettingsPage() {
     const res = await fetch('/api/invitations');
     if (res.ok) {
       const json = await res.json();
-      setIsAdmin(true);
-      setAdminChecked(true);
       setInvitations(json.data ?? []);
       const statusRes = await fetch('/api/subscription/status');
       if (statusRes.ok) {
         const statusJson = await statusRes.json() as { data?: { grace_until?: string | null } };
         setGraceUntil(statusJson.data?.grace_until ?? null);
       }
-      return;
-    }
-
-    if (res.status === 403) {
-      setIsAdmin(false);
-      setAdminChecked(true);
     }
   };
 
@@ -267,6 +259,18 @@ export default function SettingsPage() {
   // Fetch org and project context
   useEffect(() => {
     async function loadContext() {
+      // admin 감지: /api/me role 기반 (invitations 응답 결과에 의존하지 않음)
+      try {
+        const meRes = await fetch('/api/me');
+        const meJson = meRes.ok ? await meRes.json() : null;
+        const role = (meJson?.data?.role ?? 'member') as string;
+        setIsAdmin(role === 'admin');
+      } catch {
+        setIsAdmin(false);
+      } finally {
+        setAdminChecked(true);
+      }
+
       // Get current project
       const projectRes = await fetch('/api/current-project');
       if (projectRes.ok) {

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -69,7 +69,7 @@ export default function LoginPage() {
             type="email"
             placeholder="Email"
             autoComplete="email"
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
@@ -79,7 +79,7 @@ export default function LoginPage() {
             type="password"
             placeholder="Password"
             autoComplete="current-password"
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleLogin()}
@@ -91,7 +91,7 @@ export default function LoginPage() {
               inputMode="numeric"
               maxLength={6}
               placeholder="6-digit authenticator code"
-              className="w-full rounded-lg border border-gray-300 px-4 py-3 text-center text-lg font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 text-center text-lg text-gray-900 font-mono tracking-widest focus:outline-none focus:ring-2 focus:ring-blue-500"
               value={totpCode}
               onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
               onKeyDown={(e) => e.key === 'Enter' && handleLogin()}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -54,7 +54,7 @@ export default function RegisterPage() {
             type="email"
             placeholder="Email"
             autoComplete="email"
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
@@ -64,7 +64,7 @@ export default function RegisterPage() {
             type="password"
             placeholder="Password"
             autoComplete="new-password"
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleRegister()}

--- a/apps/web/src/components/ui/operator-control.tsx
+++ b/apps/web/src/components/ui/operator-control.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 import { Input } from '@/components/ui/input';
 
-const operatorControlClassName = 'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors';
+const operatorControlClassName = 'flex w-full rounded-md border border-input bg-background px-3 py-2 text-sm text-foreground ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 transition-colors';
 
 export function OperatorInput({ className, ...props }: React.ComponentProps<typeof Input>) {
   return <Input className={cn(operatorControlClassName, 'h-10', className)} {...props} />;

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -162,6 +162,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             return {
                 "org_id": str(inv.org_id),
                 "project_id": str(inv.project_id) if inv.project_id else "",
+                "role": inv.role,
             }
         return {}
 
@@ -180,6 +181,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     return {
         "org_id": str(member.org_id),
         "project_id": str(member.project_id),
+        "role": member.role,
     }
 
 

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, require_admin
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.project import OrgMember
@@ -31,6 +31,7 @@ def _get_repo(
 async def list_invitations(
     project_id: uuid.UUID | None = Query(default=None),
     repo: InvitationRepository = Depends(_get_repo),
+    _: None = Depends(require_admin),
 ) -> list[InvitationResponse]:
     items = await repo.list(project_id=project_id)
     return [InvitationResponse.model_validate(i) for i in items]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -37,7 +37,7 @@ def auth_ctx(org_id: uuid.UUID) -> MagicMock:
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+    ctx.claims = {"app_metadata": {"org_id": str(org_id), "role": "admin"}}
     return ctx
 
 

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -38,6 +38,10 @@ def _make_user(totp_enabled: bool = False, totp_secret: str | None = None) -> Ma
     u.is_active = True
     u.totp_enabled = totp_enabled
     u.totp_secret = totp_secret
+    u.org_id = uuid.uuid4()
+    u.project_id = uuid.uuid4()
+    u.role = "member"
+    u.user_id = None
     return u
 
 
@@ -199,6 +203,10 @@ async def test_refresh_token_rotation_200():
         stored.token_hash = hash_token(raw_refresh)
         stored.expires_at = exp
         stored.revoked_at = None
+        stored.org_id = uuid.uuid4()
+        stored.project_id = uuid.uuid4()
+        stored.role = "member"
+        stored.user_id = None
 
         def side_effect(stmt):
             r = MagicMock()

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -39,7 +39,7 @@ async def _client():
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}, "email": "new@example.com"}
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "role": "admin"}, "email": "new@example.com"}
 
     mock_session = AsyncMock()
 


### PR DESCRIPTION
## Summary
- PR #562 — Settings admin 감지 로직 수정: /api/me role 기반 전환
  - Frontend: loadContext()에서 /api/me 호출 → role 기반 isAdmin 판별, finally에서 adminChecked=true 보장
  - Backend: _build_app_metadata()에 role 추가, GET /api/v2/invitations에 require_admin guard
  - member 유저 Settings 탭 정상 표시 (Members/Projects)

## Test plan
- [ ] CI SUCCESS + Cloud Build SUCCESS (dev)
- [ ] member 유저 Settings 진입 시 Members/Projects 탭 표시
- [ ] admin 유저 전 탭 정상 표시 (regression 없음)
- [ ] prod Cloud Build SUCCESS 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)