### PR TITLE
feat(eventbus-s1): events 테이블 + 이벤트 라우터 CRUD API

### DIFF
--- a/backend/alembic/versions/0024_add_events_table.py
+++ b/backend/alembic/versions/0024_add_events_table.py
@@ -1,0 +1,55 @@
+"""add events table
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-05-12
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0024"
+down_revision = "0023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "events",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("event_type", sa.Text(), nullable=False),
+        sa.Column("source_entity_type", sa.Text(), nullable=True),
+        sa.Column("source_entity_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("sender_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("recipient_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("recipient_type", sa.Text(), nullable=False),
+        sa.Column("payload", JSONB(), nullable=False, server_default="{}"),
+        sa.Column("status", sa.Text(), nullable=False, server_default="pending"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("delivered_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["sender_id"], ["team_members.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["recipient_id"], ["team_members.id"], ondelete="CASCADE"),
+    )
+
+    op.create_index("ix_events_org_id", "events", ["org_id"])
+    op.create_index(
+        "ix_events_project_recipient_status",
+        "events",
+        ["project_id", "recipient_id", "status"],
+    )
+    op.create_index(
+        "ix_events_project_created_at",
+        "events",
+        ["project_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_events_project_created_at", table_name="events")
+    op.drop_index("ix_events_project_recipient_status", table_name="events")
+    op.drop_index("ix_events_org_id", table_name="events")
+    op.drop_table("events")

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+import enum
+
+
+class EventType(str, enum.Enum):
+    memo_created = "memo_created"
+    memo_replied = "memo_replied"
+    dispatched = "dispatched"
+    status_changed = "status_changed"
+
+
+class EventSourceEntityType(str, enum.Enum):
+    memo = "memo"
+    story = "story"
+    epic = "epic"
+    doc = "doc"
+    sprint = "sprint"
+
+
+class EventRecipientType(str, enum.Enum):
+    agent = "agent"
+    human = "human"
+
+
+class EventStatus(str, enum.Enum):
+    pending = "pending"
+    delivered = "delivered"
+    failed = "failed"
+
+
+class Event(Base, OrgScopedMixin):
+    __tablename__ = "events"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    event_type: Mapped[str] = mapped_column(Text, nullable=False)
+    source_entity_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    source_entity_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    sender_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    recipient_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    recipient_type: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default=EventStatus.pending.value)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -1,9 +1,7 @@
-"""C-S6: Supabase Realtime → FastAPI SSE 대체
+"""이벤트 시스템 라우터.
 
-메모 변경 이벤트를 SSE(Server-Sent Events)로 스트리밍.
-클라이언트는 EventSource로 연결하여 memo_created / memo_updated / reply_created 이벤트를 수신.
-
-실제 DB 변경 감지는 in-process 이벤트 버스 (asyncio.Queue) 사용.
+C-S6: SSE 스트림 (메모 변경 이벤트 실시간 푸시)
+E-EVENTBUS S1: events 테이블 CRUD (이벤트버스 기반)
 """
 from __future__ import annotations
 
@@ -11,12 +9,18 @@ import asyncio
 import json
 import uuid
 from collections import defaultdict
+from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.event import Event
 
 router = APIRouter(prefix="/api/v2/events", tags=["events"])
 
@@ -82,3 +86,107 @@ async def memo_event_stream(
             "Connection": "keep-alive",
         },
     )
+
+
+# ─── Pydantic schemas ─────────────────────────────────────────────────────────
+
+class CreateEventRequest(BaseModel):
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    event_type: str
+    source_entity_type: str | None = None
+    source_entity_id: uuid.UUID | None = None
+    sender_id: uuid.UUID | None = None
+    recipient_id: uuid.UUID
+    recipient_type: str
+    payload: dict = {}
+
+
+class EventResponse(BaseModel):
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    event_type: str
+    source_entity_type: str | None
+    source_entity_id: uuid.UUID | None
+    sender_id: uuid.UUID | None
+    recipient_id: uuid.UUID
+    recipient_type: str
+    payload: dict
+    status: str
+    created_at: datetime
+    delivered_at: datetime | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ─── CRUD endpoints ───────────────────────────────────────────────────────────
+
+@router.post("", response_model=EventResponse, status_code=201)
+async def create_event(
+    body: CreateEventRequest,
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> EventResponse:
+    """POST /api/v2/events — 이벤트 생성 (내부용)."""
+    from app.models.team import TeamMember
+
+    # recipient_type을 team_members.type 기준으로 확정
+    result = await db.execute(
+        select(TeamMember.type).where(TeamMember.id == body.recipient_id)
+    )
+    member_type = result.scalar_one_or_none()
+    if member_type is None:
+        raise HTTPException(status_code=404, detail="Recipient not found")
+
+    event = Event(
+        project_id=body.project_id,
+        org_id=body.org_id,
+        event_type=body.event_type,
+        source_entity_type=body.source_entity_type,
+        source_entity_id=body.source_entity_id,
+        sender_id=body.sender_id,
+        recipient_id=body.recipient_id,
+        recipient_type=member_type,
+        payload=body.payload,
+        status="pending",
+    )
+    db.add(event)
+    await db.commit()
+    await db.refresh(event)
+    return EventResponse.model_validate(event)
+
+
+@router.get("/pending", response_model=list[EventResponse])
+async def get_pending_events(
+    recipient_id: uuid.UUID = Query(...),
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> list[EventResponse]:
+    """GET /api/v2/events/pending?recipient_id={id} — 수신자별 pending 이벤트 목록."""
+    result = await db.execute(
+        select(Event)
+        .where(Event.recipient_id == recipient_id, Event.status == "pending")
+        .order_by(Event.created_at.asc())
+    )
+    events = result.scalars().all()
+    return [EventResponse.model_validate(e) for e in events]
+
+
+@router.patch("/{event_id}/delivered", response_model=EventResponse)
+async def mark_delivered(
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _auth: AuthContext = Depends(get_current_user),
+) -> EventResponse:
+    """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹."""
+    result = await db.execute(select(Event).where(Event.id == event_id))
+    event = result.scalar_one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Event not found")
+
+    event.status = "delivered"
+    event.delivered_at = datetime.now(timezone.utc)
+    await db.commit()
+    await db.refresh(event)
+    return EventResponse.model_validate(event)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.event import Event
 
@@ -92,7 +92,6 @@ async def memo_event_stream(
 
 class CreateEventRequest(BaseModel):
     project_id: uuid.UUID
-    org_id: uuid.UUID
     event_type: str
     source_entity_type: str | None = None
     source_entity_id: uuid.UUID | None = None
@@ -126,14 +125,17 @@ class EventResponse(BaseModel):
 async def create_event(
     body: CreateEventRequest,
     db: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> EventResponse:
     """POST /api/v2/events — 이벤트 생성 (내부용)."""
     from app.models.team import TeamMember
 
-    # recipient_type을 team_members.type 기준으로 확정
+    # recipient가 동일 org 소속인지 + type 확정
     result = await db.execute(
-        select(TeamMember.type).where(TeamMember.id == body.recipient_id)
+        select(TeamMember.type).where(
+            TeamMember.id == body.recipient_id,
+            TeamMember.org_id == org_id,
+        )
     )
     member_type = result.scalar_one_or_none()
     if member_type is None:
@@ -141,7 +143,7 @@ async def create_event(
 
     event = Event(
         project_id=body.project_id,
-        org_id=body.org_id,
+        org_id=org_id,
         event_type=body.event_type,
         source_entity_type=body.source_entity_type,
         source_entity_id=body.source_entity_id,
@@ -161,12 +163,16 @@ async def create_event(
 async def get_pending_events(
     recipient_id: uuid.UUID = Query(...),
     db: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[EventResponse]:
     """GET /api/v2/events/pending?recipient_id={id} — 수신자별 pending 이벤트 목록."""
     result = await db.execute(
         select(Event)
-        .where(Event.recipient_id == recipient_id, Event.status == "pending")
+        .where(
+            Event.org_id == org_id,
+            Event.recipient_id == recipient_id,
+            Event.status == "pending",
+        )
         .order_by(Event.created_at.asc())
     )
     events = result.scalars().all()
@@ -177,10 +183,12 @@ async def get_pending_events(
 async def mark_delivered(
     event_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> EventResponse:
     """PATCH /api/v2/events/{id}/delivered — 전달 완료 마킹."""
-    result = await db.execute(select(Event).where(Event.id == event_id))
+    result = await db.execute(
+        select(Event).where(Event.id == event_id, Event.org_id == org_id)
+    )
     event = result.scalar_one_or_none()
     if event is None:
         raise HTTPException(status_code=404, detail="Event not found")

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -1,0 +1,227 @@
+"""E-EVENTBUS S1: events 테이블 + 이벤트 라우터 API 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.models.event import Event
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_event(**kwargs) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "org_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "event_type": "memo_created",
+        "source_entity_type": "memo",
+        "source_entity_id": uuid.uuid4(),
+        "sender_id": uuid.uuid4(),
+        "recipient_id": uuid.uuid4(),
+        "recipient_type": "agent",
+        "payload": {"title": "test"},
+        "status": "pending",
+        "created_at": datetime.now(timezone.utc),
+        "delivered_at": None,
+    }
+    defaults.update(kwargs)
+    event = MagicMock(spec=Event)
+    for k, v in defaults.items():
+        setattr(event, k, v)
+    return event
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def auth_ctx():
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "agent@test.com"
+    ctx.claims = {"app_metadata": {"org_id": str(uuid.uuid4())}}
+    return ctx
+
+
+@pytest.fixture
+async def client(mock_session, auth_ctx):
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return auth_ctx
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ─── AC2: POST /api/v2/events ─────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_event_stores_in_db(client, mock_session):
+    recipient_id = uuid.uuid4()
+    event = _make_event(recipient_id=recipient_id, recipient_type="agent")
+
+    # team_members.type 조회 결과 mock
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = "agent"
+    mock_session.execute.return_value = member_result
+
+    # refresh populates the created event
+    async def _refresh(obj):
+        obj.id = event.id
+        obj.status = "pending"
+        obj.created_at = event.created_at
+        obj.delivered_at = None
+        obj.recipient_type = "agent"
+
+    mock_session.refresh.side_effect = _refresh
+
+    payload = {
+        "project_id": str(uuid.uuid4()),
+        "org_id": str(uuid.uuid4()),
+        "event_type": "memo_created",
+        "source_entity_type": "memo",
+        "source_entity_id": str(uuid.uuid4()),
+        "sender_id": str(uuid.uuid4()),
+        "recipient_id": str(recipient_id),
+        "recipient_type": "agent",
+        "payload": {"title": "킥오프"},
+    }
+    resp = await client.post("/api/v2/events", json=payload)
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["status"] == "pending"
+    assert data["event_type"] == "memo_created"
+    mock_session.add.assert_called_once()
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_create_event_recipient_not_found_returns_404(client, mock_session):
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = member_result
+
+    payload = {
+        "project_id": str(uuid.uuid4()),
+        "org_id": str(uuid.uuid4()),
+        "event_type": "memo_created",
+        "recipient_id": str(uuid.uuid4()),
+        "recipient_type": "agent",
+    }
+    resp = await client.post("/api/v2/events", json=payload)
+    assert resp.status_code == 404
+
+
+# ─── AC3: GET /api/v2/events/pending ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_pending_events_returns_list(client, mock_session):
+    recipient_id = uuid.uuid4()
+    events = [_make_event(recipient_id=recipient_id, status="pending") for _ in range(3)]
+
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = events
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+    mock_session.execute.return_value = result_mock
+
+    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+    assert all(e["status"] == "pending" for e in data)
+
+
+# ─── AC4: PATCH /api/v2/events/{id}/delivered ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_mark_delivered_sets_status_and_timestamp(client, mock_session):
+    event = _make_event(status="pending")
+
+    async def _refresh(obj):
+        pass  # obj already mutated in-place
+
+    mock_session.refresh.side_effect = _refresh
+
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none.return_value = event
+    mock_session.execute.return_value = scalar_mock
+
+    resp = await client.patch(f"/api/v2/events/{event.id}/delivered")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "delivered"
+    assert data["delivered_at"] is not None
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_delivered_event_not_found_returns_404(client, mock_session):
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none.return_value = None
+    mock_session.execute.return_value = scalar_mock
+
+    resp = await client.patch(f"/api/v2/events/{uuid.uuid4()}/delivered")
+    assert resp.status_code == 404
+
+
+# ─── AC5: recipient_type 분기 로직 ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_recipient_type_resolved_from_db(client, mock_session):
+    """POST 시 DB의 team_members.type이 recipient_type으로 저장됨을 확인."""
+    recipient_id = uuid.uuid4()
+    captured = {}
+
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = "human"
+    mock_session.execute.return_value = member_result
+
+    original_add = mock_session.add.side_effect
+    def capture_add(obj):
+        if isinstance(obj, Event):
+            captured["recipient_type"] = obj.recipient_type
+    mock_session.add.side_effect = capture_add
+
+    async def _refresh(obj):
+        obj.id = uuid.uuid4()
+        obj.status = "pending"
+        obj.created_at = datetime.now(timezone.utc)
+        obj.delivered_at = None
+
+    mock_session.refresh.side_effect = _refresh
+
+    payload = {
+        "project_id": str(uuid.uuid4()),
+        "org_id": str(uuid.uuid4()),
+        "event_type": "memo_created",
+        "recipient_id": str(recipient_id),
+        "recipient_type": "agent",  # 요청값과 무관하게 DB 값 사용
+    }
+    resp = await client.post("/api/v2/events", json=payload)
+    assert resp.status_code == 201
+    assert captured.get("recipient_type") == "human"

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -59,8 +59,13 @@ def auth_ctx():
 
 
 @pytest.fixture
-async def client(mock_session, auth_ctx):
-    from app.dependencies.auth import get_current_user
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+async def client(mock_session, auth_ctx, org_id):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -70,8 +75,12 @@ async def client(mock_session, auth_ctx):
     async def _auth():
         return auth_ctx
 
+    async def _org_id():
+        return org_id
+
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org_id
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -225,3 +234,68 @@ async def test_recipient_type_resolved_from_db(client, mock_session):
     resp = await client.post("/api/v2/events", json=payload)
     assert resp.status_code == 201
     assert captured.get("recipient_type") == "human"
+
+
+# ─── org scope 검증 ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_pending_filters_by_org(client, mock_session, org_id):
+    """GET /pending 은 verified org_id 내 이벤트만 반환해야 함."""
+    recipient_id = uuid.uuid4()
+    event_same_org = _make_event(recipient_id=recipient_id, org_id=org_id, status="pending")
+
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = [event_same_org]
+    result_mock = MagicMock()
+    result_mock.scalars.return_value = scalars_mock
+    mock_session.execute.return_value = result_mock
+
+    resp = await client.get(f"/api/v2/events/pending?recipient_id={recipient_id}")
+    assert resp.status_code == 200
+    # execute 호출 시 org_id 필터가 쿼리에 포함됐는지 — 실제 SQL은 mock이므로 호출 여부로 확인
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_delivered_cross_org_returns_404(client, mock_session):
+    """다른 org의 이벤트에 대한 PATCH는 404여야 함."""
+    scalar_mock = MagicMock()
+    scalar_mock.scalar_one_or_none.return_value = None  # org_id 불일치 → not found
+    mock_session.execute.return_value = scalar_mock
+
+    resp = await client.patch(f"/api/v2/events/{uuid.uuid4()}/delivered")
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_create_event_uses_verified_org(client, mock_session, org_id):
+    """POST 시 body의 org_id가 아닌 verified org_id가 Event에 설정돼야 함."""
+    captured = {}
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = "agent"
+    mock_session.execute.return_value = member_result
+
+    def capture_add(obj):
+        if isinstance(obj, Event):
+            captured["org_id"] = obj.org_id
+    mock_session.add.side_effect = capture_add
+
+    async def _refresh(obj):
+        obj.id = uuid.uuid4()
+        obj.status = "pending"
+        obj.created_at = datetime.now(timezone.utc)
+        obj.delivered_at = None
+    mock_session.refresh.side_effect = _refresh
+
+    forged_org = uuid.uuid4()  # 요청자가 임의로 보낸 org_id
+    payload = {
+        "project_id": str(uuid.uuid4()),
+        "org_id": str(forged_org),
+        "event_type": "memo_created",
+        "recipient_id": str(uuid.uuid4()),
+        "recipient_type": "agent",
+    }
+    resp = await client.post("/api/v2/events", json=payload)
+    assert resp.status_code == 201
+    # body의 forged_org가 아닌 verified org_id가 사용됐는지
+    assert captured.get("org_id") == org_id


### PR DESCRIPTION
## Summary
- `events` 테이블 Alembic migration 0024 (복합 인덱스 3개 포함)
- `Event` SQLAlchemy 모델 신설 (`app/models/event.py`)
- FastAPI CRUD 엔드포인트 3종 (`app/routers/events.py`에 추가)
  - `POST /api/v2/events` — 이벤트 생성 (recipient DB lookup으로 type 자동 확정)
  - `GET /api/v2/events/pending?recipient_id={id}` — pending 이벤트 목록
  - `PATCH /api/v2/events/{id}/delivered` — delivered 마킹 + `delivered_at` 기록
- 테스트 6종 (AC2~AC5 전량 커버), 597/597 PASS

## AC Checklist
- [x] AC1: `alembic upgrade head` 시 events 테이블 생성 (migration 0024)
- [x] AC2: POST /api/v2/events → DB 저장 (test_create_event_stores_in_db)
- [x] AC3: GET /api/v2/events/pending → pending 이벤트 목록 반환 (test_get_pending_events_returns_list)
- [x] AC4: PATCH /api/v2/events/{id}/delivered → status=delivered + delivered_at 기록 (test_mark_delivered_*)
- [x] AC5: recipient_type 분기 로직 존재 — DB의 team_members.type으로 확정 (test_recipient_type_resolved_from_db)
- [ ] AC6: dev 환경 migration 적용 (QA 단계)

## 관련 스토리
E-EVENTBUS S1: `5ea10616-4472-4cb2-9cc0-ed388912e7c8`