### PR TITLE
fix(AUTH-03): 초대 생성/삭제/재발송 require_admin 가드 추가

### DIFF
--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -37,6 +37,7 @@ async def list_invitations(
 async def create_invitation(
     body: CreateInvitation,
     repo: InvitationRepository = Depends(_get_repo),
+    _: None = Depends(require_admin),
 ) -> InvitationResponse:
     inv = await repo.create(
         email=body.email,
@@ -51,6 +52,7 @@ async def create_invitation(
 async def revoke_invitation(
     id: uuid.UUID,
     repo: InvitationRepository = Depends(_get_repo),
+    _: None = Depends(require_admin),
 ) -> InvitationResponse:
     inv = await repo.revoke(id)
     if inv is None:
@@ -62,6 +64,7 @@ async def revoke_invitation(
 async def resend_invitation(
     id: uuid.UUID,
     repo: InvitationRepository = Depends(_get_repo),
+    _: None = Depends(require_admin),
 ) -> InvitationResponse:
     inv = await repo.resend(id)
     if inv is None:


### PR DESCRIPTION
## Summary
POST /invitations, DELETE /invitations/{id}, POST /invitations/{id}/resend에 `require_admin` 미적용으로 일반 member가 org 초대 가능한 취약점 수정.

## Changes
`backend/app/routers/invitations.py` — 3개 엔드포인트에 `_: None = Depends(require_admin)` 추가

| 엔드포인트 | 변경 전 | 변경 후 |
|---|---|---|
| POST /invitations | 인증 없음 | admin/owner 전용 |
| DELETE /invitations/{id} | 인증 없음 | admin/owner 전용 |
| POST /invitations/{id}/resend | 인증 없음 | admin/owner 전용 |
| GET /invitations | admin/owner (유지) | — |
| POST /invitations/accept | 공개 (유지) | — |

## AC
- [x] POST /invitations — member → 403
- [x] DELETE /invitations/{id} — member → 403
- [x] POST /invitations/{id}/resend — member → 403
- [x] GET /invitations 기존 admin 체크 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)