### PR TITLE
[S34] chat multi-recipient — memo_assignees 기반 전체 수신자 broadcast

### DIFF
--- a/backend/app/routers/chats.py
+++ b/backend/app/routers/chats.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.event import Event
-from app.models.memo import Memo, MemoReply
+from app.models.memo import Memo, MemoAssignee, MemoReply
 from app.models.team import TeamMember
 from app.repositories.memo import MemoReplyRepository
 from app.routers.events import _push_to_agent, publish_event
@@ -80,10 +80,19 @@ async def _build_participants(
 ) -> set[uuid.UUID]:
     """chat:message 이벤트 수신자 세트 구성.
 
-    assigned_to + created_by + 기존 thread reply senders 포함, 발신자 제거.
-    assigned_to=null + sender==created_by 케이스에서 participants가 비는 문제 해소.
+    memo_assignees(다중) + assigned_to(레거시 단일) + created_by + 기존 thread reply senders 포함, 발신자 제거.
     """
     participants: set[uuid.UUID] = set()
+
+    # 다중 수신자: memo_assignees 테이블
+    assignee_result = await db.execute(
+        select(MemoAssignee.member_id).where(MemoAssignee.memo_id == thread_id)
+    )
+    for row in assignee_result.all():
+        if row[0]:
+            participants.add(row[0])
+
+    # 레거시 단일 수신자 fallback
     if memo.assigned_to:
         participants.add(memo.assigned_to)
     if memo.created_by:

--- a/backend/tests/test_chat_s17.py
+++ b/backend/tests/test_chat_s17.py
@@ -82,6 +82,11 @@ async def _make_client(auth_ctx=None):
     mock_session.flush = AsyncMock()
     mock_session.commit = AsyncMock()
 
+    nested_cm = AsyncMock()
+    nested_cm.__aenter__ = AsyncMock(return_value=None)
+    nested_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_session.begin_nested = MagicMock(return_value=nested_cm)
+
     async def override_db():
         yield mock_session
 
@@ -110,10 +115,14 @@ async def test_send_chat_message_jwt_auth():
         mock_reply = _mock_reply("안녕")
         mock_member = _mock_member()
 
-        # session.execute: Memo 조회 → TeamMember(user_id) 조회
+        # session.execute: Memo → sender(scalars().first()) → MemoAssignee → MemoReply(prior)
+        sender_result = MagicMock()
+        sender_result.scalars.return_value.first.return_value = mock_member
         exec_results = [
-            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),  # Memo
-            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)),  # sender (JWT→user_id)
+            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),   # Memo
+            sender_result,                                                       # sender (JWT→scalars().first())
+            MagicMock(all=MagicMock(return_value=[])),                          # MemoAssignee (없음)
+            MagicMock(all=MagicMock(return_value=[])),                          # MemoReply prior senders
         ]
         session.execute = AsyncMock(side_effect=exec_results)
 
@@ -148,9 +157,13 @@ async def test_send_chat_message_api_key_auth():
         mock_reply = _mock_reply()
         mock_member = _mock_member()
 
+        sender_result = MagicMock()
+        sender_result.scalars.return_value.first.return_value = mock_member
         exec_results = [
             MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),   # Memo
-            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)), # sender (api_key→member.id)
+            sender_result,                                                       # sender (api_key→scalars().first())
+            MagicMock(all=MagicMock(return_value=[])),                          # MemoAssignee
+            MagicMock(all=MagicMock(return_value=[])),                          # MemoReply prior
         ]
         session.execute = AsyncMock(side_effect=exec_results)
 
@@ -212,9 +225,13 @@ async def test_send_chat_message_upload_no_created_by_field():
         mock_reply = _mock_reply("첨부 메시지")
         mock_member = _mock_member()
 
+        sender_result = MagicMock()
+        sender_result.scalars.return_value.first.return_value = mock_member
         exec_results = [
             MagicMock(scalar_one_or_none=MagicMock(return_value=mock_memo)),
-            MagicMock(scalar_one_or_none=MagicMock(return_value=mock_member)),
+            sender_result,                                  # sender (scalars().first())
+            MagicMock(all=MagicMock(return_value=[])),      # MemoAssignee
+            MagicMock(all=MagicMock(return_value=[])),      # MemoReply prior
         ]
         session.execute = AsyncMock(side_effect=exec_results)
 
@@ -265,3 +282,65 @@ async def test_list_chat_messages_before_cursor():
         assert body["meta"]["next_cursor"] is not None
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── S34: multi-recipient — memo_assignees 기반 전체 수신자 broadcast ─────────
+
+AGENT_IDS = [uuid.uuid4() for _ in range(4)]  # 은와추쿠, 까심, 담롱, 미르코
+
+
+@pytest.mark.anyio
+async def test_build_participants_includes_all_assignees():
+    """S34: _build_participants가 memo_assignees 테이블의 전체 수신자를 포함하는지 검증."""
+    from app.routers.chats import _build_participants
+    from app.models.memo import Memo
+
+    sender_id = uuid.uuid4()
+    creator_id = uuid.uuid4()
+
+    mock_memo = MagicMock()
+    mock_memo.assigned_to = None   # 레거시 단일 필드 없음
+    mock_memo.created_by = creator_id
+
+    mock_db = AsyncMock()
+
+    # MemoAssignee 쿼리 → 4명 반환
+    assignee_rows = [(aid,) for aid in AGENT_IDS]
+    # MemoReply prior senders 쿼리 → 없음
+    mock_db.execute = AsyncMock(side_effect=[
+        MagicMock(all=MagicMock(return_value=assignee_rows)),  # MemoAssignee
+        MagicMock(all=MagicMock(return_value=[])),             # MemoReply prior
+    ])
+
+    thread_id = uuid.uuid4()
+    participants = await _build_participants(mock_db, mock_memo, thread_id, sender_id)
+
+    # 4명 에이전트 + creator 포함, sender 제외
+    for aid in AGENT_IDS:
+        assert aid in participants, f"assignee {aid} not in participants"
+    assert creator_id in participants
+    assert sender_id not in participants
+
+
+@pytest.mark.anyio
+async def test_build_participants_sender_excluded():
+    """S34: 발신자 본인은 participants에서 제외되는지 검증."""
+    from app.routers.chats import _build_participants
+
+    sender_id = AGENT_IDS[0]
+
+    mock_memo = MagicMock()
+    mock_memo.assigned_to = None
+    mock_memo.created_by = None
+
+    mock_db = AsyncMock()
+    # MemoAssignee: sender 포함 5명 반환
+    assignee_rows = [(aid,) for aid in AGENT_IDS]
+    mock_db.execute = AsyncMock(side_effect=[
+        MagicMock(all=MagicMock(return_value=assignee_rows)),
+        MagicMock(all=MagicMock(return_value=[])),
+    ])
+
+    participants = await _build_participants(mock_db, mock_memo, uuid.uuid4(), sender_id)
+    assert sender_id not in participants
+    assert len(participants) == len(AGENT_IDS) - 1


### PR DESCRIPTION
## Summary
- `_build_participants`가 `memo.assigned_to`(단일 FK)만 읽어 나머지 수신자에게 `chat:message` 이벤트 미도달하는 버그 수정
- `memo_assignees` 테이블(다중 수신자) 쿼리 추가 → `assigned_to_ids` 전체 수신자 포함
- 레거시 `assigned_to` 단일 필드는 fallback으로 유지

## 변경 파일
- `backend/app/routers/chats.py` — `_build_participants`: `MemoAssignee` import + 다중 수신자 쿼리 추가
- `backend/tests/test_chat_s17.py` — sender mock 패턴 수정(scalars().first()), begin_nested CM 추가, S34 multi-recipient 검증 2케이스

## AC 검증
- [x] 5인 assigned_to 메모 스레드에서 Chat 메시지 발송 시 전 수신자 participants 포함
- [x] 발신자 본인 제외
- [x] 레거시 단일 assigned_to fallback 유지
- [x] 7/7 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)