### PR TITLE
[SID:1b0231c1] GNB 프로젝트 스위처 — switch-project API 연동

### DIFF
--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
+import { cookieBase } from '@/lib/auth/cookies';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(request: Request): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: { code: 'UNAUTHORIZED' } }, { status: 401 });
+  }
+
+  const body = await request.json() as { project_id: string };
+  if (!body.project_id) {
+    return NextResponse.json({ error: { code: 'BAD_REQUEST', message: 'project_id required' } }, { status: 400 });
+  }
+
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/switch-project`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ project_id: body.project_id }),
+  });
+
+  const json = await fastapiRes.json() as {
+    data?: { access_token: string; refresh_token: string; token_type: string; expires_in?: number };
+    error?: { code: string; message: string };
+  };
+
+  if (!fastapiRes.ok || !json.data) {
+    return NextResponse.json(
+      { error: json.error ?? { code: 'SWITCH_FAILED', message: `HTTP ${fastapiRes.status}` } },
+      { status: fastapiRes.status },
+    );
+  }
+
+  const { access_token, refresh_token } = json.data;
+  const res = NextResponse.json({ data: { ok: true } });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  return res;
+}

--- a/apps/web/src/components/nav/project-switcher.tsx
+++ b/apps/web/src/components/nav/project-switcher.tsx
@@ -51,16 +51,30 @@ export function ProjectSwitcher({
     );
   }
 
+  // 단일 프로젝트 — 드롭다운 없이 이름만 표시
+  if (projects.length === 1) {
+    return (
+      <SidebarMenuButton className={cn('w-full cursor-default', className)} disabled>
+        <ProjectInitial name={currentProject?.projectName ?? 'S'} />
+        <span className="flex-1 truncate font-medium">
+          {currentProject?.projectName ?? projects[0]?.projectName ?? 'Sprintable'}
+        </span>
+      </SidebarMenuButton>
+    );
+  }
+
   async function switchProject(nextProjectId: string) {
     if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
     setPending(true);
     try {
-      await fetch('/api/current-project', {
+      const res = await fetch('/api/switch-project', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: nextProjectId }),
       });
-      router.refresh();
+      if (res.ok) {
+        window.location.reload();
+      }
     } finally {
       setPending(false);
     }


### PR DESCRIPTION
## 변경 사항

GNB 프로젝트 전환 UI — 백엔드 PR #655 switch-project API 연동인.

### 새 파일

- `apps/web/src/app/api/switch-project/route.ts`
  - FastAPI `POST /api/v2/auth/switch-project` 프록시
  - 응답 `access_token`/`refresh_token` → `sp_at`/`sp_rt` 쿠키 갱신 (login route 동일 패턴)

### 수정 파일

- `apps/web/src/components/nav/project-switcher.tsx`
  - `switchProject()`: `/api/current-project` → `/api/switch-project` + `window.location.reload()`
  - `projects.length === 1` 분기 추가 — 드롭다운 미표시, 이름만 노출

### AC 체크리스트

- [x] 멀티프로젝트: 현재 프로젝트 이름 + 드롭다운 화살표 표시
- [x] 드롭다운 → 소속 프로젝트 목록, 현재 활성 프로젝트 체크 표시
- [x] 다른 프로젝트 선택 → switch-project API 호출 → 쿠키 갱신 → 페이지 리로드
- [x] 단일 프로젝트: 드롭다운 미표시
- [x] 모바일: 사이드바 내 위치로 접근 가능
- [x] `pnpm build` ✓

---
@까심 아르야 리뷰 및 QA 검수 요청드리는.