### PR TITLE
feat(AUTH-02): email validation + lowercase 정규화 — Register/Login/Invitation

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -11,6 +11,15 @@ from fastapi.responses import JSONResponse
 import re
 
 from pydantic import BaseModel, field_validator
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
+
+
+def _normalize_email(v: str) -> str:
+    v = v.strip().lower()
+    if not _EMAIL_RE.match(v):
+        raise ValueError("Invalid email format")
+    return v
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -62,10 +71,20 @@ class LoginRequest(BaseModel):
     password: str
     totp_code: str | None = None
 
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return _normalize_email(v)
+
 
 class RegisterRequest(BaseModel):
     email: str
     password: str
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return _normalize_email(v)
 
     @field_validator("password")
     @classmethod

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import re
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_EMAIL_RE = re.compile(r"^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$")
 
 
 class CreateInvitation(BaseModel):
@@ -11,6 +14,14 @@ class CreateInvitation(BaseModel):
     role: str = "member"
     invited_by: uuid.UUID
     project_id: uuid.UUID | None = None
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        v = v.strip().lower()
+        if not _EMAIL_RE.match(v):
+            raise ValueError("Invalid email format")
+        return v
 
 
 class InvitationResponse(BaseModel):

--- a/backend/tests/test_auth_email_validation.py
+++ b/backend/tests/test_auth_email_validation.py
@@ -1,0 +1,66 @@
+"""AUTH-02: Email validation + 대소문자 정규화 테스트."""
+import pytest
+from pydantic import ValidationError
+
+from app.routers.auth import LoginRequest, RegisterRequest
+from app.schemas.invitation import CreateInvitation
+import uuid
+
+
+# ─── RegisterRequest ──────────────────────────────────────────────────────────
+
+def test_register_valid_email():
+    r = RegisterRequest(email="User@Example.COM", password="TestPass1!")
+    assert r.email == "user@example.com"
+
+
+def test_register_invalid_email_no_at():
+    with pytest.raises(ValidationError) as exc:
+        RegisterRequest(email="notanemail", password="TestPass1!")
+    assert "email" in str(exc.value).lower() or "Invalid" in str(exc.value)
+
+
+def test_register_invalid_email_no_domain():
+    with pytest.raises(ValidationError):
+        RegisterRequest(email="user@", password="TestPass1!")
+
+
+def test_register_email_strips_whitespace():
+    r = RegisterRequest(email="  user@example.com  ", password="TestPass1!")
+    assert r.email == "user@example.com"
+
+
+# ─── LoginRequest ─────────────────────────────────────────────────────────────
+
+def test_login_email_lowercased():
+    r = LoginRequest(email="ADMIN@EXAMPLE.COM", password="anypassword")
+    assert r.email == "admin@example.com"
+
+
+def test_login_invalid_email():
+    with pytest.raises(ValidationError):
+        LoginRequest(email="bad-email", password="pass")
+
+
+# ─── CreateInvitation ─────────────────────────────────────────────────────────
+
+def test_invitation_email_normalized():
+    inv = CreateInvitation(
+        email="Invited@Company.ORG",
+        invited_by=uuid.uuid4(),
+    )
+    assert inv.email == "invited@company.org"
+
+
+def test_invitation_invalid_email():
+    with pytest.raises(ValidationError):
+        CreateInvitation(email="not-an-email", invited_by=uuid.uuid4())
+
+
+# ─── 중복 차단 (대소문자) ────────────────────────────────────────────────────────
+
+def test_same_email_different_case_normalizes_to_same():
+    """대소문자 다른 동일 이메일이 동일 값으로 정규화되는 것 확인."""
+    r1 = RegisterRequest(email="Test@Email.com", password="TestPass1!")
+    r2 = RegisterRequest(email="test@email.com", password="TestPass1!")
+    assert r1.email == r2.email


### PR DESCRIPTION
## Summary
이메일 포맷 검증 미적용 + 대소문자 정규화 누락으로 `Test@email.com`/`test@email.com` 별도 가입 가능한 취약점 수정.

## Changes
- `auth.py`: `_normalize_email()` 헬퍼 + `LoginRequest`, `RegisterRequest`에 `@field_validator("email")` 추가
- `schemas/invitation.py`: `CreateInvitation`에 동일 validator 추가
- 모든 입력 지점에서 strip + lowercase + RFC 5322 기반 regex 검증

## AC
- [x] 이메일 포맷 미달 → 422
- [x] 대소문자 정규화 (저장/조회 모두 lowercase)
- [x] 동일 이메일 대소문자 달라도 같은 값으로 처리
- [x] Register/Login/Invitation 3개 입력 지점 전부 적용
- [x] pytest 9건

🤖 Generated with [Claude Code](https://claude.com/claude-code)