### PR TITLE
fix(SID:AO-02): test_s31 _mock_member user_id CI 수정

### DIFF
--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -47,6 +47,7 @@ def _mock_member() -> MagicMock:
     m.type = "human"
     m.role = "admin"
     m.is_active = True
+    m.user_id = uuid.uuid4()
     return m
 
 


### PR DESCRIPTION
## 수정 내용

`backend/tests/test_s31.py:50` `_mock_member()`에 `m.user_id = uuid.uuid4()` 추가.

`MeResponse`에 `user_id` 필드 추가 후 Mock 미포함으로 ValidationError 발생.

**실패 테스트:**
- `test_get_me_200`
- `test_get_me_via_api_key_200`
- `test_get_me_via_jwt_no_member_id_200`