### PR TITLE
JWT fallback ASC 복원 + GNB 프로젝트 스위처 PROD 프로모션

### DIFF
--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
+import { cookieBase } from '@/lib/auth/cookies';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(request: Request): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) {
+    return NextResponse.json({ error: { code: 'UNAUTHORIZED' } }, { status: 401 });
+  }
+
+  const body = await request.json() as { project_id: string };
+  if (!body.project_id) {
+    return NextResponse.json({ error: { code: 'BAD_REQUEST', message: 'project_id required' } }, { status: 400 });
+  }
+
+  const fastapiRes = await fetch(`${FASTAPI_URL()}/api/v2/auth/switch-project`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${session.access_token}`,
+    },
+    body: JSON.stringify({ project_id: body.project_id }),
+  });
+
+  const json = await fastapiRes.json() as {
+    data?: { access_token: string; refresh_token: string; token_type: string; expires_in?: number };
+    error?: { code: string; message: string };
+  };
+
+  if (!fastapiRes.ok || !json.data) {
+    return NextResponse.json(
+      { error: json.error ?? { code: 'SWITCH_FAILED', message: `HTTP ${fastapiRes.status}` } },
+      { status: fastapiRes.status },
+    );
+  }
+
+  const { access_token, refresh_token } = json.data;
+  const res = NextResponse.json({ data: { ok: true } });
+  res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
+  res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  return res;
+}

--- a/apps/web/src/components/nav/project-switcher.tsx
+++ b/apps/web/src/components/nav/project-switcher.tsx
@@ -51,16 +51,30 @@ export function ProjectSwitcher({
     );
   }
 
+  // 단일 프로젝트 — 드롭다운 없이 이름만 표시
+  if (projects.length === 1) {
+    return (
+      <SidebarMenuButton className={cn('w-full cursor-default', className)} disabled>
+        <ProjectInitial name={currentProject?.projectName ?? 'S'} />
+        <span className="flex-1 truncate font-medium">
+          {currentProject?.projectName ?? projects[0]?.projectName ?? 'Sprintable'}
+        </span>
+      </SidebarMenuButton>
+    );
+  }
+
   async function switchProject(nextProjectId: string) {
     if (!nextProjectId || nextProjectId === currentProjectId || pending) return;
     setPending(true);
     try {
-      await fetch('/api/current-project', {
+      const res = await fetch('/api/switch-project', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: nextProjectId }),
       });
-      router.refresh();
+      if (res.ok) {
+        window.location.reload();
+      }
     } finally {
       setPending(false);
     }

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -247,14 +247,14 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member = result.scalar_one_or_none()
 
     if not member:
-        # fallback: 가장 최근 team_member (ASC→DESC 수정 — 가장 오래된 것 선택 버그 수정)
+        # fallback: 가장 오래된 team_member (ASC) — 최초 가입 project 우선
         result = await session.execute(
             select(TeamMember)
             .where(
                 or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
                 TeamMember.is_active.is_(True),
             )
-            .order_by(TeamMember.created_at.desc())
+            .order_by(TeamMember.created_at.asc())
             .limit(1)
         )
         member = result.scalar_one_or_none()
@@ -308,6 +308,10 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
 
     if not member:
         return {}
+
+    # login 시 last_project_id 자동 갱신 — 다음 로그인부터 last_project_id 우선 경로 사용
+    if getattr(user, "last_project_id", None) != member.project_id:
+        user.last_project_id = member.project_id
 
     # 소속 전체 project 목록 (알림/전환 UI용)
     all_members_result = await session.execute(

--- a/backend/tests/test_auth_fallback_fix.py
+++ b/backend/tests/test_auth_fallback_fix.py
@@ -1,0 +1,149 @@
+"""AUTH fallback fix: _build_app_metadata ASC 복원 + login last_project_id 자동 설정."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_user(last_project_id=None) -> MagicMock:
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.email = "user@example.com"
+    u.is_active = True
+    u.last_project_id = last_project_id
+    return u
+
+
+def _make_member(project_id=None, org_id=None, days_ago=0) -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.user_id = uuid.uuid4()
+    m.project_id = project_id or uuid.uuid4()
+    m.org_id = org_id or uuid.uuid4()
+    m.role = "member"
+    m.is_active = True
+    m.created_at = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    m.type = "human"
+    return m
+
+
+# ─── AC1: fallback ASC 복원 ───────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_fallback_uses_oldest_member_when_no_last_project():
+    """last_project_id 없으면 created_at ASC (가장 오래된) member 선택."""
+    from app.routers.auth import _build_app_metadata
+
+    sprintable_member = _make_member(days_ago=40)   # 가장 오래된 — 선택돼야 함
+    jangsawang_member = _make_member(days_ago=10)   # 최신 — 선택되면 안 됨
+
+    user = _make_user(last_project_id=None)
+
+    session = AsyncMock()
+
+    # fallback ASC → sprintable_member 반환
+    fallback_result = MagicMock()
+    fallback_result.scalar_one_or_none.return_value = sprintable_member
+    # all_members
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [sprintable_member, jangsawang_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+
+    session.execute.side_effect = [fallback_result, all_result]
+
+    result = await _build_app_metadata(user, session)
+
+    assert result["project_id"] == str(sprintable_member.project_id)
+
+
+# ─── AC2: login 시 last_project_id 자동 갱신 ─────────────────────────────────
+
+@pytest.mark.anyio
+async def test_login_auto_sets_last_project_id_when_null():
+    """last_project_id=None인 사용자 로그인 → 선택된 project_id로 자동 설정."""
+    from app.routers.auth import _build_app_metadata
+
+    oldest_member = _make_member(days_ago=40)
+    user = _make_user(last_project_id=None)
+
+    session = AsyncMock()
+    fallback_result = MagicMock()
+    fallback_result.scalar_one_or_none.return_value = oldest_member
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [oldest_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+    session.execute.side_effect = [fallback_result, all_result]
+
+    await _build_app_metadata(user, session)
+
+    # user.last_project_id가 선택된 project_id로 설정됐는지
+    assert user.last_project_id == oldest_member.project_id
+
+
+# ─── AC3: last_project_id 있는 사용자는 해당 project 유지 ────────────────────
+
+@pytest.mark.anyio
+async def test_existing_last_project_id_preserved():
+    """last_project_id 있으면 해당 project member 사용 + last_project_id 갱신 안 됨."""
+    from app.routers.auth import _build_app_metadata
+
+    preferred_project = uuid.uuid4()
+    preferred_member = _make_member(project_id=preferred_project, days_ago=5)
+    user = _make_user(last_project_id=preferred_project)
+
+    session = AsyncMock()
+    # last_project_id 기반 조회 → preferred_member
+    last_project_result = MagicMock()
+    last_project_result.scalar_one_or_none.return_value = preferred_member
+    # all_members
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [preferred_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+    session.execute.side_effect = [last_project_result, all_result]
+
+    result = await _build_app_metadata(user, session)
+
+    assert result["project_id"] == str(preferred_project)
+    # last_project_id가 이미 동일하므로 변경 없음
+    assert user.last_project_id == preferred_project
+
+
+@pytest.mark.anyio
+async def test_login_updates_last_project_id_if_changed():
+    """last_project_id가 선택된 member의 project와 다르면 갱신됨."""
+    from app.routers.auth import _build_app_metadata
+
+    old_project = uuid.uuid4()
+    new_member = _make_member(days_ago=40)  # last_project 삭제됐으면 fallback으로 이쪽 선택
+    user = _make_user(last_project_id=old_project)
+
+    session = AsyncMock()
+    # last_project_id 조회 → None (해당 project에서 제거됐거나 비활성)
+    last_project_result = MagicMock()
+    last_project_result.scalar_one_or_none.return_value = None
+    # fallback ASC → new_member
+    fallback_result = MagicMock()
+    fallback_result.scalar_one_or_none.return_value = new_member
+    # all_members
+    all_scalars = MagicMock()
+    all_scalars.all.return_value = [new_member]
+    all_result = MagicMock()
+    all_result.scalars.return_value = all_scalars
+    session.execute.side_effect = [last_project_result, fallback_result, all_result]
+
+    result = await _build_app_metadata(user, session)
+
+    assert result["project_id"] == str(new_member.project_id)
+    # last_project_id가 새 project_id로 갱신됐는지
+    assert user.last_project_id == new_member.project_id


### PR DESCRIPTION
## Summary
- PR #658 cherry-pick: `_build_app_metadata` DESC→ASC 복원 + login 시 last_project_id 자동 갱신
- PR #657 cherry-pick: GNB 프로젝트 스위처 `/api/switch-project` + `ProjectSwitcher` 연동

## 배경
PR #655(JWT switch-project) prod 배포 후 DESC fallback이 선생님 계정을 장사왕 프로젝트로 고정. 근본 수정 + 프론트엔드 프로젝트 전환 UI 추가.

## Test plan
- [x] dev smoke: sellerking 로그인 → sprintable 자동 선택 (ASC fallback 정상)
- [x] 단일 프로젝트: 드롭다운 미표시
- [x] 까심군 QA APPROVE (PR #658 + #657)
- [x] Cloud Build SUCCESS