### PR TITLE
feat(eventbus): S17 — Chat E2E 사람↔에이전트 실시간 대화 검증

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -19,6 +19,26 @@ from app.routers.events import _push_to_agent, publish_event
 router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
 
 
+async def _resolve_sender(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> TeamMember:
+    """auth context → sending TeamMember 조회.
+
+    API key 경로: auth.user_id = team_member.id (직접 조회)
+    JWT 경로: auth.user_id = supabase user_id → TeamMember.user_id 매핑
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+    else:
+        stmt = select(TeamMember).where(
+            TeamMember.user_id == uuid.UUID(auth.user_id),
+            TeamMember.org_id == org_id,
+        )
+    member = (await db.execute(stmt)).scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=400, detail="Sender team member not found")
+    return member
+
+
 # ─── Chat message shape (matches ChatMessage TS interface) ─────────────────────
 
 def _to_chat_message(reply: MemoReply, sender: TeamMember) -> dict:
@@ -88,7 +108,6 @@ async def _persist_and_push_chat_events(
 
 class ChatMessageRequest(BaseModel):
     content: str
-    created_by: uuid.UUID
     attachments: list[dict] = []
 
 
@@ -161,16 +180,13 @@ async def send_chat_message(
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    sender_result = await db.execute(select(TeamMember).where(TeamMember.id == body.created_by))
-    sender = sender_result.scalar_one_or_none()
-    if sender is None:
-        raise HTTPException(status_code=400, detail="Sender not found")
+    sender = await _resolve_sender(auth, org_id, db)
 
     reply_repo = MemoReplyRepository(db)
     reply = await reply_repo.create(
         memo_id=thread_id,
         content=body.content,
-        created_by=body.created_by,
+        created_by=sender.id,
         review_type="comment",
         attachments=body.attachments,
     )
@@ -180,7 +196,7 @@ async def send_chat_message(
         participants.add(memo.assigned_to)
     if memo.created_by:
         participants.add(memo.created_by)
-    participants.discard(body.created_by)
+    participants.discard(sender.id)
 
     try:
         await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
@@ -195,7 +211,6 @@ async def send_chat_message(
 async def send_chat_message_with_file(
     thread_id: uuid.UUID,
     content: Annotated[str, Form()],
-    created_by: Annotated[uuid.UUID, Form()],
     file: Annotated[UploadFile | None, File()] = None,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
@@ -204,6 +219,7 @@ async def send_chat_message_with_file(
     """POST /api/v2/chats/{thread_id}/messages/upload — 파일 첨부 포함 채팅 메시지 전송.
 
     응답: { data: ChatMessage }
+    created_by는 auth context에서 파생 (form field 불필요).
     """
     memo_result = await db.execute(
         select(Memo).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
@@ -212,10 +228,7 @@ async def send_chat_message_with_file(
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    sender_result = await db.execute(select(TeamMember).where(TeamMember.id == created_by))
-    sender = sender_result.scalar_one_or_none()
-    if sender is None:
-        raise HTTPException(status_code=400, detail="Sender not found")
+    sender = await _resolve_sender(auth, org_id, db)
 
     attachments: list[dict] = []
     if file and file.filename:
@@ -230,7 +243,7 @@ async def send_chat_message_with_file(
     reply = await reply_repo.create(
         memo_id=thread_id,
         content=content,
-        created_by=created_by,
+        created_by=sender.id,
         review_type="comment",
         attachments=attachments,
     )
@@ -240,7 +253,7 @@ async def send_chat_message_with_file(
         participants.add(memo.assigned_to)
     if memo.created_by:
         participants.add(memo.created_by)
-    participants.discard(created_by)
+    participants.discard(sender.id)
 
     try:
         await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)

--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -1,5 +1,6 @@
-"""E-EVENTBUS P4 S15: Chat 백엔드 — 실시간 메시지 이벤트 + MCP 채팅 도구."""
+"""E-EVENTBUS P4 S15/S17: Chat 백엔드 — 실시간 메시지 이벤트 + E2E 연결."""
 import uuid
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile
@@ -13,28 +14,53 @@ from app.models.event import Event
 from app.models.memo import Memo, MemoReply
 from app.models.team import TeamMember
 from app.repositories.memo import MemoReplyRepository
-from app.routers.events import _push_to_agent
-from app.schemas.memo import ReplyResponse
+from app.routers.events import _push_to_agent, publish_event
 
 router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
 
+
+# ─── Chat message shape (matches ChatMessage TS interface) ─────────────────────
+
+def _to_chat_message(reply: MemoReply, sender: TeamMember) -> dict:
+    return {
+        "id": str(reply.id),
+        "thread_id": str(reply.memo_id),
+        "content": reply.content,
+        "sender": {
+            "id": str(sender.id),
+            "name": sender.name,
+            "type": sender.type,
+        },
+        "attachments": reply.attachments or [],
+        "created_at": reply.created_at.isoformat(),
+    }
+
+
+# ─── Internal SSE push helper ──────────────────────────────────────────────────
 
 async def _persist_and_push_chat_events(
     db: AsyncSession,
     memo: Memo,
     reply: MemoReply,
     org_id: uuid.UUID,
-    sender_id: uuid.UUID,
+    sender: TeamMember,
     participants: set[uuid.UUID],
-    payload: dict,
 ) -> None:
-    """chat:message Event를 events 테이블에 INSERT 후 SSE push (에이전트 대상)."""
+    """chat:message Event INSERT → SSE push.
+
+    에이전트: _push_to_agent (agent SSE stream)
+    사람: publish_event → /api/v2/events/memos SSE stream (Chat UI 실시간 수신)
+    """
     if not participants or not memo.project_id:
         return
-    member_types_result = await db.execute(
+
+    chat_msg = _to_chat_message(reply, sender)
+
+    member_rows = await db.execute(
         select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(participants))
     )
-    member_type_map = {row[0]: row[1] for row in member_types_result.all()}
+    member_type_map = {row[0]: row[1] for row in member_rows.all()}
+
     for participant_id in participants:
         member_type = member_type_map.get(participant_id, "human")
         event = Event(
@@ -43,17 +69,22 @@ async def _persist_and_push_chat_events(
             event_type="chat:message",
             source_entity_type="memo_reply",
             source_entity_id=reply.id,
-            sender_id=sender_id,
+            sender_id=sender.id,
             recipient_id=participant_id,
             recipient_type=member_type,
-            payload=payload,
+            payload=chat_msg,
             status="pending",
         )
         db.add(event)
         if member_type == "agent":
-            _push_to_agent(str(participant_id), payload)
+            _push_to_agent(str(participant_id), chat_msg)
+        else:
+            publish_event(str(org_id), "chat:message", chat_msg)
+
     await db.flush()
 
+
+# ─── Request schema ────────────────────────────────────────────────────────────
 
 class ChatMessageRequest(BaseModel):
     content: str
@@ -61,45 +92,79 @@ class ChatMessageRequest(BaseModel):
     attachments: list[dict] = []
 
 
-@router.get("/{thread_id}/messages", response_model=list[ReplyResponse])
+# ─── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("/{thread_id}/messages")
 async def list_chat_messages(
     thread_id: uuid.UUID,
-    limit: int = Query(default=50, le=200),
+    limit: int = Query(default=30, le=200),
+    before: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> list[ReplyResponse]:
-    """GET /api/v2/chats/{thread_id}/messages — 시간순 메시지 조회."""
+) -> dict:
+    """GET /api/v2/chats/{thread_id}/messages — 커서 기반 페이지네이션 메시지 조회.
+
+    before: ISO timestamp 커서 (이 시각보다 오래된 메시지 조회).
+    응답: { data: ChatMessage[], meta: { next_cursor, has_more } }
+    """
     memo_result = await db.execute(
         select(Memo.id).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
     )
     if memo_result.scalar_one_or_none() is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    result = await db.execute(
+    stmt = (
         select(MemoReply)
         .where(MemoReply.memo_id == thread_id)
-        .order_by(MemoReply.created_at.asc())
-        .limit(limit)
+        .order_by(MemoReply.created_at.desc())
+        .limit(limit + 1)
     )
-    replies = result.scalars().all()
-    return [ReplyResponse.model_validate(r) for r in replies]
+    if before:
+        try:
+            before_dt = datetime.fromisoformat(before)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid cursor format")
+        stmt = stmt.where(MemoReply.created_at < before_dt)
+
+    rows = (await db.execute(stmt)).scalars().all()
+
+    has_more = len(rows) > limit
+    replies = list(reversed(rows[:limit]))  # 시간 오름차순
+
+    # sender 일괄 조회
+    sender_ids = {r.created_by for r in replies}
+    members = (await db.execute(select(TeamMember).where(TeamMember.id.in_(sender_ids)))).scalars().all()
+    member_map = {m.id: m for m in members}
+
+    data = [_to_chat_message(r, member_map[r.created_by]) for r in replies if r.created_by in member_map]
+    next_cursor = replies[0].created_at.isoformat() if has_more and replies else None
+
+    return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
 
 
-@router.post("/{thread_id}/messages", response_model=ReplyResponse, status_code=201)
+@router.post("/{thread_id}/messages", status_code=201)
 async def send_chat_message(
     thread_id: uuid.UUID,
     body: ChatMessageRequest,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> ReplyResponse:
-    """POST /api/v2/chats/{thread_id}/messages — 채팅 메시지 전송 (JSON)."""
+) -> dict:
+    """POST /api/v2/chats/{thread_id}/messages — 채팅 메시지 전송 (JSON).
+
+    응답: { data: ChatMessage }
+    """
     memo_result = await db.execute(
         select(Memo).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
     )
     memo = memo_result.scalar_one_or_none()
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
+
+    sender_result = await db.execute(select(TeamMember).where(TeamMember.id == body.created_by))
+    sender = sender_result.scalar_one_or_none()
+    if sender is None:
+        raise HTTPException(status_code=400, detail="Sender not found")
 
     reply_repo = MemoReplyRepository(db)
     reply = await reply_repo.create(
@@ -110,32 +175,23 @@ async def send_chat_message(
         attachments=body.attachments,
     )
 
-    chat_participants: set[uuid.UUID] = set()
+    participants: set[uuid.UUID] = set()
     if memo.assigned_to:
-        chat_participants.add(memo.assigned_to)
+        participants.add(memo.assigned_to)
     if memo.created_by:
-        chat_participants.add(memo.created_by)
-    chat_participants.discard(body.created_by)
-    chat_payload = {
-        "event_type": "chat:message",
-        "thread_id": str(thread_id),
-        "reply_id": str(reply.id),
-        "content": reply.content,
-        "created_by": str(reply.created_by),
-        "attachments": reply.attachments,
-        "created_at": reply.created_at.isoformat(),
-    }
-    # Event INSERT + SSE push (commit 전에 flush, 오프라인 에이전트도 poll_events로 조회 가능)
+        participants.add(memo.created_by)
+    participants.discard(body.created_by)
+
     try:
-        await _persist_and_push_chat_events(db, memo, reply, org_id, body.created_by, chat_participants, chat_payload)
+        await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
         pass
 
     await db.commit()
-    return ReplyResponse.model_validate(reply)
+    return {"data": _to_chat_message(reply, sender)}
 
 
-@router.post("/{thread_id}/messages/upload", response_model=ReplyResponse, status_code=201)
+@router.post("/{thread_id}/messages/upload", status_code=201)
 async def send_chat_message_with_file(
     thread_id: uuid.UUID,
     content: Annotated[str, Form()],
@@ -144,14 +200,22 @@ async def send_chat_message_with_file(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> ReplyResponse:
-    """POST /api/v2/chats/{thread_id}/messages/upload — 파일 첨부 포함 채팅 메시지 전송 (multipart)."""
+) -> dict:
+    """POST /api/v2/chats/{thread_id}/messages/upload — 파일 첨부 포함 채팅 메시지 전송.
+
+    응답: { data: ChatMessage }
+    """
     memo_result = await db.execute(
         select(Memo).where(Memo.id == thread_id, Memo.org_id == org_id, Memo.deleted_at.is_(None))
     )
     memo = memo_result.scalar_one_or_none()
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
+
+    sender_result = await db.execute(select(TeamMember).where(TeamMember.id == created_by))
+    sender = sender_result.scalar_one_or_none()
+    if sender is None:
+        raise HTTPException(status_code=400, detail="Sender not found")
 
     attachments: list[dict] = []
     if file and file.filename:
@@ -171,25 +235,17 @@ async def send_chat_message_with_file(
         attachments=attachments,
     )
 
-    chat_participants: set[uuid.UUID] = set()
+    participants: set[uuid.UUID] = set()
     if memo.assigned_to:
-        chat_participants.add(memo.assigned_to)
+        participants.add(memo.assigned_to)
     if memo.created_by:
-        chat_participants.add(memo.created_by)
-    chat_participants.discard(created_by)
-    chat_payload = {
-        "event_type": "chat:message",
-        "thread_id": str(thread_id),
-        "reply_id": str(reply.id),
-        "content": reply.content,
-        "created_by": str(reply.created_by),
-        "attachments": reply.attachments,
-        "created_at": reply.created_at.isoformat(),
-    }
+        participants.add(memo.created_by)
+    participants.discard(created_by)
+
     try:
-        await _persist_and_push_chat_events(db, memo, reply, org_id, created_by, chat_participants, chat_payload)
+        await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
         pass
 
     await db.commit()
-    return ReplyResponse.model_validate(reply)
+    return {"data": _to_chat_message(reply, sender)}

--- a/backend/tests/test_chat_s17.py
+++ b/backend/tests/test_chat_s17.py
@@ -1,0 +1,267 @@
+"""S17 Chat E2E — backend endpoint pytest."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+THREAD_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+SUPABASE_USER_ID = uuid.uuid4()
+AGENT_MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _mock_memo() -> MagicMock:
+    m = MagicMock()
+    m.id = THREAD_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.created_by = MEMBER_ID
+    m.assigned_to = AGENT_MEMBER_ID
+    m.deleted_at = None
+    return m
+
+
+def _mock_reply(content: str = "테스트 메시지") -> MagicMock:
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.memo_id = THREAD_ID
+    r.content = content
+    r.created_by = MEMBER_ID
+    r.review_type = "comment"
+    r.attachments = []
+    r.created_at = datetime(2026, 5, 14, 1, 0, 0, tzinfo=timezone.utc)
+    return r
+
+
+def _mock_member(member_id: uuid.UUID = MEMBER_ID, member_type: str = "human") -> MagicMock:
+    m = MagicMock()
+    m.id = member_id
+    m.name = "테스트 멤버"
+    m.type = member_type
+    m.user_id = SUPABASE_USER_ID
+    m.org_id = ORG_ID
+    return m
+
+
+def _jwt_auth_ctx():
+    ctx = MagicMock()
+    ctx.user_id = str(SUPABASE_USER_ID)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}  # api_key_id 없음 → JWT 경로
+    ctx.org_id = str(ORG_ID)
+    return ctx
+
+
+def _api_key_auth_ctx():
+    ctx = MagicMock()
+    ctx.user_id = str(MEMBER_ID)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "api_key_id": "key-1"}}
+    ctx.org_id = str(ORG_ID)
+    return ctx
+
+
+async def _make_client(auth_ctx=None):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    if auth_ctx is None:
+        auth_ctx = _jwt_auth_ctx()
+
+    mock_session = AsyncMock()
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return auth_ctx
+
+    async def override_org_id():
+        return ORG_ID
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    app.dependency_overrides[get_verified_org_id] = override_org_id
+
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ─── AC1: POST /api/v2/chats/{thread_id}/messages — JWT 경로 created_by 파생 ────
+
+@pytest.mark.anyio
+async def test_send_chat_message_jwt_auth():
+    """JWT 경로: created_by를 body 없이 auth context(TeamMember.user_id)에서 파생."""
+    client, session, app = await _make_client(_jwt_auth_ctx())
+    try:
+        mock_memo = _mock_memo()
+        mock_reply = _mock_reply("안녕")
+        mock_member = _mock_member()
+
+        # session.execute: Memo 조회 → TeamMember(user_id) 조회
+        exec_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),  # Memo
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)),  # sender (JWT→user_id)
+        ]
+        session.execute = AsyncMock(side_effect=exec_results)
+
+        with patch("app.repositories.memo.MemoReplyRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.chats._persist_and_push_chat_events", new_callable=AsyncMock):
+            mock_create.return_value = mock_reply
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/chats/{THREAD_ID}/messages",
+                    json={"content": "안녕"},
+                    headers={"Authorization": "Bearer jwt-token"},
+                )
+
+        assert resp.status_code == 201
+        body = resp.json()
+        assert "data" in body
+        assert body["data"]["content"] == "안녕"
+        assert body["data"]["sender"]["id"] == str(MEMBER_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC2: POST /api/v2/chats/{thread_id}/messages — API key 경로 ────────────
+
+@pytest.mark.anyio
+async def test_send_chat_message_api_key_auth():
+    """API key 경로: created_by를 auth.user_id(=team_member.id)에서 직접 파생."""
+    client, session, app = await _make_client(_api_key_auth_ctx())
+    try:
+        mock_memo = _mock_memo()
+        mock_reply = _mock_reply()
+        mock_member = _mock_member()
+
+        exec_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),   # Memo
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)), # sender (api_key→member.id)
+        ]
+        session.execute = AsyncMock(side_effect=exec_results)
+
+        with patch("app.repositories.memo.MemoReplyRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.chats._persist_and_push_chat_events", new_callable=AsyncMock):
+            mock_create.return_value = mock_reply
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/chats/{THREAD_ID}/messages",
+                    json={"content": "에이전트 응답"},
+                    headers={"x-agent-api-key": "sk_live_test"},
+                )
+
+        assert resp.status_code == 201
+        assert "data" in resp.json()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC3: GET /api/v2/chats/{thread_id}/messages — { data, meta } 래핑 ──────
+
+@pytest.mark.anyio
+async def test_list_chat_messages_response_shape():
+    """GET 응답이 { data: [...], meta: { next_cursor, has_more } } 형태인지 검증."""
+    client, session, app = await _make_client()
+    try:
+        mock_reply = _mock_reply()
+        mock_member = _mock_member()
+
+        exec_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=THREAD_ID)),  # Memo 존재 확인
+            MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[mock_reply])))),
+            MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[mock_member])))),
+        ]
+        session.execute = AsyncMock(side_effect=exec_results)
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/chats/{THREAD_ID}/messages")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "data" in body
+        assert "meta" in body
+        assert "next_cursor" in body["meta"]
+        assert "has_more" in body["meta"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC4: POST upload — created_by form field 없이 auth에서 파생 ─────────────
+
+@pytest.mark.anyio
+async def test_send_chat_message_upload_no_created_by_field():
+    """upload endpoint: created_by form field 없이 content+file만으로 201 반환."""
+    client, session, app = await _make_client(_jwt_auth_ctx())
+    try:
+        mock_memo = _mock_memo()
+        mock_reply = _mock_reply("첨부 메시지")
+        mock_member = _mock_member()
+
+        exec_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)),
+        ]
+        session.execute = AsyncMock(side_effect=exec_results)
+
+        with patch("app.repositories.memo.MemoReplyRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.chats._persist_and_push_chat_events", new_callable=AsyncMock):
+            mock_create.return_value = mock_reply
+
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/chats/{THREAD_ID}/messages/upload",
+                    data={"content": "첨부 메시지"},  # created_by 없음
+                    headers={"Authorization": "Bearer jwt-token"},
+                )
+
+        assert resp.status_code == 201
+        assert "data" in resp.json()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC5: GET before 커서 페이지네이션 ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_chat_messages_before_cursor():
+    """GET ?before= 커서 파라미터 시 has_more + next_cursor 동작 검증."""
+    client, session, app = await _make_client()
+    try:
+        # limit=2, 응답 3개 → has_more=True
+        replies = [_mock_reply(f"msg{i}") for i in range(3)]
+        mock_member = _mock_member()
+
+        exec_results = [
+            MagicMock(scalar_one_or_none=MagicMock(return_value=THREAD_ID)),
+            MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=replies)))),
+            MagicMock(scalars=MagicMock(return_value=MagicMock(all=MagicMock(return_value=[mock_member])))),
+        ]
+        session.execute = AsyncMock(side_effect=exec_results)
+
+        async with client as c:
+            resp = await c.get(
+                f"/api/v2/chats/{THREAD_ID}/messages",
+                params={"limit": 2, "before": "2026-05-14T01:00:00"},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["meta"]["has_more"] is True
+        assert body["meta"]["next_cursor"] is not None
+    finally:
+        app.dependency_overrides.clear()

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -118,12 +118,11 @@ export function registerMemosTools(server: McpServer) {
   server.tool('send_chat_message', 'Send a chat message to a memo thread. Triggers real-time SSE delivery to all thread participants.', {
     thread_id: z.string().describe('Memo ID (= thread ID)'),
     content: z.string().describe('Message content'),
-    created_by: z.string().describe('Sender team member ID'),
-  }, async ({ thread_id, content, created_by }) => {
+  }, async ({ thread_id, content }) => {
     try {
       const data = await pmApi(`/api/v2/chats/${encodeURIComponent(thread_id)}/messages`, {
         method: 'POST',
-        body: JSON.stringify({ content, created_by, attachments: [] }),
+        body: JSON.stringify({ content, attachments: [] }),
       });
       return ok(data);
     } catch (e) { return handleError(e); }

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -1497,4 +1497,61 @@ describe('meetings tools via pmApi', () => {
     const result = await harness.invoke('get_meeting', { meeting_id: 'meeting-missing' });
     expect(result).toEqual({ error: 'Meeting not found' });
   });
+
+  // ─── S17: Chat E2E MCP tool tests ────────────────────────────────────────────
+
+  it('send_chat_message calls POST /api/v2/chats/:thread_id/messages', async () => {
+    const mockMsg = {
+      id: 'reply-1',
+      thread_id: 'thread-alpha',
+      content: '안녕하세요',
+      sender: { id: 'member-1', name: '윤재', type: 'human' },
+      attachments: [],
+      created_at: '2026-05-14T01:00:00.000000',
+    };
+    stubFetch((url, init) => {
+      expect(url).toBe('http://test-pm-api/api/v2/chats/thread-alpha/messages');
+      expect(init?.method).toBe('POST');
+      const body = JSON.parse(init?.body as string);
+      expect(body).toMatchObject({ content: '안녕하세요', created_by: 'member-1' });
+      // 백엔드: { data: ChatMessage } → pmApi extracts .data → ChatMessage
+      return new Response(JSON.stringify({ data: mockMsg }), { status: 201 });
+    });
+
+    const result = await harness.invoke('send_chat_message', {
+      thread_id: 'thread-alpha',
+      content: '안녕하세요',
+      created_by: 'member-1',
+    });
+    // pmApi extracts .data → ok(ChatMessage) → parseResult → { data: ChatMessage }
+    expect(result).toEqual({ data: mockMsg });
+  });
+
+  it('list_chat_messages calls GET /api/v2/chats/:thread_id/messages', async () => {
+    const mockMessages = [
+      {
+        id: 'reply-1',
+        thread_id: 'thread-alpha',
+        content: '안녕하세요',
+        sender: { id: 'member-1', name: '윤재', type: 'human' },
+        attachments: [],
+        created_at: '2026-05-14T01:00:00.000000',
+      },
+    ];
+    stubFetch((url) => {
+      expect(url).toContain('http://test-pm-api/api/v2/chats/thread-alpha/messages');
+      // 백엔드: { data: [...], meta: {...} } → pmApi extracts .data → [...] 배열
+      return new Response(
+        JSON.stringify({ data: mockMessages, meta: { next_cursor: null, has_more: false } }),
+        { status: 200 },
+      );
+    });
+
+    const result = await harness.invoke('list_chat_messages', {
+      thread_id: 'thread-alpha',
+      limit: 30,
+    });
+    // pmApi extracts .data (배열) → ok([...]) → parseResult → { data: [...] }
+    expect(result).toEqual({ data: mockMessages });
+  });
 });

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -1513,7 +1513,7 @@ describe('meetings tools via pmApi', () => {
       expect(url).toBe('http://test-pm-api/api/v2/chats/thread-alpha/messages');
       expect(init?.method).toBe('POST');
       const body = JSON.parse(init?.body as string);
-      expect(body).toMatchObject({ content: '안녕하세요', created_by: 'member-1' });
+      expect(body).toMatchObject({ content: '안녕하세요' });
       // 백엔드: { data: ChatMessage } → pmApi extracts .data → ChatMessage
       return new Response(JSON.stringify({ data: mockMsg }), { status: 201 });
     });
@@ -1521,7 +1521,6 @@ describe('meetings tools via pmApi', () => {
     const result = await harness.invoke('send_chat_message', {
       thread_id: 'thread-alpha',
       content: '안녕하세요',
-      created_by: 'member-1',
     });
     // pmApi extracts .data → ok(ChatMessage) → parseResult → { data: ChatMessage }
     expect(result).toEqual({ data: mockMsg });


### PR DESCRIPTION
## Summary

- **Gap 1 수정**: `_persist_and_push_chat_events`에서 human 참여자에게 `publish_event` 호출 추가 → Chat UI(`/api/v2/events/memos` SSE)가 `chat:message`를 실시간 수신
- **Gap 2 수정**: SSE 페이로드를 ChatMessage TS 인터페이스와 일치시킴 (`reply_id`→`id`, `created_by`→`sender:{id,name,type}`)
- **Gap 3/4 수정**: GET/POST 응답을 `{ data, meta }` 래핑으로 통일 (ChatView 기대 형태)
- **Gap 5 수정**: GET에 `before` 커서 기반 페이지네이션 추가 (ChatView 무한 스크롤)

## E2E Flow

```
사람 Chat UI 전송 → POST /api/v2/chats/{id}/messages
  → DB 저장 (MemoReply)
  → chat:message 이벤트 INSERT
  → 에이전트: _push_to_agent (agent SSE stream)
  → 사람(다른 탭): publish_event → /api/v2/events/memos SSE → Chat UI 실시간 표시

에이전트 send_chat_message → POST /api/v2/chats/{id}/messages
  → DB 저장
  → chat:message → publish_event → 사람 Chat UI 실시간 표시
```

## Test plan
- [ ] `send_chat_message` MCP smoke test PASS
- [ ] `list_chat_messages` MCP smoke test PASS
- [ ] MCP 빌드 PASS
- [ ] Next.js 빌드 PASS
- [ ] Chat UI: 메시지 전송 → 상대방 실시간 수신 확인
- [ ] 에이전트 send_chat_message → Chat UI 실시간 표시 확인
- [ ] 무한 스크롤 (before 커서 페이지네이션) 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)