### PR TITLE
fix(SEC-11): Backend Dockerfile non-root 사용자(appuser) 설정

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,7 +16,13 @@ COPY alembic.ini .
 COPY alembic/ alembic/
 COPY bootstrap.py .
 
+# non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
+RUN useradd --create-home --shell /bin/bash appuser \
+    && chown -R appuser:appuser /app
+
 ENV PATH="/app/.venv/bin:$PATH"
+
+USER appuser
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary

`backend/Dockerfile`에 non-root 사용자(`appuser`) 추가.

## 변경 내용

```dockerfile
# non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
RUN useradd --create-home --shell /bin/bash appuser \
    && chown -R appuser:appuser /app

USER appuser
```

## 보안 효과

컨테이너 탈출 시 host root 권한 획득 방지. Cloud Run 환경에서 non-root 권장 준수.

## 권한 처리

- `uv sync` → root로 실행 → `/app/.venv` 생성 (root 소유)
- `chown -R appuser:appuser /app` → `.venv` 포함 전체 소유권 이전
- `USER appuser` 이후 `uvicorn` 실행 → non-root 보장

## Test plan

- [x] pytest 517/517 PASS
- [x] Cloud Run: non-root 지원 — 영향 없음
- [x] Alembic migration(`bootstrap.py`): DB 연결은 USER와 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)