### PR TITLE
feat(eventbus): S14 — MCP Dispatch 수신 + E2E 검증 (poll_events 수정)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -306,18 +306,20 @@ async def create_event(
 @router.get("/pending", response_model=list[EventResponse])
 async def get_pending_events(
     recipient_id: uuid.UUID = Query(...),
+    event_type: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[EventResponse]:
-    """GET /api/v2/events/pending?recipient_id={id} — 수신자별 pending 이벤트 목록."""
+    """GET /api/v2/events/pending?recipient_id={id}&event_type={type} — 수신자별 pending 이벤트 목록."""
+    filters = [
+        Event.org_id == org_id,
+        Event.recipient_id == recipient_id,
+        Event.status == "pending",
+    ]
+    if event_type:
+        filters.append(Event.event_type == event_type)
     result = await db.execute(
-        select(Event)
-        .where(
-            Event.org_id == org_id,
-            Event.recipient_id == recipient_id,
-            Event.status == "pending",
-        )
-        .order_by(Event.created_at.asc())
+        select(Event).where(*filters).order_by(Event.created_at.asc())
     )
     events = result.scalars().all()
     return [EventResponse.model_validate(e) for e in events]

--- a/packages/mcp-server/src/tools/agent-runs.ts
+++ b/packages/mcp-server/src/tools/agent-runs.ts
@@ -83,19 +83,19 @@ export function registerAgentRunsTools(server: McpServer) {
     },
   );
 
-  // GET /api/agent-runs?project_id=X&limit=N
+  // GET /api/v2/events/pending?recipient_id=X
   server.tool(
     'poll_events',
-    'Poll recent agent run events for a project',
+    'Poll pending dispatched events for this agent (recipient_id = this agent\'s member ID). Returns dispatched events with entity_type, entity_id, title, description payload.',
     {
-      project_id: z.string().describe('Project ID'),
-      limit: z.number().optional().describe('Max results (default: 20)'),
+      recipient_id: z.string().describe('Agent team member ID (this agent\'s member ID)'),
+      event_type: z.string().optional().describe('Filter by event type, e.g. "dispatched" (default: all pending)'),
     },
-    async ({ project_id, limit }) => {
+    async ({ recipient_id, event_type }) => {
       try {
-        const params = new URLSearchParams({ project_id });
-        if (limit !== undefined) params.set('limit', String(limit));
-        const data = await pmApi(`/api/agent-runs?${params.toString()}`);
+        const params = new URLSearchParams({ recipient_id });
+        if (event_type !== undefined) params.set('event_type', event_type);
+        const data = await pmApi(`/api/v2/events/pending?${params.toString()}`);
         return ok(data);
       } catch (e) {
         return err(e instanceof PmApiError ? e.message : String(e));


### PR DESCRIPTION
## 변경 내용

S12(Dispatch API)와 SSE 인프라 위에 에이전트가 dispatched 이벤트를 수신할 수 있도록 `poll_events` MCP 도구 수정.

### `packages/mcp-server/src/tools/agent-runs.ts`
- `poll_events` 도구: `/api/agent-runs` → `/api/v2/events/pending?recipient_id` 변경
- `recipient_id` 파라미터 추가 (agent member ID)
- `event_type` 선택적 필터 파라미터 추가

### `backend/app/routers/events.py`
- `get_pending_events`: `event_type` 쿼리 파라미터 필터 추가

## E2E 흐름

```
POST /api/v2/dispatch { entity_type: "doc", entity_id: "..." }
  → _push_to_agent() (SSE 즉시 전달) [S12]
  → Event(dispatched) DB 저장 [S12]

에이전트: poll_events { recipient_id: "..." }
  → GET /api/v2/events/pending?recipient_id={id}
  → dispatched 이벤트 반환 (payload: entity_type, entity_id, title, description)

에이전트: get_doc { project_id, slug } 또는 기존 MCP 도구로 entity 조회
```

## Test plan
- [ ] poll_events(recipient_id=agent_member_id) → dispatched 이벤트 포함 확인
- [ ] poll_events(event_type="dispatched") → dispatched 타입만 필터 확인
- [ ] 에이전트 SSE 연결 시 Dispatch → SSE 즉시 수신 확인 (dev 환경)
- [ ] dispatch payload에 entity_type, entity_id, title, description 포함 확인
- [ ] 기존 get_doc MCP 도구로 entity_id 조회 가능 확인
- [ ] pnpm build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)