### PR TITLE
fix(MEMO-02): entity embed 서버사이드 파싱

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -20,6 +20,30 @@ from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResp
 
 router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
 
+_ENTITY_PATTERN = re.compile(
+    r"\(entity:(story|doc|epic|task):([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\)",
+    re.IGNORECASE,
+)
+
+
+def _parse_entity_embeds(content: str) -> list:
+    """content 내 (entity:type:uuid) 패턴 파싱 → MemoEntityLinkCreate 리스트 (중복 제거)."""
+    from app.schemas.memo import MemoEntityLinkCreate
+    seen: set[tuple[str, str]] = set()
+    result = []
+    for i, m in enumerate(_ENTITY_PATTERN.finditer(content)):
+        entity_type, entity_id_str = m.group(1).lower(), m.group(2)
+        key = (entity_type, entity_id_str)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(MemoEntityLinkCreate(
+            entity_type=entity_type,  # type: ignore[arg-type]
+            entity_id=uuid.UUID(entity_id_str),
+            position=i,
+        ))
+    return result
+
 
 async def _collect_reply_webhook_urls(
     db: AsyncSession,
@@ -151,8 +175,13 @@ async def create_memo(
                 assigned_by=body.created_by,
             ))
         await session.flush()
-    if body.embeds:
-        await repo.create_entity_links(memo.id, body.embeds)
+    parsed_embeds = _parse_entity_embeds(body.content or "")
+    all_embeds = list(body.embeds or []) + [
+        e for e in parsed_embeds
+        if not any(x.entity_type == e.entity_type and x.entity_id == e.entity_id for x in (body.embeds or []))
+    ]
+    if all_embeds:
+        await repo.create_entity_links(memo.id, all_embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})
     if body.project_id:
         from app.services.workflow_pipeline import process_event
@@ -191,7 +220,7 @@ async def create_memo(
         except Exception:
             pass
     memo_dict = {k: v for k, v in memo.__dict__.items() if not k.startswith("_")}
-    memo_dict["embed_count"] = len(body.embeds)
+    memo_dict["embed_count"] = len(all_embeds)
     return MemoListResponse.model_validate(memo_dict)
 
 

--- a/backend/tests/test_memo_02.py
+++ b/backend/tests/test_memo_02.py
@@ -1,0 +1,226 @@
+"""MEMO-02: entity embed 서버사이드 파싱 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMO_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+DOC_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ─── _parse_entity_embeds 단위 테스트 ─────────────────────────────────────────
+
+def test_parse_entity_embeds_story():
+    """(entity:story:uuid) 패턴 파싱."""
+    from app.routers.memos import _parse_entity_embeds
+    content = f"스토리 참조: [S-01](entity:story:{STORY_ID})"
+    embeds = _parse_entity_embeds(content)
+    assert len(embeds) == 1
+    assert embeds[0].entity_type == "story"
+    assert embeds[0].entity_id == STORY_ID
+
+
+def test_parse_entity_embeds_multiple_types():
+    """story + doc 복합 파싱."""
+    from app.routers.memos import _parse_entity_embeds
+    content = (
+        f"[스토리](entity:story:{STORY_ID}) 관련 "
+        f"[문서](entity:doc:{DOC_ID})"
+    )
+    embeds = _parse_entity_embeds(content)
+    assert len(embeds) == 2
+    types = {e.entity_type for e in embeds}
+    assert types == {"story", "doc"}
+
+
+def test_parse_entity_embeds_deduplication():
+    """같은 entity 중복 시 하나만 포함."""
+    from app.routers.memos import _parse_entity_embeds
+    content = (
+        f"[첫 번째](entity:story:{STORY_ID}) "
+        f"[두 번째](entity:story:{STORY_ID})"
+    )
+    embeds = _parse_entity_embeds(content)
+    assert len(embeds) == 1
+
+
+def test_parse_entity_embeds_no_match():
+    """패턴 없는 content → 빈 리스트."""
+    from app.routers.memos import _parse_entity_embeds
+    embeds = _parse_entity_embeds("entity 링크 없는 일반 텍스트")
+    assert embeds == []
+
+
+def test_parse_entity_embeds_position_order():
+    """position이 등장 순서 기반."""
+    from app.routers.memos import _parse_entity_embeds
+    content = (
+        f"[스토리](entity:story:{STORY_ID}) "
+        f"[문서](entity:doc:{DOC_ID})"
+    )
+    embeds = _parse_entity_embeds(content)
+    story = next(e for e in embeds if e.entity_type == "story")
+    doc = next(e for e in embeds if e.entity_type == "doc")
+    assert story.position < doc.position
+
+
+# ─── AC1: create_memo 시 embeds 자동 파싱 + 저장 ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_memo_auto_parses_entity_embeds():
+    """content 내 entity 링크 → embeds 자동 파싱 + create_entity_links 호출."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(MEMBER_ID)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        mock_memo = MagicMock()
+        mock_memo.id = MEMO_ID
+        mock_memo.org_id = ORG_ID
+        mock_memo.project_id = PROJECT_ID
+        mock_memo.memo_type = "memo"
+        mock_memo.title = "테스트"
+        mock_memo.content = f"[스토리 참조](entity:story:{STORY_ID})"
+        mock_memo.created_by = MEMBER_ID
+        mock_memo.assigned_to = None
+        mock_memo.status = "open"
+        mock_memo.supersedes_id = None
+        mock_memo.resolved_by = None
+        mock_memo.resolved_at = None
+        mock_memo.archived_at = None
+        mock_memo.deleted_at = None
+        mock_memo.memo_metadata = {}
+        mock_memo.embed_count = 0
+        mock_memo.reply_count = 0
+        mock_memo.latest_reply_at = None
+        mock_memo.created_at = datetime(2026, 5, 11, tzinfo=timezone.utc)
+        mock_memo.updated_at = datetime(2026, 5, 11, tzinfo=timezone.utc)
+
+        with patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.repositories.memo.MemoRepository.create_entity_links", new_callable=AsyncMock) as mock_links, \
+             patch("app.routers.memos.publish_event"), \
+             patch("app.services.workflow_pipeline.process_event", new_callable=AsyncMock):
+            mock_create.return_value = mock_memo
+            mock_session.execute = AsyncMock(return_value=MagicMock())
+
+            from httpx import ASGITransport, AsyncClient
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/memos", json={
+                    "org_id": str(ORG_ID),
+                    "project_id": str(PROJECT_ID),
+                    "content": f"[스토리 참조](entity:story:{STORY_ID})",
+                    "memo_type": "memo",
+                    "title": "테스트",
+                    "created_by": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["embed_count"] == 1
+        mock_links.assert_called_once()
+        call_embeds = mock_links.call_args[0][1]
+        assert len(call_embeds) == 1
+        assert str(call_embeds[0].entity_id) == str(STORY_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC2: embed_count == len(embeds) ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_memo_embed_count_matches_parsed():
+    """두 entity 링크 파싱 시 embed_count=2."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(MEMBER_ID)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        mock_memo = MagicMock()
+        mock_memo.id = MEMO_ID
+        mock_memo.org_id = ORG_ID
+        mock_memo.project_id = PROJECT_ID
+        mock_memo.memo_type = "memo"
+        mock_memo.title = "테스트"
+        mock_memo.content = f"[스토리](entity:story:{STORY_ID}) [문서](entity:doc:{DOC_ID})"
+        mock_memo.created_by = MEMBER_ID
+        mock_memo.assigned_to = None
+        mock_memo.status = "open"
+        mock_memo.supersedes_id = None
+        mock_memo.resolved_by = None
+        mock_memo.resolved_at = None
+        mock_memo.archived_at = None
+        mock_memo.deleted_at = None
+        mock_memo.memo_metadata = {}
+        mock_memo.embed_count = 0
+        mock_memo.reply_count = 0
+        mock_memo.latest_reply_at = None
+        mock_memo.created_at = datetime(2026, 5, 11, tzinfo=timezone.utc)
+        mock_memo.updated_at = datetime(2026, 5, 11, tzinfo=timezone.utc)
+
+        with patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.repositories.memo.MemoRepository.create_entity_links", new_callable=AsyncMock), \
+             patch("app.routers.memos.publish_event"), \
+             patch("app.services.workflow_pipeline.process_event", new_callable=AsyncMock):
+            mock_create.return_value = mock_memo
+            mock_session.execute = AsyncMock(return_value=MagicMock())
+
+            from httpx import ASGITransport, AsyncClient
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.post("/api/v2/memos", json={
+                    "org_id": str(ORG_ID),
+                    "project_id": str(PROJECT_ID),
+                    "content": f"[스토리](entity:story:{STORY_ID}) [문서](entity:doc:{DOC_ID})",
+                    "memo_type": "memo",
+                    "title": "테스트",
+                    "created_by": str(MEMBER_ID),
+                })
+
+        assert resp.status_code == 201
+        assert resp.json()["embed_count"] == 2
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 스토리
[MEMO-02 entity embed 4계층 스키마 관통](entity:story:da6c5f76-b5e4-4f5b-9b3c-c63941949ada)

## 버그 원인
MCP→shared→core→FastAPI 체인에서 embeds 필드 미관통. content에 `(entity:type:uuid)` 문법 사용해도 embeds 저장 안 됨.

## 해결 방법 — B안: 서버사이드 파싱

FastAPI create_memo에서 content를 파싱하여 embeds 자동 생성. MCP/상위 계층 수정 없이 기존 에이전트 완전 호환.

### `_parse_entity_embeds(content)` helper
- 정규식 `(entity:(story|doc|epic|task):uuid)` 패턴 감지
- 중복 제거 (같은 entity_type + entity_id)
- position은 등장 순서 기반

### create_memo 수정
- `body.embeds` (명시적) + 파싱된 embeds 합산 → 중복 제외
- `create_entity_links` 일괄 호출
- `embed_count = len(all_embeds)` 정확 반영

## AC 체크리스트
- [x] AC1: send_memo entity embed 문법 → embeds 배열 정상 저장
- [x] AC2: embed_count == len(embeds)
- [x] AC3: 기존 메모 CRUD 영향 없음 (20/20 통과)
- [x] AC4: pytest 통과 (신규 7건 + 기존 13건 = 20/20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)