### PR TITLE
[SID:AUTH-12] verify-email middleware 공개 경로 추가

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -20,10 +20,14 @@ const PUBLIC_PREFIX = [
   '/signup',
   '/register',
   '/forgot-password',
+  '/reset-password',
+  '/verify-email',
   '/auth/callback',
   '/auth/login',
   '/invite',
   '/internal-dogfood',
+  '/terms',
+  '/privacy',
 ];
 
 export const SP_AT_COOKIE = 'sp_at';


### PR DESCRIPTION
## 변경 사항

`apps/web/src/proxy.ts` `PUBLIC_PREFIX`에 미인증 접근 필요 경로 추가:

| 경로 | 이유 |
|---|---|
| `/verify-email` | 이메일 인증 링크 — 미로그인 상태에서 클릭 |
| `/reset-password` | 비밀번호 재설정 링크 — 미로그인 상태에서 접근 |
| `/terms` | 약관 페이지 — 가입 전 참조 |
| `/privacy` | 개인정보 페이지 — 가입 전 참조 |

## AC 체크리스트
- [x] 미인증 상태에서 `/verify-email?token=xxx` → 리다이렉트 없이 페이지 렌더링
- [x] 기존 인증 플로우(`/login`, `/register`, `/forgot-password` 등) 영향 없음
- [x] `pnpm build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)