### PR TITLE
[S36] fakechat 역방향 자동 relay — Sprintable Chat API 코드 레벨 연결

### DIFF
--- a/packages/mcp-server/src/sse-bridge.ts
+++ b/packages/mcp-server/src/sse-bridge.ts
@@ -23,11 +23,19 @@ async function relayToFakechat(eventType: string, data: unknown): Promise<void> 
   const id = `sse-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
   let text: string;
+  let threadId = '';
   if (typeof data === 'object' && data !== null) {
     const d = data as Record<string, unknown>;
-    const sender = d.sender_name ?? d.sender ?? d.member_name ?? '';
-    const content = d.content ?? d.message ?? d.text ?? JSON.stringify(data);
-    text = sender ? `[${eventType}] ${sender}: ${content}` : `[${eventType}] ${content}`;
+    // payload가 중첩된 경우(chat:message 이벤트) payload에서 꺼냄
+    const payload = (d.payload ?? d) as Record<string, unknown>;
+    const senderRaw = payload.sender ?? d.sender_name ?? d.member_name ?? '';
+    const senderName =
+      typeof senderRaw === 'object' && senderRaw !== null
+        ? String((senderRaw as Record<string, unknown>).name ?? '')
+        : String(senderRaw);
+    const content = payload.content ?? d.content ?? d.message ?? d.text ?? JSON.stringify(data);
+    text = senderName ? `[${eventType}] ${senderName}: ${content}` : `[${eventType}] ${content}`;
+    threadId = String(payload.thread_id ?? d.thread_id ?? '');
   } else {
     text = `[${eventType}] ${String(data)}`;
   }
@@ -35,6 +43,17 @@ async function relayToFakechat(eventType: string, data: unknown): Promise<void> 
   const form = new FormData();
   form.set('id', id);
   form.set('text', text);
+
+  // 역방향 relay를 위해 thread_id + callback 정보 포함
+  if (threadId) {
+    const pmApiUrl = (process.env.PM_API_URL ?? '').replace(/\/$/, '');
+    const agentApiKey = process.env.AGENT_API_KEY ?? '';
+    form.set('thread_id', threadId);
+    if (pmApiUrl && agentApiKey) {
+      form.set('reply_callback_url', `${pmApiUrl}/api/v2/chats/${threadId}/messages`);
+      form.set('reply_callback_api_key', agentApiKey);
+    }
+  }
 
   const res = await fetch(`http://127.0.0.1:${port}/upload`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- 에이전트가 `fakechat.reply` 호출 시 Sprintable Chat에 미도달하는 문제 해결
- 프롬프트 행동패턴 아닌 **코드 레벨 자동 라우팅** 구현 — fakechat 플러그인만 있으면 양방향 통신

## 변경 파일
### `packages/mcp-server/src/sse-bridge.ts`
- `relayToFakechat`: `payload.thread_id` 추출 + `PM_API_URL`/`AGENT_API_KEY` 환경변수로 callback URL 구성
- fakechat `/upload`에 `thread_id`, `reply_callback_url`, `reply_callback_api_key` form field 추가

### `~/.claude/plugins/.../fakechat/server.ts` (별도 파일, 로컬 적용)
- `InboundMeta` 타입 + `inboundMeta` 맵 + `latestInboundMeta` fallback 추가
- `/upload` 핸들러: relay 메타 파싱 → `deliver()`에 전달
- `deliver()`: thread_id 있으면 meta 저장 + channel notification에 `thread_id` 포함
- `reply` 도구: `reply_to` 메시지 meta(또는 최근 inbound) → `fetch(replyCallbackUrl, ...)` 자동 호출

## 동작 흐름
```
Sprintable Chat → SSE → sse-bridge(thread_id+callback 포함) → fakechat /upload
에이전트 → fakechat.reply → 자동 fetch(replyCallbackUrl) → Sprintable Chat API
```

## AC
- [x] chat:message 수신 시 sse-bridge가 thread_id + callback_url 포함하여 relay
- [x] fakechat reply 시 Sprintable Chat API 자동 호출 (코드 레벨)
- [x] reply_to 없는 경우 latestInboundMeta fallback
- [x] type-check PASS, build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)