### PR TITLE
feat(AUTH-01): 비밀번호 복잡성 규칙 추가 — 백엔드 validator + 프론트 실시간 피드백

### DIFF
--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -5,15 +5,38 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { SprintableLogo } from '@/components/brand/sprintable-logo';
 
+function checkPasswordRules(pw: string) {
+  return {
+    length: pw.length >= 8,
+    upper: /[A-Z]/.test(pw),
+    lower: /[a-z]/.test(pw),
+    digit: /\d/.test(pw),
+    special: /[^A-Za-z0-9]/.test(pw),
+  };
+}
+
+function countCategories(rules: ReturnType<typeof checkPasswordRules>) {
+  return [rules.upper, rules.lower, rules.digit, rules.special].filter(Boolean).length;
+}
+
 export default function RegisterPage() {
   const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [passwordTouched, setPasswordTouched] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
+  const rules = checkPasswordRules(password);
+  const categoriesMet = countCategories(rules);
+  const isPasswordValid = rules.length && categoriesMet >= 3;
+
   const handleRegister = async () => {
     if (!email.trim() || !password.trim()) return;
+    if (!isPasswordValid) {
+      setPasswordTouched(true);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -27,7 +50,6 @@ export default function RegisterPage() {
         setError(json.error?.message ?? 'Registration failed. Please try again.');
         return;
       }
-      // Invited users already have org context from JWT; direct signups need onboarding.
       const meRes = await fetch('/api/me');
       const meJson = await meRes.json() as { data?: { org_id?: string } };
       router.push(meJson.data?.org_id ? '/inbox' : '/onboarding');
@@ -38,6 +60,8 @@ export default function RegisterPage() {
       setLoading(false);
     }
   };
+
+  const showRules = passwordTouched && password.length > 0;
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-50">
@@ -67,12 +91,23 @@ export default function RegisterPage() {
             type="password"
             placeholder="Password"
             autoComplete="new-password"
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            className={`w-full rounded-lg border px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              showRules && !isPasswordValid ? 'border-red-400' : 'border-gray-300'
+            }`}
             value={password}
-            onChange={(e) => setPassword(e.target.value)}
+            onChange={(e) => { setPassword(e.target.value); setPasswordTouched(true); }}
             onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
             disabled={loading}
           />
+          {showRules && (
+            <ul className="space-y-1 text-xs">
+              <RuleItem met={rules.length} label="At least 8 characters" />
+              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-green-600' : 'text-gray-400'}`}>
+                <span>{categoriesMet >= 3 ? '✓' : '○'}</span>
+                <span>At least 3 of: uppercase, lowercase, digit, special character ({categoriesMet}/3)</span>
+              </li>
+            </ul>
+          )}
           {error && <p className="text-sm text-red-600">{error}</p>}
           <button
             onClick={handleRegister}
@@ -91,5 +126,14 @@ export default function RegisterPage() {
         </p>
       </div>
     </div>
+  );
+}
+
+function RuleItem({ met, label }: { met: boolean; label: string }) {
+  return (
+    <li className={`flex items-center gap-1.5 ${met ? 'text-green-600' : 'text-gray-400'}`}>
+      <span>{met ? '✓' : '○'}</span>
+      <span>{label}</span>
+    </li>
   );
 }

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -8,7 +8,9 @@ from urllib.parse import urlencode
 import httpx
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+import re
+
+from pydantic import BaseModel, field_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -64,6 +66,23 @@ class LoginRequest(BaseModel):
 class RegisterRequest(BaseModel):
     email: str
     password: str
+
+    @field_validator("password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        categories = [
+            bool(re.search(r"[A-Z]", v)),
+            bool(re.search(r"[a-z]", v)),
+            bool(re.search(r"\d", v)),
+            bool(re.search(r"[^A-Za-z0-9]", v)),
+        ]
+        if sum(categories) < 3:
+            raise ValueError(
+                "Password must include at least 3 of: uppercase letters, lowercase letters, digits, special characters"
+            )
+        return v
 
 
 class RefreshRequest(BaseModel):

--- a/backend/tests/test_auth_password_validation.py
+++ b/backend/tests/test_auth_password_validation.py
@@ -1,0 +1,66 @@
+"""AUTH-01: RegisterRequest 비밀번호 검증 규칙 테스트."""
+import pytest
+from pydantic import ValidationError
+
+from app.routers.auth import RegisterRequest
+
+
+def _make(password: str) -> RegisterRequest:
+    return RegisterRequest(email="test@example.com", password=password)
+
+
+def test_valid_password_upper_lower_digit():
+    """대문자+소문자+숫자 3조합 — 통과."""
+    r = _make("Abcdef12")
+    assert r.password == "Abcdef12"
+
+
+def test_valid_password_upper_lower_special():
+    """대문자+소문자+특수문자 3조합 — 통과."""
+    r = _make("Abcdef!@")
+    assert r.password == "Abcdef!@"
+
+
+def test_valid_password_all_four():
+    """4가지 전부 — 통과."""
+    r = _make("Abcde1!!")
+    assert r.password == "Abcde1!!"
+
+
+def test_too_short_rejects():
+    """7자 이하 — 422."""
+    with pytest.raises(ValidationError) as exc_info:
+        _make("Ab1!xyz")
+    assert "8 characters" in str(exc_info.value)
+
+
+def test_only_two_categories_rejects():
+    """소문자+숫자 2조합만 — 422."""
+    with pytest.raises(ValidationError) as exc_info:
+        _make("abcde123")
+    assert "3 of" in str(exc_info.value)
+
+
+def test_only_lowercase_rejects():
+    """소문자만 — 422."""
+    with pytest.raises(ValidationError):
+        _make("abcdefgh")
+
+
+def test_only_uppercase_rejects():
+    """대문자만 — 422."""
+    with pytest.raises(ValidationError):
+        _make("ABCDEFGH")
+
+
+def test_single_char_rejects():
+    """단일 문자 — 422."""
+    with pytest.raises(ValidationError):
+        _make("a")
+
+
+def test_login_not_affected():
+    """LoginRequest는 validator 없음 — 약한 비밀번호도 객체 생성 가능."""
+    from app.routers.auth import LoginRequest
+    req = LoginRequest(email="u@example.com", password="weak")
+    assert req.password == "weak"

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -228,7 +228,7 @@ async def test_register_new_user_201():
         session.execute = AsyncMock(return_value=result_none)
         with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
             async with client as c:
-                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "pass123"})
+                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "TestPass1!"})
         assert resp.status_code == 201
         body = resp.json()
         assert body["error"] is None
@@ -247,7 +247,7 @@ async def test_register_duplicate_email_409():
         result_existing.scalar_one_or_none.return_value = _make_user()
         session.execute = AsyncMock(return_value=result_existing)
         async with client as c:
-            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "pass"})
+            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "TestPass1!"})
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "EMAIL_TAKEN"
     finally:


### PR DESCRIPTION
## Summary
`RegisterRequest.password`에 최소 길이 + 복잡성 규칙 추가. 프론트엔드 실시간 validation 피드백 추가.

## Changes

### Backend (`auth.py`)
- `RegisterRequest`에 `@field_validator("password")` 추가
- 8자 이상 필수
- 대문자/소문자/숫자/특수문자 중 3가지 이상 조합 필수
- 미충족 시 422 + 명확한 에러 메시지

### Frontend (`register/page.tsx`)
- 비밀번호 입력 시 실시간 규칙 충족 여부 표시 (✓/○)
- 제출 전 클라이언트 validation
- `LoginRequest` 미영향 — 기존 약한 비밀번호 로그인 유지

### Tests
- `test_auth_password_validation.py` 9건 추가

## AC
- [x] 8자 미만 → 422
- [x] 2가지 조합만 → 422
- [x] 3가지 이상 조합 → 통과
- [x] LoginRequest 미영향
- [x] 프론트 실시간 피드백

🤖 Generated with [Claude Code](https://claude.com/claude-code)