### PR TITLE
[P0] fix(memo): webhook dispatch 복구 — migration 0023 후유증

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -14,6 +14,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.memo import MemoAssignee, MemoReply
 from app.models.team import TeamMember
+from app.models.webhook_config import WebhookConfig
 from app.repositories.memo import MemoReplyRepository, MemoRepository
 from app.routers.events import publish_event
 from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResponse, ReplyResponse, UpdateMemo
@@ -65,10 +66,9 @@ async def _collect_reply_webhook_urls(
     if not recipient_ids:
         return []
     rows = await db.execute(
-        select(TeamMember.webhook_url).where(
-            TeamMember.id.in_(recipient_ids),
-            TeamMember.is_active.is_(True),
-            TeamMember.webhook_url.isnot(None),
+        select(WebhookConfig.url).where(
+            WebhookConfig.member_id.in_(recipient_ids),
+            WebhookConfig.is_active.is_(True),
         )
     )
     return [row[0] for row in rows if row[0]]
@@ -156,6 +156,7 @@ async def list_memos(
 @router.post("", response_model=MemoListResponse, status_code=201)
 async def create_memo(
     body: CreateMemo,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> MemoListResponse:
@@ -186,6 +187,27 @@ async def create_memo(
     if all_embeds:
         await repo.create_entity_links(memo.id, all_embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})
+    memo_recipient_ids: set[uuid.UUID] = set()
+    if body.assigned_to:
+        memo_recipient_ids.add(body.assigned_to)
+    if body.assigned_to_ids:
+        memo_recipient_ids.update(body.assigned_to_ids)
+    memo_recipient_ids.discard(body.created_by)
+    if memo_recipient_ids:
+        wh_rows = await session.execute(
+            select(WebhookConfig.url).where(
+                WebhookConfig.member_id.in_(memo_recipient_ids),
+                WebhookConfig.is_active.is_(True),
+            )
+        )
+        memo_webhook_urls = [row[0] for row in wh_rows if row[0]]
+        if memo_webhook_urls:
+            app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
+            memo_url = f"{app_url}/memos?id={memo.id}" if app_url else ""
+            wh_content = f"**새 메모**\n{(body.content or '')[:500]}\n\nmemo_id: {memo.id}"
+            wh_title = body.title or "새 메모"
+            for wh_url in memo_webhook_urls:
+                background_tasks.add_task(_fire_webhook, wh_url, wh_content, wh_title, memo_url, str(memo.id))
     _is_workflow_origin = (body.memo_metadata or {}).get("origin") == "workflow"
     if body.project_id and not _is_workflow_origin:
         from app.services.workflow_pipeline import process_event


### PR DESCRIPTION
## Summary
- migration 0023이 `team_members.webhook_url`을 `webhook_configs`로 이전 후 NULL 처리했으나, memo 코드가 미갱신되어 모든 메모 웹훅이 깨진 상태
- `create_memo()`에 webhook dispatch 추가 (기존에 send에는 없고 reply에만 있었음)
- `_collect_reply_webhook_urls()`가 deprecated `team_members.webhook_url` 대신 `webhook_configs` 테이블 조회하도록 수정

## Changes
1. **Import 추가**: `WebhookConfig` 모델 import
2. **`_collect_reply_webhook_urls()` 수정**: `TeamMember.webhook_url` → `WebhookConfig.url` + `WebhookConfig.member_id` 기반 조회
3. **`create_memo()` webhook dispatch 추가**: `BackgroundTasks` 의존성 추가, memo 생성 후 수신자의 `webhook_configs` URL로 웹훅 발송

## Test plan
- [ ] send_memo 호출 → 수신자 에이전트 Discord 채널에 웹훅 도착 확인
- [ ] reply_memo 호출 → thread participants 전원 웹훅 도착 확인
- [ ] 기존 story webhook (assignee_changed, status_changed) 정상 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)