### PR TITLE
feat: POST /api/v2/workflow/report-done — 에이전트 완료 보고 + 다음 단계 자동 트리거

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -127,6 +127,7 @@ app.include_router(workflow_versions.router)
 app.include_router(workflow_trigger_types.router)
 app.include_router(workflow_executions.router)
 app.include_router(workflow_templates.router)
+app.include_router(workflow_report.router)
 app.include_router(workflow_trigger.router)
 app.include_router(mockups.router)
 

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -1,4 +1,5 @@
 """POST /api/v2/workflow/report-done — 에이전트 작업 완료 보고 + 다음 단계 자동 트리거."""
+import json
 import uuid
 from typing import Any
 
@@ -35,7 +36,7 @@ _TRANSITIONS: dict[str, dict[str, Any]] = {
         "memo_type": "task",
         "memo_title_prefix": "[REVIEW 요청]",
         "memo_content": "개발 완료. PR 리뷰 요청드리는.",
-        "story_status": None,
+        "story_status": "in-review",
     },
     "review": {
         "next_stage": "qa",
@@ -65,7 +66,7 @@ _TRANSITIONS: dict[str, dict[str, Any]] = {
 
 # role → member_id (하드코딩)
 _ROLE_TO_MEMBER: dict[str, uuid.UUID] = {
-    "po": uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1"),
+    "po": uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406"),
     "dev": uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52"),
     "qa": uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad"),
 }
@@ -130,7 +131,7 @@ async def report_done(
         title = f"{transition['memo_title_prefix']} {story_title}"
         content_parts = [transition["memo_content"]]
         if body.context:
-            content_parts.append(f"\n\n**Context:**\n{body.context}")
+            content_parts.append(f"\n\n**Context:**\n{json.dumps(body.context, indent=2, ensure_ascii=False)}")
 
         memo_repo = MemoRepository(session, story.org_id)
         memo = await memo_repo.create(

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -1,0 +1,158 @@
+"""POST /api/v2/workflow/report-done — 에이전트 작업 완료 보고 + 다음 단계 자동 트리거."""
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.memo import MemoAssignee
+from app.models.pm import Story
+from app.repositories.memo import MemoRepository
+from app.repositories.story import StoryRepository
+
+router = APIRouter(prefix="/api/v2/workflow", tags=["workflow"])
+
+# ─── 파이프라인 정의 (하드코딩) ───────────────────────────────────────────────
+
+_VALID_STAGES = ("kickoff", "dev", "review", "qa", "merge")
+
+_TRANSITIONS: dict[str, dict[str, Any]] = {
+    "kickoff": {
+        "next_stage": "dev",
+        "next_role": "dev",
+        "memo_type": "task",
+        "memo_title_prefix": "[DEV 킥오프]",
+        "memo_content": "DEV 착수 요청인. story.description 확인 후 즉시 착수 바라는.",
+        "story_status": "in-progress",
+    },
+    "dev": {
+        "next_stage": "review",
+        "next_role": "po",
+        "memo_type": "task",
+        "memo_title_prefix": "[REVIEW 요청]",
+        "memo_content": "개발 완료. PR 리뷰 요청드리는.",
+        "story_status": None,
+    },
+    "review": {
+        "next_stage": "qa",
+        "next_role": "qa",
+        "memo_type": "task",
+        "memo_title_prefix": "[QA 킥오프]",
+        "memo_content": "PO 리뷰 LGTM. QA 검수 요청드리는.",
+        "story_status": None,
+    },
+    "qa": {
+        "next_stage": "merge",
+        "next_role": "po",
+        "memo_type": "task",
+        "memo_title_prefix": "[MERGE 요청]",
+        "memo_content": "QA APPROVE. 머지 요청드리는.",
+        "story_status": None,
+    },
+    "merge": {
+        "next_stage": "done",
+        "next_role": None,
+        "memo_type": None,
+        "memo_title_prefix": None,
+        "memo_content": None,
+        "story_status": "done",
+    },
+}
+
+# role → member_id (하드코딩)
+_ROLE_TO_MEMBER: dict[str, uuid.UUID] = {
+    "po": uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1"),
+    "dev": uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52"),
+    "qa": uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad"),
+}
+
+# ─── Schema ──────────────────────────────────────────────────────────────────
+
+class ReportDoneRequest(BaseModel):
+    story_id: uuid.UUID
+    stage: str
+    agent_id: uuid.UUID
+    context: dict[str, Any] | None = None
+
+
+class ReportDoneResponse(BaseModel):
+    story_id: uuid.UUID
+    completed_stage: str
+    next_stage: str
+    memo_id: uuid.UUID | None = None
+    story_status: str | None = None
+
+# ─── Endpoint ─────────────────────────────────────────────────────────────────
+
+@router.post("/report-done", response_model=ReportDoneResponse, status_code=200)
+async def report_done(
+    body: ReportDoneRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> ReportDoneResponse:
+    if body.stage not in _VALID_STAGES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid stage '{body.stage}'. Valid: {list(_VALID_STAGES)}",
+        )
+
+    # 스토리 조회
+    result = await session.execute(select(Story).where(Story.id == body.story_id))
+    story = result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Story not found")
+
+    transition = _TRANSITIONS[body.stage]
+    next_stage: str = transition["next_stage"]
+    next_role: str | None = transition["next_role"]
+    story_status: str | None = transition["story_status"]
+
+    # 스토리 상태 업데이트
+    if story_status:
+        story_repo = StoryRepository(session, story.org_id)
+        await story_repo.update(story.id, status=story_status)
+
+    # 메모 발송
+    memo_id: uuid.UUID | None = None
+    if next_role and transition["memo_type"]:
+        next_member_id = _ROLE_TO_MEMBER.get(next_role)
+        if next_member_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=f"No member mapping for role '{next_role}'",
+            )
+
+        story_title = story.title or str(story.id)
+        title = f"{transition['memo_title_prefix']} {story_title}"
+        content_parts = [transition["memo_content"]]
+        if body.context:
+            content_parts.append(f"\n\n**Context:**\n{body.context}")
+
+        memo_repo = MemoRepository(session, story.org_id)
+        memo = await memo_repo.create(
+            project_id=story.project_id,
+            content="\n".join(content_parts),
+            memo_type=transition["memo_type"],
+            title=title,
+            assigned_to=next_member_id,
+            created_by=body.agent_id,
+        )
+        session.add(MemoAssignee(
+            memo_id=memo.id,
+            member_id=next_member_id,
+            assigned_by=body.agent_id,
+        ))
+        await session.flush()
+        memo_id = memo.id
+
+    return ReportDoneResponse(
+        story_id=body.story_id,
+        completed_stage=body.stage,
+        next_stage=next_stage,
+        memo_id=memo_id,
+        story_status=story_status,
+    )

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -12,7 +12,7 @@ STORY_ID = uuid.uuid4()
 AGENT_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
 MEMO_ID = uuid.uuid4()
 
-_PO_ID = uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
+_PO_ID = uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406")
 _DEV_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
 _QA_ID = uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
 
@@ -162,7 +162,7 @@ async def test_dev_to_review():
         data = resp.json()
         assert data["completed_stage"] == "dev"
         assert data["next_stage"] == "review"
-        assert data["story_status"] is None
+        assert data["story_status"] == "in-review"
         assert data["memo_id"] is not None
     finally:
         app.dependency_overrides.clear()
@@ -259,7 +259,7 @@ async def test_next_assignee_mapping():
     """각 stage별 next_role이 올바른 member_id에 매핑된다."""
     from app.routers.workflow_report import _ROLE_TO_MEMBER, _TRANSITIONS
 
-    assert _ROLE_TO_MEMBER["po"] == uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
+    assert _ROLE_TO_MEMBER["po"] == uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406")
     assert _ROLE_TO_MEMBER["dev"] == uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
     assert _ROLE_TO_MEMBER["qa"] == uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
     assert _TRANSITIONS["kickoff"]["next_role"] == "dev"

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -230,9 +230,9 @@ async def test_all_valid_stages():
     """모든 유효 stage가 400 없이 처리된다."""
     from app.routers.workflow_report import _VALID_STAGES
 
-    client, session, app = await _client()
-    try:
-        for stage in _VALID_STAGES:
+    for stage in _VALID_STAGES:
+        client, session, app = await _client()
+        try:
             story = _mock_story()
             mock_result = MagicMock()
             mock_result.scalar_one_or_none.return_value = story
@@ -250,8 +250,8 @@ async def test_all_valid_stages():
                     })
 
             assert resp.status_code == 200, f"stage={stage} → {resp.status_code}"
-    finally:
-        app.dependency_overrides.clear()
+        finally:
+            app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -1,0 +1,288 @@
+"""report-done API 단위 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+AGENT_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
+MEMO_ID = uuid.uuid4()
+
+_PO_ID = uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
+_DEV_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
+_QA_ID = uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
+
+
+def _mock_story(status: str = "in-progress") -> MagicMock:
+    s = MagicMock()
+    s.id = STORY_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.title = "테스트 스토리"
+    s.status = status
+    return s
+
+
+def _mock_memo() -> MagicMock:
+    m = MagicMock()
+    m.id = MEMO_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    return m
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(AGENT_ID)
+    ctx.email = "agent@test.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    ctx.org_id = str(ORG_ID)
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_invalid_stage_400():
+    """유효하지 않은 stage는 400 반환."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(STORY_ID),
+                "stage": "invalid_stage",
+                "agent_id": str(AGENT_ID),
+            })
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_story_not_found_404():
+    """존재하지 않는 story_id는 404 반환."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.post("/api/v2/workflow/report-done", json={
+                "story_id": str(uuid.uuid4()),
+                "stage": "kickoff",
+                "agent_id": str(AGENT_ID),
+            })
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_kickoff_to_dev():
+    """kickoff 완료 → DEV 킥오프 메모 발송 + 스토리 in-progress 전환."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(status="ready-for-dev")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = story
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update,
+            patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create,
+        ):
+            mock_update.return_value = story
+            mock_create.return_value = _mock_memo()
+
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json={
+                    "story_id": str(STORY_ID),
+                    "stage": "kickoff",
+                    "agent_id": str(AGENT_ID),
+                })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["completed_stage"] == "kickoff"
+        assert data["next_stage"] == "dev"
+        assert data["story_status"] == "in-progress"
+        assert data["memo_id"] is not None
+        mock_update.assert_called_once()
+        mock_create.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dev_to_review():
+    """dev 완료 → PO 리뷰 메모 발송, 스토리 상태 변경 없음."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(status="in-progress")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = story
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_memo()
+
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json={
+                    "story_id": str(STORY_ID),
+                    "stage": "dev",
+                    "agent_id": str(AGENT_ID),
+                })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["completed_stage"] == "dev"
+        assert data["next_stage"] == "review"
+        assert data["story_status"] is None
+        assert data["memo_id"] is not None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_merge_to_done():
+    """merge 완료 → 스토리 done 전환, 메모 없음."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(status="in-review")
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = story
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json={
+                    "story_id": str(STORY_ID),
+                    "stage": "merge",
+                    "agent_id": str(AGENT_ID),
+                })
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["completed_stage"] == "merge"
+        assert data["next_stage"] == "done"
+        assert data["story_status"] == "done"
+        assert data["memo_id"] is None
+        mock_update.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_context_field_accepted():
+    """context 필드를 포함한 요청이 정상 처리된다."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = story
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = _mock_memo()
+
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json={
+                    "story_id": str(STORY_ID),
+                    "stage": "dev",
+                    "agent_id": str(AGENT_ID),
+                    "context": {"pr_url": "https://github.com/moonklabs/sprintable/pull/999"},
+                })
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_all_valid_stages():
+    """모든 유효 stage가 400 없이 처리된다."""
+    from app.routers.workflow_report import _VALID_STAGES
+
+    client, session, app = await _client()
+    try:
+        for stage in _VALID_STAGES:
+            story = _mock_story()
+            mock_result = MagicMock()
+            mock_result.scalar_one_or_none.return_value = story
+            session.execute = AsyncMock(return_value=mock_result)
+
+            with (
+                patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock, return_value=story),
+                patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock, return_value=_mock_memo()),
+            ):
+                async with client as c:
+                    resp = await c.post("/api/v2/workflow/report-done", json={
+                        "story_id": str(STORY_ID),
+                        "stage": stage,
+                        "agent_id": str(AGENT_ID),
+                    })
+
+            assert resp.status_code == 200, f"stage={stage} → {resp.status_code}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_next_assignee_mapping():
+    """각 stage별 next_role이 올바른 member_id에 매핑된다."""
+    from app.routers.workflow_report import _ROLE_TO_MEMBER, _TRANSITIONS
+
+    assert _ROLE_TO_MEMBER["po"] == uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
+    assert _ROLE_TO_MEMBER["dev"] == uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
+    assert _ROLE_TO_MEMBER["qa"] == uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
+    assert _TRANSITIONS["kickoff"]["next_role"] == "dev"
+    assert _TRANSITIONS["dev"]["next_role"] == "po"
+    assert _TRANSITIONS["review"]["next_role"] == "qa"
+    assert _TRANSITIONS["qa"]["next_role"] == "po"
+    assert _TRANSITIONS["merge"]["next_role"] is None
+
+
+@pytest.mark.anyio
+async def test_pipeline_sequence():
+    """kickoff→dev→review→qa→merge→done 순서가 올바르다."""
+    from app.routers.workflow_report import _TRANSITIONS, _VALID_STAGES
+
+    stage = "kickoff"
+    visited = [stage]
+    while True:
+        t = _TRANSITIONS.get(stage)
+        if t is None:
+            break
+        stage = t["next_stage"]
+        visited.append(stage)
+        if stage == "done":
+            break
+
+    assert visited == ["kickoff", "dev", "review", "qa", "merge", "done"]


### PR DESCRIPTION
## Summary
에이전트가 `report_done`을 호출하면 파이프라인 엔진이 다음 단계를 자동 트리거. PO 수동 `reply_memo` + `update_story_status` 호출 제거.

## 파이프라인
```
kickoff → dev → review → qa → merge → done
```

## 구현
- `POST /api/v2/workflow/report-done` 신규 엔드포인트
- Request: `{ story_id, stage, agent_id, context? }`
- stage별 전이: 메모 자동 발송 + 스토리 상태 업데이트
- role→member_id 하드코딩 (PO/DEV/QA)
- pytest 9건 추가

## 단계별 동작
| stage | next | 메모 대상 | 스토리 상태 |
|---|---|---|---|
| kickoff | dev | DEV | in-progress |
| dev | review | PO | 유지 |
| review | qa | QA | 유지 |
| qa | merge | PO | 유지 |
| merge | done | — | done |

## AC
- [x] POST /api/v2/workflow/report-done 엔드포인트 응답
- [x] 유효하지 않은 stage → 400
- [x] 존재하지 않는 story_id → 404
- [x] kickoff → dev: 스토리 in-progress + DEV 메모
- [x] merge → done: 스토리 done + 메모 없음
- [x] context 필드 선택적 수용
- [x] 모든 유효 stage 200 처리
- [x] role→member_id 매핑 정확성
- [x] 파이프라인 순서 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)