### PR TITLE
[SID:AO-02] 에이전트 상세 ownership UI gate

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -629,8 +629,8 @@
     "addAgent": "Add Agent",
     "noOrgAgents": "No agents registered in this organization",
     "noOrgAgentsCta": "Add an agent to use it as an AI team member across projects.",
-    "agentDeactivated": "Agent deactivated",
-    "agentActivated": "Agent activated",
+    "agentDeactivated": "Agent deactivated.",
+    "agentActivated": "Agent activated.",
     "agentAdded": "Agent added",
     "agentActionFailed": "Agent operation failed",
     "deactivateAgent": "Deactivate",
@@ -640,7 +640,9 @@
     "agentWebhookDescription": "Events will be POSTed to this endpoint when triggered for this agent. Must be HTTPS.",
     "agentMcpTitle": "MCP Config",
     "agentMcpDescription": "Paste this into Claude Code or any MCP client to connect as this agent.",
-    "agentMcpKeyRequired": "Generate an API key first to include the real key in the config."
+    "agentMcpKeyRequired": "Generate an API key first to include the real key in the config.",
+    "ownershipDenied": "Permission denied. Only the agent owner or admin can edit.",
+    "agentOwner": "my agent"
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -629,8 +629,8 @@
     "addAgent": "에이전트 추가",
     "noOrgAgents": "조직에 등록된 에이전트가 없습니다",
     "noOrgAgentsCta": "에이전트를 추가하면 각 프로젝트에서 AI 팀원으로 활용할 수 있습니다.",
-    "agentDeactivated": "에이전트를 비활성화했습니다",
-    "agentActivated": "에이전트를 활성화했습니다",
+    "agentDeactivated": "에이전트 비활성화 완료인.",
+    "agentActivated": "에이전트 활성화 완료인.",
     "agentAdded": "에이전트를 추가했습니다",
     "agentActionFailed": "에이전트 처리에 실패했습니다",
     "deactivateAgent": "비활성화",
@@ -640,7 +640,9 @@
     "agentWebhookDescription": "이 에이전트로 이벤트가 발생할 때 POST로 전송됩니다. HTTPS 필수.",
     "agentMcpTitle": "MCP Config",
     "agentMcpDescription": "Claude Code나 MCP 클라이언트에 붙여넣으면 이 에이전트로 Sprintable에 연결됩니다.",
-    "agentMcpKeyRequired": "API Key를 먼저 발급하면 실제 키가 포함된 설정을 복사할 수 있습니다."
+    "agentMcpKeyRequired": "API Key를 먼저 발급하면 실제 키가 포함된 설정을 복사할 수 있습니다.",
+    "ownershipDenied": "권한이 없는. 에이전트 소유자 또는 admin만 수정 가능인.",
+    "agentOwner": "내 에이전트"
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -629,8 +629,8 @@
     "addAgent": "에이전트 추가",
     "noOrgAgents": "조직에 등록된 에이전트가 없습니다",
     "noOrgAgentsCta": "에이전트를 추가하면 각 프로젝트에서 AI 팀원으로 활용할 수 있습니다.",
-    "agentDeactivated": "에이전트 비활성화 완료인.",
-    "agentActivated": "에이전트 활성화 완료인.",
+    "agentDeactivated": "에이전트를 비활성화했습니다.",
+    "agentActivated": "에이전트를 활성화했습니다.",
     "agentAdded": "에이전트를 추가했습니다",
     "agentActionFailed": "에이전트 처리에 실패했습니다",
     "deactivateAgent": "비활성화",
@@ -641,7 +641,7 @@
     "agentMcpTitle": "MCP Config",
     "agentMcpDescription": "Claude Code나 MCP 클라이언트에 붙여넣으면 이 에이전트로 Sprintable에 연결됩니다.",
     "agentMcpKeyRequired": "API Key를 먼저 발급하면 실제 키가 포함된 설정을 복사할 수 있습니다.",
-    "ownershipDenied": "권한이 없는. 에이전트 소유자 또는 admin만 수정 가능인.",
+    "ownershipDenied": "권한이 없습니다. 에이전트 소유자 또는 관리자만 수정할 수 있습니다.",
     "agentOwner": "내 에이전트"
   },
   "landing": {

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -27,6 +27,7 @@ interface AgentMember {
   project_id: string;
   is_active: boolean;
   webhook_url: string | null;
+  created_by: string | null;
 }
 
 interface WebhookConfig {
@@ -84,6 +85,8 @@ export default function AgentDetailPage() {
 
   const [agent, setAgent] = useState<AgentMember | null>(null);
   const [loading, setLoading] = useState(true);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [orgRole, setOrgRole] = useState<string>('member');
 
   const [editingName, setEditingName] = useState(false);
   const [editName, setEditName] = useState('');
@@ -114,9 +117,10 @@ export default function AgentDetailPage() {
   }, [id, router]);
 
   const fetchOrgContext = useCallback(async () => {
-    const [projectRes, contextRes] = await Promise.all([
+    const [projectRes, contextRes, meRes] = await Promise.all([
       fetch('/api/projects'),
       fetch('/api/current-project'),
+      fetch('/api/me'),
     ]);
     if (projectRes.ok) {
       const json = await projectRes.json() as { data: ProjectOption[] };
@@ -125,6 +129,11 @@ export default function AgentDetailPage() {
     if (contextRes.ok) {
       const json = await contextRes.json() as { data?: { org_id?: string } };
       setOrgId(json.data?.org_id ?? null);
+    }
+    if (meRes.ok) {
+      const json = await meRes.json() as { data?: { user_id?: string | null; role?: string } };
+      setCurrentUserId(json.data?.user_id ?? null);
+      setOrgRole(json.data?.role ?? 'member');
     }
   }, []);
 
@@ -189,8 +198,13 @@ export default function AgentDetailPage() {
       setEditingName(false);
       addToast({ type: 'success', title: tc('saved') });
     } else {
+      const status = res.status;
       const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
-      addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+      if (status === 403) {
+        addToast({ type: 'error', title: t('ownershipDenied') });
+      } else {
+        addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+      }
     }
     setSavingEdit(false);
   };
@@ -311,6 +325,33 @@ export default function AgentDetailPage() {
 
   if (!agent) return null;
 
+  const canEdit =
+    (currentUserId !== null && agent.created_by === currentUserId) ||
+    orgRole === 'admin' ||
+    orgRole === 'owner';
+
+  const handleToggleActive = async () => {
+    const next = !agent.is_active;
+    const res = await fetch(`/api/team-members/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_active: next }),
+    });
+    if (res.ok) {
+      const json = await res.json() as { data: AgentMember };
+      setAgent(json.data);
+      addToast({ type: 'success', title: next ? t('agentActivated') : t('agentDeactivated') });
+    } else {
+      const status = res.status;
+      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      if (status === 403) {
+        addToast({ type: 'error', title: t('ownershipDenied') });
+      } else {
+        addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+      }
+    }
+  };
+
   return (
     <div className="w-full max-w-3xl mx-auto p-6 space-y-6">
       <div className="flex items-center gap-3">
@@ -357,6 +398,7 @@ export default function AgentDetailPage() {
                     <Badge variant="outline">{agent.role}</Badge>
                   </div>
                 </div>
+                {canEdit && (
                 <button
                   type="button"
                   onClick={() => { setEditName(agent.name); setEditRole(agent.role); setEditingName(true); }}
@@ -364,18 +406,32 @@ export default function AgentDetailPage() {
                 >
                   <Pencil className="h-3.5 w-3.5" />
                 </button>
+              )}
               </div>
             )}
           </div>
         </SectionCardHeader>
+        {canEdit && (
+          <SectionCardBody>
+            <Button
+              variant="glass"
+              size="sm"
+              onClick={() => void handleToggleActive()}
+            >
+              {agent.is_active ? t('deactivateAgent') : t('activateAgent')}
+            </Button>
+          </SectionCardBody>
+        )}
       </SectionCard>
 
       {/* API Keys */}
-      <AgentApiKeyManager
-        agentId={id}
-        agentName={agent.name}
-        onNewKey={(key) => { setFreshApiKey(key); setHasActiveKey(true); }}
-      />
+      {canEdit && (
+        <AgentApiKeyManager
+          agentId={id}
+          agentName={agent.name}
+          onNewKey={(key) => { setFreshApiKey(key); setHasActiveKey(true); }}
+        />
+      )}
 
       {/* Webhook 설정 */}
       <SectionCard>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -66,6 +66,7 @@ interface ProjectMember {
   project_id: string;
   is_active: boolean;
   webhook_url?: string | null;
+  created_by?: string | null;
 }
 
 const EVENT_TYPES = ['story_assigned', 'memo_received', 'reward_granted', 'story_status_changed'];
@@ -123,6 +124,7 @@ export default function SettingsPage() {
   const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [adminChecked, setAdminChecked] = useState(false);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
   const [deleteProjectConfirmId, setDeleteProjectConfirmId] = useState<string | null>(null);
   const [projectInviteEmail, setProjectInviteEmail] = useState('');
@@ -269,6 +271,7 @@ export default function SettingsPage() {
         const meJson = meRes.ok ? await meRes.json() : null;
         const role = (meJson?.data?.role ?? 'member') as string;
         setIsAdmin(role === 'admin' || role === 'owner');
+        setCurrentUserId((meJson?.data?.user_id as string | null) ?? null);
       } catch {
         setIsAdmin(false);
       } finally {
@@ -917,6 +920,7 @@ export default function SettingsPage() {
                                     <Badge variant="secondary">{t('agentMember')}</Badge>
                                     <Badge variant="outline">{agent.role}</Badge>
                                     <span className="text-xs text-muted-foreground">{projectName}</span>
+                                    {currentUserId && agent.created_by === currentUserId ? <Badge variant="outline" className="border-primary/40 text-primary text-[10px]">{t('agentOwner')}</Badge> : null}
                                     {!agent.is_active ? <Badge variant="destructive">inactive</Badge> : null}
                                   </div>
                                 </div>

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -42,6 +42,7 @@ async def get_me(
         raise HTTPException(status_code=404, detail="Member not found")
     data = MeResponse.model_validate(member)
     data.project_name = member.project.name if member.project else None
+    data.user_id = member.user_id
 
     if not is_api_key and member.user_id:
         user_result = await session.execute(select(User).where(User.id == member.user_id))

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -12,6 +12,7 @@ class MeResponse(BaseModel):
     id: uuid.UUID
     org_id: uuid.UUID
     project_id: uuid.UUID
+    user_id: uuid.UUID | None = None
     name: str
     type: str
     role: str


### PR DESCRIPTION
## 변경 사항

### Backend (AO-01 누락 보완 — 오르테가군 승인)
- `backend/app/schemas/me.py` — `MeResponse`에 `user_id: uuid.UUID | None = None` 추가
- `backend/app/routers/me.py` — `data.user_id = member.user_id` 설정

### Frontend

**`settings/members/agents/[id]/page.tsx`**
- `AgentMember`에 `created_by: string | null` 추가
- `fetchOrgContext`에서 `/api/me` 호출 → `currentUserId` + `orgRole` 저장
- `canEdit = (agent.created_by === currentUserId) || orgRole === 'admin' || orgRole === 'owner'`
- 편집 폼 (Pencil 버튼) — `canEdit` 조건부 표시
- `AgentApiKeyManager` 섹션 — `canEdit` 조건부 표시
- `handleToggleActive` 신설: is_active PATCH + 403 시 한국어 에러 토스트
- `handleSaveEdit` 403 케이스 — 한국어 토스트 처리

**`settings/page.tsx`**
- `ProjectMember`에 `created_by?: string | null` 추가
- `/api/me` 응답에서 `currentUserId` 저장
- 에이전트 목록에 `agent.created_by === currentUserId` 시 "내 에이전트" badge 표시

**i18n (ko/en):** `ownershipDenied`, `agentOwner`, `agentActivated`, `agentDeactivated`

## AC 체크리스트

- [x] AC1: 타인 에이전트 이름/role 편집 폼 비노출 (`canEdit` gate)
- [x] AC2: 타인 에이전트 API Key 섹션 비노출 (`canEdit` gate)
- [x] AC3: 타인 에이전트 비활성화 버튼 비노출 (`canEdit` gate)
- [x] AC4: admin/owner role → 전체 에이전트 편집 가능
- [x] AC5: 에이전트 목록에서 내 에이전트 "내 에이전트" badge 표시
- [x] AC6: 403 응답 시 "권한이 없는..." 한국어 에러 토스트

## 빌드 검증

- `pnpm lint` — 0 errors
- `pnpm build` — 성공