### PR TITLE
fix(SEC-10): 에러 응답 내부 정보 노출 제거

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from fastapi import FastAPI, HTTPException, Request
@@ -10,6 +11,7 @@ from app.core.logging_config import configure_logging
 from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
+_logger = logging.getLogger(__name__)
 from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
@@ -48,6 +50,17 @@ async def rate_limit_handler(request: Request, exc: RateLimitExceeded) -> JSONRe
     )
     resp.headers["Retry-After"] = retry_after
     return resp
+
+
+@app.exception_handler(Exception)
+async def unhandled_exception_handler(request: Request, exc: Exception) -> JSONResponse:
+    """예상치 못한 500 에러 — 내부 정보는 로그에만, 클라이언트엔 일반 메시지."""
+    _logger.exception("Unhandled exception on %s %s: %s", request.method, request.url.path, exc)
+    detail = str(exc) if settings.debug else "Internal server error"
+    return JSONResponse(
+        status_code=500,
+        content={"data": None, "error": {"code": "INTERNAL_ERROR", "message": detail}, "meta": None},
+    )
 
 
 app.state.limiter = limiter

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -4,11 +4,14 @@ All endpoints require CRON_SECRET via Authorization: Bearer header.
 """
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
+
+logger = logging.getLogger(__name__)
 from fastapi.responses import JSONResponse
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -77,7 +80,8 @@ async def agent_session_recovery(
             "resumed_count": 0,
         })
     except Exception as exc:
-        return _err("INTERNAL_ERROR", str(exc), 500)
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
 # ─── POST /api/v2/internal/cron/anonymize ─────────────────────────────────────
@@ -122,7 +126,8 @@ async def hitl_timeouts(
 
         return _ok({"expired_count": expired_count, "notified_count": 0})
     except Exception as exc:
-        return _err("INTERNAL_ERROR", str(exc), 500)
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)
 
 
 # ─── GET /api/v2/internal/cron/inbox-outbox ────────────────────────────────────
@@ -179,4 +184,5 @@ async def retry_agent_runs(
             "total": len(retried) + len(final_failures),
         })
     except Exception as exc:
-        return _err("INTERNAL_ERROR", str(exc), 500)
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)


### PR DESCRIPTION
## Summary

500 에러에서 `str(exc)` 직접 반환 제거 — 클라이언트는 일반 메시지, 서버 로그는 상세 기록.

## 변경 내용

**`cron.py`** — 3곳 수정
- `logger = logging.getLogger(__name__)` 추가
- `_err("INTERNAL_ERROR", str(exc), 500)` → `_err("INTERNAL_ERROR", "Internal server error", 500)` + `logger.exception()`

**`main.py`** — global Exception handler 추가
```python
@app.exception_handler(Exception)
async def unhandled_exception_handler(request, exc):
    _logger.exception("Unhandled exception on %s %s: %s", ...)
    detail = str(exc) if settings.debug else "Internal server error"
    return JSONResponse(500, {"error": {"code": "INTERNAL_ERROR", "message": detail}})
```
- `DEBUG=True`(로컬 개발)일 때만 상세 에러 노출 — prod(`DEBUG=False`)에서는 "Internal server error"만 반환
- SEC-07에서 `DEBUG` 기본값이 `False`로 변경됐으므로 prod 자동 보호

## 4xx 에러 처리

`sprints.py`, `stories.py`, `retros.py` 등의 `400/403`에서 `str(exc)` 사용은 **의도적 메시지**이므로 변경 없음.

## Test plan

- [x] pytest 517/517 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)