### PR TITLE
fix(SEC-02): X-Org-Id/X-Project-Id IDOR 차단 — membership DB 검증 추가

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Literal
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -109,6 +109,67 @@ async def get_current_user(
 
 # ─── Scope dependencies ───────────────────────────────────────────────────────
 
+async def _verify_org_membership(
+    user_id: str,
+    org_id: uuid.UUID,
+    db: AsyncSession,
+    request: Request,
+) -> None:
+    """caller가 org 멤버인지 DB 조회 — request.state 캐시로 N+1 방지."""
+    cache_key = f"_org_mbr_{user_id}_{org_id}"
+    cached = getattr(request.state, cache_key, None)
+    if cached is True:
+        return
+    if cached is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="해당 조직의 멤버가 아닌",
+        )
+
+    from app.models.project import OrgMember
+
+    result = await db.execute(
+        select(OrgMember.id).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == uuid.UUID(user_id),
+            OrgMember.deleted_at.is_(None),
+        )
+    )
+    is_member = result.scalar_one_or_none() is not None
+    setattr(request.state, cache_key, is_member)
+    if not is_member:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="해당 조직의 멤버가 아닌",
+        )
+
+
+async def get_verified_org_id(
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
+) -> uuid.UUID:
+    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증."""
+    jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
+    raw = jwt_org_id or x_org_id
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    try:
+        org_id = uuid.UUID(str(raw))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid org_id format")
+
+    if not jwt_org_id and x_org_id:
+        # 헤더 fallback 사용 시에만 membership 검증 — JWT org_id는 발급 시 검증됨
+        await _verify_org_membership(auth.user_id, org_id, db, request)
+
+    return org_id
+
+
 def get_org_scope(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
@@ -169,13 +230,53 @@ def require_project_access(
     return project_id
 
 
-def get_scope_context(
+async def _verify_project_in_org(
+    project_id: uuid.UUID,
+    org_id: uuid.UUID,
+    db: AsyncSession,
+    request: Request,
+) -> None:
+    """project가 org에 속하는지 DB 조회 — request.state 캐시로 N+1 방지."""
+    cache_key = f"_proj_in_org_{project_id}_{org_id}"
+    cached = getattr(request.state, cache_key, None)
+    if cached is True:
+        return
+    if cached is False:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="해당 조직에 속하지 않는 프로젝트인",
+        )
+
+    from app.models.project import Project
+
+    result = await db.execute(
+        select(Project.id).where(
+            Project.id == project_id,
+            Project.org_id == org_id,
+            Project.deleted_at.is_(None),
+        )
+    )
+    exists = result.scalar_one_or_none() is not None
+    setattr(request.state, cache_key, exists)
+    if not exists:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="해당 조직에 속하지 않는 프로젝트인",
+        )
+
+
+async def get_scope_context(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
     x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
 ) -> dict:
-    """org_id + project_id 컨텍스트를 한번에 추출."""
-    org_id = get_org_scope(auth, x_org_id)
-    project_id_raw = auth.claims.get("app_metadata", {}).get("project_id") or x_project_id
+    """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증."""
+    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, db=db, request=request)
+    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    project_id_raw = jwt_project_id or x_project_id
     project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
+    if not jwt_project_id and x_project_id and project_id:
+        await _verify_project_in_org(project_id, org_id, db, request)
     return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -147,10 +147,11 @@ async def _verify_org_membership(
 async def get_verified_org_id(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
     db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> uuid.UUID:
-    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증."""
+    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증."""
     jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
     raw = jwt_org_id or x_org_id
     if not raw:
@@ -166,6 +167,15 @@ async def get_verified_org_id(
     if not jwt_org_id and x_org_id:
         # 헤더 fallback 사용 시에만 membership 검증 — JWT org_id는 발급 시 검증됨
         await _verify_org_membership(auth.user_id, org_id, db, request)
+
+    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    if not jwt_project_id and x_project_id:
+        # X-Project-Id 헤더 fallback 사용 시 해당 project가 org에 속하는지 검증
+        try:
+            project_id = uuid.UUID(x_project_id)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
+        await _verify_project_in_org(project_id, org_id, db, request)
 
     return org_id
 
@@ -273,10 +283,9 @@ async def get_scope_context(
     request: Request = None,
 ) -> dict:
     """org_id + project_id 컨텍스트를 한번에 추출 — 헤더 fallback 시 membership/소속 검증."""
-    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, db=db, request=request)
+    # x_project_id를 get_verified_org_id에 전달해서 project 소속 검증도 위임
+    org_id = await get_verified_org_id(auth=auth, x_org_id=x_org_id, x_project_id=x_project_id, db=db, request=request)
     jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
     project_id_raw = jwt_project_id or x_project_id
     project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
-    if not jwt_project_id and x_project_id and project_id:
-        await _verify_project_in_org(project_id, org_id, db, request)
     return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -1,31 +1,21 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.schemas.subscription import AccountDeleteResponse
 
 router = APIRouter(prefix="/api/v2/account", tags=["account"])
 
 
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
-
-
 @router.post("/delete", response_model=AccountDeleteResponse)
 async def delete_account(
     user_id: uuid.UUID | None = None,
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> AccountDeleteResponse:

--- a/backend/app/routers/analytics.py
+++ b/backend/app/routers/analytics.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.analytics import AnalyticsRepository
 from app.schemas.analytics import (
@@ -23,13 +23,9 @@ router = APIRouter(prefix="/api/v2", tags=["analytics"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> AnalyticsRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return AnalyticsRepository(session, uuid.UUID(str(org_id_str)))
+    return AnalyticsRepository(session, org_id)
 
 
 @router.get("/analytics/overview", response_model=ProjectOverviewResponse)

--- a/backend/app/routers/audit_logs.py
+++ b/backend/app/routers/audit_logs.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.audit import AuditLogRepository
 from app.schemas.audit import AuditLogResponse
@@ -13,13 +13,9 @@ router = APIRouter(prefix="/api/v2/audit-logs", tags=["audit-logs"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> AuditLogRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return AuditLogRepository(session, uuid.UUID(str(org_id_str)))
+    return AuditLogRepository(session, org_id)
 
 
 @router.get("", response_model=list[AuditLogResponse])

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
@@ -18,16 +18,9 @@ router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> DocRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return DocRepository(session, uuid.UUID(str(org_id_str)))
+    return DocRepository(session, org_id)
 
 
 @router.get("", response_model=list[DocResponse])

--- a/backend/app/routers/entities.py
+++ b/backend/app/routers/entities.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import Doc
 from app.models.pm import Epic, Story, Task
@@ -25,29 +25,14 @@ class EntitySearchResult(BaseModel):
     created_at: datetime
 
 
-def _get_org_id(
-    auth: AuthContext,
-    x_org_id: str | None,
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required",
-        )
-    return uuid.UUID(str(org_id_str))
-
-
 @router.get("/search", response_model=list[EntitySearchResult])
 async def search_entities(
     project_id: uuid.UUID = Query(...),
     q: str | None = Query(default=None),
     types: str | None = Query(default=None, description="Comma-separated: story,doc,epic,task"),
     db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[EntitySearchResult]:
-    org_id = _get_org_id(auth, x_org_id)
 
     requested = set(types.split(",")) if types else VALID_TYPES
     requested = requested & VALID_TYPES

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.epic import EpicRepository
 from app.schemas.epic import EpicCreate, EpicProgressResponse, EpicResponse, EpicUpdate
@@ -13,16 +13,9 @@ router = APIRouter(prefix="/api/v2/epics", tags=["epics"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> EpicRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return EpicRepository(session, uuid.UUID(str(org_id_str)))
+    return EpicRepository(session, org_id)
 
 
 @router.get("", response_model=list[EpicResponse])

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -1,11 +1,11 @@
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, require_admin
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.project import OrgMember
@@ -18,13 +18,9 @@ router = APIRouter(prefix="/api/v2/invitations", tags=["invitations"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> InvitationRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return InvitationRepository(session, uuid.UUID(str(org_id_str)))
+    return InvitationRepository(session, org_id)
 
 
 @router.get("", response_model=list[InvitationResponse])

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -4,13 +4,13 @@ import uuid
 import logging
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.memo import MemoAssignee, MemoReply
 from app.models.team import TeamMember
@@ -86,16 +86,9 @@ async def _resolve_author_role(db: AsyncSession, created_by: uuid.UUID | None) -
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> MemoRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required",
-        )
-    return MemoRepository(session, uuid.UUID(str(org_id_str)))
+    return MemoRepository(session, org_id)
 
 
 @router.get("", response_model=list[MemoListResponse])

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
 from app.schemas.notification import (
@@ -17,26 +17,16 @@ from app.schemas.notification import (
 router = APIRouter(prefix="/api/v2", tags=["notifications"])
 
 
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
-
-
 def _notif_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> NotificationRepository:
     return NotificationRepository(session, org_id)
 
 
 def _inbox_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> InboxRepository:
     return InboxRepository(session, org_id)
 
@@ -85,7 +75,7 @@ async def upsert_notification_setting(
     member_id: uuid.UUID = Query(...),
     body: UpsertNotificationSetting = ...,
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> NotificationSettingResponse:
     repo = NotificationSettingRepository(session)
     setting = await repo.upsert(

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.org_member import OrgMemberRepository
 from app.schemas.org_member import ORG_ROLES, OrgMemberCreate, OrgMemberResponse, OrgMemberUpdate
@@ -13,16 +13,9 @@ router = APIRouter(prefix="/api/v2/org-members", tags=["org-members"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> OrgMemberRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return OrgMemberRepository(session, uuid.UUID(str(org_id_str)))
+    return OrgMemberRepository(session, org_id)
 
 
 async def _require_admin(

--- a/backend/app/routers/policy_documents.py
+++ b/backend/app/routers/policy_documents.py
@@ -1,25 +1,15 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Query
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.policy_document import PolicyDocument
 from app.schemas.policy_document import PolicyDocumentResponse
 
 router = APIRouter(prefix="/api/v2/policy-documents", tags=["policy-documents"])
-
-
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
 
 
 @router.get("", response_model=list[PolicyDocumentResponse])
@@ -28,7 +18,7 @@ async def list_policy_documents(
     sprint_id: uuid.UUID | None = Query(default=None),
     q: str | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[PolicyDocumentResponse]:
     stmt = select(PolicyDocument).where(
         PolicyDocument.org_id == org_id,

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -1,10 +1,10 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.project import ProjectRepository
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
@@ -14,16 +14,9 @@ router = APIRouter(prefix="/api/v2/projects", tags=["projects"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ProjectRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return ProjectRepository(session, uuid.UUID(str(org_id_str)))
+    return ProjectRepository(session, org_id)
 
 
 @router.get("", response_model=list[ProjectResponse])

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.retro import (
     RetroActionRepository,
@@ -29,16 +29,9 @@ router = APIRouter(prefix="/api/v2/retros", tags=["retros"])
 
 def _get_session_repo(
     db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> RetroSessionRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required",
-        )
-    return RetroSessionRepository(db, uuid.UUID(str(org_id_str)))
+    return RetroSessionRepository(db, org_id)
 
 
 @router.get("", response_model=list[SessionListResponse])

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.reward import RewardRepository
 from app.schemas.reward import BalanceResponse, GrantReward, LeaderboardEntry, RewardLedgerResponse
@@ -13,13 +13,9 @@ router = APIRouter(prefix="/api/v2/rewards", tags=["rewards"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> RewardRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return RewardRepository(session, uuid.UUID(str(org_id_str)))
+    return RewardRepository(session, org_id)
 
 
 @router.get("", response_model=list[RewardLedgerResponse])

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -1,11 +1,11 @@
 import uuid
 from datetime import date as date_type
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.models.standup import StandupEntry
@@ -18,16 +18,9 @@ router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintRepository:
-    org_id_str = (
-        auth.claims.get("app_metadata", {}).get("org_id")
-        or x_org_id
-    )
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required (X-Org-Id header or JWT app_metadata)")
-    return SprintRepository(session, uuid.UUID(str(org_id_str)))
+    return SprintRepository(session, org_id)
 
 
 @router.get("", response_model=list[SprintResponse])

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -1,11 +1,11 @@
 import uuid
 from datetime import date
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.standup import StandupEntry, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
@@ -21,16 +21,9 @@ router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return StandupEntryRepository(session, uuid.UUID(str(org_id_str)))
+    return StandupEntryRepository(session, org_id)
 
 
 @router.get("", response_model=list[StandupEntryResponse])
@@ -91,14 +84,8 @@ async def list_feedback(
     project_id: uuid.UUID = Query(...),
     date_filter: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[FeedbackResponse]:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    org_id = uuid.UUID(str(org_id_str))
-
     q = (
         select(StandupFeedback)
         .join(StandupEntry, StandupFeedback.standup_entry_id == StandupEntry.id)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
@@ -41,16 +41,9 @@ async def _resolve_epic_title(db: AsyncSession, epic_id: uuid.UUID | None) -> st
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StoryRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return StoryRepository(session, uuid.UUID(str(org_id_str)))
+    return StoryRepository(session, org_id)
 
 
 @router.get("", response_model=list[StoryResponse])

--- a/backend/app/routers/subscription.py
+++ b/backend/app/routers/subscription.py
@@ -1,10 +1,10 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.org_subscription import OrgSubscription
 from app.schemas.subscription import SubscriptionStatusResponse
@@ -12,19 +12,9 @@ from app.schemas.subscription import SubscriptionStatusResponse
 router = APIRouter(prefix="/api/v2/subscription", tags=["subscription"])
 
 
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
-
-
 @router.get("/status", response_model=SubscriptionStatusResponse)
 async def get_subscription_status(
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> SubscriptionStatusResponse:

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.task import TaskRepository
 from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
@@ -13,16 +13,9 @@ router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return TaskRepository(session, uuid.UUID(str(org_id_str)))
+    return TaskRepository(session, org_id)
 
 
 @router.get("", response_model=list[TaskResponse])

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
@@ -13,16 +13,9 @@ router = APIRouter(prefix="/api/v2/team-members", tags=["team-members"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TeamMemberRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="org_id required (X-Org-Id header or JWT app_metadata)",
-        )
-    return TeamMemberRepository(session, uuid.UUID(str(org_id_str)))
+    return TeamMemberRepository(session, org_id)
 
 
 @router.get("", response_model=list[TeamMemberResponse])

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -1,9 +1,9 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.webhook_config import WebhookConfigRepository
 from app.schemas.webhook_config import UpsertWebhookConfig, WebhookConfigResponse
@@ -13,13 +13,9 @@ router = APIRouter(prefix="/api/v2/webhooks", tags=["webhooks"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> WebhookConfigRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return WebhookConfigRepository(session, uuid.UUID(str(org_id_str)))
+    return WebhookConfigRepository(session, org_id)
 
 
 @router.get("/config", response_model=list[WebhookConfigResponse])

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -1,28 +1,18 @@
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, require_admin
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.team import TeamMember
 from app.models.workflow_execution_log import WorkflowExecutionLog
 
 router = APIRouter(prefix="/api/v2/workflow-executions", tags=["workflow-executions"])
-
-
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=400, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
 
 
 class ExecutionLogItem(BaseModel):
@@ -67,7 +57,7 @@ async def story_execution_summary(
     project_id: uuid.UUID = Query(...),
     story_ids: list[str] = Query(default=[]),
     db: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
 ) -> dict[str, StorySummaryItem]:
     """Return latest execution status per story (no admin required — board/member view)."""
@@ -119,7 +109,7 @@ async def list_executions(
     offset: int = Query(default=0, ge=0),
     limit: int = Query(default=20, le=100),
     db: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> ExecutionLogListResponse:
     role = auth.claims.get("app_metadata", {}).get("role", "member")
@@ -213,7 +203,7 @@ async def list_executions(
 async def get_execution(
     id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     _: AuthContext = Depends(require_admin),
 ) -> ExecutionLogDetail:
     result = await db.execute(

--- a/backend/app/routers/workflow_templates.py
+++ b/backend/app/routers/workflow_templates.py
@@ -5,12 +5,12 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.team import TeamMember
@@ -65,16 +65,6 @@ class ApplyTemplateResponse(BaseModel):
     rules_deleted: int
 
 
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
-
-
 @router.get("", response_model=list[WorkflowTemplateListItem])
 async def list_templates(
     db: AsyncSession = Depends(get_db),
@@ -104,7 +94,7 @@ async def apply_template(
     body: ApplyTemplateRequest,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ApplyTemplateResponse:
     repo = WorkflowTemplateRepository(db)
     tmpl = await repo.get_by_slug(slug)

--- a/backend/app/routers/workflow_trigger.py
+++ b/backend/app/routers/workflow_trigger.py
@@ -1,12 +1,12 @@
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Header, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.workflow_execution_log import WorkflowExecutionLog
 from app.services.rule_evaluator import EventContext
@@ -15,16 +15,6 @@ from app.services.workflow_pipeline import process_event
 router = APIRouter(prefix="/api/v2/workflow", tags=["workflow"])
 
 _DEDUP_SECONDS = 30
-
-
-def _get_org_id(
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-) -> uuid.UUID:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=400, detail="org_id required")
-    return uuid.UUID(str(org_id_str))
 
 
 class TriggerRequest(BaseModel):
@@ -44,7 +34,7 @@ async def trigger_workflow(
     body: TriggerRequest,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-    org_id: uuid.UUID = Depends(_get_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TriggerResponse:
     cutoff = datetime.now(timezone.utc) - timedelta(seconds=_DEDUP_SECONDS)
     recent = await db.execute(

--- a/backend/app/routers/workflow_trigger_types.py
+++ b/backend/app/routers/workflow_trigger_types.py
@@ -1,11 +1,11 @@
 import uuid
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, require_admin
+from app.dependencies.auth import get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.repositories.workflow_trigger_type import WorkflowTriggerTypeRepository
 
@@ -38,13 +38,9 @@ class TriggerTypeUpdate(BaseModel):
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
-    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> WorkflowTriggerTypeRepository:
-    org_id_str = auth.claims.get("app_metadata", {}).get("org_id") or x_org_id
-    if not org_id_str:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="org_id required")
-    return WorkflowTriggerTypeRepository(session, uuid.UUID(str(org_id_str)))
+    return WorkflowTriggerTypeRepository(session, org_id)
 
 
 @router.get("", response_model=list[TriggerTypeResponse])

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -1,8 +1,9 @@
 """C-S5: RLS → FastAPI 권한 검증 전환 — dependency injection 테스트"""
 from __future__ import annotations
 
+import types
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -139,22 +140,35 @@ def test_require_project_access_allows_legacy_token_without_project_ids():
 
 # ─── get_scope_context ────────────────────────────────────────────────────────
 
-def test_get_scope_context_returns_org_and_project():
+@pytest.mark.anyio
+async def test_get_scope_context_returns_org_and_project():
     from app.dependencies.auth import get_scope_context
     org = uuid.uuid4()
     proj = uuid.uuid4()
     auth = _make_auth(org_id=str(org))
-    ctx = get_scope_context(auth=auth, x_org_id=None, x_project_id=str(proj))
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = proj  # project exists in org
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_request = MagicMock()
+    mock_request.state = types.SimpleNamespace()
+
+    ctx = await get_scope_context(
+        auth=auth, x_org_id=None, x_project_id=str(proj),
+        db=mock_db, request=mock_request,
+    )
     assert ctx["org_id"] == org
     assert ctx["project_id"] == proj
     assert ctx["user_id"] == "user-1"
 
 
-def test_get_scope_context_project_none_when_not_provided():
+@pytest.mark.anyio
+async def test_get_scope_context_project_none_when_not_provided():
     from app.dependencies.auth import get_scope_context
     org = uuid.uuid4()
     auth = _make_auth(org_id=str(org))
-    ctx = get_scope_context(auth=auth, x_org_id=None, x_project_id=None)
+    ctx = await get_scope_context(auth=auth, x_org_id=None, x_project_id=None, db=None, request=None)
     assert ctx["org_id"] == org
     assert ctx["project_id"] is None
 

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException
 
 # ─── get_org_scope ────────────────────────────────────────────────────────────
 
-def _make_auth(org_id: str | None = None, role: str = "member", project_ids: list | None = None):
+def _make_auth(org_id: str | None = None, role: str = "member", project_ids: list | None = None, user_id: str = "user-1"):
     from app.dependencies.auth import AuthContext
     app_metadata: dict = {}
     if org_id:
@@ -20,7 +20,7 @@ def _make_auth(org_id: str | None = None, role: str = "member", project_ids: lis
         app_metadata["role"] = role
     if project_ids is not None:
         app_metadata["project_ids"] = project_ids
-    return AuthContext(user_id="user-1", email="u@test.com", claims={"app_metadata": app_metadata})
+    return AuthContext(user_id=user_id, email="u@test.com", claims={"app_metadata": app_metadata})
 
 
 def test_get_org_scope_from_jwt():
@@ -171,6 +171,101 @@ async def test_get_scope_context_project_none_when_not_provided():
     ctx = await get_scope_context(auth=auth, x_org_id=None, x_project_id=None, db=None, request=None)
     assert ctx["org_id"] == org
     assert ctx["project_id"] is None
+
+
+# ─── SEC-02 IDOR 차단 보안 테스트 ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_verified_org_id_403_on_foreign_org():
+    """X-Org-Id 헤더로 비소속 org 접근 시 403."""
+    from app.dependencies.auth import get_verified_org_id
+    caller_id = str(uuid.uuid4())
+    auth = _make_auth(org_id=None, user_id=caller_id)  # JWT에 org_id 없음 → 헤더 fallback
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # 멤버 아님
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_request = MagicMock()
+    mock_request.state = types.SimpleNamespace()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_verified_org_id(
+            auth=auth,
+            x_org_id=str(uuid.uuid4()),
+            x_project_id=None,
+            db=mock_db,
+            request=mock_request,
+        )
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_get_verified_org_id_pass_when_member():
+    """X-Org-Id 헤더로 소속 org 접근 시 정상 통과."""
+    from app.dependencies.auth import get_verified_org_id
+    org = uuid.uuid4()
+    caller_id = str(uuid.uuid4())
+    auth = _make_auth(org_id=None, user_id=caller_id)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = MagicMock()  # 멤버임
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_request = MagicMock()
+    mock_request.state = types.SimpleNamespace()
+
+    result = await get_verified_org_id(
+        auth=auth,
+        x_org_id=str(org),
+        x_project_id=None,
+        db=mock_db,
+        request=mock_request,
+    )
+    assert result == org
+
+
+@pytest.mark.anyio
+async def test_get_verified_org_id_jwt_org_skips_db():
+    """JWT에 org_id 있으면 DB 조회 없이 통과 (N+1 방지 경로 확인)."""
+    from app.dependencies.auth import get_verified_org_id
+    org = uuid.uuid4()
+    auth = _make_auth(org_id=str(org))
+
+    mock_db = AsyncMock()
+    mock_request = MagicMock()
+    mock_request.state = types.SimpleNamespace()
+
+    result = await get_verified_org_id(
+        auth=auth, x_org_id=None, x_project_id=None, db=mock_db, request=mock_request,
+    )
+    assert result == org
+    mock_db.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_get_verified_org_id_403_on_foreign_project():
+    """X-Project-Id 헤더로 비소속 project 접근 시 403."""
+    from app.dependencies.auth import get_verified_org_id
+    org = uuid.uuid4()
+    auth = _make_auth(org_id=str(org))  # JWT에 org_id 있음 (org 검증 skip)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # project 비소속
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_result)
+    mock_request = MagicMock()
+    mock_request.state = types.SimpleNamespace()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await get_verified_org_id(
+            auth=auth,
+            x_org_id=None,
+            x_project_id=str(uuid.uuid4()),
+            db=mock_db,
+            request=mock_request,
+        )
+    assert exc_info.value.status_code == 403
 
 
 # ─── AuthContext org_id field ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `get_verified_org_id` 신설 — X-Org-Id 헤더 fallback 시에만 `org_members` DB 조회로 membership 검증
- `request.state` 캐시 적용으로 N+1 방지 (같은 요청 내 중복 조회 없음)
- `get_scope_context` async 전환 + X-Project-Id 헤더 사용 시 project-org 소속 검증
- 전체 25개 라우터의 `_get_repo`/`_get_org_id` 패턴을 `Depends(get_verified_org_id)`로 일괄 교체

## 취약점 상세

JWT에 `org_id`가 없을 때 `X-Org-Id` 헤더를 검증 없이 그대로 사용 → 타 org 데이터 IDOR 가능
→ 헤더 fallback 시 `org_members` 테이블 DB 조회로 membership 검증 추가

## 영향 없는 경로

| 경로 | 이유 |
|---|---|
| JWT에 `org_id` 있는 정상 요청 | 검증 skip — JWT 발급 시 이미 검증됨 |
| API Key 경로 | `app_metadata.org_id`가 설정되므로 헤더 검증 미진입 |
| `GET` 조회 엔드포인트 | `_get_repo` 동일하게 적용 → 동작 유지 |

## Test plan

- [x] pytest 487/487 PASS
- [x] pnpm build 성공
- [x] 기존 25개 라우터 테스트 전량 통과 (JWT mock에 org_id 설정 → 검증 bypass)
- [x] test_c_s5.py get_scope_context 테스트 async 전환 후 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)