### PR TITLE
[SID:DR-02] /docs/[slug] 라우트 전환 + layout.tsx 분리

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -53,7 +53,7 @@ export default function DocSlugPage() {
   const router = useRouter();
   const t = useTranslations('docs');
 
-  const { projectId, setTree } = useDocsLayout();
+  const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
 
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
   const [title, setTitle] = useState('');
@@ -92,6 +92,14 @@ export default function DocSlugPage() {
   }, [projectId, slug]);
 
   useEffect(() => { void fetchDoc(); }, [fetchDoc]);
+
+  // layout handleRename PATCH 성공 후 updated_at 동기화 — useDocSync 기준선 desync 방지
+  useEffect(() => {
+    if (!pendingDocUpdate || !selectedDoc || pendingDocUpdate.id !== selectedDoc.id) return;
+    setSelectedDoc((prev) => prev ? { ...prev, title: pendingDocUpdate.title, updated_at: pendingDocUpdate.updated_at } : null);
+    setTitle(pendingDocUpdate.title);
+    clearPendingDocUpdate();
+  }, [pendingDocUpdate, selectedDoc, clearPendingDocUpdate]);
 
   const handleCopyMarkdown = useCallback(async () => {
     try {

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { DocEditor } from '@/components/docs/doc-editor';
+import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Check, Copy, Trash2 } from 'lucide-react';
+import { useDocsLayout } from '../docs-context';
+
+interface DocDetail {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  content_format?: 'markdown' | 'html';
+  updated_at: string;
+  parent_id?: string | null;
+  icon?: string | null;
+  is_folder?: boolean;
+  doc_type?: string;
+  org_id?: string;
+}
+
+const SAVE_STATUS_CLASS: Partial<Record<SaveStatus, string>> = {
+  saving: 'text-[color:var(--operator-muted)]',
+  saved: 'text-emerald-500/70',
+  unsaved: 'text-amber-500/70',
+  error: 'text-rose-500',
+  conflict: 'text-rose-500',
+  'remote-changed': 'text-amber-500',
+};
+
+function SaveStatusIndicator({ status, t }: { status: SaveStatus; t: ReturnType<typeof useTranslations> }) {
+  const map: Partial<Record<SaveStatus, string>> = {
+    saving: t('statusSaving'),
+    saved: t('statusSaved'),
+    unsaved: t('statusUnsaved'),
+    error: t('statusError'),
+    conflict: t('statusConflict'),
+    'remote-changed': t('statusRemoteChanged'),
+  };
+  const text = map[status] ?? null;
+  if (!text) return null;
+  return <span className={`shrink-0 text-xs ${SAVE_STATUS_CLASS[status] ?? ''}`}>{text}</span>;
+}
+
+export default function DocSlugPage() {
+  const params = useParams();
+  const slug = typeof params.slug === 'string' ? params.slug : '';
+  const router = useRouter();
+  const t = useTranslations('docs');
+
+  const { projectId, setTree } = useDocsLayout();
+
+  const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [contentFormat, setContentFormat] = useState<'markdown' | 'html'>('markdown');
+  const [autosave, setAutosave] = useState(true);
+  const [mdCopied, setMdCopied] = useState(false);
+
+  const handleDocSaved = useCallback((doc: DocDetail) => {
+    setSelectedDoc(doc);
+    setTree((prev) => prev.map((d) => (d.id === doc.id ? { ...d, title: doc.title } : d)));
+  }, [setTree]);
+
+  const { status: saveStatus, isDirty, save } = useDocSync<DocDetail>({
+    docId: selectedDoc?.id ?? null,
+    savePayload: { title, content, content_format: contentFormat },
+    serverUpdatedAt: selectedDoc?.updated_at ?? null,
+    editing: selectedDoc !== null,
+    autosave,
+    onSaved: handleDocSaved,
+  });
+
+  const fetchDoc = useCallback(async () => {
+    if (!projectId || !slug) return;
+    try {
+      const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`);
+      if (!res.ok) throw new Error('Failed to fetch doc');
+      const { data } = await res.json();
+      setSelectedDoc(data);
+      setTitle(data.title);
+      setContent(data.content);
+      setContentFormat(data.content_format || 'markdown');
+    } catch {
+      setSelectedDoc(null);
+    }
+  }, [projectId, slug]);
+
+  useEffect(() => { void fetchDoc(); }, [fetchDoc]);
+
+  const handleCopyMarkdown = useCallback(async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content);
+      }
+    } catch { /* clipboard unavailable */ }
+    setMdCopied(true);
+    window.setTimeout(() => setMdCopied(false), 1600);
+  }, [content]);
+
+  const handleDelete = useCallback(async () => {
+    if (!selectedDoc || !projectId) return;
+    if (!confirm(t('confirmDelete'))) return;
+    try {
+      const res = await fetch(`/api/docs/${selectedDoc.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete doc');
+      setTree((prev) => prev.filter((d) => d.id !== selectedDoc.id));
+      router.replace('/docs');
+    } catch { /* delete failed */ }
+  }, [selectedDoc, projectId, router, setTree, t]);
+
+  const handleNavigate = useCallback((targetSlug: string) => {
+    router.push(`/docs/${targetSlug}`);
+  }, [router]);
+
+  if (!selectedDoc) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="border-none bg-transparent px-0 text-2xl font-semibold focus-visible:ring-0"
+              placeholder={t('titlePlaceholder')}
+            />
+          </div>
+          <div className="flex items-center gap-3">
+            <SaveStatusIndicator status={saveStatus} t={t} />
+            <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
+              {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
+            </Button>
+            {selectedDoc.doc_type !== 'sprint_report' && (
+              <Button variant="ghost" size="sm" onClick={handleDelete}>
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-4 lg:px-6 lg:py-6">
+        <DocEditor
+          value={content}
+          contentFormat={contentFormat}
+          editable={selectedDoc.doc_type !== 'sprint_report'}
+          currentDocId={selectedDoc.id}
+          onNavigate={handleNavigate}
+          onChange={setContent}
+          onContentFormatChange={setContentFormat}
+          isDirty={isDirty}
+          onSave={save}
+          autosave={autosave}
+          onAutosaveToggle={setAutosave}
+          labels={{
+            contentFormat: t('contentFormat'),
+            markdown: t('formatMarkdown'),
+            preview: t('formatPreview'),
+            save: t('save'),
+            toolbar: t('toolbar'),
+            placeholder: t('editorPlaceholder'),
+            h1: t('toolbarH1'),
+            h2: t('toolbarH2'),
+            bold: t('toolbarBold'),
+            italic: t('toolbarItalic'),
+            bullet: t('toolbarBullet'),
+            quote: t('toolbarQuote'),
+            code: t('toolbarCode'),
+            link: t('toolbarLink'),
+            autosave: t('autosave'),
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/docs-context.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-context.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { createContext, useContext, type Dispatch, type SetStateAction } from 'react';
+
+export interface Doc {
+  id: string;
+  parent_id: string | null;
+  title: string;
+  slug: string;
+  icon: string | null;
+  sort_order: number;
+  is_folder?: boolean;
+}
+
+interface DocsLayoutContextType {
+  projectId: string | undefined;
+  setTree: Dispatch<SetStateAction<Doc[]>>;
+  handleNewDoc: () => void;
+  fetchTree: () => Promise<void>;
+}
+
+export const DocsLayoutContext = createContext<DocsLayoutContextType | null>(null);
+
+export function useDocsLayout(): DocsLayoutContextType {
+  const ctx = useContext(DocsLayoutContext);
+  if (!ctx) throw new Error('useDocsLayout must be used within DocsLayout');
+  return ctx;
+}

--- a/apps/web/src/app/(authenticated)/docs/docs-context.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-context.tsx
@@ -12,11 +12,19 @@ export interface Doc {
   is_folder?: boolean;
 }
 
+export interface DocUpdate {
+  id: string;
+  title: string;
+  updated_at: string;
+}
+
 interface DocsLayoutContextType {
   projectId: string | undefined;
   setTree: Dispatch<SetStateAction<Doc[]>>;
   handleNewDoc: () => void;
   fetchTree: () => Promise<void>;
+  pendingDocUpdate: DocUpdate | null;
+  clearPendingDocUpdate: () => void;
 }
 
 export const DocsLayoutContext = createContext<DocsLayoutContextType | null>(null);

--- a/apps/web/src/app/(authenticated)/docs/docs-empty-view.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-empty-view.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import { useTranslations } from 'next-intl';
+import { useDocsLayout } from './docs-context';
+
+export function DocsEmptyView() {
+  const t = useTranslations('docs');
+  const { handleNewDoc } = useDocsLayout();
+
+  return (
+    <div className="flex h-full items-center justify-center p-4 lg:p-6">
+      <EmptyState
+        title={t('title')}
+        description={t('selectDoc')}
+        className="w-full max-w-lg bg-background/70"
+        action={
+          <Button size="sm" onClick={handleNewDoc}>
+            <Plus className="mr-1 h-4 w-4" />
+            {t('newDoc')}
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { DocTree } from '@/components/docs/doc-tree';
+import { DocsShell } from '@/components/docs/docs-shell';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Input } from '@/components/ui/input';
+import { ToastContainer, useToast } from '@/components/ui/toast';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { ChevronDown, ChevronRight, Menu, Plus, X } from 'lucide-react';
+import { useDashboardContext } from '../../dashboard/dashboard-shell';
+import { DocsLayoutContext, type Doc } from './docs-context';
+
+export default function DocsLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const params = useParams();
+  const currentSlug = typeof params.slug === 'string' ? params.slug : null;
+  const t = useTranslations('docs');
+  const tc = useTranslations('common');
+  const { projectId } = useDashboardContext();
+  const { toasts, addToast, dismissToast } = useToast();
+
+  const [tree, setTree] = useState<Doc[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [treeDrawerOpen, setTreeDrawerOpen] = useState(false);
+  const [selectedTags, setSelectedTags] = useState<string[]>([]);
+  const [docsHasMore, setDocsHasMore] = useState(false);
+  const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
+  const [docsLoadingMore, setDocsLoadingMore] = useState(false);
+  const [tagsCollapsed, setTagsCollapsed] = useState(true);
+
+  // Create form states
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newContent, setNewContent] = useState('');
+  const [newSlug, setNewSlug] = useState('');
+  const [newParentId, setNewParentId] = useState<string | null>(null);
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+
+  const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
+    if (!projectId) return;
+    try {
+      const fetchParams = new URLSearchParams({ project_id: projectId, limit: '20' });
+      if (tags?.length) fetchParams.set('tags', tags.join(','));
+      else fetchParams.set('view', 'tree');
+      if (cursor) fetchParams.set('cursor', cursor);
+      const res = await fetch(`/api/docs?${fetchParams.toString()}`);
+      if (!res.ok) throw new Error('Failed to fetch tree');
+      const { data, meta } = await res.json() as { data: Doc[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
+      if (cursor) {
+        setTree((prev) => [...prev, ...(data || [])]);
+      } else {
+        setTree(data || []);
+      }
+      setDocsHasMore(meta?.hasMore ?? false);
+      setDocsNextCursor(meta?.nextCursor ?? null);
+    } catch {
+      // tree fetch failed — keep existing
+    } finally {
+      setLoading(false);
+      setDocsLoadingMore(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => { void fetchTree(selectedTags.length ? selectedTags : undefined); }, [fetchTree, selectedTags]);
+
+  const handleSelectDoc = useCallback((slug: string) => {
+    router.push(`/docs/${slug}`);
+    setTreeDrawerOpen(false);
+  }, [router]);
+
+  const handleReorder = useCallback(async (docId: string, newSortOrder: number) => {
+    setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, sort_order: newSortOrder } : doc)));
+    try {
+      const res = await fetch(`/api/docs/${docId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ sort_order: newSortOrder }) });
+      if (!res.ok) await fetchTree();
+    } catch { await fetchTree(); }
+  }, [fetchTree]);
+
+  const handleMove = useCallback(async (docId: string, newParent: string | null, newSortOrder: number) => {
+    setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, parent_id: newParent, sort_order: newSortOrder } : doc)));
+    try {
+      const res = await fetch(`/api/docs/${docId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ parent_id: newParent, sort_order: newSortOrder }) });
+      if (!res.ok) await fetchTree();
+    } catch { await fetchTree(); }
+  }, [fetchTree]);
+
+  const handleMoveDenied = useCallback((reason: 'circular' | 'no-permission') => {
+    if (reason === 'circular') addToast({ title: t('moveCircularError'), type: 'error' });
+    else addToast({ title: t('movePermissionError'), type: 'warning' });
+  }, [addToast, t]);
+
+  const handleRename = useCallback(async (docId: string, newName: string) => {
+    setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, title: newName } : doc)));
+    try {
+      const res = await fetch(`/api/docs/${docId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ title: newName }) });
+      if (!res.ok) await fetchTree();
+    } catch { await fetchTree(); }
+  }, [fetchTree]);
+
+  const handleDeleteDoc = useCallback(async (docId: string) => {
+    setTree((prev) => prev.filter((doc) => doc.id !== docId));
+    try {
+      const res = await fetch(`/api/docs/${docId}`, { method: 'DELETE' });
+      if (!res.ok) await fetchTree();
+    } catch { await fetchTree(); }
+  }, [fetchTree]);
+
+  const generateSlug = useCallback((s: string): string =>
+    s.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^\wㄱ-힝-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, ''),
+  []);
+
+  const handleNewTitleChange = useCallback((val: string) => {
+    setNewTitle(val);
+    if (!slugManuallyEdited) setNewSlug(generateSlug(val));
+  }, [slugManuallyEdited, generateSlug]);
+
+  const handleSlugChange = useCallback((val: string) => {
+    setNewSlug(val);
+    setSlugManuallyEdited(true);
+  }, []);
+
+  const handleAddChild = useCallback(async (parentId: string) => {
+    setNewParentId(parentId);
+    setShowCreate(true);
+    setNewTitle(''); setNewContent(''); setNewSlug(''); setSlugManuallyEdited(false);
+  }, []);
+
+  const handleNewDoc = useCallback(() => {
+    setShowCreate(true);
+    setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
+  }, []);
+
+  const handleCreate = useCallback(async () => {
+    if (!projectId || !newTitle.trim() || !newSlug.trim()) return;
+    try {
+      const res = await fetch('/api/docs', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId, title: newTitle, slug: newSlug, content: newContent, content_format: 'markdown', parent_id: newParentId }),
+      });
+      if (!res.ok) throw new Error('Failed to create doc');
+      const { data } = await res.json();
+      setTree((prev) => [{ id: data.id, parent_id: data.parent_id || null, title: data.title, slug: data.slug, icon: data.icon || null, sort_order: data.sort_order || 0, is_folder: data.is_folder || false }, ...prev]);
+      setShowCreate(false); setShowAdvancedOptions(false);
+      setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
+      router.push(`/docs/${data.slug}`);
+    } catch {
+      // create failed
+    }
+  }, [projectId, newTitle, newSlug, newContent, newParentId, router]);
+
+  const sidebarContent = (
+    <>
+      {(() => {
+        const allTags = [...new Set(tree.flatMap((d) => (d as unknown as { tags?: string[] | null }).tags ?? []))];
+        if (allTags.length === 0) return null;
+        return (
+          <div className="border-b border-border">
+            <button type="button" onClick={() => setTagsCollapsed((v) => !v)} className="flex w-full items-center justify-between px-4 py-1 text-[11px] text-muted-foreground hover:text-foreground">
+              <span className="flex items-center gap-1.5">
+                {tagsCollapsed ? <ChevronRight className="size-3" /> : <ChevronDown className="size-3" />}
+                {t('tagFilter')}
+                {tagsCollapsed && selectedTags.length > 0 && (
+                  <span className="rounded-full bg-primary px-1.5 py-0.5 text-[10px] font-semibold text-primary-foreground">{selectedTags.length}</span>
+                )}
+              </span>
+            </button>
+            {!tagsCollapsed && (
+              <div className="flex max-h-[120px] flex-wrap gap-1 overflow-y-auto px-4 py-1">
+                {allTags.map((tag) => (
+                  <button key={tag} type="button" onClick={() => setSelectedTags((prev) => prev.includes(tag) ? prev.filter((tg) => tg !== tag) : [...prev, tag])} className={`rounded-full px-2 py-0.5 text-[11px] font-medium transition ${selectedTags.includes(tag) ? 'bg-primary text-primary-foreground' : 'bg-muted/60 text-muted-foreground hover:bg-muted'}`}>
+                    #{tag}
+                  </button>
+                ))}
+                {selectedTags.length > 0 && <button type="button" onClick={() => setSelectedTags([])} className="text-[11px] text-muted-foreground underline hover:text-foreground">{t('clearFilter')}</button>}
+              </div>
+            )}
+          </div>
+        );
+      })()}
+      <div className="flex-1 overflow-y-auto p-2">
+        {loading ? (
+          <p className="px-2 py-4 text-xs text-muted-foreground">{t('loading')}</p>
+        ) : tree.length === 0 ? (
+          <EmptyState title={t('title')} description={t('selectDoc')} className="mt-2 bg-background/70" action={<Button size="sm" onClick={handleNewDoc}><Plus className="mr-1 h-4 w-4" />{t('newDoc')}</Button>} />
+        ) : (
+          <>
+            <DocTree docs={tree} selectedSlug={currentSlug} onSelect={handleSelectDoc} onReorder={handleReorder} onMove={handleMove} onMoveDenied={handleMoveDenied} onRename={handleRename} onDelete={handleDeleteDoc} onAddChild={handleAddChild} />
+            {docsHasMore && (
+              <div className="px-2 py-1">
+                <Button variant="ghost" size="sm" className="w-full text-xs text-muted-foreground" disabled={docsLoadingMore} onClick={() => { if (!docsNextCursor || docsLoadingMore) return; setDocsLoadingMore(true); void fetchTree(selectedTags.length ? selectedTags : undefined, docsNextCursor); }}>
+                  {docsLoadingMore ? tc('loading') : tc('loadMore')}
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+
+  const createForm = (
+    <div className="flex h-full flex-col">
+      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
+        <div className="flex items-center justify-between">
+          <div className="space-y-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Draft</p>
+            <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
+          </div>
+          <Button variant="ghost" size="sm" onClick={() => { setShowCreate(false); setNewParentId(null); }}><X className="h-4 w-4" /></Button>
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto px-4 py-4 lg:px-6 lg:py-6">
+        <div className="max-w-3xl space-y-5">
+          <div>
+            <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
+            <Input value={newTitle} onChange={(e) => handleNewTitleChange(e.target.value)} placeholder={t('titlePlaceholder')} />
+          </div>
+          <div>
+            <label className="text-sm font-medium mb-2 block">{t('contentLabel')}</label>
+            <textarea value={newContent} onChange={(e) => setNewContent(e.target.value)} placeholder={t('editorPlaceholder')} className="w-full min-h-[220px] rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-foreground resize-none placeholder:text-muted-foreground" />
+          </div>
+          <div>
+            <button type="button" onClick={() => setShowAdvancedOptions((prev) => !prev)} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
+              <span>{showAdvancedOptions ? '▾' : '▸'}</span>
+              <span>{t('advancedOptions')}</span>
+            </button>
+            {showAdvancedOptions && (
+              <div className="mt-3">
+                <label className="text-sm font-medium mb-2 block">{t('slugLabel')}</label>
+                <Input value={newSlug} onChange={(e) => handleSlugChange(e.target.value)} placeholder={t('slugPlaceholder')} />
+              </div>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button onClick={handleCreate} disabled={!newTitle.trim() || !newSlug.trim()}>{tc('create')}</Button>
+            <Button variant="ghost" onClick={() => { setShowCreate(false); setNewParentId(null); }}>{tc('cancel')}</Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  const mainContent = showCreate ? createForm : children;
+
+  return (
+    <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree }}>
+      <TopBarSlot
+        title={<h1 className="text-sm font-medium">{t('title')}</h1>}
+        actions={<Button size="sm" variant="outline" onClick={handleNewDoc}><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newDoc')}</Button>}
+      />
+
+      {/* Desktop: 2-panel (lg+) */}
+      <DocsShell sidebar={sidebarContent} className="hidden min-h-0 flex-1 lg:flex">
+        {mainContent}
+      </DocsShell>
+
+      {/* Mobile: content + tree drawer (< lg) */}
+      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+        <div className="flex-shrink-0 flex items-center gap-2 border-b border-border/80 bg-background px-4 py-2">
+          <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] items-center gap-2 text-sm text-[color:var(--operator-muted)] hover:text-[color:var(--operator-foreground)]" aria-label="문서 트리 열기">
+            <Menu className="size-4" />
+            <span>{t('title')}</span>
+          </button>
+        </div>
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+          {mainContent}
+        </div>
+        {treeDrawerOpen && (
+          <>
+            <div className="fixed inset-0 z-40 bg-black/50" onClick={() => setTreeDrawerOpen(false)} aria-hidden="true" />
+            <div className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl">
+              <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-3">
+                <span className="text-sm font-medium text-foreground">{t('title')}</span>
+                <button type="button" onClick={() => setTreeDrawerOpen(false)} className="rounded p-1 text-muted-foreground hover:text-foreground" aria-label="닫기"><X className="size-4" /></button>
+              </div>
+              <div className="flex-1 overflow-y-auto">{sidebarContent}</div>
+            </div>
+          </>
+        )}
+      </div>
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </DocsLayoutContext.Provider>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -12,7 +12,7 @@ import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronRight, Menu, Plus, X } from 'lucide-react';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
-import { DocsLayoutContext, type Doc } from './docs-context';
+import { DocsLayoutContext, type Doc, type DocUpdate } from './docs-context';
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -31,6 +31,9 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
   const [docsLoadingMore, setDocsLoadingMore] = useState(false);
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
+
+  const [pendingDocUpdate, setPendingDocUpdate] = useState<DocUpdate | null>(null);
+  const clearPendingDocUpdate = useCallback(() => setPendingDocUpdate(null), []);
 
   // Create form states
   const [showCreate, setShowCreate] = useState(false);
@@ -98,7 +101,12 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, title: newName } : doc)));
     try {
       const res = await fetch(`/api/docs/${docId}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ title: newName }) });
-      if (!res.ok) await fetchTree();
+      if (!res.ok) {
+        await fetchTree();
+      } else {
+        const { data } = await res.json() as { data: { updated_at: string } };
+        setPendingDocUpdate({ id: docId, title: newName, updated_at: data.updated_at });
+      }
     } catch { await fetchTree(); }
   }, [fetchTree]);
 
@@ -249,7 +257,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const mainContent = showCreate ? createForm : children;
 
   return (
-    <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree }}>
+    <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate }}>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
         actions={<Button size="sm" variant="outline" onClick={handleNewDoc}><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newDoc')}</Button>}

--- a/apps/web/src/app/(authenticated)/docs/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/page.tsx
@@ -1,20 +1,8 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { DocsEmptyView } from './docs-empty-view';
 
-import { useDashboardContext } from '../../dashboard/dashboard-shell';
-import { DocsShellClient } from './docs-shell-client';
-import { useTranslations } from 'next-intl';
-
-export default function DocsPage() {
-  const { projectId } = useDashboardContext();
-  const t = useTranslations('docs');
-
-  if (!projectId) {
-    return (
-      <div className="flex h-64 items-center justify-center">
-        <p className="text-sm text-gray-400">{t('noProject')}</p>
-      </div>
-    );
-  }
-
-  return <DocsShellClient projectId={projectId} />;
+export default async function DocsPage({ searchParams }: { searchParams: Promise<{ slug?: string }> }) {
+  const { slug } = await searchParams;
+  if (slug) redirect(`/docs/${slug}`);
+  return <DocsEmptyView />;
 }


### PR DESCRIPTION
## 변경 사항

docs-shell-client.tsx(713줄)를 Next.js App Router 구조로 분해.

### 신설 파일

| 파일 | 역할 |
|------|------|
| `docs/layout.tsx` | 트리 state + 사이드바 + Context provider |
| `docs/docs-context.tsx` | 공유 Context 타입 정의 |
| `docs/docs-empty-view.tsx` | 빈 상태 Client Component |
| `docs/[slug]/page.tsx` | 에디터 영역 (DocEditor + useDocSync) |

### 수정 파일

- `docs/page.tsx` — Server Component + server-side redirect

### 핵심 구조

**layout.tsx** ('use client'):
- 트리 state/handlers, 문서 생성 form, 사이드바 JSX, 모바일 drawer
- `DocsLayoutContext.Provider`로 `projectId`, `setTree`, `handleNewDoc`, `fetchTree` 공유
- `useParams()`로 currentSlug 읽어 `DocTree selectedSlug`에 전달 → AC2 트리 리렌더 없음
- `showCreate` 시 `{children}` 대신 create form 렌더 → 에디터 영역 오버라이드

**page.tsx** (Server Component):
- `searchParams.slug` 있으면 `redirect('/docs/${slug}')` → AC3 깜빡임 없는 server-side redirect

**[slug]/page.tsx** ('use client'):
- `useParams()`로 slug 읽기 → `fetchDoc` 실행
- 독립적 `useDocSync` → AC4 자동저장 정상
- `handleNavigate`로 문서 내 링크 클릭 시 `router.push('/docs/${slug}')` → AC6 TipTap 정상

## AC 체크리스트

- [x] AC1: `/docs/slug-name` URL로 문서 접근 가능 — `[slug]/page.tsx` 라우트
- [x] AC2: 트리 클릭 시 에디터만 교체, 트리 리렌더 없음 — layout이 유지, children만 교체
- [x] AC3: `/docs?slug=xxx` → `/docs/xxx` server-side redirect — Server Component redirect()
- [x] AC4: 편집 + 자동저장 정상 — `[slug]/page.tsx` 독립 useDocSync
- [x] AC5: 모바일 뷰 정상 — layout에 drawer 로직 유지
- [x] AC6: TipTap 마운트/언마운트 정상 — slug 변경 시 fetchDoc rerun, doc 교체

## 빌드 검증

- `pnpm lint` — 0 errors
- `pnpm build` — 성공 (`/docs` + `/docs/[slug]` 모두 빌드 출력 확인)

## 스크린샷

> 로컬 dev 서버 미실행. 라우트 구조 변경 위주 — 빌드 출력으로 대체.