### PR TITLE
fix(SEC-09): CORS allow_methods/allow_headers 와일드카드 → 명시적 목록

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,8 +57,14 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=[o.strip() for o in settings.cors_origins.split(",") if o.strip()],
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=[
+        "Authorization",
+        "Content-Type",
+        "X-Org-Id",
+        "X-Project-Id",
+        "X-Request-ID",
+    ],
 )
 
 app.include_router(auth.router)


### PR DESCRIPTION
## Summary

`main.py` CORSMiddleware의 와일드카드(`*`) 설정을 실제 사용 목록으로 교체.

## 변경 내용

| 설정 | 기존 | 변경 후 |
|---|---|---|
| `allow_methods` | `["*"]` | `["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]` |
| `allow_headers` | `["*"]` | `["Authorization", "Content-Type", "X-Org-Id", "X-Project-Id", "X-Request-ID"]` |
| `allow_origins` | 기존 유지 | 변경 없음 |
| `allow_credentials` | 기존 유지 | 변경 없음 |

## 헤더 목록 근거

| 헤더 | 사용처 |
|---|---|
| `Authorization` | JWT/API Key 인증 |
| `Content-Type` | JSON request body |
| `X-Org-Id` | org 스코핑 (SEC-02 도입) |
| `X-Project-Id` | project 스코핑 (SEC-02 도입) |
| `X-Request-ID` | 요청 추적 |

## Test plan

- [x] pytest 517/517 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)