### PR TITLE
[SID:60a3b186] 조건 엔진 event_params 매칭 확장

### DIFF
--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -35,6 +35,13 @@ def _normalize_conditions(value: Any) -> dict[str, Any]:
                 seen.add(cleaned)
                 deduped.append(cleaned)
         result["trigger_type_slugs"] = deduped
+    if "event_params" in value:
+        raw_params = value["event_params"]
+        if isinstance(raw_params, dict):
+            normalized_params: dict[str, list] = {}
+            for k, v in raw_params.items():
+                normalized_params[k] = v if isinstance(v, list) else [v]
+            result["event_params"] = normalized_params
     return result
 
 

--- a/backend/app/services/rule_evaluator.py
+++ b/backend/app/services/rule_evaluator.py
@@ -59,6 +59,14 @@ def _matches(rule: AgentRoutingRule, ctx: EventContext) -> bool:
         if ctx.memo_type not in memo_types:
             return False
 
+    event_params: dict[str, Any] = conditions.get("event_params") or {}
+    for key, allowed_values in event_params.items():
+        if not isinstance(allowed_values, list) or not allowed_values:
+            continue
+        actual = ctx.metadata.get(key)
+        if actual not in allowed_values:
+            return False
+
     return True
 
 

--- a/backend/tests/test_rule_evaluator.py
+++ b/backend/tests/test_rule_evaluator.py
@@ -157,3 +157,86 @@ async def test_evaluate_returns_target_agent_id():
     ctx = EventContext(event_type="e", trigger_type_slug="kickoff")
     result = await evaluate(session, ORG_ID, PROJECT_ID, ctx)
     assert result.target_agent_id == AGENT_ID
+
+
+# ── event_params matching tests (S4-2) ───────────────────────────────────────
+
+def _rule_with_params(event_params: dict, **kwargs) -> MagicMock:
+    r = _rule(**kwargs)
+    r.conditions["event_params"] = event_params
+    return r
+
+
+def test_event_params_single_key_match():
+    rule = _rule_with_params({"reply_author_role": ["agent"]})
+    ctx = EventContext(event_type="memo.reply_created", metadata={"reply_author_role": "agent"})
+    assert _matches(rule, ctx) is True
+
+
+def test_event_params_single_key_no_match():
+    rule = _rule_with_params({"reply_author_role": ["agent"]})
+    ctx = EventContext(event_type="memo.reply_created", metadata={"reply_author_role": "human"})
+    assert _matches(rule, ctx) is False
+
+
+def test_event_params_multi_key_and():
+    rule = _rule_with_params({"reply_author_role": ["agent"], "has_pr_link": [True]})
+    ctx_ok = EventContext(event_type="e", metadata={"reply_author_role": "agent", "has_pr_link": True})
+    ctx_bad = EventContext(event_type="e", metadata={"reply_author_role": "agent", "has_pr_link": False})
+    assert _matches(rule, ctx_ok) is True
+    assert _matches(rule, ctx_bad) is False
+
+
+def test_event_params_or_values():
+    rule = _rule_with_params({"review_type": ["approve", "request_changes"]})
+    ctx_approve = EventContext(event_type="e", metadata={"review_type": "approve"})
+    ctx_rc = EventContext(event_type="e", metadata={"review_type": "request_changes"})
+    ctx_miss = EventContext(event_type="e", metadata={"review_type": "comment"})
+    assert _matches(rule, ctx_approve) is True
+    assert _matches(rule, ctx_rc) is True
+    assert _matches(rule, ctx_miss) is False
+
+
+def test_event_params_empty_backward_compat():
+    rule = _rule(trigger_type_slugs=["reply"])
+    ctx = EventContext(event_type="memo.reply_created", trigger_type_slug="reply", metadata={})
+    assert _matches(rule, ctx) is True
+
+
+def test_event_params_bool_matching():
+    rule = _rule_with_params({"has_pr_link": [True]})
+    ctx_true = EventContext(event_type="e", metadata={"has_pr_link": True})
+    ctx_false = EventContext(event_type="e", metadata={"has_pr_link": False})
+    assert _matches(rule, ctx_true) is True
+    assert _matches(rule, ctx_false) is False
+
+
+def test_event_params_missing_key_treated_as_miss():
+    rule = _rule_with_params({"reply_author_role": ["agent"]})
+    ctx = EventContext(event_type="e", metadata={})
+    assert _matches(rule, ctx) is False
+
+
+# ── _normalize_conditions event_params tests (S4-2) ──────────────────────────
+
+from app.repositories.agent_routing_rule import _normalize_conditions
+
+
+def test_normalize_conditions_event_params_passthrough():
+    result = _normalize_conditions({
+        "event_params": {"reply_author_role": ["agent"], "has_pr_link": [True]}
+    })
+    assert result["event_params"] == {"reply_author_role": ["agent"], "has_pr_link": [True]}
+
+
+def test_normalize_conditions_event_params_scalar_wrapped():
+    result = _normalize_conditions({
+        "event_params": {"review_type": "approve"}
+    })
+    assert result["event_params"] == {"review_type": ["approve"]}
+
+
+def test_normalize_conditions_no_event_params_unchanged():
+    result = _normalize_conditions({"memo_type": ["task"]})
+    assert "event_params" not in result
+    assert result["memo_type"] == ["task"]


### PR DESCRIPTION
## Summary

- `_matches()`: `conditions.event_params` 기반 metadata 매칭 추가 — 키=AND, 값배열=OR
- `_normalize_conditions()`: `event_params` 정규화 — 스칼라→배열 자동 래핑, dict 외 무시
- 기존 trigger_type_slugs + memo_type 하위 호환 유지

## Changes

| 파일 | 변경 |
|------|------|
| `app/services/rule_evaluator.py` | `_matches()` event_params AND/OR 매칭 추가 |
| `app/repositories/agent_routing_rule.py` | `_normalize_conditions()` event_params 정규화 |
| `tests/test_rule_evaluator.py` | event_params 테스트 10개 추가 |

## Acceptance Criteria 체크리스트

- [x] AC1: conditions.event_params 내 key-value 매칭 정상
- [x] AC2: 복수 event_params는 AND 조건으로 동작
- [x] AC3: 각 value 배열은 OR 조건으로 동작
- [x] AC4: event_params 없는 기존 규칙 하위 호환
- [x] AC5: _normalize_conditions에서 event_params 정규화 (스칼라→배열)

## Test Plan

- [ ] `pytest tests/test_rule_evaluator.py -v` → 23/23 PASS
- [ ] `pytest -q` → 427 PASS
- [ ] reply_author_role="agent" + has_pr_link=True 규칙으로 매칭 검증
- [ ] event_params 없는 기존 규칙 → 기존대로 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)