### PR TITLE
[S19] pytest 18건 수정 — PR #681 async_session_factory 전환 후 mock 패턴 불일치 해소

### DIFF
--- a/backend/tests/test_c_s5.py
+++ b/backend/tests/test_c_s5.py
@@ -348,7 +348,7 @@ def test_auth_context_includes_org_id_from_jwt():
     import asyncio
     with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
         from app.dependencies.auth import get_current_user
-        ctx = asyncio.run(get_current_user(credentials=creds, db=None))
+        ctx = asyncio.run(get_current_user(credentials=creds, x_agent_api_key=None, db=None))
 
     assert ctx.org_id == "org-abc"
     assert ctx.user_id == "user-1"

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -110,6 +110,7 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
     from app.dependencies.auth import get_current_user, get_verified_org_id
     from app.dependencies.database import get_db
     from app.main import app
+    from contextlib import asynccontextmanager
 
     async def _db():
         yield mock_session
@@ -123,17 +124,22 @@ async def test_agent_stream_registers_connection(mock_session, org_id):
     async def _org():
         return org_id
 
+    @asynccontextmanager
+    async def _session_factory():
+        yield mock_session
+
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            # SSE 스트림 연결 시작 후 즉시 해제
-            async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
-                assert resp.status_code == 200
-                # 연결 중 등록됐는지 확인
-                assert str(member_id) in _agent_connections
+        with patch("app.core.database.async_session_factory", _session_factory):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                # SSE 스트림 연결 시작 후 즉시 해제
+                async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
+                    assert resp.status_code == 200
+                    # 연결 중 등록됐는지 확인
+                    assert str(member_id) in _agent_connections
     finally:
         app.dependency_overrides.clear()
         _agent_connections.pop(str(member_id), None)
@@ -146,7 +152,7 @@ async def test_push_to_agent_delivers_when_connected():
     """연결된 에이전트에게 _push_to_agent 호출 시 True 반환."""
     member_id = str(uuid.uuid4())
     queue: asyncio.Queue = asyncio.Queue(maxsize=10)
-    _agent_connections[member_id] = queue
+    _agent_connections[member_id] = {queue}  # set[Queue] 타입
 
     try:
         payload = {"event_type": "memo_created", "event_id": str(uuid.uuid4())}
@@ -217,7 +223,7 @@ async def test_create_event_delivered_when_agent_connected(client, mock_session)
 
     # 에이전트 연결 등록
     queue: asyncio.Queue = asyncio.Queue(maxsize=10)
-    _agent_connections[member_id_str] = queue
+    _agent_connections[member_id_str] = {queue}  # set[Queue] 타입
 
     member_result = MagicMock()
     member_result.scalar_one_or_none.return_value = "agent"
@@ -314,14 +320,21 @@ async def test_stream_delivers_pending_on_connect(mock_session, org_id):
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _session_factory():
+        yield mock_session
+
     received_lines: list[str] = []
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
-                async for line in resp.aiter_lines():
-                    received_lines.append(line)
-                    if line.startswith("data:"):
-                        break  # 첫 이벤트 수신 후 종료
+        with patch("app.core.database.async_session_factory", _session_factory):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
+                    async for line in resp.aiter_lines():
+                        received_lines.append(line)
+                        if line.startswith("data:"):
+                            break  # 첫 이벤트 수신 후 종료
     finally:
         app.dependency_overrides.clear()
         _agent_connections.pop(str(member_id), None)
@@ -342,8 +355,8 @@ async def test_agent_isolation_multiple_connections():
 
     queue_a: asyncio.Queue = asyncio.Queue(maxsize=10)
     queue_b: asyncio.Queue = asyncio.Queue(maxsize=10)
-    _agent_connections[agent_a] = queue_a
-    _agent_connections[agent_b] = queue_b
+    _agent_connections[agent_a] = {queue_a}  # set[Queue] 타입
+    _agent_connections[agent_b] = {queue_b}
 
     try:
         payload_a = {"event_type": "memo_created", "for": "agent_a"}
@@ -393,9 +406,16 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _session_factory():
+        yield mock_session
+
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.get(f"/api/v2/events/stream?member_id={foreign_member_id}")
-            assert resp.status_code == 404
+        with patch("app.core.database.async_session_factory", _session_factory):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get(f"/api/v2/events/stream?member_id={foreign_member_id}")
+                assert resp.status_code == 404
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -242,15 +242,22 @@ async def test_stream_batch_delivers_over_100_events(mock_session, org_id):
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
 
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _session_factory():
+        yield mock_session
+
     received_count = [0]
     try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
-                async for line in resp.aiter_lines():
-                    if line.startswith("data:"):
-                        received_count[0] += 1
-                    if received_count[0] >= 110:
-                        break
+        with patch("app.core.database.async_session_factory", _session_factory):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                async with c.stream("GET", f"/api/v2/events/stream?member_id={member_id}") as resp:
+                    async for line in resp.aiter_lines():
+                        if line.startswith("data:"):
+                            received_count[0] += 1
+                        if received_count[0] >= 110:
+                            break
     finally:
         app.dependency_overrides.clear()
         _agent_connections.pop(str(member_id), None)

--- a/backend/tests/test_eventbus_s4.py
+++ b/backend/tests/test_eventbus_s4.py
@@ -134,21 +134,23 @@ async def test_dispatch_memo_replied_event(mock_session, org_id, project_id):
 # ─── AC4: 기존 웹훅 코드 여전히 존재하는지 ────────────────────────────────────
 
 def test_webhook_dispatch_still_exists_in_create_memo():
-    """create_memo에 기존 웹훅 디스패치 코드가 제거되지 않았는지."""
+    """create_memo/side_effects_bg에 기존 웹훅 + eventbus 연동이 있는지."""
     import inspect
     from app.routers import memos as memos_module
-    source = inspect.getsource(memos_module.create_memo)
-    assert "_fire_webhook" in source, "create_memo의 기존 웹훅 코드가 제거됨"
-    assert "dispatch_memo_event" in source, "create_memo에 eventbus 연동 없음"
+    create_src = inspect.getsource(memos_module.create_memo)
+    bg_src = inspect.getsource(memos_module._memo_side_effects_bg)
+    assert "_fire_webhook" in create_src or "_fire_webhook" in bg_src, "create_memo 웹훅 코드 제거됨"
+    assert "dispatch_memo_event" in bg_src, "_memo_side_effects_bg에 eventbus 연동 없음"
 
 
 def test_webhook_dispatch_still_exists_in_add_reply():
     """add_reply에 기존 웹훅 디스패치 코드가 제거되지 않았는지."""
     import inspect
     from app.routers import memos as memos_module
-    source = inspect.getsource(memos_module.add_reply)
-    assert "_fire_webhook" in source, "add_reply의 기존 웹훅 코드가 제거됨"
-    assert "dispatch_memo_event" in source, "add_reply에 eventbus 연동 없음"
+    src = inspect.getsource(memos_module.add_reply)
+    bg_src = inspect.getsource(memos_module._memo_side_effects_bg)
+    assert "_fire_webhook" in src, "add_reply의 기존 웹훅 코드가 제거됨"
+    assert "dispatch_memo_event" in bg_src, "eventbus 연동 없음"
 
 
 # ─── AC6: prod 환경 분기 — EVENTBUS_ENABLED 플래그 확인 ─────────────────────

--- a/backend/tests/test_eventbus_s5.py
+++ b/backend/tests/test_eventbus_s5.py
@@ -139,15 +139,15 @@ async def test_mark_read_sets_read_at(client, mock_session, member_id):
     event_id = uuid.uuid4()
     event = _make_event(id=event_id, recipient_id=member_id, read_at=None)
 
-    member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = member_id
     event_result = MagicMock()
     event_result.scalar_one_or_none.return_value = event
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
 
     async def _refresh(obj):
         pass  # event already mutated
 
-    mock_session.execute.side_effect = [member_result, event_result]
+    mock_session.execute.side_effect = [event_result, member_result]
     mock_session.refresh.side_effect = _refresh
 
     resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
@@ -163,15 +163,15 @@ async def test_mark_read_already_read_skips_commit(client, mock_session, member_
     now = datetime.now(timezone.utc)
     event = _make_event(id=event_id, recipient_id=member_id, read_at=now)
 
-    member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = member_id
     event_result = MagicMock()
     event_result.scalar_one_or_none.return_value = event
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
 
     async def _refresh(obj):
         pass
 
-    mock_session.execute.side_effect = [member_result, event_result]
+    mock_session.execute.side_effect = [event_result, member_result]
     mock_session.refresh.side_effect = _refresh
 
     resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
@@ -188,11 +188,11 @@ async def test_mark_read_other_user_returns_403(client, mock_session, member_id)
     other_member = uuid.uuid4()
     event = _make_event(id=event_id, recipient_id=other_member)  # 다른 사람 알림
 
-    member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = member_id
     event_result = MagicMock()
     event_result.scalar_one_or_none.return_value = event
-    mock_session.execute.side_effect = [member_result, event_result]
+    member_result = MagicMock()
+    member_result.scalar_one_or_none.return_value = member_id
+    mock_session.execute.side_effect = [event_result, member_result]
 
     resp = await client.patch(f"/api/v2/event-notifications/{event_id}/read")
     assert resp.status_code == 403
@@ -201,11 +201,9 @@ async def test_mark_read_other_user_returns_403(client, mock_session, member_id)
 @pytest.mark.anyio
 async def test_mark_read_not_found_returns_404(client, mock_session, member_id):
     """존재하지 않는 알림 PATCH → 404."""
-    member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = member_id
     event_result = MagicMock()
-    event_result.scalar_one_or_none.return_value = None
-    mock_session.execute.side_effect = [member_result, event_result]
+    event_result.scalar_one_or_none.return_value = None  # 이벤트 없음 → 즉시 404
+    mock_session.execute.side_effect = [event_result]
 
     resp = await client.patch(f"/api/v2/event-notifications/{uuid.uuid4()}/read")
     assert resp.status_code == 404

--- a/backend/tests/test_memo_03.py
+++ b/backend/tests/test_memo_03.py
@@ -113,14 +113,24 @@ async def test_workflow_origin_memo_skips_process_event():
 @pytest.mark.anyio
 async def test_normal_memo_calls_process_event():
     """origin 없는 일반 메모는 process_event 정상 호출됨."""
+    from contextlib import asynccontextmanager
+
     client, session, app = await _client()
     try:
         mock_memo = _mock_memo()
 
+        @asynccontextmanager
+        async def _bg_session_factory():
+            bg_session = AsyncMock()
+            bg_session.execute = AsyncMock(return_value=MagicMock())
+            bg_session.commit = AsyncMock()
+            yield bg_session
+
         with patch("app.repositories.memo.MemoRepository.create", new_callable=AsyncMock) as mock_create, \
              patch("app.repositories.memo.MemoRepository.create_entity_links", new_callable=AsyncMock), \
              patch("app.routers.memos.publish_event"), \
-             patch("app.services.workflow_pipeline.process_event", new_callable=AsyncMock) as mock_process:
+             patch("app.services.workflow_pipeline.process_event", new_callable=AsyncMock) as mock_process, \
+             patch("app.core.database.async_session_factory", _bg_session_factory):
             mock_create.return_value = mock_memo
             session.execute = AsyncMock(return_value=MagicMock())
 

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -25,6 +25,11 @@ def mock_session():
     session.add = MagicMock()
     session.flush = AsyncMock()
     session.execute = AsyncMock()
+    session.refresh = AsyncMock()
+    nested_cm = AsyncMock()
+    nested_cm.__aenter__ = AsyncMock(return_value=None)
+    nested_cm.__aexit__ = AsyncMock(return_value=False)
+    session.begin_nested = MagicMock(return_value=nested_cm)
     return session
 
 
@@ -49,6 +54,8 @@ def _members_result(rows: list[tuple]) -> MagicMock:
         row = MagicMock()
         row.id = mid
         row.user_id = uid
+        row.type = "human"      # human → Notification INSERT
+        row.project_id = None   # None → Event INSERT 스킵 (1번 add)
         rows_mock.append(row)
     result.all.return_value = rows_mock
     return result


### PR DESCRIPTION
## Summary
PR #681(SSE DB 커넥션 풀 개편)이 `async_session_factory` 직접 사용으로 전환한 이후 18건의 pytest가 실제 DB에 연결 시도하거나 mock 패턴 불일치로 실패하는 문제를 수정.

## 변경 내용 (7 파일)

| 파일 | 원인 | 수정 |
|------|------|------|
| test_eventbus_s2.py | `async_session_factory` 미mock, Queue 타입 불일치 | `patch("app.core.database.async_session_factory")` + `{queue}` set 사용 |
| test_eventbus_s3.py | 동일 | 동일 |
| test_eventbus_s4.py | `create_memo`가 `_memo_side_effects_bg`로 위임 | inspect 대상 변경 |
| test_eventbus_s5.py | `mark_read` execute 순서 역전 (event→member) | side_effect 순서 수정 |
| test_c_s5.py | `get_current_user` 직접 호출 시 `x_agent_api_key` 누락 | `x_agent_api_key=None` 명시 |
| test_memo_03.py | `_memo_side_effects_bg`의 `async_session_factory` 미mock | patch 추가 |
| test_notification_dispatch.py | `begin_nested` CM 미설정, member type/project_id 누락 | fixture 수정 |

## AC
- [x] 기존 실패 18건 → 0건 목표
- [x] 기존 통과 642건 regression 없음 (CI 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)