### PR TITLE
feat(eventbus): S15 — Chat 백엔드 + MCP 채팅 도구 (실시간 메시지 이벤트)

### DIFF
--- a/backend/alembic/versions/0028_add_attachments_to_memo_replies.py
+++ b/backend/alembic/versions/0028_add_attachments_to_memo_replies.py
@@ -1,0 +1,25 @@
+"""add attachments to memo_replies
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-05-13
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0028"
+down_revision = "0027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "memo_replies",
+        sa.Column("attachments", JSONB, nullable=False, server_default="[]"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("memo_replies", "attachments")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -84,6 +84,7 @@ app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(events.router)
 app.include_router(dispatch.router)
+app.include_router(chats.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)

--- a/backend/app/models/memo.py
+++ b/backend/app/models/memo.py
@@ -55,6 +55,7 @@ class MemoReply(Base):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     review_type: Mapped[str] = mapped_column(Text, nullable=False, default="comment")
+    attachments: Mapped[list] = mapped_column(JSONB, nullable=False, default=list)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -72,7 +72,9 @@ async def send_chat_message(
         attachments=body.attachments,
     )
 
-    # chat:message 이벤트 → thread 참여자 SSE 전달
+    await db.commit()
+
+    # chat:message 이벤트 → commit 완료 후 SSE 전달 (commit 실패 시 유령 SSE 방지)
     try:
         chat_participants: set[uuid.UUID] = set()
         if memo.assigned_to:
@@ -94,7 +96,6 @@ async def send_chat_message(
     except Exception:
         pass
 
-    await db.commit()
     return ReplyResponse.model_validate(reply)
 
 
@@ -134,7 +135,9 @@ async def send_chat_message_with_file(
         attachments=attachments,
     )
 
-    # chat:message SSE 전달
+    await db.commit()
+
+    # chat:message SSE 전달 (commit 완료 후)
     try:
         chat_participants: set[uuid.UUID] = set()
         if memo.assigned_to:
@@ -156,5 +159,4 @@ async def send_chat_message_with_file(
     except Exception:
         pass
 
-    await db.commit()
     return ReplyResponse.model_validate(reply)

--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -1,0 +1,160 @@
+"""E-EVENTBUS P4 S15: Chat 백엔드 — 실시간 메시지 이벤트 + MCP 채팅 도구."""
+import uuid
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.memo import Memo, MemoReply
+from app.repositories.memo import MemoReplyRepository
+from app.routers.events import _push_to_agent
+from app.schemas.memo import ReplyResponse
+
+router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
+
+
+class ChatMessageRequest(BaseModel):
+    content: str
+    created_by: uuid.UUID
+    attachments: list[dict] = []
+
+
+@router.get("/{thread_id}/messages", response_model=list[ReplyResponse])
+async def list_chat_messages(
+    thread_id: uuid.UUID,
+    limit: int = Query(default=50, le=200),
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[ReplyResponse]:
+    """GET /api/v2/chats/{thread_id}/messages — 시간순 메시지 조회."""
+    memo_result = await db.execute(
+        select(Memo.id).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
+    )
+    if memo_result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    result = await db.execute(
+        select(MemoReply)
+        .where(MemoReply.memo_id == thread_id)
+        .order_by(MemoReply.created_at.asc())
+        .limit(limit)
+    )
+    replies = result.scalars().all()
+    return [ReplyResponse.model_validate(r) for r in replies]
+
+
+@router.post("/{thread_id}/messages", response_model=ReplyResponse, status_code=201)
+async def send_chat_message(
+    thread_id: uuid.UUID,
+    body: ChatMessageRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ReplyResponse:
+    """POST /api/v2/chats/{thread_id}/messages — 채팅 메시지 전송 (JSON)."""
+    memo_result = await db.execute(
+        select(Memo).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
+    )
+    memo = memo_result.scalar_one_or_none()
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    reply_repo = MemoReplyRepository(db)
+    reply = await reply_repo.create(
+        memo_id=thread_id,
+        content=body.content,
+        created_by=body.created_by,
+        review_type="comment",
+        attachments=body.attachments,
+    )
+
+    # chat:message 이벤트 → thread 참여자 SSE 전달
+    try:
+        chat_participants: set[uuid.UUID] = set()
+        if memo.assigned_to:
+            chat_participants.add(memo.assigned_to)
+        if memo.created_by:
+            chat_participants.add(memo.created_by)
+        chat_participants.discard(body.created_by)
+        chat_payload = {
+            "event_type": "chat:message",
+            "thread_id": str(thread_id),
+            "reply_id": str(reply.id),
+            "content": reply.content,
+            "created_by": str(reply.created_by),
+            "attachments": reply.attachments,
+            "created_at": reply.created_at.isoformat(),
+        }
+        for participant_id in chat_participants:
+            _push_to_agent(str(participant_id), chat_payload)
+    except Exception:
+        pass
+
+    await db.commit()
+    return ReplyResponse.model_validate(reply)
+
+
+@router.post("/{thread_id}/messages/upload", response_model=ReplyResponse, status_code=201)
+async def send_chat_message_with_file(
+    thread_id: uuid.UUID,
+    content: Annotated[str, Form()],
+    created_by: Annotated[uuid.UUID, Form()],
+    file: Annotated[UploadFile | None, File()] = None,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ReplyResponse:
+    """POST /api/v2/chats/{thread_id}/messages/upload — 파일 첨부 포함 채팅 메시지 전송 (multipart)."""
+    memo_result = await db.execute(
+        select(Memo).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
+    )
+    memo = memo_result.scalar_one_or_none()
+    if memo is None:
+        raise HTTPException(status_code=404, detail="Thread not found")
+
+    attachments: list[dict] = []
+    if file and file.filename:
+        file_content = await file.read()
+        attachments.append({
+            "filename": file.filename,
+            "content_type": file.content_type or "application/octet-stream",
+            "size": len(file_content),
+        })
+
+    reply_repo = MemoReplyRepository(db)
+    reply = await reply_repo.create(
+        memo_id=thread_id,
+        content=content,
+        created_by=created_by,
+        review_type="comment",
+        attachments=attachments,
+    )
+
+    # chat:message SSE 전달
+    try:
+        chat_participants: set[uuid.UUID] = set()
+        if memo.assigned_to:
+            chat_participants.add(memo.assigned_to)
+        if memo.created_by:
+            chat_participants.add(memo.created_by)
+        chat_participants.discard(created_by)
+        chat_payload = {
+            "event_type": "chat:message",
+            "thread_id": str(thread_id),
+            "reply_id": str(reply.id),
+            "content": reply.content,
+            "created_by": str(reply.created_by),
+            "attachments": reply.attachments,
+            "created_at": reply.created_at.isoformat(),
+        }
+        for participant_id in chat_participants:
+            _push_to_agent(str(participant_id), chat_payload)
+    except Exception:
+        pass
+
+    await db.commit()
+    return ReplyResponse.model_validate(reply)

--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -9,12 +9,50 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.event import Event
 from app.models.memo import Memo, MemoReply
+from app.models.team import TeamMember
 from app.repositories.memo import MemoReplyRepository
 from app.routers.events import _push_to_agent
 from app.schemas.memo import ReplyResponse
 
 router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
+
+
+async def _persist_and_push_chat_events(
+    db: AsyncSession,
+    memo: Memo,
+    reply: MemoReply,
+    org_id: uuid.UUID,
+    sender_id: uuid.UUID,
+    participants: set[uuid.UUID],
+    payload: dict,
+) -> None:
+    """chat:message Event를 events 테이블에 INSERT 후 SSE push (에이전트 대상)."""
+    if not participants or not memo.project_id:
+        return
+    member_types_result = await db.execute(
+        select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(participants))
+    )
+    member_type_map = {row[0]: row[1] for row in member_types_result.all()}
+    for participant_id in participants:
+        member_type = member_type_map.get(participant_id, "human")
+        event = Event(
+            project_id=memo.project_id,
+            org_id=org_id,
+            event_type="chat:message",
+            source_entity_type="memo_reply",
+            source_entity_id=reply.id,
+            sender_id=sender_id,
+            recipient_id=participant_id,
+            recipient_type=member_type,
+            payload=payload,
+            status="pending",
+        )
+        db.add(event)
+        if member_type == "agent":
+            _push_to_agent(str(participant_id), payload)
+    await db.flush()
 
 
 class ChatMessageRequest(BaseModel):
@@ -72,30 +110,28 @@ async def send_chat_message(
         attachments=body.attachments,
     )
 
-    await db.commit()
-
-    # chat:message 이벤트 → commit 완료 후 SSE 전달 (commit 실패 시 유령 SSE 방지)
+    chat_participants: set[uuid.UUID] = set()
+    if memo.assigned_to:
+        chat_participants.add(memo.assigned_to)
+    if memo.created_by:
+        chat_participants.add(memo.created_by)
+    chat_participants.discard(body.created_by)
+    chat_payload = {
+        "event_type": "chat:message",
+        "thread_id": str(thread_id),
+        "reply_id": str(reply.id),
+        "content": reply.content,
+        "created_by": str(reply.created_by),
+        "attachments": reply.attachments,
+        "created_at": reply.created_at.isoformat(),
+    }
+    # Event INSERT + SSE push (commit 전에 flush, 오프라인 에이전트도 poll_events로 조회 가능)
     try:
-        chat_participants: set[uuid.UUID] = set()
-        if memo.assigned_to:
-            chat_participants.add(memo.assigned_to)
-        if memo.created_by:
-            chat_participants.add(memo.created_by)
-        chat_participants.discard(body.created_by)
-        chat_payload = {
-            "event_type": "chat:message",
-            "thread_id": str(thread_id),
-            "reply_id": str(reply.id),
-            "content": reply.content,
-            "created_by": str(reply.created_by),
-            "attachments": reply.attachments,
-            "created_at": reply.created_at.isoformat(),
-        }
-        for participant_id in chat_participants:
-            _push_to_agent(str(participant_id), chat_payload)
+        await _persist_and_push_chat_events(db, memo, reply, org_id, body.created_by, chat_participants, chat_payload)
     except Exception:
         pass
 
+    await db.commit()
     return ReplyResponse.model_validate(reply)
 
 
@@ -135,28 +171,25 @@ async def send_chat_message_with_file(
         attachments=attachments,
     )
 
-    await db.commit()
-
-    # chat:message SSE 전달 (commit 완료 후)
+    chat_participants: set[uuid.UUID] = set()
+    if memo.assigned_to:
+        chat_participants.add(memo.assigned_to)
+    if memo.created_by:
+        chat_participants.add(memo.created_by)
+    chat_participants.discard(created_by)
+    chat_payload = {
+        "event_type": "chat:message",
+        "thread_id": str(thread_id),
+        "reply_id": str(reply.id),
+        "content": reply.content,
+        "created_by": str(reply.created_by),
+        "attachments": reply.attachments,
+        "created_at": reply.created_at.isoformat(),
+    }
     try:
-        chat_participants: set[uuid.UUID] = set()
-        if memo.assigned_to:
-            chat_participants.add(memo.assigned_to)
-        if memo.created_by:
-            chat_participants.add(memo.created_by)
-        chat_participants.discard(created_by)
-        chat_payload = {
-            "event_type": "chat:message",
-            "thread_id": str(thread_id),
-            "reply_id": str(reply.id),
-            "content": reply.content,
-            "created_by": str(reply.created_by),
-            "attachments": reply.attachments,
-            "created_at": reply.created_at.isoformat(),
-        }
-        for participant_id in chat_participants:
-            _push_to_agent(str(participant_id), chat_payload)
+        await _persist_and_push_chat_events(db, memo, reply, org_id, created_by, chat_participants, chat_payload)
     except Exception:
         pass
 
+    await db.commit()
     return ReplyResponse.model_validate(reply)

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -341,9 +341,33 @@ async def add_reply(
         raise HTTPException(status_code=404, detail="Memo not found")
     reply_repo = MemoReplyRepository(db)
     reply = await reply_repo.create(
-        memo_id=id, content=body.content, created_by=body.created_by, review_type=body.review_type
+        memo_id=id, content=body.content, created_by=body.created_by, review_type=body.review_type,
+        attachments=body.attachments,
     )
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
+
+    # E-EVENTBUS P4 S15: chat:message 이벤트 발행 (thread 참여자 전원 SSE 전달)
+    try:
+        from app.routers.events import _push_to_agent
+        chat_participants: set[uuid.UUID] = set()
+        if memo.assigned_to:
+            chat_participants.add(memo.assigned_to)
+        if memo.created_by:
+            chat_participants.add(memo.created_by)
+        chat_participants.discard(body.created_by)
+        chat_payload = {
+            "event_type": "chat:message",
+            "thread_id": str(id),
+            "reply_id": str(reply.id),
+            "content": reply.content,
+            "created_by": str(reply.created_by),
+            "attachments": reply.attachments,
+            "created_at": reply.created_at.isoformat(),
+        }
+        for participant_id in chat_participants:
+            _push_to_agent(str(participant_id), chat_payload)
+    except Exception:
+        pass
 
     # E-EVENTBUS P3 S8: 알림 설정 필터 후 Notification INSERT (원 메모 작성자에게)
     reply_notification_targets = [

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -346,9 +346,9 @@ async def add_reply(
     )
     publish_event(str(repo.org_id), "reply_created", {"id": str(reply.id), "memo_id": str(id)})
 
-    # E-EVENTBUS P4 S15: chat:message 이벤트 발행 (thread 참여자 전원 SSE 전달)
+    # E-EVENTBUS P4 S15: chat:message 이벤트 발행 + events 테이블 persist + SSE push
     try:
-        from app.routers.events import _push_to_agent
+        from app.routers.chats import _persist_and_push_chat_events
         chat_participants: set[uuid.UUID] = set()
         if memo.assigned_to:
             chat_participants.add(memo.assigned_to)
@@ -364,8 +364,7 @@ async def add_reply(
             "attachments": reply.attachments,
             "created_at": reply.created_at.isoformat(),
         }
-        for participant_id in chat_participants:
-            _push_to_agent(str(participant_id), chat_payload)
+        await _persist_and_push_chat_events(db, memo, reply, repo.org_id, body.created_by, chat_participants, chat_payload)
     except Exception:
         pass
 

--- a/backend/app/schemas/memo.py
+++ b/backend/app/schemas/memo.py
@@ -75,6 +75,7 @@ class CreateReply(BaseModel):
     created_by: uuid.UUID
     review_type: str = "comment"
     assigned_to_ids: list[uuid.UUID] | None = None
+    attachments: list[dict] = []
 
 
 class ReplyResponse(BaseModel):
@@ -85,6 +86,7 @@ class ReplyResponse(BaseModel):
     created_by: uuid.UUID
     content: str
     review_type: str
+    attachments: list[dict] = []
     created_at: datetime
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Sprintable FastAPI backend — Phase B migration layer"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
+    "python-multipart>=0.0.9",
     "uvicorn[standard]>=0.32.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "asyncpg>=0.30.0",

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -113,4 +113,32 @@ export function registerMemosTools(server: McpServer) {
       return ok(data);
     } catch (e) { return handleError(e); }
   });
+
+  // E-EVENTBUS P4 S15: 채팅 메시지 전송 — 에이전트가 thread에 즉시 응답
+  server.tool('send_chat_message', 'Send a chat message to a memo thread. Triggers real-time SSE delivery to all thread participants.', {
+    thread_id: z.string().describe('Memo ID (= thread ID)'),
+    content: z.string().describe('Message content'),
+    created_by: z.string().describe('Sender team member ID'),
+  }, async ({ thread_id, content, created_by }) => {
+    try {
+      const data = await pmApi(`/api/v2/chats/${encodeURIComponent(thread_id)}/messages`, {
+        method: 'POST',
+        body: JSON.stringify({ content, created_by, attachments: [] }),
+      });
+      return ok(data);
+    } catch (e) { return handleError(e); }
+  });
+
+  // 채팅 메시지 목록 조회
+  server.tool('list_chat_messages', 'List chat messages in a memo thread (chronological order)', {
+    thread_id: z.string().describe('Memo ID (= thread ID)'),
+    limit: z.number().optional().describe('Max messages (default: 50)'),
+  }, async ({ thread_id, limit }) => {
+    try {
+      const params = new URLSearchParams();
+      if (limit !== undefined) params.set('limit', String(limit));
+      const data = await pmApi(`/api/v2/chats/${encodeURIComponent(thread_id)}/messages?${params.toString()}`);
+      return ok(data);
+    } catch (e) { return handleError(e); }
+  });
 }


### PR DESCRIPTION
## 변경 내용

Phase 4 "메모 → Chat UI 전환" 백엔드 인프라 구축.

### Migration 0028
- `memo_replies.attachments` JSONB 컬럼 추가 (server_default: `[]`)

### `backend/app/routers/chats.py` (신설)
- `GET /api/v2/chats/{thread_id}/messages` — MemoReply 시간순 조회
- `POST /api/v2/chats/{thread_id}/messages` — JSON 채팅 메시지 전송
- `POST /api/v2/chats/{thread_id}/messages/upload` — 파일 첨부 (multipart)
- 메시지 전송 시 `chat:message` 이벤트 → thread 참여자 `_push_to_agent()` SSE 전달

### `backend/app/routers/memos.py`
- `add_reply` 수정: `chat:message` 이벤트 발행 (reply_memo 경로에서도 SSE 전달)
- `attachments` 파라미터 전달

### `packages/mcp-server/src/tools/memos.ts`
- `send_chat_message` 도구: `POST /api/v2/chats/{thread_id}/messages` 호출
- `list_chat_messages` 도구: `GET /api/v2/chats/{thread_id}/messages` 호출

## E2E 흐름

```
reply_memo OR send_chat_message(thread_id, content)
  → MemoReply DB 저장 (attachments 포함)
  → chat:message 이벤트 → _push_to_agent() → thread 참여자 SSE 수신

에이전트: list_chat_messages(thread_id) → 시간순 메시지 조회
```

## Test plan
- [ ] reply_memo → chat:message SSE 에이전트 수신 확인
- [ ] POST /api/v2/chats/{id}/messages → 201 + DB 저장
- [ ] GET /api/v2/chats/{id}/messages → 시간순 반환
- [ ] POST /upload (multipart) → attachments 메타데이터 저장
- [ ] send_chat_message MCP 도구 작동
- [ ] list_chat_messages MCP 도구 작동
- [ ] Migration 0028 apply 성공
- [ ] pnpm build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)