### PR TITLE
fix(SID:42287b3a): BaseRepository.update() refresh 누락 수정

### DIFF
--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -45,6 +45,7 @@ class BaseRepository(Generic[T]):
         for key, value in data.items():
             setattr(obj, key, value)
         await self.session.flush()
+        await self.session.refresh(obj)
         return obj
 
     async def delete(self, id: uuid.UUID) -> bool:


### PR DESCRIPTION
## Summary
`BaseRepository.update()` — `flush()` 후 `refresh(obj)` 누락으로 `updated_at` 등 server-side `onupdate` 컬럼이 Python 객체에 반영되지 않아 `model_validate()` 시 `MissingGreenlet` 에러 발생. 1줄 추가.

## 변경 내용
`backend/app/repositories/base.py:47` — `await self.session.flush()` 바로 다음에 `await self.session.refresh(obj)` 추가

`create()`에 이미 적용된 동일 패턴 참조.

## AC 체크
- [x] BaseRepository.update()에 refresh(obj) 추가
- [x] pytest 484/484 PASS

## Test plan
- [ ] Settings > 에이전트 Disable → 200 반환 확인 (MissingGreenlet 에러 미발생)
- [ ] Settings > 에이전트 Enable → 200 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)