### PR TITLE
feat(wh-01): webhook_url 레거시 → webhook_configs 자동 마이그레이션

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -439,11 +439,6 @@ export default function AgentDetailPage() {
           <div className="space-y-1">
             <h2 className="text-base font-semibold text-foreground">Webhook URL</h2>
             <p className="text-sm text-muted-foreground">이 에이전트로 이벤트가 발생할 때 POST로 전송됩니다. HTTPS 필수.</p>
-            {agent.webhook_url && webhookConfigs.length === 0 ? (
-              <p className="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
-                기존 webhook URL(<code className="font-mono">{agent.webhook_url}</code>)이 레거시 필드에 저장되어 있습니다. 아래에 다시 입력해 저장하면 새 webhook_configs 방식으로 마이그레이션됩니다.
-              </p>
-            ) : null}
           </div>
         </SectionCardHeader>
         <SectionCardBody className="space-y-3">

--- a/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
+++ b/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
@@ -31,7 +31,8 @@ def upgrade() -> None:
             FROM team_members tm
             WHERE tm.webhook_url IS NOT NULL
               AND NOT EXISTS (
-                  SELECT 1 FROM webhook_configs wc WHERE wc.member_id = tm.id
+                  SELECT 1 FROM webhook_configs wc
+                  WHERE wc.member_id = tm.id AND wc.project_id IS NULL
               )
         """)
     )

--- a/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
+++ b/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
@@ -1,0 +1,45 @@
+"""migrate webhook_url to webhook_configs
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-12
+"""
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+            INSERT INTO webhook_configs (id, org_id, member_id, project_id, url, channel, is_active)
+            SELECT
+                gen_random_uuid(),
+                tm.org_id,
+                tm.id,
+                NULL,
+                tm.webhook_url,
+                'discord',
+                true
+            FROM team_members tm
+            WHERE tm.webhook_url IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM webhook_configs wc WHERE wc.member_id = tm.id
+              )
+        """)
+    )
+    conn.execute(
+        sa.text("UPDATE team_members SET webhook_url = NULL WHERE webhook_url IS NOT NULL")
+    )
+
+
+def downgrade() -> None:
+    # 복구 불가 (원본 URL이 webhook_configs에 있으나 member당 여러 개일 수 있음)
+    pass


### PR DESCRIPTION
## Summary

- Alembic data migration 0023 — `team_members.webhook_url` → `webhook_configs` 자동 이전
  - `NOT EXISTS` 조건으로 중복 방지
  - `channel = 'discord'` 고정 (현재 전량 Discord URL)
  - `project_id = NULL` (default webhook)
  - 이전 완료 후 `webhook_url = NULL` 클리어 (컬럼 DROP 없음, 트리거 폴백 보존)
- 에이전트 상세 페이지 레거시 안내 배너 제거 (`page.tsx:442-446`)

## AC 체크리스트

- [x] AC1: Alembic migration 파일 PR 포함 (0023)
- [x] AC2: localhost alembic upgrade head → 0022→0023 적용, webhook_url IS NOT NULL = 0건 확인
- [x] AC3: 레거시 배너 코드 제거 (TS 빌드 오류 없음)
- [ ] AC4: 웹훅 수신 정상 동작 (dev 환경 검증)
- [ ] AC5: dev 환경 migration 적용 + UI 검증

## 로컬 검증

```
alembic 0022 → 0023 적용 ✅
webhook_configs COUNT = 0 (로컬 DB 데이터 없음, migration 정상 실행 확인)
team_members.webhook_url IS NOT NULL = 0 ✅
TS 빌드 오류 없음 ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)