### PR TITLE
[SID:21565b79] 액션 side_effects 확장 — update_status + auto_assign

### DIFF
--- a/backend/app/repositories/agent_routing_rule.py
+++ b/backend/app/repositories/agent_routing_rule.py
@@ -47,7 +47,7 @@ def _normalize_conditions(value: Any) -> dict[str, Any]:
 
 def _normalize_action(value: Any) -> dict[str, Any]:
     if not value or not isinstance(value, dict):
-        return {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None}
+        return {"auto_reply_mode": "process_and_report", "forward_to_agent_id": None, "side_effects": []}
     mode = value.get("auto_reply_mode", "process_and_report")
     if mode not in ("process_and_forward", "process_and_report"):
         mode = "process_and_report"
@@ -56,7 +56,13 @@ def _normalize_action(value: Any) -> dict[str, Any]:
         forward_to = fwd.strip()
     else:
         forward_to = None
-    return {"auto_reply_mode": mode, "forward_to_agent_id": forward_to}
+    raw_effects = value.get("side_effects", [])
+    valid_types = {"update_status", "auto_assign"}
+    if isinstance(raw_effects, list):
+        side_effects = [se for se in raw_effects if isinstance(se, dict) and se.get("type") in valid_types]
+    else:
+        side_effects = []
+    return {"auto_reply_mode": mode, "forward_to_agent_id": forward_to, "side_effects": side_effects}
 
 
 def _to_response(rule: AgentRoutingRule) -> RoutingRuleResponse:

--- a/backend/app/services/rule_evaluator.py
+++ b/backend/app/services/rule_evaluator.py
@@ -25,6 +25,7 @@ class EventContext:
     memo_id: str | None = None
     actor_id: str | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    is_side_effect: bool = False
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/backend/app/services/workflow_pipeline.py
+++ b/backend/app/services/workflow_pipeline.py
@@ -9,7 +9,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.workflow_execution_log import WorkflowExecutionLog
@@ -64,6 +64,47 @@ async def _send_memo(
     )
 
 
+async def _execute_side_effects(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    side_effects: list[dict],
+    ctx: EventContext,
+) -> None:
+    from app.models.pm import Story
+    from app.models.team import TeamMember
+
+    story_id_str = ctx.metadata.get("story_id")
+
+    for se in side_effects:
+        try:
+            effect_type = se.get("type")
+            if effect_type == "update_status" and story_id_str:
+                target_status = se.get("target_status")
+                if target_status:
+                    await session.execute(
+                        update(Story)
+                        .where(Story.id == uuid.UUID(str(story_id_str)), Story.org_id == org_id)
+                        .values(status=target_status)
+                    )
+            elif effect_type == "auto_assign" and story_id_str:
+                role = se.get("assign_to_role")
+                if role:
+                    result = await session.execute(
+                        select(TeamMember.id)
+                        .where(TeamMember.org_id == org_id, TeamMember.role == role)
+                        .limit(1)
+                    )
+                    member_id = result.scalar_one_or_none()
+                    if member_id:
+                        await session.execute(
+                            update(Story)
+                            .where(Story.id == uuid.UUID(str(story_id_str)), Story.org_id == org_id)
+                            .values(assignee_id=member_id)
+                        )
+        except Exception:
+            pass
+
+
 async def _update_log(
     session: AsyncSession,
     log_id: uuid.UUID,
@@ -89,6 +130,9 @@ async def process_event(
     project_id: uuid.UUID,
     ctx: EventContext,
 ) -> None:
+    if ctx.is_side_effect:
+        return
+
     result = await evaluate(session, org_id, project_id, ctx)
 
     if not result.matched or not result.action:
@@ -116,6 +160,10 @@ async def process_event(
                     await _send_memo(session, org_id, project_id, fwd_id, ctx)
                 except ValueError:
                     raise ValueError(f"Invalid forward_to_agent_id: {fwd_str}")
+
+        side_effects = (action or {}).get("side_effects", [])
+        if side_effects:
+            await _execute_side_effects(session, org_id, side_effects, ctx)
 
         if result.log_id:
             await _update_log(session, result.log_id, "completed")

--- a/backend/tests/test_workflow_pipeline.py
+++ b/backend/tests/test_workflow_pipeline.py
@@ -137,3 +137,97 @@ async def test_process_event_independent_of_webhook():
         await process_event(session, ORG_ID, PROJECT_ID, ctx)
     # Should complete without touching any webhook code
     assert True
+
+
+# ── side_effects tests (S4-3) ─────────────────────────────────────────────────
+
+from app.services.workflow_pipeline import _execute_side_effects
+from app.repositories.agent_routing_rule import _normalize_action
+
+
+def _make_result_with_side_effects(side_effects: list) -> EvaluationResult:
+    action = {
+        "auto_reply_mode": "process_and_report",
+        "forward_to_agent_id": None,
+        "side_effects": side_effects,
+    }
+    return EvaluationResult(
+        matched=True,
+        rule=MagicMock(),
+        action=action,
+        target_agent_id=AGENT_ID,
+        log_id=LOG_ID,
+    )
+
+
+@pytest.mark.asyncio
+async def test_side_effect_update_status():
+    session = _mock_session()
+    story_id = str(uuid.uuid4())
+    ctx = EventContext(event_type="e", metadata={"story_id": story_id})
+    side_effects = [{"type": "update_status", "target_status": "in-review"}]
+    await _execute_side_effects(session, ORG_ID, side_effects, ctx)
+    session.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_side_effect_auto_assign():
+    session = _mock_session()
+    story_id = str(uuid.uuid4())
+    member_id = uuid.uuid4()
+    result_mock = MagicMock()
+    result_mock.scalar_one_or_none.return_value = member_id
+    session.execute = AsyncMock(return_value=result_mock)
+    ctx = EventContext(event_type="e", metadata={"story_id": story_id})
+    side_effects = [{"type": "auto_assign", "assign_to_role": "qa"}]
+    await _execute_side_effects(session, ORG_ID, side_effects, ctx)
+    assert session.execute.call_count == 2  # select + update
+
+
+@pytest.mark.asyncio
+async def test_side_effect_loop_prevention():
+    session = _mock_session()
+    ctx = EventContext(event_type="e", is_side_effect=True)
+    with patch("app.services.workflow_pipeline.evaluate", new=AsyncMock()) as mock_eval:
+        await process_event(session, ORG_ID, PROJECT_ID, ctx)
+    mock_eval.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_side_effect_partial_failure_memo_sent():
+    session = _mock_session()
+    ctx = EventContext(event_type="e", metadata={})
+    result = _make_result_with_side_effects([{"type": "update_status", "target_status": "in-review"}])
+    with patch("app.services.workflow_pipeline.evaluate", new=AsyncMock(return_value=result)), \
+         patch("app.services.workflow_pipeline._send_memo", new=AsyncMock()) as mock_send, \
+         patch("app.services.workflow_pipeline._execute_side_effects", side_effect=Exception("se_fail")):
+        await process_event(session, ORG_ID, PROJECT_ID, ctx)
+    mock_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_side_effect_empty_backward_compat():
+    session = _mock_session()
+    ctx = EventContext(event_type="e")
+    result = _make_result(matched=True, mode="process_and_report")
+    with patch("app.services.workflow_pipeline.evaluate", new=AsyncMock(return_value=result)), \
+         patch("app.services.workflow_pipeline._send_memo", new=AsyncMock()) as mock_send:
+        await process_event(session, ORG_ID, PROJECT_ID, ctx)
+    mock_send.assert_awaited_once()
+
+
+def test_normalize_action_side_effects():
+    result = _normalize_action({
+        "auto_reply_mode": "process_and_report",
+        "side_effects": [
+            {"type": "update_status", "target_status": "in-review"},
+            {"type": "invalid_type"},
+        ],
+    })
+    assert len(result["side_effects"]) == 1
+    assert result["side_effects"][0]["type"] == "update_status"
+
+
+def test_normalize_action_no_side_effects_backward_compat():
+    result = _normalize_action({"auto_reply_mode": "process_and_report"})
+    assert result["side_effects"] == []


### PR DESCRIPTION
## Summary

- `EventContext.is_side_effect`: 순환 호출 방지 플래그 추가
- `_normalize_action()`: `side_effects` 배열 정규화 (valid_types: update_status, auto_assign)
- `_execute_side_effects()`: Story 테이블 직접 UPDATE — 라우터 미경유로 순환 원천 차단
- `process_event()`: `is_side_effect=True` 즉시 return + 메모 전송 후 side_effects 실행

## Changes

| 파일 | 변경 |
|------|------|
| `app/services/rule_evaluator.py` | `EventContext.is_side_effect` 필드 추가 |
| `app/repositories/agent_routing_rule.py` | `_normalize_action()` side_effects 정규화 |
| `app/services/workflow_pipeline.py` | `_execute_side_effects()` 신설 + `process_event()` 확장 |
| `tests/test_workflow_pipeline.py` | side_effects 테스트 7개 추가 |

## Acceptance Criteria 체크리스트

- [x] AC1: update_status side_effect → 스토리 상태 자동 전이
- [x] AC2: auto_assign side_effect → 담당자 자동 변경
- [x] AC3: 순환 방지 (is_side_effect=True → process_event 즉시 return)
- [x] AC4: side_effect 실패 시 메모 전송 유지 (부분 실패 허용)
- [x] AC5: 기존 action 구조 하위 호환 (side_effects 없으면 기존대로)

## Test Plan

- [ ] `pytest tests/test_workflow_pipeline.py -v` → 16/16 PASS
- [ ] `pytest -q` → 434 PASS
- [ ] update_status side_effect로 스토리 상태 변경 확인
- [ ] is_side_effect=True 시 evaluate() 미호출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)