### PR TITLE
[SID:77f5786d] S28 AC6 — ChatBubble sender 이름/에이전트 뱃지 표시

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Bot, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 
 interface ChatBubbleProps {
@@ -8,21 +9,35 @@ interface ChatBubbleProps {
 }
 
 export function ChatBubble({ message, isMine }: ChatBubbleProps) {
+  const isAgent = message.sender_type === 'agent';
+  const displayName = isMine ? '나' : (message.sender_name || '팀');
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
 
   return (
     <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
       {/* Avatar */}
       <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-        isMine
-          ? 'bg-primary/20 text-primary'
-          : 'bg-muted text-muted-foreground'
+        isAgent
+          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+          : isMine
+            ? 'bg-primary/20 text-primary'
+            : 'bg-muted text-muted-foreground'
       }`}>
-        {isMine ? '나' : '팀'}
+        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
       </div>
 
       {/* Bubble + meta */}
       <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
+        {/* Sender name */}
+        <div className="flex items-center gap-1.5">
+          <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
+          {isAgent && (
+            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+              AI
+            </span>
+          )}
+        </div>
+
         {/* Content */}
         <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
           isMine

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -5,8 +5,10 @@ import { useEffect, useRef, useState } from 'react';
 // Mirrors backend _to_chat_message: { id, thread_id, sender: { id, name, type }, ... }
 export interface ChatMessage {
   id: string;
-  memo_id: string;       // backend: thread_id
-  created_by: string;    // backend: sender.id
+  memo_id: string;        // backend: thread_id
+  created_by: string;     // backend: sender.id
+  sender_name: string;    // backend: sender.name
+  sender_type: string;    // backend: sender.type ('human' | 'agent')
   content: string;
   review_type?: string;
   attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
@@ -15,11 +17,13 @@ export interface ChatMessage {
 
 // Normalize backend _to_chat_message format → ChatMessage
 export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
-  const sender = raw.sender as { id?: string } | undefined;
+  const sender = raw.sender as { id?: string; name?: string; type?: string } | undefined;
   return {
     id: (raw.id ?? '') as string,
     memo_id: (raw.thread_id ?? raw.memo_id ?? '') as string,
     created_by: (raw.created_by ?? sender?.id ?? '') as string,
+    sender_name: (sender?.name ?? '') as string,
+    sender_type: (sender?.type ?? 'human') as string,
     content: (raw.content ?? '') as string,
     attachments: (raw.attachments ?? []) as ChatMessage['attachments'],
     created_at: (raw.created_at ?? '') as string,


### PR DESCRIPTION
## 변경 사항

Chat 버블 `'팀'` 하드코딩 → 실제 sender 이름 표시 + 에이전트 뱃지 복원.

**`use-chat-sse.ts`**: `ChatMessage`에 `sender_name`, `sender_type` 추가, `normalizeToMessage()`에서 추출
**`chat-bubble.tsx`**: `sender_name || '팀'` fallback, 에이전트 AI 뱃지 + 보라색 아바타

## 검증
- tsc --noEmit ✅  
- 까심군 APPROVE ✅ (PR #696)

🤖 Generated with [Claude Code](https://claude.com/claude-code)