### PR TITLE
[SID:e44aaaa7] GNB 프로젝트 스위처 dim 수정 — dashboard/layout memberships fetch

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,7 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from '@/lib/db/server';
 import { DashboardShell } from './dashboard-shell';
-import { fastapiCall } from '@sprintable/storage-api';
 
 interface MemberContext {
   id: string;
@@ -18,16 +17,30 @@ export default async function DashboardLayout({
   const session = await getServerSession().catch(() => null);
   if (!session) redirect('/login');
 
-  const me = await fastapiCall<MemberContext | null>('GET', '/api/v2/me', session.access_token).catch(() => null);
-  if (!me) redirect('/login');
+  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+  const authHeader = { Authorization: `Bearer ${session.access_token}` };
+
+  const [meRes, membershipsRes] = await Promise.all([
+    fetch(`${fastapiUrl}/api/v2/me`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+    fetch(`${fastapiUrl}/api/v2/me/memberships`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+  ]);
+
+  if (!meRes || meRes.status === 401) redirect('/login');
+
+  const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+  const memberships: { projectId: string; projectName: string }[] =
+    membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
+  const projectMemberships = memberships.length > 0
+    ? memberships
+    : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
 
   return (
     <DashboardShell
-      currentTeamMemberId={me.id}
-      orgId={me.org_id}
-      projectId={me.project_id}
-      projectName={me.project_name}
-      projectMemberships={[{ projectId: me.project_id, projectName: me.project_name }]}
+      currentTeamMemberId={me?.id}
+      orgId={me?.org_id}
+      projectId={me?.project_id}
+      projectName={me?.project_name ?? undefined}
+      projectMemberships={projectMemberships}
     >
       {children}
     </DashboardShell>


### PR DESCRIPTION
## 변경 사항

`dashboard/layout.tsx`에서 `projectMemberships` 단일 프로젝트 하드코딩 제거.
`/api/v2/me` + `/api/v2/me/memberships` 병렬 fetch 패턴으로 교체.

### 이슈

```typescript
// Before — 단일 프로젝트 하드코딩
projectMemberships={[{ projectId: me.project_id, projectName: me.project_name }]}
```

`projectMemberships.length === 1`이면 프로젝트 스위처가 항상 dim/비활성화.

```typescript
// After — 전체 멤버십 fetch
const [meRes, membershipsRes] = await Promise.all([...])
projectMemberships={memberships.length > 0 ? memberships : [fallback]}
```

### 참조

`(authenticated)/layout.tsx`에 이미 올바른 패턴이 구현되어 있었음. 해당 패턴 그대로 적용.

## AC 체크리스트

- [x] AC-1: `dashboard/layout.tsx`에서 `/api/v2/me/memberships` fetch 추가
- [x] AC-2: 복수 멤버십 사용자 → 스위처 드롭다운 활성화 / 단일 → 비활성 유지
- [x] AC-3: `api/docs/route.ts`는 이미 project_id query param을 FastAPI에 전달 중 — 백엔드 PR #665 배포 후 자동 해결
- [x] AC-4: 새로고침 후 정상 렌더링 (memberships 서버에서 fetch)
- [x] AC-5: 단일 멤버십 fallback 유지 — regression 없음

## 테스트 방법

1. 복수 프로젝트 멤버십 계정으로 로그인
2. `/dashboard` 진입 → GNB 프로젝트 스위처 드롭다운 활성화 확인
3. 새로고침 후에도 정상 렌더링 확인
4. 단일 멤버십 계정 → 기존대로 비활성 확인

## 빌드/검증

- [x] `pnpm type-check` — PASS
- [x] `pnpm lint` — 0 errors (기존 경고 14건은 사전 존재)
- [x] `pnpm build` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)