### PR TITLE
[SID:bc949ab4] Phase 5 통합 검증 + 워크플로우 템플릿 문서

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,45 @@ Contributors should **not** reimplement billing logic in these files — if
 you need feature gating, add an optional Repository via the registry
 pattern and keep the public surface BYOA-neutral.
 
+## Contributing Workflow Templates
+
+Workflow templates let contributors add new multi-step automation patterns without touching routing rule logic. See [`docs/workflow-templates.md`](docs/workflow-templates.md) for the full spec.
+
+### Adding a new template
+
+1. Add an entry to `SEED_TEMPLATES` in `backend/alembic/versions/0016_add_workflow_templates.py`.
+2. Each entry needs: `slug`, `name`, `description`, `chain_length`, `steps`, `presets`, `rules_template`.
+3. Use `step_1`, `step_2`, ... as `role_ref` placeholders — they are resolved at apply time.
+4. Set `is_system: false` for community templates (users can delete them).
+5. Write a pytest test in `backend/tests/test_e2e_workflow_template.py` asserting the correct rule count after `apply_template`.
+6. Run `alembic upgrade head` locally and verify `GET /api/v2/workflow-templates` returns your new template.
+
+### Template schema quick reference
+
+```python
+{
+  "slug": "my-template",
+  "name": "My Template",
+  "description": "Short description",
+  "chain_length": 2,
+  "steps": [
+    {"pattern": "assign", "role_ref": "step_1", "default_label": "Maker"},
+    {"pattern": "review", "role_ref": "step_2", "default_label": "Reviewer"},
+  ],
+  "presets": {"default": {"step_1": "Writer", "step_2": "Editor"}},
+  "rules_template": [
+    {
+      "role_ref": "step_1",
+      "name": "{step_1} kickoff",
+      "priority": 10,
+      "match_type": "event",
+      "conditions": {"memo_type": ["task"], "trigger_type_slugs": ["kickoff"]},
+      "action": {"auto_reply_mode": "process_and_report", "side_effects": []},
+    }
+  ],
+}
+```
+
 ## Code of Conduct
 
 Be respectful. Be constructive. We're all here to build something great.

--- a/backend/tests/test_e2e_workflow_template.py
+++ b/backend/tests/test_e2e_workflow_template.py
@@ -1,0 +1,168 @@
+"""E2E scenario tests for WorkflowTemplate apply pipeline (S5-4)."""
+import uuid
+from collections import namedtuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.workflow_templates import ApplyTemplateRequest, apply_template
+
+AgentRow = namedtuple("AgentRow", ["id", "name", "role"])
+
+
+def _make_template(slug: str, chain_length: int, step_refs: list[str], rule_count: int) -> MagicMock:
+    tmpl = MagicMock()
+    tmpl.slug = slug
+    tmpl.name = slug.replace("-", " ").title()
+    tmpl.description = f"{slug} template"
+    tmpl.chain_length = chain_length
+    tmpl.steps = [{"pattern": "assign", "role_ref": ref, "default_label": ref} for ref in step_refs]
+    tmpl.rules_template = [
+        {
+            "role_ref": step_refs[i % len(step_refs)],
+            "name": f"rule {i + 1}",
+            "priority": (i + 1) * 10,
+            "match_type": "event",
+            "conditions": {},
+            "action": {"auto_reply_mode": "process_and_report", "side_effects": []},
+        }
+        for i in range(rule_count)
+    ]
+    tmpl.presets = {}
+    return tmpl
+
+
+def _make_agents(*roles: str) -> tuple[list[uuid.UUID], MagicMock]:
+    ids = [uuid.uuid4() for _ in roles]
+    result = MagicMock()
+    result.all.return_value = [AgentRow(id=ids[i], name=f"Agent{i+1}", role=roles[i]) for i in range(len(roles))]
+    return ids, result
+
+
+def _db_with_execute(execute_results: list) -> AsyncMock:
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=execute_results)
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+# ── E2E: three-step 적용 ─────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_e2e_template_apply_three_step():
+    """three-step(po-dev-qa) 템플릿 적용 → 규칙 4개 생성 확인."""
+    tmpl = _make_template("three-step", 3, ["step_1", "step_2", "step_3"], 4)
+    agent_ids, agent_result = _make_agents("developer", "product-owner", "qa")
+
+    db = _db_with_execute([agent_result])
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={f"step_{i+1}": str(agent_ids[i]) for i in range(3)},
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        auth = MagicMock()
+        auth.user_id = str(uuid.uuid4())
+        result = await apply_template(slug="three-step", body=body, db=db, auth=auth, org_id=uuid.uuid4())
+
+    assert result.ok is True
+    assert result.rules_created == 4
+    assert db.add.call_count == 4
+
+
+# ── E2E: solo 적용 ──────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_e2e_template_apply_solo():
+    """solo 템플릿 적용 → 규칙 1개 생성 확인."""
+    tmpl = _make_template("solo", 1, ["step_1"], 1)
+    agent_ids, agent_result = _make_agents("developer")
+
+    db = _db_with_execute([agent_result])
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(agent_ids[0])},
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        auth = MagicMock()
+        auth.user_id = str(uuid.uuid4())
+        result = await apply_template(slug="solo", body=body, db=db, auth=auth, org_id=uuid.uuid4())
+
+    assert result.ok is True
+    assert result.rules_created == 1
+    assert result.rules_deleted == 0
+
+
+# ── E2E: overwrite 시나리오 ──────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_e2e_template_overwrite():
+    """적용 후 다른 템플릿 overwrite → 기존 삭제 + 신규 생성."""
+    tmpl = _make_template("two-step", 2, ["step_1", "step_2"], 2)
+    agent_ids, agent_result = _make_agents("developer", "product-owner")
+
+    existing_id = uuid.uuid4()
+    m_existing = MagicMock()
+    m_existing.all.return_value = [(existing_id,)]
+    m_update = MagicMock()
+
+    db = _db_with_execute([agent_result, m_existing, m_update])
+
+    body = ApplyTemplateRequest(
+        project_id=uuid.uuid4(),
+        role_mapping={"step_1": str(agent_ids[0]), "step_2": str(agent_ids[1])},
+        overwrite_existing=True,
+    )
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.get_by_slug = AsyncMock(return_value=tmpl)
+        MockRepo.return_value = instance
+        auth = MagicMock()
+        auth.user_id = str(uuid.uuid4())
+        result = await apply_template(slug="two-step", body=body, db=db, auth=auth, org_id=uuid.uuid4())
+
+    assert result.ok is True
+    assert result.rules_created == 2
+    assert result.rules_deleted == 1
+
+
+# ── E2E: 목록 + 단건 조회 ────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_e2e_list_and_get_template():
+    """목록 조회 4건 + 단건 조회 fields 확인."""
+    from app.routers.workflow_templates import list_templates, get_template
+
+    slugs = ["solo", "two-step", "three-step", "kanban"]
+    mock_templates = [_make_template(s, i, ["step_1"], 1) for i, s in enumerate(slugs)]
+    for t in mock_templates:
+        t.is_system = True
+        t.is_enabled = True
+
+    db = AsyncMock()
+
+    with patch("app.routers.workflow_templates.WorkflowTemplateRepository") as MockRepo:
+        instance = AsyncMock()
+        instance.list = AsyncMock(return_value=mock_templates)
+        instance.get_by_slug = AsyncMock(return_value=mock_templates[2])
+        MockRepo.return_value = instance
+
+        tmpl_list = await list_templates(db=db, _auth=MagicMock())
+        assert len(tmpl_list) == 4
+        assert {t.slug for t in tmpl_list} == set(slugs)
+
+        detail = await get_template(slug="three-step", db=db, _auth=MagicMock())
+        assert detail.slug == "three-step"
+        assert "step_1" in [s["role_ref"] for s in detail.steps]
+        assert len(detail.rules_template) == 1

--- a/docs/workflow-templates.md
+++ b/docs/workflow-templates.md
@@ -1,0 +1,207 @@
+# Workflow Templates
+
+Workflow templates let you auto-generate routing rules from pre-defined chain patterns. Instead of manually wiring `AgentRoutingRule` rows, pick a template, map roles to agents, and the system creates the full rule set.
+
+## Concepts
+
+### Chain Patterns
+
+Every template is built from three primitive patterns:
+
+| Pattern | Meaning |
+|---------|---------|
+| `assign` | Kick off — route the task to a role |
+| `submit` | Role signals work is done (e.g., PR submitted) |
+| `review` | Another role reviews/approves |
+
+Templates chain these patterns into N-step pipelines.
+
+### System Templates
+
+Four templates ship out of the box:
+
+| Slug | Chain Length | Use Case |
+|------|-------------|----------|
+| `solo` | 1 | Single assignee, no review |
+| `two-step` | 2 | Maker → Reviewer (code review, approvals) |
+| `three-step` | 3 | Executor → Reviewer → Final Approver (PO-Dev-QA) |
+| `kanban` | 0 | Status-change notifications, role-agnostic |
+
+### role_ref Convention
+
+Steps are identified by `step_1`, `step_2`, `step_3`. When a template is applied, each `step_X` placeholder is replaced with the actual agent and role you supply.
+
+```
+rules_template:
+  - role_ref: "step_1"        → agent_id: <Dev agent>
+    conditions:
+      event_params:
+        reply_author_role: ["step_1"]  → ["developer"]
+    action:
+      side_effects:
+        - assign_to_role: "step_1"    → "developer"
+```
+
+Three substitution paths are resolved automatically:
+
+1. `role_ref` → `agent_id` (top-level rule assignment)
+2. `conditions.event_params.*: ["step_X"]` → actual role string
+3. `action.side_effects[].assign_to_role: "step_X"` → actual role string
+4. `name: "{step_X} …"` → agent name
+
+## API
+
+### List templates
+
+```
+GET /api/v2/workflow-templates
+```
+
+Returns `WorkflowTemplateListItem[]` (slug, name, description, chain_length, presets, is_system).
+
+### Get template detail
+
+```
+GET /api/v2/workflow-templates/{slug}
+```
+
+Returns full `WorkflowTemplateResponse` including `steps`, `presets`, `rules_template`.
+
+### Apply template
+
+```
+POST /api/v2/workflow-templates/{slug}/apply
+```
+
+Request body:
+
+```json
+{
+  "project_id": "uuid",
+  "role_mapping": {
+    "step_1": "agent-uuid-1",
+    "step_2": "agent-uuid-2"
+  },
+  "custom_labels": {
+    "step_1": "Frontend Dev"
+  },
+  "overwrite_existing": false
+}
+```
+
+- `role_mapping` is required for every `role_ref` that appears in `steps`.
+- `overwrite_existing: true` deletes existing rules tagged with `from_workflow_template: true` before inserting new ones.
+- All agent UUIDs must belong to the calling org (422 otherwise).
+
+Response:
+
+```json
+{
+  "ok": true,
+  "rules_created": 4,
+  "rules_deleted": 0
+}
+```
+
+## Presets
+
+Each template ships named presets that map `step_X` keys to human-readable label strings. Presets are cosmetic — they do **not** auto-select agents. Use them as UX hints in the role-mapping dialog.
+
+```json
+"presets": {
+  "po-dev-qa": { "step_1": "Developer", "step_2": "Product Owner", "step_3": "QA" }
+}
+```
+
+## Adding a Custom Template
+
+### Option A — Database INSERT
+
+```sql
+INSERT INTO workflow_templates (id, slug, name, description, chain_length, steps, presets, rules_template, is_system, is_enabled)
+VALUES (
+  gen_random_uuid(),
+  'my-template',
+  'My Template',
+  'Description here',
+  2,
+  '[{"pattern":"assign","role_ref":"step_1"},{"pattern":"review","role_ref":"step_2"}]',
+  '{"my-preset":{"step_1":"Writer","step_2":"Editor"}}',
+  '[{"role_ref":"step_1","name":"{step_1} kickoff","priority":10,"match_type":"event","conditions":{"memo_type":["task"],"trigger_type_slugs":["kickoff"]},"action":{"auto_reply_mode":"process_and_report","side_effects":[]}}]',
+  false,
+  true
+);
+```
+
+Set `is_system = false` so users can delete it.
+
+### Option B — Alembic Migration
+
+Add a new entry to `SEED_TEMPLATES` in `backend/alembic/versions/0016_add_workflow_templates.py` and run:
+
+```bash
+cd backend && alembic upgrade head
+```
+
+### Template Schema Reference
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slug` | string | Unique identifier (URL-safe) |
+| `name` | string | Display name |
+| `description` | text | Short description |
+| `chain_length` | int | Number of review hops (0 = kanban) |
+| `steps` | JSONB array | `[{pattern, role_ref, default_label?}]` |
+| `presets` | JSONB object | Named label mappings |
+| `rules_template` | JSONB array | Rule prototypes with `role_ref` placeholders |
+| `is_system` | bool | `true` = not deletable by users |
+| `is_enabled` | bool | `false` = hidden from API |
+
+### rules_template entry schema
+
+```json
+{
+  "role_ref": "step_1",
+  "name": "{step_1} kickoff",
+  "priority": 10,
+  "match_type": "event",
+  "conditions": {
+    "memo_type": ["task"],
+    "trigger_type_slugs": ["kickoff"],
+    "event_params": {
+      "reply_author_role": ["step_1"]
+    }
+  },
+  "action": {
+    "auto_reply_mode": "process_and_report",
+    "side_effects": [
+      { "type": "auto_assign", "assign_to_role": "step_1" },
+      { "type": "update_status", "target_status": "in-review" }
+    ]
+  }
+}
+```
+
+Supported `side_effects` types: `auto_assign`, `update_status`.
+
+## resolve_rules_template
+
+`backend/app/repositories/workflow_template.py` exports `resolve_rules_template(rules_template, role_map)`.
+
+`role_map` shape:
+
+```python
+{
+  "step_1": {
+    "agent_id": "uuid-string",
+    "agent_name": "Dev",
+    "role": "developer",          # TeamMember.role value
+    "persona_id": None,
+    "deployment_id": None,
+    "target_runtime": "openclaw",
+    "target_model": None,
+  }
+}
+```
+
+The function returns a deep copy — original `rules_template` is not mutated.


### PR DESCRIPTION
## Summary

Phase 5 마지막 스토리 — E2E 검증 + OSS 기여자용 문서 작성.

- `test_e2e_workflow_template.py`: 4개 E2E 시나리오 (three-step 4규칙 생성, solo 1규칙, overwrite 삭제+재생성, 목록+단건 조회)
- `docs/workflow-templates.md`: 템플릿 구조/role_ref/API/커스텀 추가 가이드/resolve_rules_template 레퍼런스
- `CONTRIBUTING.md`: 워크플로우 템플릿 기여 섹션 추가 (schema + 절차)

## Changes

| 파일 | 변경 |
|------|------|
| `backend/tests/test_e2e_workflow_template.py` | E2E 테스트 4개 신규 |
| `docs/workflow-templates.md` | 신규 문서 |
| `CONTRIBUTING.md` | 템플릿 기여 섹션 추가 |

## Acceptance Criteria 체크리스트

- [x] AC1: three-step 적용 E2E (rules_created=4)
- [x] AC2: solo 적용 E2E (rules_created=1, rules_deleted=0)
- [x] AC3: overwrite 시나리오 (rules_deleted=1, rules_created=2)
- [x] AC4: `docs/workflow-templates.md` 작성
- [x] AC5: 커스텀 템플릿 추가 가이드 포함

## Test Plan

- [ ] `pytest tests/test_e2e_workflow_template.py -v` → 4/4 PASS
- [ ] `pytest -q` → 468 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)