### PR TITLE
[SID:DR-03] /docs/[slug]/view 읽기 전용 뷰 + DocContentRenderer 통합

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1070,13 +1070,16 @@
     "docTagsLabel": "Tags",
     "docTagsPlaceholder": "For example, docs, mobile, parity",
     "docTagsHint": "Separate tags with commas to show them as badges.",
-    "codeCopy": "Copy code",
+    "codeCopy": "Copy",
     "codeCopied": "Copied",
     "moveCircularError": "Cannot move a document into its own subtree",
     "movePermissionError": "You do not have permission to move documents here",
     "tagFilter": "Tags",
     "clearFilter": "Clear filters",
-    "advancedOptions": "Advanced options"
+    "advancedOptions": "Advanced options",
+    "preview": "Preview",
+    "editDoc": "Edit",
+    "notFound": "Document not found"
   },
   "rewards": {
     "title": "Rewards",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1070,13 +1070,16 @@
     "docTagsLabel": "태그",
     "docTagsPlaceholder": "예: docs, mobile, parity",
     "docTagsHint": "쉼표로 구분하면 배지로 표시되어 주세요",
-    "codeCopy": "코드 복사",
+    "codeCopy": "복사",
     "codeCopied": "복사됨",
     "moveCircularError": "문서를 자신의 하위로 이동할 수 없습니다",
     "movePermissionError": "이 위치로 문서를 이동할 권한이 없습니다",
     "tagFilter": "태그",
     "clearFilter": "필터 지우기",
-    "advancedOptions": "고급 옵션"
+    "advancedOptions": "고급 옵션",
+    "preview": "미리보기",
+    "editDoc": "편집",
+    "notFound": "문서를 찾을 수 없는"
   },
   "rewards": {
     "title": "리워드",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -7,7 +7,8 @@ import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { Check, Copy, Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { Check, Copy, Eye, Trash2 } from 'lucide-react';
 import { useDocsLayout } from '../docs-context';
 
 interface DocDetail {
@@ -149,6 +150,11 @@ export default function DocSlugPage() {
           </div>
           <div className="flex items-center gap-3">
             <SaveStatusIndicator status={saveStatus} t={t} />
+            <Button asChild variant="ghost" size="sm" title={t('preview')}>
+              <Link href={`/docs/${slug}/view`}>
+                <Eye className="h-4 w-4" />
+              </Link>
+            </Button>
             <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
               {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
             </Button>

--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
+import { Button } from '@/components/ui/button';
+import { Edit2 } from 'lucide-react';
+import { useDocsLayout } from '../../docs-context';
+
+interface DocDetail {
+  id: string;
+  title: string;
+  slug: string;
+  content: string;
+  content_format?: 'markdown' | 'html';
+}
+
+export default function DocViewPage() {
+  const params = useParams();
+  const slug = typeof params.slug === 'string' ? params.slug : '';
+  const t = useTranslations('docs');
+  const { projectId } = useDocsLayout();
+
+  const [doc, setDoc] = useState<DocDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!projectId || !slug) return;
+    setLoading(true);
+    fetch(`/api/docs?project_id=${projectId}&slug=${slug}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => { setDoc(json?.data ?? null); })
+      .catch(() => { setDoc(null); })
+      .finally(() => { setLoading(false); });
+  }, [projectId, slug]);
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (!doc) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">{t('notFound')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-4">
+        <div className="flex items-center justify-between gap-4">
+          <h1 className="truncate text-xl font-semibold">{doc.title}</h1>
+          <Button asChild size="sm" variant="outline">
+            <Link href={`/docs/${slug}`}>
+              <Edit2 className="mr-1.5 h-3.5 w-3.5" />
+              {t('editDoc')}
+            </Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-y-auto px-4 py-6 lg:px-8 lg:py-8">
+        <div className="mx-auto max-w-3xl">
+          <DocContentRenderer
+            content={doc.content}
+            contentFormat={doc.content_format ?? 'markdown'}
+            codeCopyLabel={t('codeCopy')}
+            codeCopiedLabel={t('codeCopied')}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -17,26 +17,28 @@ interface DocDetail {
   content_format?: 'markdown' | 'html';
 }
 
+// null = 로딩 중, false = not found, DocDetail = 로드 완료
+type DocState = DocDetail | null | false;
+
 export default function DocViewPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const t = useTranslations('docs');
   const { projectId } = useDocsLayout();
 
-  const [doc, setDoc] = useState<DocDetail | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [doc, setDoc] = useState<DocState>(null);
 
   useEffect(() => {
     if (!projectId || !slug) return;
-    setLoading(true);
+    let cancelled = false;
     fetch(`/api/docs?project_id=${projectId}&slug=${slug}`)
       .then((res) => (res.ok ? res.json() : null))
-      .then((json) => { setDoc(json?.data ?? null); })
-      .catch(() => { setDoc(null); })
-      .finally(() => { setLoading(false); });
+      .then((json) => { if (!cancelled) setDoc((json?.data as DocDetail) ?? false); })
+      .catch(() => { if (!cancelled) setDoc(false); });
+    return () => { cancelled = true; };
   }, [projectId, slug]);
 
-  if (loading) {
+  if (doc === null) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
@@ -44,7 +46,7 @@ export default function DocViewPage() {
     );
   }
 
-  if (!doc) {
+  if (doc === false) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-muted-foreground">{t('notFound')}</p>


### PR DESCRIPTION
## 변경 사항

### 신설
**`docs/[slug]/view/page.tsx`** ('use client')
- `useDocsLayout()`으로 `projectId` 공유
- `useParams()`로 slug 읽기 → API fetch
- `DocContentRenderer`로 markdown/HTML 렌더링 (heading ID, 코드 복사 포함)
- 헤더: 문서 제목 + "편집" 버튼(Link → `/docs/[slug]`)

### 수정
**`docs/[slug]/page.tsx`**
- 헤더 버튼 영역에 Eye 아이콘 "미리보기" 링크(→ `/docs/[slug]/view`) 추가

### i18n
- `preview`, `editDoc`, `notFound`, `codeCopy`, `codeCopied` 키 추가 (ko/en)

## AC 체크리스트

- [x] AC1: `/docs/[slug]/view` URL로 읽기 전용 뷰 접근 가능
- [x] AC2: markdown/HTML 정상 렌더링 — DocContentRenderer 내장 (heading, 코드블록, 테이블, 이미지)
- [x] AC3: 코드 블록 복사 버튼 정상 동작 — DocContentRenderer 내장
- [x] AC4: 에디터 페이지 → "미리보기" Eye 버튼 → `/docs/[slug]/view`
- [x] AC5: view 페이지 → "편집" 버튼 → `/docs/[slug]`

## 빌드 검증

- `pnpm build` — `/docs/[slug]/view` 라우트 빌드 출력 확인