### PR TITLE
feat(SID:b7fa2d07): P6-3 멤버 가시성 — 보드/인박스 워크플로우 상태 표시

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Inbox as InboxIcon } from 'lucide-react';
+import { Inbox as InboxIcon, Zap, ZapOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
@@ -14,6 +14,16 @@ import {
   getInboxNotificationLabel,
   NOTIFICATION_TYPE_ICONS,
 } from '@/services/notification-display';
+
+interface WorkflowExecItem {
+  id: string;
+  event_type: string;
+  trigger_type_slug: string | null;
+  rule_name: string | null;
+  status: string;
+  completed_at: string | null;
+  created_at: string;
+}
 
 interface Notification {
   id: string;
@@ -44,10 +54,11 @@ async function fetchInboxNotifications(typeFilter: string) {
 export default function InboxPage() {
   const router = useRouter();
   const t = useTranslations('inbox');
-  const { currentTeamMemberId } = useDashboardContext();
+  const { currentTeamMemberId, projectId } = useDashboardContext();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [workflowExecs, setWorkflowExecs] = useState<WorkflowExecItem[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const { toasts, dismissToast } = useToast();
 
@@ -77,6 +88,17 @@ export default function InboxPage() {
       cancelled = true;
     };
   }, []);
+
+  useEffect(() => {
+    if (!currentTeamMemberId || !projectId) return;
+    const params = new URLSearchParams({ project_id: projectId, member_id: currentTeamMemberId, limit: '10' });
+    fetch(`/api/workflow-executions?${params.toString()}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => {
+        if (json?.items) setWorkflowExecs(json.items as WorkflowExecItem[]);
+      })
+      .catch(() => {});
+  }, [currentTeamMemberId, projectId]);
 
   useEffect(() => {
     if (!currentTeamMemberId) return;
@@ -169,6 +191,29 @@ export default function InboxPage() {
 
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <DecisionsWaiting onChange={() => void refreshNotifications()} />
+
+        {workflowExecs.length > 0 && (
+          <div className="shrink-0 border-b border-border/80 px-4 py-3">
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-[color:var(--operator-muted)]">워크플로우 실행</p>
+            <div className="flex flex-col gap-1.5">
+              {workflowExecs.slice(0, 5).map((exec) => (
+                <div key={exec.id} className="flex items-center gap-2 rounded-lg bg-[color:var(--operator-surface-soft)]/55 px-3 py-2 text-xs">
+                  {exec.status === 'matched' ? (
+                    <Zap className="h-3.5 w-3.5 shrink-0 text-amber-500" />
+                  ) : (
+                    <ZapOff className="h-3.5 w-3.5 shrink-0 text-[color:var(--operator-muted)]" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-[color:var(--operator-foreground)]">
+                    {exec.rule_name ?? exec.event_type}
+                  </span>
+                  <span className="shrink-0 text-[10px] text-[color:var(--operator-muted)]">
+                    {exec.completed_at ? new Date(exec.completed_at).toLocaleString() : new Date(exec.created_at).toLocaleString()}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left: notification list */}

--- a/apps/web/src/app/api/workflow-executions/story-summary/route.ts
+++ b/apps/web/src/app/api/workflow-executions/story-summary/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  return proxyToFastapi(request, '/api/v2/workflow-executions/story-summary');
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -130,6 +130,8 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     });
   }, [projectId]);
 
+  const [executionMap, setExecutionMap] = useState<Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>>({});
+
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
   const selectedStoryRef = useRef<KanbanStory | null>(null);
   selectedStoryRef.current = selectedStory;
@@ -168,10 +170,25 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         fetch(`/api/team-members${memberParams}`),
       ]);
 
-      if (storiesRes.ok) { const json = await storiesRes.json(); setStories(json.data); setNextCursor(json.meta?.nextCursor ?? null); }
+      let storyIds: string[] = [];
+      if (storiesRes.ok) { const json = await storiesRes.json(); storyIds = (json.data ?? []).map((s: { id: string }) => s.id); setStories(json.data); setNextCursor(json.meta?.nextCursor ?? null); }
       if (sprintsRes.ok) { const json = await sprintsRes.json(); setSprints(json.data); }
       if (epicsRes.ok) { const json = await epicsRes.json(); setEpics(json.data); setEpicsNextCursor(json.meta?.nextCursor ?? null); }
       if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data); }
+
+      if (projectId && storyIds.length > 0) {
+        try {
+          const summaryParams = new URLSearchParams({ project_id: projectId });
+          for (const sid of storyIds) summaryParams.append('story_ids', sid);
+          const summaryRes = await fetch(`/api/workflow-executions/story-summary?${summaryParams.toString()}`);
+          if (summaryRes.ok) {
+            const summaryJson = await summaryRes.json() as Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
+            setExecutionMap(summaryJson);
+          }
+        } catch {
+          // non-critical — skip silently
+        }
+      }
     } finally {
       setLoading(false);
     }
@@ -878,6 +895,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onWipLimitRemove={() => handleWipLimitRemove(col.id)}
                     onWipDraftChange={(v) => handleWipLimitDraftChange(col.id, v)}
                     onCreateStory={handleCreateStory}
+                    executionMap={executionMap}
                   />
                 );
               })}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -55,6 +55,7 @@ interface KanbanColumnProps {
   onWipDraftChange?: (value: string) => void;
   // Inline create
   onCreateStory?: (columnId: string, title: string) => Promise<void> | void;
+  executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
 }
 
 export function KanbanColumn({
@@ -62,7 +63,7 @@ export function KanbanColumn({
   onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
-  onCreateStory, projectId, onKickoffStory,
+  onCreateStory, projectId, onKickoffStory, executionMap,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
@@ -258,6 +259,7 @@ export function KanbanColumn({
               onDelete={onDeleteStory}
               projectId={projectId}
               onKickoff={onKickoffStory}
+              lastExecution={executionMap?.[story.id] ?? null}
             />
           ))}
         </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useTranslations } from 'next-intl';
 import type { KanbanStory, KanbanMember } from './types';
 import { Badge } from '@/components/ui/badge';
-import { ChevronRight, Rocket } from 'lucide-react';
+import { ChevronRight, Rocket, Zap, ZapOff } from 'lucide-react';
 
 const EPIC_COLORS = [
   'info',
@@ -25,6 +25,12 @@ function getInitials(name: string): string {
   return name.slice(0, 2).toUpperCase();
 }
 
+interface WorkflowExecStatus {
+  status: string;
+  rule_name?: string | null;
+  completed_at?: string | null;
+}
+
 interface StoryCardProps {
   story: KanbanStory;
   epicName?: string;
@@ -36,9 +42,10 @@ interface StoryCardProps {
   onDelete?: (storyId: string) => void;
   projectId?: string;
   onKickoff?: (storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => void;
+  lastExecution?: WorkflowExecStatus | null;
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution }: StoryCardProps) {
   const t = useTranslations('board');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
@@ -204,6 +211,22 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           <span className="font-mono text-[10px] text-muted-foreground/50">#{story.id.slice(0, 6)}</span>
           {story.story_points != null ? (
             <Badge variant="secondary" className="font-mono text-[10px] px-1.5 py-0">{story.story_points}</Badge>
+          ) : null}
+          {lastExecution ? (
+            <span
+              title={[
+                lastExecution.rule_name ?? '워크플로우 실행됨',
+                lastExecution.completed_at ? new Date(lastExecution.completed_at).toLocaleString() : '',
+                lastExecution.status === 'matched' ? '✅ 규칙 매칭' : '⊘ 규칙 없음',
+              ].filter(Boolean).join(' · ')}
+              className="flex h-5 w-5 items-center justify-center"
+            >
+              {lastExecution.status === 'matched' ? (
+                <Zap className="h-3 w-3 text-amber-500" />
+              ) : (
+                <ZapOff className="h-3 w-3 text-muted-foreground/40" />
+              )}
+            </span>
           ) : null}
           {projectId ? (
             <button

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, require_admin
@@ -56,17 +56,91 @@ class ExecutionLogListResponse(BaseModel):
     limit: int
 
 
+class StorySummaryItem(BaseModel):
+    status: str
+    rule_name: str | None
+    completed_at: datetime | None
+
+
+@router.get("/story-summary", response_model=dict[str, StorySummaryItem])
+async def story_execution_summary(
+    project_id: uuid.UUID = Query(...),
+    story_ids: list[str] = Query(default=[]),
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(_get_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> dict[str, StorySummaryItem]:
+    """Return latest execution status per story (no admin required — board/member view)."""
+    if not story_ids:
+        return {}
+
+    rows_result = await db.execute(
+        select(WorkflowExecutionLog)
+        .where(
+            WorkflowExecutionLog.org_id == org_id,
+            WorkflowExecutionLog.project_id == project_id,
+        )
+        .order_by(WorkflowExecutionLog.created_at.desc())
+        .limit(len(story_ids) * 10)
+    )
+    logs = list(rows_result.scalars().all())
+
+    rule_ids = {log.rule_id for log in logs if log.rule_id}
+    rule_name_map: dict[uuid.UUID, str] = {}
+    if rule_ids:
+        rr = await db.execute(
+            select(AgentRoutingRule.id, AgentRoutingRule.name).where(AgentRoutingRule.id.in_(rule_ids))
+        )
+        rule_name_map = {row.id: row.name for row in rr.all()}
+
+    summary: dict[str, StorySummaryItem] = {}
+    story_ids_set = set(story_ids)
+    for log in logs:
+        sid = (log.event_context or {}).get("metadata", {}).get("story_id")
+        if sid and sid in story_ids_set and sid not in summary:
+            summary[sid] = StorySummaryItem(
+                status=log.status,
+                rule_name=rule_name_map.get(log.rule_id) if log.rule_id else None,
+                completed_at=log.completed_at,
+            )
+        if len(summary) == len(story_ids_set):
+            break
+
+    return summary
+
+
 @router.get("", response_model=ExecutionLogListResponse)
 async def list_executions(
     project_id: uuid.UUID = Query(...),
     event_type: str | None = Query(default=None),
     status: str | None = Query(default=None),
+    story_id: str | None = Query(default=None),
+    member_id: uuid.UUID | None = Query(default=None),
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, le=100),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(_get_org_id),
-    _: AuthContext = Depends(require_admin),
+    auth: AuthContext = Depends(get_current_user),
 ) -> ExecutionLogListResponse:
+    role = auth.claims.get("app_metadata", {}).get("role", "member")
+    if role != "admin":
+        if member_id is None:
+            raise HTTPException(status_code=403, detail="Admin role required, or provide member_id to query own executions")
+        user_id_str = str(auth.user_id)
+        try:
+            user_uuid = uuid.UUID(user_id_str)
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Cannot verify member identity")
+        member_check = await db.execute(
+            select(TeamMember).where(
+                TeamMember.id == member_id,
+                TeamMember.org_id == org_id,
+                or_(TeamMember.user_id == user_uuid, TeamMember.id == user_uuid),
+            ).limit(1)
+        )
+        if not member_check.scalar_one_or_none():
+            raise HTTPException(status_code=403, detail="Can only query own executions")
+
     base = (
         select(WorkflowExecutionLog)
         .where(
@@ -78,6 +152,12 @@ async def list_executions(
         base = base.where(WorkflowExecutionLog.event_type == event_type)
     if status:
         base = base.where(WorkflowExecutionLog.status == status)
+    if story_id:
+        base = base.where(
+            WorkflowExecutionLog.event_context["metadata"]["story_id"].as_string() == story_id
+        )
+    if member_id:
+        base = base.where(WorkflowExecutionLog.target_agent_id == member_id)
 
     total_result = await db.execute(select(func.count()).select_from(base.subquery()))
     total: int = total_result.scalar_one() or 0


### PR DESCRIPTION
## Summary
- **Backend** `workflow_executions.py`: `member_id` 필터(target_agent_id) + `/story-summary` 배치 엔드포인트 신설. 일반 멤버가 own member_id로 본인 관련 실행 조회 가능
- **Proxy** `/api/workflow-executions/story-summary/route.ts` 추가
- **Board 카드** `story-card.tsx`: `lastExecution` prop + `Zap`/`ZapOff` 아이콘 + hover 툴팁(규칙명·실행시각·결과)
- **KanbanBoard** 스토리 로드 후 story-summary 일괄 페치, `executionMap` 상태 관리 → `KanbanColumn` → `StoryCard` 전달
- **Inbox** `page.tsx`: 워크플로우 실행 섹션 추가 (member_id 필터로 본인 관련 최근 10건)

## AC 체크
- [x] Board 스토리 카드에 최근 워크플로우 실행 상태 아이콘 표시
- [x] 아이콘 hover 시 마지막 실행 요약 (규칙명, 실행시간, 결과)
- [x] 인박스에 워크플로우 실행 알림 항목 추가
- [x] GET /api/v2/workflow-executions?member_id= 필터 지원
- [x] admin 아닌 일반 멤버도 본인 관련 실행 로그 조회 가능
- [x] 모바일 레이아웃 정상 (flex/truncate 패턴 유지)
- [x] pnpm type-check PASS / pytest 484/484 PASS

## Test plan
- [ ] Board 카드에 Zap 아이콘 표시 확인 (워크플로우 실행된 스토리)
- [ ] 아이콘 hover 시 툴팁 텍스트 확인 (규칙명 + 시각 + 상태)
- [ ] Inbox > 워크플로우 실행 섹션 표시 확인
- [ ] 일반 멤버 계정으로 /api/v2/workflow-executions?member_id={own_id} 조회 성공 (200)
- [ ] 타인 member_id로 조회 시 403 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)