### PR TITLE
test: test_s35 해시 기댓값 plaintext 기준으로 수정 — CI 복구

### DIFF
--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -13,7 +13,7 @@ _RAW = "t" * 64  # dummy hex-like string for testing
 _PREFIX_MARKER = "sk" + "_" + "live" + "_"  # split to avoid secret scanner
 PLAINTEXT = _PREFIX_MARKER + _RAW
 KEY_PREFIX = _PREFIX_MARKER + _RAW[:8]
-KEY_HASH = hashlib.sha256(_RAW.encode()).hexdigest()
+KEY_HASH = hashlib.sha256(PLAINTEXT.encode()).hexdigest()
 
 
 def _mock_key(revoked: bool = False) -> MagicMock:
@@ -184,8 +184,7 @@ async def test_key_hash_is_sha256():
     assert plaintext.startswith(_marker)
     assert prefix.startswith(_marker)
     assert len(key_hash) == 64
-    raw = plaintext[len(_marker):]
-    assert hashlib.sha256(raw.encode()).hexdigest() == key_hash
+    assert hashlib.sha256(plaintext.encode()).hexdigest() == key_hash
     assert key_hash != plaintext
 
 


### PR DESCRIPTION
## Summary
- PR #607(`_generate_key()` 순서 수정) 머지 시 테스트 수정분이 누락되어 CI 실패 상태
- `test_s35.py` 2곳을 `plaintext` 기준 해시로 업데이트

## Changes
- `KEY_HASH = hashlib.sha256(PLAINTEXT.encode()).hexdigest()`
- `test_key_hash_is_sha256`: `raw` 경유 제거 → `plaintext.encode()` 직접 사용

🤖 Generated with [Claude Code](https://claude.com/claude-code)