### PR TITLE
[SID:77f5786d] S28 AC6 — ChatBubble sender 이름/에이전트 뱃지 표시

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/new/page.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { MemoCreateForm } from '@/components/memos/memo-create-form';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
+import { useRefreshContext } from '@/contexts/refresh-context';
 
 interface Member {
   id: string;
@@ -16,6 +17,7 @@ export default function NewMemoPage() {
   const router = useRouter();
   const t = useTranslations('memos');
   const { projectId } = useDashboardContext();
+  const { forceRefresh } = useRefreshContext();
   const [members, setMembers] = useState<Member[]>([]);
 
   useEffect(() => {
@@ -41,12 +43,13 @@ export default function NewMemoPage() {
       });
       if (!res.ok) return false;
       const { data: newMemo } = await res.json();
+      forceRefresh('memo-list');
       router.push(`/memos/${newMemo.id}`);
       return true;
     } catch {
       return false;
     }
-  }, [projectId, router]);
+  }, [projectId, router, forceRefresh]);
 
   const handleCancel = useCallback(() => {
     router.push('/memos');

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Bot, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 
 interface ChatBubbleProps {
@@ -9,32 +8,21 @@ interface ChatBubbleProps {
 }
 
 export function ChatBubble({ message, isMine }: ChatBubbleProps) {
-  const isAgent = message.sender.type === 'agent';
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
 
   return (
     <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
       {/* Avatar */}
-      <div className={`flex-shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium ${
-        isAgent
-          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+      <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+        isMine
+          ? 'bg-primary/20 text-primary'
           : 'bg-muted text-muted-foreground'
       }`}>
-        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+        {isMine ? '나' : '팀'}
       </div>
 
       {/* Bubble + meta */}
       <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
-        {/* Sender name */}
-        <div className="flex items-center gap-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">{message.sender.name}</span>
-          {isAgent && (
-            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-              AI
-            </span>
-          )}
-        </div>
-
         {/* Content */}
         <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
           isMine
@@ -47,22 +35,27 @@ export function ChatBubble({ message, isMine }: ChatBubbleProps) {
         {/* Attachments */}
         {message.attachments && message.attachments.length > 0 && (
           <div className="flex flex-col gap-1.5">
-            {message.attachments.map((att) => (
-              <a
-                key={att.url}
-                href={att.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
-              >
-                {att.content_type.startsWith('image/') ? (
-                  /* eslint-disable-next-line @next/next/no-img-element */
-                  <img src={att.url} alt={att.name} className="max-h-40 max-w-[240px] rounded object-contain" />
-                ) : (
-                  <span className="truncate text-muted-foreground">{att.name}</span>
-                )}
-              </a>
-            ))}
+            {message.attachments.map((att, i) => {
+              const href = att.url;
+              const label = att.name ?? att.filename ?? '첨부파일';
+              const isImage = att.content_type?.startsWith('image/');
+              return (
+                <a
+                  key={href ?? i}
+                  href={href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
+                >
+                  {isImage && href ? (
+                    /* eslint-disable-next-line @next/next/no-img-element */
+                    <img src={href} alt={label} className="max-h-40 max-w-[240px] rounded object-contain" />
+                  ) : (
+                    <span className="truncate text-muted-foreground">{label}</span>
+                  )}
+                </a>
+              );
+            })}
           </div>
         )}
 

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Bot, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 
 interface ChatBubbleProps {
@@ -8,21 +9,35 @@ interface ChatBubbleProps {
 }
 
 export function ChatBubble({ message, isMine }: ChatBubbleProps) {
+  const isAgent = message.sender_type === 'agent';
+  const displayName = isMine ? '나' : (message.sender_name || '팀');
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
 
   return (
     <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
       {/* Avatar */}
       <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-        isMine
-          ? 'bg-primary/20 text-primary'
-          : 'bg-muted text-muted-foreground'
+        isAgent
+          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+          : isMine
+            ? 'bg-primary/20 text-primary'
+            : 'bg-muted text-muted-foreground'
       }`}>
-        {isMine ? '나' : '팀'}
+        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
       </div>
 
       {/* Bubble + meta */}
       <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
+        {/* Sender name */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
+          {isAgent && (
+            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+              AI
+            </span>
+          )}
+        </div>
+
         {/* Content */}
         <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
           isMine

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -33,12 +33,11 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
 
 export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatViewProps) {
   const router = useRouter();
-  // key={threadId} on parent ensures fresh mount per thread — no reset useEffect needed
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
-  const [cursor, setCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [cursor, setCursor] = useState<string | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -50,18 +49,18 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
 
   const fetchMessages = useCallback(async (before?: string) => {
     try {
-      const params = new URLSearchParams({ limit: '30' });
+      const params = new URLSearchParams({ limit: '50' });
       if (before) params.set('before', before);
       const res = await fetch(`/api/chats/${threadId}/messages?${params.toString()}`);
       if (!res.ok) return;
-      const { data, meta } = await res.json() as {
-        data: ChatMessage[];
-        meta: { next_cursor?: string; has_more?: boolean };
-      };
+      // Backend returns list[ReplyResponse] directly (no { data, meta } wrapper)
+      const raw = await res.json() as ChatMessage[] | { data?: ChatMessage[]; meta?: { next_cursor?: string; has_more?: boolean } };
+      const data = Array.isArray(raw) ? raw : (raw.data ?? []);
+      const meta = Array.isArray(raw) ? null : raw.meta;
       if (before) {
-        setMessages((prev) => [...(data ?? []), ...prev]);
+        setMessages((prev) => [...data, ...prev]);
       } else {
-        setMessages(data ?? []);
+        setMessages(data);
       }
       setCursor(meta?.next_cursor ?? null);
       setHasMore(meta?.has_more ?? false);
@@ -71,9 +70,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [threadId]);
 
-  // Initial load — key={threadId} guarantees fresh component, so no reset needed
   useEffect(() => {
-    void fetchMessages();
+    fetchMessages();
   }, [fetchMessages]);
 
   useEffect(() => {
@@ -83,16 +81,26 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
     }
   }, [loading, scrollToBottom]);
 
-  const handleNewMessage = useCallback((msg: ChatMessage) => {
-    if (msg.thread_id !== threadId) return;
+  const addMessage = useCallback((msg: ChatMessage) => {
     setMessages((prev) => {
       if (prev.some((m) => m.id === msg.id)) return prev;
       return [...prev, msg];
     });
     setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+  }, [scrollToBottom]);
 
-  useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage });
+  const handleNewMessage = useCallback((msg: ChatMessage) => {
+    if (msg.memo_id !== threadId) return;
+    addMessage(msg);
+  }, [threadId, addMessage]);
+
+  const handleReplyCreated = useCallback((memoId: string) => {
+    if (memoId !== threadId) return;
+    // reply_created SSE: refetch to pick up messages not delivered via chat:message
+    fetchMessages();
+  }, [threadId, fetchMessages]);
+
+  useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage, onReplyCreated: handleReplyCreated });
 
   const handleSend = useCallback(async (content: string) => {
     const res = await fetch(`/api/chats/${threadId}/messages`, {
@@ -101,13 +109,11 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: JSON.stringify({ content }),
     });
     if (!res.ok) throw new Error('Failed to send message');
-    const { data } = await res.json() as { data: ChatMessage };
-    setMessages((prev) => {
-      if (prev.some((m) => m.id === data.id)) return prev;
-      return [...prev, data];
-    });
-    setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+    // Backend returns ReplyResponse directly (no { data } wrapper)
+    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
+    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
+    addMessage(msg);
+  }, [threadId, addMessage]);
 
   const handleUpload = useCallback(async (file: File) => {
     const formData = new FormData();
@@ -117,13 +123,10 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: formData,
     });
     if (!res.ok) throw new Error('Failed to upload file');
-    const { data } = await res.json() as { data: ChatMessage };
-    setMessages((prev) => {
-      if (prev.some((m) => m.id === data.id)) return prev;
-      return [...prev, data];
-    });
-    setTimeout(() => scrollToBottom(true), 50);
-  }, [threadId, scrollToBottom]);
+    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
+    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
+    addMessage(msg);
+  }, [threadId, addMessage]);
 
   const handleLoadMore = useCallback(async () => {
     if (!hasMore || !cursor || loadingMore) return;
@@ -224,7 +227,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
                   <ChatBubble
                     key={msg.id}
                     message={msg}
-                    isMine={msg.sender.id === currentTeamMemberId}
+                    isMine={msg.created_by === currentTeamMemberId}
                   />
                 ))}
               </div>

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
-import { useChatSse } from '@/hooks/use-chat-sse';
+import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
 
 interface ChatViewProps {
@@ -53,10 +53,11 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       if (before) params.set('before', before);
       const res = await fetch(`/api/chats/${threadId}/messages?${params.toString()}`);
       if (!res.ok) return;
-      // Backend returns list[ReplyResponse] directly (no { data, meta } wrapper)
-      const raw = await res.json() as ChatMessage[] | { data?: ChatMessage[]; meta?: { next_cursor?: string; has_more?: boolean } };
-      const data = Array.isArray(raw) ? raw : (raw.data ?? []);
-      const meta = Array.isArray(raw) ? null : raw.meta;
+      // Backend: { data: _to_chat_message[], meta: { next_cursor, has_more } }
+      const raw = await res.json() as Record<string, unknown>;
+      const rawData = (Array.isArray(raw) ? raw : (raw.data ?? [])) as Record<string, unknown>[];
+      const meta = Array.isArray(raw) ? null : raw.meta as { next_cursor?: string; has_more?: boolean } | undefined;
+      const data = rawData.map(normalizeToMessage);
       if (before) {
         setMessages((prev) => [...data, ...prev]);
       } else {
@@ -109,10 +110,10 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: JSON.stringify({ content }),
     });
     if (!res.ok) throw new Error('Failed to send message');
-    // Backend returns ReplyResponse directly (no { data } wrapper)
-    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
-    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
-    addMessage(msg);
+    // Backend: { data: _to_chat_message }
+    const raw = await res.json() as Record<string, unknown>;
+    const payload = (raw.data ?? raw) as Record<string, unknown>;
+    addMessage(normalizeToMessage(payload));
   }, [threadId, addMessage]);
 
   const handleUpload = useCallback(async (file: File) => {
@@ -123,9 +124,9 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       body: formData,
     });
     if (!res.ok) throw new Error('Failed to upload file');
-    const raw = await res.json() as ChatMessage | { data?: ChatMessage };
-    const msg = ('data' in raw && raw.data) ? raw.data : raw as ChatMessage;
-    addMessage(msg);
+    const raw = await res.json() as Record<string, unknown>;
+    const payload = (raw.data ?? raw) as Record<string, unknown>;
+    addMessage(normalizeToMessage(payload));
   }, [threadId, addMessage]);
 
   const handleLoadMore = useCallback(async () => {

--- a/apps/web/src/contexts/refresh-context.tsx
+++ b/apps/web/src/contexts/refresh-context.tsx
@@ -18,6 +18,7 @@ interface RefreshContextValue {
   setIntervalMs: (ms: number) => void;
   register: (key: string, fn: () => void) => void;
   unregister: (key: string) => void;
+  forceRefresh: (key?: string) => void;
 }
 
 const RefreshContext = createContext<RefreshContextValue | null>(null);
@@ -47,6 +48,14 @@ export function RefreshProvider({ children }: { children: React.ReactNode }) {
     registryRef.current.delete(key);
   }, []);
 
+  const forceRefresh = useCallback((key?: string) => {
+    if (key) {
+      registryRef.current.get(key)?.();
+    } else {
+      registryRef.current.forEach((fn) => fn());
+    }
+  }, []);
+
   useEffect(() => {
     if (intervalMs === 0) return;
     const id = setInterval(() => {
@@ -56,7 +65,7 @@ export function RefreshProvider({ children }: { children: React.ReactNode }) {
   }, [intervalMs]);
 
   return (
-    <RefreshContext.Provider value={{ intervalMs, setIntervalMs, register, unregister }}>
+    <RefreshContext.Provider value={{ intervalMs, setIntervalMs, register, unregister, forceRefresh }}>
       {children}
     </RefreshContext.Provider>
   );

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -2,35 +2,45 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+// Mirrors backend ReplyResponse schema
 export interface ChatMessage {
   id: string;
-  thread_id: string;
+  memo_id: string;       // thread ID (MemoReply.memo_id)
+  created_by: string;    // sender team_member_id
   content: string;
-  sender: {
-    id: string;
-    name: string;
-    type: 'human' | 'agent';
-  };
-  attachments?: Array<{ url: string; name: string; content_type: string }>;
+  review_type?: string;
+  attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
+  created_at: string;
+}
+
+interface SseChatPayload {
+  thread_id: string;
+  reply_id: string;
+  content: string;
+  created_by: string;
+  attachments: unknown[];
   created_at: string;
 }
 
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
+  onReplyCreated?: (memoId: string) => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);
   const onNewMessageRef = useRef(onNewMessage);
+  const onReplyCreatedRef = useRef(onReplyCreated);
   const memberIdRef = useRef(currentTeamMemberId);
 
   useEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
+  useEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   useEffect(() => {
@@ -65,9 +75,27 @@ export function useChatSse({ currentTeamMemberId, onNewMessage }: UseChatSseOpti
         }
       };
 
+      // chat:message — from agent-push events (when backend publishes via _push_to_agent)
       source.addEventListener('chat:message', (e: MessageEvent) => {
         try {
-          onNewMessageRef.current?.(JSON.parse(e.data) as ChatMessage);
+          const payload = JSON.parse(e.data as string) as SseChatPayload;
+          const msg: ChatMessage = {
+            id: payload.reply_id,
+            memo_id: payload.thread_id,
+            created_by: payload.created_by,
+            content: payload.content,
+            attachments: (payload.attachments ?? []) as ChatMessage['attachments'],
+            created_at: payload.created_at,
+          };
+          onNewMessageRef.current?.(msg);
+        } catch { /* ignore parse errors */ }
+      });
+
+      // reply_created — from memos.py publish_event; use as refetch trigger
+      source.addEventListener('reply_created', (e: MessageEvent) => {
+        try {
+          const payload = JSON.parse(e.data as string) as { id?: string; memo_id?: string };
+          if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
         } catch { /* ignore parse errors */ }
       });
     }

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -2,22 +2,36 @@
 
 import { useEffect, useRef, useState } from 'react';
 
-// Mirrors backend ReplyResponse schema
+// Mirrors backend _to_chat_message: { id, thread_id, sender: { id, name, type }, ... }
 export interface ChatMessage {
   id: string;
-  memo_id: string;       // thread ID (MemoReply.memo_id)
-  created_by: string;    // sender team_member_id
+  memo_id: string;       // backend: thread_id
+  created_by: string;    // backend: sender.id
   content: string;
   review_type?: string;
   attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
   created_at: string;
 }
 
+// Normalize backend _to_chat_message format → ChatMessage
+export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
+  const sender = raw.sender as { id?: string } | undefined;
+  return {
+    id: (raw.id ?? '') as string,
+    memo_id: (raw.thread_id ?? raw.memo_id ?? '') as string,
+    created_by: (raw.created_by ?? sender?.id ?? '') as string,
+    content: (raw.content ?? '') as string,
+    attachments: (raw.attachments ?? []) as ChatMessage['attachments'],
+    created_at: (raw.created_at ?? '') as string,
+  };
+}
+
+// Backend SSE chat:message payload format (_to_chat_message)
 interface SseChatPayload {
+  id: string;
   thread_id: string;
-  reply_id: string;
   content: string;
-  created_by: string;
+  sender: { id: string; name?: string; type?: string };
   attachments: unknown[];
   created_at: string;
 }
@@ -75,19 +89,11 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated }
         }
       };
 
-      // chat:message — from agent-push events (when backend publishes via _push_to_agent)
+      // chat:message — backend _to_chat_message format: { id, thread_id, sender: { id }, ... }
       source.addEventListener('chat:message', (e: MessageEvent) => {
         try {
           const payload = JSON.parse(e.data as string) as SseChatPayload;
-          const msg: ChatMessage = {
-            id: payload.reply_id,
-            memo_id: payload.thread_id,
-            created_by: payload.created_by,
-            content: payload.content,
-            attachments: (payload.attachments ?? []) as ChatMessage['attachments'],
-            created_at: payload.created_at,
-          };
-          onNewMessageRef.current?.(msg);
+          onNewMessageRef.current?.(normalizeToMessage(payload as unknown as Record<string, unknown>));
         } catch { /* ignore parse errors */ }
       });
 

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -5,8 +5,10 @@ import { useEffect, useRef, useState } from 'react';
 // Mirrors backend _to_chat_message: { id, thread_id, sender: { id, name, type }, ... }
 export interface ChatMessage {
   id: string;
-  memo_id: string;       // backend: thread_id
-  created_by: string;    // backend: sender.id
+  memo_id: string;        // backend: thread_id
+  created_by: string;     // backend: sender.id
+  sender_name: string;    // backend: sender.name
+  sender_type: string;    // backend: sender.type ('human' | 'agent')
   content: string;
   review_type?: string;
   attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
@@ -15,11 +17,13 @@ export interface ChatMessage {
 
 // Normalize backend _to_chat_message format → ChatMessage
 export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
-  const sender = raw.sender as { id?: string } | undefined;
+  const sender = raw.sender as { id?: string; name?: string; type?: string } | undefined;
   return {
     id: (raw.id ?? '') as string,
     memo_id: (raw.thread_id ?? raw.memo_id ?? '') as string,
     created_by: (raw.created_by ?? sender?.id ?? '') as string,
+    sender_name: (sender?.name ?? '') as string,
+    sender_type: (sender?.type ?? 'human') as string,
     content: (raw.content ?? '') as string,
     attachments: (raw.attachments ?? []) as ChatMessage['attachments'],
     created_at: (raw.created_at ?? '') as string,

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -1,17 +1,23 @@
-"""E-EVENTBUS P3 S8: 이벤트→알림 설정 필터 엔진.
+"""E-EVENTBUS P3 S8/S27: 이벤트→알림 설정 필터 엔진.
 
 notification_settings 조회 후 enabled인 member에게만 Notification INSERT.
 설정 없으면 기본 enabled (opt-out 방식).
+
+S27: agent type 멤버는 Notification 대신 events 테이블 INSERT (dispatched, pending).
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.event import Event
 from app.models.notification import Notification, NotificationSetting
 from app.models.team import TeamMember
+
+logger = logging.getLogger(__name__)
 
 
 async def dispatch_notification(
@@ -25,7 +31,11 @@ async def dispatch_notification(
     reference_type: str | None = None,
     reference_id: uuid.UUID | None = None,
 ) -> None:
-    """notification_settings 필터 후 enabled member에게 Notification INSERT.
+    """notification_settings 필터 후 enabled member에게 알림 발송.
+
+    human 멤버: Notification 테이블 INSERT (in-app 알림)
+    agent 멤버: events 테이블 INSERT (event_type=dispatched, status=pending)
+               → poll_events / SSE 브릿지로 에이전트 수신
 
     설정이 없는 member는 기본 enabled (opt-out).
     channel 기준: 'in_app'.
@@ -45,40 +55,62 @@ async def dispatch_notification(
         )
         settings = {row.member_id: row.enabled for row in settings_result.all()}
 
-        # 설정 없으면 기본 enabled → 전체 대상 member_ids 중 enabled인 것만 필터
+        # 설정 없으면 기본 enabled → enabled인 member만 필터
         enabled_member_ids = [
             mid for mid in target_member_ids
-            if settings.get(mid, True)  # 설정 없으면 True (기본 enabled)
+            if settings.get(mid, True)
         ]
 
         if not enabled_member_ids:
             return
 
-        # enabled member의 user_id 조회 (Notification.user_id는 users.id)
+        # BUG-2 수정: user_id.isnot(None) 필터 제거 — agent는 user_id=NULL이므로 제외됐던 문제
+        # type 및 project_id도 함께 조회
         members_result = await db.execute(
-            select(TeamMember.id, TeamMember.user_id).where(
+            select(TeamMember.id, TeamMember.user_id, TeamMember.type, TeamMember.project_id).where(
                 TeamMember.id.in_(enabled_member_ids),
                 TeamMember.org_id == org_id,
-                TeamMember.user_id.isnot(None),
             )
         )
         members = members_result.all()
 
+        inserted = False
         for member_row in members:
-            notification = Notification(
-                org_id=org_id,
-                user_id=member_row.user_id,
-                type=event_type,
-                title=title,
-                body=body,
-                is_read=False,
-                reference_type=reference_type,
-                reference_id=reference_id,
-            )
-            db.add(notification)
+            if member_row.type == "agent":
+                # BUG-3 수정: agent → Notification 대신 events 테이블 INSERT
+                if member_row.project_id:
+                    event = Event(
+                        project_id=member_row.project_id,
+                        org_id=org_id,
+                        event_type="dispatched",
+                        source_entity_type=reference_type,
+                        source_entity_id=reference_id,
+                        sender_id=None,
+                        recipient_id=member_row.id,
+                        recipient_type="agent",
+                        payload={"title": title, "body": body, "event_type": event_type},
+                        status="pending",
+                    )
+                    db.add(event)
+                    inserted = True
+            elif member_row.user_id:
+                # human: user_id 있는 경우만 Notification INSERT
+                notification = Notification(
+                    org_id=org_id,
+                    user_id=member_row.user_id,
+                    type=event_type,
+                    title=title,
+                    body=body,
+                    is_read=False,
+                    reference_type=reference_type,
+                    reference_id=reference_id,
+                )
+                db.add(notification)
+                inserted = True
 
-        if members:
+        if inserted:
             await db.flush()
 
     except Exception:
-        pass
+        # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅
+        logger.exception("dispatch_notification failed org_id=%s event_type=%s", org_id, event_type)


### PR DESCRIPTION
## 변경 사항

Chat 버블 avatar `'팀'` 하드코딩 → 실제 sender 이름 표시.

### 수정 파일

**`use-chat-sse.ts`**
- `ChatMessage` interface에 `sender_name: string`, `sender_type: string` 추가
- `normalizeToMessage()`에서 `sender.name`, `sender.type` 추출

**`chat-bubble.tsx`**
- `'팀'` → `message.sender_name || '팀'` (fallback 유지)
- 에이전트 AI 뱃지 + 보라색 아바타 복원 (`sender_type === 'agent'`)
- sender name 표시 라인 추가

## 검증
- tsc --noEmit ✅
- ESLint 0건 ✅

## PR 체인
- Base: `feature/eventbus-s24-v2` (PR #693 머지 후 develop base 전환 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)