### PR TITLE
[SID:AUTH-07] TOS / Privacy Policy 약관 동의 — 프론트엔드

### DIFF
--- a/apps/web/src/app/api/auth/callback/[provider]/route.ts
+++ b/apps/web/src/app/api/auth/callback/[provider]/route.ts
@@ -30,7 +30,9 @@ export async function GET(request: Request, { params }: RouteParams) {
   // CSRF state 검증
   const cookieStore = await cookies();
   const storedState = cookieStore.get(`oauth_state_${provider}`)?.value;
+  const tosAccepted = cookieStore.get(`oauth_tos_${provider}`)?.value === 'true';
   cookieStore.delete(`oauth_state_${provider}`);
+  cookieStore.delete(`oauth_tos_${provider}`);
 
   if (!storedState || storedState !== state) {
     return NextResponse.redirect(`${origin}/login?error=csrf_mismatch`);
@@ -40,7 +42,7 @@ export async function GET(request: Request, { params }: RouteParams) {
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/oauth/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ provider, code, state }),
+    body: JSON.stringify({ provider, code, state, tos_accepted: tosAccepted }),
   }).catch(() => null);
 
   if (!fastapiRes?.ok) {

--- a/apps/web/src/app/api/auth/register/route.ts
+++ b/apps/web/src/app/api/auth/register/route.ts
@@ -10,12 +10,12 @@ export async function POST(request: Request) {
   const csrfError = verifyCsrfOrigin(request);
   if (csrfError) return csrfError;
 
-  const body = await request.json() as { email: string; password: string; name?: string };
+  const body = await request.json() as { email: string; password: string; name?: string; tos_accepted?: boolean };
 
   const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/register`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email: body.email, password: body.password }),
+    body: JSON.stringify({ email: body.email, password: body.password, tos_accepted: body.tos_accepted ?? false }),
   });
 
   const json = await fastapiRes.json() as { data?: { access_token: string; refresh_token: string; token_type: string }; error?: { code: string; message: string } };

--- a/apps/web/src/app/auth/login/route.ts
+++ b/apps/web/src/app/auth/login/route.ts
@@ -7,6 +7,7 @@ const FASTAPI_BASE = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const provider = searchParams.get('provider');
+  const tosAccepted = searchParams.get('tos_accepted') === 'true';
   const origin = resolveAppUrl(null);
 
   if (!provider || !['google', 'github'].includes(provider)) {
@@ -34,6 +35,15 @@ export async function GET(request: Request) {
     maxAge: 300,
     path: '/',
   });
+  if (tosAccepted) {
+    cookieStore.set(`oauth_tos_${provider}`, 'true', {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 300,
+      path: '/',
+    });
+  }
 
   return NextResponse.redirect(url);
 }

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -116,7 +116,7 @@ export default function LoginPage() {
             <div className="flex-grow border-t border-gray-200" />
           </div>
 
-          <a href="/auth/login?provider=google" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
+          <a href="/auth/login?provider=google&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50">
             <svg className="h-5 w-5" viewBox="0 0 24 24">
               <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
               <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
@@ -126,12 +126,19 @@ export default function LoginPage() {
             Continue with Google
           </a>
 
-          <a href="/auth/login?provider=github" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
+          <a href="/auth/login?provider=github&tos_accepted=true" className="flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800">
             <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
               <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
             </svg>
             Continue with GitHub
           </a>
+
+          <p className="text-center text-xs text-gray-400">
+            By continuing, you agree to our{' '}
+            <a href="/terms" target="_blank" className="underline hover:text-gray-600">Terms of Service</a>
+            {' '}and{' '}
+            <a href="/privacy" target="_blank" className="underline hover:text-gray-600">Privacy Policy</a>
+          </p>
         </div>
 
         <p className="text-center text-sm text-gray-500">

--- a/apps/web/src/app/privacy/page.tsx
+++ b/apps/web/src/app/privacy/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export const metadata = { title: 'Privacy Policy — Sprintable' };
+
+export default function PrivacyPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="mx-auto max-w-2xl px-4">
+        <div className="mb-8 flex items-center gap-3">
+          <Link href="/">
+            <SprintableLogo variant="mark" className="text-gray-900" markClassName="h-8" />
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900">Privacy Policy</h1>
+        </div>
+
+        <div className="rounded-2xl bg-white p-8 shadow-sm space-y-6 text-sm text-gray-700 leading-relaxed">
+          <p className="text-xs text-gray-400">Last updated: May 2026</p>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">1. Information We Collect</h2>
+            <p>We collect information you provide directly (e.g., email address, name) and information generated through your use of Sprintable (e.g., sprint data, activity logs).</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">2. How We Use Your Information</h2>
+            <p>We use your information to provide and improve the Sprintable service, communicate with you, and ensure the security of your account.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">3. Data Sharing</h2>
+            <p>We do not sell your personal information. We may share information with service providers who assist in operating our platform, subject to confidentiality agreements.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">4. Data Retention</h2>
+            <p>We retain your data for as long as your account is active or as needed to provide services. You may request deletion of your data at any time.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">5. Security</h2>
+            <p>We implement industry-standard security measures to protect your information. However, no method of transmission over the internet is 100% secure.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">6. Your Rights</h2>
+            <p>Depending on your location, you may have rights to access, correct, or delete your personal information. Contact us to exercise these rights.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">7. Contact</h2>
+            <p>For privacy inquiries, contact us at <a href="mailto:privacy@moonklabs.com" className="text-blue-600 hover:underline">privacy@moonklabs.com</a>.</p>
+          </section>
+
+          <p className="text-xs text-gray-400 pt-4 border-t border-gray-100">
+            This is a placeholder document. Full privacy policy will be provided before public launch.
+          </p>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-gray-500">
+          <Link href="/terms" className="text-blue-600 hover:text-blue-700">Terms of Service</Link>
+          {' · '}
+          <Link href="/register" className="text-blue-600 hover:text-blue-700">Back to Sign Up</Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -24,6 +24,7 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordTouched, setPasswordTouched] = useState(false);
+  const [tosAccepted, setTosAccepted] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -33,6 +34,7 @@ export default function RegisterPage() {
 
   const handleRegister = async () => {
     if (!email.trim() || !password.trim()) return;
+    if (!tosAccepted) return;
     if (!isPasswordValid) {
       setPasswordTouched(true);
       return;
@@ -43,7 +45,7 @@ export default function RegisterPage() {
       const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.trim(), password }),
+        body: JSON.stringify({ email: email.trim(), password, tos_accepted: true }),
       });
       const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
       if (!res.ok || !json.data?.ok) {
@@ -108,14 +110,68 @@ export default function RegisterPage() {
               </li>
             </ul>
           )}
+
+          <label className="flex items-start gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={tosAccepted}
+              onChange={(e) => setTosAccepted(e.target.checked)}
+              className="mt-0.5 h-4 w-4 shrink-0 rounded border-gray-300 accent-blue-600"
+              disabled={loading}
+            />
+            <span className="text-xs text-gray-600">
+              I agree to the{' '}
+              <Link href="/terms" target="_blank" className="font-medium text-blue-600 hover:text-blue-700">
+                Terms of Service
+              </Link>{' '}
+              and{' '}
+              <Link href="/privacy" target="_blank" className="font-medium text-blue-600 hover:text-blue-700">
+                Privacy Policy
+              </Link>
+            </span>
+          </label>
+
           {error && <p className="text-sm text-red-600">{error}</p>}
           <button
             onClick={handleRegister}
-            disabled={loading || !email.trim() || !password.trim()}
+            disabled={loading || !email.trim() || !password.trim() || !tosAccepted}
             className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-blue-600 px-4 py-3 text-sm font-medium text-white transition hover:bg-blue-700 disabled:opacity-50"
           >
             {loading ? 'Creating account...' : 'Sign up'}
           </button>
+        </div>
+
+        <div className="space-y-3">
+          <div className="relative flex items-center">
+            <div className="flex-grow border-t border-gray-200" />
+            <span className="mx-3 flex-shrink text-xs text-gray-400">or continue with</span>
+            <div className="flex-grow border-t border-gray-200" />
+          </div>
+
+          <a
+            href={tosAccepted ? '/auth/login?provider=google&tos_accepted=true' : undefined}
+            onClick={!tosAccepted ? (e) => { e.preventDefault(); setError('Please agree to the Terms of Service and Privacy Policy first.'); } : undefined}
+            className={`flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-white px-4 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50 ${!tosAccepted ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4" />
+              <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853" />
+              <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05" />
+              <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335" />
+            </svg>
+            Continue with Google
+          </a>
+
+          <a
+            href={tosAccepted ? '/auth/login?provider=github&tos_accepted=true' : undefined}
+            onClick={!tosAccepted ? (e) => { e.preventDefault(); setError('Please agree to the Terms of Service and Privacy Policy first.'); } : undefined}
+            className={`flex w-full min-h-[44px] items-center justify-center gap-3 rounded-lg border border-gray-300 bg-gray-900 px-4 py-3 text-sm font-medium text-white transition hover:bg-gray-800 ${!tosAccepted ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+              <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+            </svg>
+            Continue with GitHub
+          </a>
         </div>
 
         <p className="text-center text-sm text-gray-500">

--- a/apps/web/src/app/terms/page.tsx
+++ b/apps/web/src/app/terms/page.tsx
@@ -1,0 +1,68 @@
+import Link from 'next/link';
+import { SprintableLogo } from '@/components/brand/sprintable-logo';
+
+export const metadata = { title: 'Terms of Service — Sprintable' };
+
+export default function TermsPage() {
+  return (
+    <div className="min-h-screen bg-gray-50 py-12">
+      <div className="mx-auto max-w-2xl px-4">
+        <div className="mb-8 flex items-center gap-3">
+          <Link href="/">
+            <SprintableLogo variant="mark" className="text-gray-900" markClassName="h-8" />
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900">Terms of Service</h1>
+        </div>
+
+        <div className="rounded-2xl bg-white p-8 shadow-sm space-y-6 text-sm text-gray-700 leading-relaxed">
+          <p className="text-xs text-gray-400">Last updated: May 2026</p>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">1. Acceptance of Terms</h2>
+            <p>By accessing or using Sprintable, you agree to be bound by these Terms of Service. If you do not agree, do not use the service.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">2. Use of Service</h2>
+            <p>Sprintable is an AI-powered sprint management platform. You may use the service for lawful purposes only and in accordance with these terms.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">3. User Accounts</h2>
+            <p>You are responsible for maintaining the confidentiality of your account credentials and for all activities that occur under your account.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">4. Intellectual Property</h2>
+            <p>All content and functionality on Sprintable is the exclusive property of Moonklabs and is protected by applicable intellectual property laws.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">5. Limitation of Liability</h2>
+            <p>Sprintable is provided &quot;as is&quot; without warranties of any kind. In no event shall Moonklabs be liable for any indirect, incidental, or consequential damages.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">6. Changes to Terms</h2>
+            <p>We reserve the right to modify these terms at any time. Continued use of the service after changes constitutes acceptance of the new terms.</p>
+          </section>
+
+          <section className="space-y-2">
+            <h2 className="font-semibold text-gray-900">7. Contact</h2>
+            <p>For questions about these terms, contact us at <a href="mailto:legal@moonklabs.com" className="text-blue-600 hover:underline">legal@moonklabs.com</a>.</p>
+          </section>
+
+          <p className="text-xs text-gray-400 pt-4 border-t border-gray-100">
+            This is a placeholder document. Full terms will be provided before public launch.
+          </p>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-gray-500">
+          <Link href="/privacy" className="text-blue-600 hover:text-blue-700">Privacy Policy</Link>
+          {' · '}
+          <Link href="/register" className="text-blue-600 hover:text-blue-700">Back to Sign Up</Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항 (프론트엔드 범위)

- register/page.tsx: TOS 체크박스 + OAuth 버튼 추가, 미동의 시 disabled
- login/page.tsx: OAuth 버튼 tos_accepted=true 파라미터 + 동의 안내 문구
- auth/login/route.ts: tos_accepted 쿼리 파라미터 → oauth_tos_{provider} 쿠키 저장
- api/auth/callback/[provider]/route.ts: tos 쿠키 읽어 FastAPI OAuth 콜백 전달
- api/auth/register/route.ts: tos_accepted 필드 FastAPI로 전달
- terms/page.tsx, privacy/page.tsx: placeholder 페이지 신규 생성

## ⚠️ 백엔드 작업 별도 필요 (은와추쿠군)
- user 모델 tos_accepted_at 필드, register/OAuth 엔드포인트 검증, pytest

## AC (프론트 범위)
- [x] 가입 화면 약관 동의 체크박스 (필수)
- [x] 미체크 시 가입 불가
- [x] TOS/Privacy 페이지 존재
- [x] tos_accepted 필드 API 전달
- [x] OAuth 가입 적용
- [x] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)