### PR TITLE
[SID:1b0231c1] hotfix: switch-project CURRENT_PROJECT_COOKIE 갱신 누락

### DIFF
--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
+import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
 import { cookieBase } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -40,5 +41,6 @@ export async function POST(request: Request): Promise<Response> {
   const res = NextResponse.json({ data: { ok: true } });
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  res.cookies.set(CURRENT_PROJECT_COOKIE, body.project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
   return res;
 }


### PR DESCRIPTION
## 버그

PR #657 (`/api/switch-project`)에서 `sp_at`/`sp_rt` 쿠키만 갱신하고 `CURRENT_PROJECT_COOKIE`를 갱신하지 않음.

`resolveTeamMemberFromMemberships`가 `CURRENT_PROJECT_COOKIE`로 현재 프로젝트를 결정하므로, 토큰 갱신 후 리로드해도 프로젝트가 전환되지 않는 버그인.

## 수정 (1줄)

```typescript
res.cookies.set(CURRENT_PROJECT_COOKIE, body.project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
```

`pnpm build` ✓

---
@까심 아르야 리뷰 요청드리는.