### PR TITLE
[SID:1c7729e4] 웹앱 알림 UI — GNB 벨 아이콘 + 알림 목록 패널

### DIFF
--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Plus, X, Play, StopCircle, ChevronRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
@@ -151,6 +152,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
 export function SprintsClient({ projectId }: SprintsClientProps) {
   const t = useTranslations('sprints');
   const tc = useTranslations('common');
+  const searchParams = useSearchParams();
 
   const [sprints, setSprints] = useState<Sprint[]>([]);
   const [loading, setLoading] = useState(true);
@@ -262,6 +264,14 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
     setSelected(sprint);
     await loadSprintDetail(sprint);
   }, [loadSprintDetail]);
+
+  // ?id= 파라미터로 sprint 자동 선택 (알림 딥링크 지원)
+  useEffect(() => {
+    const sprintId = searchParams.get('id');
+    if (!sprintId || sprints.length === 0 || selected?.id === sprintId) return;
+    const sprint = sprints.find((s) => s.id === sprintId);
+    if (sprint) void handleSelect(sprint);
+  }, [searchParams, sprints, selected, handleSelect]);
 
   const handleActivate = async () => {
     if (!selected) return;

--- a/apps/web/src/app/api/event-notifications/[id]/read/route.ts
+++ b/apps/web/src/app/api/event-notifications/[id]/read/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapiWithParams(request, '/api/v2/event-notifications/[id]/read', { id });
+}

--- a/apps/web/src/app/api/event-notifications/read-all/route.ts
+++ b/apps/web/src/app/api/event-notifications/read-all/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function PATCH(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/event-notifications/read-all');
+}

--- a/apps/web/src/app/api/event-notifications/route.ts
+++ b/apps/web/src/app/api/event-notifications/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/event-notifications');
+}

--- a/apps/web/src/app/api/event-notifications/unread-count/route.ts
+++ b/apps/web/src/app/api/event-notifications/unread-count/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/event-notifications/unread-count');
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -255,6 +255,34 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     }
   }, [searchParams, stories, handleStoryClick]);
 
+  // URL에서 task_id 읽어서 해당 task의 story 패널 열기 (알림 딥링크 지원)
+  useEffect(() => {
+    const taskId = searchParams.get('task_id');
+    if (!taskId || stories.length === 0) return;
+
+    fetch(`/api/tasks/${taskId}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        const storyId = json?.data?.story_id as string | undefined;
+        if (!storyId || selectedStoryRef.current?.id === storyId) return;
+        const story = stories.find((s) => s.id === storyId);
+        if (story) {
+          void handleStoryClick(story, { replace: true });
+        } else {
+          fetch(`/api/stories/${storyId}`)
+            .then((r) => (r.ok ? r.json() : null))
+            .then((json2) => {
+              const fetched = json2?.data as KanbanStory | undefined;
+              if (fetched && selectedStoryRef.current?.id !== storyId) {
+                void handleStoryClick(fetched, { replace: true });
+              }
+            })
+            .catch(() => {});
+        }
+      })
+      .catch(() => {});
+  }, [searchParams, stories, handleStoryClick]);
+
   const filteredStories = stories.filter((s) => {
     if (selectedEpicId && s.epic_id !== selectedEpicId) return false;
     if (selectedAssigneeId && s.assignee_id !== selectedAssigneeId) return false;

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -31,13 +31,13 @@ function getEntityHref(notification: EventNotification): string | null {
   const { source_entity_type, source_entity_id } = notification;
   if (!source_entity_id) return null;
   switch (source_entity_type) {
-    case 'memo': return `/memos?id=${source_entity_id}`;
-    case 'story': return '/board';
-    case 'task': return '/board';
-    case 'epic': return '/epics';
-    case 'sprint': return '/sprints';
-    case 'doc': return '/docs';
-    default: return null;
+    case 'memo':   return `/memos?id=${source_entity_id}`;
+    case 'story':  return `/board?story_id=${source_entity_id}`;
+    case 'task':   return `/board?task_id=${source_entity_id}`;
+    case 'epic':   return `/epics/${source_entity_id}`;
+    case 'sprint': return `/sprints?id=${source_entity_id}`;
+    case 'doc':    return `/docs?id=${source_entity_id}`;
+    default:       return null;
   }
 }
 
@@ -244,17 +244,32 @@ export function NotificationBell() {
   }, [open]);
 
   const handleMarkRead = useCallback(async (id: string) => {
+    const readAt = new Date().toISOString();
+    // 낙관적 업데이트
     setNotifications((prev) =>
-      prev ? prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)) : prev,
+      prev ? prev.map((n) => (n.id === id ? { ...n, read_at: readAt } : n)) : prev,
     );
     setUnreadCount((c) => Math.max(0, c - 1));
-    await fetch(`/api/event-notifications/${id}/read`, { method: 'PATCH' });
+    const res = await fetch(`/api/event-notifications/${id}/read`, { method: 'PATCH' });
+    // 서버 실패 시 롤백
+    if (!res.ok) {
+      setNotifications((prev) =>
+        prev ? prev.map((n) => (n.id === id ? { ...n, read_at: null } : n)) : prev,
+      );
+      setUnreadCount((c) => c + 1);
+    }
   }, []);
 
   const handleMarkAllRead = useCallback(async () => {
-    setNotifications((prev) => prev ? prev.map((n) => ({ ...n, read_at: n.read_at ?? new Date().toISOString() })) : prev);
+    const readAt = new Date().toISOString();
+    // 낙관적 업데이트
+    setNotifications((prev) => prev ? prev.map((n) => ({ ...n, read_at: n.read_at ?? readAt })) : prev);
     setUnreadCount(0);
-    await fetch('/api/event-notifications/read-all', { method: 'PATCH' });
+    const res = await fetch('/api/event-notifications/read-all', { method: 'PATCH' });
+    // 서버 실패 시 unread count 재폴링으로 보정
+    if (!res.ok) {
+      void fetchUnreadCount().then(setUnreadCount);
+    }
   }, []);
 
   const handleNavigate = useCallback(

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import {
+  Bell,
+  BookOpen,
+  CheckCheck,
+  FolderKanban,
+  MessageSquareMore,
+  X,
+  Zap,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface EventNotification {
+  id: string;
+  event_type: string;
+  source_entity_type: string | null;
+  source_entity_id: string | null;
+  payload: {
+    summary?: string;
+    sender_name?: string;
+    [key: string]: unknown;
+  } | null;
+  read_at: string | null;
+  created_at: string;
+}
+
+function getEntityHref(notification: EventNotification): string | null {
+  const { source_entity_type, source_entity_id } = notification;
+  if (!source_entity_id) return null;
+  switch (source_entity_type) {
+    case 'memo': return `/memos?id=${source_entity_id}`;
+    case 'story': return '/board';
+    case 'task': return '/board';
+    case 'epic': return '/epics';
+    case 'sprint': return '/sprints';
+    case 'doc': return '/docs';
+    default: return null;
+  }
+}
+
+function getEventIcon(eventType: string) {
+  if (eventType.startsWith('memo')) return <MessageSquareMore className="size-4" />;
+  if (eventType.startsWith('story') || eventType.startsWith('status')) return <FolderKanban className="size-4" />;
+  if (eventType === 'dispatched') return <Zap className="size-4" />;
+  if (eventType.startsWith('doc')) return <BookOpen className="size-4" />;
+  return <Bell className="size-4" />;
+}
+
+function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return '방금 전';
+  if (mins < 60) return `${mins}분 전`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}시간 전`;
+  const days = Math.floor(hours / 24);
+  return `${days}일 전`;
+}
+
+async function fetchNotifications(): Promise<EventNotification[]> {
+  const res = await fetch('/api/event-notifications?limit=30');
+  if (!res.ok) return [];
+  const json = (await res.json()) as unknown;
+  if (Array.isArray(json)) return json as EventNotification[];
+  if (json && typeof json === 'object') {
+    const obj = json as Record<string, unknown>;
+    if (Array.isArray(obj['data'])) return obj['data'] as EventNotification[];
+    if (obj['items'] && Array.isArray(obj['items'])) return obj['items'] as EventNotification[];
+  }
+  return [];
+}
+
+async function fetchUnreadCount(): Promise<number> {
+  const res = await fetch('/api/event-notifications/unread-count');
+  if (!res.ok) return 0;
+  const json = (await res.json()) as unknown;
+  if (json && typeof json === 'object') {
+    const obj = json as Record<string, unknown>;
+    if (typeof obj['count'] === 'number') return obj['count'];
+    if (typeof obj['unread_count'] === 'number') return obj['unread_count'];
+    if (obj['data'] && typeof obj['data'] === 'object') {
+      const data = obj['data'] as Record<string, unknown>;
+      if (typeof data['count'] === 'number') return data['count'];
+    }
+  }
+  return 0;
+}
+
+interface NotificationPanelProps {
+  notifications: EventNotification[] | null;
+  onMarkAllRead: () => void;
+  onNavigate: (notification: EventNotification) => void;
+  onClose: () => void;
+}
+
+function NotificationPanel({
+  notifications,
+  onMarkAllRead,
+  onNavigate,
+  onClose,
+}: NotificationPanelProps) {
+  const loading = notifications === null;
+  const hasUnread = notifications?.some((n) => !n.read_at) ?? false;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex shrink-0 items-center justify-between border-b px-4 py-3">
+        <span className="text-sm font-semibold">알림</span>
+        <div className="flex items-center gap-1">
+          {hasUnread && (
+            <button
+              type="button"
+              onClick={onMarkAllRead}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition hover:bg-accent hover:text-foreground"
+            >
+              <CheckCheck className="size-3.5" />
+              전체 읽음
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex size-7 items-center justify-center rounded text-muted-foreground transition hover:bg-accent hover:text-foreground"
+            aria-label="닫기"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {loading ? (
+          <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+            로딩 중…
+          </div>
+        ) : notifications?.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-12 text-sm text-muted-foreground">
+            <Bell className="size-8 opacity-30" />
+            <span>새 알림이 없습니다</span>
+          </div>
+        ) : (
+          <ul>
+            {(notifications ?? []).map((n) => (
+              <li key={n.id}>
+                <button
+                  type="button"
+                  onClick={() => onNavigate(n)}
+                  className={cn(
+                    'flex w-full gap-3 px-4 py-3 text-left transition hover:bg-accent',
+                    !n.read_at && 'bg-primary/5',
+                  )}
+                >
+                  <span
+                    className={cn(
+                      'mt-0.5 shrink-0 rounded-full p-1.5',
+                      n.read_at
+                        ? 'bg-muted text-muted-foreground'
+                        : 'bg-primary/10 text-primary',
+                    )}
+                  >
+                    {getEventIcon(n.event_type)}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <p
+                      className={cn(
+                        'truncate text-sm',
+                        !n.read_at && 'font-medium',
+                      )}
+                    >
+                      {n.payload?.summary ?? n.event_type}
+                    </p>
+                    {n.payload?.sender_name ? (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {n.payload.sender_name}
+                      </p>
+                    ) : null}
+                    <p className="mt-0.5 text-xs text-muted-foreground">
+                      {timeAgo(n.created_at)}
+                    </p>
+                  </div>
+                  {!n.read_at && (
+                    <span className="mt-1.5 size-2 shrink-0 rounded-full bg-primary" />
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function NotificationBell() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [unreadCount, setUnreadCount] = useState(0);
+  // null = 로딩 중, array = 로드 완료
+  const [notifications, setNotifications] = useState<EventNotification[] | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // unread count 폴링 (30초)
+  useEffect(() => {
+    let cancelled = false;
+    const poll = async () => {
+      const count = await fetchUnreadCount();
+      if (!cancelled) setUnreadCount(count);
+    };
+    void poll();
+    intervalRef.current = setInterval(() => { void poll(); }, 30_000);
+    const onVisibility = () => { if (!document.hidden) void poll(); };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      cancelled = true;
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, []);
+
+  // 패널 열릴 때 알림 목록 로드
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void fetchNotifications().then((data) => {
+      if (!cancelled) setNotifications(data);
+    });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  // 외부 클릭으로 패널 닫기 (데스크톱)
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => document.removeEventListener('pointerdown', onPointerDown);
+  }, [open]);
+
+  const handleMarkRead = useCallback(async (id: string) => {
+    setNotifications((prev) =>
+      prev ? prev.map((n) => (n.id === id ? { ...n, read_at: new Date().toISOString() } : n)) : prev,
+    );
+    setUnreadCount((c) => Math.max(0, c - 1));
+    await fetch(`/api/event-notifications/${id}/read`, { method: 'PATCH' });
+  }, []);
+
+  const handleMarkAllRead = useCallback(async () => {
+    setNotifications((prev) => prev ? prev.map((n) => ({ ...n, read_at: n.read_at ?? new Date().toISOString() })) : prev);
+    setUnreadCount(0);
+    await fetch('/api/event-notifications/read-all', { method: 'PATCH' });
+  }, []);
+
+  const handleNavigate = useCallback(
+    (notification: EventNotification) => {
+      if (!notification.read_at) void handleMarkRead(notification.id);
+      const href = getEntityHref(notification);
+      setOpen(false);
+      if (href) router.push(href);
+    },
+    [handleMarkRead, router],
+  );
+
+  const badgeLabel = unreadCount > 99 ? '99+' : String(unreadCount);
+
+  return (
+    <div ref={containerRef} className="relative">
+      {/* 벨 버튼 */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label={unreadCount > 0 ? `알림 ${badgeLabel}개` : '알림'}
+        aria-expanded={open}
+        className="relative flex size-8 items-center justify-center rounded-md text-foreground/70 transition hover:bg-accent hover:text-foreground"
+      >
+        <Bell className="size-4" />
+        {unreadCount > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex min-w-[16px] items-center justify-center rounded-full bg-destructive px-1 py-px font-mono text-[9px] font-bold leading-none text-destructive-foreground">
+            {badgeLabel}
+          </span>
+        )}
+      </button>
+
+      {/* 데스크톱 드롭다운 (lg+) */}
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 hidden w-80 overflow-hidden rounded-lg border bg-background shadow-lg lg:flex lg:flex-col" style={{ maxHeight: '480px' }}>
+          <NotificationPanel
+            notifications={notifications}
+            onMarkAllRead={handleMarkAllRead}
+            onNavigate={handleNavigate}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      )}
+
+      {/* 모바일 풀스크린 오버레이 (< lg) */}
+      {open && (
+        <div className="fixed inset-0 z-50 flex flex-col bg-background lg:hidden">
+          <NotificationPanel
+            notifications={notifications}
+            onMarkAllRead={handleMarkAllRead}
+            onNavigate={handleNavigate}
+            onClose={() => setOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -31,13 +31,26 @@ function getEntityHref(notification: EventNotification): string | null {
   const { source_entity_type, source_entity_id } = notification;
   if (!source_entity_id) return null;
   switch (source_entity_type) {
-    case 'memo':   return `/memos?id=${source_entity_id}`;
-    case 'story':  return `/board?story_id=${source_entity_id}`;
-    case 'task':   return `/board?task_id=${source_entity_id}`;
-    case 'epic':   return `/epics/${source_entity_id}`;
-    case 'sprint': return `/sprints?id=${source_entity_id}`;
-    case 'doc':    return `/docs?id=${source_entity_id}`;
-    default:       return null;
+    case 'memo':
+      return `/memos?id=${source_entity_id}`;
+    case 'story':
+      // kanban-board.tsx는 searchParams.get('story') 키 사용
+      return `/board?story=${source_entity_id}`;
+    case 'task':
+      // kanban-board.tsx에서 task_id 파라미터 처리 — task → story 패널 자동 오픈
+      return `/board?task_id=${source_entity_id}`;
+    case 'epic':
+      return `/epics/${source_entity_id}`;
+    case 'sprint':
+      // sprints-client.tsx에서 id 파라미터 처리 추가됨
+      return `/sprints?id=${source_entity_id}`;
+    case 'doc': {
+      // docs-shell-client.tsx는 slug 파라미터 사용. payload에 slug가 있으면 deep link
+      const slug = notification.payload?.slug as string | undefined;
+      return slug ? `/docs?slug=${slug}` : `/docs`;
+    }
+    default:
+      return null;
   }
 }
 

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -2,6 +2,7 @@
 
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
+import { NotificationBell } from './notification-bell';
 import { useTopBar } from './top-bar-context';
 
 interface TopBarProps {
@@ -16,7 +17,10 @@ export function TopBar({ className }: TopBarProps) {
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}
       </div>
-      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+      <div className="flex shrink-0 items-center gap-1">
+        {actions}
+        <NotificationBell />
+      </div>
     </div>
   );
 }

--- a/backend/alembic/versions/0025_add_read_at_to_events.py
+++ b/backend/alembic/versions/0025_add_read_at_to_events.py
@@ -1,0 +1,24 @@
+"""add read_at to events table
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-05-12
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "events",
+        sa.Column("read_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("events", "read_at")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -97,6 +97,7 @@ app.include_router(standups.router)
 app.include_router(retros.router)
 app.include_router(memos.router)
 app.include_router(entities.router)
+app.include_router(event_notifications.router)
 app.include_router(notifications.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -62,3 +62,4 @@ class Event(Base, OrgScopedMixin):
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     delivered_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    read_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -14,7 +14,7 @@ from app.dependencies.database import get_db
 from app.models.event import Event
 from app.models.team import TeamMember
 
-router = APIRouter(prefix="/api/v2/notifications", tags=["event-notifications"])
+router = APIRouter(prefix="/api/v2/event-notifications", tags=["event-notifications"])
 
 
 # ─── Helper ───────────────────────────────────────────────────────────────────

--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -1,0 +1,151 @@
+"""E-EVENTBUS S5: Notifications API — events 테이블 기반 알림 읽음 추적."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import func, or_, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.event import Event
+from app.models.team import TeamMember
+
+router = APIRouter(prefix="/api/v2/notifications", tags=["event-notifications"])
+
+
+# ─── Helper ───────────────────────────────────────────────────────────────────
+
+async def _resolve_member_id(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    db: AsyncSession,
+) -> uuid.UUID:
+    """JWT auth → 현재 사용자의 team_member_id 반환. 없으면 403."""
+    user_id = uuid.UUID(str(auth.user_id))
+    result = await db.execute(
+        select(TeamMember.id).where(
+            or_(TeamMember.user_id == user_id, TeamMember.id == user_id),
+            TeamMember.org_id == org_id,
+        ).limit(1)
+    )
+    member_id = result.scalar_one_or_none()
+    if member_id is None:
+        raise HTTPException(status_code=403, detail="Team member not found")
+    return member_id
+
+
+# ─── Pydantic schemas ─────────────────────────────────────────────────────────
+
+class NotificationResponse(BaseModel):
+    id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    event_type: str
+    source_entity_type: str | None
+    source_entity_id: uuid.UUID | None
+    sender_id: uuid.UUID | None
+    recipient_id: uuid.UUID
+    recipient_type: str
+    payload: dict
+    status: str
+    created_at: datetime
+    delivered_at: datetime | None
+    read_at: datetime | None
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=list[NotificationResponse])
+async def list_notifications(
+    limit: int = Query(default=20, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> list[NotificationResponse]:
+    """GET /api/v2/notifications — 현재 사용자의 알림 목록 (최신순)."""
+    member_id = await _resolve_member_id(auth, org_id, db)
+    result = await db.execute(
+        select(Event)
+        .where(Event.org_id == org_id, Event.recipient_id == member_id)
+        .order_by(Event.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    events = result.scalars().all()
+    return [NotificationResponse.model_validate(e) for e in events]
+
+
+@router.get("/unread-count")
+async def get_unread_count(
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """GET /api/v2/notifications/unread-count — 읽지 않은 알림 수."""
+    member_id = await _resolve_member_id(auth, org_id, db)
+    result = await db.execute(
+        select(func.count()).where(
+            Event.org_id == org_id,
+            Event.recipient_id == member_id,
+            Event.read_at.is_(None),
+        )
+    )
+    count = result.scalar_one()
+    return {"count": count}
+
+
+@router.patch("/{event_id}/read", response_model=NotificationResponse)
+async def mark_read(
+    event_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> NotificationResponse:
+    """PATCH /api/v2/notifications/{id}/read — 단일 알림 읽음 처리."""
+    member_id = await _resolve_member_id(auth, org_id, db)
+    result = await db.execute(
+        select(Event).where(
+            Event.id == event_id,
+            Event.org_id == org_id,
+        )
+    )
+    event = result.scalar_one_or_none()
+    if event is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    if event.recipient_id != member_id:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if event.read_at is None:
+        event.read_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(event)
+    return NotificationResponse.model_validate(event)
+
+
+@router.patch("/read-all")
+async def mark_all_read(
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """PATCH /api/v2/notifications/read-all — 전체 읽음 처리."""
+    member_id = await _resolve_member_id(auth, org_id, db)
+    now = datetime.now(timezone.utc)
+    result = await db.execute(
+        update(Event)
+        .where(
+            Event.org_id == org_id,
+            Event.recipient_id == member_id,
+            Event.read_at.is_(None),
+        )
+        .values(read_at=now)
+    )
+    await db.commit()
+    return {"updated": result.rowcount}

--- a/backend/tests/test_eventbus_s5.py
+++ b/backend/tests/test_eventbus_s5.py
@@ -92,7 +92,7 @@ def _make_event(**kwargs) -> MagicMock:
     return event
 
 
-# ─── AC2: GET /api/v2/notifications ──────────────────────────────────────────
+# ─── AC2: GET /api/v2/event-notifications ──────────────────────────────────────────
 
 @pytest.mark.anyio
 async def test_list_notifications_returns_current_user_events(client, mock_session, org_id, member_id):
@@ -109,13 +109,13 @@ async def test_list_notifications_returns_current_user_events(client, mock_sessi
     events_result.scalars.return_value = scalars_mock
     mock_session.execute.side_effect = [member_result, events_result]
 
-    resp = await client.get("/api/v2/notifications")
+    resp = await client.get("/api/v2/event-notifications")
     assert resp.status_code == 200
     data = resp.json()
     assert len(data) == 3
 
 
-# ─── AC3: GET /api/v2/notifications/unread-count ─────────────────────────────
+# ─── AC3: GET /api/v2/event-notifications/unread-count ─────────────────────────────
 
 @pytest.mark.anyio
 async def test_unread_count_returns_null_read_at_count(client, mock_session, member_id):
@@ -126,12 +126,12 @@ async def test_unread_count_returns_null_read_at_count(client, mock_session, mem
     count_result.scalar_one.return_value = 7
     mock_session.execute.side_effect = [member_result, count_result]
 
-    resp = await client.get("/api/v2/notifications/unread-count")
+    resp = await client.get("/api/v2/event-notifications/unread-count")
     assert resp.status_code == 200
     assert resp.json()["count"] == 7
 
 
-# ─── AC4: PATCH /api/v2/notifications/{id}/read ──────────────────────────────
+# ─── AC4: PATCH /api/v2/event-notifications/{id}/read ──────────────────────────────
 
 @pytest.mark.anyio
 async def test_mark_read_sets_read_at(client, mock_session, member_id):
@@ -150,7 +150,7 @@ async def test_mark_read_sets_read_at(client, mock_session, member_id):
     mock_session.execute.side_effect = [member_result, event_result]
     mock_session.refresh.side_effect = _refresh
 
-    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
     assert resp.status_code == 200
     assert event.read_at is not None
     mock_session.commit.assert_called_once()
@@ -174,7 +174,7 @@ async def test_mark_read_already_read_skips_commit(client, mock_session, member_
     mock_session.execute.side_effect = [member_result, event_result]
     mock_session.refresh.side_effect = _refresh
 
-    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
     assert resp.status_code == 200
     mock_session.commit.assert_not_called()
 
@@ -194,7 +194,7 @@ async def test_mark_read_other_user_returns_403(client, mock_session, member_id)
     event_result.scalar_one_or_none.return_value = event
     mock_session.execute.side_effect = [member_result, event_result]
 
-    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
     assert resp.status_code == 403
 
 
@@ -207,11 +207,11 @@ async def test_mark_read_not_found_returns_404(client, mock_session, member_id):
     event_result.scalar_one_or_none.return_value = None
     mock_session.execute.side_effect = [member_result, event_result]
 
-    resp = await client.patch(f"/api/v2/notifications/{uuid.uuid4()}/read")
+    resp = await client.patch(f"/api/v2/event-notifications/{uuid.uuid4()}/read")
     assert resp.status_code == 404
 
 
-# ─── AC5: PATCH /api/v2/notifications/read-all ───────────────────────────────
+# ─── AC5: PATCH /api/v2/event-notifications/read-all ───────────────────────────────
 
 @pytest.mark.anyio
 async def test_mark_all_read_updates_all_unread(client, mock_session, member_id):
@@ -222,7 +222,7 @@ async def test_mark_all_read_updates_all_unread(client, mock_session, member_id)
     update_result.rowcount = 5
     mock_session.execute.side_effect = [member_result, update_result]
 
-    resp = await client.patch("/api/v2/notifications/read-all")
+    resp = await client.patch("/api/v2/event-notifications/read-all")
     assert resp.status_code == 200
     assert resp.json()["updated"] == 5
     mock_session.commit.assert_called_once()

--- a/backend/tests/test_eventbus_s5.py
+++ b/backend/tests/test_eventbus_s5.py
@@ -1,0 +1,249 @@
+"""E-EVENTBUS S5: Notifications API — 알림 읽음 추적 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.models.event import Event
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def member_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def auth_ctx(org_id, member_id):
+    ctx = MagicMock()
+    ctx.user_id = str(member_id)
+    ctx.email = "user@test.com"
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+    return ctx
+
+
+@pytest.fixture
+async def client(mock_session, auth_ctx, org_id, member_id):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return auth_ctx
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _make_event(**kwargs) -> MagicMock:
+    defaults = {
+        "id": uuid.uuid4(),
+        "org_id": uuid.uuid4(),
+        "project_id": uuid.uuid4(),
+        "event_type": "memo_created",
+        "source_entity_type": "memo",
+        "source_entity_id": uuid.uuid4(),
+        "sender_id": uuid.uuid4(),
+        "recipient_id": uuid.uuid4(),
+        "recipient_type": "human",
+        "payload": {},
+        "status": "delivered",
+        "created_at": datetime.now(timezone.utc),
+        "delivered_at": datetime.now(timezone.utc),
+        "read_at": None,
+    }
+    defaults.update(kwargs)
+    event = MagicMock(spec=Event)
+    for k, v in defaults.items():
+        setattr(event, k, v)
+    return event
+
+
+# ─── AC2: GET /api/v2/notifications ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_notifications_returns_current_user_events(client, mock_session, org_id, member_id):
+    """GET /notifications → 현재 사용자 알림 목록 반환."""
+    events = [_make_event(recipient_id=member_id, org_id=org_id) for _ in range(3)]
+
+    # 1st execute: member_id 조회
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    # 2nd execute: 알림 목록
+    scalars_mock = MagicMock()
+    scalars_mock.all.return_value = events
+    events_result = MagicMock()
+    events_result.scalars.return_value = scalars_mock
+    mock_session.execute.side_effect = [member_result, events_result]
+
+    resp = await client.get("/api/v2/notifications")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 3
+
+
+# ─── AC3: GET /api/v2/notifications/unread-count ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_unread_count_returns_null_read_at_count(client, mock_session, member_id):
+    """GET /notifications/unread-count → read_at IS NULL 카운트."""
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    count_result = MagicMock()
+    count_result.scalar_one.return_value = 7
+    mock_session.execute.side_effect = [member_result, count_result]
+
+    resp = await client.get("/api/v2/notifications/unread-count")
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 7
+
+
+# ─── AC4: PATCH /api/v2/notifications/{id}/read ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_mark_read_sets_read_at(client, mock_session, member_id):
+    """PATCH /notifications/{id}/read → read_at 기록."""
+    event_id = uuid.uuid4()
+    event = _make_event(id=event_id, recipient_id=member_id, read_at=None)
+
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    event_result = MagicMock()
+    event_result.scalar_one_or_none.return_value = event
+
+    async def _refresh(obj):
+        pass  # event already mutated
+
+    mock_session.execute.side_effect = [member_result, event_result]
+    mock_session.refresh.side_effect = _refresh
+
+    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    assert resp.status_code == 200
+    assert event.read_at is not None
+    mock_session.commit.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_mark_read_already_read_skips_commit(client, mock_session, member_id):
+    """이미 read_at 있는 알림에 PATCH → commit 없이 200 반환."""
+    event_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    event = _make_event(id=event_id, recipient_id=member_id, read_at=now)
+
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    event_result = MagicMock()
+    event_result.scalar_one_or_none.return_value = event
+
+    async def _refresh(obj):
+        pass
+
+    mock_session.execute.side_effect = [member_result, event_result]
+    mock_session.refresh.side_effect = _refresh
+
+    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    assert resp.status_code == 200
+    mock_session.commit.assert_not_called()
+
+
+# ─── AC6: 타인 알림 접근 차단 ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_mark_read_other_user_returns_403(client, mock_session, member_id):
+    """다른 사용자의 알림에 PATCH → 403."""
+    event_id = uuid.uuid4()
+    other_member = uuid.uuid4()
+    event = _make_event(id=event_id, recipient_id=other_member)  # 다른 사람 알림
+
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    event_result = MagicMock()
+    event_result.scalar_one_or_none.return_value = event
+    mock_session.execute.side_effect = [member_result, event_result]
+
+    resp = await client.patch(f"/api/v2/notifications/{event_id}/read")
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_mark_read_not_found_returns_404(client, mock_session, member_id):
+    """존재하지 않는 알림 PATCH → 404."""
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    event_result = MagicMock()
+    event_result.scalar_one_or_none.return_value = None
+    mock_session.execute.side_effect = [member_result, event_result]
+
+    resp = await client.patch(f"/api/v2/notifications/{uuid.uuid4()}/read")
+    assert resp.status_code == 404
+
+
+# ─── AC5: PATCH /api/v2/notifications/read-all ───────────────────────────────
+
+@pytest.mark.anyio
+async def test_mark_all_read_updates_all_unread(client, mock_session, member_id):
+    """PATCH /notifications/read-all → 전체 읽음 처리."""
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    update_result = MagicMock()
+    update_result.rowcount = 5
+    mock_session.execute.side_effect = [member_result, update_result]
+
+    resp = await client.patch("/api/v2/notifications/read-all")
+    assert resp.status_code == 200
+    assert resp.json()["updated"] == 5
+    mock_session.commit.assert_called_once()
+
+
+# ─── AC1: migration 파일 존재 확인 ────────────────────────────────────────────
+
+def test_migration_0025_exists():
+    """Alembic migration 0025 파일 존재 확인."""
+    import os
+    migration_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "alembic",
+        "versions",
+        "0025_add_read_at_to_events.py",
+    )
+    assert os.path.exists(migration_path)
+
+
+def test_event_model_has_read_at():
+    """Event 모델에 read_at 필드 존재 확인."""
+    from app.models.event import Event
+    assert hasattr(Event, "read_at")


### PR DESCRIPTION
## 변경 사항

E-EVENTBUS S6: GNB 우측에 벨 아이콘과 알림 목록 패널을 추가하는.

### 구현 내용

**새 파일**
- `apps/web/src/components/nav/notification-bell.tsx` — 벨 아이콘 + 패널 컴포넌트
- `apps/web/src/app/api/event-notifications/route.ts` — GET 목록 프록시
- `apps/web/src/app/api/event-notifications/unread-count/route.ts` — GET unread count 프록시
- `apps/web/src/app/api/event-notifications/[id]/read/route.ts` — PATCH 단일 읽음 프록시
- `apps/web/src/app/api/event-notifications/read-all/route.ts` — PATCH 전체 읽음 프록시

**수정 파일**
- `apps/web/src/components/nav/top-bar.tsx` — NotificationBell 추가

### AC 체크리스트

- [x] GNB에 벨 아이콘 노출 + unread count 배지 (30초 폴링)
- [x] 벨 클릭 → 알림 목록 패널 열림
- [x] 알림 목록: 시간순, 읽음/안읽음 시각적 구분 (배경색 + dot indicator)
- [x] 알림 클릭 → 해당 엔티티 페이지 이동 + 읽음 처리 (낙관적 업데이트)
- [x] "전체 읽음" 버튼 동작
- [x] 모바일 반응형: breakpoint lg 기준, 모바일에서 풀스크린 오버레이

### 반응형 동작

| 화면 | 패널 형태 |
|------|-----------|
| lg+ (≥1024px) | 절대 위치 드롭다운 (w-80, max-h-480px) |
| < lg | fixed 풀스크린 오버레이 |

### API 매핑

| Next.js route | FastAPI endpoint |
|---------------|-----------------|
| GET /api/event-notifications | GET /api/v2/event-notifications |
| GET /api/event-notifications/unread-count | GET /api/v2/event-notifications/unread-count |
| PATCH /api/event-notifications/{id}/read | PATCH /api/v2/event-notifications/{id}/read |
| PATCH /api/event-notifications/read-all | PATCH /api/v2/event-notifications/read-all |

### 스크린샷

> QA 검수 시 dev 환경에서 시각적 확인 요청드리는. (로컬에서 벨 아이콘 TopBar 우측 위치 확인 완료)

### 체크리스트

- [x] `pnpm build` 통과
- [x] `pnpm lint` — 신규 파일 오류 0개
- [x] TypeScript strict 모드 통과
- [x] breakpoint lg:hidden과 일치 확인
- [x] 낙관적 업데이트 (읽음 처리 즉시 반영)

---
@까심 아르야 리뷰 및 QA 검수 요청드리는.