### PR TITLE
fix(me): P0 — JWT 멀티프로젝트 /api/v2/me project_id 미반영 수정

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -30,7 +30,16 @@ async def get_me(
         where_clause = TeamMember.id == uid
     else:
         # JWT 인증: auth.user_id = user.id = TeamMember.user_id
-        where_clause = TeamMember.user_id == uid
+        # app_metadata.project_id로 멀티프로젝트 유저 분기 필수
+        project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+        if project_id_str:
+            try:
+                project_id = uuid.UUID(project_id_str)
+                where_clause = (TeamMember.user_id == uid) & (TeamMember.project_id == project_id)
+            except (ValueError, AttributeError):
+                where_clause = TeamMember.user_id == uid
+        else:
+            where_clause = TeamMember.user_id == uid
 
     result = await session.execute(
         select(TeamMember)


### PR DESCRIPTION
## 근본 원인

`get_me()` JWT 경로(line 32~33)에서 `TeamMember.user_id == uid`로만 필터링. `app_metadata.project_id` 무시. ORDER BY 없이 `.first()` → PostgreSQL이 임의 멤버십 반환.

`switch_project()`는 정상 — 새 JWT에 올바른 `project_id` 삽입하지만, 페이지 리로드 시 `/api/v2/me`가 이를 무시해 이전 프로젝트 컨텍스트 유지.

## 수정 내용

`app_metadata.project_id` 존재 시 `TeamMember.project_id` 조건 AND 추가. fallback은 기존 동작 유지 (project_id 없는 토큰 하위 호환).

## 영향 범위

- `backend/app/routers/me.py` 1파일
- API key / member_id 쿼리 경로 무변경
- 싱글 프로젝트 유저: project_id_str 있으면 정상 필터, 없으면 기존 동작 유지

## Test plan
- [ ] 멀티프로젝트 유저 — switch-project 후 GET /api/v2/me 응답 project_id 일치 확인
- [ ] 싱글프로젝트 유저 — 기존 동작 유지 확인
- [ ] API key 인증 — 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)