### PR TITLE
fix: Settings owner role admin 미인식 버그 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -267,7 +267,7 @@ export default function SettingsPage() {
         const meRes = await fetch('/api/me');
         const meJson = meRes.ok ? await meRes.json() : null;
         const role = (meJson?.data?.role ?? 'member') as string;
-        setIsAdmin(role === 'admin');
+        setIsAdmin(role === 'admin' || role === 'owner');
       } catch {
         setIsAdmin(false);
       } finally {


### PR DESCRIPTION
## Summary

PR #562에서 `setIsAdmin(role === 'admin')`으로 전환하면서 `owner` 역할이 admin으로 인식되지 않는 버그 수정.

## Change

```ts
// Before
setIsAdmin(role === 'admin');

// After
setIsAdmin(role === 'admin' || role === 'owner');
```

## Acceptance Criteria

- [x] AC1: owner 계정 → admin 탭 전부 표시
- [x] AC2: admin 계정 → 동일하게 표시
- [x] AC3: member 계정 → admin 탭 미표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)