### PR TITLE
fix: 메모 생성 시 memo_assignees 미저장 → reply 웹훅 수신자 누락 수정

### DIFF
--- a/apps/web/src/app/api/memos/route.ts
+++ b/apps/web/src/app/api/memos/route.ts
@@ -37,11 +37,10 @@ export async function POST(request: Request) {
         return apiError('BAD_REQUEST', `memo_type '${body.memo_type}' requires at least one assignee`, 400);
       }
     }
-    const dbClient = undefined;
     const repo = await createMemoRepository();
     const teamMemberRepo = await createTeamMemberRepository();
     const projectRepo = await createProjectRepository();
-    const service = new MemoService(repo, dbClient, teamMemberRepo, projectRepo);
+    const service = new MemoService(repo, undefined, teamMemberRepo, projectRepo);
     const memo = await service.create({
       ...body,
       org_id: me.org_id,
@@ -78,9 +77,8 @@ export async function GET(request: Request) {
       limit: searchParams.get('limit') ? Number(searchParams.get('limit')) : undefined,
       cursor: searchParams.get('cursor'),
     }, { defaultLimit: 30, maxLimit: 100 });
-    const dbClient = undefined;
     const repo = await createMemoRepository();
-    const service = new MemoService(repo, dbClient);
+    const service = new MemoService(repo);
     const sentOnly = searchParams.get('sent') === 'true';
     const memos = await service.list({
       org_id: me.org_id,

--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -416,6 +416,7 @@ export class MemoService {
       content: input.content.trim(),
       memo_type: input.memo_type ?? 'memo',
       assigned_to: assigneeIds[0] ?? null,
+      assigned_to_ids: assigneeIds.length > 0 ? assigneeIds : undefined,
       supersedes_id: input.supersedes_id ?? null,
       created_by: input.created_by,
       metadata: input.metadata ?? {},

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -138,6 +138,14 @@ async def create_memo(
         supersedes_id=body.supersedes_id,
         memo_metadata=body.memo_metadata,
     )
+    if body.assigned_to_ids:
+        for member_id in body.assigned_to_ids:
+            session.add(MemoAssignee(
+                memo_id=memo.id,
+                member_id=member_id,
+                assigned_by=body.created_by,
+            ))
+        await session.flush()
     if body.embeds:
         await repo.create_entity_links(memo.id, body.embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -31,6 +31,7 @@ class CreateMemo(BaseModel):
     memo_type: str = "memo"
     title: str | None = None
     assigned_to: uuid.UUID | None = None
+    assigned_to_ids: list[uuid.UUID] | None = None
     created_by: uuid.UUID | None = None
     supersedes_id: uuid.UUID | None = None
     memo_metadata: dict[str, Any] = {}

--- a/packages/core-storage/src/interfaces/IMemoRepository.ts
+++ b/packages/core-storage/src/interfaces/IMemoRepository.ts
@@ -27,6 +27,7 @@ export interface CreateMemoInput {
   content: string;
   memo_type?: string;
   assigned_to?: string | null;
+  assigned_to_ids?: string[];
   supersedes_id?: string | null;
   created_by: string;
   metadata?: Record<string, unknown>;


### PR DESCRIPTION
## Summary
- 메모 생성 시 `memo_assignees` 테이블에 수신자가 저장되지 않아 reply 웹훅 발송 대상 누락
- `MemoService.create()`가 `this.db`(Supabase) 경로로만 insert했는데, OSS에서 `dbClient = undefined`라 항상 스킵됨
- FastAPI 백엔드에서 `assigned_to_ids` → `MemoAssignee` insert를 처리하도록 수정

## Root Cause
```
route.ts → MemoService.create() → this.repo.create(body 에 assigned_to_ids 미포함)
                                 → if (this.db) ... ← dbClient=undefined이므로 스킵
FastAPI create_memo: assigned_to_ids 수신하지만 memo_assignees insert 없음
```

## Changes
- `packages/core-storage/src/interfaces/IMemoRepository.ts`: `CreateMemoInput`에 `assigned_to_ids?` 추가
- `apps/web/src/services/memo.ts`: `repo.create()` 호출 시 `assigned_to_ids` 포함
- `backend/app/routers/memos.py`: `assigned_to_ids` → `MemoAssignee` insert 추가
- `apps/web/src/app/api/memos/route.ts`: `dbClient = undefined` 라인 제거 (POST/GET 양쪽)

## AC
- [ ] 메모 생성(assigned_to_ids 포함) 후 `memo_assignees` 테이블 레코드 존재 확인
- [ ] reply 발송 시 assigned 수신자에게 웹훅 도달 확인
- [ ] `assigned_to_ids` 없이 생성 시 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)