### PR TITLE
fix(P0): _generate_key() 해시 대상 plaintext로 수정 — API Key 인증 불일치 해소

### DIFF
--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -14,8 +14,8 @@ from app.models.api_key import ApiKey
 def _generate_key() -> tuple[str, str, str]:
     raw = secrets.token_hex(32)
     prefix = f"sk_live_{raw[:8]}"
-    key_hash = hashlib.sha256(raw.encode()).hexdigest()
     plaintext = f"sk_live_{raw}"
+    key_hash = hashlib.sha256(plaintext.encode()).hexdigest()
     return plaintext, prefix, key_hash
 
 


### PR DESCRIPTION
## Summary
- `_generate_key()`에서 `key_hash`를 `raw`(sk_live_ 미포함)로 해시하고, 인증 경로(`_resolve_api_key`)는 `sk_live_` 포함 전체 토큰을 해시해 저장값 ≠ 조회값 불일치 발생
- `plaintext` 생성을 `key_hash` 계산보다 먼저 배치하여 해시 대상 통일

## Root Cause
```python
# Before (버그)
key_hash = hashlib.sha256(raw.encode()).hexdigest()   # "abc123..." 해시
plaintext = f"sk_live_{raw}"                           # "sk_live_abc123..." 저장

# 인증 시
key_hash = hash_token(raw_key)  # "sk_live_abc123..." 해시 → 불일치!

# After (수정)
plaintext = f"sk_live_{raw}"
key_hash = hashlib.sha256(plaintext.encode()).hexdigest()  # 동일 문자열 해시
```

## Changes
- `backend/app/repositories/api_key.py`: `plaintext` / `key_hash` 할당 순서 교환 (1줄)

## AC
- [x] 신규 발급 API Key로 즉시 인증 성공
- [x] 기존 발급 키는 rotate 후 정상화 (저장 해시 자체가 달라졌으므로 rotate 필요)

## Test plan
- [ ] 신규 API Key 발급 후 인증 엔드포인트 200 확인
- [ ] member role 키로 write 엔드포인트 403 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)