### PR TITLE
feat(AUTH-07): tos_accepted_at 필드 + TOS 동의 검증 (백엔드)

### DIFF
--- a/backend/alembic/versions/0018_add_tos_accepted_at.py
+++ b/backend/alembic/versions/0018_add_tos_accepted_at.py
@@ -1,0 +1,23 @@
+"""add tos_accepted_at to users
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-11
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("tos_accepted_at", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "tos_accepted_at")

--- a/backend/alembic/versions/0020_add_tos_accepted_at.py
+++ b/backend/alembic/versions/0020_add_tos_accepted_at.py
@@ -1,7 +1,7 @@
 """add tos_accepted_at to users
 
-Revision ID: 0018
-Revises: 0017
+Revision ID: 0020
+Revises: 0019
 Create Date: 2026-05-11
 """
 from __future__ import annotations
@@ -9,8 +9,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0018"
-down_revision = "0017"
+revision = "0020"
+down_revision = "0019"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -18,6 +18,7 @@ class User(Base):
     login_fail_count: Mapped[int] = mapped_column(nullable=False, default=0)
     login_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    tos_accepted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     totp_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     totp_last_timestep: Mapped[int | None] = mapped_column(nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -85,6 +85,7 @@ class LoginRequest(BaseModel):
 class RegisterRequest(BaseModel):
     email: str
     password: str
+    tos_accepted: bool = False
 
     @field_validator("email")
     @classmethod
@@ -304,6 +305,9 @@ async def register(
     body: RegisterRequest,
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
+    if not body.tos_accepted:
+        return _err("TOS_NOT_ACCEPTED", "You must accept the Terms of Service to register", 400)
+
     existing = await _get_user_by_email(session, body.email)
     if existing:
         return _err("EMAIL_TAKEN", "Email already registered", 409)
@@ -313,6 +317,7 @@ async def register(
         hashed_password=hash_password(body.password),
         is_active=True,
         email_verified=False,
+        tos_accepted_at=datetime.now(timezone.utc),
     )
     session.add(user)
     try:
@@ -582,6 +587,7 @@ class OAuthCallbackRequest(BaseModel):
     provider: str
     code: str
     state: str
+    tos_accepted: bool = False
 
 
 @router.get("/oauth/{provider}/authorize")
@@ -684,11 +690,14 @@ async def oauth_callback(
             await session.refresh(user)
         else:
             # 신규 유저 생성 (비밀번호 없음 — OAuth 전용, 이메일 인증 완료)
+            if not body.tos_accepted:
+                return _err("TOS_NOT_ACCEPTED", "You must accept the Terms of Service to register", 400)
             user = User(
                 email=email,
                 hashed_password="",
                 is_active=True,
                 email_verified=True,
+                tos_accepted_at=datetime.now(timezone.utc),
                 **{f"{provider}_id": oauth_id},
             )
             session.add(user)

--- a/backend/tests/test_auth_tos.py
+++ b/backend/tests/test_auth_tos.py
@@ -1,0 +1,69 @@
+"""AUTH-07: TOS 동의 검증 단위 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.flush = AsyncMock()
+    mock_session.add = MagicMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.mark.anyio
+async def test_register_without_tos_400():
+    """tos_accepted=False → 400 TOS_NOT_ACCEPTED."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json={
+                "email": "new@example.com",
+                "password": "TestPass1!",
+                "tos_accepted": False,
+            })
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "TOS_NOT_ACCEPTED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_without_tos_field_400():
+    """tos_accepted 미전달(기본값 False) → 400."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json={
+                "email": "new@example.com",
+                "password": "TestPass1!",
+            })
+        assert resp.status_code == 400
+        assert resp.json()["error"]["code"] == "TOS_NOT_ACCEPTED"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -232,7 +232,7 @@ async def test_register_new_user_201():
         session.execute = AsyncMock(return_value=result_none)
         with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
             async with client as c:
-                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "TestPass1!"})
+                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "TestPass1!", "tos_accepted": True})
         assert resp.status_code == 201
         body = resp.json()
         assert body["error"] is None
@@ -251,7 +251,7 @@ async def test_register_duplicate_email_409():
         result_existing.scalar_one_or_none.return_value = _make_user()
         session.execute = AsyncMock(return_value=result_existing)
         async with client as c:
-            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "TestPass1!"})
+            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "TestPass1!", "tos_accepted": True})
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "EMAIL_TAKEN"
     finally:


### PR DESCRIPTION
## Summary
미르코군 PR #622 (프론트엔드)와 연동하는 백엔드 TOS 처리.

## 변경 내역
- `User.tos_accepted_at: datetime | None` 컬럼 추가 (migration 0018)
- `RegisterRequest.tos_accepted: bool = False` 추가
- `tos_accepted=False` → 400 `TOS_NOT_ACCEPTED`
- `tos_accepted=True` → `tos_accepted_at=datetime.now()` 기록
- `OAuthCallbackRequest.tos_accepted: bool` 추가 (신규 OAuth 가입자에만 적용)
- pytest 2건

## AC
- [x] tos_accepted 미동의 → 400
- [x] tos_accepted=True → tos_accepted_at DB 기록
- [x] OAuth 신규 가입자 동일 검증
- [x] 기존 사용자 영향 없음 (nullable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)