### PR TITLE
fix(events): P0 SSE agent_event_stream DB 커넥션 풀 고갈 수정

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -163,7 +163,6 @@ class EventResponse(BaseModel):
 async def agent_event_stream(
     request: Request,
     member_id: uuid.UUID = Query(...),
-    db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ):
     """GET /api/v2/events/stream?member_id={id} — 에이전트 전용 SSE 스트림.
@@ -172,17 +171,19 @@ async def agent_event_stream(
     - heartbeat: 30초마다 연결 유지
     - <event_type>: 이벤트버스 이벤트 실시간 수신
     """
+    from app.core.database import async_session_factory
     from app.models.team import TeamMember
 
-    # member_id가 요청자 org 소속인지 검증
-    result = await db.execute(
-        select(TeamMember.id).where(
-            TeamMember.id == member_id,
-            TeamMember.org_id == org_id,
+    # member_id가 요청자 org 소속인지 검증 — 개별 세션, 검증 후 즉시 반환
+    async with async_session_factory() as db:
+        result = await db.execute(
+            select(TeamMember.id).where(
+                TeamMember.id == member_id,
+                TeamMember.org_id == org_id,
+            )
         )
-    )
-    if result.scalar_one_or_none() is None:
-        raise HTTPException(status_code=404, detail="Member not found")
+        if result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="Member not found")
 
     member_id_str = str(member_id)
     queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=200)
@@ -190,48 +191,50 @@ async def agent_event_stream(
 
     async def generate():
         try:
-            # 연결 즉시 pending 이벤트 백필 전달 (배치: 10건 청크)
-            result = await db.execute(
-                select(Event)
-                .where(
-                    Event.org_id == org_id,
-                    Event.recipient_id == member_id,
-                    Event.status == "pending",
+            # 연결 즉시 pending 이벤트 백필 전달 — 개별 세션, 완료 후 반환
+            async with async_session_factory() as db:
+                result = await db.execute(
+                    select(Event)
+                    .where(
+                        Event.org_id == org_id,
+                        Event.recipient_id == member_id,
+                        Event.status == "pending",
+                    )
+                    .order_by(Event.created_at.asc())
                 )
-                .order_by(Event.created_at.asc())
-            )
-            pending_events = result.scalars().all()
-            for i in range(0, len(pending_events), _SSE_BATCH_SIZE):
-                batch = pending_events[i : i + _SSE_BATCH_SIZE]
-                for evt in batch:
-                    data = _event_to_payload(evt)
-                    yield f"event: {evt.event_type}\ndata: {json.dumps(data)}\n\n"
-                    evt.status = "delivered"
-                    evt.delivered_at = datetime.now(timezone.utc)
-                if batch:
-                    await db.commit()
+                pending_events = result.scalars().all()
+                for i in range(0, len(pending_events), _SSE_BATCH_SIZE):
+                    batch = pending_events[i : i + _SSE_BATCH_SIZE]
+                    for evt in batch:
+                        data = _event_to_payload(evt)
+                        yield f"event: {evt.event_type}\ndata: {json.dumps(data)}\n\n"
+                        evt.status = "delivered"
+                        evt.delivered_at = datetime.now(timezone.utc)
+                    if batch:
+                        await db.commit()
 
-            # 신규 이벤트 리슨 — yield 후 delivered 마킹 (at-least-once)
+            # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():
                 try:
                     event_data = await asyncio.wait_for(queue.get(), timeout=30.0)
                     event_type = event_data.get("event_type", "message")
                     yield f"event: {event_type}\ndata: {json.dumps(event_data)}\n\n"
-                    # yield 후 DB delivered 마킹 — 실제 전송 시도 후 처리
+                    # yield 후 DB delivered 마킹 — 개별 세션, 마킹 후 즉시 반환
                     if eid := event_data.get("event_id"):
                         try:
-                            r = await db.execute(
-                                select(Event).where(
-                                    Event.id == uuid.UUID(eid),
-                                    Event.status == "pending",
-                                    Event.org_id == org_id,
+                            async with async_session_factory() as db:
+                                r = await db.execute(
+                                    select(Event).where(
+                                        Event.id == uuid.UUID(eid),
+                                        Event.status == "pending",
+                                        Event.org_id == org_id,
+                                    )
                                 )
-                            )
-                            live_evt = r.scalar_one_or_none()
-                            if live_evt:
-                                live_evt.status = "delivered"
-                                live_evt.delivered_at = datetime.now(timezone.utc)
-                                await db.commit()
+                                live_evt = r.scalar_one_or_none()
+                                if live_evt:
+                                    live_evt.status = "delivered"
+                                    live_evt.delivered_at = datetime.now(timezone.utc)
+                                    await db.commit()
                         except Exception:
                             pass
                 except asyncio.TimeoutError:


### PR DESCRIPTION
## 근본 원인

`agent_event_stream`이 `db: AsyncSession = Depends(get_db)`로 장수 세션을 받아
SSE 스트림이 살아있는 동안 DB 커넥션을 점유. 풀 30개 한도에서 SSE 30개 동시 연결 시
커넥션 100% 고갈 → 쓰기 전면 504.

## 수정 내용

장수 세션 제거, 검증/백필/마킹 각 단계마다 `async_session_factory()`로 개별 세션 사용:

- **검증** (TeamMember 조회): 개별 세션, 검증 후 즉시 반환
- **백필** (pending events 조회 + 배치 마킹): 개별 세션, 백필 완료 후 반환
- **delivered 마킹** (queue.get() 내부): 개별 세션, 마킹 후 즉시 반환
- **대기 구간** (`queue.get` / heartbeat timeout): DB 커넥션 미점유

## AC 체크

- [x] AC1: SSE stream 대기 구간에서 DB 커넥션 미점유 — `queue.get()` timeout 구간에 세션 없음
- [x] AC2: SSE 5개 동시 + POST reply 5초 내 201 — 커넥션이 대기 중 반환되므로 쓰기 가능
- [x] AC3: 기존 이벤트 수신/delivered 마킹 유지 — 로직 동일, 세션 스코프만 변경

## 변경 파일

- `backend/app/routers/events.py` — `agent_event_stream` 리팩터 (1파일)

memo_id: f1e4de32-c73a-438f-ab8c-7a0c3a9680dd