### PR TITLE
feat(eventbus): E-EVENTBUS P3 S9 — 이벤트 소스 확장 (스토리/태스크/스프린트)

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -12,6 +12,7 @@ from app.models.standup import StandupEntry
 from app.models.team import TeamMember
 from app.repositories.sprint import SprintRepository
 from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate
+from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
 
@@ -106,11 +107,33 @@ async def activate_sprint(
 async def close_sprint(
     id: uuid.UUID,
     repo: SprintRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
 ) -> SprintResponse:
     try:
         sprint = await repo.close(id)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    # E-EVENTBUS P3 S9: sprint_closed → 프로젝트 전체 active 멤버에게 알림
+    if sprint.project_id:
+        members_result = await db.execute(
+            select(TeamMember.id).where(
+                TeamMember.project_id == sprint.project_id,
+                TeamMember.is_active.is_(True),
+                TeamMember.type == "human",
+            )
+        )
+        member_ids = [row[0] for row in members_result.all()]
+        if member_ids:
+            await dispatch_notification(
+                db,
+                org_id=repo.org_id,
+                event_type="sprint_closed",
+                target_member_ids=member_ids,
+                title=f"스프린트 종료: {sprint.title}",
+                body=None,
+                reference_type="sprint",
+                reference_id=sprint.id,
+            )
     return SprintResponse.model_validate(sprint)
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -13,6 +13,7 @@ from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.routers.events import publish_event
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
 from app.services.rule_evaluator import EventContext
@@ -170,6 +171,18 @@ async def update_story(
             ))
         except Exception:
             pass
+        # E-EVENTBUS P3 S9: story_assigned → assignee에게 알림
+        if story.assignee_id and story.assignee_id != old_assignee_id:
+            await dispatch_notification(
+                db,
+                org_id=org_id,
+                event_type="story_assigned",
+                target_member_ids=[story.assignee_id],
+                title=f"스토리 담당자로 지정됨: {story.title}",
+                body=None,
+                reference_type="story",
+                reference_id=story.id,
+            )
         if actor_id:
             try:
                 db.add(StoryActivity(
@@ -263,6 +276,23 @@ async def update_story_status(
             ))
         except Exception:
             pass
+        # E-EVENTBUS P3 S9: story_status_changed → assignee + actor에게 알림
+        notify_ids: set[uuid.UUID] = set()
+        if story.assignee_id:
+            notify_ids.add(story.assignee_id)
+        if actor_id and actor_id != story.assignee_id:
+            notify_ids.add(actor_id)
+        if notify_ids:
+            await dispatch_notification(
+                db,
+                org_id=org_id,
+                event_type="story_status_changed",
+                target_member_ids=list(notify_ids),
+                title=f"스토리 상태 변경: {story.title} → {story.status}",
+                body=None,
+                reference_type="story",
+                reference_id=story.id,
+            )
         if actor_id:
             try:
                 db.add(StoryActivity(

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -1,12 +1,15 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.pm import Story
 from app.repositories.task import TaskRepository
 from app.schemas.task import TaskCreate, TaskResponse, TaskUpdate
+from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/tasks", tags=["tasks"])
 
@@ -69,11 +72,31 @@ async def update_task(
     id: uuid.UUID,
     body: TaskUpdate,
     repo: TaskRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
 ) -> TaskResponse:
+    task_before = await repo.get(id)
+    old_status = task_before.status if task_before else None
     data = body.model_dump(exclude_unset=True)
     task = await repo.update(id, **data)
     if task is None:
         raise HTTPException(status_code=404, detail="Task not found")
+    # E-EVENTBUS P3 S9: task_completed → story assignee에게 알림
+    if old_status != "done" and task.status == "done" and task.story_id:
+        story_result = await db.execute(
+            select(Story.assignee_id, Story.title, Story.org_id).where(Story.id == task.story_id)
+        )
+        story_row = story_result.one_or_none()
+        if story_row and story_row.assignee_id:
+            await dispatch_notification(
+                db,
+                org_id=repo.org_id,
+                event_type="task_completed",
+                target_member_ids=[story_row.assignee_id],
+                title=f"태스크 완료: {task.title}",
+                body=f"스토리: {story_row.title}" if story_row.title else None,
+                reference_type="task",
+                reference_id=task.id,
+            )
     return TaskResponse.model_validate(task)
 
 


### PR DESCRIPTION
## 변경 내용

S8(`dispatch_notification`)과 연동하여 4개 이벤트 소스 추가.

| 이벤트 | 트리거 | 수신 대상 |
|---|---|---|
| `story_assigned` | assign_story | assignee |
| `story_status_changed` | update_story_status | assignee + actor |
| `task_completed` | update_task (status→"done") | story.assignee_id |
| `sprint_closed` | close_sprint | 프로젝트 전체 human active 멤버 |

## 수정 파일
- `backend/app/routers/stories.py` — dispatch_notification import + 2개 이벤트 추가
- `backend/app/routers/tasks.py` — dispatch_notification + task_completed 이벤트
- `backend/app/routers/sprints.py` — dispatch_notification + sprint_closed 이벤트

## Test plan
- [ ] story 담당자 변경 → 새 assignee에게 `story_assigned` 알림 생성
- [ ] story 상태 변경 → assignee + actor에게 `story_status_changed` 알림 생성
- [ ] task status → "done" → story assignee에게 `task_completed` 알림 생성
- [ ] sprint close → 프로젝트 멤버 전원에게 `sprint_closed` 알림 생성
- [ ] notification_settings disabled 시 알림 미생성 확인
- [ ] python compile PASS
- [ ] PR → develop 대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)