### PR TITLE
fix(AUTH-06): 계정 삭제 시 JWT user_id만 사용 — 타인 삭제 차단

### DIFF
--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -14,13 +14,12 @@ router = APIRouter(prefix="/api/v2/account", tags=["account"])
 
 @router.post("/delete", response_model=AccountDeleteResponse)
 async def delete_account(
-    user_id: uuid.UUID | None = None,
     org_id: uuid.UUID = Depends(get_verified_org_id),
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> AccountDeleteResponse:
     now = datetime.now(timezone.utc).isoformat()
-    uid = user_id or auth.user_id
+    uid = auth.user_id
 
     await session.execute(
         text("UPDATE org_members SET deleted_at = :now WHERE user_id = :uid::uuid"),


### PR DESCRIPTION
## Summary
`DELETE /api/v2/account/delete`에서 `user_id` 쿼리 파라미터를 통해 타인 계정을 soft-delete 가능한 취약점 수정.

## Root Cause
```python
# Before (취약)
uid = user_id or auth.user_id  # 쿼리 파라미터로 타인 ID 주입 가능

# After (수정)
uid = auth.user_id  # JWT에서만 추출
```

## Changes
- `user_id: uuid.UUID | None = None` 파라미터 제거
- `uid = auth.user_id` 고정

## AC
- [x] 쿼리 파라미터 user_id 제거 — 타인 ID 주입 불가
- [x] JWT user_id 기반 본인 계정만 삭제
- [x] 인증 없는 요청 → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)