### PR TITLE
feat(eventbus): S12 — Dispatch API + Epic/Doc Assignee 확장

### DIFF
--- a/backend/alembic/versions/0027_add_assignee_id_to_epics_and_docs.py
+++ b/backend/alembic/versions/0027_add_assignee_id_to_epics_and_docs.py
@@ -1,0 +1,40 @@
+"""add assignee_id to epics and docs tables
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-05-13
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "epics",
+        sa.Column(
+            "assignee_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("team_members.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "docs",
+        sa.Column(
+            "assignee_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("team_members.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("epics", "assignee_id")
+    op.drop_column("docs", "assignee_id")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -83,6 +83,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(events.router)
+app.include_router(dispatch.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -23,6 +23,9 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
     )
+    assignee_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -38,6 +38,9 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    assignee_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
     priority: Mapped[str] = mapped_column(String(20), nullable=False, default="medium")

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -40,35 +40,35 @@ async def _fetch_entity(
     entity_type: str,
     entity_id: uuid.UUID,
     org_id: uuid.UUID,
-) -> tuple[uuid.UUID | None, str | None, str | None]:
-    """(assignee_id, title, description) 반환."""
+) -> tuple[uuid.UUID | None, str | None, str | None, uuid.UUID | None]:
+    """(assignee_id, title, description, project_id) 반환."""
     if entity_type == "epic":
         row = await db.execute(
-            select(Epic.assignee_id, Epic.title, Epic.description).where(
+            select(Epic.assignee_id, Epic.title, Epic.description, Epic.project_id).where(
                 Epic.id == entity_id, Epic.org_id == org_id
             )
         )
         r = row.one_or_none()
     elif entity_type == "story":
         row = await db.execute(
-            select(Story.assignee_id, Story.title, Story.description).where(
+            select(Story.assignee_id, Story.title, Story.description, Story.project_id).where(
                 Story.id == entity_id, Story.org_id == org_id
             )
         )
         r = row.one_or_none()
     elif entity_type == "doc":
         row = await db.execute(
-            select(Doc.assignee_id, Doc.title, Doc.content).where(
+            select(Doc.assignee_id, Doc.title, Doc.content, Doc.project_id).where(
                 Doc.id == entity_id, Doc.org_id == org_id, Doc.deleted_at.is_(None)
             )
         )
         r = row.one_or_none()
     else:
-        return None, None, None
+        return None, None, None, None
 
     if r is None:
-        return None, None, None
-    return r[0], r[1], r[2]
+        return None, None, None, None
+    return r[0], r[1], r[2], r[3]
 
 
 @router.post("", response_model=DispatchResponse)
@@ -82,11 +82,13 @@ async def dispatch_entity(
     if body.entity_type not in _ENTITY_TYPES:
         raise HTTPException(status_code=400, detail=f"entity_type must be one of {_ENTITY_TYPES}")
 
-    assignee_id, title, description = await _fetch_entity(db, body.entity_type, body.entity_id, org_id)
+    assignee_id, title, description, entity_project_id = await _fetch_entity(db, body.entity_type, body.entity_id, org_id)
     if title is None:
         raise HTTPException(status_code=404, detail="Entity not found")
     if not assignee_id:
         return DispatchResponse(dispatched=False)
+    # entity의 실제 project_id 사용 (body.project_id 불일치 방지)
+    project_id = entity_project_id or body.project_id
 
     # assignee TeamMember 조회 (type: human/agent)
     member_result = await db.execute(
@@ -124,7 +126,7 @@ async def dispatch_entity(
     }
 
     event = Event(
-        project_id=body.project_id,
+        project_id=project_id,
         org_id=org_id,
         event_type=EventType.dispatched.value,
         source_entity_type=body.entity_type,

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -1,0 +1,162 @@
+"""E-EVENTBUS P3 S12: Dispatch API — entity_type + entity_id → dispatched 이벤트."""
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.doc import Doc
+from app.models.event import Event, EventType
+from app.models.pm import Epic, Story
+from app.models.team import TeamMember
+from app.routers.events import _event_to_payload, _push_to_agent
+from app.services.notification_dispatch import dispatch_notification
+
+router = APIRouter(prefix="/api/v2/dispatch", tags=["dispatch"])
+
+_ENTITY_TYPES = {"epic", "story", "doc"}
+
+
+class DispatchRequest(BaseModel):
+    entity_type: str
+    entity_id: uuid.UUID
+    project_id: uuid.UUID
+    message: str | None = None
+
+
+class DispatchResponse(BaseModel):
+    dispatched: bool
+    event_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    assignee_type: str | None = None
+
+
+async def _fetch_entity(
+    db: AsyncSession,
+    entity_type: str,
+    entity_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> tuple[uuid.UUID | None, str | None, str | None]:
+    """(assignee_id, title, description) 반환."""
+    if entity_type == "epic":
+        row = await db.execute(
+            select(Epic.assignee_id, Epic.title, Epic.description).where(
+                Epic.id == entity_id, Epic.org_id == org_id
+            )
+        )
+        r = row.one_or_none()
+    elif entity_type == "story":
+        row = await db.execute(
+            select(Story.assignee_id, Story.title, Story.description).where(
+                Story.id == entity_id, Story.org_id == org_id
+            )
+        )
+        r = row.one_or_none()
+    elif entity_type == "doc":
+        row = await db.execute(
+            select(Doc.assignee_id, Doc.title, Doc.content).where(
+                Doc.id == entity_id, Doc.org_id == org_id, Doc.deleted_at.is_(None)
+            )
+        )
+        r = row.one_or_none()
+    else:
+        return None, None, None
+
+    if r is None:
+        return None, None, None
+    return r[0], r[1], r[2]
+
+
+@router.post("", response_model=DispatchResponse)
+async def dispatch_entity(
+    body: DispatchRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> DispatchResponse:
+    """entity의 assignee에게 dispatched 이벤트 생성 + 알림 전달."""
+    if body.entity_type not in _ENTITY_TYPES:
+        raise HTTPException(status_code=400, detail=f"entity_type must be one of {_ENTITY_TYPES}")
+
+    assignee_id, title, description = await _fetch_entity(db, body.entity_type, body.entity_id, org_id)
+    if title is None:
+        raise HTTPException(status_code=404, detail="Entity not found")
+    if not assignee_id:
+        return DispatchResponse(dispatched=False)
+
+    # assignee TeamMember 조회 (type: human/agent)
+    member_result = await db.execute(
+        select(TeamMember.type).where(TeamMember.id == assignee_id, TeamMember.org_id == org_id)
+    )
+    member_row = member_result.one_or_none()
+    if not member_row:
+        return DispatchResponse(dispatched=False, assignee_id=assignee_id)
+
+    member_type = member_row[0]
+
+    # sender_id: 현재 auth user의 TeamMember id
+    sender_id: uuid.UUID | None = None
+    try:
+        uid = uuid.UUID(auth.user_id)
+        sender_result = await db.execute(
+            select(TeamMember.id).where(
+                (TeamMember.user_id == uid) | (TeamMember.id == uid),
+                TeamMember.org_id == org_id,
+                TeamMember.is_active.is_(True),
+            ).limit(1)
+        )
+        sender_row = sender_result.scalar_one_or_none()
+        sender_id = sender_row
+    except Exception:
+        pass
+
+    payload = {
+        "entity_type": body.entity_type,
+        "entity_id": str(body.entity_id),
+        "title": title,
+        "description": (description or "")[:500],
+        "message": body.message,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+
+    event = Event(
+        project_id=body.project_id,
+        org_id=org_id,
+        event_type=EventType.dispatched.value,
+        source_entity_type=body.entity_type,
+        source_entity_id=body.entity_id,
+        sender_id=sender_id,
+        recipient_id=assignee_id,
+        recipient_type=member_type,
+        payload=payload,
+        status="pending",
+    )
+    db.add(event)
+    await db.flush()
+    await db.refresh(event)
+
+    if member_type == "agent":
+        _push_to_agent(str(assignee_id), _event_to_payload(event))
+    else:
+        await dispatch_notification(
+            db,
+            org_id=org_id,
+            event_type="dispatched",
+            target_member_ids=[assignee_id],
+            title=f"[{body.entity_type}] {title}",
+            body=body.message or (description or "")[:200] or None,
+            reference_type=body.entity_type,
+            reference_id=body.entity_id,
+        )
+
+    await db.commit()
+    return DispatchResponse(
+        dispatched=True,
+        event_id=event.id,
+        assignee_id=assignee_id,
+        assignee_type=member_type,
+    )

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -29,6 +29,7 @@ class DocUpdate(BaseModel):
     doc_type: str | None = None
     content_format: str | None = None
     tags: list[str] | None = None
+    assignee_id: uuid.UUID | None = None
 
 
 class DocResponse(BaseModel):
@@ -39,6 +40,7 @@ class DocResponse(BaseModel):
     org_id: uuid.UUID
     parent_id: uuid.UUID | None = None
     created_by: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
     title: str
     slug: str
     content: str

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -29,6 +29,7 @@ class EpicUpdate(BaseModel):
     success_criteria: str | None = None
     target_sp: int | None = None
     target_date: date | None = None
+    assignee_id: uuid.UUID | None = None
 
 
 class EpicResponse(BaseModel):
@@ -37,6 +38,7 @@ class EpicResponse(BaseModel):
     id: uuid.UUID
     project_id: uuid.UUID
     org_id: uuid.UUID
+    assignee_id: uuid.UUID | None = None
     title: str
     status: str
     priority: str

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -18,6 +18,7 @@ def _mock_doc() -> MagicMock:
     d.project_id = PROJECT_ID
     d.parent_id = None
     d.created_by = None
+    d.assignee_id = None
     d.title = "Getting Started"
     d.slug = "getting-started"
     d.content = "# Hello"

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -16,6 +16,7 @@ def _mock_epic(status: str = "active") -> MagicMock:
     e.id = EPIC_ID
     e.org_id = ORG_ID
     e.project_id = PROJECT_ID
+    e.assignee_id = None
     e.title = "Epic 1"
     e.status = status
     e.priority = "medium"


### PR DESCRIPTION
## 변경 내용

### Migration 0027
- `epics.assignee_id` UUID nullable FK → team_members
- `docs.assignee_id` UUID nullable FK → team_members

### 모델 / 스키마
- `Epic`, `Doc` 모델에 `assignee_id` 필드 추가
- `EpicUpdate`, `EpicResponse`, `DocUpdate`, `DocResponse` 스키마 반영

### POST /api/v2/dispatch
- `entity_type` (epic/story/doc) + `entity_id` → entity 조회
- assignee_id 확인 → TeamMember.type 분기
  - human → `dispatch_notification()` → in-app Notification
  - agent → `_push_to_agent()` → SSE 즉시 전달
- Event(dispatched) DB 기록
- payload: entity title + description[:500] + 임의 message 포함

## Test plan
- [ ] PATCH /api/v2/epics/{id} `assignee_id` 업데이트 후 GET 반영 확인
- [ ] PATCH /api/v2/docs/{id} `assignee_id` 업데이트 후 GET 반영 확인
- [ ] POST /api/v2/dispatch (epic, story, doc) → Event 생성 + Notification 생성
- [ ] agent assignee → SSE push (Event 생성)
- [ ] assignee 없는 entity → dispatched=False (204 아닌 200)
- [ ] migration 0027 apply 성공
- [ ] pnpm build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)