### PR TITLE
[P0] MCP→FastAPI SSE 자동 연결 브릿지 + poll_events 빈 배열 버그 수정

### DIFF
--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -10,6 +10,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { configurePmApi } from './pm-api.js';
+import { startSseBridge } from './sse-bridge.js';
 import { registerCoreTools } from './tools/core.js';
 import { registerRetroTools } from './tools/retro.js';
 import { registerAnalyticsTools } from './tools/analytics.js';
@@ -31,6 +32,7 @@ import { registerAuditTools } from './tools/audit.js';
 const PM_API_URL = process.env['PM_API_URL'] ?? '';
 const AGENT_API_KEY = process.env['AGENT_API_KEY'] ?? '';
 const MCP_API_KEY = process.env['MCP_API_KEY'] ?? '';
+const MEMBER_ID = process.env['MEMBER_ID'] ?? '';
 const MODE = process.env['MCP_MODE'] ?? 'stdio'; // 'stdio' | 'sse'
 const PORT = Number(process.env['MCP_PORT'] ?? '3100');
 
@@ -106,6 +108,11 @@ async function main() {
     const transport = new StdioServerTransport();
     await server.connect(transport);
     console.error('Sprintable MCP Server (stdio) connected');
+
+    // FastAPI SSE 자동 연결 — MEMBER_ID 있을 때만
+    if (MEMBER_ID) {
+      startSseBridge(PM_API_URL, AGENT_API_KEY, MEMBER_ID);
+    }
   }
 }
 

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -32,7 +32,7 @@ import { registerAuditTools } from './tools/audit.js';
 const PM_API_URL = process.env['PM_API_URL'] ?? '';
 const AGENT_API_KEY = process.env['AGENT_API_KEY'] ?? '';
 const MCP_API_KEY = process.env['MCP_API_KEY'] ?? '';
-const MEMBER_ID = process.env['MEMBER_ID'] ?? '';
+const MEMBER_ID = process.env['CURRENT_MEMBER_ID'] ?? process.env['MEMBER_ID'] ?? '';
 const MODE = process.env['MCP_MODE'] ?? 'stdio'; // 'stdio' | 'sse'
 const PORT = Number(process.env['MCP_PORT'] ?? '3100');
 

--- a/packages/mcp-server/src/pm-api.ts
+++ b/packages/mcp-server/src/pm-api.ts
@@ -63,6 +63,10 @@ export async function pmApi<T = unknown>(path: string, init: PmApiInit = {}): Pr
     throw new PmApiError(response.status, String(message), body);
   }
 
-  const json = (await response.json()) as { data?: T };
-  return json.data as T;
+  const json = await response.json();
+  // {data: T} 래핑 형식이면 .data, 아니면 직접 반환 (배열 등)
+  if (json !== null && typeof json === 'object' && !Array.isArray(json) && 'data' in json) {
+    return json.data as T;
+  }
+  return json as T;
 }

--- a/packages/mcp-server/src/sse-bridge.ts
+++ b/packages/mcp-server/src/sse-bridge.ts
@@ -1,0 +1,98 @@
+/**
+ * SSE Bridge — MCP stdio 서버가 FastAPI /api/v2/events/stream 에 자동 연결.
+ * 이벤트 수신 시 stderr 출력, 연결 끊김 시 exponential backoff 재연결.
+ */
+
+const BASE_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 60_000;
+const JITTER_MS = 500;
+
+function log(msg: string) {
+  process.stderr.write(`[sse-bridge] ${msg}\n`);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function connectOnce(url: string, headers: Record<string, string>): Promise<void> {
+  const response = await fetch(url, {
+    headers: { ...headers, Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
+  });
+
+  if (!response.ok) {
+    throw new Error(`SSE connect failed: HTTP ${response.status}`);
+  }
+  if (!response.body) {
+    throw new Error('SSE response has no body');
+  }
+
+  log('connected');
+
+  const decoder = new TextDecoder();
+  let eventType = 'message';
+  let dataLines: string[] = [];
+
+  const reader = response.body.getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        log('stream ended');
+        break;
+      }
+      const chunk = decoder.decode(value, { stream: true });
+      for (const rawLine of chunk.split('\n')) {
+        const line = rawLine.trimEnd();
+        if (line.startsWith('event:')) {
+          eventType = line.slice(6).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice(5).trim());
+        } else if (line === '') {
+          if (dataLines.length > 0) {
+            const dataStr = dataLines.join('\n');
+            if (eventType !== 'heartbeat') {
+              log(`event=${eventType} data=${dataStr}`);
+            }
+            eventType = 'message';
+            dataLines = [];
+          }
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function startSseBridge(
+  pmApiUrl: string,
+  agentApiKey: string,
+  memberId: string,
+): void {
+  const url = `${pmApiUrl.replace(/\/$/, '')}/api/v2/events/stream?member_id=${memberId}`;
+  const authHeaders = {
+    Authorization: `Bearer ${agentApiKey}`,
+    'x-api-key': agentApiKey,
+  };
+
+  const run = async () => {
+    let attempt = 0;
+    while (true) {
+      try {
+        await connectOnce(url, authHeaders);
+        attempt = 0; // 정상 종료(서버 측 닫힘) 시 backoff 리셋
+      } catch (err) {
+        log(`error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+      attempt++;
+      const backoff = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
+      const jitter = Math.random() * JITTER_MS;
+      const wait = Math.round(backoff + jitter);
+      log(`reconnecting in ${wait}ms (attempt ${attempt})`);
+      await delay(wait);
+    }
+  };
+
+  void run();
+}

--- a/packages/mcp-server/src/tools/agent-runs.ts
+++ b/packages/mcp-server/src/tools/agent-runs.ts
@@ -96,7 +96,7 @@ export function registerAgentRunsTools(server: McpServer) {
         const params = new URLSearchParams({ recipient_id });
         if (event_type !== undefined) params.set('event_type', event_type);
         const data = await pmApi(`/api/v2/events/pending?${params.toString()}`);
-        return ok(data);
+        return ok(data ?? []);
       } catch (e) {
         return err(e instanceof PmApiError ? e.message : String(e));
       }

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -946,24 +946,31 @@ describe('agent-runs tools via pmApi', () => {
     expect(result).toEqual({ data: { id: 'run-1', status: 'completed' } });
   });
 
-  it('poll_events calls GET /api/agent-runs with project_id', async () => {
+  it('poll_events calls GET /api/v2/events/pending with recipient_id', async () => {
     stubFetch((url) => {
-      expect(url).toContain('/api/agent-runs?');
-      expect(url).toContain('project_id=project-alpha');
-      return new Response(JSON.stringify({ data: [{ id: 'run-1' }, { id: 'run-2' }] }), { status: 200 });
+      expect(url).toContain('/api/v2/events/pending?');
+      expect(url).toContain('recipient_id=member-1');
+      return new Response(JSON.stringify([{ id: 'evt-1' }, { id: 'evt-2' }]), { status: 200 });
     });
 
-    const result = await harness.invoke('poll_events', { project_id: 'project-alpha' });
-    expect(result).toEqual({ data: [{ id: 'run-1' }, { id: 'run-2' }] });
+    const result = await harness.invoke('poll_events', { recipient_id: 'member-1' });
+    expect(result).toEqual([{ id: 'evt-1' }, { id: 'evt-2' }]);
   });
 
-  it('poll_events passes optional limit param', async () => {
+  it('poll_events passes optional event_type param', async () => {
     stubFetch((url) => {
-      expect(url).toContain('limit=5');
-      return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      expect(url).toContain('event_type=dispatched');
+      return new Response(JSON.stringify([]), { status: 200 });
     });
 
-    await harness.invoke('poll_events', { project_id: 'project-alpha', limit: 5 });
+    await harness.invoke('poll_events', { recipient_id: 'member-1', event_type: 'dispatched' });
+  });
+
+  it('poll_events returns empty array when no pending events', async () => {
+    stubFetch(() => new Response(JSON.stringify([]), { status: 200 }));
+
+    const result = await harness.invoke('poll_events', { recipient_id: 'member-1' });
+    expect(result).toEqual([]);
   });
 
   it('propagates PmApiError on non-2xx response', async () => {


### PR DESCRIPTION
## Summary
- `packages/mcp-server/src/sse-bridge.ts` (신규): stdio 시작 시 `PM_API_URL/api/v2/events/stream?member_id=MEMBER_ID` SSE 자동 연결, 이벤트 수신→stderr 출력, exponential backoff(1s→60s) 재연결
- `index.ts`: stdio 모드에서 `MEMBER_ID` 환경변수 있으면 `startSseBridge()` 호출
- `pm-api.ts`: 배열 직접 응답(`[]`) + `{data:T}` 래핑 모두 처리 — poll_events 빈 배열 시 `content[0].text undefined` 근본 원인 수정
- `tools/agent-runs.ts`: `poll_events` 결과 `?? []` 방어 추가

## AC 검증
- AC1 — stdio 시작 시 `MEMBER_ID` 환경변수 있으면 SSE 자동 연결 ✅ (`index.ts:107`)
- AC2 — SSE 이벤트 수신 → stderr 출력 (`[sse-bridge] event=<type> data=<json>`) ✅ (`sse-bridge.ts:47`)
- AC3 — 연결 끊김 → exponential backoff(초기 1s, 최대 60s, jitter 0~500ms) 재연결 ✅ (`sse-bridge.ts:74-81`)
- AC4 — poll_events 빈 배열 `content[0].text undefined` 수정 ✅ (pm-api.ts 배열 직접 응답 처리 + agent-runs.ts `?? []`)

## Test plan
- [ ] `MEMBER_ID=<uuid>` 환경변수 추가 후 MCP stdio 시작 → stderr에 `[sse-bridge] connected` 출력 확인
- [ ] FastAPI SSE 서버 재시작 시 `[sse-bridge] reconnecting in ...ms` 출력 후 자동 재연결 확인
- [ ] `poll_events` 도구 호출 시 pending 이벤트 없어도 에러 없이 `[]` 반환 확인
- [ ] tsc --noEmit PASS ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)