### PR TITLE
fix: cross-project 리소스 접근 — 다른 프로젝트 docs/stories 링크 400 → 정상 조회

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -236,10 +236,11 @@ async def get_project_scoped_org_id(
         select(Project.org_id).where(Project.id == project_id)
     )
     project_org_id = result.scalar_one_or_none()
-    if not project_org_id or project_org_id == base_org_id:
-        return project_org_id or base_org_id
+    if not project_org_id:
+        return base_org_id
 
-    # cross-org: 해당 project의 active TeamMember인지 검증
+    # project_id가 지정된 경우 org 동일 여부 무관하게 TeamMember 검증
+    # (동일 org 내 다른 project 미멤버 우회 방지)
     from app.models.team import TeamMember
     from sqlalchemy import or_
     uid = uuid.UUID(auth.user_id)

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Literal
 
-from fastapi import Depends, Header, HTTPException, Request, status
+from fastapi import Depends, Header, HTTPException, Query, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -213,6 +213,49 @@ async def get_verified_org_id(
         await _verify_project_in_org(project_id, org_id, db, request)
 
     return org_id
+
+
+async def get_project_scoped_org_id(
+    project_id: uuid.UUID | None = Query(default=None),
+    auth: AuthContext = Depends(get_current_user),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    db: AsyncSession = Depends(get_db),
+    request: Request = None,
+) -> uuid.UUID:
+    """project_id query param 또는 X-Project-Id 헤더가 있을 때, 해당 project의 org_id로
+    cross-org 접근을 허용. TeamMember.is_active 기반 검증. 미멤버 → 403.
+    project_id가 없으면 get_verified_org_id 동작과 동일."""
+    base_org_id = await get_verified_org_id(
+        auth=auth, x_org_id=x_org_id, x_project_id=None, db=db, request=request
+    )
+    if not project_id:
+        return base_org_id
+
+    from app.models.project import Project
+    result = await db.execute(
+        select(Project.org_id).where(Project.id == project_id)
+    )
+    project_org_id = result.scalar_one_or_none()
+    if not project_org_id or project_org_id == base_org_id:
+        return project_org_id or base_org_id
+
+    # cross-org: 해당 project의 active TeamMember인지 검증
+    from app.models.team import TeamMember
+    from sqlalchemy import or_
+    uid = uuid.UUID(auth.user_id)
+    member = await db.execute(
+        select(TeamMember.id).where(
+            or_(TeamMember.user_id == uid, TeamMember.id == uid),
+            TeamMember.project_id == project_id,
+            TeamMember.is_active.is_(True),
+        ).limit(1)
+    )
+    if member.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="해당 프로젝트의 멤버가 아닌",
+        )
+    return project_org_id
 
 
 def get_org_scope(

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> DocRepository:
     return DocRepository(session, org_id)
 
@@ -112,6 +112,7 @@ class DocPreviewResponse(BaseModel):
 async def get_doc_preview(
     q: str = Query(..., description="slug or UUID"),
     db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: DocRepository = Depends(_get_repo),
 ) -> DocPreviewResponse:
     from app.models.doc import Doc
@@ -124,8 +125,28 @@ async def get_doc_preview(
 
     result = await db.execute(stmt.limit(1))
     doc = result.scalar_one_or_none()
+
     if doc is None:
-        raise HTTPException(status_code=404, detail="Document not found")
+        # cross-org fallback: slug/uuid 기반 전체 org 조회 후 membership 검증
+        try:
+            doc_uuid2 = uuid.UUID(q)
+            fallback_stmt = select(Doc).where(Doc.id == doc_uuid2, Doc.deleted_at.is_(None))
+        except ValueError:
+            fallback_stmt = select(Doc).where(Doc.slug == q, Doc.deleted_at.is_(None))
+        fallback = await db.execute(fallback_stmt.limit(1))
+        doc = fallback.scalar_one_or_none()
+        if doc is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+        uid = uuid.UUID(auth.user_id)
+        member = await db.execute(
+            select(TeamMember.id).where(
+                or_(TeamMember.user_id == uid, TeamMember.id == uid),
+                TeamMember.project_id == doc.project_id,
+                TeamMember.is_active.is_(True),
+            ).limit(1)
+        )
+        if member.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="해당 프로젝트의 멤버가 아닌")
 
     return DocPreviewResponse(
         id=doc.id,
@@ -141,11 +162,30 @@ async def get_doc_preview(
 @router.get("/{id}", response_model=DocResponse)
 async def get_doc(
     id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: DocRepository = Depends(_get_repo),
 ) -> DocResponse:
     doc = await repo.get(id)
     if doc is None:
-        raise HTTPException(status_code=404, detail="Doc not found")
+        # cross-org fallback: project_id query param 없이 단일 id로 접근한 경우
+        from app.models.doc import Doc
+        result = await session.execute(
+            select(Doc).where(Doc.id == id, Doc.deleted_at.is_(None))
+        )
+        doc = result.scalar_one_or_none()
+        if doc is None:
+            raise HTTPException(status_code=404, detail="Doc not found")
+        uid = uuid.UUID(auth.user_id)
+        member = await session.execute(
+            select(TeamMember.id).where(
+                or_(TeamMember.user_id == uid, TeamMember.id == uid),
+                TeamMember.project_id == doc.project_id,
+                TeamMember.is_active.is_(True),
+            ).limit(1)
+        )
+        if member.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="해당 프로젝트의 멤버가 아닌")
     return DocResponse.model_validate(doc)
 
 

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.memo import MemoAssignee, MemoReply
 from app.models.team import TeamMember
@@ -111,7 +111,7 @@ async def _resolve_author_role(db: AsyncSession, created_by: uuid.UUID | None) -
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> MemoRepository:
     return MemoRepository(session, org_id)
 

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.models.standup import StandupEntry
@@ -18,7 +18,7 @@ router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> SprintRepository:
     return SprintRepository(session, org_id)
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.standup import StandupEntry, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> StandupEntryRepository:
     return StandupEntryRepository(session, org_id)
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -84,7 +84,7 @@ async def list_feedback(
     project_id: uuid.UUID = Query(...),
     date_filter: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> list[FeedbackResponse]:
     q = (
         select(StandupFeedback)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
@@ -41,7 +41,7 @@ async def _resolve_epic_title(db: AsyncSession, epic_id: uuid.UUID | None) -> st
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
 ) -> StoryRepository:
     return StoryRepository(session, org_id)
 


### PR DESCRIPTION
## 원인

`get_verified_org_id` → `BaseRepository._org_filter()`가 JWT `org_id`만으로 scope 제한. cross-org 프로젝트의 리소스는 `_org_filter` 에 걸려 404/400 반환.

## 수정 내용

### `backend/app/dependencies/auth.py`
`get_project_scoped_org_id` dependency 추가:
- `project_id` query param이 있으면 해당 project의 org_id를 DB에서 조회
- cross-org(JWT org ≠ project org)이면 `TeamMember.is_active=True` 검증
- 멤버 → project org_id 반환, 미멤버 → 403

### `backend/app/routers/docs.py`
- `_get_repo`: `get_verified_org_id` → `get_project_scoped_org_id`
- `get_doc(/{id})`: cross-org fallback — 현재 org에서 miss 시 전체 조회 + TeamMember 검증
- `get_doc_preview(/preview)`: 동일 패턴

### `backend/app/routers/stories.py`, `memos.py`, `sprints.py`, `standups.py`
- 각 `_get_repo`: `get_verified_org_id` → `get_project_scoped_org_id`

## 동작 원리

```
GET /api/v2/docs?project_id={B_project}&slug={slug}
  → get_project_scoped_org_id(project_id=B_project)
  → Project.org_id == B_ORG
  → JWT org_id == A_ORG → cross-org
  → TeamMember(user, B_project, is_active=True) 검증
  → DocRepository(session, B_ORG)
  → 정상 조회 ✅
```

## Test plan
- [ ] 멀티프로젝트 유저: 프로젝트 A 세션에서 프로젝트 B docs 링크 접근 → 200
- [ ] 미멤버: 403 반환 (400 아님)
- [ ] 싱글프로젝트 유저: 기존 동작 유지 (project_id 없으면 get_project_scoped_org_id → base_org_id 반환)
- [ ] stories/memos/sprints/standups: 동일 패턴 확인
- [ ] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)