### PR TITLE
fix(migration): guard organizations.id PK before workflow_trigger_types FK

### DIFF
--- a/backend/alembic/versions/0013_add_workflow_trigger_types.py
+++ b/backend/alembic/versions/0013_add_workflow_trigger_types.py
@@ -17,6 +17,19 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # Guard: ensure organizations.id has a primary key constraint (may be missing in dev envs
+    # that were bootstrapped via create_all() before this migration ran)
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'organizations'::regclass AND contype = 'p'
+            ) THEN
+                ALTER TABLE organizations ADD PRIMARY KEY (id);
+            END IF;
+        END $$;
+    """)
     op.create_table(
         "workflow_trigger_types",
         sa.Column("id", UUID(as_uuid=True), primary_key=True),

--- a/backend/alembic/versions/0013_add_workflow_trigger_types.py
+++ b/backend/alembic/versions/0013_add_workflow_trigger_types.py
@@ -33,7 +33,7 @@ def upgrade() -> None:
     op.create_table(
         "workflow_trigger_types",
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
-        sa.Column("org_id", UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True),
+        sa.Column("org_id", UUID(as_uuid=True), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
         sa.Column("slug", sa.Text, nullable=False),
         sa.Column("label", sa.Text, nullable=False),
         sa.Column("description", sa.Text, nullable=True),


### PR DESCRIPTION
## Summary
Migration 0013 fails on dev environments where `organizations.id` lacks a PRIMARY KEY constraint.

Root cause: On dev, `create_all()` was run before this migration existed. In some environments, the `organizations` table was bootstrapped without a proper PK constraint (possibly from Supabase schema migration path).

## Fix
Add an idempotent PL/pgSQL guard in 0013's `upgrade()` that adds PK to `organizations.id` if missing, before creating the `workflow_trigger_types` FK.

## Impact
- No-op on databases where the PK already exists
- Fixes migration 0013→0016 path on dev
- Does not affect prod (prod has proper PK from initial create_all)