### PR TITLE
[SID:f0a9ba30] S3-4 Board 킥오프 액션 버튼

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -166,7 +166,12 @@
     "searchSprints": "Search sprints...",
     "searchEpics": "Search epics...",
     "searchAssignees": "Search assignees...",
-    "noResults": "No results"
+    "noResults": "No results",
+    "kickoff": "Kickoff",
+    "kickoffTriggered": "Workflow triggered",
+    "kickoffNoMatch": "No matching rule found",
+    "kickoffConflict": "Workflow already triggered recently",
+    "kickoffError": "Failed to trigger workflow"
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -166,7 +166,12 @@
     "searchSprints": "스프린트 검색...",
     "searchEpics": "에픽 검색...",
     "searchAssignees": "담당자 검색...",
-    "noResults": "결과 없음"
+    "noResults": "결과 없음",
+    "kickoff": "킥오프",
+    "kickoffTriggered": "워크플로우가 실행되었습니다",
+    "kickoffNoMatch": "매칭되는 규칙이 없습니다",
+    "kickoffConflict": "최근 실행된 워크플로우가 있습니다",
+    "kickoffError": "워크플로우 실행에 실패했습니다"
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/app/api/workflow/trigger/route.ts
+++ b/apps/web/src/app/api/workflow/trigger/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function POST(request: Request) {
+  return proxyToFastapi(request, '/api/v2/workflow/trigger');
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useToast, ToastContainer } from '@/components/ui/toast';
 import { KanbanColumn } from './kanban-column';
 import { KanbanListView } from './kanban-list-view';
 import { KanbanSkeleton } from './kanban-skeleton';
@@ -73,6 +74,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const t = useTranslations('board');
+  const { toasts, addToast, dismissToast } = useToast();
   const [transitionError, setTransitionError] = useState<string | null>(null);
   const [stories, setStories] = useState<KanbanStory[]>([]);
   const [sprints, setSprints] = useState<KanbanSprint[]>([]);
@@ -463,6 +465,17 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     }
   }, [fetchData]);
 
+  const handleKickoff = useCallback((_storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => {
+    const messages: Record<string, { title: string; type: 'success' | 'error' | 'info' | 'warning' }> = {
+      triggered: { title: t('kickoffTriggered'), type: 'success' },
+      no_match: { title: t('kickoffNoMatch'), type: 'info' },
+      conflict: { title: t('kickoffConflict'), type: 'warning' },
+      error: { title: t('kickoffError'), type: 'error' },
+    };
+    const msg = messages[result] ?? { title: t('kickoffError'), type: 'error' };
+    addToast({ title: msg.title, type: msg.type });
+  }, [t, addToast]);
+
   const handleCreateStory = useCallback(async (columnId: string, title: string) => {
     if (!projectId) return;
     try {
@@ -537,6 +550,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
       {transitionError && (
         <div className="fixed bottom-4 right-4 z-50 rounded-md border border-destructive bg-destructive px-4 py-3 text-sm text-destructive-foreground shadow-md">
           ⚠️ {transitionError}
@@ -853,6 +867,8 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onChangeStatus={handleChangeStatus}
                     onAssignStory={handleAssignStory}
                     onDeleteStory={handleDeleteStory}
+                    projectId={projectId}
+                    onKickoffStory={handleKickoff}
                     wipLimit={wipState.limit}
                     wipExceeded={isExceeded}
                     wipEditing={wipState.editing}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -42,6 +42,8 @@ interface KanbanColumnProps {
   onChangeStatus?: (storyId: string, newStatus: string) => void;
   onAssignStory?: (storyId: string) => void;
   onDeleteStory?: (storyId: string) => void;
+  projectId?: string;
+  onKickoffStory?: (storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => void;
   // AC1/AC5: WIP limit
   wipLimit?: number | null;
   wipExceeded?: boolean;
@@ -60,7 +62,7 @@ export function KanbanColumn({
   onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
-  onCreateStory,
+  onCreateStory, projectId, onKickoffStory,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
@@ -254,6 +256,8 @@ export function KanbanColumn({
               onChangeStatus={onChangeStatus}
               onAssign={onAssignStory}
               onDelete={onDeleteStory}
+              projectId={projectId}
+              onKickoff={onKickoffStory}
             />
           ))}
         </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useTranslations } from 'next-intl';
 import type { KanbanStory, KanbanMember } from './types';
 import { Badge } from '@/components/ui/badge';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Rocket } from 'lucide-react';
 
 const EPIC_COLORS = [
   'info',
@@ -34,13 +34,41 @@ interface StoryCardProps {
   onChangeStatus?: (storyId: string, newStatus: string) => void;
   onAssign?: (storyId: string) => void;
   onDelete?: (storyId: string) => void;
+  projectId?: string;
+  onKickoff?: (storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => void;
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff }: StoryCardProps) {
   const t = useTranslations('board');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
+  const [triggering, setTriggering] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  const handleKickoff = useCallback(async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!projectId || triggering) return;
+    setTriggering(true);
+    try {
+      const res = await fetch('/api/workflow/trigger', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId, story_id: story.id, trigger_type_slug: 'kickoff' }),
+      });
+      if (res.status === 409) {
+        onKickoff?.(story.id, 'conflict');
+      } else if (res.ok) {
+        const data = await res.json() as { status: string };
+        onKickoff?.(story.id, data.status === 'triggered' ? 'triggered' : 'no_match');
+      } else {
+        onKickoff?.(story.id, 'error');
+      }
+    } catch {
+      onKickoff?.(story.id, 'error');
+    } finally {
+      setTriggering(false);
+    }
+  }, [projectId, story.id, triggering, onKickoff]);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: story.id,
@@ -176,6 +204,20 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           <span className="font-mono text-[10px] text-muted-foreground/50">#{story.id.slice(0, 6)}</span>
           {story.story_points != null ? (
             <Badge variant="secondary" className="font-mono text-[10px] px-1.5 py-0">{story.story_points}</Badge>
+          ) : null}
+          {projectId ? (
+            <button
+              onClick={(e) => void handleKickoff(e)}
+              disabled={triggering}
+              title={t('kickoff')}
+              className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground/60 hover:text-primary hover:bg-primary/10 disabled:opacity-40 transition"
+            >
+              {triggering ? (
+                <span className="h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" />
+              ) : (
+                <Rocket className="h-3 w-3" />
+              )}
+            </button>
           ) : null}
         </div>
       </div>

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -91,6 +91,7 @@ app.include_router(integrations.router)
 app.include_router(workflow_versions.router)
 app.include_router(workflow_trigger_types.router)
 app.include_router(workflow_executions.router)
+app.include_router(workflow_trigger.router)
 app.include_router(mockups.router)
 
 if settings.is_ee_enabled:

--- a/backend/app/routers/workflow_trigger.py
+++ b/backend/app/routers/workflow_trigger.py
@@ -53,7 +53,7 @@ async def trigger_workflow(
             WorkflowExecutionLog.org_id == org_id,
             WorkflowExecutionLog.project_id == body.project_id,
             WorkflowExecutionLog.trigger_type_slug == body.trigger_type_slug,
-            WorkflowExecutionLog.event_context["story_id"].astext == body.story_id,
+            WorkflowExecutionLog.event_context["metadata"]["story_id"].astext == body.story_id,
             WorkflowExecutionLog.created_at >= cutoff,
         )
         .limit(1)

--- a/backend/app/routers/workflow_trigger.py
+++ b/backend/app/routers/workflow_trigger.py
@@ -1,0 +1,94 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends, Header, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.workflow_execution_log import WorkflowExecutionLog
+from app.services.rule_evaluator import EventContext
+from app.services.workflow_pipeline import process_event
+
+router = APIRouter(prefix="/api/v2/workflow", tags=["workflow"])
+
+_DEDUP_SECONDS = 30
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=400, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+class TriggerRequest(BaseModel):
+    project_id: uuid.UUID
+    story_id: str
+    trigger_type_slug: str = "kickoff"
+
+
+class TriggerResponse(BaseModel):
+    status: str
+    execution_id: str | None = None
+    message: str | None = None
+
+
+@router.post("/trigger", response_model=TriggerResponse)
+async def trigger_workflow(
+    body: TriggerRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> TriggerResponse:
+    cutoff = datetime.now(timezone.utc) - timedelta(seconds=_DEDUP_SECONDS)
+    recent = await db.execute(
+        select(WorkflowExecutionLog.id)
+        .where(
+            WorkflowExecutionLog.org_id == org_id,
+            WorkflowExecutionLog.project_id == body.project_id,
+            WorkflowExecutionLog.trigger_type_slug == body.trigger_type_slug,
+            WorkflowExecutionLog.event_context["story_id"].astext == body.story_id,
+            WorkflowExecutionLog.created_at >= cutoff,
+        )
+        .limit(1)
+    )
+    if recent.scalar_one_or_none():
+        raise HTTPException(
+            status_code=409,
+            detail="Workflow already triggered recently for this story",
+        )
+
+    ctx = EventContext(
+        event_type="manual_trigger",
+        trigger_type_slug=body.trigger_type_slug,
+        actor_id=str(auth.user_id),
+        metadata={"story_id": body.story_id},
+    )
+
+    await process_event(db, org_id, body.project_id, ctx)
+    await db.commit()
+
+    last_log = await db.execute(
+        select(WorkflowExecutionLog)
+        .where(
+            WorkflowExecutionLog.org_id == org_id,
+            WorkflowExecutionLog.project_id == body.project_id,
+            WorkflowExecutionLog.trigger_type_slug == body.trigger_type_slug,
+        )
+        .order_by(WorkflowExecutionLog.created_at.desc())
+        .limit(1)
+    )
+    log = last_log.scalar_one_or_none()
+
+    if log and log.status in ("matched", "running", "completed"):
+        return TriggerResponse(
+            status="triggered",
+            execution_id=str(log.id),
+        )
+    return TriggerResponse(status="no_match", message="No matching rule found")


### PR DESCRIPTION
## Summary

**Backend**
- `backend/app/routers/workflow_trigger.py` — POST /api/v2/workflow/trigger
  - body: `{ project_id, story_id, trigger_type_slug="kickoff" }`
  - 30초 내 동일 story+slug 중복 실행 방지 → 409 Conflict
  - `process_event()` → matched: `{ status: "triggered", execution_id }` / no_match: `{ status: "no_match" }`
- `main.py` — workflow_trigger 라우터 등록

**Frontend**
- `api/workflow/trigger/route.ts` — POST proxy
- `story-card.tsx` — Rocket 아이콘 버튼 + `onKickoff` callback + triggering 로딩 스피너
- `kanban-column.tsx` — `projectId` + `onKickoffStory` props 추가
- `kanban-board.tsx` — `handleKickoff()` + `useToast` + `ToastContainer`
- `ko.json` / `en.json` — board 네임스페이스 5키 추가

## AC Coverage

| AC | 구현 |
|---|---|
| AC1 보드 스토리 카드 킥오프 버튼 노출 (admin+member) | projectId 있으면 항상 표시 |
| AC2 매칭 규칙 에이전트에 메모 자동 전송 | workflow_trigger → process_event |
| AC3 실행 완료/실패 토스트 알림 | handleKickoff + ToastContainer |
| AC4 30초 내 중복 실행 차단 409 | workflow_execution_logs 쿼리 |
| AC5 규칙 미매칭 안내 | "매칭되는 규칙이 없습니다" 토스트 |
| AC6 보드 뷰 스토리 카드 우측 | flex 하단 우측 Rocket 버튼 |

## Test plan

- [ ] 보드 스토리 카드 우측 하단에 🚀 아이콘 버튼 표시 확인
- [ ] 버튼 클릭 → 로딩 스피너 → 토스트 알림 확인
- [ ] matched rule → "워크플로우가 실행되었습니다" (green)
- [ ] no_match → "매칭되는 규칙이 없습니다" (info)
- [ ] 30초 내 재클릭 → "최근 실행된 워크플로우가 있습니다" (warning)
- [ ] tsc PASS + 397 테스트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)