### PR TITLE
fix(eventbus): S30 — Event INSERT 실패 진단 로깅 추가

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -1,4 +1,5 @@
-"""E-EVENTBUS P4 S15/S17: Chat 백엔드 — 실시간 메시지 이벤트 + E2E 연결."""
+"""E-EVENTBUS P4 S15/S17/S30: Chat 백엔드 — 실시간 메시지 이벤트 + E2E 연결."""
+import logging
 import uuid
 from datetime import datetime
 from typing import Annotated
@@ -15,6 +16,8 @@ from app.models.memo import Memo, MemoReply
 from app.models.team import TeamMember
 from app.repositories.memo import MemoReplyRepository
 from app.routers.events import _push_to_agent, publish_event
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
 
@@ -71,7 +74,11 @@ async def _persist_and_push_chat_events(
     에이전트: _push_to_agent (agent SSE stream)
     사람: publish_event → /api/v2/events/memos SSE stream (Chat UI 실시간 수신)
     """
-    if not participants or not memo.project_id:
+    if not memo.project_id:
+        logger.warning("chat event skipped: memo.project_id is None memo_id=%s", reply.memo_id)
+        return
+    if not participants:
+        logger.warning("chat event skipped: participants empty memo_id=%s sender_id=%s", reply.memo_id, sender.id)
         return
 
     chat_msg = _to_chat_message(reply, sender)
@@ -202,7 +209,7 @@ async def send_chat_message(
         async with db.begin_nested():
             await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
-        pass  # Event INSERT 실패 시 savepoint rollback — reply commit은 유지
+        logger.exception("chat event insert failed thread_id=%s reply_id=%s", thread_id, reply.id)
 
     await db.commit()
     return {"data": _to_chat_message(reply, sender)}
@@ -260,7 +267,7 @@ async def send_chat_message_with_file(
         async with db.begin_nested():
             await _persist_and_push_chat_events(db, memo, reply, org_id, sender, participants)
     except Exception:
-        pass  # Event INSERT 실패 시 savepoint rollback — reply commit은 유지
+        logger.exception("chat event insert failed (upload) thread_id=%s reply_id=%s", thread_id, reply.id)
 
     await db.commit()
     return {"data": _to_chat_message(reply, sender)}


### PR DESCRIPTION
## 문제

Chat POST 201이지만 events 테이블 INSERT 없음. `poll_events(recipient=오르테가) → []`.

savepoint except 블록이 에러를 `pass`로 소멸시켜 실제 원인 불명.

## 수정 (1단계: 진단)

- `logging` 모듈 + `logger` 추가
- `_persist_and_push_chat_events` early return 조건별 `logger.warning`
  - `memo.project_id = None` → 명시 경고
  - `participants` 비어있음 → `sender_id` 포함 경고
- savepoint `except` 블록: `pass` → `logger.exception` (스택 트레이스 포함)
  - `send_chat_message` + `send_chat_message_with_file` 양 endpoint

## 다음 단계

dev 배포 후 Cloud Run 로그에서 실제 에러 확인 → 2차 커밋으로 근본 원인 수정.

의심 원인:
1. `participants` 비어있음 (`memo.assigned_to=None`, `memo.created_by=sender`)
2. DB FK violation (project_id/recipient_id)
3. flush 타이밍 이슈

## Test plan
- [ ] import PASS ✅
- [ ] dev 배포 후 로그에서 `chat event insert failed` 또는 early return 경고 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)