### PR TITLE
fix(SEC-07): DEBUG 기본값 False + Swagger prod 비노출

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
 
     # App
     app_env: str = "development"
-    debug: bool = True
+    debug: bool = False
 
     # OAuth — Google / GitHub
     google_client_id: str = ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       ALEMBIC_DATABASE_URL: postgresql://${POSTGRES_USER:-sprintable}:${POSTGRES_PASSWORD:-sprintable}@db:5432/${POSTGRES_DB:-sprintable}
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production-min-32-chars}
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production-min-32-chars}
+      DEBUG: "True"
     command: >
       sh -c "python bootstrap.py && uvicorn app.main:app --host 0.0.0.0 --port 8000"
     ports:


### PR DESCRIPTION
## Summary

- `config.py`: `debug: bool = True` → `False` — prod/CI 환경에서 DEBUG 미설정 시 안전한 기본값
- `docker-compose.yml`: `DEBUG: "True"` 추가 — 로컬 개발 환경에서 Swagger UI 유지

## 영향

| 환경 | DEBUG 값 | Swagger `/api/v2/_swagger` |
|---|---|---|
| prod/CI (환경변수 미설정) | `False` | **비노출** ✅ |
| docker-compose 로컬 개발 | `True` | 노출 (개발 편의) |
| `.env`에 `DEBUG=True` 설정 시 | `True` | 노출 |

`main.py`의 `docs_url` 조건은 기존(`debug=True`일 때만)이므로 변경 없음.

## Test plan

- [x] pytest 517/517 PASS
- [x] `Settings()` 기본값 `debug=False` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)