### PR TITLE
[S21 RC2] notifications CHECK 제약 드랍 + savepoint 격리

### DIFF
--- a/backend/alembic/versions/0029_drop_notifications_type_check.py
+++ b/backend/alembic/versions/0029_drop_notifications_type_check.py
@@ -1,0 +1,20 @@
+"""drop notifications_type_check constraint
+
+Revision ID: 0029
+Revises: 0028
+Create Date: 2026-05-14
+"""
+from alembic import op
+
+revision = "0029"
+down_revision = "0028"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE notifications DROP CONSTRAINT IF EXISTS notifications_type_check")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -94,33 +94,42 @@ async def dispatch_notification(
                     db.add(event)
                     inserted = True
             elif member_row.user_id:
-                # human: Notification INSERT (Inbox 호환) + Event INSERT (bell 패널용)
-                notification = Notification(
-                    org_id=org_id,
-                    user_id=member_row.user_id,
-                    type=event_type,
-                    title=title,
-                    body=body,
-                    is_read=False,
-                    reference_type=reference_type,
-                    reference_id=reference_id,
-                )
-                db.add(notification)
+                # human: Notification + Event 각각 독립 savepoint — 하나 실패해도 다른 쪽 롤백 방지
+                try:
+                    async with db.begin_nested():
+                        notification = Notification(
+                            org_id=org_id,
+                            user_id=member_row.user_id,
+                            type=event_type,
+                            title=title,
+                            body=body,
+                            is_read=False,
+                            reference_type=reference_type,
+                            reference_id=reference_id,
+                        )
+                        db.add(notification)
+                    inserted = True
+                except Exception:
+                    logger.warning("Notification INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
                 if member_row.project_id:
-                    event = Event(
-                        project_id=member_row.project_id,
-                        org_id=org_id,
-                        event_type="dispatched",
-                        source_entity_type=reference_type,
-                        source_entity_id=reference_id,
-                        sender_id=None,
-                        recipient_id=member_row.id,
-                        recipient_type="human",
-                        payload={"title": title, "body": body, "event_type": event_type},
-                        status="delivered",
-                    )
-                    db.add(event)
-                inserted = True
+                    try:
+                        async with db.begin_nested():
+                            event = Event(
+                                project_id=member_row.project_id,
+                                org_id=org_id,
+                                event_type="dispatched",
+                                source_entity_type=reference_type,
+                                source_entity_id=reference_id,
+                                sender_id=None,
+                                recipient_id=member_row.id,
+                                recipient_type="human",
+                                payload={"title": title, "body": body, "event_type": event_type},
+                                status="delivered",
+                            )
+                            db.add(event)
+                        inserted = True
+                    except Exception:
+                        logger.warning("Event INSERT failed member_id=%s event_type=%s", member_row.id, event_type)
 
         if inserted:
             await db.flush()


### PR DESCRIPTION
## Summary

PR #699 머지 후 dev 배포 시 `CheckViolationError` 발견. 근본 원인 수정.

**Root Cause**: `notifications` 테이블에 Supabase 레거시 CHECK 제약 `notifications_type_check` 존재. `story_status_changed` 등 신규 event_type이 허용 목록에 없어 INSERT 실패 → 같은 flush의 Event INSERT도 롤백.

## Changes

### 1. `backend/alembic/versions/0029_drop_notifications_type_check.py` (신규)
- `notifications_type_check` CHECK 제약 드랍 (`DROP CONSTRAINT IF EXISTS`)

### 2. `backend/app/services/notification_dispatch.py`
- human 분기 Notification + Event INSERT를 각각 독립 `begin_nested()` savepoint로 격리
- Notification 실패 시에도 Event INSERT는 독립적으로 성공 보장

## AC
- [ ] Migration 0029 dev 적용 (담롱군)
- [ ] story_status_changed 타입 Notification INSERT 성공
- [ ] bell 패널 알림 표시
- [ ] Notification 실패 시 Event는 독립 생성

🤖 Generated with [Claude Code](https://claude.com/claude-code)