### PR TITLE
fix(auth): JWT 멀티프로젝트 컨텍스트 전환 CRITICAL 버그 수정

### DIFF
--- a/backend/alembic/versions/0026_add_last_project_id_to_users.py
+++ b/backend/alembic/versions/0026_add_last_project_id_to_users.py
@@ -1,0 +1,30 @@
+"""add last_project_id to users table
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-05-13
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0026"
+down_revision = "0025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "last_project_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("projects.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "last_project_id")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Text, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,6 +26,9 @@ class User(Base):
     totp_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     github_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
+    last_project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -232,17 +232,33 @@ async def _get_user_by_id(session: AsyncSession, user_id: uuid.UUID) -> User | N
 async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     from app.models.team import TeamMember
 
-    # 1. user_id 또는 PK(id)로 연결된 team_member 조회
-    result = await session.execute(
-        select(TeamMember)
-        .where(
-            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
-            TeamMember.is_active.is_(True),
+    # 1. last_project_id 우선 → 해당 project의 active team_member
+    member = None
+    if getattr(user, "last_project_id", None):
+        result = await session.execute(
+            select(TeamMember)
+            .where(
+                TeamMember.project_id == user.last_project_id,
+                or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+                TeamMember.is_active.is_(True),
+            )
+            .limit(1)
         )
-        .order_by(TeamMember.created_at.asc())
-        .limit(1)
-    )
-    member = result.scalar_one_or_none()
+        member = result.scalar_one_or_none()
+
+    if not member:
+        # fallback: 가장 최근 team_member (ASC→DESC 수정 — 가장 오래된 것 선택 버그 수정)
+        result = await session.execute(
+            select(TeamMember)
+            .where(
+                or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+                TeamMember.is_active.is_(True),
+            )
+            .order_by(TeamMember.created_at.desc())
+            .limit(1)
+        )
+        member = result.scalar_one_or_none()
+
     if member and member.user_id is None:
         member.user_id = user.id
 
@@ -293,10 +309,25 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
     if not member:
         return {}
 
+    # 소속 전체 project 목록 (알림/전환 UI용)
+    all_members_result = await session.execute(
+        select(TeamMember)
+        .where(
+            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+            TeamMember.is_active.is_(True),
+        )
+    )
+    all_members = all_members_result.scalars().all()
+    projects = [
+        {"id": str(m.project_id), "org_id": str(m.org_id), "role": m.role}
+        for m in all_members
+    ]
+
     return {
         "org_id": str(member.org_id),
         "project_id": str(member.project_id),
         "role": member.role,
+        "projects": projects,
     }
 
 
@@ -927,3 +958,54 @@ async def resend_verification(
         ),
     )
     return _ok({"message": "Verification email sent"})
+
+
+# ─── POST /api/v2/auth/switch-project ────────────────────────────────────────
+
+class SwitchProjectRequest(BaseModel):
+    project_id: uuid.UUID
+
+
+@router.post("/switch-project")
+async def switch_project(
+    body: SwitchProjectRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> JSONResponse:
+    """프로젝트 전환 — user.last_project_id 갱신 + 새 토큰 발급."""
+    user = await _get_user_by_id(session, uuid.UUID(auth.user_id))
+    if user is None:
+        return _err("USER_NOT_FOUND", "User not found", 404)
+
+    # 해당 project의 active team_member 검증 (cross-org 허용 — 멀티 org 사용자 지원)
+    result = await session.execute(
+        select(TeamMember)
+        .where(
+            TeamMember.project_id == body.project_id,
+            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
+            TeamMember.is_active.is_(True),
+        )
+        .limit(1)
+    )
+    member = result.scalar_one_or_none()
+    if member is None:
+        return _err("NOT_MEMBER", "Not an active member of this project", 403)
+
+    # last_project_id 갱신
+    user.last_project_id = body.project_id
+
+    # 기존 refresh token 무효화
+    await session.execute(
+        update(RefreshToken)
+        .where(RefreshToken.user_id == user.id, RefreshToken.revoked_at.is_(None))
+        .values(revoked_at=datetime.now(timezone.utc))
+    )
+
+    # 새 토큰 발급
+    app_metadata = await _build_app_metadata(user, session)
+    tokens = create_tokens(str(user.id), email=user.email, app_metadata=app_metadata)
+    _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
+    await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
+
+    await session.commit()
+    return _ok(tokens)

--- a/backend/tests/test_auth_switch_project.py
+++ b/backend/tests/test_auth_switch_project.py
@@ -1,0 +1,250 @@
+"""AUTH: switch-project 엔드포인트 + _build_app_metadata 멀티프로젝트 수정 테스트."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_user(last_project_id=None) -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.email = "user@example.com"
+    u.hashed_password = ""
+    u.is_active = True
+    u.last_project_id = last_project_id
+    return u
+
+
+def _make_member(project_id=None, org_id=None, is_active=True) -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.user_id = uuid.uuid4()
+    m.project_id = project_id or uuid.uuid4()
+    m.org_id = org_id or uuid.uuid4()
+    m.role = "member"
+    m.is_active = is_active
+    m.created_at = datetime.now(timezone.utc)
+    m.type = "human"
+    return m
+
+
+@pytest.fixture
+def mock_session():
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+    session.execute = AsyncMock()
+    return session
+
+
+@pytest.fixture
+def org_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture
+def auth_ctx(org_id):
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "user@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+    return ctx
+
+
+@pytest.fixture
+async def client(mock_session, auth_ctx):
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return auth_ctx
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ─── AC5-1: switch-project 성공 ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_switch_project_success_returns_new_tokens(client, mock_session, auth_ctx):
+    """POST /auth/switch-project → 200 + 새 토큰."""
+    user = _make_user()
+    auth_ctx.user_id = str(user.id)
+    project_id = uuid.uuid4()
+    member = _make_member(project_id=project_id)
+    member2 = _make_member(project_id=project_id)
+
+    # user 조회 → member 검증 → all_members 조회
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member
+    all_members_scalars = MagicMock()
+    all_members_scalars.all.return_value = [member, member2]
+    all_members_result = MagicMock()
+    all_members_result.scalars.return_value = all_members_scalars
+    revoke_result = MagicMock()
+
+    # switch_project에서 user.last_project_id = project_id 설정 후 _build_app_metadata 호출
+    # → last_project_id 있으므로 해당 project member 조회 → member 반환
+    last_project_result = MagicMock()
+    last_project_result.scalar_one_or_none.return_value = member
+
+    mock_session.execute.side_effect = [
+        user_result,         # _get_user_by_id
+        member_result,       # validate membership
+        revoke_result,       # revoke old refresh tokens
+        last_project_result, # _build_app_metadata: last_project_id member 조회
+        all_members_result,  # _build_app_metadata: all projects
+    ]
+
+    with patch("app.routers.auth.create_tokens") as mock_create, \
+         patch("app.routers.auth._store_refresh_token") as mock_store:
+        mock_create.return_value = {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh",
+            "token_type": "bearer",
+            "refresh_expires_at": "2026-06-12T00:00:00Z",
+        }
+        mock_store.return_value = None
+
+        resp = await client.post("/api/v2/auth/switch-project", json={"project_id": str(project_id)})
+
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["access_token"] == "new-access"
+    assert user.last_project_id == project_id
+
+
+# ─── AC5-2: 비멤버 프로젝트 403 ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_switch_project_not_member_returns_403(client, mock_session, auth_ctx):
+    """비멤버 project로 switch → 403."""
+    user = _make_user()
+    auth_ctx.user_id = str(user.id)
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = None  # 멤버 아님
+
+    mock_session.execute.side_effect = [user_result, member_result]
+
+    resp = await client.post("/api/v2/auth/switch-project", json={"project_id": str(uuid.uuid4())})
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "NOT_MEMBER"
+
+
+# ─── AC5-3: 비활성 team_member 거부 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_switch_project_inactive_member_returns_403(client, mock_session, auth_ctx):
+    """비활성(is_active=False) team_member는 403."""
+    user = _make_user()
+    auth_ctx.user_id = str(user.id)
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+    # is_active.is_(True) 조건으로 필터링되므로 None 반환
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = None
+
+    mock_session.execute.side_effect = [user_result, member_result]
+
+    resp = await client.post("/api/v2/auth/switch-project", json={"project_id": str(uuid.uuid4())})
+    assert resp.status_code == 403
+
+
+# ─── AC2: _build_app_metadata last_project_id 우선 선택 ─────────────────────
+
+@pytest.mark.anyio
+async def test_build_app_metadata_uses_last_project_id():
+    """last_project_id 있으면 해당 project의 team_member 우선 선택."""
+    from app.routers.auth import _build_app_metadata
+
+    target_project = uuid.uuid4()
+    user = _make_user(last_project_id=target_project)
+
+    target_member = _make_member(project_id=target_project)
+    old_member = _make_member()  # 더 오래된 다른 project
+
+    session = AsyncMock()
+
+    # 1st execute: last_project_id 기반 조회 → target_member 반환
+    last_project_result = MagicMock()
+    last_project_result.scalar_one_or_none.return_value = target_member
+    # projects 목록 조회
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [target_member, old_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+
+    session.execute.side_effect = [last_project_result, all_result]
+
+    result = await _build_app_metadata(user, session)
+
+    assert result["project_id"] == str(target_project)
+    assert "projects" in result
+    assert len(result["projects"]) == 2
+
+
+@pytest.mark.anyio
+async def test_build_app_metadata_fallback_desc_when_no_last_project():
+    """last_project_id 없으면 created_at DESC (최신) 기반 fallback."""
+    from app.routers.auth import _build_app_metadata
+
+    user = _make_user(last_project_id=None)
+    latest_member = _make_member()
+
+    session = AsyncMock()
+
+    # 1st execute: fallback DESC 조회 → latest_member 반환
+    fallback_result = MagicMock()
+    fallback_result.scalar_one_or_none.return_value = latest_member
+    # projects 목록 조회
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [latest_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+
+    session.execute.side_effect = [fallback_result, all_result]
+
+    result = await _build_app_metadata(user, session)
+
+    assert result["project_id"] == str(latest_member.project_id)
+    assert "projects" in result
+
+
+# ─── migration 파일 존재 확인 ─────────────────────────────────────────────────
+
+def test_migration_0026_exists():
+    import os
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions",
+        "0026_add_last_project_id_to_users.py"
+    )
+    assert os.path.exists(path)
+
+
+def test_user_model_has_last_project_id():
+    from app.models.user import User
+    assert hasattr(User, "last_project_id")


### PR DESCRIPTION
## Summary
- JWT `_build_app_metadata`가 `created_at ASC LIMIT 1`로 가장 오래된 프로젝트(MVP) 선택 → 멀티프로젝트 사용자의 문서/데이터 접근 불가 버그 수정
- `last_project_id` 우선 선택 + `created_at DESC` fallback + `projects` 배열 반환
- `POST /api/v2/auth/switch-project` 엔드포인트 신설
- Migration 0026: `users.last_project_id` 컬럼 추가
- 테스트 7/7 PASS (637 전체 회귀 PASS)

## Cherry-pick
- develop 커밋 958c787c → main cherry-pick (선생님 지시: JWT 건만 prod 프로모션)

## Test plan
- [x] dev 환경 smoke 완료 (로그인 → sprintable 프로젝트 자동선택 → 문서 접근 확인)
- [ ] prod migration 0026 실행
- [ ] prod smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)