### PR TITLE
fix(eventbus): S24 추가 — _resolve_sender project_id 필터 (sender 반전 수정)

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -22,21 +22,31 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v2/chats", tags=["chats"])
 
 
-async def _resolve_sender(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> TeamMember:
+async def _resolve_sender(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    db: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> TeamMember:
     """auth context → sending TeamMember 조회.
 
     API key 경로: auth.user_id = team_member.id (직접 조회)
-    JWT 경로: auth.user_id = supabase user_id → TeamMember.user_id 매핑
+    JWT 경로: auth.user_id = supabase user_id → TeamMember.user_id + project_id 매핑
+
+    project_id 필터: 동일 org 내 복수 project team_member 중 정확한 레코드 반환.
+    프론트 currentTeamMemberId는 last_project_id 기준 member → project_id 필터 필수.
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
         stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
     else:
-        stmt = select(TeamMember).where(
+        conditions = [
             TeamMember.user_id == uuid.UUID(auth.user_id),
             TeamMember.org_id == org_id,
-        )
-    # scalar_one_or_none → MultipleResultsFound (동일 org 내 복수 project에 team_member 중복 등록 케이스)
+        ]
+        if project_id:
+            conditions.append(TeamMember.project_id == project_id)
+        stmt = select(TeamMember).where(*conditions)
     member = (await db.execute(stmt)).scalars().first()
     if member is None:
         raise HTTPException(status_code=400, detail="Sender team member not found")
@@ -221,7 +231,7 @@ async def send_chat_message(
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    sender = await _resolve_sender(auth, org_id, db)
+    sender = await _resolve_sender(auth, org_id, db, project_id=memo.project_id)
 
     reply_repo = MemoReplyRepository(db)
     reply = await reply_repo.create(
@@ -265,7 +275,7 @@ async def send_chat_message_with_file(
     if memo is None:
         raise HTTPException(status_code=404, detail="Thread not found")
 
-    sender = await _resolve_sender(auth, org_id, db)
+    sender = await _resolve_sender(auth, org_id, db, project_id=memo.project_id)
 
     attachments: list[dict] = []
     if file and file.filename:


### PR DESCRIPTION
## 원인

`_resolve_sender` JWT 경로에서 `org_id` 필터만 있어 `.first()`가 **다른 project의 team_member** 반환.

프론트 `currentTeamMemberId`는 `last_project_id` 기준 member.id  
→ `created_by`가 다른 member_id → `isMine = false` → **sender 반전**

## 수정

`_resolve_sender`에 `project_id: uuid.UUID | None` 파라미터 추가:
```python
if project_id:
    conditions.append(TeamMember.project_id == project_id)
```

`send_chat_message`, `send_chat_message_with_file` 호출 시 `memo.project_id` 전달.

## Test plan
- [ ] import PASS ✅
- [ ] 송윤재 세션 Chat POST → `created_by`가 last_project 기준 member_id
- [ ] `isMine = true` → 본인 메시지 오른쪽 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)