### PR TITLE
fix(eventbus): S31 — Chat POST 500 MultipleResultsFound 수정

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -36,7 +36,8 @@ async def _resolve_sender(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession
             TeamMember.user_id == uuid.UUID(auth.user_id),
             TeamMember.org_id == org_id,
         )
-    member = (await db.execute(stmt)).scalar_one_or_none()
+    # scalar_one_or_none → MultipleResultsFound (동일 org 내 복수 project에 team_member 중복 등록 케이스)
+    member = (await db.execute(stmt)).scalars().first()
     if member is None:
         raise HTTPException(status_code=400, detail="Sender team member not found")
     return member


### PR DESCRIPTION
## Root Cause (Cloud Run 로그 확인)

```
chats.py:39 _resolve_sender
sqlalchemy.exc.MultipleResultsFound: Multiple rows were found when one or none was required
```

동일 org 내 복수 project에 team_member로 등록된 사용자(송윤재)의 JWT 세션에서  
`TeamMember.user_id == auth.user_id AND org_id == org_id` 조건으로 복수 레코드 반환  
→ `scalar_one_or_none()` → `MultipleResultsFound` → 500

## 수정

`scalar_one_or_none()` → `scalars().first()`  
복수 레코드가 있어도 첫 번째를 사용 — sellerking 등 단일 레코드 케이스는 동일 동작.

## Test plan
- [ ] import PASS ✅
- [ ] 송윤재 세션 Chat POST → 201 (500 아님)
- [ ] sellerking 세션 regression 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)