### PR TITLE
fix(SEC-04): Webhook URL SSRF 차단 — DNS resolve + private IP 검증

### DIFF
--- a/backend/app/core/ssrf.py
+++ b/backend/app/core/ssrf.py
@@ -1,0 +1,50 @@
+"""SSRF 방어 유틸 — webhook URL이 private/link-local/metadata IP를 가리키지 않는지 검증."""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlparse
+
+_BLOCKED_NETWORKS = [
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("169.254.0.0/16"),   # link-local (AWS/GCP metadata 포함)
+    ipaddress.ip_network("127.0.0.0/8"),       # loopback
+    ipaddress.ip_network("0.0.0.0/8"),
+    ipaddress.ip_network("::1/128"),            # IPv6 loopback
+    ipaddress.ip_network("fc00::/7"),           # IPv6 ULA private
+    ipaddress.ip_network("fe80::/10"),          # IPv6 link-local
+]
+
+
+def _is_blocked_ip(ip: str) -> bool:
+    try:
+        addr = ipaddress.ip_address(ip)
+        return any(addr in net for net in _BLOCKED_NETWORKS)
+    except ValueError:
+        return True  # 파싱 실패 → 차단
+
+
+def validate_webhook_url(url: str) -> None:
+    """URL hostname을 DNS resolve하여 private/link-local IP면 ValueError."""
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+    if not hostname:
+        raise ValueError("Invalid URL: no hostname")
+
+    try:
+        infos = socket.getaddrinfo(hostname, None)
+    except socket.gaierror as exc:
+        raise ValueError(f"Cannot resolve hostname '{hostname}': {exc}") from exc
+
+    for info in infos:
+        ip = info[4][0]
+        if _is_blocked_ip(ip):
+            raise ValueError(f"URL resolves to blocked IP: {ip}")
+
+
+async def validate_webhook_url_async(url: str) -> None:
+    """Async context용 — thread pool에서 DNS resolve 실행 (이벤트 루프 블로킹 방지)."""
+    import asyncio
+    await asyncio.to_thread(validate_webhook_url, url)

--- a/backend/app/core/ssrf.py
+++ b/backend/app/core/ssrf.py
@@ -21,6 +21,9 @@ _BLOCKED_NETWORKS = [
 def _is_blocked_ip(ip: str) -> bool:
     try:
         addr = ipaddress.ip_address(ip)
+        # ::ffff:x.x.x.x 형태의 IPv4-mapped IPv6 → IPv4로 언매핑 후 재검사
+        if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped is not None:
+            addr = addr.ipv4_mapped
         return any(addr in net for net in _BLOCKED_NETWORKS)
     except ValueError:
         return True  # 파싱 실패 → 차단

--- a/backend/app/schemas/webhook_config.py
+++ b/backend/app/schemas/webhook_config.py
@@ -5,6 +5,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict, field_validator
 
+from app.core.ssrf import validate_webhook_url
+
 
 class WebhookConfigResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
@@ -32,4 +34,5 @@ class UpsertWebhookConfig(BaseModel):
     def url_must_be_https(cls, v: str) -> str:
         if not v.startswith("https://"):
             raise ValueError("url must start with https://")
+        validate_webhook_url(v)  # DNS resolve → private IP 차단 (SSRF 방어)
         return v

--- a/backend/app/services/deployment_lifecycle.py
+++ b/backend/app/services/deployment_lifecycle.py
@@ -74,10 +74,16 @@ async def _fire_webhooks(session: AsyncSession, org_id: uuid.UUID, event: str, d
     payload_obj = {"event": event, "data": data}
     body = json.dumps(payload_obj)
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
         for row in configs:
             url, secret, events = row
             if events and event not in events:
+                continue
+            # dispatch 전 IP 재검증 (DNS rebinding 방지)
+            from app.core.ssrf import validate_webhook_url_async
+            try:
+                await validate_webhook_url_async(url)
+            except ValueError:
                 continue
             headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
             try:

--- a/backend/app/services/webhook_dispatch.py
+++ b/backend/app/services/webhook_dispatch.py
@@ -12,6 +12,7 @@ import httpx
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.ssrf import validate_webhook_url_async
 from app.models.webhook_config import WebhookConfig
 
 
@@ -38,10 +39,15 @@ async def fire_webhooks(session: AsyncSession, org_id: uuid.UUID, event: str, da
     payload_obj = {"event": event, "data": data}
     body = json.dumps(payload_obj)
 
-    async with httpx.AsyncClient(timeout=10.0) as client:
+    async with httpx.AsyncClient(timeout=10.0, follow_redirects=False) as client:
         for row in configs:
             url, secret, events = row
             if events and event not in events:
+                continue
+            # dispatch 시 IP 재검증 (DNS rebinding 방지)
+            try:
+                await validate_webhook_url_async(url)
+            except ValueError:
                 continue
             headers = {"Content-Type": "application/json", **_build_signature_headers(secret, body)}
             try:

--- a/backend/tests/test_s34.py
+++ b/backend/tests/test_s34.py
@@ -93,7 +93,8 @@ async def test_list_configs_empty_200():
 async def test_upsert_config_create_200():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+        with patch("app.schemas.webhook_config.validate_webhook_url"), \
+             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = _mock_config()
 
             async with client as c:
@@ -115,7 +116,8 @@ async def test_upsert_config_update_200():
     client, session, app = await _client()
     try:
         updated = _mock_config(is_active=False)
-        with patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+        with patch("app.schemas.webhook_config.validate_webhook_url"), \
+             patch("app.repositories.webhook_config.WebhookConfigRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = updated
 
             async with client as c:

--- a/backend/tests/test_ssrf.py
+++ b/backend/tests/test_ssrf.py
@@ -50,6 +50,20 @@ def test_public_ip_allowed():
     assert _is_blocked_ip("52.223.0.1") is False  # Discord CDN 대역
 
 
+def test_ipv4_mapped_ipv6_loopback_blocked():
+    """::ffff:127.0.0.1 형태 IPv4-mapped IPv6 우회 차단."""
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("::ffff:127.0.0.1") is True
+
+
+def test_ipv4_mapped_ipv6_private_blocked():
+    """::ffff:10.x / ::ffff:192.168.x IPv4-mapped 우회 차단."""
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("::ffff:10.0.0.1") is True
+    assert _is_blocked_ip("::ffff:192.168.1.1") is True
+    assert _is_blocked_ip("::ffff:169.254.169.254") is True
+
+
 # ─── validate_webhook_url ──────────────────────────────────────────────────────
 
 def test_validate_blocks_private_ip():

--- a/backend/tests/test_ssrf.py
+++ b/backend/tests/test_ssrf.py
@@ -1,0 +1,110 @@
+"""SEC-04: SSRF 차단 단위 테스트."""
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _addrinfo(ip: str):
+    """socket.getaddrinfo 반환 형식 모킹."""
+    return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))]
+
+
+# ─── _is_blocked_ip ────────────────────────────────────────────────────────────
+
+def test_private_10_blocked():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("10.0.0.1") is True
+    assert _is_blocked_ip("10.255.255.255") is True
+
+
+def test_private_172_blocked():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("172.16.0.1") is True
+    assert _is_blocked_ip("172.31.255.255") is True
+
+
+def test_private_192_168_blocked():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("192.168.1.1") is True
+
+
+def test_link_local_169_blocked():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("169.254.169.254") is True  # AWS 메타데이터 서버
+
+
+def test_loopback_blocked():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("127.0.0.1") is True
+    assert _is_blocked_ip("::1") is True
+
+
+def test_public_ip_allowed():
+    from app.core.ssrf import _is_blocked_ip
+    assert _is_blocked_ip("1.2.3.4") is False
+    assert _is_blocked_ip("8.8.8.8") is False
+    assert _is_blocked_ip("52.223.0.1") is False  # Discord CDN 대역
+
+
+# ─── validate_webhook_url ──────────────────────────────────────────────────────
+
+def test_validate_blocks_private_ip():
+    from app.core.ssrf import validate_webhook_url
+    with patch("socket.getaddrinfo", return_value=_addrinfo("192.168.1.100")):
+        with pytest.raises(ValueError, match="blocked IP"):
+            validate_webhook_url("https://internal.example.com/hook")
+
+
+def test_validate_blocks_metadata_ip():
+    from app.core.ssrf import validate_webhook_url
+    with patch("socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+        with pytest.raises(ValueError, match="blocked IP"):
+            validate_webhook_url("https://metadata.example.com/hook")
+
+
+def test_validate_blocks_loopback():
+    from app.core.ssrf import validate_webhook_url
+    with patch("socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+        with pytest.raises(ValueError, match="blocked IP"):
+            validate_webhook_url("https://localhost/hook")
+
+
+def test_validate_passes_public_ip():
+    from app.core.ssrf import validate_webhook_url
+    with patch("socket.getaddrinfo", return_value=_addrinfo("162.159.135.232")):
+        validate_webhook_url("https://discord.com/api/webhooks/123/abc")  # 예외 없음
+
+
+def test_validate_raises_on_dns_failure():
+    from app.core.ssrf import validate_webhook_url
+    with patch("socket.getaddrinfo", side_effect=socket.gaierror("NXDOMAIN")):
+        with pytest.raises(ValueError, match="Cannot resolve"):
+            validate_webhook_url("https://nonexistent.invalid/hook")
+
+
+# ─── schema validator 통합 ────────────────────────────────────────────────────
+
+def test_schema_blocks_private_ip_url():
+    from app.schemas.webhook_config import UpsertWebhookConfig
+    import uuid
+    with patch("socket.getaddrinfo", return_value=_addrinfo("10.0.0.1")):
+        with pytest.raises(Exception):  # pydantic ValidationError
+            UpsertWebhookConfig(
+                member_id=uuid.uuid4(),
+                url="https://internal.corp/hook",
+            )
+
+
+def test_schema_passes_public_url():
+    from app.schemas.webhook_config import UpsertWebhookConfig
+    import uuid
+    with patch("socket.getaddrinfo", return_value=_addrinfo("162.159.135.232")):
+        obj = UpsertWebhookConfig(
+            member_id=uuid.uuid4(),
+            url="https://discord.com/api/webhooks/123/abc",
+        )
+    assert obj.url == "https://discord.com/api/webhooks/123/abc"


### PR DESCRIPTION
## Summary

- `app/core/ssrf.py` 신설 — SSRF 차단 순수 함수 모음
- `schemas/webhook_config.py` validator 강화 — URL 등록 시 DNS resolve + private IP 차단
- `webhook_dispatch.py` 강화 — `follow_redirects=False` + dispatch 시 IP 재검증

## 차단 대상 IP 범위

| 네트워크 | 이유 |
|---|---|
| `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16` | RFC1918 private |
| `169.254.0.0/16` | link-local (AWS/GCP 메타데이터 서버 포함) |
| `127.0.0.0/8`, `::1/128` | loopback |
| `fc00::/7`, `fe80::/10` | IPv6 private/link-local |

## 방어 레이어

1. **등록 시** (`UpsertWebhookConfig`): DNS resolve → blocked IP → `422 Unprocessable`
2. **dispatch 시** (`fire_webhooks`): 재검증 + `follow_redirects=False` (DNS rebinding 방어)

## Test plan

- [x] `test_ssrf.py` 13건 신규 추가 (private IP 차단, 공인 IP 통과, DNS 실패, schema 통합)
- [x] `test_s34.py` upsert 테스트 mock 추가
- [x] pytest 504/504 PASS
- [x] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)