### PR TITLE
[S21 RC3] multi-project member bell 알림 0건 수정

### DIFF
--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -19,26 +19,31 @@ router = APIRouter(prefix="/api/v2/event-notifications", tags=["event-notificati
 
 # ─── Helper ───────────────────────────────────────────────────────────────────
 
-async def _resolve_member_ids(
+async def _resolve_member_id(
     auth: AuthContext,
     org_id: uuid.UUID,
     db: AsyncSession,
-) -> list[uuid.UUID]:
-    """JWT auth → 현재 사용자의 org 내 전체 team_member_id 목록 반환. 없으면 403.
+    project_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """JWT auth → team_member_id 반환. project_id 있으면 해당 project member 정확히 지정.
 
-    multi-project 사용자는 org 내 복수 member를 가질 수 있어 전체 반환.
+    multi-project 사용자에서 project_id 없으면 임의 member 반환 위험 있음.
+    list/unread-count는 project_id query param으로 필터링 권장.
     """
     user_id = uuid.UUID(str(auth.user_id))
+    filters = [
+        or_(TeamMember.user_id == user_id, TeamMember.id == user_id),
+        TeamMember.org_id == org_id,
+    ]
+    if project_id:
+        filters.append(TeamMember.project_id == project_id)
     result = await db.execute(
-        select(TeamMember.id).where(
-            or_(TeamMember.user_id == user_id, TeamMember.id == user_id),
-            TeamMember.org_id == org_id,
-        )
+        select(TeamMember.id).where(*filters).limit(1)
     )
-    member_ids = [row[0] for row in result.all()]
-    if not member_ids:
+    member_id = result.scalar_one_or_none()
+    if member_id is None:
         raise HTTPException(status_code=403, detail="Team member not found")
-    return member_ids
+    return member_id
 
 
 # ─── Pydantic schemas ─────────────────────────────────────────────────────────
@@ -68,15 +73,19 @@ class NotificationResponse(BaseModel):
 async def list_notifications(
     limit: int = Query(default=20, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
+    project_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> list[NotificationResponse]:
-    """GET /api/v2/notifications — 현재 사용자의 알림 목록 (최신순)."""
-    member_ids = await _resolve_member_ids(auth, org_id, db)
+    """GET /api/v2/event-notifications — 현재 사용자의 알림 목록 (최신순).
+
+    project_id 필터: 해당 프로젝트의 member_id로 조회 (multi-project 사용자 대응).
+    """
+    member_id = await _resolve_member_id(auth, org_id, db, project_id=project_id)
     result = await db.execute(
         select(Event)
-        .where(Event.org_id == org_id, Event.recipient_id.in_(member_ids))
+        .where(Event.org_id == org_id, Event.recipient_id == member_id)
         .order_by(Event.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -87,16 +96,20 @@ async def list_notifications(
 
 @router.get("/unread-count")
 async def get_unread_count(
+    project_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """GET /api/v2/notifications/unread-count — 읽지 않은 알림 수."""
-    member_ids = await _resolve_member_ids(auth, org_id, db)
+    """GET /api/v2/event-notifications/unread-count — 읽지 않은 알림 수.
+
+    project_id 필터: 해당 프로젝트 알림만 집계.
+    """
+    member_id = await _resolve_member_id(auth, org_id, db, project_id=project_id)
     result = await db.execute(
         select(func.count()).where(
             Event.org_id == org_id,
-            Event.recipient_id.in_(member_ids),
+            Event.recipient_id == member_id,
             Event.read_at.is_(None),
         )
     )
@@ -111,8 +124,7 @@ async def mark_read(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> NotificationResponse:
-    """PATCH /api/v2/notifications/{id}/read — 단일 알림 읽음 처리."""
-    member_ids = await _resolve_member_ids(auth, org_id, db)
+    """PATCH /api/v2/event-notifications/{id}/read — 단일 알림 읽음 처리."""
     result = await db.execute(
         select(Event).where(
             Event.id == event_id,
@@ -122,7 +134,9 @@ async def mark_read(
     event = result.scalar_one_or_none()
     if event is None:
         raise HTTPException(status_code=404, detail="Notification not found")
-    if event.recipient_id not in member_ids:
+    # event.project_id로 정확한 member_id resolve → access check
+    member_id = await _resolve_member_id(auth, org_id, db, project_id=event.project_id)
+    if event.recipient_id != member_id:
         raise HTTPException(status_code=403, detail="Access denied")
 
     if event.read_at is None:
@@ -134,18 +148,19 @@ async def mark_read(
 
 @router.patch("/read-all")
 async def mark_all_read(
+    project_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """PATCH /api/v2/notifications/read-all — 전체 읽음 처리."""
-    member_ids = await _resolve_member_ids(auth, org_id, db)
+    """PATCH /api/v2/event-notifications/read-all — 전체 읽음 처리."""
+    member_id = await _resolve_member_id(auth, org_id, db, project_id=project_id)
     now = datetime.now(timezone.utc)
     result = await db.execute(
         update(Event)
         .where(
             Event.org_id == org_id,
-            Event.recipient_id.in_(member_ids),
+            Event.recipient_id == member_id,
             Event.read_at.is_(None),
         )
         .values(read_at=now)

--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -19,23 +19,26 @@ router = APIRouter(prefix="/api/v2/event-notifications", tags=["event-notificati
 
 # ─── Helper ───────────────────────────────────────────────────────────────────
 
-async def _resolve_member_id(
+async def _resolve_member_ids(
     auth: AuthContext,
     org_id: uuid.UUID,
     db: AsyncSession,
-) -> uuid.UUID:
-    """JWT auth → 현재 사용자의 team_member_id 반환. 없으면 403."""
+) -> list[uuid.UUID]:
+    """JWT auth → 현재 사용자의 org 내 전체 team_member_id 목록 반환. 없으면 403.
+
+    multi-project 사용자는 org 내 복수 member를 가질 수 있어 전체 반환.
+    """
     user_id = uuid.UUID(str(auth.user_id))
     result = await db.execute(
         select(TeamMember.id).where(
             or_(TeamMember.user_id == user_id, TeamMember.id == user_id),
             TeamMember.org_id == org_id,
-        ).limit(1)
+        )
     )
-    member_id = result.scalar_one_or_none()
-    if member_id is None:
+    member_ids = [row[0] for row in result.all()]
+    if not member_ids:
         raise HTTPException(status_code=403, detail="Team member not found")
-    return member_id
+    return member_ids
 
 
 # ─── Pydantic schemas ─────────────────────────────────────────────────────────
@@ -70,10 +73,10 @@ async def list_notifications(
     auth: AuthContext = Depends(get_current_user),
 ) -> list[NotificationResponse]:
     """GET /api/v2/notifications — 현재 사용자의 알림 목록 (최신순)."""
-    member_id = await _resolve_member_id(auth, org_id, db)
+    member_ids = await _resolve_member_ids(auth, org_id, db)
     result = await db.execute(
         select(Event)
-        .where(Event.org_id == org_id, Event.recipient_id == member_id)
+        .where(Event.org_id == org_id, Event.recipient_id.in_(member_ids))
         .order_by(Event.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -89,11 +92,11 @@ async def get_unread_count(
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """GET /api/v2/notifications/unread-count — 읽지 않은 알림 수."""
-    member_id = await _resolve_member_id(auth, org_id, db)
+    member_ids = await _resolve_member_ids(auth, org_id, db)
     result = await db.execute(
         select(func.count()).where(
             Event.org_id == org_id,
-            Event.recipient_id == member_id,
+            Event.recipient_id.in_(member_ids),
             Event.read_at.is_(None),
         )
     )
@@ -109,7 +112,7 @@ async def mark_read(
     auth: AuthContext = Depends(get_current_user),
 ) -> NotificationResponse:
     """PATCH /api/v2/notifications/{id}/read — 단일 알림 읽음 처리."""
-    member_id = await _resolve_member_id(auth, org_id, db)
+    member_ids = await _resolve_member_ids(auth, org_id, db)
     result = await db.execute(
         select(Event).where(
             Event.id == event_id,
@@ -119,7 +122,7 @@ async def mark_read(
     event = result.scalar_one_or_none()
     if event is None:
         raise HTTPException(status_code=404, detail="Notification not found")
-    if event.recipient_id != member_id:
+    if event.recipient_id not in member_ids:
         raise HTTPException(status_code=403, detail="Access denied")
 
     if event.read_at is None:
@@ -136,13 +139,13 @@ async def mark_all_read(
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
     """PATCH /api/v2/notifications/read-all — 전체 읽음 처리."""
-    member_id = await _resolve_member_id(auth, org_id, db)
+    member_ids = await _resolve_member_ids(auth, org_id, db)
     now = datetime.now(timezone.utc)
     result = await db.execute(
         update(Event)
         .where(
             Event.org_id == org_id,
-            Event.recipient_id == member_id,
+            Event.recipient_id.in_(member_ids),
             Event.read_at.is_(None),
         )
         .values(read_at=now)


### PR DESCRIPTION
## Root Cause

`event_notifications.py:_resolve_member_id`가 `ORDER BY` 없이 `LIMIT 1` 사용.
동일 org 내 복수 project member(sprintable+장사왕) 보유 시 DB가 임의 member를 반환
→ Event 조회 시 recipient_id 불일치 → bell 패널 0건.

## Fix

`_resolve_member_id` → `_resolve_member_ids` (복수) 변환:
- `LIMIT 1` 제거, 전체 member_id 목록 반환
- `recipient_id == member_id` → `recipient_id.in_(member_ids)` (4개 endpoint 전체)
- `mark_read` access check: `!= member_id` → `not in member_ids`

## Changed files

- `backend/app/routers/event_notifications.py` (+18/-15)

## AC
- [ ] multi-project 사용자(선생님) bell 패널 알림 표시
- [ ] unread-count 전 member_id 집계
- [ ] mark_read / mark_all_read 전 member_id 대상

🤖 Generated with [Claude Code](https://claude.com/claude-code)