### PR TITLE
feat(AUTH-05): 이메일 인증 플로우 구현

### DIFF
--- a/apps/web/src/app/api/auth/verify-email/route.ts
+++ b/apps/web/src/app/api/auth/verify-email/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+/** POST /api/auth/verify-email */
+export async function POST(request: Request) {
+  const body = await request.json() as { token: string };
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/verify-email?token=${encodeURIComponent(body.token)}`, {
+    method: 'GET',
+  });
+  const json = await fastapiRes.json() as Record<string, unknown>;
+  if (!fastapiRes.ok) {
+    return NextResponse.json({ error: json['error'] ?? { code: 'VERIFY_FAILED', message: 'Verification failed' } }, { status: fastapiRes.status });
+  }
+  return NextResponse.json({ data: json['data'] ?? { message: 'ok' } });
+}

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -10,15 +10,15 @@ export default function VerifyEmailPage() {
   const router = useRouter();
   const token = searchParams.get('token') ?? '';
 
-  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
-  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
+    () => (token ? 'loading' : 'error')
+  );
+  const [message, setMessage] = useState(
+    () => (token ? '' : '유효하지 않은 인증 링크입니다.')
+  );
 
   useEffect(() => {
-    if (!token) {
-      setStatus('error');
-      setMessage('유효하지 않은 인증 링크입니다.');
-      return;
-    }
+    if (!token) return;
 
     fetch('/api/auth/verify-email', {
       method: 'POST',

--- a/apps/web/src/app/verify-email/page.tsx
+++ b/apps/web/src/app/verify-email/page.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export default function VerifyEmailPage() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const token = searchParams.get('token') ?? '';
+
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (!token) {
+      setStatus('error');
+      setMessage('유효하지 않은 인증 링크입니다.');
+      return;
+    }
+
+    fetch('/api/auth/verify-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    })
+      .then((res) => res.json())
+      .then((json: { data?: { message: string }; error?: { message: string } }) => {
+        if (json.data) {
+          setStatus('success');
+          setMessage(json.data.message);
+        } else {
+          setStatus('error');
+          setMessage(json.error?.message ?? '인증에 실패했습니다.');
+        }
+      })
+      .catch(() => {
+        setStatus('error');
+        setMessage('인증 중 오류가 발생했습니다.');
+      });
+  }, [token]);
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-sm space-y-6 rounded-2xl bg-white p-4 shadow-lg sm:p-8 text-center">
+        <div className="flex flex-col items-center gap-3">
+          <SprintableLogo variant="stacked" className="text-gray-900" markClassName="h-14" wordmarkClassName="h-5" />
+        </div>
+
+        {status === 'loading' && (
+          <p className="text-sm text-gray-500">이메일 인증 중...</p>
+        )}
+
+        {status === 'success' && (
+          <div className="space-y-4">
+            <p className="text-sm font-medium text-green-600">{message}</p>
+            <button
+              onClick={() => router.push('/inbox')}
+              className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700"
+            >
+              시작하기
+            </button>
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="space-y-4">
+            <p className="text-sm text-red-600">{message}</p>
+            <Link href="/login" className="block text-sm font-medium text-blue-600 hover:text-blue-700">
+              로그인으로 돌아가기
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/backend/alembic/versions/0018_add_email_verified.py
+++ b/backend/alembic/versions/0018_add_email_verified.py
@@ -1,0 +1,25 @@
+"""add email_verified to users
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-11
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 기존 사용자는 이미 인증된 것으로 처리 (서비스 연속성)
+    op.add_column("users", sa.Column("email_verified", sa.Boolean(), nullable=False, server_default="true"))
+    op.alter_column("users", "email_verified", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "email_verified")

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -16,6 +16,7 @@ __all__ = [
     "decode_jwt", "JWTError",
     "create_access_token", "create_refresh_token", "create_tokens",
     "create_password_reset_token", "decode_password_reset_token",
+    "create_email_verification_token", "decode_email_verification_token",
     "hash_password", "verify_password",
     "generate_totp_secret", "verify_totp", "get_totp_provisioning_uri",
     "hash_token",
@@ -165,5 +166,31 @@ def decode_password_reset_token(token: str) -> dict:
     """Reset token 검증. 만료/타입 불일치 시 JWTError."""
     payload = decode_jwt(token)
     if payload.get("type") != "password_reset":
+        raise JWTError("Invalid token type")
+    return payload
+
+
+# ─── Email Verification Token ─────────────────────────────────────────────────
+
+EMAIL_VERIFICATION_EXPIRE_HOURS = 24
+
+
+def create_email_verification_token(user_id: str) -> str:
+    """24시간 만료 이메일 인증 토큰."""
+    now = datetime.now(timezone.utc)
+    exp = now + timedelta(hours=EMAIL_VERIFICATION_EXPIRE_HOURS)
+    payload = {
+        "sub": user_id,
+        "type": "email_verification",
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+    }
+    return jwt.encode(payload, _get_secret(), algorithm="HS256")
+
+
+def decode_email_verification_token(token: str) -> dict:
+    """Email verification token 검증. 만료/타입 불일치 시 JWTError."""
+    payload = decode_jwt(token)
+    if payload.get("type") != "email_verification":
         raise JWTError("Invalid token type")
     return payload

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,6 +15,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(Text, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     totp_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     totp_last_timestep: Mapped[int | None] = mapped_column(nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -30,8 +30,10 @@ from app.core.config import settings
 from app.core.security import (
     create_tokens,
     create_password_reset_token,
+    create_email_verification_token,
     decode_jwt,
     decode_password_reset_token,
+    decode_email_verification_token,
     generate_totp_secret,
     get_totp_provisioning_uri,
     hash_password,
@@ -287,6 +289,7 @@ async def register(
         email=body.email,
         hashed_password=hash_password(body.password),
         is_active=True,
+        email_verified=False,
     )
     session.add(user)
     try:
@@ -298,6 +301,23 @@ async def register(
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
+
+    # 이메일 인증 발송 (비동기 — 실패해도 가입은 완료)
+    try:
+        verification_token = create_email_verification_token(str(user.id))
+        app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+        verify_link = f"{app_url}/verify-email?token={verification_token}"
+        from app.services.email import send_email
+        send_email(
+            to=user.email,
+            subject="Sprintable 이메일 인증",
+            html_body=(
+                f"<p>아래 링크를 클릭하여 이메일 인증을 완료해 주세요. 24시간 유효합니다.</p>"
+                f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
+            ),
+        )
+    except Exception:
+        pass  # 이메일 발송 실패는 가입에 영향 없음
 
     return _ok(tokens, 201)
 
@@ -605,11 +625,12 @@ async def oauth_callback(
             await session.commit()
             await session.refresh(user)
         else:
-            # 신규 유저 생성 (비밀번호 없음 — OAuth 전용)
+            # 신규 유저 생성 (비밀번호 없음 — OAuth 전용, 이메일 인증 완료)
             user = User(
                 email=email,
                 hashed_password="",
                 is_active=True,
+                email_verified=True,
                 **{f"{provider}_id": oauth_id},
             )
             session.add(user)
@@ -708,3 +729,58 @@ async def change_password(
         update(User).where(User.id == user.id).values(hashed_password=hash_password(body.new_password))
     )
     return _ok({"message": "Password changed successfully"})
+
+
+# ─── Email Verification ───────────────────────────────────────────────────────
+
+@router.get("/verify-email")
+async def verify_email(
+    token: str,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    try:
+        payload = decode_email_verification_token(token)
+    except JWTError:
+        return _err("INVALID_TOKEN", "Verification link is invalid or expired", 400)
+
+    user_id = payload.get("sub")
+    user = await _get_user_by_id(session, uuid.UUID(user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    if user.email_verified:
+        return _ok({"message": "Email already verified"})
+
+    await session.execute(
+        update(User).where(User.id == user.id).values(email_verified=True)
+    )
+    return _ok({"message": "Email verified successfully"})
+
+
+@router.post("/resend-verification")
+@limiter.limit("3/hour")
+async def resend_verification(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    user = await _get_user_by_id(session, uuid.UUID(auth.user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    if user.email_verified:
+        return _ok({"message": "Email already verified"})
+
+    verification_token = create_email_verification_token(str(user.id))
+    app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+    verify_link = f"{app_url}/verify-email?token={verification_token}"
+    from app.services.email import send_email
+    send_email(
+        to=user.email,
+        subject="Sprintable 이메일 인증",
+        html_body=(
+            f"<p>아래 링크를 클릭하여 이메일 인증을 완료해 주세요. 24시간 유효합니다.</p>"
+            f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
+        ),
+    )
+    return _ok({"message": "Verification email sent"})

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -1,11 +1,12 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.user import User
 from app.repositories.organization import OrganizationRepository
 from app.schemas.organization import CreateOrganization, OrganizationResponse
 
@@ -23,6 +24,12 @@ async def create_organization(
     repo: OrganizationRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
 ) -> OrganizationResponse:
+    # 이메일 미인증 사용자는 org 생성 차단
+    user_result = await session.execute(select(User).where(User.id == uuid.UUID(auth.user_id)))
+    user = user_result.scalar_one_or_none()
+    if user and not user.email_verified:
+        raise HTTPException(status_code=403, detail="Email verification required to create organization")
+
     org = await repo.create(name=body.name, slug=body.slug, owner_member_id=body.owner_member_id)
     if org is None:
         raise HTTPException(status_code=409, detail="Slug already exists")

--- a/backend/tests/test_auth_email_verification.py
+++ b/backend/tests/test_auth_email_verification.py
@@ -1,0 +1,89 @@
+"""AUTH-05: Email verification 단위 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.security import (
+    JWTError,
+    create_email_verification_token,
+    decode_email_verification_token,
+)
+
+
+# ─── 토큰 유틸리티 ─────────────────────────────────────────────────────────────
+
+def test_verification_token_roundtrip():
+    uid = str(uuid.uuid4())
+    token = create_email_verification_token(uid)
+    payload = decode_email_verification_token(token)
+    assert payload["sub"] == uid
+    assert payload["type"] == "email_verification"
+
+
+def test_verification_token_wrong_type_rejected():
+    from app.core.security import _get_secret
+    from jose import jwt
+    from datetime import datetime, timezone, timedelta
+    payload = {"sub": str(uuid.uuid4()), "type": "access", "exp": int((datetime.now(timezone.utc) + timedelta(hours=24)).timestamp())}
+    token = jwt.encode(payload, _get_secret(), algorithm="HS256")
+    with pytest.raises(JWTError):
+        decode_email_verification_token(token)
+
+
+# ─── GET /verify-email ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_verify_email_invalid_token_400():
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/auth/verify-email?token=badtoken")
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_verify_email_already_verified_200():
+    """이미 인증된 이메일 → 200 (幂等)."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    uid = str(uuid.uuid4())
+    token = create_email_verification_token(uid)
+
+    user_mock = MagicMock()
+    user_mock.id = uuid.UUID(uid)
+    user_mock.email_verified = True
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = user_mock
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(f"/api/v2/auth/verify-email?token={token}")
+        assert resp.status_code == 200
+        assert "already" in resp.json()["data"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -131,6 +131,12 @@ async def test_list_audit_logs_empty_200():
 async def test_create_organization_201():
     client, session, app = await _client()
     try:
+        mock_user = MagicMock()
+        mock_user.email_verified = True
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_user
+        session.execute = AsyncMock(return_value=mock_result)
+
         with patch("app.repositories.organization.OrganizationRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = _mock_org()
 
@@ -151,6 +157,12 @@ async def test_create_organization_201():
 async def test_create_organization_409_slug_conflict():
     client, session, app = await _client()
     try:
+        mock_user = MagicMock()
+        mock_user.email_verified = True
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = mock_user
+        session.execute = AsyncMock(return_value=mock_result)
+
         with patch("app.repositories.organization.OrganizationRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = None
 


### PR DESCRIPTION
## Summary
가입 후 이메일 인증 필수화. 미인증 사용자 org 생성 차단.

## 변경 내역

### Backend
- `User.email_verified` 컬럼 추가 (migration 0018)
  - 기존 사용자: `server_default='true'` 백필 (서비스 연속성)
  - 신규 가입자: `email_verified=False`로 시작
- `GET /api/v2/auth/verify-email?token=` — JWT 검증 후 `email_verified=True`
- `POST /api/v2/auth/resend-verification` — rate limit 3/hour
- `register` 엔드포인트: 가입 직후 인증 이메일 자동 발송
- OAuth 신규 가입자: `email_verified=True` (Google/GitHub 이메일 신뢰)
- `organizations.py`: 미인증 사용자 org 생성 403 차단
- `security.py`: `create/decode_email_verification_token` (24시간)

### Frontend
- `verify-email/page.tsx` — 토큰 파라미터 수신 → 인증 완료 화면

## AC
- [x] email_verified=False로 가입 시작
- [x] 인증 이메일 발송 (fallback 로그)
- [x] 토큰 검증 후 email_verified=True
- [x] 24시간 만료
- [x] 미인증 org 생성 403
- [x] 재발송 rate limit
- [x] pytest 4건

🤖 Generated with [Claude Code](https://claude.com/claude-code)