### PR TITLE
[SID:e32b65aa] S3-1 Rule Evaluator 서비스 + workflow_execution_log

### DIFF
--- a/backend/alembic/versions/0015_add_workflow_execution_logs.py
+++ b/backend/alembic/versions/0015_add_workflow_execution_logs.py
@@ -1,0 +1,44 @@
+"""add workflow_execution_logs table
+
+Revision ID: 0015
+Revises: 0014
+Create Date: 2026-05-09
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0015"
+down_revision = "0014"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workflow_execution_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("rule_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("event_type", sa.Text, nullable=False),
+        sa.Column("trigger_type_slug", sa.Text, nullable=True),
+        sa.Column("event_context", JSONB, nullable=False, server_default="{}"),
+        sa.Column("action", JSONB, nullable=True),
+        sa.Column("target_agent_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("status", sa.Text, nullable=False, server_default="matched"),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_workflow_execution_logs_org_project", "workflow_execution_logs", ["org_id", "project_id"])
+    op.create_index("ix_workflow_execution_logs_created_at", "workflow_execution_logs", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_workflow_execution_logs_created_at", table_name="workflow_execution_logs")
+    op.drop_index("ix_workflow_execution_logs_org_project", table_name="workflow_execution_logs")
+    op.drop_table("workflow_execution_logs")

--- a/backend/app/models/workflow_execution_log.py
+++ b/backend/app/models/workflow_execution_log.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Integer, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class WorkflowExecutionLog(Base):
+    __tablename__ = "workflow_execution_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    rule_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    trigger_type_slug: Mapped[str | None] = mapped_column(Text, nullable=True)
+    event_context: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    action: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    target_agent_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="matched")
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False, index=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/services/rule_evaluator.py
+++ b/backend/app/services/rule_evaluator.py
@@ -1,0 +1,118 @@
+"""Rule Evaluator — Phase 3 Rule Evaluation Engine.
+
+Internal service only; no API endpoint exposed.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent_routing_rule import AgentRoutingRule
+from app.models.workflow_execution_log import WorkflowExecutionLog
+
+
+@dataclass
+class EventContext:
+    event_type: str
+    trigger_type_slug: str | None = None
+    memo_type: str | None = None
+    memo_id: str | None = None
+    actor_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_type": self.event_type,
+            "trigger_type_slug": self.trigger_type_slug,
+            "memo_type": self.memo_type,
+            "memo_id": self.memo_id,
+            "actor_id": self.actor_id,
+            "metadata": self.metadata,
+        }
+
+
+@dataclass
+class EvaluationResult:
+    matched: bool
+    rule: AgentRoutingRule | None
+    action: dict[str, Any] | None
+    target_agent_id: uuid.UUID | None
+
+
+def _matches(rule: AgentRoutingRule, ctx: EventContext) -> bool:
+    conditions: dict[str, Any] = rule.conditions or {}
+
+    trigger_slugs: list[str] = conditions.get("trigger_type_slugs") or []
+    if trigger_slugs:
+        if ctx.trigger_type_slug not in trigger_slugs:
+            return False
+
+    memo_types: list[str] = conditions.get("memo_type") or []
+    if memo_types:
+        if ctx.memo_type not in memo_types:
+            return False
+
+    return True
+
+
+async def evaluate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    ctx: EventContext,
+) -> EvaluationResult:
+    started = time.monotonic()
+
+    result = await session.execute(
+        select(AgentRoutingRule)
+        .where(
+            AgentRoutingRule.org_id == org_id,
+            AgentRoutingRule.project_id == project_id,
+            AgentRoutingRule.is_enabled.is_(True),
+            AgentRoutingRule.deleted_at.is_(None),
+        )
+        .order_by(AgentRoutingRule.priority.asc(), AgentRoutingRule.created_at.asc())
+    )
+    rules = list(result.scalars().all())
+
+    matched_rule: AgentRoutingRule | None = None
+    for rule in rules:
+        if _matches(rule, ctx):
+            matched_rule = rule
+            break
+
+    duration_ms = int((time.monotonic() - started) * 1000)
+
+    action = matched_rule.action if matched_rule else None
+    target_agent_id: uuid.UUID | None = None
+    if matched_rule:
+        target_agent_id = matched_rule.agent_id
+
+    log = WorkflowExecutionLog(
+        org_id=org_id,
+        project_id=project_id,
+        rule_id=matched_rule.id if matched_rule else None,
+        event_type=ctx.event_type,
+        trigger_type_slug=ctx.trigger_type_slug,
+        event_context=ctx.to_dict(),
+        action=action,
+        target_agent_id=target_agent_id,
+        status="matched" if matched_rule else "no_match",
+        duration_ms=duration_ms,
+        completed_at=datetime.now(timezone.utc),
+    )
+    session.add(log)
+    await session.flush()
+
+    return EvaluationResult(
+        matched=matched_rule is not None,
+        rule=matched_rule,
+        action=action,
+        target_agent_id=target_agent_id,
+    )

--- a/backend/tests/test_rule_evaluator.py
+++ b/backend/tests/test_rule_evaluator.py
@@ -1,0 +1,159 @@
+"""Tests for rule_evaluator service — Phase 3 AC1~AC6."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.rule_evaluator import EventContext, EvaluationResult, _matches, evaluate
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_ID = uuid.uuid4()
+
+
+def _rule(
+    priority: int = 100,
+    is_enabled: bool = True,
+    trigger_type_slugs: list[str] | None = None,
+    memo_type: list[str] | None = None,
+) -> MagicMock:
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.org_id = ORG_ID
+    r.project_id = PROJECT_ID
+    r.agent_id = AGENT_ID
+    r.priority = priority
+    r.is_enabled = is_enabled
+    r.deleted_at = None
+    conditions: dict = {}
+    if trigger_type_slugs is not None:
+        conditions["trigger_type_slugs"] = trigger_type_slugs
+    if memo_type is not None:
+        conditions["memo_type"] = memo_type
+    r.conditions = conditions
+    r.action = {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}
+    return r
+
+
+# ── _matches unit tests ───────────────────────────────────────────────────────
+
+def test_matches_trigger_slug_hit():
+    rule = _rule(trigger_type_slugs=["kickoff"])
+    ctx = EventContext(event_type="memo.received", trigger_type_slug="kickoff")
+    assert _matches(rule, ctx) is True
+
+
+def test_matches_trigger_slug_miss():
+    rule = _rule(trigger_type_slugs=["kickoff"])
+    ctx = EventContext(event_type="memo.received", trigger_type_slug="qa_request")
+    assert _matches(rule, ctx) is False
+
+
+def test_matches_memo_type_hit():
+    rule = _rule(memo_type=["requirement", "user_story"])
+    ctx = EventContext(event_type="memo.received", memo_type="requirement")
+    assert _matches(rule, ctx) is True
+
+
+def test_matches_memo_type_miss():
+    rule = _rule(memo_type=["requirement"])
+    ctx = EventContext(event_type="memo.received", memo_type="review")
+    assert _matches(rule, ctx) is False
+
+
+def test_matches_both_conditions_must_pass():
+    rule = _rule(trigger_type_slugs=["kickoff"], memo_type=["requirement"])
+    ctx_ok = EventContext(event_type="e", trigger_type_slug="kickoff", memo_type="requirement")
+    ctx_bad = EventContext(event_type="e", trigger_type_slug="kickoff", memo_type="review")
+    assert _matches(rule, ctx_ok) is True
+    assert _matches(rule, ctx_bad) is False
+
+
+def test_matches_empty_conditions_wildcard():
+    rule = _rule()  # no trigger_type_slugs, no memo_type
+    ctx = EventContext(event_type="anything", trigger_type_slug="whatever", memo_type="any")
+    assert _matches(rule, ctx) is True
+
+
+def test_matches_empty_list_treated_as_wildcard():
+    rule = _rule(trigger_type_slugs=[], memo_type=[])
+    ctx = EventContext(event_type="e", trigger_type_slug="kickoff", memo_type="review")
+    assert _matches(rule, ctx) is True
+
+
+# ── evaluate integration tests ────────────────────────────────────────────────
+
+def _mock_session(rules: list) -> AsyncMock:
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = rules
+    mock_session.execute.return_value = mock_result
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    return mock_session
+
+
+@pytest.mark.asyncio
+async def test_evaluate_returns_first_priority_match():
+    r1 = _rule(priority=10, trigger_type_slugs=["kickoff"])
+    r2 = _rule(priority=20, trigger_type_slugs=["kickoff"])
+    session = _mock_session([r1, r2])
+    ctx = EventContext(event_type="e", trigger_type_slug="kickoff")
+    result = await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    assert result.matched is True
+    assert result.rule is r1
+
+
+@pytest.mark.asyncio
+async def test_evaluate_no_match_returns_false():
+    r = _rule(trigger_type_slugs=["kickoff"])
+    session = _mock_session([r])
+    ctx = EventContext(event_type="e", trigger_type_slug="qa_request")
+    result = await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    assert result.matched is False
+    assert result.rule is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_logs_execution():
+    r = _rule(trigger_type_slugs=["kickoff"])
+    session = _mock_session([r])
+    ctx = EventContext(event_type="memo.received", trigger_type_slug="kickoff")
+    await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    session.add.assert_called_once()
+    log_obj = session.add.call_args[0][0]
+    assert log_obj.status == "matched"
+    assert log_obj.trigger_type_slug == "kickoff"
+    assert log_obj.event_type == "memo.received"
+    assert log_obj.rule_id == r.id
+
+
+@pytest.mark.asyncio
+async def test_evaluate_no_match_logs_no_match():
+    session = _mock_session([])
+    ctx = EventContext(event_type="e", trigger_type_slug="kickoff")
+    await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    log_obj = session.add.call_args[0][0]
+    assert log_obj.status == "no_match"
+    assert log_obj.rule_id is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_memo_type_filter():
+    r_po = _rule(priority=10, trigger_type_slugs=["kickoff"], memo_type=["requirement"])
+    r_dev = _rule(priority=20, trigger_type_slugs=["kickoff"], memo_type=["task"])
+    session = _mock_session([r_po, r_dev])
+    ctx = EventContext(event_type="e", trigger_type_slug="kickoff", memo_type="task")
+    result = await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    assert result.matched is True
+    assert result.rule is r_dev
+
+
+@pytest.mark.asyncio
+async def test_evaluate_returns_target_agent_id():
+    r = _rule(trigger_type_slugs=["kickoff"])
+    session = _mock_session([r])
+    ctx = EventContext(event_type="e", trigger_type_slug="kickoff")
+    result = await evaluate(session, ORG_ID, PROJECT_ID, ctx)
+    assert result.target_agent_id == AGENT_ID


### PR DESCRIPTION
## Summary

- `app/services/rule_evaluator.py` — Phase 3 Rule Evaluation Engine (내부 서비스 전용, API 미노출)
  - `EventContext`: event_type / trigger_type_slug / memo_type / memo_id / actor_id
  - `evaluate(session, org_id, project_id, ctx)`: enabled 규칙 priority ASC 조회 → first-match
  - 매칭: trigger_type_slugs AND memo_type 조건 / 빈 조건 = wildcard
  - execution_log 자동 기록 (matched / no_match)
- `app/models/workflow_execution_log.py` — WorkflowExecutionLog ORM 모델
- `alembic/versions/0015_add_workflow_execution_logs.py` — workflow_execution_logs 테이블 + 인덱스 2개

## AC Coverage

| AC | 테스트 |
|---|---|
| AC1 trigger_type_slug 매칭 | `test_matches_trigger_slug_hit/miss` |
| AC2 memo_type 필터 | `test_matches_memo_type_hit/miss`, `test_evaluate_memo_type_filter` |
| AC3 priority 정렬 | `test_evaluate_returns_first_priority_match` |
| AC4 disabled 규칙 제외 | DB 쿼리 `is_enabled.is_(True)` 조건 |
| AC5 execution_log 기록 | `test_evaluate_logs_execution`, `test_evaluate_no_match_logs_no_match` |
| AC6 API 미노출 | 라우터 미등록 — 내부 서비스 전용 |

## Test plan

- [ ] 테스트 13/13 PASS (신규) + 기존 375개 회귀 없음 확인
- [ ] `evaluate()` trigger_type_slug 매칭 정상 (kickoff → PO 규칙)
- [ ] memo_type 필터 동작 (requirement vs task 분기)
- [ ] disabled 규칙 제외 확인 (is_enabled=False인 규칙 skip)
- [ ] workflow_execution_logs 테이블 생성 + 인덱스 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)