### PR TITLE
promote: develop → main (P0 _generate_key hash fix)

### DIFF
--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -14,8 +14,8 @@ from app.models.api_key import ApiKey
 def _generate_key() -> tuple[str, str, str]:
     raw = secrets.token_hex(32)
     prefix = f"sk_live_{raw[:8]}"
-    key_hash = hashlib.sha256(raw.encode()).hexdigest()
     plaintext = f"sk_live_{raw}"
+    key_hash = hashlib.sha256(plaintext.encode()).hexdigest()
     return plaintext, prefix, key_hash
 
 

--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -13,7 +13,7 @@ _RAW = "t" * 64  # dummy hex-like string for testing
 _PREFIX_MARKER = "sk" + "_" + "live" + "_"  # split to avoid secret scanner
 PLAINTEXT = _PREFIX_MARKER + _RAW
 KEY_PREFIX = _PREFIX_MARKER + _RAW[:8]
-KEY_HASH = hashlib.sha256(_RAW.encode()).hexdigest()
+KEY_HASH = hashlib.sha256(PLAINTEXT.encode()).hexdigest()
 
 
 def _mock_key(revoked: bool = False) -> MagicMock:
@@ -184,8 +184,7 @@ async def test_key_hash_is_sha256():
     assert plaintext.startswith(_marker)
     assert prefix.startswith(_marker)
     assert len(key_hash) == 64
-    raw = plaintext[len(_marker):]
-    assert hashlib.sha256(raw.encode()).hexdigest() == key_hash
+    assert hashlib.sha256(plaintext.encode()).hexdigest() == key_hash
     assert key_hash != plaintext
 
 


### PR DESCRIPTION
## Summary
- fix(P0): `_generate_key()` 해시 대상 plaintext로 수정 (#607)
- test: `test_s35` 해시 기댓값 plaintext 기준으로 수정 — CI 복구 (#608)

## Impact
prod에서 새 API key 발급 시 해시 불일치 401 해소.