### PR TITLE
feat(agent-ownership): AO-01 created_by 마이그레이션 + ownership guard

### DIFF
--- a/backend/alembic/versions/0022_add_created_by_to_team_members.py
+++ b/backend/alembic/versions/0022_add_created_by_to_team_members.py
@@ -1,0 +1,30 @@
+"""add created_by to team_members
+
+Revision ID: 0022
+Revises: 0021
+Create Date: 2026-05-12
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0022"
+down_revision = "0021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "team_members",
+        sa.Column(
+            "created_by",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("team_members", "created_by")

--- a/backend/app/dependencies/ownership.py
+++ b/backend/app/dependencies/ownership.py
@@ -1,0 +1,40 @@
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project import OrgMember
+from app.models.team import TeamMember
+
+
+async def _is_org_admin(session: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID) -> bool:
+    result = await session.execute(
+        select(OrgMember.role).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == user_id,
+            OrgMember.deleted_at.is_(None),
+        )
+    )
+    role = result.scalar_one_or_none()
+    return role in ("admin", "owner")
+
+
+async def assert_agent_owner(
+    agent_id: uuid.UUID,
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    current_user_id: uuid.UUID,
+) -> TeamMember:
+    """agent 존재 확인 + ownership guard. TeamMember를 반환."""
+    result = await session.execute(
+        select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
+    )
+    agent = result.scalar_one_or_none()
+    if agent is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+    if agent.created_by == current_user_id:
+        return agent
+    if await _is_org_admin(session, org_id, current_user_id):
+        return agent
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not the owner of this agent")

--- a/backend/app/dependencies/ownership.py
+++ b/backend/app/dependencies/ownership.py
@@ -28,7 +28,11 @@ async def assert_agent_owner(
 ) -> TeamMember:
     """agent 존재 확인 + ownership guard. TeamMember를 반환."""
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
+        select(TeamMember).where(
+            TeamMember.id == agent_id,
+            TeamMember.type == "agent",
+            TeamMember.org_id == org_id,
+        )
     )
     agent = result.scalar_one_or_none()
     if agent is None:

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -25,6 +25,9 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8")
     agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
 
     project: Mapped["Project"] = relationship("Project", back_populates="team_members")
 

--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -1,12 +1,11 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.team import TeamMember
+from app.dependencies.ownership import assert_agent_owner
 from app.repositories.api_key import ApiKeyRepository
 from app.schemas.api_key import (
     ApiKeyCreatedResponse,
@@ -40,14 +39,11 @@ async def rotate_api_key(
 async def list_agent_api_keys(
     agent_id: uuid.UUID,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: ApiKeyRepository = Depends(_get_repo),
 ) -> list[ApiKeyResponse]:
-    member_r = await session.execute(
-        select(TeamMember.id).where(TeamMember.id == agent_id, TeamMember.type == "agent")
-    )
-    if member_r.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     keys = await repo.list_by_member(agent_id)
     return [ApiKeyResponse.model_validate(k) for k in keys]
 
@@ -57,14 +53,11 @@ async def create_agent_api_key(
     agent_id: uuid.UUID,
     body: CreateApiKeyRequest,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: ApiKeyRepository = Depends(_get_repo),
 ) -> ApiKeyCreatedResponse:
-    member_r = await session.execute(
-        select(TeamMember.id).where(TeamMember.id == agent_id, TeamMember.type == "agent")
-    )
-    if member_r.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     key, plaintext = await repo.create(
         team_member_id=agent_id,
         scope=body.scope,
@@ -78,9 +71,12 @@ async def create_agent_api_key(
 async def revoke_agent_api_key(
     agent_id: uuid.UUID,
     key_id: uuid.UUID,
-    _auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
     repo: ApiKeyRepository = Depends(_get_repo),
 ) -> dict:
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     key = await repo.get(key_id)
     if key is None or key.team_member_id != agent_id:
         raise HTTPException(status_code=404, detail="API key not found for this agent")

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.dependencies.ownership import assert_agent_owner
 from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
 
@@ -40,9 +41,10 @@ async def list_team_members(
 async def create_team_member(
     body: TeamMemberCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> TeamMemberResponse:
     repo = TeamMemberRepository(session, body.org_id)
+    created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
     member = await repo.create(
         project_id=body.project_id,
         type=body.type,
@@ -54,6 +56,7 @@ async def create_team_member(
         webhook_url=body.webhook_url,
         color=body.color,
         agent_role=body.agent_role,
+        created_by=created_by,
     )
     return TeamMemberResponse.model_validate(member)
 
@@ -73,20 +76,34 @@ async def get_team_member(
 async def update_team_member(
     id: uuid.UUID,
     body: TeamMemberUpdate,
-    repo: TeamMemberRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TeamMemberResponse:
-    data = body.model_dump(exclude_unset=True)
-    member = await repo.update(id, **data)
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
-    return TeamMemberResponse.model_validate(member)
+    if member.type == "agent":
+        await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
+    data = body.model_dump(exclude_unset=True)
+    updated = await repo.update(id, **data)
+    return TeamMemberResponse.model_validate(updated)
 
 
 @router.delete("/{id}", status_code=200)
 async def deactivate_team_member(
     id: uuid.UUID,
-    repo: TeamMemberRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    if member.type == "agent":
+        await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
     ok = await repo.deactivate(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Team member not found")

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -46,5 +46,6 @@ class TeamMemberResponse(BaseModel):
     is_active: bool
     color: str
     agent_role: str | None = None
+    created_by: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime


### PR DESCRIPTION
## Summary

- `team_members` 테이블에 `created_by UUID` 컬럼 추가 (nullable, FK→users, ondelete=SET NULL)
- agent 생성 시 `created_by = current_user.id` 자동 기록 (human type 미적용)
- PATCH/DELETE: `agent.type == 'agent'` && `created_by != current_user` → **403**, admin/owner bypass
- API Key GET/POST/DELETE: non-owner → **403**, admin/owner bypass
- `created_by IS NULL` 기존 에이전트: admin/owner만 수정 가능
- `GET /team-members` 응답에 `created_by` 필드 포함

## AC 체크리스트

- [x] AC1: created_by 컬럼 추가 migration (0022)
- [x] AC2: agent 생성 시 created_by 자동 기록
- [x] AC3: PATCH — non-owner member → 403
- [x] AC4: DELETE — non-owner member → 403
- [x] AC5: API Key GET/POST/DELETE — non-owner → 403
- [x] AC6: admin/owner role bypass (PATCH, DELETE, API Key 전부)
- [x] AC7: GET 응답에 created_by 포함
- [x] AC8: created_by NULL 에이전트 → member 403, admin/owner pass

## 주요 변경 파일

- `backend/alembic/versions/0022_add_created_by_to_team_members.py` — migration
- `backend/app/dependencies/ownership.py` — 공통 ownership guard 헬퍼
- `backend/app/models/team.py` — TeamMember.created_by 필드
- `backend/app/schemas/team_member.py` — TeamMemberResponse.created_by
- `backend/app/routers/team_members.py` — POST/PATCH/DELETE guard
- `backend/app/routers/api_keys.py` — GET/POST/DELETE guard

## 로컬 검증

```
alembic upgrade: 0021 → 0022 ✅
DB 컬럼: team_members.created_by uuid YES ✅
서버 기동: uvicorn startup complete ✅
AC2~AC8 curl 테스트 전부 PASS ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)