### PR TITLE
[SID:DR-04] EmbedCard doc embed intercepting route 전환

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/[id]/@modal/(..)docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/@modal/(..)docs/[slug]/view/page.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
+import { ExternalLink, X } from 'lucide-react';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+
+interface DocDetail {
+  title: string;
+  content: string;
+  content_format?: 'markdown' | 'html';
+  slug: string;
+}
+
+type DocState = DocDetail | null | false;
+
+export default function DocEmbedModal() {
+  const params = useParams();
+  const slug = typeof params.slug === 'string' ? params.slug : '';
+  const router = useRouter();
+  const t = useTranslations('docs');
+  const { projectId } = useDashboardContext();
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const [doc, setDoc] = useState<DocState>(null);
+
+  useEffect(() => {
+    if (!projectId || !slug) return;
+    let cancelled = false;
+    fetch(`/api/docs?project_id=${projectId}&slug=${slug}`)
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => { if (!cancelled) setDoc((json?.data as DocDetail) ?? false); })
+      .catch(() => { if (!cancelled) setDoc(false); });
+    return () => { cancelled = true; };
+  }, [projectId, slug]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') router.back(); };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [router]);
+
+  return (
+    <div
+      ref={overlayRef}
+      onClick={(e) => { if (e.target === overlayRef.current) router.back(); }}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+    >
+      <div className="relative flex w-full max-w-3xl max-h-[80vh] flex-col rounded-xl border border-border bg-popover text-popover-foreground shadow-xl">
+        {/* Header */}
+        <div className="flex-shrink-0 flex items-center justify-between gap-3 px-6 pt-5 pb-3 border-b border-border">
+          <h2 className="truncate text-base font-semibold">
+            {doc !== null && doc !== false ? doc.title : '📄'}
+          </h2>
+          <button
+            type="button"
+            onClick={() => router.back()}
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+            aria-label="닫기"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {doc === null ? (
+            <div className="flex items-center justify-center py-8">
+              <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            </div>
+          ) : doc === false ? (
+            <p className="py-4 text-sm text-muted-foreground">{t('notFound')}</p>
+          ) : (
+            <DocContentRenderer
+              content={doc.content}
+              contentFormat={doc.content_format ?? 'markdown'}
+              codeCopyLabel={t('codeCopy')}
+              codeCopiedLabel={t('codeCopied')}
+            />
+          )}
+        </div>
+
+        {/* Footer */}
+        {doc !== null && doc !== false && (
+          <div className="flex-shrink-0 px-6 py-3 border-t border-border">
+            <Link
+              href={`/docs/${slug}`}
+              className="flex items-center gap-1.5 text-sm text-primary hover:underline"
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              {t('editDoc')}
+            </Link>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/memos/[id]/@modal/default.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/@modal/default.tsx
@@ -1,0 +1,3 @@
+export default function ModalDefault() {
+  return null;
+}

--- a/apps/web/src/app/(authenticated)/memos/[id]/layout.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/layout.tsx
@@ -1,0 +1,14 @@
+export default function MemoDetailLayout({
+  children,
+  modal,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <>
+      {children}
+      {modal}
+    </>
+  );
+}

--- a/apps/web/src/components/memos/embed-card.tsx
+++ b/apps/web/src/components/memos/embed-card.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { ExternalLink, X } from 'lucide-react';
@@ -218,10 +219,24 @@ function EntityPreviewModal({
 
 export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardData) {
   const [showModal, setShowModal] = useState(false);
+  const [navigating, setNavigating] = useState(false);
+  const router = useRouter();
   const icon = ENTITY_ICONS[entity_type] ?? '#';
   const colorClass = ENTITY_COLORS[entity_type] ?? 'border-border bg-muted text-foreground';
   const href = getEntityHref(entity_type, entity_id);
   const label = title ?? entity_id;
+
+  const handleDocClick = useCallback(async () => {
+    setNavigating(true);
+    try {
+      const res = await fetch(`/api/docs/${entity_id}`);
+      if (!res.ok) throw new Error();
+      const { data } = await res.json() as { data: { slug: string } };
+      router.push(`/docs/${data.slug}/view`);
+    } catch {
+      setNavigating(false);
+    }
+  }, [entity_id, router]);
 
   const inner = (
     <div className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm ${colorClass}`}>
@@ -230,8 +245,22 @@ export function EmbedCard({ entity_type, entity_id, title, status }: EmbedCardDa
       {status ? (
         <span className="ml-auto rounded px-1.5 py-0.5 text-xs bg-black/10 dark:bg-white/10">{status}</span>
       ) : null}
+      {navigating && <span className="ml-auto h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />}
     </div>
   );
+
+  if (entity_type === 'doc') {
+    return (
+      <button
+        type="button"
+        onClick={handleDocClick}
+        disabled={navigating}
+        className="block w-full text-left transition-opacity hover:opacity-80 disabled:opacity-60"
+      >
+        {inner}
+      </button>
+    );
+  }
 
   return (
     <>


### PR DESCRIPTION
## 변경 사항

메모 상세에서 doc embed 클릭 시 React state 모달 → Next.js intercepting route 기반 모달로 전환.

### 신설 파일

| 파일 | 역할 |
|------|------|
| `memos/[id]/layout.tsx` | @modal parallel route 슬롯 정의 |
| `memos/[id]/@modal/default.tsx` | 모달 없음 기본값 (null) |
| `memos/[id]/@modal/(..)docs/[slug]/view/page.tsx` | 인터셉팅 라우트 모달 UI |

### 수정 파일

- `embed-card.tsx` — doc 타입 클릭 로직 분기

### 동작 흐름

1. 메모 상세 페이지에서 doc embed 클릭
2. `/api/docs/${id}` 호출 → slug 추출
3. `router.push('/docs/${slug}/view')` (soft navigation)
4. `memos/[id]/@modal/(..)docs/[slug]/view` 인터셉팅 라우트가 모달로 표시
5. URL은 `/docs/${slug}/view`로 변경됨
6. ESC / 오버레이 클릭 / 닫기 버튼 → `router.back()` → URL 원복, 메모 상세 복귀

story/epic embed는 기존 EntityPreviewModal 유지.

## AC 체크리스트

- [x] AC1: doc embed 클릭 시 모달 표시 + URL `/docs/[slug]/view`로 변경
- [x] AC2: DocContentRenderer로 문서 전체 렌더링 (markdown/HTML 듀얼)
- [x] AC3: 모달 닫으면 `router.back()` → 메모 상세로 복귀 + URL 원복
- [x] AC4: 모달 내 "편집" 링크 → `/docs/[slug]` 에디터 페이지
- [x] AC5: story/epic embed 기존 EntityPreviewModal 유지 — regression 없음

## 빌드 검증

- `pnpm lint` — 0 errors
- `pnpm build` — `/memos/[id]/(..)docs/[slug]/view` 라우트 빌드 확인