### PR TITLE
[SID:20c6cfa4] S39 채팅 상세 — 연속 메시지 그룹핑 + 대화 헤더

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -1,15 +1,35 @@
 'use client';
 
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChatView } from '@/components/chat/chat-view';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 
+interface ConversationMeta {
+  title: string | null;
+  type: 'dm' | 'group';
+}
+
 export default function ConversationPage() {
   const { conversation_id } = useParams<{ conversation_id: string }>();
   const router = useRouter();
   const { currentTeamMemberId, projectId } = useDashboardContext();
+  const [meta, setMeta] = useState<ConversationMeta | null>(null);
+
+  const fetchMeta = useCallback(async () => {
+    if (!projectId) return;
+    try {
+      const res = await fetch(`/api/conversations?project_id=${projectId}`);
+      if (!res.ok) return;
+      const json = await res.json() as { data: Array<{ id: string; title: string | null; type: 'dm' | 'group' }> };
+      const conv = json.data.find((c) => c.id === conversation_id);
+      if (conv) setMeta({ title: conv.title, type: conv.type });
+    } catch { /* non-critical */ }
+  }, [conversation_id, projectId]);
+
+  useEffect(() => { void fetchMeta(); }, [fetchMeta]);
 
   if (!currentTeamMemberId) {
     return (
@@ -19,18 +39,25 @@ export default function ConversationPage() {
     );
   }
 
+  const headerTitle = meta?.title ?? (meta?.type === 'dm' ? 'DM' : '그룹 채팅');
+
   return (
     <>
       <TopBarSlot
         title={
-          <button
-            type="button"
-            onClick={() => router.push('/chats')}
-            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground lg:hidden"
-          >
-            <ChevronLeft className="h-4 w-4" />
-            채팅
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => router.push('/chats')}
+              className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground lg:hidden"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              채팅
+            </button>
+            <span className="hidden truncate text-sm font-medium lg:block">
+              {headerTitle}
+            </span>
+          </div>
         }
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
@@ -38,6 +65,7 @@ export default function ConversationPage() {
           key={conversation_id}
           threadId={conversation_id}
           currentTeamMemberId={currentTeamMemberId}
+          threadTitle={headerTitle}
           projectId={projectId}
           apiPrefix="/api/conversations"
         />

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -9,6 +9,7 @@ import { EntityChip, getEntityHref } from '@/components/memos/embed-card';
 interface ChatBubbleProps {
   message: ChatMessage;
   isMine: boolean;
+  isGrouped?: boolean;
 }
 
 // Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
@@ -73,35 +74,41 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
   );
 }
 
-export function ChatBubble({ message, isMine }: ChatBubbleProps) {
+export function ChatBubble({ message, isMine, isGrouped = false }: ChatBubbleProps) {
   const isAgent = message.sender_type === 'agent';
   const displayName = isMine ? '나' : (message.sender_name || '팀');
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
 
   return (
-    <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'}`}>
-      {/* Avatar */}
-      <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-        isAgent
-          ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
-          : isMine
-            ? 'bg-primary/20 text-primary'
-            : 'bg-muted text-muted-foreground'
-      }`}>
-        {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
-      </div>
+    <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'} ${isGrouped ? 'mt-0.5' : 'mt-2'}`}>
+      {/* Avatar — hidden when grouped */}
+      {isGrouped ? (
+        <div className="w-7 flex-shrink-0" />
+      ) : (
+        <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+          isAgent
+            ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+            : isMine
+              ? 'bg-primary/20 text-primary'
+              : 'bg-muted text-muted-foreground'
+        }`}>
+          {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+        </div>
+      )}
 
       {/* Bubble + meta */}
-      <div className={`flex max-w-[72%] flex-col gap-1 ${isMine ? 'items-end' : 'items-start'}`}>
-        {/* Sender name */}
-        <div className="flex items-center gap-1.5">
-          <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
-          {isAgent && (
-            <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-              AI
-            </span>
-          )}
-        </div>
+      <div className={`flex max-w-[72%] flex-col gap-0.5 ${isMine ? 'items-end' : 'items-start'}`}>
+        {/* Sender name — hidden when grouped */}
+        {!isGrouped && (
+          <div className="flex items-center gap-1.5">
+            <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
+            {isAgent && (
+              <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+                AI
+              </span>
+            )}
+          </div>
+        )}
 
         {/* Content */}
         <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words ${

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -240,13 +240,18 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
                   <div className="h-px flex-1 bg-border/60" />
                 </div>
 
-                {group.messages.map((msg) => (
-                  <ChatBubble
-                    key={msg.id}
-                    message={msg}
-                    isMine={msg.created_by === currentTeamMemberId}
-                  />
-                ))}
+                {group.messages.map((msg, idx) => {
+                  const prev = group.messages[idx - 1];
+                  const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
+                  return (
+                    <ChatBubble
+                      key={msg.id}
+                      message={msg}
+                      isMine={msg.created_by === currentTeamMemberId}
+                      isGrouped={isGrouped}
+                    />
+                  );
+                })}
               </div>
             ))}
 


### PR DESCRIPTION
## Summary

S38에서 구현한 `/chats/[conversation_id]` 구조를 기반으로 AC6(연속 그룹핑)과 대화 헤더 추가.

- **AC6** — ChatBubble에 `isGrouped` prop 추가. 같은 발신자 연속 메시지 → 아바타/이름 생략, 간격 축소
- ChatView — 이전 메시지와 동일 `created_by` 이면 `isGrouped=true` 전달
- 대화 헤더 — conversation 목록 API로 title 조회 → TopBarSlot + threadTitle 표시 (DM: "DM", 그룹: title)
- AC1~5, AC7 — S38에서 이미 완성 (ChatView apiPrefix, SSE conversation:message, 무한 스크롤, 멘션/임베드)

## Changed Files

- `apps/web/src/components/chat/chat-bubble.tsx` — isGrouped prop 추가
- `apps/web/src/components/chat/chat-view.tsx` — 그룹핑 로직 적용
- `apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx` — conversation title 조회 + 헤더

## Test Plan

- [ ] /chats/{id} 접속 → 메시지 히스토리 표시 (AC1)
- [ ] 위로 스크롤 → 이전 메시지 자동 로드 (AC2)
- [ ] @멘션 하이라이트, #임베드 EntityChip 표시 (AC3)
- [ ] 메시지 전송 → 화면에 실시간 반영 (AC4)
- [ ] 같은 발신자 연속 메시지 → 아바타/이름 생략 확인 (AC6)
- [ ] 헤더에 DM/"그룹이름" 표시 확인
- [ ] 모바일(375px) 정상 표시 (AC7)
- [ ] `pnpm build` ✅ / `pnpm type-check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)