### PR TITLE
P0 HOTFIX: require_admin owner role 허용 — prod 프로모션

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -232,7 +232,7 @@ def get_org_scope(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid org_id format")
 
 
-RoleType = Literal["admin", "member", "viewer"]
+RoleType = Literal["admin", "member", "viewer", "owner"]
 
 
 def require_role(*allowed_roles: RoleType):
@@ -249,9 +249,9 @@ def require_role(*allowed_roles: RoleType):
 
 
 def require_admin(auth: AuthContext = Depends(get_current_user)) -> AuthContext:
-    """admin role 전용 엔드포인트 가드."""
+    """admin 또는 owner role 전용 엔드포인트 가드."""
     role = auth.claims.get("app_metadata", {}).get("role", "member")
-    if role != "admin":
+    if role not in ("admin", "owner"):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Admin role required",

--- a/backend/app/routers/workflow_executions.py
+++ b/backend/app/routers/workflow_executions.py
@@ -113,7 +113,7 @@ async def list_executions(
     auth: AuthContext = Depends(get_current_user),
 ) -> ExecutionLogListResponse:
     role = auth.claims.get("app_metadata", {}).get("role", "member")
-    if role != "admin":
+    if role not in ("admin", "owner"):
         if member_id is None:
             raise HTTPException(status_code=403, detail="Admin role required, or provide member_id to query own executions")
         user_id_str = str(auth.user_id)


### PR DESCRIPTION
## Summary
- SEC-01 (PR #592) 배포 후 `require_admin` 가드가 owner role을 차단하는 P0 리그레션 수정
- PR #605 → develop 머지 완료, dev smoke 통과
- 선생님 계정(owner) prod 차단 중 — 즉시 프로모션 필요

## Changes (PR #605)
- `backend/app/dependencies/auth.py`: `require_admin` → `role not in ("admin", "owner")`
- `backend/app/routers/workflow_executions.py:116`: 인라인 체크 동일 수정
- 전수 grep 잔여 패턴 0건

## Test plan
- [x] dev CI + Cloud Build SUCCESS
- [x] dev Cloud Run 배포 완료 (02:24:35Z)
- [x] dev backend health 200 OK
- [ ] prod Cloud Build + Cloud Run 배포 확인
- [ ] prod smoke: owner 계정 403 해소 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)