### PR TITLE
[S41] memo→conversation 마이그레이션 + MCP 도구 라우팅 전환

### DIFF
--- a/backend/scripts/migrate_memo_to_conversations.py
+++ b/backend/scripts/migrate_memo_to_conversations.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""
+S41: memo_replies(chat) → conversation_messages 마이그레이션.
+
+conversation.id = memo.id 1:1 매핑으로 thread_id 호환성 유지.
+MCP 도구의 thread_id(=memo_id)가 conversation_id로 그대로 동작함.
+
+실행:
+  cd backend
+  python scripts/migrate_memo_to_conversations.py [--dry-run]
+"""
+import argparse
+import asyncio
+import sys
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+sys.path.insert(0, ".")
+from app.core.database import async_session_factory  # noqa: E402
+from app.models.memo import Memo, MemoAssignee, MemoReply  # noqa: E402
+from app.models.conversation import Conversation, ConversationParticipant, ConversationMessage  # noqa: E402
+
+
+async def migrate(dry_run: bool = False) -> None:
+    print(f"[migrate] {'DRY RUN — ' if dry_run else ''}memo → conversations 마이그레이션 시작인")
+
+    async with async_session_factory() as db:
+        # 이미 마이그레이션된 conversation.id 조회
+        existing_ids = set(
+            r[0] for r in (await db.execute(select(Conversation.id))).all()
+        )
+        print(f"[migrate] 기존 conversations: {len(existing_ids)}건")
+
+        # chat 스레드가 있는 memo 조회 (reply가 1건 이상)
+        memos_result = await db.execute(
+            select(Memo)
+            .where(Memo.deleted_at.is_(None))
+            .order_by(Memo.created_at.asc())
+        )
+        memos = memos_result.scalars().all()
+        print(f"[migrate] 대상 memo: {len(memos)}건")
+
+        created_conv = 0
+        created_msg = 0
+
+        for memo in memos:
+            if memo.id in existing_ids:
+                print(f"  [skip] memo {memo.id} — 이미 conversation 존재")
+                continue
+
+            # assignees 조회 (MemoAssignee 테이블)
+            assignee_rows = (await db.execute(
+                select(MemoAssignee.member_id).where(MemoAssignee.memo_id == memo.id)
+            )).all()
+            participant_ids: set[uuid.UUID] = {r[0] for r in assignee_rows}
+            if memo.assigned_to:
+                participant_ids.add(memo.assigned_to)
+            if memo.created_by:
+                participant_ids.add(memo.created_by)
+
+            # memo_replies 조회 (chat 메시지)
+            replies = (await db.execute(
+                select(MemoReply)
+                .where(MemoReply.memo_id == memo.id)
+                .order_by(MemoReply.created_at.asc())
+            )).scalars().all()
+
+            if not replies and not participant_ids:
+                continue  # 빈 memo는 스킵
+
+            print(f"  [conv] memo {memo.id} → conversation (replies={len(replies)}, participants={len(participant_ids)})")
+
+            if not dry_run:
+                # conversation 생성 (memo.id 재사용 → thread_id 호환)
+                conv = Conversation(
+                    id=memo.id,
+                    project_id=memo.project_id,
+                    org_id=memo.org_id,
+                    type="group",
+                    title=memo.title,
+                    created_by=memo.created_by,
+                )
+                # created_at/updated_at 수동 설정
+                conv.created_at = memo.created_at
+                conv.updated_at = memo.updated_at or memo.created_at
+                db.add(conv)
+
+                # participants
+                for pid in participant_ids:
+                    db.add(ConversationParticipant(
+                        conversation_id=memo.id,
+                        member_id=pid,
+                    ))
+
+                # conversation_messages
+                for reply in replies:
+                    msg = ConversationMessage(
+                        conversation_id=memo.id,
+                        sender_id=reply.created_by,
+                        content=reply.content,
+                        mentioned_ids=[],
+                    )
+                    msg.created_at = reply.created_at
+                    msg.updated_at = reply.created_at
+                    db.add(msg)
+                    created_msg += 1
+
+                created_conv += 1
+
+        if not dry_run:
+            await db.commit()
+
+        print(f"[migrate] 완료인 — conversations: {created_conv}건, messages: {created_msg}건")
+        if dry_run:
+            print("[migrate] DRY RUN — 실제 DB 변경 없음인")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="memo → conversations 마이그레이션")
+    parser.add_argument("--dry-run", action="store_true", help="DB 변경 없이 결과만 출력")
+    args = parser.parse_args()
+    asyncio.run(migrate(dry_run=args.dry_run))

--- a/backend/scripts/migrate_memo_to_conversations.py
+++ b/backend/scripts/migrate_memo_to_conversations.py
@@ -24,7 +24,7 @@ from app.models.memo import Memo, MemoAssignee, MemoReply  # noqa: E402
 from app.models.conversation import Conversation, ConversationParticipant, ConversationMessage  # noqa: E402
 
 
-async def migrate(dry_run: bool = False) -> None:
+async def migrate(dry_run: bool = False, yes: bool = False) -> None:
     print(f"[migrate] {'DRY RUN — ' if dry_run else ''}memo → conversations 마이그레이션 시작인")
 
     async with async_session_factory() as db:
@@ -95,12 +95,17 @@ async def migrate(dry_run: bool = False) -> None:
                         member_id=pid,
                     ))
 
-                # conversation_messages
+                # conversation_messages (attachments → content에 포함)
                 for reply in replies:
+                    # MEDIUM-2: attachments 보존 — content에 JSON 블록으로 추가
+                    content = reply.content
+                    if reply.attachments:
+                        import json as _json
+                        content = f"{content}\n[attachments:{_json.dumps(reply.attachments)}]"
                     msg = ConversationMessage(
                         conversation_id=memo.id,
                         sender_id=reply.created_by,
-                        content=reply.content,
+                        content=content,
                         mentioned_ids=[],
                     )
                     msg.created_at = reply.created_at
@@ -110,16 +115,24 @@ async def migrate(dry_run: bool = False) -> None:
 
                 created_conv += 1
 
-        if not dry_run:
-            await db.commit()
-
-        print(f"[migrate] 완료인 — conversations: {created_conv}건, messages: {created_msg}건")
         if dry_run:
+            print(f"[migrate] DRY RUN — 변환 예정: conversations {created_conv}건, messages {created_msg}건인")
             print("[migrate] DRY RUN — 실제 DB 변경 없음인")
+            return
+
+        if not yes:
+            print(f"\n⚠️  경고: {created_conv}개 conversation, {created_msg}개 message를 생성합니다.")
+            print("    계속하려면 --yes 플래그를 추가하세요.")
+            import sys as _sys
+            _sys.exit(1)
+
+        await db.commit()
+        print(f"[migrate] 완료인 — conversations: {created_conv}건, messages: {created_msg}건")
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="memo → conversations 마이그레이션")
     parser.add_argument("--dry-run", action="store_true", help="DB 변경 없이 결과만 출력")
+    parser.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
     args = parser.parse_args()
-    asyncio.run(migrate(dry_run=args.dry_run))
+    asyncio.run(migrate(dry_run=args.dry_run, yes=args.yes))

--- a/backend/scripts/rollback_conversations.py
+++ b/backend/scripts/rollback_conversations.py
@@ -1,42 +1,65 @@
 #!/usr/bin/env python3
 """
-S41: conversations 롤백 — memo 원본 보존, conversations만 삭제.
+S41: conversations 롤백 — memo-origin conversation만 삭제, memo 원본 보존.
+
+롤백 대상: Memo 테이블에 동일한 id가 있는 conversation (memo.id=conversation.id 1:1 매핑)
+         → S37/S38에서 생성된 native DM/그룹은 보존됨.
 
 실행:
   cd backend
-  python scripts/rollback_conversations.py [--dry-run]
+  python scripts/rollback_conversations.py --dry-run   # 삭제 대상 확인 (안전)
+  python scripts/rollback_conversations.py --yes        # 실제 삭제
 """
 import argparse
 import asyncio
 import sys
 
-from sqlalchemy import delete
+from sqlalchemy import delete, select
 
 sys.path.insert(0, ".")
 from app.core.database import async_session_factory  # noqa: E402
-from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant  # noqa: E402
+from app.models.conversation import Conversation  # noqa: E402
+from app.models.memo import Memo  # noqa: E402
 
 
-async def rollback(dry_run: bool = False) -> None:
-    print(f"[rollback] {'DRY RUN — ' if dry_run else ''}conversations 롤백 시작인")
-
+async def rollback(dry_run: bool = False, yes: bool = False) -> None:
     async with async_session_factory() as db:
-        # CASCADE로 participants + messages도 자동 삭제됨
-        if not dry_run:
-            result = await db.execute(delete(Conversation))
-            deleted = result.rowcount
-            await db.commit()
-            print(f"[rollback] conversations {deleted}건 삭제 완료인")
-            print("[rollback] memo 원본 데이터 보존됨인")
-        else:
-            from sqlalchemy import select, func
-            count = (await db.execute(select(func.count()).select_from(Conversation))).scalar_one()
-            print(f"[rollback] DRY RUN — 삭제 예정 conversations: {count}건")
+        # memo-origin conversation: Memo.id와 동일한 conversation.id만 대상
+        memo_ids = [r[0] for r in (await db.execute(select(Memo.id))).all()]
+        target_ids = [r[0] for r in (await db.execute(
+            select(Conversation.id).where(Conversation.id.in_(memo_ids))
+        )).all()]
+
+        native_count = (await db.execute(
+            select(Conversation.id).where(Conversation.id.notin_(memo_ids))
+        )).rowcount
+
+        print(f"[rollback] memo-origin conversation (삭제 대상): {len(target_ids)}건")
+        print(f"[rollback] native conversation (보존): {native_count}건")
+
+        if dry_run:
             print("[rollback] DRY RUN — 실제 DB 변경 없음인")
+            return
+
+        if not yes:
+            print(f"\n⚠️  경고: memo-origin conversation {len(target_ids)}건을 삭제합니다.")
+            print("    계속하려면 --yes 플래그를 추가하세요.")
+            sys.exit(1)
+
+        if not target_ids:
+            print("[rollback] 삭제 대상 없음인")
+            return
+
+        result = await db.execute(
+            delete(Conversation).where(Conversation.id.in_(target_ids))
+        )
+        await db.commit()
+        print(f"[rollback] {result.rowcount}건 삭제 완료인. memo 원본 보존됨인")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="conversations 롤백 (memo 보존)")
-    parser.add_argument("--dry-run", action="store_true", help="DB 변경 없이 결과만 출력")
+    parser = argparse.ArgumentParser(description="memo-origin conversations 롤백 (memo 보존)")
+    parser.add_argument("--dry-run", action="store_true", help="삭제 대상만 출력, DB 변경 없음")
+    parser.add_argument("--yes", action="store_true", help="확인 없이 즉시 실행")
     args = parser.parse_args()
-    asyncio.run(rollback(dry_run=args.dry_run))
+    asyncio.run(rollback(dry_run=args.dry_run, yes=args.yes))

--- a/backend/scripts/rollback_conversations.py
+++ b/backend/scripts/rollback_conversations.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+S41: conversations 롤백 — memo 원본 보존, conversations만 삭제.
+
+실행:
+  cd backend
+  python scripts/rollback_conversations.py [--dry-run]
+"""
+import argparse
+import asyncio
+import sys
+
+from sqlalchemy import delete
+
+sys.path.insert(0, ".")
+from app.core.database import async_session_factory  # noqa: E402
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant  # noqa: E402
+
+
+async def rollback(dry_run: bool = False) -> None:
+    print(f"[rollback] {'DRY RUN — ' if dry_run else ''}conversations 롤백 시작인")
+
+    async with async_session_factory() as db:
+        # CASCADE로 participants + messages도 자동 삭제됨
+        if not dry_run:
+            result = await db.execute(delete(Conversation))
+            deleted = result.rowcount
+            await db.commit()
+            print(f"[rollback] conversations {deleted}건 삭제 완료인")
+            print("[rollback] memo 원본 데이터 보존됨인")
+        else:
+            from sqlalchemy import select, func
+            count = (await db.execute(select(func.count()).select_from(Conversation))).scalar_one()
+            print(f"[rollback] DRY RUN — 삭제 예정 conversations: {count}건")
+            print("[rollback] DRY RUN — 실제 DB 변경 없음인")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="conversations 롤백 (memo 보존)")
+    parser.add_argument("--dry-run", action="store_true", help="DB 변경 없이 결과만 출력")
+    args = parser.parse_args()
+    asyncio.run(rollback(dry_run=args.dry_run))

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -114,29 +114,31 @@ export function registerMemosTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  // E-EVENTBUS P4 S15: 채팅 메시지 전송 — 에이전트가 thread에 즉시 응답
-  server.tool('send_chat_message', 'Send a chat message to a memo thread. Triggers real-time SSE delivery to all thread participants.', {
-    thread_id: z.string().describe('Memo ID (= thread ID)'),
+  // S41: conversations API로 라우팅 전환 (thread_id = conversation_id = memo.id)
+  server.tool('send_chat_message', 'Send a chat message to a thread (conversation). Triggers real-time SSE delivery to all participants.', {
+    thread_id: z.string().describe('Thread ID (memo ID = conversation ID)'),
     content: z.string().describe('Message content'),
   }, async ({ thread_id, content }) => {
     try {
-      const data = await pmApi(`/api/v2/chats/${encodeURIComponent(thread_id)}/messages`, {
+      const data = await pmApi(`/api/v2/conversations/${encodeURIComponent(thread_id)}/messages`, {
         method: 'POST',
-        body: JSON.stringify({ content, attachments: [] }),
+        body: JSON.stringify({ content }),
       });
       return ok(data);
     } catch (e) { return handleError(e); }
   });
 
-  // 채팅 메시지 목록 조회
-  server.tool('list_chat_messages', 'List chat messages in a memo thread (chronological order)', {
-    thread_id: z.string().describe('Memo ID (= thread ID)'),
-    limit: z.number().optional().describe('Max messages (default: 50)'),
-  }, async ({ thread_id, limit }) => {
+  // S41: conversations API로 라우팅 전환
+  server.tool('list_chat_messages', 'List chat messages in a thread (conversation, chronological order)', {
+    thread_id: z.string().describe('Thread ID (memo ID = conversation ID)'),
+    limit: z.number().optional().describe('Max messages (default: 30)'),
+    before: z.string().optional().describe('Cursor: ISO timestamp, fetch messages before this time'),
+  }, async ({ thread_id, limit, before }) => {
     try {
       const params = new URLSearchParams();
       if (limit !== undefined) params.set('limit', String(limit));
-      const data = await pmApi(`/api/v2/chats/${encodeURIComponent(thread_id)}/messages?${params.toString()}`);
+      if (before !== undefined) params.set('before', before);
+      const data = await pmApi(`/api/v2/conversations/${encodeURIComponent(thread_id)}/messages?${params.toString()}`);
       return ok(data);
     } catch (e) { return handleError(e); }
   });

--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -1500,21 +1500,20 @@ describe('meetings tools via pmApi', () => {
 
   // ─── S17: Chat E2E MCP tool tests ────────────────────────────────────────────
 
-  it('send_chat_message calls POST /api/v2/chats/:thread_id/messages', async () => {
+  // S41: conversations API로 라우팅 전환
+  it('send_chat_message calls POST /api/v2/conversations/:thread_id/messages', async () => {
     const mockMsg = {
-      id: 'reply-1',
-      thread_id: 'thread-alpha',
+      id: 'msg-1',
+      conversation_id: 'thread-alpha',
       content: '안녕하세요',
       sender: { id: 'member-1', name: '윤재', type: 'human' },
-      attachments: [],
       created_at: '2026-05-14T01:00:00.000000',
     };
     stubFetch((url, init) => {
-      expect(url).toBe('http://test-pm-api/api/v2/chats/thread-alpha/messages');
+      expect(url).toBe('http://test-pm-api/api/v2/conversations/thread-alpha/messages');
       expect(init?.method).toBe('POST');
       const body = JSON.parse(init?.body as string);
       expect(body).toMatchObject({ content: '안녕하세요' });
-      // 백엔드: { data: ChatMessage } → pmApi extracts .data → ChatMessage
       return new Response(JSON.stringify({ data: mockMsg }), { status: 201 });
     });
 
@@ -1522,24 +1521,21 @@ describe('meetings tools via pmApi', () => {
       thread_id: 'thread-alpha',
       content: '안녕하세요',
     });
-    // pmApi extracts .data → ok(ChatMessage) → parseResult → { data: ChatMessage }
     expect(result).toEqual({ data: mockMsg });
   });
 
-  it('list_chat_messages calls GET /api/v2/chats/:thread_id/messages', async () => {
+  it('list_chat_messages calls GET /api/v2/conversations/:thread_id/messages', async () => {
     const mockMessages = [
       {
-        id: 'reply-1',
-        thread_id: 'thread-alpha',
+        id: 'msg-1',
+        conversation_id: 'thread-alpha',
         content: '안녕하세요',
         sender: { id: 'member-1', name: '윤재', type: 'human' },
-        attachments: [],
         created_at: '2026-05-14T01:00:00.000000',
       },
     ];
     stubFetch((url) => {
-      expect(url).toContain('http://test-pm-api/api/v2/chats/thread-alpha/messages');
-      // 백엔드: { data: [...], meta: {...} } → pmApi extracts .data → [...] 배열
+      expect(url).toContain('http://test-pm-api/api/v2/conversations/thread-alpha/messages');
       return new Response(
         JSON.stringify({ data: mockMessages, meta: { next_cursor: null, has_more: false } }),
         { status: 200 },
@@ -1550,7 +1546,6 @@ describe('meetings tools via pmApi', () => {
       thread_id: 'thread-alpha',
       limit: 30,
     });
-    // pmApi extracts .data (배열) → ok([...]) → parseResult → { data: [...] }
     expect(result).toEqual({ data: mockMessages });
   });
 });


### PR DESCRIPTION
## Summary
S37(conversations API) 완료 후 기존 memo chat 데이터를 conversations로 이전하고, MCP 도구를 새 API로 라우팅.

## 변경 파일

### `backend/scripts/migrate_memo_to_conversations.py`
- `memo.id = conversation.id` 1:1 매핑 → MCP thread_id 호환성 유지
- MemoAssignee + assigned_to → conversation_participants
- memo_replies → conversation_messages (created_at 보존)
- `--dry-run` 지원

### `backend/scripts/rollback_conversations.py`
- conversations 전삭 (CASCADE), memo 원본 보존
- `--dry-run` 지원

### `packages/mcp-server/src/tools/memos.ts`
- `send_chat_message`: `/api/v2/chats` → `/api/v2/conversations/{id}/messages`
- `list_chat_messages`: 동일 + `before` cursor 파라미터 추가

### `packages/mcp-server/src/tools/smoke.test.ts`
- 새 endpoint URL로 테스트 업데이트

## AC 검증
- [x] 마이그레이션 스크립트 (`--dry-run` + 실행 시 변환)
- [x] 롤백 스크립트 (memo 보존)
- [x] MCP 도구 send/list → conversations API
- [x] type-check PASS, build PASS, 108 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)