### PR TITLE
[SID:d8c58ee7] Entity Dispatch UI — 담당자 드롭다운 + Dispatch 버튼

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { Input } from '@/components/ui/input';
 import Link from 'next/link';
 import { Check, Copy, Eye, Trash2 } from 'lucide-react';
 import { useDocsLayout } from '../docs-context';
+import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 
 interface DocDetail {
   id: string;
@@ -23,6 +24,7 @@ interface DocDetail {
   is_folder?: boolean;
   doc_type?: string;
   org_id?: string;
+  assignee_id?: string | null;
 }
 
 const SAVE_STATUS_CLASS: Partial<Record<SaveStatus, string>> = {
@@ -166,6 +168,19 @@ export default function DocSlugPage() {
           </div>
         </div>
       </div>
+
+      {/* Dispatch */}
+      {projectId && (
+        <div className="flex-shrink-0 border-b border-border px-4 py-2 lg:px-6">
+          <EntityDispatchPanel
+            entityType="doc"
+            entityId={selectedDoc.id}
+            projectId={projectId}
+            currentAssigneeId={selectedDoc.assignee_id}
+            onAssigneePatched={(aid) => setSelectedDoc((prev) => prev ? { ...prev, assignee_id: aid } : prev)}
+          />
+        </div>
+      )}
 
       {/* Editor */}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-4 lg:px-6 lg:py-6">

--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, Pencil, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 
 type EpicStatus = 'draft' | 'active' | 'done' | 'archived';
 type EpicPriority = 'critical' | 'high' | 'medium' | 'low';
@@ -29,6 +30,8 @@ interface Epic {
   priority: EpicPriority;
   target_date?: string;
   target_sp?: number;
+  assignee_id?: string | null;
+  project_id?: string;
   created_at: string;
   stories?: Story[];
 }
@@ -159,11 +162,16 @@ export default function EpicDetailPage() {
   const [epic, setEpic] = useState<Epic | null>(null);
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
+  const [epicAssigneeId, setEpicAssigneeId] = useState<string | null>(null);
 
   useEffect(() => {
     fetch(`/api/epics/${id}`)
       .then((r) => r.ok ? r.json() : Promise.reject())
-      .then((json) => setEpic((json as { data: Epic }).data))
+      .then((json) => {
+        const data = (json as { data: Epic }).data;
+        setEpic(data);
+        setEpicAssigneeId(data.assignee_id ?? null);
+      })
       .catch(() => router.replace('/epics'))
       .finally(() => setLoading(false));
   }, [id, router]);
@@ -214,6 +222,20 @@ export default function EpicDetailPage() {
             {epic.target_sp != null && <span className="text-xs text-muted-foreground">목표 SP: {epic.target_sp}</span>}
           </div>
         </div>
+
+        {/* Dispatch */}
+        {epic.project_id && (
+          <div className="rounded-xl border border-border bg-muted/20 p-4">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Dispatch</p>
+            <EntityDispatchPanel
+              entityType="epic"
+              entityId={epic.id}
+              projectId={epic.project_id}
+              currentAssigneeId={epicAssigneeId}
+              onAssigneePatched={(aid) => setEpicAssigneeId(aid)}
+            />
+          </div>
+        )}
 
         {/* Edit form */}
         {isEditing && (

--- a/apps/web/src/app/api/dispatch/route.ts
+++ b/apps/web/src/app/api/dispatch/route.ts
@@ -1,0 +1,15 @@
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function POST(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+    const _r = await proxyToFastapi(request, '/api/v2/dispatch');
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -63,6 +63,8 @@ export function EntityDispatchPanel({
         body: JSON.stringify({ entity_type: entityType, entity_id: entityId, project_id: projectId }),
       });
       if (!dispatchRes.ok) throw new Error('dispatch failed');
+      const dispatchData = await dispatchRes.json() as { dispatched?: boolean };
+      if (!dispatchData.dispatched) throw new Error('dispatch not executed — assignee missing');
       addToast({ type: 'success', title: 'Dispatch 완료' });
     } catch {
       addToast({ type: 'error', title: 'Dispatch 실패. 다시 시도하겠는.' });

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Zap } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { ToastContainer, useToast } from '@/components/ui/toast';
+
+interface TeamMember {
+  id: string;
+  name: string;
+  type: 'human' | 'agent';
+  is_active: boolean;
+}
+
+interface EntityDispatchPanelProps {
+  entityType: 'doc' | 'epic' | 'story';
+  entityId: string;
+  projectId: string;
+  currentAssigneeId?: string | null;
+  onAssigneePatched?: (assigneeId: string) => void;
+}
+
+export function EntityDispatchPanel({
+  entityType,
+  entityId,
+  projectId,
+  currentAssigneeId,
+  onAssigneePatched,
+}: EntityDispatchPanelProps) {
+  const [members, setMembers] = useState<TeamMember[]>([]);
+  const [assigneeId, setAssigneeId] = useState<string>(currentAssigneeId ?? '');
+  const [dispatching, setDispatching] = useState(false);
+  const { toasts, addToast, dismissToast } = useToast();
+
+  useEffect(() => {
+    fetch(`/api/team-members?project_id=${projectId}`)
+      .then((r) => r.ok ? r.json() : Promise.reject())
+      .then((json) => {
+        const data = (json?.data ?? json) as TeamMember[];
+        setMembers(data.filter((m) => m.is_active));
+      })
+      .catch(() => {});
+  }, [projectId]);
+
+  const handleDispatch = useCallback(async () => {
+    if (!assigneeId || dispatching) return;
+    setDispatching(true);
+    try {
+      const patchPath = entityType === 'doc' ? `/api/docs/${entityId}` : `/api/epics/${entityId}`;
+      if (entityType !== 'story') {
+        const patchRes = await fetch(patchPath, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ assignee_id: assigneeId }),
+        });
+        if (!patchRes.ok) throw new Error('assignee patch failed');
+        onAssigneePatched?.(assigneeId);
+      }
+
+      const dispatchRes = await fetch('/api/dispatch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ entity_type: entityType, entity_id: entityId, project_id: projectId }),
+      });
+      if (!dispatchRes.ok) throw new Error('dispatch failed');
+      addToast({ type: 'success', title: 'Dispatch 완료' });
+    } catch {
+      addToast({ type: 'error', title: 'Dispatch 실패. 다시 시도하겠는.' });
+    } finally {
+      setDispatching(false);
+    }
+  }, [assigneeId, dispatching, entityType, entityId, projectId, onAssigneePatched, addToast]);
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <select
+        value={assigneeId}
+        onChange={(e) => setAssigneeId(e.target.value)}
+        className="min-w-0 flex-1 rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+      >
+        <option value="">담당자 선택</option>
+        {members.map((m) => (
+          <option key={m.id} value={m.id}>
+            {m.name}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        disabled={!assigneeId || dispatching}
+        onClick={() => void handleDispatch()}
+        className={cn(
+          'flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition',
+          assigneeId && !dispatching
+            ? 'bg-primary text-primary-foreground hover:bg-primary/90'
+            : 'cursor-not-allowed bg-muted text-muted-foreground',
+        )}
+      >
+        <Zap className="size-3.5" />
+        {dispatching ? 'Dispatching…' : 'Dispatch'}
+      </button>
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
+    </div>
+  );
+}

--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -57,10 +57,8 @@ function getEntityHref(notification: EventNotification): string | null {
     case 'memo':
       return `/memos?id=${source_entity_id}`;
     case 'story':
-      // kanban-board.tsx는 searchParams.get('story') 키 사용
       return `/board?story=${source_entity_id}`;
     case 'task':
-      // kanban-board.tsx에서 task_id 파라미터 처리 — task → story 패널 자동 오픈
       return `/board?task_id=${source_entity_id}`;
     case 'epic':
       return `/epics/${source_entity_id}`;

--- a/packages/shared/src/schemas/epics.ts
+++ b/packages/shared/src/schemas/epics.ts
@@ -24,4 +24,5 @@ export const updateEpicSchema = z.object({
   success_criteria: z.string().optional().nullable(),
   target_sp: z.number().int().positive().optional().nullable(),
   target_date: z.string().optional().nullable(),
+  assignee_id: z.string().optional().nullable(),
 });


### PR DESCRIPTION
## 변경 사항

Epic/Doc 상세 페이지에 담당자 선택 드롭다운 + Dispatch 버튼 UI 추가.

### 신규 파일
- `apps/web/src/app/api/dispatch/route.ts` — POST `/api/v2/dispatch` FastAPI proxy
- `apps/web/src/components/dispatch/entity-dispatch-panel.tsx` — 공용 Dispatch 패널 컴포넌트

### 수정 파일
- `epics/[id]/page.tsx` — Epic 상세에 Dispatch 패널 삽입, `assignee_id` 추가
- `docs/[slug]/page.tsx` — Doc 상세 헤더 하단에 Dispatch 패널 삽입, `assignee_id` 추가
- `notification-bell.tsx` — 주석 정리

### Dispatch 흐름
1. 팀원 드롭다운에서 담당자 선택
2. Dispatch 버튼 클릭
3. `PATCH /api/epics/{id}` 또는 `PATCH /api/docs/{id}` → `{ assignee_id }` 저장
4. `POST /api/dispatch` → `{ entity_type, entity_id, project_id }` → dispatched 이벤트 발생
5. 성공/실패 toast 피드백

## AC 체크리스트

- [x] Doc 상세 페이지 담당자 선택 가능
- [x] Epic 상세 페이지 담당자 선택 가능
- [x] 담당자 지정 후 Dispatch 버튼 클릭 → API 호출 → toast 표시
- [x] 담당자 미지정 시 Dispatch 버튼 disabled
- [x] dispatched 이벤트는 기존 벨 아이콘 (⚡ Zap 아이콘) + `source_entity_type` 기반 딥링크 지원
- [x] 모바일 flex-wrap 대응

## 빌드/검증

- [x] `pnpm type-check` — PASS
- [x] `pnpm build` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)