### PR TITLE
fix(test): CI pytest 실패 수정 — created_by 필드 + assert_agent_owner mock

### DIFF
--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -65,11 +65,8 @@ async def _client():
 async def test_create_api_key_201():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = AGENT_ID
-        session.execute = AsyncMock(return_value=mock_result)
-
-        with patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = (_mock_key(), PLAINTEXT)
 
             async with client as c:
@@ -86,11 +83,8 @@ async def test_create_api_key_201():
 async def test_list_agent_keys_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = AGENT_ID
-        session.execute = AsyncMock(return_value=mock_result)
-
-        with patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = [_mock_key()]
 
             async with client as c:
@@ -107,11 +101,8 @@ async def test_list_agent_keys_200():
 async def test_list_agent_keys_empty_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = AGENT_ID
-        session.execute = AsyncMock(return_value=mock_result)
-
-        with patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = []
 
             async with client as c:
@@ -163,12 +154,12 @@ async def test_rotate_key_404():
 async def test_agent_not_found_404():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
-        session.execute = AsyncMock(return_value=mock_result)
+        from fastapi import HTTPException as _HTTPException
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock) as mock_oa:
+            mock_oa.side_effect = _HTTPException(status_code=404, detail="Agent not found")
 
-        async with client as c:
-            resp = await c.get(f"/api/v2/agents/{uuid.uuid4()}/api-keys")
+            async with client as c:
+                resp = await c.get(f"/api/v2/agents/{uuid.uuid4()}/api-keys")
 
         assert resp.status_code == 404
     finally:
@@ -201,14 +192,11 @@ async def test_revoked_key_in_list():
     """list_by_member는 revoked 키도 포함해서 반환하는."""
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = AGENT_ID
-        session.execute = AsyncMock(return_value=mock_result)
-
         revoked = _mock_key(revoked=True)
         active = _mock_key()
 
-        with patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
+        with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.list_by_member", new_callable=AsyncMock) as mock_list:
             mock_list.return_value = [active, revoked]
 
             async with client as c:

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -26,6 +26,7 @@ def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
     m.is_active = is_active
     m.color = "#3385f8"
     m.agent_role = None
+    m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return m


### PR DESCRIPTION
## Summary

- `test_team_members.py` `_mock_member()`에 `created_by = None` 추가 — `TeamMemberResponse` Pydantic validation이 `MagicMock`을 UUID로 변환 시도하다 발생한 ValidationError 수정
- `test_s35.py` API Key 성공 케이스에 `assert_agent_owner` patch 추가 — 기존 mock이 `UUID`를 반환하는데 헬퍼가 `TeamMember` 객체를 기대해서 발생한 AttributeError 수정
- `test_agent_not_found_404` `side_effect = HTTPException(404)` 패턴으로 전환

## 로컬 검증

```
17 passed, 1 warning in 0.74s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)