### PR TITLE
fix(mcp-server): P0 pmApi /api/ → /api/v2/ 리라이트 — MCP 도구 전량 404 수정

### DIFF
--- a/packages/mcp-server/src/pm-api.ts
+++ b/packages/mcp-server/src/pm-api.ts
@@ -43,7 +43,12 @@ export type PmApiInit = Omit<RequestInit, 'headers'> & {
  * @throws      {PmApiError} on non-2xx responses
  */
 export async function pmApi<T = unknown>(path: string, init: PmApiInit = {}): Promise<T> {
-  const url = `${_pmApiUrl}${path}`;
+  // /api/ 시작이지만 /api/v2/ 아닌 경로 → /api/v2/ 리라이트 (백엔드 직접 URL 대응)
+  const normalizedPath =
+    path.startsWith('/api/') && !path.startsWith('/api/v2/')
+      ? path.replace(/^\/api\//, '/api/v2/')
+      : path;
+  const url = `${_pmApiUrl}${normalizedPath}`;
   const headers: Record<string, string> = {
     Authorization: `Bearer ${_agentApiKey}`,
     'x-api-key': _agentApiKey, // fallback for environments where Authorization header is stripped by CDN


### PR DESCRIPTION
## 문제

`PM_API_URL`이 백엔드 직접 URL(`sprintable-backend-dev`)로 전환됐으나 MCP 도구들이 `/api/stories`, `/api/memos` 등 `/api/v2/` 없는 경로를 사용해 전량 404 반환.

## 수정

`pmApi()` 함수에서 path 정규화 1줄 추가:

```ts
// /api/ 시작이지만 /api/v2/ 아닌 경로 → /api/v2/ 리라이트
const normalizedPath =
  path.startsWith('/api/') && !path.startsWith('/api/v2/')
    ? path.replace(/^\/api\//, '/api/v2/')
    : path;
```

이미 `/api/v2/` 사용 중인 chat 도구 경로는 조건 불일치로 변경 없음 (이중 리라이트 방지).

## AC 체크

- AC1 ✅ `list_stories`, `check_notifications`, `send_memo` — `/api/v2/` 리라이트로 200 반환
- AC2 ✅ `/api/v2/` 시작 경로 — `!path.startsWith('/api/v2/')` 조건으로 이중 리라이트 없음
- AC3 ✅ `pnpm build` 통과

## 변경 파일

- `packages/mcp-server/src/pm-api.ts` — 6줄 추가

memo_id: 6ab67f1e-de15-492f-b395-f2e6d2b5af32