### PR TITLE
fix: API key 관리 UX 개선 및 인증/온보딩 버그 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ sprintable.db
 
 # Test
 coverage/
+test-results/
 .omx/
 .gstack/
 .omc/

--- a/apps/web/.env.playwright.example
+++ b/apps/web/.env.playwright.example
@@ -1,0 +1,14 @@
+# Copy this file to .env.playwright and set the URL for your test target.
+# .env.playwright is gitignored — safe to put local/Tailscale endpoints here.
+#
+# Examples:
+#   Local dev server (default if omitted):
+#     PLAYWRIGHT_BASE_URL=http://localhost:3108
+#
+#   Tailscale / remote host:
+#     PLAYWRIGHT_BASE_URL=https://my-machine.tail1234.ts.net:3108
+#
+#   Staging:
+#     PLAYWRIGHT_BASE_URL=https://staging.sprintable.dev
+
+PLAYWRIGHT_BASE_URL=http://localhost:3108

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -16,6 +16,7 @@
 /playwright-report
 /test-results
 /blob-report
+/playwright/.auth
 
 # next.js
 /.next/

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+
+const OWNER_EMAIL = 'owner@sprintable.dev';
+const OWNER_PASSWORD = 'password123';
+const BASE_URL = () => process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3108';
+
+test.describe('Authentication', () => {
+  test('login API succeeds and session is recognized at /inbox', async ({ browser }) => {
+    const context = await browser.newContext({ baseURL: BASE_URL() });
+
+    // Call login API directly — mirrors what the browser form does
+    const resp = await context.request.post('/api/auth/login', {
+      data: { email: OWNER_EMAIL, password: OWNER_PASSWORD },
+      headers: { 'Content-Type': 'application/json', Origin: BASE_URL() },
+    });
+    expect(resp.status(), 'login API should return 200').toBe(200);
+    const body = await resp.json() as { data?: { ok: boolean } };
+    expect(body.data?.ok, 'login response data.ok should be true').toBe(true);
+
+    // Navigate to /inbox — server-side auth guard should pass
+    const page = await context.newPage();
+    await page.goto('/inbox');
+    await page.waitForURL(/\/inbox/, { timeout: 15000 });
+    expect(page.url(), 'should land on /inbox with valid session').toContain('/inbox');
+
+    await context.close();
+  });
+
+  test('wrong password → login API returns error', async ({ request }) => {
+    const resp = await request.post('/api/auth/login', {
+      data: { email: OWNER_EMAIL, password: 'wrong-password-xyz' },
+      headers: { 'Content-Type': 'application/json', Origin: BASE_URL() },
+    });
+    expect(resp.status(), 'wrong password should return 4xx').toBeGreaterThanOrEqual(400);
+    const body = await resp.json() as { error?: { message: string } };
+    expect(body.error, 'should include an error object').toBeTruthy();
+  });
+
+  test('unauthenticated browser → accessing /inbox redirects to /login', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const baseURL = BASE_URL();
+    await page.goto(`${baseURL}/inbox`);
+    await page.waitForURL(/\/login/, { timeout: 10000 });
+    expect(page.url(), 'should redirect to /login').toContain('/login');
+    await context.close();
+  });
+
+  test('login page renders form elements', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.locator('input[placeholder="Email"]'), 'email input should be visible').toBeVisible();
+    await expect(page.locator('input[placeholder="Password"]'), 'password input should be visible').toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in' }), 'sign in button should be visible').toBeVisible();
+  });
+
+  test('register page renders form elements', async ({ page }) => {
+    await page.goto('/register');
+    await expect(page.locator('input[placeholder="Email"]'), 'email input should be visible').toBeVisible();
+    await expect(page.locator('input[placeholder="Password"]'), 'password input should be visible').toBeVisible();
+  });
+});

--- a/apps/web/e2e/board.spec.ts
+++ b/apps/web/e2e/board.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Board — kanban aha moment', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/board');
+    await page.waitForLoadState('load');
+  });
+
+  test('board page loads with kanban columns', async ({ page }) => {
+    const response = await page.goto('/board');
+    expect(response?.status(), 'board should return 200').toBe(200);
+    await page.waitForLoadState('load');
+    // KanbanColumn renders h3 headers with status names (Todo / In Progress / etc.)
+    const colHeaders = page.locator('h3').filter({ hasText: /todo|progress|review|blocked|done|backlog/i });
+    await expect(colHeaders.first(), 'at least one kanban column header should be visible').toBeVisible({ timeout: 10000 });
+  });
+
+  test('clicking a story card opens detail panel and updates URL', async ({ page }) => {
+    // Find a story card
+    const cards = page.locator('[class*="story-card"], [class*="StoryCard"], [draggable="true"]').first();
+    if (!(await cards.isVisible())) {
+      test.skip(true, 'no story cards present');
+      return;
+    }
+    await cards.click();
+    await page.waitForLoadState('load');
+    // URL should contain ?story=
+    expect(page.url(), 'URL should contain ?story= after clicking a card').toContain('story=');
+  });
+
+  test('creating a new story adds card to column', async ({ page }) => {
+    // Look for a "New story" / "+" button in a column
+    const addBtn = page.getByRole('button', { name: /new story|add story|\+/i }).first();
+    if (!(await addBtn.isVisible())) {
+      test.skip(true, 'no add-story button visible');
+      return;
+    }
+
+    const storyTitle = `e2e-story-${Date.now()}`;
+    await addBtn.click();
+
+    // Fill in the story title
+    const titleInput = page.locator('input[placeholder*="title" i], input[placeholder*="story" i], textarea[placeholder*="title" i]').first();
+    await titleInput.waitFor({ state: 'visible', timeout: 5000 });
+    await titleInput.fill(storyTitle);
+    await titleInput.press('Enter');
+
+    await page.waitForLoadState('load');
+    // New card should appear with the title
+    await expect(page.getByText(storyTitle), 'new story card should be visible').toBeVisible({ timeout: 8000 });
+  });
+
+  test('drag card between columns moves it (keyboard simulation)', async ({ page }) => {
+    // Use keyboard-accessible dnd — press Space to grab, arrow to move, Space to drop
+    const draggableCard = page.locator('[draggable="true"]').first();
+    if (!(await draggableCard.isVisible())) {
+      test.skip(true, 'no draggable cards');
+      return;
+    }
+
+    // Record initial column before drag
+    const initialParent = await draggableCard.evaluate((el) => el.closest('[class*="column"], [class*="Column"]')?.textContent?.slice(0, 30));
+
+    await draggableCard.focus();
+    await draggableCard.press('Space'); // dnd-kit lift
+    await page.waitForTimeout(200);
+    await draggableCard.press('ArrowRight'); // move to next column
+    await page.waitForTimeout(200);
+    await draggableCard.press('Space'); // dnd-kit drop
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/stories') && resp.request().method() === 'PATCH',
+      { timeout: 8000 }
+    ).catch(() => {}); // allow failure if card didn't move (valid transition rules)
+
+    // Just verify no crash — card should still exist
+    await expect(draggableCard.or(page.locator('[draggable="true"]').first()), 'cards should still exist after drag').toBeVisible();
+    void initialParent; // silence unused var
+  });
+});

--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Dashboard — first impression', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dashboard');
+    await page.waitForLoadState('load');
+  });
+
+  test('page loads with HTTP 200 and no JS errors', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+    const response = await page.goto('/dashboard');
+    await page.waitForLoadState('load');
+    expect(response?.status(), 'dashboard should return 200').toBe(200);
+    const critical = errors.filter((e) => !e.includes('Warning:'));
+    expect(critical, 'no critical JS console errors').toHaveLength(0);
+  });
+
+  test('stat widgets are visible and show numeric values', async ({ page }) => {
+    // Dashboard should show at least one numeric counter card
+    const cards = page.locator('[class*="card"], [class*="Card"]');
+    await expect(cards.first(), 'at least one stat card visible').toBeVisible();
+  });
+
+  test('navigation to /board works from authenticated context', async ({ page }) => {
+    // Verify sidebar nav or board link is present or navigate directly
+    await page.goto('/board');
+    await page.waitForLoadState('load');
+    expect(page.url(), 'should reach /board').toContain('/board');
+  });
+});

--- a/apps/web/e2e/global-setup.ts
+++ b/apps/web/e2e/global-setup.ts
@@ -1,0 +1,36 @@
+import { chromium } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+async function globalSetup() {
+  const baseURL = process.env['PLAYWRIGHT_BASE_URL'] ?? 'http://localhost:3108';
+  const authDir = path.join(__dirname, '../playwright/.auth');
+  fs.mkdirSync(authDir, { recursive: true });
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ baseURL });
+
+  // Call login API directly — cookies are set in the browser context
+  const resp = await context.request.post('/api/auth/login', {
+    data: { email: 'owner@sprintable.dev', password: 'password123' },
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: baseURL,
+    },
+  });
+
+  if (!resp.ok()) {
+    const body = await resp.text();
+    throw new Error(`Login failed (${resp.status()}): ${body}`);
+  }
+
+  // Navigate to /inbox once to confirm the session works server-side
+  const page = await context.newPage();
+  await page.goto('/inbox');
+  await page.waitForURL(/\/inbox/, { timeout: 15000 });
+
+  await context.storageState({ path: path.join(authDir, 'owner.json') });
+  await browser.close();
+}
+
+export default globalSetup;

--- a/apps/web/e2e/inbox.spec.ts
+++ b/apps/web/e2e/inbox.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Inbox — notification triage', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/inbox');
+    await page.waitForLoadState('load');
+  });
+
+  test('inbox page loads successfully', async ({ page }) => {
+    const response = await page.goto('/inbox');
+    expect(response?.status(), 'inbox should return 200').toBe(200);
+    await page.waitForLoadState('load');
+  });
+
+  test('clicking a notification card opens detail panel', async ({ page }) => {
+    const cards = page.locator('[class*="notification"], [class*="Notification"]').filter({ hasNot: page.locator('header') });
+    const count = await cards.count();
+
+    if (count === 0) {
+      test.skip(true, 'no notifications to interact with');
+      return;
+    }
+
+    const firstCard = cards.first();
+    await firstCard.click();
+    await page.waitForLoadState('load');
+    // Detail panel should appear — look for a panel or article that wasn't visible
+    const panel = page.locator('main, [role="complementary"], aside').last();
+    await expect(panel, 'detail panel should be visible after click').toBeVisible();
+  });
+
+  test('"mark all read" button clears unread state', async ({ page }) => {
+    // Find the mark-all-read button (various possible texts)
+    const markAllBtn = page.getByRole('button', { name: /mark all|all read/i });
+    if (await markAllBtn.isVisible()) {
+      await markAllBtn.click();
+      await page.waitForResponse((resp) => resp.url().includes('/api/notifications') && resp.status() < 300);
+      // After marking all read, the button may hide or count drop to 0
+    } else {
+      test.skip(true, 'no unread notifications to mark');
+    }
+  });
+});

--- a/apps/web/e2e/layout-verification.spec.ts
+++ b/apps/web/e2e/layout-verification.spec.ts
@@ -16,18 +16,7 @@
 
 import { expect, test, type Page } from '@playwright/test';
 
-// ---------------------------------------------------------------------------
-// Auth helper — OSS mode uses cookie-less session; adapt to your auth flow
-// ---------------------------------------------------------------------------
-async function ensureLoggedIn(page: Page) {
-  await page.goto('/');
-  const url = page.url();
-  if (url.includes('/login') || url.includes('/auth')) {
-    // OSS mode auto-seeds a session — just navigate to the seed endpoint first
-    await page.request.post('/api/oss/seed').catch(() => {});
-    await page.goto('/dashboard');
-  }
-}
+test.use({ storageState: 'playwright/.auth/owner.json' });
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -94,9 +83,6 @@ const ROUTES: RouteSpec[] = [
 // Tests
 // ---------------------------------------------------------------------------
 test.describe('Layout Verification', () => {
-  test.beforeEach(async ({ page }) => {
-    await ensureLoggedIn(page);
-  });
 
   for (const route of ROUTES) {
     test(`[A-E] ${route.label}`, async ({ page }) => {

--- a/apps/web/e2e/memo-create.spec.ts
+++ b/apps/web/e2e/memo-create.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Memo — create and share', () => {
+  test('memos list page loads', async ({ page }) => {
+    const response = await page.goto('/memos');
+    expect(response?.status(), 'memos should return 200').toBe(200);
+    await page.waitForLoadState('load');
+  });
+
+  test('creating a new memo adds it to the list', async ({ page }) => {
+    const memoContent = `e2e test memo ${Date.now()}`;
+
+    await page.goto('/memos/new');
+    await page.waitForLoadState('load');
+
+    // Fill in memo content
+    const contentArea = page.locator('textarea, [contenteditable="true"], [role="textbox"]').first();
+    await contentArea.waitFor({ state: 'visible', timeout: 8000 });
+    await contentArea.click();
+    await contentArea.fill(memoContent);
+
+    // Submit / publish
+    const publishBtn = page.getByRole('button', { name: /publish|post|send|submit/i }).first();
+    if (!(await publishBtn.isVisible())) {
+      test.skip(true, 'no publish button found — memo form structure may have changed');
+      return;
+    }
+    await publishBtn.click();
+
+    // Should redirect back to /memos after publish
+    await page.waitForURL(/\/memos(?!\/new)/, { timeout: 10000 });
+    await page.waitForLoadState('load');
+
+    // New memo should appear in list
+    await expect(page.getByText(memoContent), 'new memo should appear in list').toBeVisible({ timeout: 8000 });
+  });
+
+  test('applying a template pre-fills the form', async ({ page }) => {
+    await page.goto('/memos/new');
+    await page.waitForLoadState('load');
+
+    const templateBtn = page.getByRole('button', { name: /template/i }).first();
+    if (!(await templateBtn.isVisible())) {
+      test.skip(true, 'template button not visible');
+      return;
+    }
+
+    await templateBtn.click();
+    // Template picker should appear
+    const templateOption = page.locator('[class*="template"], [class*="Template"]').first();
+    if (await templateOption.isVisible()) {
+      await templateOption.click();
+      await page.waitForLoadState('load');
+      // Content area should now have pre-filled text
+      const contentArea = page.locator('textarea, [contenteditable="true"], [role="textbox"]').first();
+      const value = await contentArea.textContent() ?? await contentArea.inputValue().catch(() => '');
+      expect(value.length, 'template should pre-fill content').toBeGreaterThan(0);
+    }
+  });
+
+  test('memo detail page is accessible', async ({ page }) => {
+    // Navigate to memos list and click the first one
+    await page.goto('/memos');
+    await page.waitForLoadState('load');
+
+    const memoCard = page.locator('[class*="memo"], [class*="Memo"]').filter({ hasText: /./}).first();
+    if (!(await memoCard.isVisible())) {
+      test.skip(true, 'no memos to click');
+      return;
+    }
+
+    await memoCard.click();
+    await page.waitForURL(/\/memos\/\w/, { timeout: 8000 });
+    const response = await page.goto(page.url());
+    expect(response?.status(), 'memo detail should return 200').toBe(200);
+  });
+});

--- a/apps/web/e2e/onboarding.spec.ts
+++ b/apps/web/e2e/onboarding.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '@playwright/test';
+
+// Onboarding tests use a fresh account — no storageState
+// Serial mode: each test creates a new account; parallel workers collide on the same email
+test.describe('Onboarding — new user setup', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  async function registerAndGetToOnboarding(page: Parameters<Parameters<typeof test>[1]>[0]) {
+    const email = `onboard-${Date.now()}-${Math.random().toString(36).slice(2, 6)}@example.com`;
+    const password = 'TestPassword123!';
+
+    await page.goto('/register');
+    await page.waitForLoadState('networkidle');
+    const emailInput = page.locator('input[placeholder="Email"]');
+    await emailInput.waitFor({ state: 'visible', timeout: 10000 });
+    await emailInput.click();
+    await emailInput.pressSequentially(email, { delay: 30 });
+    // Verify fill landed before moving on
+    await expect(emailInput).toHaveValue(email, { timeout: 5000 });
+    const passwordInput = page.locator('input[placeholder="Password"]');
+    await passwordInput.click();
+    await passwordInput.pressSequentially(password, { delay: 30 });
+    await expect(passwordInput).toHaveValue(password, { timeout: 5000 });
+    const signUpBtn = page.getByRole('button', { name: /sign up|create account|register/i });
+    await expect(signUpBtn, 'Sign up button should be enabled').toBeEnabled({ timeout: 5000 });
+    await signUpBtn.click();
+
+    // Wait for redirect to onboarding or inbox
+    await page.waitForURL(/\/(onboarding|inbox)/, { timeout: 15000 });
+    return { email, password };
+  }
+
+  test('new user lands on /onboarding after registration', async ({ page }) => {
+    await registerAndGetToOnboarding(page);
+    const url = page.url();
+    expect(
+      url.includes('/onboarding') || url.includes('/inbox'),
+      'new user should land on onboarding or inbox'
+    ).toBe(true);
+  });
+
+  test('onboarding org step: fills org name and advances', async ({ page }) => {
+    await registerAndGetToOnboarding(page);
+
+    if (!page.url().includes('/onboarding')) {
+      test.skip(true, 'user already has org — skipping onboarding test');
+      return;
+    }
+
+    const orgName = `Test Org ${Date.now()}`;
+
+    // Step 1: org name
+    const orgInput = page.locator('input[placeholder*="org" i], input[placeholder*="company" i], input[placeholder*="workspace" i], input[type="text"]').first();
+    await orgInput.waitFor({ state: 'visible', timeout: 8000 });
+    await orgInput.fill(orgName);
+
+    const nextBtn = page.getByRole('button', { name: /next|continue|create/i }).first();
+    await nextBtn.click();
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/organizations') && resp.request().method() === 'POST',
+      { timeout: 10000 }
+    );
+
+    // Should advance to project step
+    await page.waitForLoadState('load');
+    // Look for project-related text or next form
+    const projectInput = page.locator('input[placeholder*="project" i], input[type="text"]').first();
+    await expect(projectInput, 'project step input should appear').toBeVisible({ timeout: 8000 });
+  });
+
+  test('completing onboarding reaches /dashboard', async ({ page }) => {
+    await registerAndGetToOnboarding(page);
+
+    if (!page.url().includes('/onboarding')) {
+      test.skip(true, 'user already has org — skipping full onboarding test');
+      return;
+    }
+
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+    // Step 1: Org — wait for "Create Organization" button specifically
+    const createOrgBtn = page.getByRole('button', { name: /create org/i });
+    await createOrgBtn.waitFor({ state: 'visible', timeout: 8000 });
+    const orgInput = page.locator('input[type="text"]').first();
+    await orgInput.pressSequentially(`Org ${suffix}`, { delay: 30 });
+    await expect(createOrgBtn).toBeEnabled({ timeout: 5000 });
+    await createOrgBtn.click();
+
+    // Step 2: Project — wait for "Create Project" button to appear (confirms step transition)
+    const createProjectBtn = page.getByRole('button', { name: /create project/i });
+    await createProjectBtn.waitFor({ state: 'visible', timeout: 20000 });
+    const projectInput = page.locator('input[type="text"]').first();
+    await projectInput.pressSequentially(`Project ${suffix}`, { delay: 30 });
+    await expect(createProjectBtn).toBeEnabled({ timeout: 5000 });
+    await createProjectBtn.click();
+
+    // Step 3: Agent — wait for "Skip" button to appear, then skip
+    // Clicking Skip calls router.push('/dashboard') directly
+    const skipBtn = page.getByRole('button', { name: 'Skip' });
+    await skipBtn.waitFor({ state: 'visible', timeout: 20000 });
+    await skipBtn.click();
+
+    await page.waitForURL(/\/(dashboard|inbox|board)/, { timeout: 15000 });
+    const finalUrl = page.url();
+    expect(
+      finalUrl.includes('/dashboard') || finalUrl.includes('/inbox') || finalUrl.includes('/board'),
+      'should reach app after completing onboarding'
+    ).toBe(true);
+  });
+});

--- a/apps/web/e2e/retro-flow.spec.ts
+++ b/apps/web/e2e/retro-flow.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Retro — full session cycle', () => {
+  test('retro list page loads', async ({ page }) => {
+    const response = await page.goto('/retro');
+    expect(response?.status(), 'retro should return 200').toBe(200);
+    await page.waitForLoadState('load');
+  });
+
+  test('create new retro session → appears in list', async ({ page }) => {
+    await page.goto('/retro');
+    await page.waitForLoadState('load');
+
+    const sessionTitle = `e2e-retro-${Date.now()}`;
+
+    // Fill title input — stable id on the retro page
+    const titleInput = page.locator('#retro-title-input');
+    await titleInput.waitFor({ state: 'visible', timeout: 8000 });
+    await titleInput.click();
+    await titleInput.pressSequentially(sessionTitle, { delay: 30 });
+
+    // Create button enables once title is non-empty
+    const createBtn = page.getByRole('button', { name: 'Create' });
+    await createBtn.waitFor({ state: 'visible', timeout: 5000 });
+    await expect(createBtn, 'create button should be enabled after filling title').toBeEnabled({ timeout: 5000 });
+    await createBtn.click();
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/retro') && resp.request().method() === 'POST',
+      { timeout: 8000 }
+    );
+
+    await page.waitForLoadState('load');
+    await expect(page.getByText(sessionTitle), 'new retro session should appear in list').toBeVisible({ timeout: 8000 });
+  });
+
+  test('retro session: add items in collect phase', async ({ page }) => {
+    // Create a session first via API for a clean state
+    const createResp = await page.request.post('/api/retro-sessions', {
+      data: { title: `e2e-collect-${Date.now()}` },
+    });
+    if (!createResp.ok()) {
+      test.skip(true, 'could not create retro session via API');
+      return;
+    }
+    const { data } = await createResp.json() as { data: { id: string } };
+    const sessionId = data.id;
+
+    await page.goto(`/retro/${sessionId}`);
+    await page.waitForLoadState('load');
+
+    // Add a "good" item
+    const goodText = `What went well: ${Date.now()}`;
+    const addButtons = page.getByRole('button', { name: /add|^\+$/i });
+    const firstAdd = addButtons.first();
+    if (!(await firstAdd.isVisible())) {
+      test.skip(true, 'no add button in collect phase');
+      return;
+    }
+
+    await firstAdd.click();
+    const itemInput = page.locator('textarea, input[type="text"]').last();
+    await itemInput.waitFor({ state: 'visible', timeout: 3000 });
+    await itemInput.fill(goodText);
+    await itemInput.press('Enter');
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/retro') && resp.request().method() === 'POST',
+      { timeout: 8000 }
+    );
+
+    await expect(page.getByText(goodText), 'retro item should appear after adding').toBeVisible({ timeout: 8000 });
+  });
+
+  test('retro session: advance phase changes phase badge', async ({ page }) => {
+    const createResp = await page.request.post('/api/retro-sessions', {
+      data: { title: `e2e-phase-${Date.now()}` },
+    });
+    if (!createResp.ok()) {
+      test.skip(true, 'could not create retro session');
+      return;
+    }
+    const { data } = await createResp.json() as { data: { id: string } };
+
+    await page.goto(`/retro/${data.id}`);
+    await page.waitForLoadState('load');
+
+    const advanceBtn = page.getByRole('button', { name: /next|advance|proceed/i }).first();
+    if (!(await advanceBtn.isVisible())) {
+      test.skip(true, 'no advance phase button');
+      return;
+    }
+
+    await advanceBtn.click();
+    await page.waitForLoadState('load');
+
+    // Phase badge should change (no longer "collect")
+    const phaseBadge = page.locator('[class*="badge"], [class*="phase"], [class*="Phase"]').first();
+    const phaseText = await phaseBadge.textContent();
+    expect(phaseText?.toLowerCase(), 'phase should advance past collect').not.toBe('collect');
+  });
+});

--- a/apps/web/e2e/settings-invite.spec.ts
+++ b/apps/web/e2e/settings-invite.spec.ts
@@ -1,0 +1,96 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Settings — member invitation (conversion moment)', () => {
+  test('settings page loads', async ({ page }) => {
+    const response = await page.goto('/settings');
+    expect(response?.status(), 'settings should return 200').toBe(200);
+    await page.waitForLoadState('load');
+  });
+
+  test('inviting a member shows invite URL in success banner', async ({ page }) => {
+    // Navigate to members settings tab
+    await page.goto('/settings/members');
+    await page.waitForLoadState('load');
+
+    const inviteEmail = `invite-test-${Date.now()}@example.com`;
+
+    // Fill email input for invitation
+    const emailInput = page.locator('input[type="email"], input[placeholder*="email" i]').first();
+    if (!(await emailInput.isVisible())) {
+      // Try clicking a Members tab first
+      const membersTab = page.getByRole('tab', { name: /members/i }).or(
+        page.getByRole('link', { name: /members/i })
+      ).first();
+      if (await membersTab.isVisible()) {
+        await membersTab.click();
+        await page.waitForLoadState('load');
+      } else {
+        test.skip(true, 'could not find members invite form');
+        return;
+      }
+    }
+
+    await emailInput.fill(inviteEmail);
+
+    // Click invite button
+    const inviteBtn = page.getByRole('button', { name: /invite|send/i }).first();
+    if (!(await inviteBtn.isVisible())) {
+      test.skip(true, 'no invite button found');
+      return;
+    }
+
+    const [inviteResp] = await Promise.all([
+      page.waitForResponse(
+        (resp) => resp.url().includes('/api/invitations') && resp.request().method() === 'POST',
+        { timeout: 10000 }
+      ),
+      inviteBtn.click(),
+    ]);
+
+    expect(inviteResp.status(), 'invitation POST should succeed').toBeLessThan(300);
+
+    await page.waitForLoadState('load');
+    // Success banner with invite URL should appear (emerald/green banner)
+    const successBanner = page.locator('[class*="emerald"], [class*="green"], [class*="success"]').filter({ hasText: /http/i }).first();
+    if (await successBanner.isVisible({ timeout: 5000 })) {
+      await expect(successBanner, 'invite URL banner should be visible').toBeVisible();
+    } else {
+      // At minimum the API succeeded — check pending list updated
+      await expect(page.getByText(inviteEmail), 'invited email should appear in pending list').toBeVisible({ timeout: 5000 });
+    }
+  });
+
+  test('creating a project shows it in the project list', async ({ page }) => {
+    await page.goto('/settings/projects');
+    await page.waitForLoadState('load');
+
+    const projectName = `e2e-project-${Date.now()}`;
+
+    const nameInput = page.locator('input[placeholder*="name" i], input[placeholder*="project" i]').first();
+    if (!(await nameInput.isVisible())) {
+      const projectsTab = page.getByRole('tab', { name: /projects/i }).first();
+      if (await projectsTab.isVisible()) {
+        await projectsTab.click();
+        await page.waitForLoadState('load');
+      } else {
+        test.skip(true, 'could not find projects form');
+        return;
+      }
+    }
+
+    await nameInput.fill(projectName);
+
+    const createBtn = page.getByRole('button', { name: /create|add/i }).first();
+    await createBtn.click();
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/projects') && resp.request().method() === 'POST',
+      { timeout: 8000 }
+    );
+
+    await page.waitForLoadState('load');
+    await expect(page.getByText(projectName), 'new project should appear in list').toBeVisible({ timeout: 8000 });
+  });
+});

--- a/apps/web/e2e/standup.spec.ts
+++ b/apps/web/e2e/standup.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test } from '@playwright/test';
+
+test.use({ storageState: './playwright/.auth/owner.json' });
+
+test.describe('Standup — daily entry aha moment', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/standup');
+    await page.waitForLoadState('load');
+  });
+
+  test('standup page loads with member cards', async ({ page }) => {
+    const response = await page.goto('/standup');
+    expect(response?.status(), 'standup should return 200').toBe(200);
+    await page.waitForLoadState('load');
+  });
+
+  test('clicking edit on own card expands the form', async ({ page }) => {
+    // Look for edit button on the current user's card
+    const editBtn = page.getByRole('button', { name: /edit|write|update/i }).first();
+    if (!(await editBtn.isVisible())) {
+      // Try clicking directly on a card — some UIs expand on click
+      const cards = page.locator('[class*="standup"], [class*="Standup"]').first();
+      if (await cards.isVisible()) {
+        await cards.click();
+      } else {
+        test.skip(true, 'no standup cards found');
+        return;
+      }
+    } else {
+      await editBtn.click();
+    }
+
+    // Form should expand with Done/Plan/Blockers textareas
+    const doneArea = page.locator('textarea, [placeholder*="done" i], [placeholder*="완료" i]').first();
+    await expect(doneArea, 'done textarea should be visible in edit mode').toBeVisible({ timeout: 5000 });
+  });
+
+  test('writing standup entry and saving switches card to view mode', async ({ page }) => {
+    const editBtn = page.getByRole('button', { name: /edit|write|update/i }).first();
+    if (!(await editBtn.isVisible())) {
+      test.skip(true, 'no edit button found');
+      return;
+    }
+
+    await editBtn.click();
+
+    const textareas = page.locator('textarea');
+    const count = await textareas.count();
+    if (count === 0) {
+      test.skip(true, 'no textareas in standup form');
+      return;
+    }
+
+    const doneText = `Completed e2e test ${Date.now()}`;
+    await textareas.first().fill(doneText);
+
+    const saveBtn = page.getByRole('button', { name: /save|submit|done/i }).first();
+    await saveBtn.click();
+
+    await page.waitForResponse(
+      (resp) => resp.url().includes('/api/standup') && resp.request().method() === 'PUT',
+      { timeout: 8000 }
+    );
+
+    // Card should switch back to view mode — done text should be visible
+    await expect(page.getByText(doneText), 'saved standup entry should appear in card').toBeVisible({ timeout: 8000 });
+  });
+
+  test('date navigation loads different standup data', async ({ page }) => {
+    const prevBtn = page.getByRole('button', { name: /previous|←|prev|yesterday/i }).first();
+    if (!(await prevBtn.isVisible())) {
+      test.skip(true, 'no date navigation button found');
+      return;
+    }
+
+    await prevBtn.click();
+    await page.waitForLoadState('load');
+    // URL or page state should change — just verify no crash
+    expect(page.url(), 'page should not crash after date navigation').not.toContain('error');
+  });
+});

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -5,6 +5,9 @@ import path from 'path';
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
 const nextConfig: NextConfig = {
+  // Allow dev server access from non-localhost origins (e.g. Tailscale, LAN)
+  // Set NEXT_DEV_ALLOWED_ORIGINS=host1,host2 in .env.local to enable
+  allowedDevOrigins: process.env['NEXT_DEV_ALLOWED_ORIGINS']?.split(',').map((s) => s.trim()).filter(Boolean) ?? [],
   output: 'standalone',
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
   devIndicators: {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig, devices } from '@playwright/test';
+import { config as dotenvConfig } from 'dotenv';
+import { existsSync } from 'fs';
+import { resolve } from 'path';
+
+// Load .env.playwright if it exists (local overrides, gitignored)
+const localEnvFile = resolve(__dirname, '.env.playwright');
+if (existsSync(localEnvFile)) dotenvConfig({ path: localEnvFile });
 
 export default defineConfig({
   testDir: './e2e',
+  globalSetup: './e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env['CI'],
   retries: process.env['CI'] ? 2 : 0,

--- a/apps/web/src/app/(authenticated)/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/page.tsx
@@ -30,7 +30,7 @@ const PHASE_VARIANTS: Record<string, 'success' | 'info' | 'outline' | 'secondary
 export default function RetroPage() {
   const t = useTranslations('retro');
   const shellT = useTranslations('shell');
-  const { projectId } = useDashboardContext();
+  const { projectId, orgId } = useDashboardContext();
   const [sessions, setSessions] = useState<RetroSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [title, setTitle] = useState('');
@@ -66,14 +66,14 @@ export default function RetroPage() {
   }, [projectId]);
 
   const handleCreate = async () => {
-    if (!title.trim() || !projectId) return;
+    if (!title.trim() || !projectId || !orgId) return;
     setCreating(true);
     setCreateError(null);
     try {
       const res = await fetch('/api/retro-sessions', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), project_id: projectId }),
+        body: JSON.stringify({ title: title.trim(), project_id: projectId, org_id: orgId }),
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const json = await res.json();
@@ -133,7 +133,7 @@ export default function RetroPage() {
               placeholder={t('newSessionPlaceholder')}
               className="flex-1"
             />
-            <Button variant="default" onClick={handleCreate} disabled={!title.trim() || creating}>
+            <Button variant="default" onClick={handleCreate} disabled={!title.trim() || !orgId || creating}>
               {creating ? t('creating') : t('create')}
             </Button>
           </div>

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -13,7 +13,11 @@ import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
+function getAppOrigin() {
+  if (typeof window !== 'undefined') return window.location.origin;
+  return process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai';
+}
+const MCP_SERVER_URL = () => `${getAppOrigin()}/api/v2/mcp`;
 
 interface AgentMember {
   id: string;
@@ -61,7 +65,7 @@ function buildMcpConfig(apiKey: string) {
       mcpServers: {
         sprintable: {
           type: 'streamable-http',
-          url: MCP_SERVER_URL,
+          url: MCP_SERVER_URL(),
           headers: { Authorization: `Bearer ${apiKey}` },
         },
       },

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -419,22 +419,26 @@ export default function AgentDetailPage() {
               <h2 className="text-base font-semibold text-foreground">MCP Config</h2>
               <p className="text-sm text-muted-foreground">Claude Code나 MCP 클라이언트에 붙여넣으면 이 에이전트로 Sprintable에 연결됩니다.</p>
             </div>
-            <Button variant="glass" size="sm" onClick={() => void handleCopyMcp()}>
-              {mcpCopied ? <Check className="h-3.5 w-3.5" /> : 'Copy'}
-            </Button>
+            {freshApiKey && (
+              <Button variant="glass" size="sm" onClick={() => void handleCopyMcp()}>
+                {mcpCopied ? <Check className="h-3.5 w-3.5" /> : 'Copy'}
+              </Button>
+            )}
           </div>
         </SectionCardHeader>
         <SectionCardBody>
           {freshApiKey ? (
-            <p className="text-xs text-emerald-500 mb-2">새 API Key가 포함된 설정입니다. 지금 복사해 두세요 — 페이지를 새로고침하면 사라집니다.</p>
+            <>
+              <p className="text-xs text-emerald-500 mb-2">새 API Key가 포함된 설정입니다. 지금 복사해 두세요 — 페이지를 새로고침하면 사라집니다.</p>
+              <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
+                {buildMcpConfig(freshApiKey)}
+              </pre>
+            </>
           ) : !hasActiveKey ? (
-            <p className="text-xs text-amber-400 mb-2">API Key를 먼저 발급하세요. 발급 직후 실제 키가 이 블록에 자동으로 포함됩니다.</p>
+            <p className="text-xs text-amber-400">API Key를 먼저 발급하세요. 발급 직후 실제 키가 이 블록에 자동으로 포함됩니다.</p>
           ) : (
-            <p className="text-xs text-muted-foreground mb-2">보안상 기존 키는 재표시되지 않습니다. 새 키를 발급하면 이 블록에 자동으로 포함됩니다.</p>
+            <p className="text-xs text-muted-foreground">보안상 기존 키는 재표시되지 않습니다. 위 API Keys 섹션에서 새 키를 발급하면 실제 키가 포함된 Config가 여기에 자동으로 나타납니다.</p>
           )}
-          <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
-            {buildMcpConfig(freshApiKey ?? '<YOUR_API_KEY>')}
-          </pre>
         </SectionCardBody>
       </SectionCard>
 

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1158,8 +1158,8 @@ export default function SettingsPage() {
 
                     <div className="space-y-2">
                       <div className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('projectMembers')}</div>
-                      {projectMembers.length > 0 ? (
-                        projectMembers.map((member) => {
+                      {projectMembers.filter((m) => m.type === 'human').length > 0 ? (
+                        projectMembers.filter((m) => m.type === 'human').map((member) => {
                           const isEditingWebhook = member.id in webhookEditing;
                           const currentWebhookUrl = member.webhook_url ?? '';
                           return (

--- a/apps/web/src/app/api/team-members/route.ts
+++ b/apps/web/src/app/api/team-members/route.ts
@@ -1,7 +1,8 @@
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { parseBody, createTeamMemberSchema } from '@sprintable/shared';
+import { createTeamMemberSchema } from '@sprintable/shared';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
+import { getServerSession } from '@/lib/db/server';
 
 export async function GET(request: Request) {
   try {
@@ -17,11 +18,29 @@ export async function GET(request: Request) {
 /** POST — 프로젝트 멤버 추가/재활성화 */
 export async function POST(request: Request) {
   try {
-    const parsed = await parseBody(request, createTeamMemberSchema);
-    if (!parsed.success) return parsed.response;
-    const body = parsed.data;
-    if (!body.name) return ApiErrors.badRequest('name required for agent');
-    const _r = await proxyToFastapi(request, '/api/v2/team-members');
+    const rawBody = JSON.parse(await request.text()) as Record<string, unknown>;
+
+    // human 타입: user_id를 세션에서 자동 주입 (클라이언트가 전달하지 않아도 됨)
+    if (!rawBody['type'] || rawBody['type'] === 'human') {
+      if (!rawBody['user_id']) {
+        const session = await getServerSession();
+        if (!session) return ApiErrors.unauthorized();
+        rawBody['user_id'] = session.user_id;
+      }
+    }
+
+    const parsed = createTeamMemberSchema.safeParse(rawBody);
+    if (!parsed.success) return ApiErrors.validationFailed(
+      parsed.error.issues.map(e => ({ path: String(e.path.join('.')), message: e.message }))
+    );
+
+    // 검증된 body로 새 Request를 만들어 FastAPI로 proxy (원본 request body는 이미 소비됨)
+    const proxied = new Request(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify(rawBody),
+    });
+    const _r = await proxyToFastapi(proxied, '/api/v2/team-members');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -145,7 +145,7 @@ export function OnboardingForm() {
           project_id: project.id,
           type: 'human',
           name: memberName,
-          role: 'member',
+          role: 'admin',
         }),
       }).catch(() => null);
     }

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -6,8 +6,12 @@ import { useRouter } from 'next/navigation';
 import { UpgradeModal } from '@/components/ui/upgrade-modal';
 import { useTranslations } from 'next-intl';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
-const LLMS_PROMPT = `Read this document and complete onboarding: ${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/llms.txt`;
+function getAppOrigin() {
+  if (typeof window !== 'undefined') return window.location.origin;
+  return process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai';
+}
+const MCP_SERVER_URL = () => `${getAppOrigin()}/api/v2/mcp`;
+const LLMS_PROMPT = () => `Read this document and complete onboarding: ${getAppOrigin()}/llms.txt`;
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
 
 function buildMcpConfig(apiKey: string) {
@@ -16,7 +20,7 @@ function buildMcpConfig(apiKey: string) {
       mcpServers: {
         sprintable: {
           type: 'streamable-http',
-          url: MCP_SERVER_URL,
+          url: MCP_SERVER_URL(),
           headers: { Authorization: `Bearer ${apiKey}` },
         },
       },
@@ -378,14 +382,14 @@ export function OnboardingForm() {
               <div className="flex items-center justify-between gap-2">
                 <p className="text-xs font-semibold text-gray-700">{t('promptTitle')}</p>
                 <button
-                  onClick={() => void handleCopy(LLMS_PROMPT, 'prompt')}
+                  onClick={() => void handleCopy(LLMS_PROMPT(), 'prompt')}
                   className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 transition"
                 >
                   {copied === 'prompt' ? '✓ Copied' : 'Copy'}
                 </button>
               </div>
               <p className="break-all rounded bg-white border border-gray-100 p-2 text-xs text-gray-700">
-                {LLMS_PROMPT}
+                {LLMS_PROMPT()}
               </p>
             </div>
 

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -42,6 +42,8 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [selectedScopes, setSelectedScopes] = useState<Scope[]>(['read', 'write']);
   const [copiedOnboarding, setCopiedOnboarding] = useState(false);
+  const [copiedKey, setCopiedKey] = useState(false);
+  const [revokeConfirmDialog, setRevokeConfirmDialog] = useState(false);
   const { addToast } = useToast();
 
   const LLMS_URL = 'https://app.sprintable.ai/llms.txt';
@@ -97,6 +99,24 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
     }
   };
 
+  const revokeAllAndGenerate = async () => {
+    setRevokeConfirmDialog(false);
+    setLoading(true);
+    try {
+      await Promise.all(
+        activeKeys.map((key) =>
+          fetch(`/api/agents/${agentId}/api-key/${key.id}`, { method: 'DELETE' })
+        )
+      );
+    } catch {
+      // 일부 revoke 실패해도 신규 발급은 진행
+    } finally {
+      setLoading(false);
+    }
+    setNewKeyDialog(true);
+    void generateApiKey();
+  };
+
   const revokeApiKey = async (keyId: string) => {
     if (!confirm('Are you sure you want to revoke this API key?')) return;
 
@@ -123,23 +143,45 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
     }
   };
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-    addToast({
-      type: 'success',
-      title: 'Copied',
-      body: 'API key copied to clipboard',
-    });
+  const writeToClipboard = async (text: string): Promise<void> => {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+    const prev = document.activeElement as HTMLElement | null;
+    const el = document.createElement('textarea');
+    el.value = text;
+    el.setAttribute('readonly', '');
+    el.style.cssText = 'position:fixed;top:-9999px;left:-9999px;width:1px;height:1px';
+    document.body.appendChild(el);
+    el.focus();
+    el.select();
+    el.setSelectionRange(0, el.value.length);
+    const ok = document.execCommand('copy');
+    document.body.removeChild(el);
+    prev?.focus();
+    if (!ok) throw new Error('execCommand copy failed');
+  };
+
+  const copyToClipboard = async (text: string) => {
+    try {
+      await writeToClipboard(text);
+      setCopiedKey(true);
+      addToast({ type: 'success', title: 'Copied', body: 'API key copied to clipboard' });
+      window.setTimeout(() => setCopiedKey(false), 1500);
+    } catch {
+      addToast({ type: 'error', title: 'Copy failed', body: '클립보드 접근에 실패했습니다.' });
+    }
   };
 
   const copyOnboardingMessage = async (apiKey: string) => {
     try {
-      await navigator.clipboard.writeText(buildOnboardingMessage(apiKey));
+      await writeToClipboard(buildOnboardingMessage(apiKey));
       setCopiedOnboarding(true);
       addToast({ type: 'success', title: '온보딩 메시지 복사됨' });
       window.setTimeout(() => setCopiedOnboarding(false), 1500);
     } catch {
-      addToast({ type: 'error', title: '복사 실패', body: '클립보드 접근 권한을 확인하세요.' });
+      addToast({ type: 'error', title: '복사 실패', body: '클립보드 접근에 실패했습니다.' });
     }
   };
 
@@ -171,8 +213,12 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
             </Button>
             <Button
               onClick={() => {
-                setNewKeyDialog(true);
-                generateApiKey();
+                if (activeKeys.length > 0) {
+                  setRevokeConfirmDialog(true);
+                } else {
+                  setNewKeyDialog(true);
+                  void generateApiKey();
+                }
               }}
               disabled={loading}
             >
@@ -255,8 +301,28 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
         </div>
       )}
 
-      <Dialog open={newKeyDialog} onOpenChange={setNewKeyDialog}>
+      <Dialog open={revokeConfirmDialog} onOpenChange={setRevokeConfirmDialog}>
         <DialogContent>
+          <DialogHeader>
+            <DialogTitle>기존 키 무효화 후 새 키 발급</DialogTitle>
+            <DialogDescription>
+              활성 API 키 {activeKeys.length}개를 모두 무효화하고 새 키를 발급합니다.
+              기존 키로 연결된 에이전트는 새 키로 업데이트가 필요합니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setRevokeConfirmDialog(false)}>
+              취소
+            </Button>
+            <Button variant="destructive" onClick={() => void revokeAllAndGenerate()}>
+              무효화하고 새 키 발급
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={newKeyDialog} onOpenChange={setNewKeyDialog}>
+        <DialogContent className="sm:max-w-lg">
           <DialogHeader>
             <DialogTitle>API Key Generated</DialogTitle>
             <DialogDescription>
@@ -273,14 +339,15 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
                     readOnly
                     className="font-mono text-sm"
                   />
-                  <Button onClick={() => copyToClipboard(generatedKey)}>
-                    Copy
+                  <Button onClick={() => void copyToClipboard(generatedKey)} className="gap-1.5 shrink-0">
+                    {copiedKey ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+                    {copiedKey ? 'Copied!' : 'Copy'}
                   </Button>
                 </div>
               </div>
               <p className="text-sm text-muted-foreground">
                 Use this key in the Authorization header:
-                <code className="block mt-1 p-2 bg-muted rounded text-xs">
+                <code className="block mt-1 p-2 bg-muted rounded text-xs break-all">
                   Authorization: Bearer {generatedKey}
                 </code>
               </p>

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -148,55 +148,57 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
 
   return (
     <Card className="p-6">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-start justify-between mb-4">
         <div>
           <h3 className="text-lg font-semibold">API Keys - {agentName}</h3>
           <p className="text-sm text-muted-foreground">
             Manage API keys for agent authentication
           </p>
         </div>
-        <div className="flex gap-2">
-          <Button variant="outline" onClick={loadApiKeys} disabled={loading}>
-            Refresh
-          </Button>
-          <Button
-            variant="outline"
-            disabled={!hasActiveKey || copiedOnboarding}
-            onClick={() => void copyOnboardingMessage(generatedKey ?? (activeKeys[0] ? `${activeKeys[0].key_prefix}...` : ''))}
-            className="gap-1.5"
-          >
-            {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
-            온보딩 메시지 복사
-          </Button>
-          <Button
-            onClick={() => {
-              setNewKeyDialog(true);
-              generateApiKey();
-            }}
-            disabled={loading}
-          >
-            Generate API Key
-          </Button>
-        </div>
-        <div className="flex gap-4 mt-3">
-          <p className="text-xs text-muted-foreground self-center">Scope:</p>
-          {SCOPES.map((scope) => (
-            <label key={scope} className="flex items-center gap-1.5 text-xs cursor-pointer">
-              <input
-                type="checkbox"
-                checked={selectedScopes.includes(scope)}
-                onChange={(e) => {
-                  if (e.target.checked) {
-                    setSelectedScopes((prev) => [...prev, scope]);
-                  } else {
-                    setSelectedScopes((prev) => prev.filter((s) => s !== scope));
-                  }
-                }}
-                className="h-3 w-3"
-              />
-              <span className={scope === 'admin' ? 'text-orange-500 font-medium' : ''}>{scope}</span>
-            </label>
-          ))}
+        <div className="flex flex-col items-end gap-2">
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={loadApiKeys} disabled={loading}>
+              Refresh
+            </Button>
+            <Button
+              variant="outline"
+              disabled={!hasActiveKey || copiedOnboarding}
+              onClick={() => void copyOnboardingMessage(generatedKey ?? (activeKeys[0] ? `${activeKeys[0].key_prefix}...` : ''))}
+              className="gap-1.5"
+            >
+              {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+              온보딩 메시지 복사
+            </Button>
+            <Button
+              onClick={() => {
+                setNewKeyDialog(true);
+                generateApiKey();
+              }}
+              disabled={loading}
+            >
+              Generate API Key
+            </Button>
+          </div>
+          <div className="flex gap-4">
+            <p className="text-xs text-muted-foreground self-center">Scope:</p>
+            {SCOPES.map((scope) => (
+              <label key={scope} className="flex items-center gap-1.5 text-xs cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={selectedScopes.includes(scope)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setSelectedScopes((prev) => [...prev, scope]);
+                    } else {
+                      setSelectedScopes((prev) => prev.filter((s) => s !== scope));
+                    }
+                  }}
+                  className="h-3 w-3"
+                />
+                <span className={scope === 'admin' ? 'text-orange-500 font-medium' : ''}>{scope}</span>
+              </label>
+            ))}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -6,8 +6,13 @@ import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/components/ui/toast';
 
-const MCP_SERVER_URL = `${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/api/v2/mcp`;
-const LLMS_PROMPT = `Read this document and complete onboarding: ${process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai'}/llms.txt`;
+function getAppOrigin() {
+  if (typeof window !== 'undefined') return window.location.origin;
+  return process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai';
+}
+
+const MCP_SERVER_URL = () => `${getAppOrigin()}/api/v2/mcp`;
+const LLMS_PROMPT = () => `Read this document and complete onboarding: ${getAppOrigin()}/llms.txt`;
 
 interface AgentMember {
   id: string;
@@ -38,7 +43,7 @@ function buildMcpConfig(apiKey: string) {
       mcpServers: {
         sprintable: {
           type: 'streamable-http',
-          url: MCP_SERVER_URL,
+          url: MCP_SERVER_URL(),
           headers: { Authorization: `Bearer ${apiKey}` },
         },
       },
@@ -372,12 +377,12 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                 size="sm"
                 variant="outline"
                 className="h-6 text-xs"
-                onClick={() => void handleCopy(LLMS_PROMPT, '온보딩 프롬프트')}
+                onClick={() => void handleCopy(LLMS_PROMPT(), '온보딩 프롬프트')}
               >
                 Copy
               </Button>
             </div>
-            <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-foreground/80 whitespace-pre-wrap">{LLMS_PROMPT}</pre>
+            <pre className="overflow-x-auto rounded bg-background p-2 text-xs text-foreground/80 whitespace-pre-wrap">{LLMS_PROMPT()}</pre>
           </div>
         </SectionCardBody>
       </SectionCard>

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -31,7 +31,7 @@ function DialogOverlay({
     <DialogPrimitive.Backdrop
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        "fixed inset-0 isolate z-50 bg-black/50 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
         className
       )}
       {...props}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -9,8 +9,13 @@ const PUBLIC_EXACT = [
   '/llms-baos.txt',
 ];
 
+// Fully public paths — no token check at all
 const PUBLIC_PREFIX = [
-  '/api/',
+  // Auth endpoints — open by design
+  '/api/auth/',
+  '/api/oss/',
+  '/api/webhook/',
+  // UI public routes
   '/login',
   '/signup',
   '/register',
@@ -70,6 +75,21 @@ function applyTokenCookies(
   response.cookies.set(SP_RT_COOKIE, refreshToken, { ...base, maxAge: 30 * 24 * 60 * 60 });
 }
 
+/** Rebuild request headers with updated sp_at/sp_rt so route handlers see fresh tokens */
+function buildRefreshedHeaders(
+  request: NextRequest,
+  tokens: { accessToken: string; refreshToken: string },
+): Headers {
+  const headers = new Headers(request.headers);
+  const existing = headers.get('cookie') ?? '';
+  const replace = (str: string, name: string, value: string) =>
+    str.includes(`${name}=`)
+      ? str.replace(new RegExp(`${name}=[^;]*`), `${name}=${value}`)
+      : str ? `${str}; ${name}=${value}` : `${name}=${value}`;
+  headers.set('cookie', replace(replace(existing, SP_AT_COOKIE, tokens.accessToken), SP_RT_COOKIE, tokens.refreshToken));
+  return headers;
+}
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -81,9 +101,12 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next({ request });
   }
 
+  // Authenticated API routes — try token refresh but never redirect to /login
+  const isApiPath = pathname.startsWith('/api/');
+
   // Agent API keys are for MCP/HTTP API only — block UI route access
   const authHeader = request.headers.get('Authorization');
-  if (authHeader?.startsWith('Bearer ')) {
+  if (!isApiPath && authHeader?.startsWith('Bearer ')) {
     return new NextResponse(
       JSON.stringify({ error: { code: 'FORBIDDEN', message: 'Agent API keys cannot access UI routes' } }),
       { status: 403, headers: { 'Content-Type': 'application/json' } },
@@ -95,11 +118,13 @@ export async function proxy(request: NextRequest) {
   if (!accessToken) {
     const tokens = await tryRefreshViaFastapi(request);
     if (!tokens) {
+      if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
       url.pathname = '/login';
       return NextResponse.redirect(url);
     }
-    const response = NextResponse.next({ request });
+    const headers = buildRefreshedHeaders(request, tokens);
+    const response = NextResponse.next({ request: { headers } });
     applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
     return response;
   }
@@ -107,14 +132,16 @@ export async function proxy(request: NextRequest) {
   const claims = await verifyAccessToken(accessToken);
 
   if (!claims) {
-    // access token invalid/expired — try refresh before redirecting
+    // access token invalid/expired — try refresh
     const tokens = await tryRefreshViaFastapi(request);
     if (!tokens) {
+      if (isApiPath) return NextResponse.next({ request }); // let handler return 401
       const url = request.nextUrl.clone();
       url.pathname = '/login';
       return NextResponse.redirect(url);
     }
-    const response = NextResponse.next({ request });
+    const headers = buildRefreshedHeaders(request, tokens);
+    const response = NextResponse.next({ request: { headers } });
     applyTokenCookies(response, tokens.accessToken, tokens.refreshToken);
     return response;
   }

--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -25,21 +25,22 @@ class OrganizationRepository:
         )
         return result.scalar_one_or_none() is not None
 
-    async def create(self, name: str, slug: str, owner_member_id: uuid.UUID) -> Organization | None:
+    async def create(self, name: str, slug: str, owner_member_id: uuid.UUID | None) -> Organization | None:
         if await self.slug_exists(slug):
             return None
         org = Organization(name=name, slug=slug)
         self.session.add(org)
         await self.session.flush()
         await self.session.refresh(org)
-        await self.session.execute(
-            text(
-                "INSERT INTO org_members (org_id, user_id, role)"
-                " SELECT :org_id, user_id, 'owner' FROM team_members WHERE id = :member_id"
-                " ON CONFLICT (org_id, user_id) DO NOTHING"
-            ),
-            {"org_id": str(org.id), "member_id": str(owner_member_id)},
-        )
+        if owner_member_id is not None:
+            await self.session.execute(
+                text(
+                    "INSERT INTO org_members (org_id, user_id, role)"
+                    " SELECT :org_id, user_id, 'owner' FROM team_members WHERE id = :member_id"
+                    " ON CONFLICT (org_id, user_id) DO NOTHING"
+                ),
+                {"org_id": str(org.id), "member_id": str(owner_member_id)},
+            )
         return org
 
     async def delete(self, org_id: uuid.UUID, requester_member_id: uuid.UUID) -> dict:

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -49,9 +49,9 @@ async def create_project(
         await session.execute(
             text(
                 "INSERT INTO team_members"
-                " (id, org_id, project_id, user_id, name, type, role, is_active)"
+                " (id, org_id, project_id, user_id, name, type, role, is_active, color)"
                 " SELECT gen_random_uuid(), :org_id, :project_id, :user_id,"
-                "        COALESCE(u.email, 'owner'), 'human', 'member', true"
+                "        COALESCE(u.email, 'owner'), 'human', 'member', true, '#4F46E5'"
                 " FROM users u WHERE u.id = :user_id"
                 " ON CONFLICT DO NOTHING"
             ),


### PR DESCRIPTION
## Summary

- **API key 관리 UX**: 기존 활성 키 있을 때 확인 다이얼로그 → 일괄 무효화 후 신규 발급
- **클립보드 fallback**: HTTP(Tailscale) 환경에서 `navigator.clipboard` 미지원 시 `execCommand` fallback 구현
- **다이얼로그 개선**: 너비 확장(`sm:max-w-lg`), code 블록 `break-all`, Copy 버튼 완료 상태 표시
- **dialog overlay**: `backdrop-blur` 제거로 다이얼로그 배경 렌더링 글리치 수정
- **People 탭 필터**: Members > People 탭에서 agent 타입 멤버 노출 제거
- **온보딩 role 수정**: 온보딩 시 org 생성자를 `member` 대신 `admin`으로 등록
- **인증 미들웨어**: API 경로에서 토큰 만료 시 401 반환 (로그인 리다이렉트 방지)
- **MCP URL 동적화**: `window.location.origin` 사용으로 Tailscale/외부 호스트 지원
- **팀 멤버 생성 400 수정**: `human` 타입 `user_id` 서버 세션에서 자동 주입
- **gitignore**: 루트에 `test-results/` 추가

## Test plan

- [ ] 신규 회원가입 → 온보딩 → Settings에서 admin 권한 확인
- [ ] Tailscale HTTP 환경에서 API 키 복사 / 온보딩 메시지 복사 동작 확인
- [ ] 활성 키 있는 상태에서 Generate API Key → 확인 다이얼로그 → 기존 키 무효화 + 신규 발급
- [ ] Settings > Members > People 탭에 agent 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)