### PR TITLE
[SID:598474f6] S21 bell handleMarkAllRead project_id 미전달 수정

### DIFF
--- a/apps/web/src/components/nav/notification-bell.tsx
+++ b/apps/web/src/components/nav/notification-bell.tsx
@@ -386,7 +386,8 @@ export function NotificationBell() {
     // 낙관적 업데이트
     setNotifications((prev) => prev ? prev.map((n) => ({ ...n, read_at: n.read_at ?? readAt })) : prev);
     setUnreadCount(0);
-    const res = await fetch('/api/event-notifications/read-all', { method: 'PATCH' });
+    const readAllParams = projectId ? `?project_id=${projectId}` : '';
+    const res = await fetch(`/api/event-notifications/read-all${readAllParams}`, { method: 'PATCH' });
     // 서버 실패 시 unread count 재폴링으로 보정
     if (!res.ok) {
       void fetchUnreadCount(projectId ?? undefined).then(setUnreadCount);


### PR DESCRIPTION
## 변경 사항

PR #702 follow-up. `handleMarkAllRead`에서 `read-all` PATCH 호출 시 `project_id` query param 누락 수정.

```typescript
const readAllParams = projectId ? `?project_id=${projectId}` : '';
await fetch(`/api/event-notifications/read-all${readAllParams}`, { method: 'PATCH' });
```

## 검증
- tsc --noEmit ✅
- ESLint 0건 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)