### PR TITLE
fix(SID:6570658c): update_story_status persist 버그 수정

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -111,6 +111,9 @@ async def update_story(
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
 
+    # 변경사항 먼저 commit — side effects 에러가 rollback시키지 않도록
+    await db.commit()
+
     if "assignee_id" in data and old_assignee_id != story.assignee_id:
         org_id = repo.org_id
         actor_id: uuid.UUID | None = None
@@ -185,6 +188,10 @@ async def update_story_status(
         story = await repo.set_status(id, body.status)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    # status 변경을 side effects 실행 전에 먼저 commit — process_event/webhook
+    # 내부 DB 에러가 트랜잭션을 aborted 상태로 만들어 status 변경까지 rollback하는 버그 방지
+    await db.commit()
 
     if old_status != story.status:
         org_id = repo.org_id


### PR DESCRIPTION
## Root Cause

`process_event` / `fire_webhooks` 내부에서 DB 에러 발생 시 SQLAlchemy 트랜잭션이 aborted 상태가 됨. `try/except Exception: pass`로 예외를 삼켜도 PostgreSQL 트랜잭션은 여전히 에러 상태 → `get_db`에서 `commit()` 호출 시 실제로 ROLLBACK 실행 → story status 변경까지 함께 롤백.

## Fix

`set_status()` / `update()` 직후 `await db.commit()`으로 story 변경을 먼저 persist 후, side effects(event/webhook/process_event)를 별도 트랜잭션에서 실행.

```python
story = await repo.set_status(id, body.status)
await db.commit()  # ← 추가: status 변경 먼저 commit

# 이후 side effects는 새 트랜잭션에서 실행
```

## Changes

- `update_story_status()`: `set_status()` 직후 `await db.commit()`
- `update_story()`: `repo.update()` 직후 `await db.commit()`

## Test

- `pytest tests/test_stories.py` → 20/20 PASS
- `pytest -q` → 468 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)