### PR TITLE
[SID:98f7319a] WorkflowTemplate CRUD + 적용 API

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.logging_config import configure_logging
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -91,6 +91,7 @@ app.include_router(integrations.router)
 app.include_router(workflow_versions.router)
 app.include_router(workflow_trigger_types.router)
 app.include_router(workflow_executions.router)
+app.include_router(workflow_templates.router)
 app.include_router(workflow_trigger.router)
 app.include_router(mockups.router)
 

--- a/backend/app/routers/workflow_templates.py
+++ b/backend/app/routers/workflow_templates.py
@@ -1,0 +1,207 @@
+"""WorkflowTemplate CRUD + apply API — S5-2."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.agent_routing_rule import AgentRoutingRule
+from app.models.team import TeamMember
+from app.repositories.agent_routing_rule import _normalize_action, _normalize_conditions
+from app.repositories.workflow_template import WorkflowTemplateRepository, resolve_rules_template
+
+router = APIRouter(prefix="/api/v2/workflow-templates", tags=["workflow-templates"])
+
+
+class TemplateStepResponse(BaseModel):
+    pattern: str
+    role_ref: str
+    default_label: str | None = None
+
+
+class WorkflowTemplateResponse(BaseModel):
+    slug: str
+    name: str
+    description: str
+    chain_length: int
+    steps: list[dict]
+    presets: dict
+    rules_template: list[dict]
+    is_system: bool
+    is_enabled: bool
+
+    model_config = {"from_attributes": True}
+
+
+class WorkflowTemplateListItem(BaseModel):
+    slug: str
+    name: str
+    description: str
+    chain_length: int
+    presets: dict
+    is_system: bool
+
+    model_config = {"from_attributes": True}
+
+
+class ApplyTemplateRequest(BaseModel):
+    project_id: uuid.UUID
+    preset: str | None = None
+    role_mapping: dict[str, str]
+    custom_labels: dict[str, str] | None = None
+    overwrite_existing: bool = False
+
+
+class ApplyTemplateResponse(BaseModel):
+    ok: bool
+    rules_created: int
+    rules_deleted: int
+
+
+def _get_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+) -> uuid.UUID:
+    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
+    if not org_id_str:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
+    return uuid.UUID(str(org_id_str))
+
+
+@router.get("", response_model=list[WorkflowTemplateListItem])
+async def list_templates(
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> list[WorkflowTemplateListItem]:
+    repo = WorkflowTemplateRepository(db)
+    templates = await repo.list()
+    return [WorkflowTemplateListItem.model_validate(t) for t in templates]
+
+
+@router.get("/{slug}", response_model=WorkflowTemplateResponse)
+async def get_template(
+    slug: str,
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> WorkflowTemplateResponse:
+    repo = WorkflowTemplateRepository(db)
+    tmpl = await repo.get_by_slug(slug)
+    if tmpl is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+    return WorkflowTemplateResponse.model_validate(tmpl)
+
+
+@router.post("/{slug}/apply", response_model=ApplyTemplateResponse, status_code=201)
+async def apply_template(
+    slug: str,
+    body: ApplyTemplateRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(_get_org_id),
+) -> ApplyTemplateResponse:
+    repo = WorkflowTemplateRepository(db)
+    tmpl = await repo.get_by_slug(slug)
+    if tmpl is None:
+        raise HTTPException(status_code=404, detail="Template not found")
+
+    # role_mapping의 step_X → agent_id 매핑 검증 및 role_map 구성
+    step_refs = {step["role_ref"] for step in tmpl.steps if step.get("role_ref")}
+    missing = [ref for ref in step_refs if ref not in body.role_mapping]
+    if missing:
+        raise HTTPException(
+            status_code=422,
+            detail=f"role_mapping missing required step refs: {missing}",
+        )
+
+    agent_ids = [uuid.UUID(v) for v in body.role_mapping.values()]
+    agents_result = await db.execute(
+        select(TeamMember.id, TeamMember.name, TeamMember.role).where(TeamMember.id.in_(agent_ids))
+    )
+    agent_info_by_id: dict[uuid.UUID, dict] = {
+        row.id: {"agent_id": str(row.id), "agent_name": row.name or str(row.id), "role": row.role or ""}
+        for row in agents_result.all()
+    }
+
+    custom_labels = body.custom_labels or {}
+    role_map: dict[str, dict[str, Any]] = {}
+    for step_ref, agent_id_str in body.role_mapping.items():
+        agent_uuid = uuid.UUID(agent_id_str)
+        info = agent_info_by_id.get(agent_uuid, {
+            "agent_id": agent_id_str,
+            "agent_name": custom_labels.get(step_ref, step_ref),
+            "role": "",
+        })
+        role_map[step_ref] = {
+            **info,
+            "agent_name": custom_labels.get(step_ref, info.get("agent_name", step_ref)),
+            "persona_id": None,
+            "deployment_id": None,
+            "target_runtime": "openclaw",
+            "target_model": None,
+        }
+
+    now = datetime.now(timezone.utc)
+    deleted_count = 0
+
+    if body.overwrite_existing:
+        existing = await db.execute(
+            select(AgentRoutingRule.id).where(
+                AgentRoutingRule.org_id == org_id,
+                AgentRoutingRule.project_id == body.project_id,
+                AgentRoutingRule.deleted_at.is_(None),
+                AgentRoutingRule.rule_metadata["from_workflow_template"].astext == "true",
+            )
+        )
+        ids_to_delete = [row[0] for row in existing]
+        if ids_to_delete:
+            await db.execute(
+                update(AgentRoutingRule)
+                .where(AgentRoutingRule.id.in_(ids_to_delete))
+                .values(deleted_at=now, updated_at=now)
+            )
+            deleted_count = len(ids_to_delete)
+
+    resolved = resolve_rules_template(tmpl.rules_template, role_map)
+    meta: dict[str, Any] = {
+        "template_slug": slug,
+        "from_workflow_template": True,
+        "applied_at": now.isoformat(),
+    }
+
+    actor_id: uuid.UUID | None = None
+    try:
+        actor_id = uuid.UUID(str(auth.user_id))
+    except Exception:
+        pass
+
+    for r in resolved:
+        agent_id_val = r.get("agent_id")
+        if not agent_id_val:
+            continue
+        db.add(AgentRoutingRule(
+            org_id=org_id,
+            project_id=body.project_id,
+            agent_id=uuid.UUID(str(agent_id_val)),
+            persona_id=uuid.UUID(str(r["persona_id"])) if r.get("persona_id") else None,
+            deployment_id=uuid.UUID(str(r["deployment_id"])) if r.get("deployment_id") else None,
+            name=str(r.get("name") or ""),
+            priority=r.get("priority", 100),
+            match_type=str(r.get("match_type") or "event"),
+            conditions=_normalize_conditions(r.get("conditions")),
+            action=_normalize_action(r.get("action")),
+            target_runtime=str(r.get("target_runtime") or "openclaw"),
+            target_model=r.get("target_model"),
+            is_enabled=r.get("is_enabled", True),
+            rule_metadata=meta,
+            created_by=actor_id,
+        ))
+
+    await db.flush()
+    return ApplyTemplateResponse(ok=True, rules_created=len(resolved), rules_deleted=deleted_count)

--- a/backend/app/routers/workflow_templates.py
+++ b/backend/app/routers/workflow_templates.py
@@ -122,12 +122,23 @@ async def apply_template(
 
     agent_ids = [uuid.UUID(v) for v in body.role_mapping.values()]
     agents_result = await db.execute(
-        select(TeamMember.id, TeamMember.name, TeamMember.role).where(TeamMember.id.in_(agent_ids))
+        select(TeamMember.id, TeamMember.name, TeamMember.role).where(
+            TeamMember.id.in_(agent_ids),
+            TeamMember.org_id == org_id,
+        )
     )
     agent_info_by_id: dict[uuid.UUID, dict] = {
         row.id: {"agent_id": str(row.id), "agent_name": row.name or str(row.id), "role": row.role or ""}
         for row in agents_result.all()
     }
+
+    # org 스코프 검증 — 조회 안 된 UUID는 타 org이거나 존재하지 않는 멤버
+    missing_agents = [v for v in body.role_mapping.values() if uuid.UUID(v) not in agent_info_by_id]
+    if missing_agents:
+        raise HTTPException(
+            status_code=422,
+            detail=f"agent(s) not found in this org: {missing_agents}",
+        )
 
     custom_labels = body.custom_labels or {}
     role_map: dict[str, dict[str, Any]] = {}
@@ -159,7 +170,7 @@ async def apply_template(
                 AgentRoutingRule.rule_metadata["from_workflow_template"].astext == "true",
             )
         )
-        ids_to_delete = [row[0] for row in existing]
+        ids_to_delete = [row[0] for row in existing.all()]
         if ids_to_delete:
             await db.execute(
                 update(AgentRoutingRule)

--- a/backend/tests/test_workflow_template_api.py
+++ b/backend/tests/test_workflow_template_api.py
@@ -1,0 +1,217 @@
+"""Tests for workflow-templates CRUD + apply API (S5-2)."""
+import uuid
+from collections import namedtuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.workflow_templates import ApplyTemplateRequest, ApplyTemplateResponse
+
+AgentRow = namedtuple("AgentRow", ["id", "name", "role"])
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+def _make_template(slug: str = "two-step", chain_length: int = 2) -> MagicMock:
+    tmpl = MagicMock()
+    tmpl.slug = slug
+    tmpl.name = "Two-Step Review"
+    tmpl.description = "desc"
+    tmpl.chain_length = chain_length
+    tmpl.steps = [
+        {"pattern": "assign", "role_ref": "step_1", "default_label": "Maker"},
+        {"pattern": "review", "role_ref": "step_2", "default_label": "Reviewer"},
+    ]
+    tmpl.presets = {"dev-review": {"step_1": "Developer", "step_2": "Tech Lead"}}
+    tmpl.rules_template = [
+        {"role_ref": "step_1", "name": "{step_1} kickoff", "priority": 10, "match_type": "event", "conditions": {}, "action": {"auto_reply_mode": "process_and_report", "side_effects": []}},
+        {"role_ref": "step_2", "name": "{step_1} submit → {step_2} review", "priority": 20, "match_type": "event", "conditions": {"event_params": {"reply_author_role": ["step_1"]}}, "action": {"auto_reply_mode": "process_and_report", "side_effects": []}},
+    ]
+    tmpl.is_system = True
+    tmpl.is_enabled = True
+    return tmpl
+
+
+def _mock_db() -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+# ── list templates ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_list_templates_returns_enabled_only():
+    from app.routers.workflow_templates import list_templates
+
+    db = _mock_db()
+    tmpl = _make_template()
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.list = AsyncMock(return_value=[tmpl])
+        MockRepo.return_value = instance
+        result = await list_templates(db=db, _auth=MagicMock())
+    assert len(result) == 1
+    assert result[0].slug == "two-step"
+
+
+# ── get template ──────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_template_found():
+    from app.routers.workflow_templates import get_template
+
+    db = _mock_db()
+    tmpl = _make_template()
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        result = await get_template(slug="two-step", db=db, _auth=MagicMock())
+    assert result.slug == "two-step"
+    assert len(result.steps) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_template_not_found():
+    from fastapi import HTTPException
+    from app.routers.workflow_templates import get_template
+
+    db = _mock_db()
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=None)
+        MockRepo.return_value = instance
+        with pytest.raises(HTTPException) as exc:
+            await get_template(slug="nonexistent", db=db, _auth=MagicMock())
+    assert exc.value.status_code == 404
+
+
+# ── apply template ────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_apply_template_creates_rules():
+    from app.routers.workflow_templates import apply_template
+
+    db = _mock_db()
+    tmpl = _make_template()
+
+    agent1_id = uuid.uuid4()
+    agent2_id = uuid.uuid4()
+
+    agents_result = MagicMock()
+    agents_result.all.return_value = [
+        AgentRow(id=agent1_id, name="Dev", role="developer"),
+        AgentRow(id=agent2_id, name="PO", role="product-owner"),
+    ]
+    db.execute = AsyncMock(return_value=agents_result)
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(agent1_id), "step_2": str(agent2_id)},
+    )
+    org_id = uuid.uuid4()
+    auth = MagicMock()
+    auth.user_id = str(uuid.uuid4())
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        result = await apply_template(slug="two-step", body=body, db=db, auth=auth, org_id=org_id)
+
+    assert result.ok is True
+    assert result.rules_created == 2
+    assert db.add.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_apply_template_missing_role_mapping_422():
+    from fastapi import HTTPException
+    from app.routers.workflow_templates import apply_template
+
+    db = _mock_db()
+    tmpl = _make_template()
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(uuid.uuid4())},
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        with pytest.raises(HTTPException) as exc:
+            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_apply_template_404():
+    from fastapi import HTTPException
+    from app.routers.workflow_templates import apply_template
+
+    db = _mock_db()
+    body = ApplyTemplateRequest(project_id=uuid.uuid4(), role_mapping={})
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=None)
+        MockRepo.return_value = instance
+        with pytest.raises(HTTPException) as exc:
+            await apply_template(slug="ghost", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_apply_template_overwrite_deletes_existing():
+    from app.routers.workflow_templates import apply_template
+
+    db = _mock_db()
+    tmpl = _make_template()
+
+    agent1_id = uuid.uuid4()
+    agent2_id = uuid.uuid4()
+    existing_rule_id = uuid.uuid4()
+
+    call_count = 0
+
+    async def _execute_side_effect(stmt):
+        nonlocal call_count
+        call_count += 1
+        m = MagicMock()
+        if call_count == 1:
+            # select existing rules — for row in existing → [(id,)]
+            m.__iter__ = MagicMock(return_value=iter([(existing_rule_id,)]))
+        elif call_count == 2:
+            # update existing rules (ids_to_delete 있으므로)
+            pass
+        else:
+            # select agents
+            m.all.return_value = [
+                AgentRow(id=agent1_id, name="Dev", role="developer"),
+                AgentRow(id=agent2_id, name="PO", role="product-owner"),
+            ]
+        return m
+
+    db.execute = AsyncMock(side_effect=_execute_side_effect)
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(agent1_id), "step_2": str(agent2_id)},
+        overwrite_existing=True,
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        result = await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+
+    assert result.ok is True
+    assert result.rules_deleted >= 0

--- a/backend/tests/test_workflow_template_api.py
+++ b/backend/tests/test_workflow_template_api.py
@@ -128,6 +128,35 @@ async def test_apply_template_creates_rules():
 
 
 @pytest.mark.asyncio
+async def test_apply_template_cross_org_agent_422():
+    """타 org 멤버 UUID → DB에서 조회 안 됨 → 422."""
+    from fastapi import HTTPException
+    from app.routers.workflow_templates import apply_template
+
+    db = _mock_db()
+    tmpl = _make_template()
+
+    cross_org_id = uuid.uuid4()
+    agents_result = MagicMock()
+    agents_result.all.return_value = []  # org 조건 필터로 결과 없음
+    db.execute = AsyncMock(return_value=agents_result)
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(cross_org_id), "step_2": str(uuid.uuid4())},
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        with pytest.raises(HTTPException) as exc:
+            await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
+
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
 async def test_apply_template_missing_role_mapping_422():
     from fastapi import HTTPException
     from app.routers.workflow_templates import apply_template
@@ -179,27 +208,20 @@ async def test_apply_template_overwrite_deletes_existing():
     agent2_id = uuid.uuid4()
     existing_rule_id = uuid.uuid4()
 
-    call_count = 0
+    # execute calls: 1=select existing, 2=update, 3=select agents
+    m_existing = MagicMock()
+    m_existing.all.return_value = [(existing_rule_id,)]
 
-    async def _execute_side_effect(stmt):
-        nonlocal call_count
-        call_count += 1
-        m = MagicMock()
-        if call_count == 1:
-            # select existing rules — for row in existing → [(id,)]
-            m.__iter__ = MagicMock(return_value=iter([(existing_rule_id,)]))
-        elif call_count == 2:
-            # update existing rules (ids_to_delete 있으므로)
-            pass
-        else:
-            # select agents
-            m.all.return_value = [
-                AgentRow(id=agent1_id, name="Dev", role="developer"),
-                AgentRow(id=agent2_id, name="PO", role="product-owner"),
-            ]
-        return m
+    m_update = MagicMock()
 
-    db.execute = AsyncMock(side_effect=_execute_side_effect)
+    m_agents = MagicMock()
+    m_agents.all.return_value = [
+        AgentRow(id=agent1_id, name="Dev", role="developer"),
+        AgentRow(id=agent2_id, name="PO", role="product-owner"),
+    ]
+
+    # 코드 execute 순서: 1=select agents, 2=select existing_rules, 3=update
+    db.execute = AsyncMock(side_effect=[m_agents, m_existing, m_update])
 
     body = ApplyTemplateRequest(
         project_id=uuid.uuid4(),
@@ -214,4 +236,4 @@ async def test_apply_template_overwrite_deletes_existing():
         result = await apply_template(slug="two-step", body=body, db=db, auth=MagicMock(), org_id=uuid.uuid4())
 
     assert result.ok is True
-    assert result.rules_deleted >= 0
+    assert result.rules_deleted == 1


### PR DESCRIPTION
## Summary

- `GET /api/v2/workflow-templates`: 목록 (is_enabled=true)
- `GET /api/v2/workflow-templates/{slug}`: 단건 (steps/presets/rules_template 포함)
- `POST /api/v2/workflow-templates/{slug}/apply`: role_mapping 기반 규칙 배치 생성
  - step_ref 누락 → 422, slug 미존재 → 404
  - `overwrite_existing=true` → `from_workflow_template=true` 기존 규칙 삭제 후 재생성
  - 생성 규칙에 `template_slug`, `from_workflow_template`, `applied_at` 태깅

## Changes

| 파일 | 변경 |
|------|------|
| `app/routers/workflow_templates.py` | 신규 라우터 3 엔드포인트 |
| `app/main.py` | workflow_templates 라우터 등록 |
| `tests/test_workflow_template_api.py` | 7개 테스트 신규 |

## Acceptance Criteria 체크리스트

- [x] AC1: GET 목록 조회 (is_enabled=true만)
- [x] AC2: GET 단건 조회 (steps/presets/rules_template)
- [x] AC3: POST apply → role_mapping 기반 규칙 생성
- [x] AC4: overwrite_existing=true → 기존 auto-gen 규칙 교체
- [x] AC5: role_mapping 필수 역할 누락 시 422
- [x] AC6: 생성 규칙에 template_slug 메타데이터 태깅
- [x] AC7: 존재하지 않는 slug 시 404

## Test Plan

- [ ] `pytest tests/test_workflow_template_api.py -v` → 7/7 PASS
- [ ] `pytest -q` → 463 PASS
- [ ] GET /api/v2/workflow-templates → 4종 목록 확인
- [ ] POST /apply role_mapping 누락 → 422 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)