### PR TITLE
fix(eventbus): S30 2차 — participants empty 근본 수정 (_build_participants)

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -59,6 +59,39 @@ def _to_chat_message(reply: MemoReply, sender: TeamMember) -> dict:
     }
 
 
+# ─── Participants helper ───────────────────────────────────────────────────────
+
+async def _build_participants(
+    db: AsyncSession,
+    memo: Memo,
+    thread_id: uuid.UUID,
+    sender_id: uuid.UUID,
+) -> set[uuid.UUID]:
+    """chat:message 이벤트 수신자 세트 구성.
+
+    assigned_to + created_by + 기존 thread reply senders 포함, 발신자 제거.
+    assigned_to=null + sender==created_by 케이스에서 participants가 비는 문제 해소.
+    """
+    participants: set[uuid.UUID] = set()
+    if memo.assigned_to:
+        participants.add(memo.assigned_to)
+    if memo.created_by:
+        participants.add(memo.created_by)
+
+    # 기존 thread 참여자 포함 (이전 reply sender)
+    prior_result = await db.execute(
+        select(MemoReply.created_by)
+        .where(MemoReply.memo_id == thread_id, MemoReply.created_by.isnot(None))
+        .distinct()
+    )
+    for row in prior_result.all():
+        if row[0]:
+            participants.add(row[0])
+
+    participants.discard(sender_id)
+    return participants
+
+
 # ─── Internal SSE push helper ──────────────────────────────────────────────────
 
 async def _persist_and_push_chat_events(
@@ -198,12 +231,7 @@ async def send_chat_message(
         attachments=body.attachments,
     )
 
-    participants: set[uuid.UUID] = set()
-    if memo.assigned_to:
-        participants.add(memo.assigned_to)
-    if memo.created_by:
-        participants.add(memo.created_by)
-    participants.discard(sender.id)
+    participants = await _build_participants(db, memo, thread_id, sender.id)
 
     try:
         async with db.begin_nested():
@@ -256,12 +284,7 @@ async def send_chat_message_with_file(
         attachments=attachments,
     )
 
-    participants: set[uuid.UUID] = set()
-    if memo.assigned_to:
-        participants.add(memo.assigned_to)
-    if memo.created_by:
-        participants.add(memo.created_by)
-    participants.discard(sender.id)
+    participants = await _build_participants(db, memo, thread_id, sender.id)
 
     try:
         async with db.begin_nested():


### PR DESCRIPTION
## Root Cause

`assigned_to=null` + `sender==created_by` 케이스에서 participants가 빈 set → Event INSERT 스킵.

```
participants = {created_by(sellerking)} - {sender(sellerking)} = {}
→ "if not participants: return" → Event 없음
```

## 수정

`_build_participants(db, memo, thread_id, sender_id)` 헬퍼 추가:
- `memo.assigned_to` + `memo.created_by` 기존 멤버
- **기존 thread reply senders** (`MemoReply.created_by DISTINCT`) 추가
- `sender_id` 제거

→ 오르테가가 thread에 이전 reply 기록이 있으면 participants에 포함 → Event INSERT 정상

`send_chat_message` + `send_chat_message_with_file` 양 endpoint 적용.

## 전 PR

PR #689: 1차 진단 로깅 (already merged)

## Test plan
- [ ] import PASS ✅
- [ ] sellerking이 자신의 메모에 Chat POST → 오르테가 reply 있으면 Event INSERT 성공
- [ ] poll_events(recipient=오르테가) → chat:message 반환

🤖 Generated with [Claude Code](https://claude.com/claude-code)