### PR TITLE
[S21] human 멤버 bell 패널 알림 미표시 수정

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -94,7 +94,7 @@ async def dispatch_notification(
                     db.add(event)
                     inserted = True
             elif member_row.user_id:
-                # human: user_id 있는 경우만 Notification INSERT
+                # human: Notification INSERT (Inbox 호환) + Event INSERT (bell 패널용)
                 notification = Notification(
                     org_id=org_id,
                     user_id=member_row.user_id,
@@ -106,6 +106,20 @@ async def dispatch_notification(
                     reference_id=reference_id,
                 )
                 db.add(notification)
+                if member_row.project_id:
+                    event = Event(
+                        project_id=member_row.project_id,
+                        org_id=org_id,
+                        event_type="dispatched",
+                        source_entity_type=reference_type,
+                        source_entity_id=reference_id,
+                        sender_id=None,
+                        recipient_id=member_row.id,
+                        recipient_type="human",
+                        payload={"title": title, "body": body, "event_type": event_type},
+                        status="delivered",
+                    )
+                    db.add(event)
                 inserted = True
 
         if inserted:


### PR DESCRIPTION
## Summary

- Bell 패널(`/api/v2/event-notifications`)은 `Event` 테이블(recipient_id) 조회
- Inbox(`/api/notifications`)는 `Notification` 테이블(user_id) 조회
- human 멤버는 `Notification`만 INSERT → bell 패널에 0건

**수정**: `dispatch_notification` human 분기에 `Event` INSERT 추가 (status=`delivered`, recipient_type=`human`)
- Notification INSERT는 Inbox 호환성 유지를 위해 그대로 유지

## Changed files

- `backend/app/services/notification_dispatch.py` (+15/-1)

## Test plan

- [ ] dev 배포 후 스토리 상태 변경 등 dispatch_notification 트리거
- [ ] bell 패널에서 알림 표시 확인
- [ ] unread-count badge 증가 확인
- [ ] Inbox 기존 알림 정상 표시 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)