### PR TITLE
feat(projects): UI 새 프로젝트 모달 + project_memberships 자동 INSERT [R-4]

### DIFF
--- a/apps/web/src/app/api/projects/route.ts
+++ b/apps/web/src/app/api/projects/route.ts
@@ -1,5 +1,6 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess } from '@/lib/api-response';
+import { ApiErrors, apiSuccess } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
 import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 /** GET — 조직 프로젝트 목록 */
@@ -14,10 +15,21 @@ export async function GET(request: Request) {
   }
 }
 
-/** POST — 프로젝트 생성 */
+/** POST — 프로젝트 생성 (org_id는 auth context에서 자동 주입) */
 export async function POST(request: Request) {
   try {
-    const _r = await proxyToFastapi(request, '/api/v2/projects');
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+
+    const body = await request.json().catch(() => ({})) as Record<string, unknown>;
+    const enriched = { ...body, org_id: me.org_id };
+
+    const syntheticRequest = new Request(request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify(enriched),
+    });
+    const _r = await proxyToFastapi(syntheticRequest, '/api/v2/projects');
     if (!_r.ok) return _r;
     if (_r.status === 204) return apiSuccess({ ok: true });
     return apiSuccess(await _r.json());

--- a/apps/web/src/components/nav/project-switcher.tsx
+++ b/apps/web/src/components/nav/project-switcher.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Check, ChevronDown } from 'lucide-react';
+import { Check, ChevronDown, Plus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import {
   DropdownMenu,
@@ -11,9 +11,19 @@ import {
   DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { SidebarMenuButton } from '@/components/ui/sidebar';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
 
 interface ProjectSwitcherItem {
   projectId: string;
@@ -40,6 +50,33 @@ export function ProjectSwitcher({
   const router = useRouter();
   const t = useTranslations('shell');
   const [pending, setPending] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDesc, setNewDesc] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  async function createProject(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newName.trim() || creating) return;
+    setCreating(true);
+    try {
+      const res = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newName.trim(), description: newDesc.trim() || null }),
+      });
+      if (!res.ok) return;
+      const data = await res.json() as { id?: string; data?: { id: string } };
+      const newId = data.id ?? data.data?.id;
+      setDialogOpen(false);
+      setNewName('');
+      setNewDesc('');
+      if (newId) await switchProject(newId);
+      else router.refresh();
+    } finally {
+      setCreating(false);
+    }
+  }
 
   const currentProject = projects.find((p) => p.projectId === currentProjectId);
 
@@ -67,38 +104,88 @@ export function ProjectSwitcher({
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        disabled={pending}
-        render={
-          <SidebarMenuButton className={cn('w-full', className)}>
-            <ProjectInitial name={currentProject?.projectName ?? 'S'} />
-            <span className="flex-1 truncate font-medium">
-              {currentProject?.projectName ?? t('projectSelectPrompt')}
-            </span>
-            <ChevronDown className="size-3 text-muted-foreground" />
-          </SidebarMenuButton>
-        }
-      />
-      <DropdownMenuContent className="w-auto min-w-56" align="start" side="bottom" sideOffset={4}>
-        <DropdownMenuGroup>
-          <DropdownMenuLabel className="text-xs text-muted-foreground">
-            {t('projects')}
-          </DropdownMenuLabel>
-          {projects.map((project) => (
-            <DropdownMenuItem
-              key={project.projectId}
-              onClick={() => void switchProject(project.projectId)}
-            >
-              <ProjectInitial name={project.projectName} />
-              <span className="flex-1 truncate">{project.projectName}</span>
-              {project.projectId === currentProjectId && (
-                <Check className="h-3.5 w-3.5 text-primary" />
-              )}
-            </DropdownMenuItem>
-          ))}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          disabled={pending}
+          render={
+            <SidebarMenuButton className={cn('w-full', className)}>
+              <ProjectInitial name={currentProject?.projectName ?? 'S'} />
+              <span className="flex-1 truncate font-medium">
+                {currentProject?.projectName ?? t('projectSelectPrompt')}
+              </span>
+              <ChevronDown className="size-3 text-muted-foreground" />
+            </SidebarMenuButton>
+          }
+        />
+        <DropdownMenuContent className="w-auto min-w-56" align="start" side="bottom" sideOffset={4}>
+          <DropdownMenuGroup>
+            <DropdownMenuLabel className="text-xs text-muted-foreground">
+              {t('projects')}
+            </DropdownMenuLabel>
+            {projects.map((project) => (
+              <DropdownMenuItem
+                key={project.projectId}
+                onClick={() => void switchProject(project.projectId)}
+              >
+                <ProjectInitial name={project.projectName} />
+                <span className="flex-1 truncate">{project.projectName}</span>
+                {project.projectId === currentProjectId && (
+                  <Check className="h-3.5 w-3.5 text-primary" />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={() => setDialogOpen(true)}>
+            <Plus className="h-3.5 w-3.5" />
+            <span>새 프로젝트</span>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>새 프로젝트 만들기</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={(e) => void createProject(e)} className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-sm font-medium" htmlFor="proj-name">
+                프로젝트 이름 <span className="text-destructive">*</span>
+              </label>
+              <input
+                id="proj-name"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="예: 웹 리뉴얼"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                required
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1">
+              <label className="text-sm font-medium" htmlFor="proj-desc">
+                설명 <span className="text-muted-foreground text-xs">(선택)</span>
+              </label>
+              <textarea
+                id="proj-desc"
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                placeholder="프로젝트에 대한 간단한 설명"
+                rows={3}
+                value={newDesc}
+                onChange={(e) => setNewDesc(e.target.value)}
+              />
+            </div>
+            <DialogFooter>
+              <DialogClose render={<Button type="button" variant="ghost" disabled={creating}>취소</Button>} />
+              <Button type="submit" disabled={!newName.trim() || creating}>
+                {creating ? '생성 중…' : '만들기'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -43,6 +43,17 @@ async def create_project(
     repo = ProjectRepository(session, body.org_id)
     project = await repo.create(name=body.name, description=body.description)
 
+    # Auto-attach org-level team members (project_id IS NULL) to new project
+    await session.execute(
+        text(
+            "INSERT INTO project_memberships (project_id, team_member_id)"
+            " SELECT :project_id, id FROM team_members"
+            " WHERE org_id = :org_id AND project_id IS NULL AND is_active = TRUE"
+            " ON CONFLICT DO NOTHING"
+        ),
+        {"org_id": str(body.org_id), "project_id": str(project.id)},
+    )
+
     # OSS bootstrap: 프로젝트 생성 시 인증 유저 team_member 자동 생성
     # (Supabase trg_org_bootstrap_owner 대체 — project_id가 확정된 이 시점에 생성)
     if auth.user_id:
@@ -57,7 +68,8 @@ async def create_project(
             ),
             {"org_id": str(body.org_id), "project_id": str(project.id), "user_id": auth.user_id},
         )
-        await session.commit()
+
+    await session.commit()
 
     return ProjectResponse.model_validate(project)
 


### PR DESCRIPTION
## Summary

- `project-switcher.tsx`: 사이드바 드롭다운 하단 '새 프로젝트' 클릭 → Dialog 모달 (이름 필수, 설명 선택) → `POST /api/projects` → 생성 후 자동 프로젝트 전환
- `apps/web/src/app/api/projects/route.ts`: POST 시 `getAuthContext`에서 `org_id` 자동 주입 (UI가 org_id 알 필요 없음)
- `backend/app/routers/projects.py`: `create_project()` 완료 후 org-level team_members(`project_id IS NULL`) 전원 `project_memberships`에 auto-INSERT (`ON CONFLICT DO NOTHING`)

## Test plan

- [x] TypeScript `tsc --noEmit` exit 0
- [x] DB 시뮬레이션: 신규 프로젝트 → 5 rows project_memberships INSERT PASS
- [x] QA(까심) AC3 PASS — UI 모달 소스 검증
- [x] QA(까심) AC4 PASS — backend auto-INSERT 코드 검증
- [x] Test30Sec 프로젝트 실 생성 → 5 rows 확인

Resolves story: c99675cc-ce5c-44e8-bc63-d262c4086bca (R-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)