### PR TITLE
feat(AUTH-09): OAuth state JWT 검증 + 로그인 brute force lockout

### DIFF
--- a/backend/alembic/versions/0018_add_login_lockout_fields.py
+++ b/backend/alembic/versions/0018_add_login_lockout_fields.py
@@ -1,0 +1,25 @@
+"""add login_fail_count and login_locked_until to users
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-11
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("login_fail_count", sa.Integer(), nullable=False, server_default="0"))
+    op.add_column("users", sa.Column("login_locked_until", sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "login_locked_until")
+    op.drop_column("users", "login_fail_count")

--- a/backend/alembic/versions/0019_add_login_lockout_fields.py
+++ b/backend/alembic/versions/0019_add_login_lockout_fields.py
@@ -1,7 +1,7 @@
 """add login_fail_count and login_locked_until to users
 
-Revision ID: 0018
-Revises: 0017
+Revision ID: 0019
+Revises: 0018
 Create Date: 2026-05-11
 """
 from __future__ import annotations
@@ -9,8 +9,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0018"
-down_revision = "0017"
+revision = "0019"
+down_revision = "0018"
 branch_labels = None
 depends_on = None
 

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -194,3 +194,30 @@ def decode_email_verification_token(token: str) -> dict:
     if payload.get("type") != "email_verification":
         raise JWTError("Invalid token type")
     return payload
+
+
+# ─── OAuth State Token ────────────────────────────────────────────────────────
+
+OAUTH_STATE_EXPIRE_MINUTES = 10
+
+
+def create_oauth_state_token(provider: str) -> str:
+    """10분 만료 OAuth state JWT. CSRF 방지용."""
+    now = datetime.now(timezone.utc)
+    exp = now + timedelta(minutes=OAUTH_STATE_EXPIRE_MINUTES)
+    payload = {
+        "type": "oauth_state",
+        "provider": provider,
+        "iat": int(now.timestamp()),
+        "exp": int(exp.timestamp()),
+    }
+    return jwt.encode(payload, _get_secret(), algorithm="HS256")
+
+
+def decode_oauth_state_token(token: str, expected_provider: str) -> None:
+    """OAuth state token 검증. 만료/타입/provider 불일치 시 JWTError."""
+    payload = decode_jwt(token)
+    if payload.get("type") != "oauth_state":
+        raise JWTError("Invalid state token type")
+    if payload.get("provider") != expected_provider:
+        raise JWTError("Provider mismatch in state token")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,6 +15,8 @@ class User(Base):
     email: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(Text, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    login_fail_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    login_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     email_verified: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     totp_secret: Mapped[str | None] = mapped_column(Text, nullable=True)
     totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -31,9 +31,11 @@ from app.core.security import (
     create_tokens,
     create_password_reset_token,
     create_email_verification_token,
+    create_oauth_state_token,
     decode_jwt,
     decode_password_reset_token,
     decode_email_verification_token,
+    decode_oauth_state_token,
     generate_totp_secret,
     get_totp_provisioning_uri,
     hash_password,
@@ -332,7 +334,30 @@ async def login(
     session: AsyncSession = Depends(get_db),
 ) -> JSONResponse:
     user = await _get_user_by_email(session, body.email)
+
+    # brute force lockout 체크
+    if user and user.login_locked_until:
+        if user.login_locked_until > datetime.now(timezone.utc):
+            remaining = int((user.login_locked_until - datetime.now(timezone.utc)).total_seconds())
+            return _err("ACCOUNT_LOCKED", f"Account locked. Try again in {remaining} seconds", 429)
+        # 잠금 해제 시간 경과 — 카운터 초기화
+        await session.execute(
+            update(User).where(User.id == user.id).values(login_fail_count=0, login_locked_until=None)
+        )
+
     if not user or not verify_password(body.password, user.hashed_password):
+        # 실패 카운터 증가
+        if user:
+            new_count = (user.login_fail_count or 0) + 1
+            locked_until = (
+                datetime.now(timezone.utc) + timedelta(minutes=5) if new_count >= 5 else None
+            )
+            await session.execute(
+                update(User).where(User.id == user.id).values(
+                    login_fail_count=new_count,
+                    login_locked_until=locked_until,
+                )
+            )
         return _err("INVALID_CREDENTIALS", "Invalid email or password", 401)
 
     if user.totp_enabled:
@@ -371,6 +396,12 @@ async def login(
                 totp_fail_count=0,
                 totp_locked_until=None,
             )
+        )
+
+    # 로그인 성공 — 실패 카운터 리셋
+    if user.login_fail_count or user.login_locked_until:
+        await session.execute(
+            update(User).where(User.id == user.id).values(login_fail_count=0, login_locked_until=None)
         )
 
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
@@ -537,7 +568,7 @@ async def oauth_authorize(provider: str) -> JSONResponse:
     if provider not in _OAUTH_CONFIGS:
         return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
     cfg = _OAUTH_CONFIGS[provider]
-    state = secrets.token_urlsafe(32)
+    state = create_oauth_state_token(provider)
     params = {
         "client_id": _client_id(provider),
         "redirect_uri": _redirect_uri(provider),
@@ -561,6 +592,12 @@ async def oauth_callback(
     if provider not in _OAUTH_CONFIGS:
         return _err("INVALID_PROVIDER", f"Unsupported provider: {provider}", 400)
     cfg = _OAUTH_CONFIGS[provider]
+
+    # state JWT 검증 (CSRF 방지)
+    try:
+        decode_oauth_state_token(body.state, provider)
+    except JWTError:
+        return _err("INVALID_STATE", "OAuth state is invalid or expired", 400)
 
     async with httpx.AsyncClient(timeout=15) as client:
         # 1. code → access_token 교환

--- a/backend/tests/test_auth_security.py
+++ b/backend/tests/test_auth_security.py
@@ -1,0 +1,79 @@
+"""AUTH-09: OAuth state 검증 + 로그인 lockout 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.core.security import (
+    JWTError,
+    create_oauth_state_token,
+    decode_oauth_state_token,
+)
+
+
+# ─── OAuth state token ────────────────────────────────────────────────────────
+
+def test_oauth_state_roundtrip():
+    token = create_oauth_state_token("google")
+    decode_oauth_state_token(token, "google")  # 예외 없으면 PASS
+
+
+def test_oauth_state_provider_mismatch_rejected():
+    token = create_oauth_state_token("google")
+    with pytest.raises(JWTError):
+        decode_oauth_state_token(token, "github")
+
+
+def test_oauth_state_wrong_type_rejected():
+    from app.core.security import _get_secret
+    from jose import jwt
+    from datetime import datetime, timezone, timedelta
+    payload = {"type": "access", "provider": "google", "exp": int((datetime.now(timezone.utc) + timedelta(minutes=10)).timestamp())}
+    token = jwt.encode(payload, _get_secret(), algorithm="HS256")
+    with pytest.raises(JWTError):
+        decode_oauth_state_token(token, "google")
+
+
+# ─── Login lockout ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_login_locked_account_429():
+    """잠긴 계정 로그인 시도 → 429."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+    from datetime import datetime, timezone, timedelta
+
+    mock_user = MagicMock()
+    mock_user.id = uuid.uuid4()
+    mock_user.email = "locked@example.com"
+    mock_user.hashed_password = "hash"
+    mock_user.is_active = True
+    mock_user.login_fail_count = 5
+    mock_user.login_locked_until = datetime.now(timezone.utc) + timedelta(minutes=4)
+    mock_user.totp_enabled = False
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_user
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/auth/token", json={
+                "email": "locked@example.com",
+                "password": "wrong",
+            })
+        assert resp.status_code == 429
+        assert resp.json()["error"]["code"] == "ACCOUNT_LOCKED"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -35,6 +35,8 @@ def _make_user(
     totp_last_timestep: int | None = None,
     totp_fail_count: int = 0,
     totp_locked_until=None,
+    login_fail_count: int = 0,
+    login_locked_until=None,
 ) -> MagicMock:
     from app.core.security import hash_password
     u = MagicMock()
@@ -47,6 +49,8 @@ def _make_user(
     u.totp_last_timestep = totp_last_timestep
     u.totp_fail_count = totp_fail_count
     u.totp_locked_until = totp_locked_until
+    u.login_fail_count = login_fail_count
+    u.login_locked_until = login_locked_until
     u.org_id = uuid.uuid4()
     u.project_id = uuid.uuid4()
     u.role = "member"


### PR DESCRIPTION
## Summary
두 가지 보안 강화: OAuth CSRF 방지 + 비밀번호 brute force 차단.

## 변경 내역

### OAuth state JWT 검증
- `oauth_authorize`: `secrets.token_urlsafe()` → `create_oauth_state_token(provider)` (JWT, 10분 만료)
- `oauth_callback`: state JWT decode + provider 검증 → 불일치 400 `INVALID_STATE`
- 백엔드 직접 호출 시 state 위조 불가

### Login brute force lockout
- `User.login_fail_count` + `login_locked_until` 추가 (migration 0018)
- 5회 연속 실패 → 5분 lockout → 429 `ACCOUNT_LOCKED`
- 성공 시 카운터 리셋

## AC
- [x] OAuth state 백엔드 검증
- [x] state 불일치/만료 → 400
- [x] 5회 실패 → 5분 lockout (429)
- [x] lockout 해제 후 정상 로그인
- [x] 성공 시 카운터 리셋
- [x] pytest 4건

🤖 Generated with [Claude Code](https://claude.com/claude-code)