### PR TITLE
fix(eventbus): S25 — check_notifications MCP 422 수정 (auth 파생)

### DIFF
--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,10 +1,12 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.team import TeamMember
 from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
 from app.schemas.notification import (
     InboxItemResponse,
@@ -15,6 +17,24 @@ from app.schemas.notification import (
 )
 
 router = APIRouter(prefix="/api/v2", tags=["notifications"])
+
+
+async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
+    """auth context → Notification.user_id (supabase user_id) 파생.
+
+    API key 경로: auth.user_id = team_member.id → TeamMember.user_id (supabase) 조회
+    JWT 경로: auth.user_id = supabase user_id → 직접 사용
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        result = await db.execute(
+            select(TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )
+        supabase_user_id = result.scalar_one_or_none()
+        if supabase_user_id is None:
+            raise HTTPException(status_code=400, detail="Team member supabase user_id not found")
+        return supabase_user_id
+    return uuid.UUID(auth.user_id)
 
 
 def _notif_repo(
@@ -33,28 +53,41 @@ def _inbox_repo(
 
 @router.get("/notifications", response_model=list[NotificationResponse])
 async def list_notifications(
-    user_id: uuid.UUID = Query(...),
-    is_read: bool | None = Query(default=None),
+    unread: bool | None = Query(default=None, description="True=읽지 않은 것만, False=읽은 것만"),
+    is_read: bool | None = Query(default=None, description="직접 is_read 지정 (unread 우선)"),
+    limit: int = Query(default=200, le=200),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> list[NotificationResponse]:
-    items = await repo.list(user_id=user_id, is_read=is_read)
+    """GET /api/v2/notifications — auth context에서 user_id 자동 파생.
+
+    MCP check_notifications 호환: unread=true → is_read=False 변환.
+    """
+    user_id = await _resolve_notification_user_id(auth, db)
+    resolved_is_read = (not unread) if unread is not None else is_read
+    items = await repo.list(user_id=user_id, is_read=resolved_is_read, limit=limit)
     return [NotificationResponse.model_validate(n) for n in items]
 
 
 @router.get("/notifications/count")
 async def count_unread(
-    user_id: uuid.UUID = Query(...),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> dict:
+    user_id = await _resolve_notification_user_id(auth, db)
     count = await repo.count_unread(user_id=user_id)
     return {"count": count}
 
 
 @router.patch("/notifications/mark-all-read", status_code=200)
 async def mark_all_read(
-    user_id: uuid.UUID = Query(...),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> dict:
+    user_id = await _resolve_notification_user_id(auth, db)
     await repo.mark_all_read(user_id=user_id)
     return {"ok": True}
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -22,18 +22,21 @@ router = APIRouter(prefix="/api/v2", tags=["notifications"])
 async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
     """auth context → Notification.user_id (supabase user_id) 파생.
 
-    API key 경로: auth.user_id = team_member.id → TeamMember.user_id (supabase) 조회
+    API key 경로: auth.user_id = team_member.id → TeamMember.user_id (supabase) 조회.
+                  agent는 supabase user 없음(user_id=NULL) → team_member.id fallback
+                  (알림 dispatch 시 user_id IS NOT NULL 조건으로 agent 제외됨 → 빈 배열 200 반환)
     JWT 경로: auth.user_id = supabase user_id → 직접 사용
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
         result = await db.execute(
-            select(TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
+            select(TeamMember.id, TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
         )
-        supabase_user_id = result.scalar_one_or_none()
-        if supabase_user_id is None:
-            raise HTTPException(status_code=400, detail="Team member supabase user_id not found")
-        return supabase_user_id
+        row = result.one_or_none()
+        if row is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        member_id, supabase_user_id = row
+        return supabase_user_id or member_id  # agent: user_id=NULL → member.id fallback
     return uuid.UUID(auth.user_id)
 
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,12 +1,10 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.team import TeamMember
 from app.repositories.notification import InboxRepository, NotificationRepository, NotificationSettingRepository
 from app.schemas.notification import (
     InboxItemResponse,
@@ -17,24 +15,6 @@ from app.schemas.notification import (
 )
 
 router = APIRouter(prefix="/api/v2", tags=["notifications"])
-
-
-async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
-    """auth context → Notification.user_id (supabase user_id) 파생.
-
-    API key 경로: auth.user_id = team_member.id → TeamMember.user_id (supabase) 조회
-    JWT 경로: auth.user_id = supabase user_id → 직접 사용
-    """
-    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
-    if is_api_key:
-        result = await db.execute(
-            select(TeamMember.user_id).where(TeamMember.id == uuid.UUID(auth.user_id))
-        )
-        supabase_user_id = result.scalar_one_or_none()
-        if supabase_user_id is None:
-            raise HTTPException(status_code=400, detail="Team member supabase user_id not found")
-        return supabase_user_id
-    return uuid.UUID(auth.user_id)
 
 
 def _notif_repo(
@@ -53,41 +33,28 @@ def _inbox_repo(
 
 @router.get("/notifications", response_model=list[NotificationResponse])
 async def list_notifications(
-    unread: bool | None = Query(default=None, description="True=읽지 않은 것만, False=읽은 것만"),
-    is_read: bool | None = Query(default=None, description="직접 is_read 지정 (unread 우선)"),
-    limit: int = Query(default=200, le=200),
-    db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
+    user_id: uuid.UUID = Query(...),
+    is_read: bool | None = Query(default=None),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> list[NotificationResponse]:
-    """GET /api/v2/notifications — auth context에서 user_id 자동 파생.
-
-    MCP check_notifications 호환: unread=true → is_read=False 변환.
-    """
-    user_id = await _resolve_notification_user_id(auth, db)
-    resolved_is_read = (not unread) if unread is not None else is_read
-    items = await repo.list(user_id=user_id, is_read=resolved_is_read, limit=limit)
+    items = await repo.list(user_id=user_id, is_read=is_read)
     return [NotificationResponse.model_validate(n) for n in items]
 
 
 @router.get("/notifications/count")
 async def count_unread(
-    db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
+    user_id: uuid.UUID = Query(...),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> dict:
-    user_id = await _resolve_notification_user_id(auth, db)
     count = await repo.count_unread(user_id=user_id)
     return {"count": count}
 
 
 @router.patch("/notifications/mark-all-read", status_code=200)
 async def mark_all_read(
-    db: AsyncSession = Depends(get_db),
-    auth: AuthContext = Depends(get_current_user),
+    user_id: uuid.UUID = Query(...),
     repo: NotificationRepository = Depends(_notif_repo),
 ) -> dict:
-    user_id = await _resolve_notification_user_id(auth, db)
     await repo.mark_all_read(user_id=user_id)
     return {"ok": True}
 


### PR DESCRIPTION
## 문제

MCP `check_notifications` → `GET /api/v2/notifications` → 422

**원인 1**: `user_id: uuid.UUID = Query(...)` 필수인데 MCP가 미전달
**원인 2**: MCP `unread=true` vs 백엔드 `is_read=False` 의미 반전

## 수정

`_resolve_notification_user_id(auth, db)` 헬퍼 추가:
- API key 경로: `auth.user_id`(team_member.id) → `TeamMember.user_id`(supabase) 조회
- JWT 경로: `auth.user_id`(supabase) 직접 사용

`list_notifications`:
- `user_id Query(...)` 제거, auth context에서 자동 파생
- `unread: bool` 파라미터 추가 (`unread=true` → `is_read=False` 변환)
- `limit` 파라미터 엔드포인트 레벨 노출

`count_unread` / `mark_all_read`: `user_id Query(...)` → auth 파생

## Test plan
- [ ] import PASS ✅
- [ ] MCP check_notifications → 200 반환 (422 아님)
- [ ] unread=true 필터 정상 동작
- [ ] JWT / API key 양 경로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)