### PR TITLE
feat(eventbus): S29 — SSE 에이전트 아키텍처 갭 2종 해소

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -17,7 +17,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import delete, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
@@ -310,14 +310,24 @@ async def create_event(
 async def get_pending_events(
     recipient_id: uuid.UUID = Query(...),
     event_type: str | None = Query(default=None),
+    include_recent_delivered_minutes: int = Query(default=30, le=120),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[EventResponse]:
-    """GET /api/v2/events/pending?recipient_id={id}&event_type={type} — 수신자별 pending 이벤트 목록."""
+    """GET /api/v2/events/pending — 수신자별 pending + 최근 N분 delivered 이벤트 목록.
+
+    include_recent_delivered_minutes: SSE로 delivered 마킹된 이벤트도 최근 N분 이내라면 반환.
+    → SSE 전달과 poll_events 폴링 간 충돌(갭 2) 해소.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=include_recent_delivered_minutes)
+    status_filter = or_(
+        Event.status == "pending",
+        and_(Event.status == "delivered", Event.delivered_at >= cutoff),
+    )
     filters = [
         Event.org_id == org_id,
         Event.recipient_id == recipient_id,
-        Event.status == "pending",
+        status_filter,
     ]
     if event_type:
         filters.append(Event.event_type == event_type)

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -112,7 +112,18 @@ async function main() {
 
     // FastAPI SSE 자동 연결 — MEMBER_ID 있을 때만
     if (MEMBER_ID) {
-      startSseBridge(PM_API_URL, AGENT_API_KEY, MEMBER_ID, SSE_BACKEND_URL || undefined);
+      startSseBridge(PM_API_URL, AGENT_API_KEY, MEMBER_ID, SSE_BACKEND_URL || undefined,
+        // 갭 1 해소: SSE 이벤트 수신 → MCP notifications/message로 Claude Code에 전달
+        (eventType, data) => {
+          server.server.notification({
+            method: 'notifications/message',
+            params: {
+              level: 'info',
+              data: JSON.stringify({ eventType, data }),
+            },
+          }).catch(() => { /* 클라이언트 미지원 시 무시 */ });
+        },
+      );
     }
   }
 }

--- a/packages/mcp-server/src/sse-bridge.ts
+++ b/packages/mcp-server/src/sse-bridge.ts
@@ -1,11 +1,14 @@
 /**
  * SSE Bridge — MCP stdio 서버가 FastAPI /api/v2/events/stream 에 자동 연결.
- * 이벤트 수신 시 stderr 출력, 연결 끊김 시 exponential backoff 재연결.
+ * 이벤트 수신 시 onEvent 콜백 호출 + stderr 출력.
+ * 연결 끊김 시 exponential backoff 재연결.
  */
 
 const BASE_DELAY_MS = 5_000;
 const MAX_DELAY_MS = 60_000;
 const JITTER_MS = 500;
+
+export type SseBridgeEventHandler = (eventType: string, data: unknown) => void;
 
 function log(msg: string) {
   process.stderr.write(`[sse-bridge] ${msg}\n`);
@@ -15,7 +18,11 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function connectOnce(url: string, headers: Record<string, string>): Promise<void> {
+async function connectOnce(
+  url: string,
+  headers: Record<string, string>,
+  onEvent?: SseBridgeEventHandler,
+): Promise<void> {
   const response = await fetch(url, {
     headers: { ...headers, Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
   });
@@ -44,7 +51,6 @@ async function connectOnce(url: string, headers: Record<string, string>): Promis
       }
       const text = decoder.decode(value, { stream: true });
       const lines = (remainder + text).split('\n');
-      // 마지막 줄이 불완전할 수 있으므로 버퍼에 보관
       remainder = lines.pop() ?? '';
       for (const rawLine of lines) {
         const line = rawLine.trimEnd();
@@ -57,6 +63,14 @@ async function connectOnce(url: string, headers: Record<string, string>): Promis
             const dataStr = dataLines.join('\n');
             if (eventType !== 'heartbeat') {
               log(`event=${eventType} data=${dataStr}`);
+              if (onEvent) {
+                try {
+                  const parsed = JSON.parse(dataStr);
+                  onEvent(eventType, parsed);
+                } catch {
+                  onEvent(eventType, dataStr);
+                }
+              }
             }
             eventType = 'message';
             dataLines = [];
@@ -74,6 +88,7 @@ export function startSseBridge(
   agentApiKey: string,
   memberId: string,
   sseBackendUrl?: string,
+  onEvent?: SseBridgeEventHandler,
 ): void {
   const baseUrl = (sseBackendUrl ?? pmApiUrl).replace(/\/$/, '');
   const url = `${baseUrl}/api/v2/events/stream?member_id=${memberId}`;
@@ -86,8 +101,8 @@ export function startSseBridge(
     let attempt = 0;
     while (true) {
       try {
-        await connectOnce(url, authHeaders);
-        attempt = 0; // 정상 종료(서버 측 닫힘) 시 backoff 리셋
+        await connectOnce(url, authHeaders, onEvent);
+        attempt = 0;
       } catch (err) {
         log(`error: ${err instanceof Error ? err.message : String(err)}`);
       }


### PR DESCRIPTION
## 갭 2: poll_events ↔ SSE delivered 충돌 해소

`agent_event_stream`이 SSE 전달 시 `status=delivered` 마킹 → `poll_events`(`status=pending` 전용)에서 조회 불가 문제.

**수정**: `GET /api/v2/events/pending`에 `include_recent_delivered_minutes` 파라미터 추가
```
status = pending
OR (status = delivered AND delivered_at >= now - 30m)
```
→ SSE 전달 직후 poll_events 호출 시에도 이벤트 조회 가능

## 갭 1: SSE 브릿지 → 에이전트 전달 경로 확보

`sse-bridge.ts`가 이벤트 수신 시 `log()`(stderr)만 호출 → Claude Code 미전달.

**수정**:
- `sse-bridge.ts`: `onEvent?: SseBridgeEventHandler` 콜백 파라미터 추가
- heartbeat 제외 모든 이벤트 수신 시 JSON 파싱 후 콜백 호출
- `index.ts`: `server.server.notification({ method: 'notifications/message', ... })`으로 Claude Code 클라이언트에 실시간 전달 (미지원 시 catch 무시)

## Test plan
- [ ] MCP tsc 빌드 PASS ✅
- [ ] events.py import PASS ✅
- [ ] poll_events 호출 시 최근 30분 delivered 이벤트 포함 확인
- [ ] SSE 이벤트 수신 시 stderr에 로그 + MCP notification 전송 확인
- [ ] 동시 연결 5명 이벤트 소실 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)