### PR TITLE
fix(MEMO-04): 스토리 done 시 관련 메모 자동 resolve

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -240,6 +240,7 @@ async def update_story_status(
             "epic_id": str(story.epic_id) if story.epic_id else None,
             "epic_title": epic_title,
             "status": story.status,
+            "new_status": story.status,
             "old_status": old_status,
             "project_id": str(story.project_id),
             "org_id": str(org_id),

--- a/backend/app/services/workflow_pipeline.py
+++ b/backend/app/services/workflow_pipeline.py
@@ -102,6 +102,29 @@ async def _execute_side_effects(
                             .where(Story.id == uuid.UUID(str(story_id_str)), Story.org_id == org_id)
                             .values(assignee_id=member_id)
                         )
+            elif effect_type == "resolve_memos" and story_id_str:
+                from app.models.memo import Memo, MemoEntityLink
+                link_result = await session.execute(
+                    select(MemoEntityLink.memo_id)
+                    .where(
+                        MemoEntityLink.entity_type == "story",
+                        MemoEntityLink.entity_id == uuid.UUID(str(story_id_str)),
+                    )
+                )
+                memo_ids = [row.memo_id for row in link_result]
+                if memo_ids:
+                    await session.execute(
+                        update(Memo)
+                        .where(
+                            Memo.id.in_(memo_ids),
+                            Memo.status == "open",
+                            Memo.deleted_at.is_(None),
+                        )
+                        .values(
+                            status="resolved",
+                            resolved_at=datetime.now(timezone.utc),
+                        )
+                    )
         except Exception:
             pass
 

--- a/backend/tests/test_memo_04.py
+++ b/backend/tests/test_memo_04.py
@@ -1,0 +1,123 @@
+"""MEMO-04: 스토리 done 시 관련 메모 자동 resolve 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+MEMO_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+# ─── AC1: resolve_memos side effect — story_id 기준 open 메모 전량 resolved ───
+
+@pytest.mark.anyio
+async def test_resolve_memos_side_effect():
+    """resolve_memos side effect: story 연결된 open 메모 전량 resolved 처리."""
+    from app.services.workflow_pipeline import _execute_side_effects
+    from app.services.rule_evaluator import EventContext
+
+    session = AsyncMock()
+
+    link_row = MagicMock()
+    link_row.memo_id = MEMO_ID
+
+    link_result = MagicMock()
+    link_result.__iter__ = MagicMock(return_value=iter([link_row]))
+
+    update_result = MagicMock()
+
+    call_count = 0
+
+    async def mock_execute(stmt, *a, **kw):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            return link_result
+        return update_result
+
+    session.execute = mock_execute
+
+    ctx = EventContext(
+        event_type="story.status_changed",
+        metadata={"story_id": str(STORY_ID), "new_status": "done"},
+    )
+
+    await _execute_side_effects(session, ORG_ID, [{"type": "resolve_memos"}], ctx)
+
+    assert call_count == 2
+
+
+# ─── AC1: story_id 없으면 resolve_memos 스킵 ──────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_memos_skipped_without_story_id():
+    """story_id 없는 컨텍스트에서 resolve_memos → 쿼리 없음."""
+    from app.services.workflow_pipeline import _execute_side_effects
+    from app.services.rule_evaluator import EventContext
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    ctx = EventContext(
+        event_type="story.status_changed",
+        metadata={},
+    )
+
+    await _execute_side_effects(session, ORG_ID, [{"type": "resolve_memos"}], ctx)
+
+    session.execute.assert_not_called()
+
+
+# ─── AC1: 빈 memo_ids — update 쿼리 미발생 ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_memos_no_links_skips_update():
+    """entity link 없는 story → update 쿼리 미발생."""
+    from app.services.workflow_pipeline import _execute_side_effects
+    from app.services.rule_evaluator import EventContext
+
+    session = AsyncMock()
+    empty_result = MagicMock()
+    empty_result.__iter__ = MagicMock(return_value=iter([]))
+
+    call_count = 0
+
+    async def mock_execute(stmt, *a, **kw):
+        nonlocal call_count
+        call_count += 1
+        return empty_result
+
+    session.execute = mock_execute
+
+    ctx = EventContext(
+        event_type="story.status_changed",
+        metadata={"story_id": str(STORY_ID)},
+    )
+
+    await _execute_side_effects(session, ORG_ID, [{"type": "resolve_memos"}], ctx)
+
+    assert call_count == 1
+
+
+# ─── AC2: stories.py event_data에 new_status 포함 — 코드 레벨 검증 ───────────
+
+def test_event_data_includes_new_status():
+    """update_story_status 이벤트 payload 구성 방식 — new_status 포함 여부 코드 확인."""
+    import ast, pathlib
+    src = pathlib.Path(
+        __file__
+    ).parent.parent / "app" / "routers" / "stories.py"
+    code = src.read_text()
+    assert '"new_status"' in code or "'new_status'" in code, \
+        "stories.py event_data에 new_status 필드가 없음"


### PR DESCRIPTION
## 스토리
[MEMO-04 스토리 done 시 관련 메모 자동 resolve](entity:story:22fc6fc3-6e76-4e84-8529-4fe8b36a54d5)

## 버그 원인
1. event_data에 `new_status` 미포함 → rule 조건 매칭 실패
2. `resolve_memos` side effect 미구현

## 수정 내용

### `stories.py:update_story_status`
- `event_data["new_status"] = story.status` 추가 — rule evaluator 조건 매칭 가능

### `workflow_pipeline.py:_execute_side_effects`
- `resolve_memos` case 추가:
  - `MemoEntityLink.entity_type="story"` + `entity_id=story_id` → memo_id 목록 조회
  - `Memo.status="open"` + `deleted_at IS NULL` 조건으로 UPDATE → `status="resolved"`, `resolved_at=now()`
  - story_id 없거나 memo_ids 빈 경우 쿼리 미발생

## AC 체크리스트
- [x] AC1: resolve_memos side effect 정상 동작 (2 쿼리: SELECT + UPDATE)
- [x] AC2: new_status 이벤트 payload 포함
- [x] AC3: 기존 side effect 영향 없음 (36/36 통과)
- [x] AC4: pytest 통과 (신규 4건 + 기존 36건 = 40/40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)