### PR TITLE
prod 프로모션: P0 메모 웹훅 복구 + webhook_configs 마이그레이션

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -439,11 +439,6 @@ export default function AgentDetailPage() {
           <div className="space-y-1">
             <h2 className="text-base font-semibold text-foreground">Webhook URL</h2>
             <p className="text-sm text-muted-foreground">이 에이전트로 이벤트가 발생할 때 POST로 전송됩니다. HTTPS 필수.</p>
-            {agent.webhook_url && webhookConfigs.length === 0 ? (
-              <p className="mt-1 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-600 dark:text-amber-400">
-                기존 webhook URL(<code className="font-mono">{agent.webhook_url}</code>)이 레거시 필드에 저장되어 있습니다. 아래에 다시 입력해 저장하면 새 webhook_configs 방식으로 마이그레이션됩니다.
-              </p>
-            ) : null}
           </div>
         </SectionCardHeader>
         <SectionCardBody className="space-y-3">

--- a/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
+++ b/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
@@ -31,7 +31,8 @@ def upgrade() -> None:
             FROM team_members tm
             WHERE tm.webhook_url IS NOT NULL
               AND NOT EXISTS (
-                  SELECT 1 FROM webhook_configs wc WHERE wc.member_id = tm.id
+                  SELECT 1 FROM webhook_configs wc
+                  WHERE wc.member_id = tm.id AND wc.project_id IS NULL
               )
         """)
     )

--- a/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
+++ b/backend/alembic/versions/0023_migrate_webhook_url_to_webhook_configs.py
@@ -1,0 +1,45 @@
+"""migrate webhook_url to webhook_configs
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-05-12
+"""
+import uuid
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0023"
+down_revision = "0022"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    conn.execute(
+        sa.text("""
+            INSERT INTO webhook_configs (id, org_id, member_id, project_id, url, channel, is_active)
+            SELECT
+                gen_random_uuid(),
+                tm.org_id,
+                tm.id,
+                NULL,
+                tm.webhook_url,
+                'discord',
+                true
+            FROM team_members tm
+            WHERE tm.webhook_url IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM webhook_configs wc WHERE wc.member_id = tm.id
+              )
+        """)
+    )
+    conn.execute(
+        sa.text("UPDATE team_members SET webhook_url = NULL WHERE webhook_url IS NOT NULL")
+    )
+
+
+def downgrade() -> None:
+    # 복구 불가 (원본 URL이 webhook_configs에 있으나 member당 여러 개일 수 있음)
+    pass

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -14,6 +14,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.memo import MemoAssignee, MemoReply
 from app.models.team import TeamMember
+from app.models.webhook_config import WebhookConfig
 from app.repositories.memo import MemoReplyRepository, MemoRepository
 from app.routers.events import publish_event
 from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResponse, ReplyResponse, UpdateMemo
@@ -65,10 +66,9 @@ async def _collect_reply_webhook_urls(
     if not recipient_ids:
         return []
     rows = await db.execute(
-        select(TeamMember.webhook_url).where(
-            TeamMember.id.in_(recipient_ids),
-            TeamMember.is_active.is_(True),
-            TeamMember.webhook_url.isnot(None),
+        select(WebhookConfig.url).where(
+            WebhookConfig.member_id.in_(recipient_ids),
+            WebhookConfig.is_active.is_(True),
         )
     )
     return [row[0] for row in rows if row[0]]
@@ -156,6 +156,7 @@ async def list_memos(
 @router.post("", response_model=MemoListResponse, status_code=201)
 async def create_memo(
     body: CreateMemo,
+    background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> MemoListResponse:
@@ -186,6 +187,27 @@ async def create_memo(
     if all_embeds:
         await repo.create_entity_links(memo.id, all_embeds)
     publish_event(str(body.org_id), "memo_created", {"id": str(memo.id)})
+    memo_recipient_ids: set[uuid.UUID] = set()
+    if body.assigned_to:
+        memo_recipient_ids.add(body.assigned_to)
+    if body.assigned_to_ids:
+        memo_recipient_ids.update(body.assigned_to_ids)
+    memo_recipient_ids.discard(body.created_by)
+    if memo_recipient_ids:
+        wh_rows = await session.execute(
+            select(WebhookConfig.url).where(
+                WebhookConfig.member_id.in_(memo_recipient_ids),
+                WebhookConfig.is_active.is_(True),
+            )
+        )
+        memo_webhook_urls = [row[0] for row in wh_rows if row[0]]
+        if memo_webhook_urls:
+            app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "")
+            memo_url = f"{app_url}/memos?id={memo.id}" if app_url else ""
+            wh_content = f"**새 메모**\n{(body.content or '')[:500]}\n\nmemo_id: {memo.id}"
+            wh_title = body.title or "새 메모"
+            for wh_url in memo_webhook_urls:
+                background_tasks.add_task(_fire_webhook, wh_url, wh_content, wh_title, memo_url, str(memo.id))
     _is_workflow_origin = (body.memo_metadata or {}).get("origin") == "workflow"
     if body.project_id and not _is_workflow_origin:
         from app.services.workflow_pipeline import process_event


### PR DESCRIPTION
## Summary
- **[P0] PR #646**: 메모 웹훅 dispatch 복구 — migration 0023 후유증
- **PR #643**: webhook_url → webhook_configs 마이그레이션
- **PR #642**: AO-02 test mock user_id 수정
- **PR #641**: 에이전트 상세 ownership UI gate
- **PR #640**: test mocks for created_by + assert_agent_owner
- **PR #639**: agent-ownership created_by + ownership guard
- **PR #638**: EmbedCard doc embed intercepting route 전환

## P0 긴급
migration 0023이 team_members.webhook_url을 NULL로 밀었으나 memo 코드가 미갱신되어 **에이전트 간 메모 웹훅 전면 불통**. 선생님 직접 지시로 긴급 프로모션.

## Test plan
- [ ] send_memo → 수신 에이전트 Discord 웹훅 도달 확인
- [ ] reply_memo → thread participants 웹훅 도달 확인
- [ ] 에이전트 ownership UI 정상 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)