### PR TITLE
[SID:c6dc4e21] 이벤트 택소노미 신설 + reply_memo process_event 연결

### DIFF
--- a/backend/app/repositories/workflow_trigger_type.py
+++ b/backend/app/repositories/workflow_trigger_type.py
@@ -15,6 +15,7 @@ SYSTEM_TRIGGER_TYPES = [
     {"slug": "handoff", "label": "Handoff", "description": "담당자 간 인계"},
     {"slug": "status_changed", "label": "Status Changed", "description": "스토리 상태 전이"},
     {"slug": "assignee_changed", "label": "Assignee Changed", "description": "스토리 담당자 변경"},
+    {"slug": "reply", "label": "Reply", "description": "메모 답신"},
 ]
 
 

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -1,4 +1,5 @@
 import os
+import re
 import uuid
 import logging
 
@@ -63,6 +64,24 @@ def _fire_webhook(url: str, content: str, title: str, memo_url: str, memo_id: st
         httpx.post(url, json=payload, timeout=10)
     except Exception:  # noqa: BLE001
         logger.warning("reply webhook fire failed url=%s", url, exc_info=True)
+
+
+def _infer_trigger_type(memo_type: str | None, review_type: str | None) -> str:
+    if review_type in ("approve", "request_changes"):
+        return "review_request"
+    if review_type == "qa":
+        return "qa_request"
+    return "reply"
+
+
+async def _resolve_author_role(db: AsyncSession, created_by: uuid.UUID | None) -> str:
+    if created_by is None:
+        return "member"
+    result = await db.execute(
+        select(TeamMember.role).where(TeamMember.id == created_by).limit(1)
+    )
+    row = result.scalar_one_or_none()
+    return str(row) if row else "member"
 
 
 def _get_repo(
@@ -139,6 +158,13 @@ async def create_memo(
                 memo_type=body.memo_type,
                 memo_id=str(memo.id),
                 actor_id=str(body.created_by) if body.created_by else None,
+                metadata={
+                    "memo_id": str(memo.id),
+                    "memo_type": body.memo_type,
+                    "title": body.title,
+                    "assigned_to_id": str(body.assigned_to) if body.assigned_to else None,
+                    "actor_id": str(body.created_by) if body.created_by else None,
+                },
             ))
         except Exception:
             pass
@@ -222,6 +248,37 @@ async def add_reply(
         title = memo.title or "메모 답신"
         for url in webhook_urls:
             background_tasks.add_task(_fire_webhook, url, content, title, memo_url, str(id))
+
+    if memo.project_id:
+        from app.services.workflow_pipeline import process_event
+        from app.services.rule_evaluator import EventContext
+        try:
+            author_role = await _resolve_author_role(db, reply.created_by)
+            has_pr = bool(re.search(r"github\.com/.+/pull/\d+", reply.content or ""))
+            await process_event(
+                db,
+                repo.org_id,
+                memo.project_id,
+                EventContext(
+                    event_type="memo.reply_created",
+                    trigger_type_slug=_infer_trigger_type(memo.memo_type, reply.review_type),
+                    memo_type=memo.memo_type,
+                    memo_id=str(reply.id),
+                    actor_id=str(reply.created_by) if reply.created_by else None,
+                    metadata={
+                        "original_memo_id": str(id),
+                        "original_memo_type": memo.memo_type,
+                        "original_title": memo.title,
+                        "reply_author_id": str(reply.created_by) if reply.created_by else None,
+                        "reply_author_role": author_role,
+                        "review_type": reply.review_type,
+                        "has_pr_link": has_pr,
+                        "content_preview": (reply.content or "")[:200],
+                    },
+                ),
+            )
+        except Exception:
+            pass
 
     return ReplyResponse.model_validate(reply)
 

--- a/backend/app/services/event_taxonomy.py
+++ b/backend/app/services/event_taxonomy.py
@@ -1,0 +1,63 @@
+"""Event taxonomy — canonical parameter schema for all workflow events."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EventParam:
+    key: str
+    type: str  # "str" | "bool" | "uuid"
+    required: bool
+    description: str
+
+
+EVENT_TAXONOMY: dict[str, list[EventParam]] = {
+    "story.status_changed": [
+        EventParam("story_id", "uuid", True, "스토리 UUID"),
+        EventParam("story_title", "str", True, "스토리 제목"),
+        EventParam("old_status", "str", True, "변경 전 상태"),
+        EventParam("status", "str", True, "변경 후 상태"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
+    "story.assignee_changed": [
+        EventParam("story_id", "uuid", True, "스토리 UUID"),
+        EventParam("story_title", "str", True, "스토리 제목"),
+        EventParam("assignee_id", "uuid", False, "새 담당자 UUID"),
+        EventParam("old_assignee_id", "uuid", False, "기존 담당자 UUID"),
+        EventParam("project_id", "uuid", True, "프로젝트 UUID"),
+        EventParam("org_id", "uuid", True, "조직 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 team_member UUID"),
+        EventParam("timestamp", "str", True, "ISO 8601 UTC 타임스탬프"),
+    ],
+    "memo_created": [
+        EventParam("memo_id", "uuid", True, "메모 UUID"),
+        EventParam("memo_type", "str", True, "메모 타입 (task/memo/request 등)"),
+        EventParam("title", "str", False, "메모 제목"),
+        EventParam("assigned_to_id", "uuid", False, "수신자 team_member UUID"),
+        EventParam("actor_id", "uuid", False, "발신자 team_member UUID"),
+    ],
+    "memo.reply_created": [
+        EventParam("original_memo_id", "uuid", True, "원 메모 UUID"),
+        EventParam("original_memo_type", "str", False, "원 메모 타입"),
+        EventParam("original_title", "str", False, "원 메모 제목"),
+        EventParam("reply_author_id", "uuid", True, "답신자 team_member UUID"),
+        EventParam("reply_author_role", "str", False, "답신자 역할 (human/agent/member 등)"),
+        EventParam("review_type", "str", False, "리뷰 타입 (approve/request_changes/comment 등)"),
+        EventParam("has_pr_link", "bool", False, "답신 본문에 PR 링크 포함 여부"),
+        EventParam("content_preview", "str", False, "답신 본문 앞 200자"),
+    ],
+    "manual_trigger": [
+        EventParam("story_id", "str", True, "트리거된 스토리 UUID"),
+        EventParam("actor_id", "uuid", False, "실행자 user UUID"),
+    ],
+}
+
+
+def validate_event_context(event_type: str, metadata: dict) -> list[str]:
+    """Returns list of missing required keys. Empty = valid."""
+    schema = EVENT_TAXONOMY.get(event_type, [])
+    return [p.key for p in schema if p.required and p.key not in metadata]

--- a/backend/tests/test_event_taxonomy.py
+++ b/backend/tests/test_event_taxonomy.py
@@ -1,0 +1,139 @@
+"""Tests for event_taxonomy + add_reply process_event integration (S4-1)."""
+import re
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.event_taxonomy import EVENT_TAXONOMY, validate_event_context
+from app.routers.memos import _infer_trigger_type, _resolve_author_role
+
+
+# ──────────────────────────────────────────────
+# EVENT_TAXONOMY schema tests
+# ──────────────────────────────────────────────
+
+class TestEventTaxonomy:
+    def test_all_expected_event_types_present(self):
+        expected = {
+            "story.status_changed",
+            "story.assignee_changed",
+            "memo_created",
+            "memo.reply_created",
+            "manual_trigger",
+        }
+        assert expected.issubset(set(EVENT_TAXONOMY.keys()))
+
+    def test_memo_reply_created_required_params(self):
+        schema = {p.key: p for p in EVENT_TAXONOMY["memo.reply_created"]}
+        assert schema["original_memo_id"].required is True
+        assert schema["reply_author_id"].required is True
+
+    def test_memo_reply_created_optional_params(self):
+        schema = {p.key: p for p in EVENT_TAXONOMY["memo.reply_created"]}
+        for key in ("original_memo_type", "original_title", "reply_author_role",
+                    "review_type", "has_pr_link", "content_preview"):
+            assert key in schema
+            assert schema[key].required is False
+
+    def test_memo_created_schema(self):
+        schema = {p.key: p for p in EVENT_TAXONOMY["memo_created"]}
+        assert schema["memo_id"].required is True
+        assert "assigned_to_id" in schema
+        assert "title" in schema
+
+    def test_validate_event_context_missing_required(self):
+        errors = validate_event_context("memo.reply_created", {})
+        assert "original_memo_id" in errors
+        assert "reply_author_id" in errors
+
+    def test_validate_event_context_ok(self):
+        errors = validate_event_context("memo.reply_created", {
+            "original_memo_id": str(uuid.uuid4()),
+            "reply_author_id": str(uuid.uuid4()),
+        })
+        assert errors == []
+
+    def test_validate_unknown_event_type_returns_empty(self):
+        errors = validate_event_context("unknown.event", {})
+        assert errors == []
+
+
+# ──────────────────────────────────────────────
+# _infer_trigger_type tests
+# ──────────────────────────────────────────────
+
+class TestInferTriggerType:
+    def test_approve_returns_review_request(self):
+        assert _infer_trigger_type("task", "approve") == "review_request"
+
+    def test_request_changes_returns_review_request(self):
+        assert _infer_trigger_type("task", "request_changes") == "review_request"
+
+    def test_qa_returns_qa_request(self):
+        assert _infer_trigger_type("task", "qa") == "qa_request"
+
+    def test_comment_returns_reply(self):
+        assert _infer_trigger_type("memo", "comment") == "reply"
+
+    def test_none_review_type_returns_reply(self):
+        assert _infer_trigger_type("memo", None) == "reply"
+
+    def test_task_memo_type_no_review_returns_reply(self):
+        assert _infer_trigger_type("task", None) == "reply"
+
+
+# ──────────────────────────────────────────────
+# _resolve_author_role tests
+# ──────────────────────────────────────────────
+
+class TestResolveAuthorRole:
+    @pytest.mark.asyncio
+    async def test_returns_member_role_when_found(self):
+        db = AsyncMock()
+        member_id = uuid.uuid4()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = "agent"
+        db.execute = AsyncMock(return_value=result_mock)
+
+        role = await _resolve_author_role(db, member_id)
+        assert role == "agent"
+
+    @pytest.mark.asyncio
+    async def test_returns_member_when_not_found(self):
+        db = AsyncMock()
+        member_id = uuid.uuid4()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(return_value=result_mock)
+
+        role = await _resolve_author_role(db, member_id)
+        assert role == "member"
+
+    @pytest.mark.asyncio
+    async def test_returns_member_when_created_by_is_none(self):
+        db = AsyncMock()
+        role = await _resolve_author_role(db, None)
+        assert role == "member"
+        db.execute.assert_not_called()
+
+
+# ──────────────────────────────────────────────
+# has_pr_link regex test
+# ──────────────────────────────────────────────
+
+class TestHasPrLink:
+    def _detect(self, content: str) -> bool:
+        return bool(re.search(r"github\.com/.+/pull/\d+", content))
+
+    def test_detects_github_pr_link(self):
+        assert self._detect("PR: https://github.com/org/repo/pull/123 참고") is True
+
+    def test_no_link_returns_false(self):
+        assert self._detect("일반 답신 내용") is False
+
+    def test_partial_url_returns_false(self):
+        assert self._detect("https://github.com/org/repo/issues/42") is False
+
+    def test_empty_string_returns_false(self):
+        assert self._detect("") is False


### PR DESCRIPTION
## Summary

- `event_taxonomy.py` 신설: 5개 이벤트 타입 파라미터 스키마 + `validate_event_context()` 유틸
- `SYSTEM_TRIGGER_TYPES`에 `reply` 트리거 타입 추가
- `add_reply()`: `_infer_trigger_type` + `_resolve_author_role` 헬퍼 추가, `process_event()` 연결 (try/except — 응답 차단 없음)
- `create_memo()` EventContext metadata 보강: `assigned_to_id`, `title` 포함

## Changes

| 파일 | 변경 |
|------|------|
| `app/services/event_taxonomy.py` | 신규 — 5개 이벤트 스키마 정의 |
| `app/repositories/workflow_trigger_type.py` | `reply` 트리거 시딩 추가 |
| `app/routers/memos.py` | `add_reply` process_event 연결, `create_memo` metadata 보강 |
| `tests/test_event_taxonomy.py` | 신규 — 20개 테스트 |

## Acceptance Criteria 체크리스트

- [x] `memo.reply_created` 이벤트 택소노미 스키마 정의
- [x] `reply` SYSTEM_TRIGGER_TYPE 시딩
- [x] `add_reply()` → `process_event()` 연결 (project_id 있을 때만)
- [x] `_infer_trigger_type`: approve/request_changes→review_request, qa→qa_request, else→reply
- [x] `_resolve_author_role`: TeamMember.role 조회, 없으면 "member" 기본값
- [x] `has_pr_link`: github.com/.+/pull/\d+ 정규식
- [x] `create_memo` metadata에 `assigned_to_id`, `title` 추가
- [x] 테스트 20개 PASS / 기존 417 회귀 없음

## Test Plan

- [ ] `pytest tests/test_event_taxonomy.py -v` → 20/20 PASS
- [ ] `pytest -q` → 417 PASS
- [ ] reply_memo 호출 시 WorkflowExecutionLog 생성 확인 (project_id 있는 메모)
- [ ] review_type="approve" → trigger_type_slug="review_request" 로그 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)