### PR TITLE
prod: PR #667 GNB 프로젝트 스위처 memberships fetch 수정

### DIFF
--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -1,7 +1,6 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from '@/lib/db/server';
 import { DashboardShell } from './dashboard-shell';
-import { fastapiCall } from '@sprintable/storage-api';
 
 interface MemberContext {
   id: string;
@@ -18,16 +17,30 @@ export default async function DashboardLayout({
   const session = await getServerSession().catch(() => null);
   if (!session) redirect('/login');
 
-  const me = await fastapiCall<MemberContext | null>('GET', '/api/v2/me', session.access_token).catch(() => null);
-  if (!me) redirect('/login');
+  const fastapiUrl = process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+  const authHeader = { Authorization: `Bearer ${session.access_token}` };
+
+  const [meRes, membershipsRes] = await Promise.all([
+    fetch(`${fastapiUrl}/api/v2/me`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+    fetch(`${fastapiUrl}/api/v2/me/memberships`, { headers: authHeader, cache: 'no-store' }).catch(() => null),
+  ]);
+
+  if (!meRes || meRes.status === 401) redirect('/login');
+
+  const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+  const memberships: { projectId: string; projectName: string }[] =
+    membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
+  const projectMemberships = memberships.length > 0
+    ? memberships
+    : me ? [{ projectId: me.project_id, projectName: me.project_name }] : [];
 
   return (
     <DashboardShell
-      currentTeamMemberId={me.id}
-      orgId={me.org_id}
-      projectId={me.project_id}
-      projectName={me.project_name}
-      projectMemberships={[{ projectId: me.project_id, projectName: me.project_name }]}
+      currentTeamMemberId={me?.id}
+      orgId={me?.org_id}
+      projectId={me?.project_id}
+      projectName={me?.project_name ?? undefined}
+      projectMemberships={projectMemberships}
     >
       {children}
     </DashboardShell>


### PR DESCRIPTION
## Summary
- PR #667 (develop 머지 완료) — `dashboard/layout.tsx` 프로젝트 스위처 dim/비활성 수정
- 단일 프로젝트 하드코딩 → `/api/v2/me/memberships` 병렬 fetch 적용
- 복수 프로젝트 멤버십 사용자 → 드롭다운 활성화

## 포함 변경
- feat(SID:e44aaaa7): dashboard/layout에서 memberships 병렬 fetch로 프로젝트 스위처 활성화

## Test plan
- [x] Dev Cloud Build SUCCESS
- [x] Dev smoke: dashboard 정상 렌더링, 프로젝트명 표시 정상
- [ ] Prod: 복수 프로젝트 계정 → 스위처 드롭다운 활성화 확인 (선생님 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)