### PR TITLE
feat(SEC-08): 보안 헤더 추가 — CSP + X-Frame-Options + HSTS

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,32 @@ import path from 'path';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
+const _CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  // GCS 파일, Google/GitHub 아바타 이미지
+  "img-src 'self' data: blob: https://storage.googleapis.com https://*.googleusercontent.com https://avatars.githubusercontent.com",
+  "font-src 'self' data:",
+  // API 호출 (self = Next.js rewrites 경유, googleapis = Cloud KMS/AI)
+  "connect-src 'self' https://*.googleapis.com",
+  "media-src 'self' blob:",
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  // OAuth 리다이렉트 대상
+  "form-action 'self' https://accounts.google.com https://github.com",
+].join('; ');
+
+const _SECURITY_HEADERS = [
+  { key: 'Content-Security-Policy', value: _CSP },
+  { key: 'X-Frame-Options', value: 'DENY' },
+  { key: 'X-Content-Type-Options', value: 'nosniff' },
+  { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+  { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+  { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
+];
+
 const nextConfig: NextConfig = {
   // Allow dev server access from non-localhost origins (e.g. Tailscale, LAN)
   // Set NEXT_DEV_ALLOWED_ORIGINS=host1,host2 in .env.local to enable
@@ -12,6 +38,14 @@ const nextConfig: NextConfig = {
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
   devIndicators: {
     position: 'bottom-right',
+  },
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: _SECURITY_HEADERS,
+      },
+    ];
   },
   async rewrites() {
     const fastapiUrl = process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000';


### PR DESCRIPTION
## Summary

`next.config.ts`의 `headers()` 함수에 보안 헤더 6종 추가.

## 추가된 헤더

| 헤더 | 값 |
|---|---|
| `Content-Security-Policy` | allowlist 기반 (하단 참조) |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=()` |
| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` |

## CSP allowlist

| 지시어 | 허용 출처 | 이유 |
|---|---|---|
| `script-src` | `'self' 'unsafe-inline' 'unsafe-eval'` | Next.js React hydration |
| `style-src` | `'self' 'unsafe-inline'` | Tailwind inline styles |
| `img-src` | `'self' data: blob: storage.googleapis.com *.googleusercontent.com avatars.githubusercontent.com` | GCS 파일, Google/GitHub 아바타 |
| `connect-src` | `'self' *.googleapis.com` | API + Cloud KMS/AI |
| `form-action` | `'self' accounts.google.com github.com` | OAuth 리다이렉트 |
| `frame-src` / `object-src` | `'none'` | 클릭재킹 방지 |

## Test plan

- [x] pnpm build 성공 (5/5 tasks)
- [x] `next/font/google`: Next.js self-hosted → CDN 요청 없음, CSP 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)