### PR TITLE
fix(SEC-01): org_members 권한 상승 차단 — admin/owner 가드 추가

### DIFF
--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.repositories.org_member import OrgMemberRepository
-from app.schemas.org_member import OrgMemberCreate, OrgMemberResponse, OrgMemberUpdate
+from app.schemas.org_member import ORG_ROLES, OrgMemberCreate, OrgMemberResponse, OrgMemberUpdate
 
 router = APIRouter(prefix="/api/v2/org-members", tags=["org-members"])
 
@@ -25,6 +25,20 @@ def _get_repo(
     return OrgMemberRepository(session, uuid.UUID(str(org_id_str)))
 
 
+async def _require_admin(
+    repo: OrgMemberRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+) -> OrgMemberRepository:
+    """DB에서 caller의 OrgMember role 확인 — owner 또는 admin만 통과."""
+    caller = await repo.get_by_user(uuid.UUID(auth.user_id))
+    if caller is None or caller.role not in ("owner", "admin"):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="org admin 또는 owner 권한 필요",
+        )
+    return repo
+
+
 @router.get("", response_model=list[OrgMemberResponse])
 async def list_org_members(
     repo: OrgMemberRepository = Depends(_get_repo),
@@ -36,10 +50,11 @@ async def list_org_members(
 @router.post("", response_model=OrgMemberResponse, status_code=201)
 async def create_org_member(
     body: OrgMemberCreate,
-    session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    repo: OrgMemberRepository = Depends(_require_admin),
 ) -> OrgMemberResponse:
-    repo = OrgMemberRepository(session, body.org_id)
+    if body.role not in ORG_ROLES:
+        raise HTTPException(status_code=400, detail=f"role must be one of: {', '.join(ORG_ROLES)}")
+    # repo.org_id는 JWT에서 추출됨 — body.org_id 무시 (org_id 조작 방지)
     member = await repo.create(user_id=body.user_id, role=body.role)
     return OrgMemberResponse.model_validate(member)
 
@@ -59,9 +74,8 @@ async def get_org_member(
 async def update_org_member(
     id: uuid.UUID,
     body: OrgMemberUpdate,
-    repo: OrgMemberRepository = Depends(_get_repo),
+    repo: OrgMemberRepository = Depends(_require_admin),
 ) -> OrgMemberResponse:
-    from app.schemas.org_member import ORG_ROLES
     if body.role and body.role not in ORG_ROLES:
         raise HTTPException(status_code=400, detail=f"role must be one of: {', '.join(ORG_ROLES)}")
     data = body.model_dump(exclude_unset=True)
@@ -74,7 +88,7 @@ async def update_org_member(
 @router.delete("/{id}", status_code=200)
 async def delete_org_member(
     id: uuid.UUID,
-    repo: OrgMemberRepository = Depends(_get_repo),
+    repo: OrgMemberRepository = Depends(_require_admin),
 ) -> dict:
     ok = await repo.soft_delete(id)
     if not ok:

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -8,14 +8,15 @@ from httpx import ASGITransport, AsyncClient
 
 ORG_ID = uuid.uuid4()
 USER_ID = uuid.uuid4()
+CALLER_ID = uuid.uuid4()
 MEMBER_ID = uuid.uuid4()
 
 
-def _mock_member(role: str = "member") -> MagicMock:
+def _mock_member(role: str = "member", user_id: uuid.UUID | None = None) -> MagicMock:
     m = MagicMock()
     m.id = MEMBER_ID
     m.org_id = ORG_ID
-    m.user_id = USER_ID
+    m.user_id = user_id or USER_ID
     m.role = role
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.deleted_at = None
@@ -27,11 +28,11 @@ def anyio_backend():
     return "asyncio"
 
 
-async def _client():
+async def _client(caller_role: str = "admin"):
     from app.main import app
 
     ctx = MagicMock()
-    ctx.user_id = str(uuid.uuid4())
+    ctx.user_id = str(CALLER_ID)
     ctx.email = "test@example.com"
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
 
@@ -49,12 +50,12 @@ async def _client():
     app.dependency_overrides[get_db] = override_db
     app.dependency_overrides[get_current_user] = override_auth
 
-    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app, ctx
 
 
 @pytest.mark.anyio
 async def test_list_org_members_200():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [_mock_member()]
@@ -72,10 +73,17 @@ async def test_list_org_members_200():
 
 @pytest.mark.anyio
 async def test_create_org_member_201():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
-        with patch("app.repositories.org_member.OrgMemberRepository.create", new_callable=AsyncMock) as mock_create:
-            mock_create.return_value = _mock_member()
+        caller_admin = _mock_member("admin", user_id=CALLER_ID)
+        new_member = _mock_member("member")
+
+        with (
+            patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user,
+            patch("app.repositories.org_member.OrgMemberRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_get_by_user.return_value = caller_admin
+            mock_create.return_value = new_member
 
             async with client as c:
                 resp = await c.post("/api/v2/org-members", json={
@@ -91,8 +99,30 @@ async def test_create_org_member_201():
 
 
 @pytest.mark.anyio
+async def test_create_org_member_403_non_admin():
+    """일반 멤버는 새 멤버 추가 불가."""
+    client, session, app, _ = await _client()
+    try:
+        caller_member = _mock_member("member", user_id=CALLER_ID)
+
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_member
+
+            async with client as c:
+                resp = await c.post("/api/v2/org-members", json={
+                    "org_id": str(ORG_ID),
+                    "user_id": str(USER_ID),
+                    "role": "member",
+                })
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_org_member_200():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = _mock_member()
@@ -109,7 +139,7 @@ async def test_get_org_member_200():
 
 @pytest.mark.anyio
 async def test_get_org_member_404():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
@@ -125,15 +155,20 @@ async def test_get_org_member_404():
 
 @pytest.mark.anyio
 async def test_update_role_200():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
+        caller_admin = _mock_member("admin", user_id=CALLER_ID)
         updated = _mock_member("admin")
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = updated
-        session.execute = AsyncMock(return_value=mock_result)
 
-        async with client as c:
-            resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "admin"})
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_admin
+
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = updated
+            session.execute = AsyncMock(return_value=mock_result)
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "admin"})
 
         assert resp.status_code == 200
         assert resp.json()["role"] == "admin"
@@ -142,11 +177,34 @@ async def test_update_role_200():
 
 
 @pytest.mark.anyio
-async def test_update_invalid_role_400():
-    client, session, app = await _client()
+async def test_update_role_403_non_admin():
+    """일반 멤버는 role 변경 불가."""
+    client, session, app, _ = await _client()
     try:
-        async with client as c:
-            resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "superuser"})
+        caller_member = _mock_member("member", user_id=CALLER_ID)
+
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_member
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "admin"})
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_invalid_role_400():
+    client, session, app, _ = await _client()
+    try:
+        caller_admin = _mock_member("admin", user_id=CALLER_ID)
+
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_admin
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/org-members/{MEMBER_ID}", json={"role": "superuser"})
 
         assert resp.status_code == 400
     finally:
@@ -155,8 +213,10 @@ async def test_update_invalid_role_400():
 
 @pytest.mark.anyio
 async def test_soft_delete_200():
-    client, session, app = await _client()
+    client, session, app, _ = await _client()
     try:
+        caller_admin = _mock_member("admin", user_id=CALLER_ID)
+
         call_count = 0
 
         async def mock_execute(stmt, *args, **kwargs):
@@ -169,10 +229,31 @@ async def test_soft_delete_200():
 
         session.execute = mock_execute
 
-        async with client as c:
-            resp = await c.delete(f"/api/v2/org-members/{MEMBER_ID}")
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_admin
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/org-members/{MEMBER_ID}")
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_soft_delete_403_non_admin():
+    """일반 멤버는 다른 멤버 삭제 불가."""
+    client, session, app, _ = await _client()
+    try:
+        caller_member = _mock_member("member", user_id=CALLER_ID)
+
+        with patch("app.repositories.org_member.OrgMemberRepository.get_by_user", new_callable=AsyncMock) as mock_get_by_user:
+            mock_get_by_user.return_value = caller_member
+
+            async with client as c:
+                resp = await c.delete(f"/api/v2/org-members/{MEMBER_ID}")
+
+        assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- `_require_admin` 의존성 추가: DB에서 caller의 `OrgMember.role`을 조회하여 `owner` 또는 `admin`만 통과
- `POST /org-members`: `body.org_id` 무시 → `repo.org_id`(JWT 기반) 사용으로 org_id 조작 차단
- `PATCH /org-members/{id}`: `_require_admin` 적용으로 일반 멤버의 role 상승 차단
- `DELETE /org-members/{id}`: `_require_admin` 적용으로 무단 멤버 삭제 차단
- `GET` 엔드포인트는 기존 `_get_repo` 유지 — 에이전트 API Key 멤버 조회 영향 없음

## 취약점 상세

| 엔드포인트 | 취약점 | 수정 |
|---|---|---|
| `POST /org-members` | body.org_id+role 직접 지정 가능, 권한 체크 없음 | `_require_admin` + `body.org_id` 무시 |
| `PATCH /org-members/{id}` | 일반 멤버가 자신 role을 admin으로 변경 가능 | `_require_admin` |
| `DELETE /org-members/{id}` | 일반 멤버가 다른 멤버 삭제 가능 | `_require_admin` |

## Test plan

- [x] `test_create_org_member_201` — admin 권한으로 생성 정상
- [x] `test_create_org_member_403_non_admin` — 일반 멤버 생성 시도 → 403
- [x] `test_get_org_member_200` — 조회 영향 없음
- [x] `test_update_role_200` — admin 권한으로 role 변경 정상
- [x] `test_update_role_403_non_admin` — 일반 멤버 role 변경 시도 → 403
- [x] `test_update_invalid_role_400` — 잘못된 role 값 → 400
- [x] `test_soft_delete_200` — admin 권한으로 삭제 정상
- [x] `test_soft_delete_403_non_admin` — 일반 멤버 삭제 시도 → 403
- [x] pytest 전량 487/487 PASS
- [x] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)