### PR TITLE
hotfix: switch-project CURRENT_PROJECT_COOKIE 갱신 (prod 프로모션)

### DIFF
--- a/apps/web/src/app/api/switch-project/route.ts
+++ b/apps/web/src/app/api/switch-project/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { SP_AT_COOKIE, SP_RT_COOKIE, getServerSession } from '@/lib/db/server';
+import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
 import { cookieBase } from '@/lib/auth/cookies';
 
 const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
@@ -40,5 +41,6 @@ export async function POST(request: Request): Promise<Response> {
   const res = NextResponse.json({ data: { ok: true } });
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  res.cookies.set(CURRENT_PROJECT_COOKIE, body.project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
   return res;
 }


### PR DESCRIPTION
## Summary
- PR #660 (develop 머지 완료) → main cherry-pick
- switch-project API 호출 시 `CURRENT_PROJECT_COOKIE` 쿠키 미세팅 버그 수정
- 프로젝트 전환 후 페이지 리로드해도 이전 프로젝트로 유지되던 CRITICAL 버그 해소

## Changes
- `apps/web/src/app/api/switch-project/route.ts`: `res.cookies.set(CURRENT_PROJECT_COOKIE, ...)` 1줄 추가

## Test plan
- [x] dev Cloud Build SUCCESS
- [x] dev 로그인 + switch-project API 200 OK 확인
- [ ] prod Cloud Build → prod smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)