### PR TITLE
feat(SEC-05): API Key scope enforce — read/write 자동 체크

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -144,6 +144,36 @@ async def _verify_org_membership(
         )
 
 
+_WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
+
+
+def _check_api_key_scope(auth: AuthContext, method: str) -> None:
+    """API Key 경로일 때만 scope 체크 — JWT 사용자(웹 UI)는 미적용."""
+    if not auth.claims.get("app_metadata", {}).get("api_key_id"):
+        return  # JWT 경로 → 스킵
+    scope: list[str] = auth.claims.get("app_metadata", {}).get("scope", ["read", "write"])
+    required = "write" if method.upper() in _WRITE_METHODS else "read"
+    if required not in scope:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"API Key scope '{required}' required",
+        )
+
+
+def require_api_scope(required_scope: str):
+    """특정 scope를 명시적으로 요구하는 dependency factory."""
+    def _check(auth: AuthContext = Depends(get_current_user)) -> None:
+        if not auth.claims.get("app_metadata", {}).get("api_key_id"):
+            return  # JWT 사용자 → 스킵
+        scope: list[str] = auth.claims.get("app_metadata", {}).get("scope", ["read", "write"])
+        if required_scope not in scope:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API Key scope '{required_scope}' required",
+            )
+    return _check
+
+
 async def get_verified_org_id(
     auth: AuthContext = Depends(get_current_user),
     x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
@@ -151,7 +181,12 @@ async def get_verified_org_id(
     db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> uuid.UUID:
-    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증."""
+    """org_id 추출 — X-Org-Id 헤더 fallback 시 DB membership 검증, X-Project-Id 헤더 시 project 소속 검증.
+    API Key 경로는 HTTP method 기반 scope 자동 체크."""
+    # API Key scope 체크 (request 있을 때만 — 직접 단위 테스트 호출 시 스킵)
+    if request is not None:
+        _check_api_key_scope(auth, request.method)
+
     jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
     raw = jwt_org_id or x_org_id
     if not raw:

--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -268,6 +268,72 @@ async def test_get_verified_org_id_403_on_foreign_project():
     assert exc_info.value.status_code == 403
 
 
+# ─── SEC-05 API Key scope 테스트 ────────────────────────────────────────────────
+
+def _make_api_key_auth(org_id: str, scope: list[str]) -> "AuthContext":
+    from app.dependencies.auth import AuthContext
+    return AuthContext(
+        user_id=str(uuid.uuid4()),
+        email=None,
+        claims={
+            "app_metadata": {
+                "org_id": org_id,
+                "scope": scope,
+                "api_key_id": str(uuid.uuid4()),
+            }
+        },
+        org_id=org_id,
+    )
+
+
+def test_api_key_read_scope_blocks_post():
+    """read-only API Key로 POST 시도 → 403."""
+    from app.dependencies.auth import _check_api_key_scope
+    auth = _make_api_key_auth(str(uuid.uuid4()), ["read"])
+    with pytest.raises(HTTPException) as exc_info:
+        _check_api_key_scope(auth, "POST")
+    assert exc_info.value.status_code == 403
+
+
+def test_api_key_write_scope_allows_post():
+    """write scope API Key로 POST → 통과."""
+    from app.dependencies.auth import _check_api_key_scope
+    auth = _make_api_key_auth(str(uuid.uuid4()), ["read", "write"])
+    _check_api_key_scope(auth, "POST")  # 예외 없음
+
+
+def test_api_key_read_scope_allows_get():
+    """read scope API Key로 GET → 통과."""
+    from app.dependencies.auth import _check_api_key_scope
+    auth = _make_api_key_auth(str(uuid.uuid4()), ["read"])
+    _check_api_key_scope(auth, "GET")  # 예외 없음
+
+
+def test_jwt_user_skips_scope_check():
+    """JWT 사용자(api_key_id 없음)는 scope 체크 미적용."""
+    from app.dependencies.auth import _check_api_key_scope
+    auth = _make_auth(org_id=str(uuid.uuid4()))  # api_key_id 없음
+    _check_api_key_scope(auth, "DELETE")  # 예외 없음 (스킵)
+
+
+def test_require_api_scope_factory_blocks_missing_scope():
+    """require_api_scope("write")가 read-only API Key에 403 반환."""
+    from app.dependencies.auth import require_api_scope, AuthContext
+    checker = require_api_scope("write")
+    auth = _make_api_key_auth(str(uuid.uuid4()), ["read"])
+    with pytest.raises(HTTPException) as exc_info:
+        checker(auth=auth)
+    assert exc_info.value.status_code == 403
+
+
+def test_require_api_scope_factory_passes_jwt():
+    """require_api_scope()는 JWT 사용자 스킵."""
+    from app.dependencies.auth import require_api_scope
+    checker = require_api_scope("write")
+    auth = _make_auth(org_id=str(uuid.uuid4()))
+    checker(auth=auth)  # 예외 없음
+
+
 # ─── AuthContext org_id field ──────────────────────────────────────────────────
 
 def test_auth_context_includes_org_id_from_jwt():


### PR DESCRIPTION
## Summary

- `_check_api_key_scope()` 추가 — HTTP method 기반 scope 자동 검증
- `require_api_scope(scope)` factory 추가 — 특정 엔드포인트 명시적 적용용
- `get_verified_org_id`에 통합 → 25개 라우터 추가 변경 없이 자동 적용

## Scope 체크 로직

| HTTP Method | Required Scope |
|---|---|
| `GET`, `HEAD`, `OPTIONS` | `read` |
| `POST`, `PUT`, `PATCH`, `DELETE` | `write` |

**JWT 사용자(웹 UI):** `api_key_id` 클레임이 없으면 자동 스킵 → 기존 UI 동작 무영향

## API Key scope 체크 흐름

```
request 도착
  → get_verified_org_id() 호출
  → _check_api_key_scope(auth, request.method)
     → api_key_id 없음? → 스킵 (JWT 사용자)
     → scope에 required 없음? → 403
  → 이하 org/project 검증 계속
```

## Test plan

- [x] read-only API Key + POST → 403
- [x] write scope API Key + POST → 통과
- [x] read scope API Key + GET → 통과
- [x] JWT 사용자 + DELETE → scope 체크 스킵
- [x] `require_api_scope("write")` factory — read-only API Key → 403
- [x] `require_api_scope("write")` factory — JWT → 스킵
- [x] pytest 512/512 PASS
- [x] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)