### PR TITLE
fix(eventbus): S28 — agent_event_stream hang 수정 (즉시 heartbeat + 백필 LIMIT 100)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -191,7 +191,10 @@ async def agent_event_stream(
 
     async def generate():
         try:
-            # 연결 즉시 pending 이벤트 백필 전달 — 개별 세션, 완료 후 반환
+            # 즉시 heartbeat → HTTP 응답 헤더 즉시 반환 (대량 백필 전 hang 방지)
+            yield "event: heartbeat\ndata: {}\n\n"
+
+            # 연결 즉시 pending 이벤트 백필 전달 — 최근 100건 LIMIT (무한 조회 방지)
             async with async_session_factory() as db:
                 result = await db.execute(
                     select(Event)
@@ -201,6 +204,7 @@ async def agent_event_stream(
                         Event.status == "pending",
                     )
                     .order_by(Event.created_at.asc())
+                    .limit(100)
                 )
                 pending_events = result.scalars().all()
                 for i in range(0, len(pending_events), _SSE_BATCH_SIZE):


### PR DESCRIPTION
## Root Cause

`agent_event_stream`의 `generate()`가 pending 이벤트 백필 DB 조회를 완료해야 첫 `yield` 실행.  
오르테가 등 대량 pending 이벤트 보유 시 백필 전에 HTTP 응답 헤더가 전송 안 됨 → 클라이언트 hang.

## 수정

1. **즉시 heartbeat yield 추가** — `generate()` 첫 줄에 heartbeat 전송 → HTTP 200 + 헤더 즉시 반환  
2. **백필 쿼리 `.limit(100)` 추가** — 무한 조회/전달 방지

```python
async def generate():
    # 즉시 heartbeat → HTTP 응답 헤더 즉시 반환
    yield "event: heartbeat\ndata: {}\n\n"
    
    # 백필 최근 100건만
    select(Event)...limit(100)
```

## Test plan
- [ ] import PASS ✅
- [ ] 오르테가 SSE 연결 → 즉시 heartbeat 수신 (hang 없음)
- [ ] pending 이벤트 백필 정상 수신

🤖 Generated with [Claude Code](https://claude.com/claude-code)