### PR TITLE
[SID:119f099b] _build_app_metadata 우선순위 역전 + 전량 백필 제거

### DIFF
--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/apps/web/src/services/memo-reply-webhook-dispatch.ts
+++ b/apps/web/src/services/memo-reply-webhook-dispatch.ts
@@ -288,7 +288,7 @@ export async function dispatchWorkflowMemoReplyWebhooks(
   const memoLabel = memo.title?.trim() ? `”${memo.title.trim()}”` : `#${memo.id}`;
   const memoLink = buildMemoLink(options.appUrl, memo.id);
   const title = `💬 답장: ${authorName}`;
-  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}`;
+  const description = `메모 ${memoLabel}에 답장\n${preview}\n\n${memoLink}\n\nmemo_id: ${memo.id}\nreply_id: ${reply.id}`;
 
   let sentCount = 0;
   let failedRecipientCount = 0;

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -150,24 +150,6 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             }
 
     if not member:
-        # 3. legacy fallback — email prefix name으로 연결되지 않은 human 레코드 단건 연결
-        email_name = user.email.split("@")[0]
-        result2 = await session.execute(
-            select(TeamMember)
-            .where(
-                TeamMember.user_id.is_(None),
-                TeamMember.is_active.is_(True),
-                TeamMember.type == "human",
-                TeamMember.name == email_name,
-            )
-            .order_by(TeamMember.created_at.asc())
-            .limit(1)
-        )
-        member = result2.scalar_one_or_none()
-        if member:
-            member.user_id = user.id
-
-    if not member:
         return {}
 
     return {

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -106,23 +106,7 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member.user_id = user.id
 
     if not member:
-        # 2. user_id NULL human team_member 중 첫 번째에 자동 연결
-        result2 = await session.execute(
-            select(TeamMember)
-            .where(
-                TeamMember.user_id.is_(None),
-                TeamMember.is_active.is_(True),
-                TeamMember.type == "human",
-            )
-            .order_by(TeamMember.created_at.asc())
-            .limit(1)
-        )
-        member = result2.scalar_one_or_none()
-        if member:
-            member.user_id = user.id
-
-    if not member:
-        # 3. 이메일로 pending 초대 조회 → 자동 수락 + org_member + team_member 생성
+        # 2. 이메일로 pending 초대 조회 → 자동 수락 + org_member + team_member 생성
         inv_result = await session.execute(
             select(Invitation).where(
                 Invitation.email == user.email,
@@ -164,19 +148,27 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
                 "project_id": str(inv.project_id) if inv.project_id else "",
                 "role": inv.role,
             }
-        return {}
 
-    # 4. 같은 org의 user_id NULL 레코드 전량 백필 (교차 프로젝트 멤버십 해소)
-    await session.execute(
-        update(TeamMember)
-        .where(
-            TeamMember.user_id.is_(None),
-            TeamMember.is_active.is_(True),
-            TeamMember.type == "human",
-            TeamMember.org_id == member.org_id,
+    if not member:
+        # 3. legacy fallback — email prefix name으로 연결되지 않은 human 레코드 단건 연결
+        email_name = user.email.split("@")[0]
+        result2 = await session.execute(
+            select(TeamMember)
+            .where(
+                TeamMember.user_id.is_(None),
+                TeamMember.is_active.is_(True),
+                TeamMember.type == "human",
+                TeamMember.name == email_name,
+            )
+            .order_by(TeamMember.created_at.asc())
+            .limit(1)
         )
-        .values(user_id=user.id)
-    )
+        member = result2.scalar_one_or_none()
+        if member:
+            member.user_id = user.id
+
+    if not member:
+        return {}
 
     return {
         "org_id": str(member.org_id),


### PR DESCRIPTION
## 변경 사항

`backend/app/routers/auth.py` — `_build_app_metadata()` 로직 수정.

### 수정 내용

| # | AC | 내용 |
|---|---|---|
| 1 | Step 순서 변경 | invitation 자동수락(구 Step3)을 legacy fallback(구 Step2) 앞으로 이동 |
| 2 | 전량 UPDATE 제거 | `update(TeamMember).where(user_id IS NULL)` 전량 백필 블록 삭제 |
| 3 | legacy fallback 스코핑 강화 | `name == email.split('@')[0]` 조건 추가로 무분별 연결 방지 |

### 변경 후 Step 순서
1. 기존 매칭 (user_id 또는 PK)
2. Invitation 자동수락 → org_member + team_member 생성
3. Legacy fallback — email prefix name 매칭 단건 연결
4. ~~전량 UPDATE~~ (제거)

## 테스트
- backend 353/353 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)