### PR TITLE
[SID:4a7097dc] S35 Chat UI @멘션 #임베드 복구

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
@@ -18,7 +18,7 @@ export default function MemoDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
   const t = useTranslations('memos');
-  const { currentTeamMemberId } = useDashboardContext();
+  const { currentTeamMemberId, projectId } = useDashboardContext();
 
   const [memo, setMemo] = useState<MemoSummary | null>(null);
 
@@ -77,6 +77,7 @@ export default function MemoDetailPage() {
           threadId={id}
           currentTeamMemberId={currentTeamMemberId}
           threadTitle={memo?.title ?? undefined}
+          projectId={projectId}
         />
       </div>
     </>

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,11 +1,78 @@
 'use client';
 
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import { Bot, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
+import { EntityChip, getEntityHref } from '@/components/memos/embed-card';
 
 interface ChatBubbleProps {
   message: ChatMessage;
   isMine: boolean;
+}
+
+function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean }) {
+  const text = isMine ? 'text-primary-foreground' : 'text-foreground';
+  const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
+  const codeBg = isMine ? 'bg-primary-foreground/10 text-primary-foreground' : 'bg-muted text-foreground';
+  const border = isMine ? 'border-primary-foreground/30' : 'border-border';
+
+  // Detect if content has markdown-like patterns to avoid unnecessary parsing overhead
+  const hasMarkdown = /[*_`#\[\]>~]|entity:/.test(content);
+
+  if (!hasMarkdown) {
+    return (
+      <span className={`whitespace-pre-wrap break-words text-sm leading-relaxed ${text}`}>
+        {content.split(/(@\w[\w가-힣]*)/).map((part, i) =>
+          part.startsWith('@') ? (
+            <span key={i} className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>{part}</span>
+          ) : part
+        )}
+      </span>
+    );
+  }
+
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      urlTransform={(url) => url.startsWith('entity:') ? url : defaultUrlTransform(url)}
+      components={{
+        p: ({ children }) => <p className={`mb-1.5 break-words text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
+        strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
+        em: ({ children }) => <em className={`italic ${text}`}>{children}</em>,
+        code: ({ children }) => <code className={`rounded px-1 py-0.5 font-mono text-xs ${codeBg}`}>{children}</code>,
+        pre: ({ children }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
+        ul: ({ children }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
+        ol: ({ children }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,
+        li: ({ children }) => <li className={`text-sm leading-relaxed ${text}`}>{children}</li>,
+        blockquote: ({ children }) => <blockquote className={`mb-1.5 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
+        a: ({ href, children }) => {
+          const m = href?.match(/^entity:(\w+):([0-9a-f-]+)$/i);
+          if (m) {
+            const entityType = m[1]!;
+            const entityId = m[2]!;
+            return <EntityChip entityType={entityType} entityId={entityId} label={String(children)} href={getEntityHref(entityType, entityId)} />;
+          }
+          return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
+        },
+        text: ({ children }) => {
+          const str = String(children);
+          if (!str.includes('@')) return <>{str}</>;
+          return (
+            <>
+              {str.split(/(@\w[\w가-힣]*)/).map((part, i) =>
+                part.startsWith('@') ? (
+                  <span key={i} className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>{part}</span>
+                ) : part
+              )}
+            </>
+          );
+        },
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  );
 }
 
 export function ChatBubble({ message, isMine }: ChatBubbleProps) {
@@ -39,12 +106,12 @@ export function ChatBubble({ message, isMine }: ChatBubbleProps) {
         </div>
 
         {/* Content */}
-        <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed whitespace-pre-wrap break-words ${
+        <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words ${
           isMine
             ? 'rounded-tr-sm bg-primary text-primary-foreground'
             : 'rounded-tl-sm bg-muted text-foreground'
         }`}>
-          {message.content}
+          <ChatMarkdown content={message.content} isMine={isMine} />
         </div>
 
         {/* Attachments */}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -11,31 +11,37 @@ interface ChatBubbleProps {
   isMine: boolean;
 }
 
+// Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
+// Uses negative lookbehind to skip already-linked mentions (e.g. inside [...]).
+function prepareMentions(content: string): string {
+  return content.replace(/(?<![[(])@([\w가-힣]+)/g, '[@$1](mention:$1)');
+}
+
 function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean }) {
   const text = isMine ? 'text-primary-foreground' : 'text-foreground';
   const muted = isMine ? 'text-primary-foreground/70' : 'text-muted-foreground';
   const codeBg = isMine ? 'bg-primary-foreground/10 text-primary-foreground' : 'bg-muted text-foreground';
   const border = isMine ? 'border-primary-foreground/30' : 'border-border';
 
-  // Detect if content has markdown-like patterns to avoid unnecessary parsing overhead
+  const hasMention = /@[\w가-힣]+/.test(content);
   const hasMarkdown = /[*_`#\[\]>~]|entity:/.test(content);
 
-  if (!hasMarkdown) {
+  if (!hasMarkdown && !hasMention) {
     return (
       <span className={`whitespace-pre-wrap break-words text-sm leading-relaxed ${text}`}>
-        {content.split(/(@\w[\w가-힣]*)/).map((part, i) =>
-          part.startsWith('@') ? (
-            <span key={i} className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>{part}</span>
-          ) : part
-        )}
+        {content}
       </span>
     );
   }
 
+  const prepared = hasMention ? prepareMentions(content) : content;
+
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
-      urlTransform={(url) => url.startsWith('entity:') ? url : defaultUrlTransform(url)}
+      urlTransform={(url) =>
+        url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
+      }
       components={{
         p: ({ children }) => <p className={`mb-1.5 break-words text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
         strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
@@ -47,30 +53,22 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
         li: ({ children }) => <li className={`text-sm leading-relaxed ${text}`}>{children}</li>,
         blockquote: ({ children }) => <blockquote className={`mb-1.5 border-l-2 pl-3 ${border} ${muted}`}>{children}</blockquote>,
         a: ({ href, children }) => {
+          if (href?.startsWith('mention:')) {
+            return (
+              <span className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>
+                {children}
+              </span>
+            );
+          }
           const m = href?.match(/^entity:(\w+):([0-9a-f-]+)$/i);
           if (m) {
-            const entityType = m[1]!;
-            const entityId = m[2]!;
-            return <EntityChip entityType={entityType} entityId={entityId} label={String(children)} href={getEntityHref(entityType, entityId)} />;
+            return <EntityChip entityType={m[1]!} entityId={m[2]!} label={String(children)} href={getEntityHref(m[1]!, m[2]!)} />;
           }
           return <a href={href} target="_blank" rel="noopener noreferrer" className={`underline underline-offset-2 ${text}`}>{children}</a>;
         },
-        text: ({ children }) => {
-          const str = String(children);
-          if (!str.includes('@')) return <>{str}</>;
-          return (
-            <>
-              {str.split(/(@\w[\w가-힣]*)/).map((part, i) =>
-                part.startsWith('@') ? (
-                  <span key={i} className={`font-medium ${isMine ? 'text-primary-foreground underline decoration-primary-foreground/40' : 'text-primary'}`}>{part}</span>
-                ) : part
-              )}
-            </>
-          );
-        },
       }}
     >
-      {content}
+      {prepared}
     </ReactMarkdown>
   );
 }

--- a/apps/web/src/components/chat/chat-input.test.ts
+++ b/apps/web/src/components/chat/chat-input.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+// Pure helper functions extracted from chat-input.tsx for testing
+function getMentionQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/@([\w가-힣]*)$/);
+  return m ? m[1] : null;
+}
+
+function applyMention(value: string, cursorPos: number, name: string): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/@([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  const replacement = `@${name} `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+function getEntityQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  return m ? m[1] : null;
+}
+
+function applyEntity(
+  value: string,
+  cursorPos: number,
+  title: string,
+  entityType: string,
+  entityId: string,
+): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  const replacement = `[${title}](entity:${entityType}:${entityId}) `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+describe('getMentionQuery', () => {
+  it('returns query after @', () => {
+    expect(getMentionQuery('hello @mir', 10)).toBe('mir');
+  });
+  it('returns empty string when @ just typed', () => {
+    expect(getMentionQuery('hello @', 7)).toBe('');
+  });
+  it('returns null when no @ present', () => {
+    expect(getMentionQuery('hello world', 11)).toBeNull();
+  });
+  it('returns null when cursor is past @ but no word chars follow', () => {
+    expect(getMentionQuery('hello @ world', 8)).toBeNull();
+  });
+  it('handles Korean names', () => {
+    expect(getMentionQuery('@미르코', 4)).toBe('미르코');
+  });
+});
+
+describe('applyMention', () => {
+  it('replaces @partial with @name + space', () => {
+    const { text, caretPos } = applyMention('hello @mir', 10, '미르코');
+    expect(text).toBe('hello @미르코 ');
+    // start=6, replacement='@미르코 '(5 chars) → caretPos=11
+    expect(caretPos).toBe(11);
+  });
+  it('inserts after @ with empty query', () => {
+    const { text } = applyMention('hello @', 7, '미르코');
+    expect(text).toBe('hello @미르코 ');
+  });
+  it('preserves text after cursor', () => {
+    const { text } = applyMention('hello @mir more text', 10, '미르코');
+    expect(text).toBe('hello @미르코  more text');
+  });
+});
+
+describe('getEntityQuery', () => {
+  it('returns query after #', () => {
+    expect(getEntityQuery('check #S35', 10)).toBe('S35');
+  });
+  it('returns empty string when # just typed', () => {
+    expect(getEntityQuery('check #', 7)).toBe('');
+  });
+  it('returns null when no # present', () => {
+    expect(getEntityQuery('no hash here', 12)).toBeNull();
+  });
+});
+
+describe('applyEntity', () => {
+  it('replaces #partial with markdown entity link', () => {
+    const { text } = applyEntity('check #S35', 10, 'S35 Chat UI', 'story', 'abc-123');
+    expect(text).toBe('check [S35 Chat UI](entity:story:abc-123) ');
+  });
+  it('caret position after insertion is correct', () => {
+    const { caretPos } = applyEntity('#', 1, 'S35', 'story', 'abc-123');
+    const expected = '[S35](entity:story:abc-123) '.length;
+    expect(caretPos).toBe(expected);
+  });
+  it('preserves trailing text', () => {
+    const { text } = applyEntity('see #abc and more', 8, 'Test', 'epic', 'def-456');
+    expect(text).toBe('see [Test](entity:epic:def-456)  and more');
+  });
+});

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -1,28 +1,181 @@
 'use client';
 
-import { useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
 import { Paperclip, Send, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+function getMentionQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/@([\w가-힣]*)$/);
+  return m ? m[1] : null;
+}
+
+function applyMention(value: string, cursorPos: number, name: string): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/@([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  const replacement = `@${name} `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+function getEntityQuery(value: string, cursorPos: number): string | null {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  return m ? m[1] : null;
+}
+
+function applyEntity(
+  value: string,
+  cursorPos: number,
+  title: string,
+  entityType: string,
+  entityId: string,
+): { text: string; caretPos: number } {
+  const before = value.slice(0, cursorPos);
+  const m = before.match(/#([\w가-힣]*)$/);
+  if (!m) return { text: value, caretPos: cursorPos };
+  const start = cursorPos - m[0].length;
+  const replacement = `[${title}](entity:${entityType}:${entityId}) `;
+  return { text: value.slice(0, start) + replacement + value.slice(cursorPos), caretPos: start + replacement.length };
+}
+
+const ENTITY_ICONS: Record<string, string> = {
+  story: '📋',
+  doc: '📄',
+  epic: '🎯',
+  task: '✅',
+};
+
+interface MentionMember {
+  id: string;
+  name: string;
+  role?: string | null;
+}
+
+interface EntityResult {
+  entity_type: string;
+  entity_id: string;
+  title: string;
+  status: string | null;
+}
+
 interface ChatInputProps {
-  onSend: (content: string) => Promise<void>;
+  onSend: (content: string, mentionedIds?: string[]) => Promise<void>;
   onUpload: (file: File) => Promise<void>;
   disabled?: boolean;
   placeholder?: string;
+  projectId?: string;
+  onMentionIdsChange?: (ids: string[]) => void;
 }
 
-export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInputProps) {
+export function ChatInput({ onSend, onUpload, disabled, placeholder, projectId, onMentionIdsChange }: ChatInputProps) {
   const [text, setText] = useState('');
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [sending, setSending] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const mentionedIdsRef = useRef<string[]>([]);
+
+  const [mentionQuery, setMentionQuery] = useState<string | null>(null);
+  const [mentionMembers, setMentionMembers] = useState<MentionMember[]>([]);
+  const [mentionIndex, setMentionIndex] = useState(0);
+
+  const [entityQuery, setEntityQuery] = useState<string | null>(null);
+  const [entityResults, setEntityResults] = useState<EntityResult[]>([]);
+  const [entityIndex, setEntityIndex] = useState(0);
+
+  useEffect(() => {
+    if (mentionQuery === null) { setMentionMembers([]); return; }
+    let cancelled = false;
+    fetch(`/api/team-members?is_active=true${projectId ? `&project_id=${projectId}` : ''}`)
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return;
+        const all: MentionMember[] = (json.data ?? []).map((m: { id: string; name: string; role?: string | null }) => ({ id: m.id, name: m.name, role: m.role }));
+        const q = mentionQuery.toLowerCase();
+        setMentionMembers(q ? all.filter((m) => m.name.toLowerCase().includes(q)) : all);
+        setMentionIndex(0);
+      })
+      .catch(() => {});
+    return () => { cancelled = true; };
+  }, [mentionQuery, projectId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (entityQuery === null || !projectId) { setEntityResults([]); return; }
+    const timer = window.setTimeout(() => {
+      const params = new URLSearchParams({ project_id: projectId });
+      if (entityQuery) params.set('q', entityQuery);
+      fetch(`/api/entities/search?${params}`)
+        .then((r) => r.json())
+        .then((json: EntityResult[] | { data?: EntityResult[] }) => {
+          if (cancelled) return;
+          const arr = Array.isArray(json) ? json : (json.data ?? []);
+          setEntityResults(Array.isArray(arr) ? arr : []);
+          setEntityIndex(0);
+        })
+        .catch(() => {});
+    }, 200);
+    return () => { cancelled = true; window.clearTimeout(timer); };
+  }, [entityQuery, projectId]);
 
   const adjustHeight = () => {
     const el = textareaRef.current;
     if (!el) return;
     el.style.height = 'auto';
     el.style.height = `${Math.min(el.scrollHeight, 160)}px`;
+  };
+
+  const handleTextChange = (nextValue: string, cursorPos: number) => {
+    setText(nextValue);
+    adjustHeight();
+    const mq = getMentionQuery(nextValue, cursorPos);
+    const eq = getEntityQuery(nextValue, cursorPos);
+    if (mq !== null) {
+      setMentionQuery(mq);
+      setEntityQuery(null);
+      setEntityResults([]);
+    } else if (eq !== null) {
+      setEntityQuery(eq);
+      setMentionQuery(null);
+      setMentionMembers([]);
+    } else {
+      setMentionQuery(null);
+      setMentionMembers([]);
+      setEntityQuery(null);
+      setEntityResults([]);
+    }
+  };
+
+  const selectMention = (member: MentionMember) => {
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? text.length;
+    const { text: nextText, caretPos } = applyMention(text, cursorPos, member.name);
+    setText(nextText);
+    setMentionQuery(null);
+    setMentionMembers([]);
+    if (!mentionedIdsRef.current.includes(member.id)) {
+      mentionedIdsRef.current = [...mentionedIdsRef.current, member.id];
+      onMentionIdsChange?.(mentionedIdsRef.current);
+    }
+    requestAnimationFrame(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(caretPos, caretPos);
+    });
+  };
+
+  const selectEntity = (entity: EntityResult) => {
+    const textarea = textareaRef.current;
+    const cursorPos = textarea?.selectionStart ?? text.length;
+    const { text: nextText, caretPos } = applyEntity(text, cursorPos, entity.title, entity.entity_type, entity.entity_id);
+    setText(nextText);
+    setEntityQuery(null);
+    setEntityResults([]);
+    requestAnimationFrame(() => {
+      textarea?.focus();
+      textarea?.setSelectionRange(caretPos, caretPos);
+    });
   };
 
   const handleSend = async () => {
@@ -36,8 +189,10 @@ export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInput
         setPendingFile(null);
       }
       if (trimmed) {
-        await onSend(trimmed);
+        await onSend(trimmed, mentionedIdsRef.current.length > 0 ? mentionedIdsRef.current : undefined);
         setText('');
+        mentionedIdsRef.current = [];
+        onMentionIdsChange?.([]);
         if (textareaRef.current) textareaRef.current.style.height = 'auto';
       }
     } finally {
@@ -46,6 +201,18 @@ export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInput
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (entityResults.length > 0) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setEntityIndex((i) => (i + 1) % entityResults.length); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setEntityIndex((i) => (i - 1 + entityResults.length) % entityResults.length); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); selectEntity(entityResults[entityIndex]!); return; }
+      if (e.key === 'Escape') { setEntityQuery(null); setEntityResults([]); return; }
+    }
+    if (mentionMembers.length > 0) {
+      if (e.key === 'ArrowDown') { e.preventDefault(); setMentionIndex((i) => (i + 1) % mentionMembers.length); return; }
+      if (e.key === 'ArrowUp') { e.preventDefault(); setMentionIndex((i) => (i - 1 + mentionMembers.length) % mentionMembers.length); return; }
+      if (e.key === 'Enter' || e.key === 'Tab') { e.preventDefault(); selectMention(mentionMembers[mentionIndex]!); return; }
+      if (e.key === 'Escape') { setMentionQuery(null); setMentionMembers([]); return; }
+    }
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       void handleSend();
@@ -87,7 +254,46 @@ export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInput
         </div>
       )}
 
-      <div className="flex items-end gap-2">
+      <div className="relative flex items-end gap-2">
+        {/* Mention dropdown */}
+        {mentionMembers.length > 0 && (
+          <ul className="absolute bottom-full left-8 z-50 mb-1 max-h-48 w-56 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+            {mentionMembers.map((member, idx) => (
+              <li key={member.id}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); selectMention(member); }}
+                  className={`w-full px-3 py-2 text-left text-sm transition ${idx === mentionIndex ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                >
+                  <span className="font-medium text-primary">@</span>{member.name}
+                  {member.role ? <span className="ml-2 text-xs opacity-60">{member.role}</span> : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {/* Entity dropdown */}
+        {entityResults.length > 0 && (
+          <ul className="absolute bottom-full left-8 z-50 mb-1 max-h-48 w-72 overflow-y-auto rounded-md border border-border bg-popover shadow-md">
+            {entityResults.map((entity, idx) => (
+              <li key={`${entity.entity_type}:${entity.entity_id}`}>
+                <button
+                  type="button"
+                  onMouseDown={(e) => { e.preventDefault(); selectEntity(entity); }}
+                  className={`w-full px-3 py-2 text-left text-sm transition ${idx === entityIndex ? 'bg-primary/10 text-primary font-medium' : 'text-muted-foreground hover:bg-muted hover:text-foreground'}`}
+                >
+                  <span className="mr-1.5">{ENTITY_ICONS[entity.entity_type] ?? '#'}</span>
+                  <span className="font-medium">{entity.title}</span>
+                  {entity.status ? (
+                    <span className="ml-2 rounded px-1.5 py-0.5 text-xs bg-muted text-muted-foreground">{entity.status}</span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
         {/* Attach */}
         <button
           type="button"
@@ -110,10 +316,18 @@ export function ChatInput({ onSend, onUpload, disabled, placeholder }: ChatInput
           ref={textareaRef}
           rows={1}
           value={text}
-          onChange={(e) => { setText(e.target.value); adjustHeight(); }}
+          onChange={(e) => handleTextChange(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={handleKeyDown}
+          onBlur={() => {
+            window.setTimeout(() => {
+              setMentionQuery(null);
+              setMentionMembers([]);
+              setEntityQuery(null);
+              setEntityResults([]);
+            }, 150);
+          }}
           disabled={disabled || sending}
-          placeholder={placeholder ?? '메시지를 입력하세요…'}
+          placeholder={placeholder ?? '메시지를 입력하세요… (@ 멘션 / # 엔티티)'}
           className="flex-1 resize-none rounded-xl border border-border bg-muted/30 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-40"
           style={{ minHeight: '36px', maxHeight: '160px' }}
         />

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -13,6 +13,7 @@ interface ChatViewProps {
   threadId: string;
   currentTeamMemberId: string;
   threadTitle?: string | null;
+  projectId?: string;
 }
 
 interface MessageGroup {
@@ -31,7 +32,7 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId }: ChatViewProps) {
   const router = useRouter();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -103,11 +104,13 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
 
   useChatSse({ currentTeamMemberId, onNewMessage: handleNewMessage, onReplyCreated: handleReplyCreated });
 
-  const handleSend = useCallback(async (content: string) => {
+  const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
+    const body: Record<string, unknown> = { content };
+    if (mentionedIds && mentionedIds.length > 0) body.mentioned_ids = mentionedIds;
     const res = await fetch(`/api/chats/${threadId}/messages`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) throw new Error('Failed to send message');
     // Backend: { data: _to_chat_message }
@@ -243,7 +246,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle }: ChatVie
       <ChatInput
         onSend={handleSend}
         onUpload={handleUpload}
-        placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+        projectId={projectId}
+        placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)"
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Chat 입력창에 @멘션 자동완성 복구 — `/api/team-members` 조회, 선택 시 `@이름 ` 삽입, mentioned_ids POST 전달
- Chat 입력창에 #임베드 자동완성 복구 — `/api/entities/search` 조회, 선택 시 `[title](entity:type:id)` 삽입
- ChatBubble 렌더링 개선 — react-markdown + `entity:type:id` → EntityChip, `@이름` 하이라이트
- MemoDetailPage → ChatView에 `projectId` 전달

## Changed Files

- `apps/web/src/components/chat/chat-input.tsx` — @멘션/#임베드 자동완성 UI 추가
- `apps/web/src/components/chat/chat-input.test.ts` — 단위 테스트 14개 신규
- `apps/web/src/components/chat/chat-bubble.tsx` — react-markdown 렌더링 추가
- `apps/web/src/components/chat/chat-view.tsx` — projectId prop, handleSend mentioned_ids
- `apps/web/src/app/(authenticated)/memos/[id]/page.tsx` — projectId 전달

## Test Plan

- [ ] Chat 입력창에서 `@` 입력 → 팀 멤버 드롭다운 표시
- [ ] 드롭다운에서 멤버 선택 → `@이름 ` 삽입, 키보드(↑↓/Enter/Tab/Esc) 동작
- [ ] Chat 입력창에서 `#` 입력 → 스토리/에픽 검색 드롭다운 표시
- [ ] 드롭다운에서 엔티티 선택 → `[title](entity:story:id) ` 삽입
- [ ] 메시지 전송 후 버블에서 임베드가 EntityChip으로 렌더링 확인
- [ ] `@이름` 텍스트가 하이라이트로 표시 확인
- [ ] 기존 메시지 송수신 regression 없음 (AC4)
- [ ] `pnpm vitest run` 14개 통과 확인 ✅
- [ ] `pnpm build` 통과 ✅
- [ ] `pnpm type-check` 통과 ✅

> **Note:** 기존 develop에 있던 lint error (memos/[id]/page.tsx:38 setState-in-effect) 는 이번 S35 범위 밖의 기존 이슈임.

🤖 Generated with [Claude Code](https://claude.com/claude-code)