### PR TITLE
fix(eventbus): S27 — dispatch_notification 버그 3건 수정 (agent 분기 + 로깅)

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -1,17 +1,23 @@
-"""E-EVENTBUS P3 S8: 이벤트→알림 설정 필터 엔진.
+"""E-EVENTBUS P3 S8/S27: 이벤트→알림 설정 필터 엔진.
 
 notification_settings 조회 후 enabled인 member에게만 Notification INSERT.
 설정 없으면 기본 enabled (opt-out 방식).
+
+S27: agent type 멤버는 Notification 대신 events 테이블 INSERT (dispatched, pending).
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.event import Event
 from app.models.notification import Notification, NotificationSetting
 from app.models.team import TeamMember
+
+logger = logging.getLogger(__name__)
 
 
 async def dispatch_notification(
@@ -25,7 +31,11 @@ async def dispatch_notification(
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
 ) -> None:
-    """notification_settings 필터 후 enabled member에게 Notification INSERT.
+    """notification_settings 필터 후 enabled member에게 알림 발송.
+
+    human 멤버: Notification 테이블 INSERT (in-app 알림)
+    agent 멤버: events 테이블 INSERT (event_type=dispatched, status=pending)
+               → poll_events / SSE 브릿지로 에이전트 수신
 
     설정이 없는 member는 기본 enabled (opt-out).
     channel 기준: 'in_app'.
@@ -45,40 +55,62 @@ async def dispatch_notification(
         )
         settings = {row.member_id: row.enabled for row in settings_result.all()}
 
-        # 설정 없으면 기본 enabled → 전체 대상 member_ids 중 enabled인 것만 필터
+        # 설정 없으면 기본 enabled → enabled인 member만 필터
         enabled_member_ids = [
             mid for mid in target_member_ids
-            if settings.get(mid, True)  # 설정 없으면 True (기본 enabled)
+            if settings.get(mid, True)
         ]
 
         if not enabled_member_ids:
             return
 
-        # enabled member의 user_id 조회 (Notification.user_id는 users.id)
+        # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
+        # type 및 project_id도 함께 조회
         members_result = await db.execute(
-            select(TeamMember.id, TeamMember.user_id).where(
+            select(TeamMember.id, TeamMember.user_id, TeamMember.type, TeamMember.project_id).where(
                 TeamMember.id.in_(enabled_member_ids),
                 TeamMember.org_id == org_id,
-                TeamMember.user_id.isnot(None),
             )
         )
         members = members_result.all()
 
+        inserted = False
         for member_row in members:
-            notification = Notification(
-                org_id=org_id,
-                user_id=member_row.user_id,
-                type=event_type,
-                title=title,
-                body=body,
-                is_read=False,
-                reference_type=reference_type,
-                reference_id=reference_id,
-            )
-            db.add(notification)
+            if member_row.type == "agent":
+                # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT
+                if member_row.project_id:
+                    event = Event(
+                        project_id=member_row.project_id,
+                        org_id=org_id,
+                        event_type="dispatched",
+                        source_entity_type=reference_type,
+                        source_entity_id=reference_id,
+                        sender_id=None,
+                        recipient_id=member_row.id,
+                        recipient_type="agent",
+                        payload={"title": title, "body": body, "event_type": event_type},
+                        status="pending",
+                    )
+                    db.add(event)
+                    inserted = True
+            elif member_row.user_id:
+                # human: user_id 있는 경우만 Notification INSERT
+                notification = Notification(
+                    org_id=org_id,
+                    user_id=member_row.user_id,
+                    type=event_type,
+                    title=title,
+                    body=body,
+                    is_read=False,
+                    reference_type=reference_type,
+                    reference_id=reference_id,
+                )
+                db.add(notification)
+                inserted = True
 
-        if members:
+        if inserted:
             await db.flush()
 
     except Exception:
-        pass
+        # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅
+        logger.exception("dispatch_notification failed org_id=%s event_type=%s", org_id, event_type)


### PR DESCRIPTION
## 버그 3건

**BUG-1** (`line 83`): `except Exception: pass` → `logger.exception`  
모든 예외 무조건 삼킴 → 알림 실패 원인 불명.

**BUG-2** (`line 62`): `TeamMember.user_id.isnot(None)` 필터 제거  
agent 멤버는 `user_id=NULL` → 기존 필터로 탈락 → Notification INSERT 0건  
→ `type`, `project_id` 포함 조회로 변경

**BUG-3**: agent 멤버 dispatched 경로 신설  
agent → Notification 테이블 X, **events 테이블 INSERT** (event_type=dispatched, status=pending)  
→ `poll_events` / SSE 브릿지로 에이전트 수신  
human → 기존 Notification INSERT 유지

## Test plan
- [ ] import PASS ✅
- [ ] 스토리 상태 변경 → check_notifications에 dispatched 알림 반환
- [ ] agent poll_events → dispatched 이벤트 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)