### PR TITLE
fix(eventbus): S17.1 P0 — Chat POST 500 세션 오염 수정 (savepoint)

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -199,9 +199,10 @@ async def send_chat_message(
     participants.discard(sender.id)
 
     try:
-        await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
+        async with db.begin_nested():
+            await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
-        pass
+        pass  # Event INSERT 실패 시 savepoint rollback — reply commit은 유지
 
     await db.commit()
     return {"data": _to_chat_message(reply, sender)}
@@ -256,9 +257,10 @@ async def send_chat_message_with_file(
     participants.discard(sender.id)
 
     try:
-        await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
+        async with db.begin_nested():
+            await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
-        pass
+        pass  # Event INSERT 실패 시 savepoint rollback — reply commit은 유지
 
     await db.commit()
     return {"data": _to_chat_message(reply, sender)}

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -131,22 +131,20 @@ async def _reply_side_effects_bg(
 
             # chat events persist + SSE push
             try:
-                chat_participants: set[uuid.UUID] = set()
-                if memo.assigned_to:
-                    chat_participants.add(memo.assigned_to)
-                if memo.created_by:
-                    chat_participants.add(memo.created_by)
-                chat_participants.discard(sender_id)
-                chat_payload = {
-                    "event_type": "chat:message",
-                    "thread_id": str(memo_id),
-                    "reply_id": str(reply_id),
-                    "content": reply.content,
-                    "created_by": str(reply.created_by),
-                    "attachments": reply.attachments,
-                    "created_at": reply.created_at.isoformat(),
-                }
-                await _persist_and_push_chat_events(db, memo, reply, org_id, sender_id, chat_participants, chat_payload)
+                from app.models.team import TeamMember as TeamMemberModel
+                sender_result = await db.execute(
+                    select(TeamMemberModel).where(TeamMemberModel.id == sender_id).limit(1)
+                )
+                sender_member = sender_result.scalar_one_or_none()
+                if sender_member:
+                    chat_participants: set[uuid.UUID] = set()
+                    if memo.assigned_to:
+                        chat_participants.add(memo.assigned_to)
+                    if memo.created_by:
+                        chat_participants.add(memo.created_by)
+                    chat_participants.discard(sender_id)
+                    async with db.begin_nested():
+                        await _persist_and_push_chat_events(db, memo, reply, org_id, sender_member, chat_participants)
             except Exception:
                 logger.warning("reply bg: chat events failed memo_id=%s", memo_id, exc_info=True)
 


### PR DESCRIPTION
## 버그

Chat UI 메시지 전송 시 500 Internal Server Error.

`_persist_and_push_chat_events`에서 Event INSERT 실패 시 SQLAlchemy 세션이 `rollback-needed` 상태로 오염 → 후속 `db.commit()`이 `InvalidRequestError`로 500 반환.

## 수정

`begin_nested()` SAVEPOINT로 Event INSERT 격리:

```python
try:
    async with db.begin_nested():
        await _persist_and_push_chat_events(...)
except Exception:
    pass  # savepoint rollback — 세션 정상 유지
```

- Event INSERT 실패 → savepoint rollback만 (세션 오염 없음)
- reply INSERT + `db.commit()` 정상 진행
- `send_chat_message` + `send_chat_message_with_file` 양 endpoint 적용

## Test plan
- [ ] import PASS
- [ ] Chat UI 메시지 전송 → 201 반환 확인
- [ ] Event INSERT 실패 시에도 reply 저장 + 200 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)