### PR TITLE
[SID:598474f6] S21 bell 패널 project_id query param 전달

### DIFF
--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -94,8 +94,10 @@ function timeAgo(dateStr: string): string {
   return `${days}일 전`;
 }
 
-async function fetchNotifications(): Promise<EventNotification[]> {
-  const res = await fetch('/api/event-notifications?limit=30');
+async function fetchNotifications(projectId?: string): Promise<EventNotification[]> {
+  const params = new URLSearchParams({ limit: '30' });
+  if (projectId) params.set('project_id', projectId);
+  const res = await fetch(`/api/event-notifications?${params.toString()}`);
   if (!res.ok) return [];
   const json = (await res.json()) as unknown;
   if (Array.isArray(json)) return json as EventNotification[];
@@ -107,8 +109,9 @@ async function fetchNotifications(): Promise<EventNotification[]> {
   return [];
 }
 
-async function fetchUnreadCount(): Promise<number> {
-  const res = await fetch('/api/event-notifications/unread-count');
+async function fetchUnreadCount(projectId?: string): Promise<number> {
+  const params = projectId ? `?project_id=${projectId}` : '';
+  const res = await fetch(`/api/event-notifications/unread-count${params}`);
   if (!res.ok) return 0;
   const json = (await res.json()) as unknown;
   if (json && typeof json === 'object') {
@@ -280,7 +283,7 @@ function NotificationPanel({
 
 export function NotificationBell() {
   const router = useRouter();
-  const { currentTeamMemberId } = useDashboardContext();
+  const { currentTeamMemberId, projectId } = useDashboardContext();
   const [open, setOpen] = useState(false);
   const [unreadCount, setUnreadCount] = useState(0);
   // null = 로딩 중, array = 로드 완료
@@ -321,7 +324,7 @@ export function NotificationBell() {
   useEffect(() => {
     let cancelled = false;
     const poll = async () => {
-      const count = await fetchUnreadCount();
+      const count = await fetchUnreadCount(projectId ?? undefined);
       if (!cancelled) setUnreadCount(count);
     };
     void poll();
@@ -333,13 +336,13 @@ export function NotificationBell() {
       if (intervalRef.current) clearInterval(intervalRef.current);
       document.removeEventListener('visibilitychange', onVisibility);
     };
-  }, []);
+  }, [projectId]);
 
   // 패널 열릴 때 알림 목록 로드 + 브라우저 Notification 권한 요청
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
-    void fetchNotifications().then((data) => {
+    void fetchNotifications(projectId ?? undefined).then((data) => {
       if (!cancelled) setNotifications(data);
     });
     // 브라우저 Notification 권한 — 최초 패널 오픈 시 요청
@@ -347,7 +350,7 @@ export function NotificationBell() {
       void Notification.requestPermission();
     }
     return () => { cancelled = true; };
-  }, [open]);
+  }, [open, projectId]);
 
   // 외부 클릭으로 패널 닫기 (데스크톱)
   useEffect(() => {
@@ -386,9 +389,9 @@ export function NotificationBell() {
     const res = await fetch('/api/event-notifications/read-all', { method: 'PATCH' });
     // 서버 실패 시 unread count 재폴링으로 보정
     if (!res.ok) {
-      void fetchUnreadCount().then(setUnreadCount);
+      void fetchUnreadCount(projectId ?? undefined).then(setUnreadCount);
     }
-  }, []);
+  }, [projectId]);
 
   const handleNavigate = useCallback(
     (notification: EventNotification) => {


### PR DESCRIPTION
## 변경 사항

Bell 알림 패널이 현재 활성 project_id를 백엔드에 전달하지 않아 multi-project 사용자가 잘못된 member로 조회되는 버그 수정.

### 수정 내용 (`notification-bell.tsx`)
- `fetchNotifications(projectId?)` — `?project_id=` query param 추가
- `fetchUnreadCount(projectId?)` — `?project_id=` query param 추가
- `NotificationBell`에서 `useDashboardContext().projectId` 가져와서 전달
- project 전환 시 bell 내용도 재조회 (deps에 `projectId` 추가)

## 검증
- tsc --noEmit ✅
- ESLint 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)