### PR TITLE
feat(AUTH-04): 비밀번호 찾기/재설정/변경 구현

### DIFF
--- a/apps/web/src/app/api/auth/change-password/route.ts
+++ b/apps/web/src/app/api/auth/change-password/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { getAuthContext } from '@/lib/auth-helpers';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+/** PATCH /api/auth/change-password */
+export async function PATCH(request: Request) {
+  const me = await getAuthContext(request);
+  if (!me) return NextResponse.json({ error: { code: 'UNAUTHORIZED', message: 'Unauthorized' } }, { status: 401 });
+
+  const body = await request.json() as { current_password: string; new_password: string };
+  const spAt = request.headers.get('cookie')?.match(/sp_at=([^;]+)/)?.[1] ?? '';
+
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/change-password`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${spAt}` },
+    body: JSON.stringify({ current_password: body.current_password, new_password: body.new_password }),
+  });
+
+  const json = await fastapiRes.json() as Record<string, unknown>;
+  if (!fastapiRes.ok) {
+    return NextResponse.json({ error: json['error'] ?? { code: 'FAILED', message: 'Failed' } }, { status: fastapiRes.status });
+  }
+  return NextResponse.json({ data: json['data'] ?? { message: 'ok' } });
+}

--- a/apps/web/src/app/api/auth/forgot-password/route.ts
+++ b/apps/web/src/app/api/auth/forgot-password/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+/** POST /api/auth/forgot-password */
+export async function POST(request: Request) {
+  const csrfError = verifyCsrfOrigin(request);
+  if (csrfError) return csrfError;
+
+  const body = await request.json() as { email: string };
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/forgot-password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: body.email }),
+  });
+
+  const json = await fastapiRes.json() as Record<string, unknown>;
+  if (!fastapiRes.ok) {
+    return NextResponse.json({ error: json['error'] ?? { code: 'FAILED', message: 'Request failed' } }, { status: fastapiRes.status });
+  }
+  return NextResponse.json({ data: json['data'] ?? { message: 'ok' } });
+}

--- a/apps/web/src/app/api/auth/reset-password/route.ts
+++ b/apps/web/src/app/api/auth/reset-password/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { verifyCsrfOrigin } from '@/lib/auth/csrf';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+/** POST /api/auth/reset-password */
+export async function POST(request: Request) {
+  const csrfError = verifyCsrfOrigin(request);
+  if (csrfError) return csrfError;
+
+  const body = await request.json() as { token: string; new_password: string };
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/reset-password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token: body.token, new_password: body.new_password }),
+  });
+
+  const json = await fastapiRes.json() as Record<string, unknown>;
+  if (!fastapiRes.ok) {
+    return NextResponse.json({ error: json['error'] ?? { code: 'RESET_FAILED', message: 'Reset failed' } }, { status: fastapiRes.status });
+  }
+  return NextResponse.json({ data: json['data'] ?? { message: 'ok' } });
+}

--- a/apps/web/src/app/forgot-password/page.tsx
+++ b/apps/web/src/app/forgot-password/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!email.trim()) return;
+    setLoading(true);
+    try {
+      await fetch('/api/auth/forgot-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: email.trim() }),
+      });
+      setSubmitted(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo variant="stacked" className="text-gray-900" markClassName="h-14" wordmarkClassName="h-5" />
+          <h1 className="text-lg font-semibold text-gray-900">비밀번호 찾기</h1>
+        </div>
+
+        {submitted ? (
+          <div className="space-y-4 text-center">
+            <p className="text-sm text-gray-600">
+              입력하신 이메일로 재설정 링크를 발송했습니다. 메일함을 확인해 주세요.
+            </p>
+            <Link href="/login" className="block text-sm font-medium text-blue-600 hover:text-blue-700">
+              로그인으로 돌아가기
+            </Link>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-sm text-gray-500">가입하신 이메일 주소를 입력하시면 비밀번호 재설정 링크를 보내드립니다.</p>
+            <input
+              type="email"
+              placeholder="Email"
+              autoComplete="email"
+              className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+              disabled={loading}
+            />
+            <button
+              onClick={handleSubmit}
+              disabled={loading || !email.trim()}
+              className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? '전송 중...' : '재설정 링크 전송'}
+            </button>
+            <p className="text-center text-sm text-gray-500">
+              <Link href="/login" className="font-medium text-blue-600 hover:text-blue-700">
+                로그인으로 돌아가기
+              </Link>
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -135,6 +135,11 @@ export default function LoginPage() {
         </div>
 
         <p className="text-center text-sm text-gray-500">
+          <Link href="/forgot-password" className="font-medium text-blue-600 hover:text-blue-700">
+            비밀번호를 잊으셨나요?
+          </Link>
+        </p>
+        <p className="text-center text-sm text-gray-500">
           Don&apos;t have an account?{' '}
           <Link href="/register" className="font-medium text-blue-600 hover:text-blue-700">
             Sign up

--- a/apps/web/src/app/reset-password/page.tsx
+++ b/apps/web/src/app/reset-password/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+function checkPasswordRules(pw: string) {
+  return {
+    length: pw.length >= 8,
+    upper: /[A-Z]/.test(pw),
+    lower: /[a-z]/.test(pw),
+    digit: /\d/.test(pw),
+    special: /[^A-Za-z0-9]/.test(pw),
+  };
+}
+
+export default function ResetPasswordPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token') ?? '';
+
+  const [password, setPassword] = useState('');
+  const [touched, setTouched] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const rules = checkPasswordRules(password);
+  const categoriesMet = [rules.upper, rules.lower, rules.digit, rules.special].filter(Boolean).length;
+  const isValid = rules.length && categoriesMet >= 3;
+
+  const handleSubmit = async () => {
+    setTouched(true);
+    if (!isValid) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/auth/reset-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token, new_password: password }),
+      });
+      const json = await res.json() as { data?: { message: string }; error?: { message: string } };
+      if (!res.ok) {
+        setError(json.error?.message ?? 'Failed to reset password');
+        return;
+      }
+      setDone(true);
+    } catch {
+      setError('Failed to reset password. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!token) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
+        <div className="text-center space-y-4">
+          <p className="text-sm text-red-600">유효하지 않은 링크입니다.</p>
+          <Link href="/forgot-password" className="text-sm text-blue-600 hover:text-blue-700">비밀번호 찾기</Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <SprintableLogo variant="stacked" className="text-gray-900" markClassName="h-14" wordmarkClassName="h-5" />
+          <h1 className="text-lg font-semibold text-gray-900">새 비밀번호 설정</h1>
+        </div>
+
+        {done ? (
+          <div className="space-y-4 text-center">
+            <p className="text-sm text-gray-600">비밀번호가 변경되었습니다.</p>
+            <button
+              onClick={() => router.push('/login')}
+              className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              로그인
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <input
+              type="password"
+              placeholder="새 비밀번호"
+              autoComplete="new-password"
+              className={`w-full rounded-lg border px-4 py-3 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                touched && !isValid ? 'border-red-400' : 'border-gray-300'
+              }`}
+              value={password}
+              onChange={(e) => { setPassword(e.target.value); setTouched(true); }}
+              onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+              disabled={loading}
+            />
+            {touched && password.length > 0 && (
+              <ul className="space-y-1 text-xs">
+                <li className={rules.length ? 'text-green-600' : 'text-gray-400'}>
+                  {rules.length ? '✓' : '○'} 8자 이상
+                </li>
+                <li className={categoriesMet >= 3 ? 'text-green-600' : 'text-gray-400'}>
+                  {categoriesMet >= 3 ? '✓' : '○'} 대문자/소문자/숫자/특수문자 중 3가지 이상 ({categoriesMet}/3)
+                </li>
+              </ul>
+            )}
+            {error && <p className="text-sm text-red-600">{error}</p>}
+            <button
+              onClick={handleSubmit}
+              disabled={loading || !password}
+              className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? '변경 중...' : '비밀번호 변경'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -150,10 +150,11 @@ def create_password_reset_token(user_id: str, hashed_password: str) -> str:
     """30분 만료 reset token. pw_sig 포함으로 비밀번호 변경 후 자동 무효화."""
     now = datetime.now(timezone.utc)
     exp = now + timedelta(minutes=RESET_TOKEN_EXPIRE_MINUTES)
+    pw_sig = hashlib.sha256(hashed_password.encode()).hexdigest()[:16]
     payload = {
         "sub": user_id,
         "type": "password_reset",
-        "pw_sig": hashed_password[:16],
+        "pw_sig": pw_sig,
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -15,6 +15,7 @@ from app.core.config import settings
 __all__ = [
     "decode_jwt", "JWTError",
     "create_access_token", "create_refresh_token", "create_tokens",
+    "create_password_reset_token", "decode_password_reset_token",
     "hash_password", "verify_password",
     "generate_totp_secret", "verify_totp", "get_totp_provisioning_uri",
     "hash_token",
@@ -138,3 +139,30 @@ def verify_totp_with_timestep(secret: str, code: str) -> int | None:
 
 def get_totp_provisioning_uri(secret: str, email: str, issuer: str = "Sprintable") -> str:
     return pyotp.TOTP(secret).provisioning_uri(name=email, issuer_name=issuer)
+
+
+# ─── Password Reset Token ──────────────────────────────────────────────────────
+
+RESET_TOKEN_EXPIRE_MINUTES = 30
+
+
+def create_password_reset_token(user_id: str, hashed_password: str) -> str:
+    """30분 만료 reset token. pw_sig 포함으로 비밀번호 변경 후 자동 무효화."""
+    now = datetime.now(timezone.utc)
+    exp = now + timedelta(minutes=RESET_TOKEN_EXPIRE_MINUTES)
+    payload = {
+        "sub": user_id,
+        "type": "password_reset",
+        "pw_sig": hashed_password[:16],
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+    }
+    return jwt.encode(payload, _get_secret(), algorithm="HS256")
+
+
+def decode_password_reset_token(token: str) -> dict:
+    """Reset token 검증. 만료/타입 불일치 시 JWTError."""
+    payload = decode_jwt(token)
+    if payload.get("type") != "password_reset":
+        raise JWTError("Invalid token type")
+    return payload

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -681,7 +681,8 @@ async def reset_password(
         return _err("USER_NOT_FOUND", "User not found", 404)
 
     # pw_sig 불일치 시 이미 비밀번호 변경됨 → 토큰 무효
-    if user.hashed_password[:16] != pw_sig:
+    import hashlib as _hashlib
+    if _hashlib.sha256(user.hashed_password.encode()).hexdigest()[:16] != pw_sig:
         return _err("INVALID_TOKEN", "Reset token has already been used", 400)
 
     await session.execute(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import os
 import secrets
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from urllib.parse import urlencode
 
 import httpx
@@ -28,7 +29,9 @@ from app.core.config import settings
 
 from app.core.security import (
     create_tokens,
+    create_password_reset_token,
     decode_jwt,
+    decode_password_reset_token,
     generate_totp_secret,
     get_totp_provisioning_uri,
     hash_password,
@@ -47,8 +50,6 @@ from app.models.invitation import Invitation
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import RefreshToken, User
-
-from datetime import timedelta
 
 router = APIRouter(prefix="/api/v2/auth", tags=["auth"])
 
@@ -114,6 +115,59 @@ class LogoutRequest(BaseModel):
 
 class TotpVerifyRequest(BaseModel):
     code: str
+
+
+class ForgotPasswordRequest(BaseModel):
+    email: str
+
+    @field_validator("email")
+    @classmethod
+    def normalize_email(cls, v: str) -> str:
+        return _normalize_email(v)
+
+
+class ResetPasswordRequest(BaseModel):
+    token: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        categories = [
+            bool(re.search(r"[A-Z]", v)),
+            bool(re.search(r"[a-z]", v)),
+            bool(re.search(r"\d", v)),
+            bool(re.search(r"[^A-Za-z0-9]", v)),
+        ]
+        if sum(categories) < 3:
+            raise ValueError(
+                "Password must include at least 3 of: uppercase letters, lowercase letters, digits, special characters"
+            )
+        return v
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str
+    new_password: str
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_password(cls, v: str) -> str:
+        if len(v) < 8:
+            raise ValueError("Password must be at least 8 characters long")
+        categories = [
+            bool(re.search(r"[A-Z]", v)),
+            bool(re.search(r"[a-z]", v)),
+            bool(re.search(r"\d", v)),
+            bool(re.search(r"[^A-Za-z0-9]", v)),
+        ]
+        if sum(categories) < 3:
+            raise ValueError(
+                "Password must include at least 3 of: uppercase letters, lowercase letters, digits, special characters"
+            )
+        return v
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -581,3 +635,75 @@ async def oauth_callback(
         "token_type": "bearer",
         "expires_in": ACCESS_TOKEN_EXPIRE_MINUTES * 60,
     })
+
+
+# ─── Password Reset ───────────────────────────────────────────────────────────
+
+@router.post("/forgot-password")
+async def forgot_password(
+    body: ForgotPasswordRequest,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    user = await _get_user_by_email(session, body.email)
+    # 이메일 존재 여부와 무관하게 동일 응답 (사용자 열거 방지)
+    if user is not None:
+        token = create_password_reset_token(str(user.id), user.hashed_password)
+        app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+        reset_link = f"{app_url}/reset-password?token={token}"
+        from app.services.email import send_email
+        send_email(
+            to=user.email,
+            subject="Sprintable 비밀번호 재설정",
+            html_body=(
+                f"<p>비밀번호 재설정 링크입니다. 30분 내에 사용 바랍니다.</p>"
+                f"<p><a href='{reset_link}'>비밀번호 재설정</a></p>"
+                f"<p>요청하지 않으셨다면 이 메일을 무시하세요.</p>"
+            ),
+        )
+    return _ok({"message": "If the email exists, a reset link has been sent"})
+
+
+@router.post("/reset-password")
+async def reset_password(
+    body: ResetPasswordRequest,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    try:
+        payload = decode_password_reset_token(body.token)
+    except JWTError:
+        return _err("INVALID_TOKEN", "Reset token is invalid or expired", 400)
+
+    user_id = payload.get("sub")
+    pw_sig = payload.get("pw_sig", "")
+
+    user = await _get_user_by_id(session, uuid.UUID(user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    # pw_sig 불일치 시 이미 비밀번호 변경됨 → 토큰 무효
+    if user.hashed_password[:16] != pw_sig:
+        return _err("INVALID_TOKEN", "Reset token has already been used", 400)
+
+    await session.execute(
+        update(User).where(User.id == user.id).values(hashed_password=hash_password(body.new_password))
+    )
+    return _ok({"message": "Password reset successfully"})
+
+
+@router.patch("/change-password")
+async def change_password(
+    body: ChangePasswordRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    user = await _get_user_by_id(session, uuid.UUID(auth.user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    if not verify_password(body.current_password, user.hashed_password):
+        return _err("WRONG_PASSWORD", "Current password is incorrect", 400)
+
+    await session.execute(
+        update(User).where(User.id == user.id).values(hashed_password=hash_password(body.new_password))
+    )
+    return _ok({"message": "Password changed successfully"})

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,36 @@
+"""이메일 발송 서비스 — SMTP 또는 콘솔 fallback."""
+import logging
+import os
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+logger = logging.getLogger(__name__)
+
+
+def send_email(to: str, subject: str, html_body: str) -> None:
+    """이메일 발송. EMAIL_SMTP_HOST 미설정 시 콘솔 출력으로 fallback."""
+    smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
+    if not smtp_host:
+        logger.info("[EMAIL FALLBACK] To: %s | Subject: %s\n%s", to, subject, html_body)
+        return
+
+    from_addr = os.getenv("EMAIL_FROM", "noreply@sprintable.ai")
+    smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
+    smtp_user = os.getenv("EMAIL_SMTP_USER", "")
+    smtp_pass = os.getenv("EMAIL_SMTP_PASSWORD", "")
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to
+    msg.attach(MIMEText(html_body, "html"))
+
+    try:
+        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as s:
+            s.starttls()
+            if smtp_user:
+                s.login(smtp_user, smtp_pass)
+            s.send_message(msg)
+    except Exception:
+        logger.exception("Failed to send email to %s", to)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,9 +1,13 @@
 """Shared pytest fixtures for backend tests."""
+import os
 import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from httpx import ASGITransport, AsyncClient
+
+# 테스트 환경 기본 환경변수
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-pytest-only")
 
 
 @pytest.fixture

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -1,0 +1,99 @@
+"""AUTH-04: forgot/reset/change-password 엔드포인트 단위 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.security import (
+    JWTError,
+    create_password_reset_token,
+    decode_password_reset_token,
+    hash_password,
+)
+
+
+# ─── Reset token 유틸리티 ─────────────────────────────────────────────────────
+
+def test_reset_token_roundtrip():
+    uid = str(uuid.uuid4())
+    hpw = hash_password("SomePass1!")
+    token = create_password_reset_token(uid, hpw)
+    payload = decode_password_reset_token(token)
+    assert payload["sub"] == uid
+    assert payload["type"] == "password_reset"
+    assert payload["pw_sig"] == hpw[:16]
+
+
+def test_reset_token_wrong_type_rejected():
+    from app.core.security import _get_secret
+    from jose import jwt
+    from datetime import datetime, timezone, timedelta
+    payload = {"sub": str(uuid.uuid4()), "type": "access", "exp": int((datetime.now(timezone.utc) + timedelta(minutes=30)).timestamp())}
+    token = jwt.encode(payload, _get_secret(), algorithm="HS256")
+    with pytest.raises(JWTError):
+        decode_password_reset_token(token)
+
+
+def test_pw_sig_changes_after_password_change():
+    """비밀번호 변경 후 pw_sig 불일치로 토큰 자동 무효화 확인."""
+    uid = str(uuid.uuid4())
+    old_hpw = hash_password("OldPass1!")
+    token = create_password_reset_token(uid, old_hpw)
+    payload = decode_password_reset_token(token)
+
+    new_hpw = hash_password("NewPass2@")
+    assert new_hpw[:16] != payload["pw_sig"]
+
+
+# ─── /forgot-password ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_forgot_password_always_200():
+    """존재하지 않는 이메일도 200 반환 (열거 방지)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/auth/forgot-password", json={"email": "ghost@example.com"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── /reset-password ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_reset_password_invalid_token_400():
+    """유효하지 않은 토큰 → 400."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/auth/reset-password", json={"token": "badtoken", "new_password": "NewPass1!"})
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -15,13 +15,14 @@ from app.core.security import (
 # ─── Reset token 유틸리티 ─────────────────────────────────────────────────────
 
 def test_reset_token_roundtrip():
+    import hashlib
     uid = str(uuid.uuid4())
     hpw = hash_password("SomePass1!")
     token = create_password_reset_token(uid, hpw)
     payload = decode_password_reset_token(token)
     assert payload["sub"] == uid
     assert payload["type"] == "password_reset"
-    assert payload["pw_sig"] == hpw[:16]
+    assert payload["pw_sig"] == hashlib.sha256(hpw.encode()).hexdigest()[:16]
 
 
 def test_reset_token_wrong_type_rejected():
@@ -36,13 +37,14 @@ def test_reset_token_wrong_type_rejected():
 
 def test_pw_sig_changes_after_password_change():
     """비밀번호 변경 후 pw_sig 불일치로 토큰 자동 무효화 확인."""
+    import hashlib
     uid = str(uuid.uuid4())
     old_hpw = hash_password("OldPass1!")
     token = create_password_reset_token(uid, old_hpw)
     payload = decode_password_reset_token(token)
 
     new_hpw = hash_password("NewPass2@")
-    assert new_hpw[:16] != payload["pw_sig"]
+    assert hashlib.sha256(new_hpw.encode()).hexdigest()[:16] != payload["pw_sig"]
 
 
 # ─── /forgot-password ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
forgot password / reset password / change password 전체 플로우 구현.

## 변경 내역

### Backend
- `POST /api/v2/auth/forgot-password` — JWT reset token 생성 + 이메일 발송 (사용자 열거 방지)
- `POST /api/v2/auth/reset-password` — token 검증 + 새 비밀번호 저장 (pw_sig로 1회 사용 후 자동 무효화)
- `PATCH /api/v2/auth/change-password` — 현재 비밀번호 검증 후 변경
- `services/email.py` — SMTP 발송 / EMAIL_SMTP_HOST 미설정 시 콘솔 fallback (AUTH-05 재사용)
- `security.py` — `create_password_reset_token`, `decode_password_reset_token` 추가

### Frontend
- `forgot-password/page.tsx` — 이메일 입력 → 발송 완료 화면
- `reset-password/page.tsx` — 토큰 기반 새 비밀번호 설정 + AUTH-01 실시간 validation
- `login/page.tsx` — "비밀번호를 잊으셨나요?" 링크 추가
- Next.js API 프록시 3개 추가

## AC
- [x] forgot-password 존재하지 않는 이메일도 200 (열거 방지)
- [x] reset token 30분 만료 + 비밀번호 변경 후 자동 무효화 (pw_sig)
- [x] 새 비밀번호 AUTH-01 복잡성 규칙 적용
- [x] 로그인 페이지 링크 추가
- [x] pytest 5건

🤖 Generated with [Claude Code](https://claude.com/claude-code)