### PR TITLE
fix: report_done PO member_id 05f52181 복원

### DIFF
--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -69,7 +69,7 @@ _TRANSITIONS: dict[str, dict[str, Any]] = {
 
 # role → member_id (하드코딩)
 _ROLE_TO_MEMBER: dict[str, uuid.UUID] = {
-    "po": uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406"),
+    "po": uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1"),
     "dev": uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52"),
     "qa": uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad"),
 }

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -12,7 +12,7 @@ STORY_ID = uuid.uuid4()
 AGENT_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
 MEMO_ID = uuid.uuid4()
 
-_PO_ID = uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406")
+_PO_ID = uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
 _DEV_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
 _QA_ID = uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
 
@@ -259,7 +259,7 @@ async def test_next_assignee_mapping():
     """각 stage별 next_role이 올바른 member_id에 매핑된다."""
     from app.routers.workflow_report import _ROLE_TO_MEMBER, _TRANSITIONS
 
-    assert _ROLE_TO_MEMBER["po"] == uuid.UUID("cff9055b-c671-4401-8436-a17f804a0406")
+    assert _ROLE_TO_MEMBER["po"] == uuid.UUID("05f52181-ea2a-42be-b9a8-9a418b72feb1")
     assert _ROLE_TO_MEMBER["dev"] == uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
     assert _ROLE_TO_MEMBER["qa"] == uuid.UUID("685f3f72-c85c-4a32-898f-3d3320ba39ad")
     assert _TRANSITIONS["kickoff"]["next_role"] == "dev"


### PR DESCRIPTION
## Summary
- PO member_id를 `cff9055b`(미존재 ID)에서 `05f52181`(team_members 실제 ID)로 복원
- 이전 PO 리뷰에서 잘못된 지적으로 변경된 값 원복

## Root Cause
team_members 테이블의 PO ID(`05f52181`)와 CLAUDE.md agent ID(`cff9055b`)가 다름.
PO 리뷰에서 CLAUDE.md 기준으로 잘못 지적하여 team_members에 없는 ID로 변경됨.
결과: 메모 assigned_to 불일치 + webhook_url 조회 실패 → Discord 웹훅 미발송.

🤖 Generated with [Claude Code](https://claude.com/claude-code)