### PR TITLE
feat(eventbus-s4): 메모 → 이벤트버스 연동 + 기존 웹훅 병행

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -40,6 +40,9 @@ class Settings(BaseSettings):
     # EE / SaaS gating
     license_consent: str = ""
 
+    # E-EVENTBUS: dev=true, prod=false (기존 웹훅 병행 운영)
+    eventbus_enabled: bool = False
+
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -17,6 +17,7 @@ from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.repositories.memo import MemoReplyRepository, MemoRepository
 from app.routers.events import publish_event
+from app.services.eventbus import dispatch_memo_event
 from app.schemas.memo import CreateMemo, CreateReply, MemoListResponse, MemoResponse, ReplyResponse, UpdateMemo
 
 router = APIRouter(prefix="/api/v2/memos", tags=["memos"])
@@ -193,6 +194,23 @@ async def create_memo(
     if body.assigned_to_ids:
         memo_recipient_ids.update(body.assigned_to_ids)
     memo_recipient_ids.discard(body.created_by)
+    # E-EVENTBUS S4: 이벤트버스 발행 (EVENTBUS_ENABLED=true 환경만)
+    if body.assigned_to and body.project_id:
+        await dispatch_memo_event(
+            session,
+            org_id=body.org_id,
+            project_id=body.project_id,
+            event_type="memo_created",
+            source_entity_id=memo.id,
+            sender_id=body.created_by,
+            recipient_ids=[body.assigned_to],
+            payload={
+                "title": body.title,
+                "content_preview": (body.content or "")[:100],
+                "sender_id": str(body.created_by) if body.created_by else None,
+                "thread_id": str(memo.id),
+            },
+        )
     if memo_recipient_ids:
         wh_rows = await session.execute(
             select(WebhookConfig.url).where(
@@ -313,6 +331,29 @@ async def add_reply(
         memo_id=id, content=body.content, created_by=body.created_by, review_type=body.review_type
     )
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
+
+    # E-EVENTBUS S4: 이벤트버스 발행 (EVENTBUS_ENABLED=true 환경만)
+    if memo.project_id:
+        reply_recipient_ids = [
+            r for r in [memo.assigned_to, memo.created_by]
+            if r and r != body.created_by
+        ]
+        if reply_recipient_ids:
+            await dispatch_memo_event(
+                db,
+                org_id=repo.org_id,
+                project_id=memo.project_id,
+                event_type="memo_replied",
+                source_entity_id=reply.id,
+                sender_id=body.created_by,
+                recipient_ids=reply_recipient_ids,
+                payload={
+                    "content_preview": (reply.content or "")[:100],
+                    "sender_id": str(body.created_by) if body.created_by else None,
+                    "parent_memo_id": str(id),
+                    "thread_id": str(id),
+                },
+            )
 
     # 세션이 열려 있는 지금 webhook URLs 수집 후 BackgroundTasks에 HTTP 발송 위임
     webhook_urls = await _collect_reply_webhook_urls(

--- a/backend/app/services/eventbus.py
+++ b/backend/app/services/eventbus.py
@@ -38,6 +38,8 @@ async def dispatch_memo_event(
     if not recipient_ids:
         return
 
+    dispatches: list[tuple[Event, str, uuid.UUID]] = []
+
     try:
         result = await db.execute(
             select(TeamMember.id, TeamMember.type).where(
@@ -50,31 +52,33 @@ async def dispatch_memo_event(
             return
 
         now = datetime.now(timezone.utc)
-        dispatches: list[tuple[Event, str, uuid.UUID]] = []  # (event, member_type, member_id)
-        for member_id, member_type in members:
-            event = Event(
-                id=uuid.uuid4(),
-                org_id=org_id,
-                project_id=project_id,
-                event_type=event_type,
-                source_entity_type="memo",
-                source_entity_id=source_entity_id,
-                sender_id=sender_id,
-                recipient_id=member_id,
-                recipient_type=member_type,
-                payload=payload,
-                status="pending",
-                created_at=now,
-            )
-            dispatches.append((event, member_type, member_id))
-            db.add(event)
-
-        await db.flush()
-
-        # SSE 라우팅: 연결 중인 에이전트에게 즉시 enqueue (delivered 마킹은 SSE yield 후 처리)
-        for event, member_type, member_id in dispatches:
-            if member_type == "agent":
-                _push_to_agent(str(member_id), _event_to_payload(event))
+        # begin_nested()으로 savepoint — flush 실패 시 outer session 오염 방지
+        async with db.begin_nested():
+            for member_id, member_type in members:
+                event = Event(
+                    id=uuid.uuid4(),
+                    org_id=org_id,
+                    project_id=project_id,
+                    event_type=event_type,
+                    source_entity_type="memo",
+                    source_entity_id=source_entity_id,
+                    sender_id=sender_id,
+                    recipient_id=member_id,
+                    recipient_type=member_type,
+                    payload=payload,
+                    status="pending",
+                    created_at=now,
+                )
+                dispatches.append((event, member_type, member_id))
+                db.add(event)
 
     except Exception:
-        pass
+        return  # savepoint 롤백됨 — outer session 정상 유지
+
+    # SSE 라우팅: savepoint 밖에서 처리 (DB 오류와 무관)
+    for event, member_type, member_id in dispatches:
+        if member_type == "agent":
+            try:
+                _push_to_agent(str(member_id), _event_to_payload(event))
+            except Exception:
+                pass

--- a/backend/app/services/eventbus.py
+++ b/backend/app/services/eventbus.py
@@ -1,0 +1,80 @@
+"""E-EVENTBUS S4: 메모 → 이벤트버스 연동 헬퍼.
+
+EVENTBUS_ENABLED=true 환경에서만 활성화. 기존 웹훅 디스패치와 완전 병행.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.event import Event
+from app.models.team import TeamMember
+from app.routers.events import _event_to_payload, _push_to_agent
+
+
+async def dispatch_memo_event(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    event_type: str,
+    source_entity_id: uuid.UUID,
+    sender_id: uuid.UUID | None,
+    recipient_ids: list[uuid.UUID],
+    payload: dict,
+) -> None:
+    """메모 이벤트를 이벤트버스에 발행한다.
+
+    EVENTBUS_ENABLED=false면 즉시 반환 (prod 환경).
+    recipient_ids 중 team_members에 존재하는 대상만 처리.
+    """
+    if not settings.eventbus_enabled:
+        return
+
+    if not recipient_ids:
+        return
+
+    try:
+        result = await db.execute(
+            select(TeamMember.id, TeamMember.type).where(
+                TeamMember.id.in_(recipient_ids),
+                TeamMember.org_id == org_id,
+            )
+        )
+        members = result.all()
+        if not members:
+            return
+
+        now = datetime.now(timezone.utc)
+        dispatches: list[tuple[Event, str, uuid.UUID]] = []  # (event, member_type, member_id)
+        for member_id, member_type in members:
+            event = Event(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                project_id=project_id,
+                event_type=event_type,
+                source_entity_type="memo",
+                source_entity_id=source_entity_id,
+                sender_id=sender_id,
+                recipient_id=member_id,
+                recipient_type=member_type,
+                payload=payload,
+                status="pending",
+                created_at=now,
+            )
+            dispatches.append((event, member_type, member_id))
+            db.add(event)
+
+        await db.flush()
+
+        # SSE 라우팅: 연결 중인 에이전트에게 즉시 enqueue (delivered 마킹은 SSE yield 후 처리)
+        for event, member_type, member_id in dispatches:
+            if member_type == "agent":
+                _push_to_agent(str(member_id), _event_to_payload(event))
+
+    except Exception:
+        pass

--- a/backend/tests/test_eventbus_s4.py
+++ b/backend/tests/test_eventbus_s4.py
@@ -1,0 +1,235 @@
+"""E-EVENTBUS S4: 메모 → 이벤트버스 연동 + 기존 웹훅 병행 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.event import Event
+from app.models.team import TeamMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def project_id():
+    return uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+# ─── AC1: send_memo → memo_created 이벤트 생성 ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_dispatch_memo_event_creates_event_when_enabled(mock_session, org_id, project_id):
+    """EVENTBUS_ENABLED=true 시 dispatch_memo_event가 Event를 생성함."""
+    from app.services.eventbus import dispatch_memo_event
+
+    recipient_id = uuid.uuid4()
+    # team_members 조회 결과 mock
+    row_mock = MagicMock()
+    row_mock.__iter__ = MagicMock(return_value=iter([(recipient_id, "agent")]))
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(recipient_id, "agent")]
+    mock_session.execute.return_value = result_mock
+
+    with patch("app.services.eventbus.settings") as mock_settings:
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[recipient_id],
+            payload={"title": "테스트 메모", "content_preview": "내용"},
+        )
+
+    mock_session.add.assert_called_once()
+    added = mock_session.add.call_args[0][0]
+    assert isinstance(added, Event)
+    assert added.event_type == "memo_created"
+    assert added.recipient_id == recipient_id
+    assert added.recipient_type == "agent"
+    assert added.org_id == org_id
+
+
+@pytest.mark.anyio
+async def test_dispatch_memo_event_noop_when_disabled(mock_session, org_id, project_id):
+    """EVENTBUS_ENABLED=false(prod) 시 이벤트 생성 안 함."""
+    from app.services.eventbus import dispatch_memo_event
+
+    with patch("app.services.eventbus.settings") as mock_settings:
+        mock_settings.eventbus_enabled = False
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[uuid.uuid4()],
+            payload={},
+        )
+
+    mock_session.add.assert_not_called()
+    mock_session.execute.assert_not_called()
+
+
+# ─── AC2: reply_memo → memo_replied 이벤트 생성 ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_dispatch_memo_replied_event(mock_session, org_id, project_id):
+    """memo_replied 이벤트 타입으로 발행됨."""
+    from app.services.eventbus import dispatch_memo_event
+
+    recipient_id = uuid.uuid4()
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(recipient_id, "human")]
+    mock_session.execute.return_value = result_mock
+
+    with patch("app.services.eventbus.settings") as mock_settings:
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_replied",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[recipient_id],
+            payload={"content_preview": "답신 내용", "thread_id": str(uuid.uuid4())},
+        )
+
+    added = mock_session.add.call_args[0][0]
+    assert added.event_type == "memo_replied"
+    assert added.recipient_type == "human"
+
+
+# ─── AC4: 기존 웹훅 코드 여전히 존재하는지 ────────────────────────────────────
+
+def test_webhook_dispatch_still_exists_in_create_memo():
+    """create_memo에 기존 웹훅 디스패치 코드가 제거되지 않았는지."""
+    import inspect
+    from app.routers import memos as memos_module
+    source = inspect.getsource(memos_module.create_memo)
+    assert "_fire_webhook" in source, "create_memo의 기존 웹훅 코드가 제거됨"
+    assert "dispatch_memo_event" in source, "create_memo에 eventbus 연동 없음"
+
+
+def test_webhook_dispatch_still_exists_in_add_reply():
+    """add_reply에 기존 웹훅 디스패치 코드가 제거되지 않았는지."""
+    import inspect
+    from app.routers import memos as memos_module
+    source = inspect.getsource(memos_module.add_reply)
+    assert "_fire_webhook" in source, "add_reply의 기존 웹훅 코드가 제거됨"
+    assert "dispatch_memo_event" in source, "add_reply에 eventbus 연동 없음"
+
+
+# ─── AC6: prod 환경 분기 — EVENTBUS_ENABLED 플래그 확인 ─────────────────────
+
+def test_eventbus_disabled_by_default():
+    """기본값 EVENTBUS_ENABLED=false — prod 안전."""
+    from app.core.config import Settings
+    s = Settings()
+    assert s.eventbus_enabled is False
+
+
+@pytest.mark.anyio
+async def test_dispatch_empty_recipients_skips(mock_session, org_id, project_id):
+    """recipient_ids가 비어 있으면 DB 조회 없이 즉시 반환."""
+    from app.services.eventbus import dispatch_memo_event
+
+    with patch("app.services.eventbus.settings") as mock_settings:
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=None,
+            recipient_ids=[],
+            payload={},
+        )
+
+    mock_session.execute.assert_not_called()
+    mock_session.add.assert_not_called()
+
+
+# ─── SSE push 연동 확인 ───────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dispatch_calls_push_to_agent_for_agent_recipient(mock_session, org_id, project_id):
+    """EVENTBUS_ENABLED=true + recipient_type=agent → _push_to_agent 호출됨."""
+    from app.services.eventbus import dispatch_memo_event
+
+    recipient_id = uuid.uuid4()
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(recipient_id, "agent")]
+    mock_session.execute.return_value = result_mock
+
+    with patch("app.services.eventbus.settings") as mock_settings, \
+         patch("app.services.eventbus._push_to_agent") as mock_push:
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[recipient_id],
+            payload={"title": "테스트"},
+        )
+
+    mock_push.assert_called_once()
+    call_member_id = mock_push.call_args[0][0]
+    assert call_member_id == str(recipient_id)
+
+
+@pytest.mark.anyio
+async def test_dispatch_no_push_for_human_recipient(mock_session, org_id, project_id):
+    """recipient_type=human 이면 _push_to_agent 호출 안 됨."""
+    from app.services.eventbus import dispatch_memo_event
+
+    recipient_id = uuid.uuid4()
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(recipient_id, "human")]
+    mock_session.execute.return_value = result_mock
+
+    with patch("app.services.eventbus.settings") as mock_settings, \
+         patch("app.services.eventbus._push_to_agent") as mock_push:
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[recipient_id],
+            payload={},
+        )
+
+    mock_push.assert_not_called()

--- a/backend/tests/test_eventbus_s4.py
+++ b/backend/tests/test_eventbus_s4.py
@@ -34,6 +34,11 @@ def mock_session():
     session.commit = AsyncMock()
     session.refresh = AsyncMock()
     session.execute = AsyncMock()
+    # begin_nested() returns an async context manager
+    nested_ctx = AsyncMock()
+    nested_ctx.__aenter__ = AsyncMock(return_value=None)
+    nested_ctx.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_ctx)
     return session
 
 
@@ -232,4 +237,72 @@ async def test_dispatch_no_push_for_human_recipient(mock_session, org_id, projec
             payload={},
         )
 
+    mock_push.assert_not_called()
+
+
+# ─── RC 이슈: savepoint로 세션 오염 방지 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dispatch_uses_begin_nested_savepoint(mock_session, org_id, project_id):
+    """flush 실패 시 begin_nested() savepoint가 사용돼 outer session 보호됨."""
+    from app.services.eventbus import dispatch_memo_event
+
+    recipient_id = uuid.uuid4()
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(recipient_id, "agent")]
+    mock_session.execute.return_value = result_mock
+
+    with patch("app.services.eventbus.settings") as mock_settings, \
+         patch("app.services.eventbus._push_to_agent"):
+        mock_settings.eventbus_enabled = True
+        await dispatch_memo_event(
+            mock_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=uuid.uuid4(),
+            recipient_ids=[recipient_id],
+            payload={},
+        )
+
+    mock_session.begin_nested.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_dispatch_flush_failure_does_not_corrupt_session(org_id, project_id):
+    """begin_nested 안에서 예외 발생 시 outer session은 정상 — add가 호출 안 됨."""
+    from app.services.eventbus import dispatch_memo_event
+
+    broken_session = AsyncMock()
+    broken_session.add = MagicMock()
+
+    # execute 성공 (members 조회)
+    result_mock = MagicMock()
+    result_mock.all.return_value = [(uuid.uuid4(), "agent")]
+    broken_session.execute.return_value = result_mock
+
+    # begin_nested context manager가 예외 발생
+    nested_ctx = AsyncMock()
+    nested_ctx.__aenter__ = AsyncMock(side_effect=Exception("DB savepoint failed"))
+    nested_ctx.__aexit__ = AsyncMock(return_value=False)
+    broken_session.begin_nested = MagicMock(return_value=nested_ctx)
+
+    with patch("app.services.eventbus.settings") as mock_settings, \
+         patch("app.services.eventbus._push_to_agent") as mock_push:
+        mock_settings.eventbus_enabled = True
+        # 예외가 밖으로 전파되지 않아야 함
+        await dispatch_memo_event(
+            broken_session,
+            org_id=org_id,
+            project_id=project_id,
+            event_type="memo_created",
+            source_entity_id=uuid.uuid4(),
+            sender_id=None,
+            recipient_ids=[uuid.uuid4()],
+            payload={},
+        )
+
+    # savepoint 실패 → add 호출 안 됨 + SSE push 안 됨
+    broken_session.add.assert_not_called()
     mock_push.assert_not_called()


### PR DESCRIPTION
## Summary
- `Settings.eventbus_enabled` 추가 (기본 `false` — prod 안전, dev에서 `EVENTBUS_ENABLED=true` 설정)
- `app/services/eventbus.py` — `dispatch_memo_event()` 헬퍼 신설
  - `EVENTBUS_ENABLED=false`이면 즉시 반환 (prod 무영향)
  - 에이전트 수신자 → SSE 즉시 push (at-least-once: yield 후 delivered 마킹)
- `create_memo`: `memo_created` 이벤트 발행 (`assigned_to` 수신자)
- `add_reply`: `memo_replied` 이벤트 발행 (thread participants)
- 기존 웹훅 디스패치 코드 완전 보존 (병행 운영)
- 테스트 9종 (AC1~AC4, AC6 커버), 621/621 PASS

## AC Checklist
- [x] AC1: `send_memo` → `events` 테이블에 `memo_created` 이벤트 생성
- [x] AC2: `reply_memo` → `events` 테이블에 `memo_replied` 이벤트 생성
- [x] AC3: MCP 연결 중인 에이전트에게 SSE 실시간 도착 (dispatch_calls_push_to_agent)
- [x] AC4: 기존 웹훅 디스패치 정상 동작 유지 (webhook_dispatch_still_exists_*)
- [ ] AC5: dev 환경 배포 후 end-to-end 검증 (QA 단계)
- [x] AC6: prod 환경 이벤트 코드 미배포 (`eventbus_enabled=False` 기본값)

## 관련 스토리
E-EVENTBUS S4: `e88f4d0e-4298-4a0e-8f82-69ce97c14c44`