### PR TITLE
[SID:BOARD-01] 더 보기 카드 중복 로드 수정

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -935,7 +935,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                 const res = await fetch(`/api/stories?${params}`);
                 if (res.ok) {
                   const json = await res.json();
-                  setStories((prev) => [...prev, ...(json.data ?? [])]);
+                  setStories((prev) => {
+                    const existingIds = new Set(prev.map((s) => s.id));
+                    return [...prev, ...(json.data ?? []).filter((s: KanbanStory) => !existingIds.has(s.id))];
+                  });
                   setNextCursor(json.meta?.nextCursor ?? null);
                 }
                 setLoadingMore(false);
@@ -985,7 +988,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             const res = await fetch(`/api/tasks?story_id=${selectedStory.id}&limit=20&cursor=${encodeURIComponent(storyTasksNextCursor)}`);
             if (res.ok) {
               const json = await res.json();
-              setStoryTasks((prev) => [...prev, ...(json.data ?? [])]);
+              setStoryTasks((prev) => {
+                const existingIds = new Set(prev.map((t) => t.id));
+                return [...prev, ...(json.data ?? []).filter((t: Task) => !existingIds.has(t.id))];
+              });
               setStoryTasksNextCursor(json.meta?.nextCursor ?? null);
             }
             setLoadingMoreStoryTasks(false);


### PR DESCRIPTION
## 변경 사항

`더 보기` 버튼 클릭 시 동일 `story_id` 카드가 2회 렌더링되는 버그 수정.

**원인**: `setStories((prev) => [...prev, ...(json.data ?? [])])` — 기존 스토리와 신규 페이지 데이터를 deduplication 없이 단순 append.

**수정**: append 전 `Set<id>`로 기존 ID 목록 생성 → 새 데이터에서 중복 필터링 후 병합.

```tsx
// before
setStories((prev) => [...prev, ...(json.data ?? [])]);

// after
setStories((prev) => {
  const existingIds = new Set(prev.map((s) => s.id));
  return [...prev, ...(json.data ?? []).filter((s: KanbanStory) => !existingIds.has(s.id))];
});
```

storyTasks 더 보기도 동일 패턴으로 함께 수정.

## AC 체크리스트

- [x] AC1: `더 보기` 클릭 후 동일 story_id 카드가 1번만 표시됨
- [x] AC2: 반복 클릭 시에도 중복 없음 (매 append마다 dedup 적용)
- [x] AC3: 전체/멤버/에이전트 탭 전환 후 `더 보기` 클릭해도 중복 없음 (`fetchData` 재호출 시 stories 완전 교체 → cursor 리셋됨)

## 스크린샷

> UI 변경 없는 로직 버그 수정 — 로컬 dev 서버 미실행으로 스크린샷 생략. 코드 diff로 대체.

## 빌드 검증

- `pnpm lint` — 0 errors
- `pnpm build` — 성공