### PR TITLE
[SID:cbae10b7] S24 메모/채팅 UX 버그 5건 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -22,21 +22,24 @@ export default function MemoDetailPage() {
 
   const [memo, setMemo] = useState<MemoSummary | null>(null);
 
-  const fetchMemoTitle = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/memos/${id}`);
-      if (!res.ok) return;
-      const { data } = await res.json();
-      setMemo({ id: data.id, title: data.title });
-      await fetch(`/api/memos/${id}/read`, { method: 'PATCH' }).catch(() => null);
-    } catch {
-      // non-critical — ChatView will still render
-    }
-  }, [id]);
-
   useEffect(() => {
-    void fetchMemoTitle();
-  }, [fetchMemoTitle]);
+    let cancelled = false;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/memos/${id}`);
+        if (!res.ok || cancelled) return;
+        const { data } = await res.json() as { data: { id: string; title: string | null } };
+        if (!cancelled) {
+          setMemo({ id: data.id, title: data.title });
+          fetch(`/api/memos/${id}/read`, { method: 'PATCH' }).catch(() => null);
+        }
+      } catch {
+        // non-critical — ChatView will still render
+      }
+    };
+    load();
+    return () => { cancelled = true; };
+  }, [id]);
 
   if (!currentTeamMemberId) {
     return (

--- a/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
@@ -1,88 +1,50 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useAutoRefresh } from '@/hooks/use-auto-refresh';
 import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useTranslations } from 'next-intl';
-import { MemoThread } from '@/components/memos/memo-thread';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { ChatView } from '@/components/chat/chat-view';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
-import type { MemoDetailState } from '@/components/memos/memo-state';
 
-interface Member {
+interface MemoSummary {
   id: string;
-  name: string;
-  type: string;
+  title: string | null;
 }
 
 export default function MemoDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const t = useTranslations('memos');
-  const { currentTeamMemberId, projectId } = useDashboardContext();
+  const { currentTeamMemberId } = useDashboardContext();
 
-  const [memo, setMemo] = useState<MemoDetailState | null>(null);
-  const [members, setMembers] = useState<Member[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [memo, setMemo] = useState<MemoSummary | null>(null);
 
-  const memberMap = Object.fromEntries(members.map((m) => [m.id, { name: m.name, type: m.type }]));
-
-  const fetchMemo = useCallback(async () => {
+  const fetchMemoTitle = useCallback(async () => {
     try {
       const res = await fetch(`/api/memos/${id}`);
-      if (!res.ok) throw new Error('Failed to fetch memo');
+      if (!res.ok) return;
       const { data } = await res.json();
-      setMemo(data);
+      setMemo({ id: data.id, title: data.title });
       await fetch(`/api/memos/${id}/read`, { method: 'PATCH' }).catch(() => null);
     } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
+      // non-critical — ChatView will still render
     }
   }, [id]);
 
-  const fetchMembers = useCallback(async () => {
-    if (!projectId) return;
-    try {
-      const res = await fetch(`/api/team-members?project_id=${projectId}&is_active=true`);
-      if (!res.ok) return;
-      const { data } = await res.json();
-      setMembers(data ?? []);
-    } catch {
-      // non-critical
-    }
-  }, [projectId]);
-
   useEffect(() => {
-    void Promise.all([fetchMemo(), fetchMembers()]);
-  }, [fetchMemo, fetchMembers]);
+    void fetchMemoTitle();
+  }, [fetchMemoTitle]);
 
-  useAutoRefresh('memo-detail', () => void fetchMemo());
-
-  const handleReply = useCallback(async (content: string, mentionedIds?: string[]) => {
-    if (!memo) return;
-    const res = await fetch(`/api/memos/${memo.id}/replies`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content, ...(mentionedIds && mentionedIds.length > 0 ? { assigned_to_ids: mentionedIds } : {}) }),
-    });
-    if (!res.ok) throw new Error('Failed to submit reply');
-    const { data: reply } = await res.json();
-    setMemo((prev) => prev ? { ...prev, replies: [...(prev.replies ?? []), reply] } : null);
-  }, [memo]);
-
-  const handleResolve = useCallback(async () => {
-    if (!memo) return;
-    const res = await fetch(`/api/memos/${memo.id}/resolve`, { method: 'PATCH' });
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({}));
-      throw new Error(body?.error?.message ?? 'Failed to resolve memo');
-    }
-    setMemo((prev) => prev ? { ...prev, status: 'resolved' } : null);
-  }, [memo]);
+  if (!currentTeamMemberId) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-sm text-muted-foreground">{t('noTeamMember')}</p>
+      </div>
+    );
+  }
 
   return (
     <>
@@ -97,7 +59,7 @@ export default function MemoDetailPage() {
               <ChevronLeft className="h-4 w-4" />
               {t('title')}
             </button>
-            <span className="hidden text-sm font-medium lg:block">
+            <span className="hidden truncate text-sm font-medium lg:block">
               {memo?.title ?? t('title')}
             </span>
           </div>
@@ -109,26 +71,12 @@ export default function MemoDetailPage() {
           </Button>
         }
       />
-      <div className="flex min-h-0 flex-1 flex-col bg-background">
-        {loading && (
-          <div className="flex h-64 items-center justify-center">
-            <p className="text-sm text-muted-foreground">{t('loading')}</p>
-          </div>
-        )}
-        {!loading && error && (
-          <div className="flex h-64 items-center justify-center">
-            <p className="text-sm text-destructive">{t('loadError')}</p>
-          </div>
-        )}
-        {!loading && memo && currentTeamMemberId && (
-          <MemoThread
-            memo={memo}
-            currentUserId={currentTeamMemberId}
-            onReply={handleReply}
-            onResolve={handleResolve}
-            memberMap={memberMap}
-          />
-        )}
+      <div className="flex min-h-0 flex-1 flex-col bg-background overflow-hidden">
+        <ChatView
+          threadId={id}
+          currentTeamMemberId={currentTeamMemberId}
+          threadTitle={memo?.title ?? undefined}
+        />
       </div>
     </>
   );

--- a/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
@@ -73,6 +73,7 @@ export default function MemoDetailPage() {
       />
       <div className="flex min-h-0 flex-1 flex-col bg-background overflow-hidden">
         <ChatView
+          key={id}
           threadId={id}
           currentTeamMemberId={currentTeamMemberId}
           threadTitle={memo?.title ?? undefined}

--- a/apps/web/src/app/(authenticated)/memos/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/new/page.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { MemoCreateForm } from '@/components/memos/memo-create-form';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
+import { useRefreshContext } from '@/contexts/refresh-context';
 
 interface Member {
   id: string;
@@ -16,6 +17,7 @@ export default function NewMemoPage() {
   const router = useRouter();
   const t = useTranslations('memos');
   const { projectId } = useDashboardContext();
+  const { forceRefresh } = useRefreshContext();
   const [members, setMembers] = useState<Member[]>([]);
 
   useEffect(() => {
@@ -41,12 +43,13 @@ export default function NewMemoPage() {
       });
       if (!res.ok) return false;
       const { data: newMemo } = await res.json();
+      forceRefresh('memo-list');
       router.push(`/memos/${newMemo.id}`);
       return true;
     } catch {
       return false;
     }
-  }, [projectId, router]);
+  }, [projectId, router, forceRefresh]);
 
   const handleCancel = useCallback(() => {
     router.push('/memos');

--- a/apps/web/src/app/api/chats/[thread_id]/messages/route.ts
+++ b/apps/web/src/app/api/chats/[thread_id]/messages/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ thread_id: string }> },
+): Promise<Response> {
+  const { thread_id } = await params;
+  return proxyToFastapi(request, `/api/v2/chats/${thread_id}/messages`);
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ thread_id: string }> },
+): Promise<Response> {
+  const { thread_id } = await params;
+  return proxyToFastapi(request, `/api/v2/chats/${thread_id}/messages`);
+}

--- a/apps/web/src/app/api/chats/[thread_id]/messages/upload/route.ts
+++ b/apps/web/src/app/api/chats/[thread_id]/messages/upload/route.ts
@@ -1,0 +1,28 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ thread_id: string }> },
+): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  const { thread_id } = await params;
+  const formData = await request.formData();
+
+  const res = await fetch(`${FASTAPI_URL()}/api/v2/chats/${thread_id}/messages/upload`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    body: formData,
+  });
+
+  const body = await res.text();
+  return new NextResponse(body, {
+    status: res.status,
+    headers: { 'Content-Type': res.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Bot, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 
 interface ChatBubbleProps {
@@ -9,32 +8,21 @@ interface ChatBubbleProps {
 }
 
 export function ChatBubble({ message, isMine }: ChatBubbleProps) {
-  const isAgent = message.sender.type === 'agent';
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
 
   return (
     <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
       {/* Avatar */}
-      <div className={`flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
-        isAgent
-          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+      <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+        isMine
+          ? 'bg-primary/20 text-primary'
           : 'bg-muted text-muted-foreground'
       }`}>
-        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+        {isMine ? '나' : '팀'}
       </div>
 
       {/* Bubble + meta */}
       <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
-        {/* Sender name */}
-        <div className="flex items-center gap-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">{message.sender.name}</span>
-          {isAgent && (
-            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-              AI
-            </span>
-          )}
-        </div>
-
         {/* Content */}
         <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
           isMine
@@ -47,22 +35,27 @@ export function ChatBubble({ message, isMine }: ChatBubbleProps) {
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (
           <div className="flex flex-col gap-1.5">
-            {message.attachments.map((att) => (
-              <a
-                key={att.url}
-                href={att.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
-              >
-                {att.content_type.startsWith('image/') ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img src={att.url} alt={att.name} className="max-h-40 max-w-[240px] rounded object-contain" />
-                ) : (
-                  <span className="truncate text-muted-foreground">{att.name}</span>
-                )}
-              </a>
-            ))}
+            {message.attachments.map((att, i) => {
+              const href = att.url;
+              const label = att.name ?? att.filename ?? '첨부파일';
+              const isImage = att.content_type?.startsWith('image/');
+              return (
+                <a
+                  key={href ?? i}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
+                >
+                  {isImage && href ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img src={href} alt={label} className="max-h-40 max-w-[240px] rounded object-contain" />
+                  ) : (
+                    <span className="truncate text-muted-foreground">{label}</span>
+                  )}
+                </a>
+              );
+            })}
           </div>
         )}
 

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { Bot, User } from 'lucide-react';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+
+interface ChatBubbleProps {
+  message: ChatMessage;
+  isMine: boolean;
+}
+
+export function ChatBubble({ message, isMine }: ChatBubbleProps) {
+  const isAgent = message.sender.type === 'agent';
+  const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
+
+  return (
+    <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
+      {/* Avatar */}
+      <div className={`flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
+        isAgent
+          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+          : 'bg-muted text-muted-foreground'
+      }`}>
+        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+      </div>
+
+      {/* Bubble + meta */}
+      <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
+        {/* Sender name */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">{message.sender.name}</span>
+          {isAgent && (
+            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+              AI
+            </span>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
+          isMine
+            ? 'rounded-tr-sm bg-primary text-primary-foreground'
+            : 'rounded-tl-sm bg-muted text-foreground'
+        }`}>
+          {message.content}
+        </div>
+
+        {/* Attachments */}
+        {message.attachments && message.attachments.length > 0 && (
+          <div className="flex flex-col gap-1.5">
+            {message.attachments.map((att) => (
+              <a
+                key={att.url}
+                href={att.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
+              >
+                {att.content_type.startsWith('image/') ? (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img src={att.url} alt={att.name} className="max-h-40 max-w-[240px] rounded object-contain" />
+                ) : (
+                  <span className="truncate text-muted-foreground">{att.name}</span>
+                )}
+              </a>
+            ))}
+          </div>
+        )}
+
+        <time className="text-[10px] text-muted-foreground/70">{time}</time>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useRef, useState, type KeyboardEvent } from 'react';
+import { Paperclip, Send, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+interface ChatInputProps {
+  onSend: (content: string) => Promise<void>;
+  onUpload: (file: File) => Promise<void>;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInputProps) {
+  const [text, setText] = useState('');
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [sending, setSending] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const adjustHeight = () => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  };
+
+  const handleSend = async () => {
+    const trimmed = text.trim();
+    if ((!trimmed && !pendingFile) || sending || disabled) return;
+
+    setSending(true);
+    try {
+      if (pendingFile) {
+        await onUpload(pendingFile);
+        setPendingFile(null);
+      }
+      if (trimmed) {
+        await onSend(trimmed);
+        setText('');
+        if (textareaRef.current) textareaRef.current.style.height = 'auto';
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) setPendingFile(file);
+    e.target.value = '';
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    const file = e.dataTransfer.files[0];
+    if (file) setPendingFile(file);
+  };
+
+  const canSend = (text.trim().length > 0 || pendingFile !== null) && !sending && !disabled;
+
+  return (
+    <div
+      className="border-t border-border/80 bg-background px-3 py-2"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+    >
+      {/* Pending file preview */}
+      {pendingFile && (
+        <div className="mb-2 flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-1.5">
+          <Paperclip className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+          <span className="flex-1 truncate text-xs text-foreground">{pendingFile.name}</span>
+          <button
+            type="button"
+            onClick={() => setPendingFile(null)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      )}
+
+      <div className="flex items-end gap-2">
+        {/* Attach */}
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          className="flex-shrink-0 rounded-md p-1.5 text-muted-foreground hover:bg-muted/60 hover:text-foreground disabled:opacity-40"
+        >
+          <Paperclip className="h-4 w-4" />
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="hidden"
+          onChange={handleFileChange}
+          accept="image/*,.pdf,.txt,.md,.csv"
+        />
+
+        {/* Textarea */}
+        <textarea
+          ref={textareaRef}
+          rows={1}
+          value={text}
+          onChange={(e) => { setText(e.target.value); adjustHeight(); }}
+          onKeyDown={handleKeyDown}
+          disabled={disabled || sending}
+          placeholder={placeholder ?? '메시지를 입력하세요…'}
+          className="flex-1 resize-none rounded-xl border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-40"
+          style={{ minHeight: '36px', maxHeight: '160px' }}
+        />
+
+        {/* Send */}
+        <Button
+          size="icon"
+          className="h-9 w-9 flex-shrink-0 rounded-xl"
+          onClick={() => void handleSend()}
+          disabled={!canSend}
+        >
+          <Send className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -33,12 +33,11 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
 
 export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatViewProps) {
   const router = useRouter();
-  // key={threadId} on parent ensures fresh mount per thread — no reset useEffect needed
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -50,18 +49,18 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
 
   const fetchMessages = useCallback(async (before?: string) => {
     try {
-      const params = new URLSearchParams({ limit: '30' });
+      const params = new URLSearchParams({ limit: '50' });
       if (before) params.set('before', before);
       const res = await fetch(`/api/chats/${threadId}/messages?${params.toString()}`);
       if (!res.ok) return;
-      const { data, meta } = await res.json() as {
-        data: ChatMessage[];
-        meta: { next_cursor?: string; has_more?: boolean };
-      };
+      // Backend returns list[ReplyResponse] directly (no { data, meta } wrapper)
+      const raw = await res.json() as ChatMessage[] | { data?: ChatMessage[]; meta?: { next_cursor?: string; has_more?: boolean } };
+      const data = Array.isArray(raw) ? raw : (raw.data ?? []);
+      const meta = Array.isArray(raw) ? null : raw.meta;
       if (before) {
-        setMessages((prev) => [...(data ?? []), ...prev]);
+        setMessages((prev) => [...data, ...prev]);
       } else {
-        setMessages(data ?? []);
+        setMessages(data);
       }
       setCursor(meta?.next_cursor ?? null);
       setHasMore(meta?.has_more ?? false);
@@ -71,9 +70,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [threadId]);
 
-  // Initial load — key={threadId} guarantees fresh component, so no reset needed
   useEffect(() => {
-    void fetchMessages();
+    fetchMessages();
   }, [fetchMessages]);
 
   useEffect(() => {
@@ -83,16 +81,26 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [loading, scrollToBottom]);
 
-  const handleNewMessage = useCallback((msg: ChatMessage) => {
-    if (msg.thread_id !== threadId) return;
+  const addMessage = useCallback((msg: ChatMessage) => {
     setMessages((prev) => {
       if (prev.some((m) => m.id === msg.id)) return prev;
       return [...prev, msg];
     });
     setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+  }, [scrollToBottom]);
 
-  useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage });
+  const handleNewMessage = useCallback((msg: ChatMessage) => {
+    if (msg.memo_id !== threadId) return;
+    addMessage(msg);
+  }, [threadId, addMessage]);
+
+  const handleReplyCreated = useCallback((memoId: string) => {
+    if (memoId !== threadId) return;
+    // reply_created SSE: refetch to pick up messages not delivered via chat:message
+    fetchMessages();
+  }, [threadId, fetchMessages]);
+
+  useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage, onReplyCreated: handleReplyCreated });
 
   const handleSend = useCallback(async (content: string) => {
     const res = await fetch(`/api/chats/${threadId}/messages`, {
@@ -101,13 +109,11 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: JSON.stringify({ content }),
     });
     if (!res.ok) throw new Error('Failed to send message');
-    const { data } = await res.json() as { data: ChatMessage };
-    setMessages((prev) => {
-      if (prev.some((m) => m.id === data.id)) return prev;
-      return [...prev, data];
-    });
-    setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+    // Backend returns ReplyResponse directly (no { data } wrapper)
+    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
+    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
+    addMessage(msg);
+  }, [threadId, addMessage]);
 
   const handleUpload = useCallback(async (file: File) => {
     const formData = new FormData();
@@ -117,13 +123,10 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: formData,
     });
     if (!res.ok) throw new Error('Failed to upload file');
-    const { data } = await res.json() as { data: ChatMessage };
-    setMessages((prev) => {
-      if (prev.some((m) => m.id === data.id)) return prev;
-      return [...prev, data];
-    });
-    setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
+    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
+    addMessage(msg);
+  }, [threadId, addMessage]);
 
   const handleLoadMore = useCallback(async () => {
     if (!hasMore || !cursor || loadingMore) return;
@@ -224,7 +227,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
                   <ChatBubble
                     key={msg.id}
                     message={msg}
-                    isMine={msg.sender.id === currentTeamMemberId}
+                    isMine={msg.created_by === currentTeamMemberId}
                   />
                 ))}
               </div>

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChatBubble } from './chat-bubble';
+import { ChatInput } from './chat-input';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import { useChatSse } from '@/hooks/use-chat-sse';
+import { EmptyState } from '@/components/ui/empty-state';
+
+interface ChatViewProps {
+  threadId: string;
+  currentTeamMemberId: string;
+  threadTitle?: string | null;
+}
+
+interface MessageGroup {
+  date: string;
+  messages: ChatMessage[];
+}
+
+function groupByDate(messages: ChatMessage[]): MessageGroup[] {
+  const groups: Record<string, ChatMessage[]> = {};
+  for (const msg of messages) {
+    const date = new Date(msg.created_at).toLocaleDateString('ko-KR', {
+      year: 'numeric', month: 'long', day: 'numeric',
+    });
+    (groups[date] ??= []).push(msg);
+  }
+  return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
+}
+
+export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatViewProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const isFirstLoad = useRef(true);
+
+  const scrollToBottom = useCallback((smooth = false) => {
+    bottomRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'instant' });
+  }, []);
+
+  const fetchMessages = useCallback(async (before?: string) => {
+    try {
+      const params = new URLSearchParams({ limit: '30' });
+      if (before) params.set('before', before);
+      const res = await fetch(`/api/chats/${threadId}/messages?${params.toString()}`);
+      if (!res.ok) return;
+      const { data, meta } = await res.json() as {
+        data: ChatMessage[];
+        meta: { next_cursor?: string; has_more?: boolean };
+      };
+      if (before) {
+        setMessages((prev) => [...(data ?? []), ...prev]);
+      } else {
+        setMessages(data ?? []);
+      }
+      setCursor(meta?.next_cursor ?? null);
+      setHasMore(meta?.has_more ?? false);
+    } finally {
+      setLoading(false);
+      setLoadingMore(false);
+    }
+  }, [threadId]);
+
+  useEffect(() => {
+    setLoading(true);
+    isFirstLoad.current = true;
+    setMessages([]);
+    setCursor(null);
+    setHasMore(false);
+    void fetchMessages();
+  }, [fetchMessages]);
+
+  useEffect(() => {
+    if (!loading && isFirstLoad.current) {
+      scrollToBottom();
+      isFirstLoad.current = false;
+    }
+  }, [loading, scrollToBottom]);
+
+  const handleNewMessage = useCallback((msg: ChatMessage) => {
+    if (msg.thread_id !== threadId) return;
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === msg.id)) return prev;
+      return [...prev, msg];
+    });
+    setTimeout(() => scrollToBottom(true), 50);
+  }, [threadId, scrollToBottom]);
+
+  useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage });
+
+  const handleSend = useCallback(async (content: string) => {
+    const res = await fetch(`/api/chats/${threadId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ content }),
+    });
+    if (!res.ok) throw new Error('Failed to send message');
+    const { data } = await res.json() as { data: ChatMessage };
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === data.id)) return prev;
+      return [...prev, data];
+    });
+    setTimeout(() => scrollToBottom(true), 50);
+  }, [threadId, scrollToBottom]);
+
+  const handleUpload = useCallback(async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch(`/api/chats/${threadId}/messages/upload`, {
+      method: 'POST',
+      body: formData,
+    });
+    if (!res.ok) throw new Error('Failed to upload file');
+    const { data } = await res.json() as { data: ChatMessage };
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === data.id)) return prev;
+      return [...prev, data];
+    });
+    setTimeout(() => scrollToBottom(true), 50);
+  }, [threadId, scrollToBottom]);
+
+  const handleLoadMore = useCallback(async () => {
+    if (!hasMore || !cursor || loadingMore) return;
+    const scrollEl = scrollRef.current;
+    const prevScrollHeight = scrollEl?.scrollHeight ?? 0;
+    setLoadingMore(true);
+    await fetchMessages(cursor);
+    if (scrollEl) {
+      const delta = scrollEl.scrollHeight - prevScrollHeight;
+      scrollEl.scrollTop += delta;
+    }
+  }, [hasMore, cursor, loadingMore, fetchMessages]);
+
+  const groups = groupByDate(messages);
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Thread title */}
+      {threadTitle && (
+        <div className="flex-shrink-0 border-b border-border/80 px-4 py-2.5">
+          <h2 className="truncate text-sm font-medium text-foreground">{threadTitle}</h2>
+        </div>
+      )}
+
+      {/* Messages */}
+      <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-3">
+        {loading ? (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-sm text-muted-foreground">불러오는 중…</p>
+          </div>
+        ) : messages.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <EmptyState
+              title="대화를 시작하세요"
+              description="첫 메시지를 보내면 대화가 시작됩니다."
+              className="w-full max-w-xs"
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col gap-4">
+            {/* Load more */}
+            {hasMore && (
+              <div className="flex justify-center">
+                <button
+                  type="button"
+                  onClick={() => void handleLoadMore()}
+                  disabled={loadingMore}
+                  className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                >
+                  {loadingMore ? '불러오는 중…' : '이전 메시지 보기'}
+                </button>
+              </div>
+            )}
+
+            {groups.map((group) => (
+              <div key={group.date} className="flex flex-col gap-3">
+                {/* Date separator */}
+                <div className="flex items-center gap-3">
+                  <div className="h-px flex-1 bg-border/60" />
+                  <span className="text-[11px] text-muted-foreground">{group.date}</span>
+                  <div className="h-px flex-1 bg-border/60" />
+                </div>
+
+                {group.messages.map((msg) => (
+                  <ChatBubble
+                    key={msg.id}
+                    message={msg}
+                    isMine={msg.sender.id === currentTeamMemberId}
+                  />
+                ))}
+              </div>
+            ))}
+
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <ChatInput
+        onSend={handleSend}
+        onUpload={handleUpload}
+        placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -41,6 +41,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
   const [loadingMore, setLoadingMore] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const topSentinelRef = useRef<HTMLDivElement>(null);
   const isFirstLoad = useRef(true);
 
   const scrollToBottom = useCallback((smooth = false) => {
@@ -135,6 +136,25 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [hasMore, cursor, loadingMore, fetchMessages]);
 
+  // Auto-load when scrolled to top (IntersectionObserver watches topSentinelRef inside scrollRef)
+  useEffect(() => {
+    const sentinel = topSentinelRef.current;
+    const container = scrollRef.current;
+    if (!sentinel || !container || loading) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry?.isIntersecting && hasMore && !loadingMore) {
+          void handleLoadMore();
+        }
+      },
+      { root: container, threshold: 0 },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loading, hasMore, loadingMore, handleLoadMore]);
+
   const groups = groupByDate(messages);
 
   return (
@@ -177,6 +197,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
           </div>
         ) : (
           <div className="flex flex-col gap-4">
+            {/* sentinel: IntersectionObserver triggers auto-load when scrolled to top */}
+            <div ref={topSentinelRef} className="h-px w-full" />
             {hasMore && (
               <div className="flex justify-center">
                 <button

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ChevronLeft } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
@@ -30,6 +32,8 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
 }
 
 export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatViewProps) {
+  const router = useRouter();
+  // key={threadId} on parent ensures fresh mount per thread — no reset useEffect needed
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [cursor, setCursor] = useState<string | null>(null);
@@ -66,12 +70,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [threadId]);
 
+  // Initial load — key={threadId} guarantees fresh component, so no reset needed
   useEffect(() => {
-    setLoading(true);
-    isFirstLoad.current = true;
-    setMessages([]);
-    setCursor(null);
-    setHasMore(false);
     void fetchMessages();
   }, [fetchMessages]);
 
@@ -131,18 +131,32 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     setLoadingMore(true);
     await fetchMessages(cursor);
     if (scrollEl) {
-      const delta = scrollEl.scrollHeight - prevScrollHeight;
-      scrollEl.scrollTop += delta;
+      scrollEl.scrollTop += scrollEl.scrollHeight - prevScrollHeight;
     }
   }, [hasMore, cursor, loadingMore, fetchMessages]);
 
   const groups = groupByDate(messages);
 
   return (
-    <div className="flex h-full flex-col">
-      {/* Thread title */}
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Mobile back nav (< lg) */}
+      <div className="flex flex-shrink-0 items-center gap-2 border-b border-border/80 px-3 py-2 lg:hidden">
+        <button
+          type="button"
+          onClick={() => router.push('/memos')}
+          className="flex min-h-[44px] items-center gap-1 px-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="h-4 w-4" />
+          메모
+        </button>
+        {threadTitle && (
+          <span className="truncate text-sm font-medium text-foreground">{threadTitle}</span>
+        )}
+      </div>
+
+      {/* Desktop thread title (lg+) */}
       {threadTitle && (
-        <div className="flex-shrink-0 border-b border-border/80 px-4 py-2.5">
+        <div className="hidden flex-shrink-0 border-b border-border/80 px-4 py-2.5 lg:flex">
           <h2 className="truncate text-sm font-medium text-foreground">{threadTitle}</h2>
         </div>
       )}
@@ -163,7 +177,6 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
           </div>
         ) : (
           <div className="flex flex-col gap-4">
-            {/* Load more */}
             {hasMore && (
               <div className="flex justify-center">
                 <button
@@ -179,7 +192,6 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
 
             {groups.map((group) => (
               <div key={group.date} className="flex flex-col gap-3">
-                {/* Date separator */}
                 <div className="flex items-center gap-3">
                   <div className="h-px flex-1 bg-border/60" />
                   <span className="text-[11px] text-muted-foreground">{group.date}</span>

--- a/apps/web/src/contexts/refresh-context.tsx
+++ b/apps/web/src/contexts/refresh-context.tsx
@@ -18,6 +18,7 @@ interface RefreshContextValue {
   setIntervalMs: (ms: number) => void;
   register: (key: string, fn: () => void) => void;
   unregister: (key: string) => void;
+  forceRefresh: (key?: string) => void;
 }
 
 const RefreshContext = createContext<RefreshContextValue | null>(null);
@@ -47,6 +48,14 @@ export function RefreshProvider({ children }: { children: React.ReactNode }) {
     registryRef.current.delete(key);
   }, []);
 
+  const forceRefresh = useCallback((key?: string) => {
+    if (key) {
+      registryRef.current.get(key)?.();
+    } else {
+      registryRef.current.forEach((fn) => fn());
+    }
+  }, []);
+
   useEffect(() => {
     if (intervalMs === 0) return;
     const id = setInterval(() => {
@@ -56,7 +65,7 @@ export function RefreshProvider({ children }: { children: React.ReactNode }) {
   }, [intervalMs]);
 
   return (
-    <RefreshContext.Provider value={{ intervalMs, setIntervalMs, register, unregister }}>
+    <RefreshContext.Provider value={{ intervalMs, setIntervalMs, register, unregister, forceRefresh }}>
       {children}
     </RefreshContext.Provider>
   );

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface ChatMessage {
+  id: string;
+  thread_id: string;
+  content: string;
+  sender: {
+    id: string;
+    name: string;
+    type: 'human' | 'agent';
+  };
+  attachments?: Array<{ url: string; name: string; content_type: string }>;
+  created_at: string;
+}
+
+interface UseChatSseOptions {
+  currentTeamMemberId?: string;
+  onNewMessage?: (message: ChatMessage) => void;
+}
+
+const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
+
+export function useChatSse({ currentTeamMemberId, onNewMessage }: UseChatSseOptions) {
+  const [connected, setConnected] = useState(false);
+  const sourceRef = useRef<EventSource | null>(null);
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectAttemptsRef = useRef(0);
+  const onNewMessageRef = useRef(onNewMessage);
+  const memberIdRef = useRef(currentTeamMemberId);
+
+  useEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
+  useEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
+
+  useEffect(() => {
+    if (typeof EventSource === 'undefined') return;
+
+    function connect() {
+      sourceRef.current?.close();
+      sourceRef.current = null;
+
+      const url = new URL('/api/v2/events/memos', window.location.origin);
+      if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
+
+      const source = new EventSource(url.toString());
+      sourceRef.current = source;
+
+      source.onopen = () => {
+        setConnected(true);
+        reconnectAttemptsRef.current = 0;
+      };
+
+      source.onerror = () => {
+        setConnected(false);
+        source.close();
+        sourceRef.current = null;
+        if (!reconnectTimerRef.current) {
+          const delay = RECONNECT_DELAYS_MS[Math.min(reconnectAttemptsRef.current, RECONNECT_DELAYS_MS.length - 1)];
+          reconnectAttemptsRef.current += 1;
+          reconnectTimerRef.current = setTimeout(() => {
+            reconnectTimerRef.current = null;
+            connect();
+          }, delay);
+        }
+      };
+
+      source.addEventListener('chat:message', (e: MessageEvent) => {
+        try {
+          onNewMessageRef.current?.(JSON.parse(e.data) as ChatMessage);
+        } catch { /* ignore parse errors */ }
+      });
+    }
+
+    connect();
+
+    return () => {
+      if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current);
+      sourceRef.current?.close();
+      sourceRef.current = null;
+    };
+  }, []);
+
+  return { connected };
+}

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -2,35 +2,45 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+// Mirrors backend ReplyResponse schema
 export interface ChatMessage {
   id: string;
-  thread_id: string;
+  memo_id: string;       // thread ID (MemoReply.memo_id)
+  created_by: string;    // sender team_member_id
   content: string;
-  sender: {
-    id: string;
-    name: string;
-    type: 'human' | 'agent';
-  };
-  attachments?: Array<{ url: string; name: string; content_type: string }>;
+  review_type?: string;
+  attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
+  created_at: string;
+}
+
+interface SseChatPayload {
+  thread_id: string;
+  reply_id: string;
+  content: string;
+  created_by: string;
+  attachments: unknown[];
   created_at: string;
 }
 
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
+  onReplyCreated?: (memoId: string) => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const onNewMessageRef = useRef(onNewMessage);
+  const onReplyCreatedRef = useRef(onReplyCreated);
   const memberIdRef = useRef(currentTeamMemberId);
 
   useEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
+  useEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   useEffect(() => {
@@ -65,9 +75,27 @@ export function useChatSse({ currentTeamMemberId, onNewMessage }: UseChatSseOpti
         }
       };
 
+      // chat:message — from agent-push events (when backend publishes via _push_to_agent)
       source.addEventListener('chat:message', (e: MessageEvent) => {
         try {
-          onNewMessageRef.current?.(JSON.parse(e.data) as ChatMessage);
+          const payload = JSON.parse(e.data as string) as SseChatPayload;
+          const msg: ChatMessage = {
+            id: payload.reply_id,
+            memo_id: payload.thread_id,
+            created_by: payload.created_by,
+            content: payload.content,
+            attachments: (payload.attachments ?? []) as ChatMessage['attachments'],
+            created_at: payload.created_at,
+          };
+          onNewMessageRef.current?.(msg);
+        } catch { /* ignore parse errors */ }
+      });
+
+      // reply_created — from memos.py publish_event; use as refetch trigger
+      source.addEventListener('reply_created', (e: MessageEvent) => {
+        try {
+          const payload = JSON.parse(e.data as string) as { id?: string; memo_id?: string };
+          if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
         } catch { /* ignore parse errors */ }
       });
     }


### PR DESCRIPTION
## 변경 사항

선생님 직접 발견 P0/P1 버그 5건 수정.

### P0 — 채팅 기본 동작

| # | 버그 | 원인 | 수정 |
|---|------|------|------|
| 1 | Chat POST 후 UI 미반영 | 프론트가 `{ data: ... }` 래핑 파싱, 백엔드는 raw `ReplyResponse` 반환 | raw 응답 직접 파싱 |
| 2 | sender/receiver 정렬 반전 | `msg.sender.id`로 비교했으나 `sender` 필드 없음 | `msg.created_by === currentTeamMemberId` 비교 |
| 3 | 실시간 갱신 없음 | SSE `chat:message` 미발행 | `reply_created` SSE 이벤트 구독 → refetch 트리거 추가 |

### P1 — 메모 UX

| # | 버그 | 원인 | 수정 |
|---|------|------|------|
| 4 | "대화를 시작하세요" 잔존 | `{ data, meta }` 래핑 파싱 실패 → messages 항상 빈 배열 | 배열 응답 직접 파싱 |
| 5 | 메모 목록 미갱신 | 생성 후 refresh 트리거 없음 | `RefreshContext.forceRefresh` 추가, 메모 생성 후 호출 |

### ChatMessage 인터페이스 재정의

백엔드 `ReplyResponse` 스키마에 맞게 재정의:
- `sender: { id, name, type }` → `created_by: string` (team_member_id)
- `thread_id` → `memo_id` (MemoReply.memo_id)

## 검증
- tsc --noEmit ✅
- ESLint 0건 ✅

## PR 체인
- Base: `feature/eventbus-s16` (S16 Chat UI — develop 머지 대기)
- S16 머지 후 이 PR을 develop base로 전환 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)