### PR TITLE
feat(S42): fakechat 플러그인 에이전트별 FAKECHAT_PORT 자동 감지

### DIFF
--- a/packages/fakechat/package.json
+++ b/packages/fakechat/package.json
@@ -8,7 +8,8 @@
     "fakechat": "./server.ts"
   },
   "scripts": {
-    "start": "bun run server.ts"
+    "start": "bun run server.ts",
+    "smoke": "bun smoke.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0"

--- a/packages/fakechat/server.ts
+++ b/packages/fakechat/server.ts
@@ -17,11 +17,26 @@ import { homedir } from 'os'
 import { join, extname, basename } from 'path'
 import type { ServerWebSocket } from 'bun'
 
-const PORT = Number(process.env.FAKECHAT_PORT ?? 8787)
+// CLAUDE_PROJECT_DIR is injected by Claude Code into all plugin subprocesses.
+// Read the project's .mcp.json to derive the per-agent port assignment without
+// requiring a separate env injection mechanism from the plugin system.
+function _portFromProjectDir(): number | null {
+  const dir = process.env.CLAUDE_PROJECT_DIR
+  if (!dir) return null
+  try {
+    const raw = readFileSync(join(dir, '.mcp.json'), 'utf-8')
+    const port = JSON.parse(raw)?.mcpServers?.sprintable?.env?.FAKECHAT_PORT
+    if (port) return Number(port)
+  } catch {}
+  return null
+}
+
+const PORT = Number(process.env.FAKECHAT_PORT ?? _portFromProjectDir() ?? 8787)
 const STATE_DIR = join(homedir(), '.claude', 'channels', 'fakechat')
 const INBOX_DIR = join(STATE_DIR, 'inbox')
 const OUTBOX_DIR = join(STATE_DIR, 'outbox')
-const PID_FILE = '/tmp/fakechat.pid'
+// Port-scoped PID file prevents agents on different ports from killing each other.
+const PID_FILE = `/tmp/fakechat-${PORT}.pid`
 
 type Msg = {
   id: string

--- a/packages/fakechat/smoke.ts
+++ b/packages/fakechat/smoke.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+/**
+ * AC8: Regression check — verifies _portFromProjectDir() resolves the correct
+ * per-agent port from each agent workspace's .mcp.json.
+ *
+ * Usage: bun smoke.ts
+ */
+
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { homedir } from 'os'
+
+const HOME = homedir()
+
+const EXPECTED: Record<string, number> = {
+  nwachukwu: 8787,
+  qasim: 8788,
+  mirko: 8789,
+  damrong: 8790,
+  ortega: 8791,
+}
+
+function portFromMcpJson(agentDir: string): number | null {
+  try {
+    const raw = readFileSync(join(agentDir, '.mcp.json'), 'utf-8')
+    const port = JSON.parse(raw)?.mcpServers?.sprintable?.env?.FAKECHAT_PORT
+    if (port) return Number(port)
+  } catch {}
+  return null
+}
+
+let passed = 0
+let failed = 0
+
+for (const [agent, expectedPort] of Object.entries(EXPECTED)) {
+  const workspaceDir = join(HOME, `.neoclaw-${agent}`, 'state', 'actors', agent, 'workspace')
+  const resolved = portFromMcpJson(workspaceDir)
+
+  if (resolved === expectedPort) {
+    process.stdout.write(`  ✅ ${agent}: ${resolved}\n`)
+    passed++
+  } else {
+    process.stderr.write(`  ❌ ${agent}: expected ${expectedPort}, got ${resolved ?? 'null'} (${workspaceDir}/.mcp.json)\n`)
+    failed++
+  }
+}
+
+process.stdout.write(`\n${passed}/${passed + failed} passed\n`)
+if (failed > 0) process.exit(1)


### PR DESCRIPTION
## Summary

- `CLAUDE_PROJECT_DIR` (Claude Code가 플러그인 서브프로세스에 주입하는 env) 기반으로 에이전트별 포트 자동 결정
- 각 에이전트 workspace `.mcp.json`의 `mcpServers.sprintable.env.FAKECHAT_PORT` 값을 읽어 적용
- PID 파일을 포트별로 분리(`/tmp/fakechat-${PORT}.pid`)해 에이전트 간 SIGTERM 충돌 방지

## 핵심 메커니즘 (AC2)

Claude Code 플러그인 시스템은 플러그인 `.mcp.json`에 `env` 섹션이 있어도 프로젝트별 override를 지원하지 않는다. 대신 `CLAUDE_PROJECT_DIR`을 모든 플러그인 서브프로세스에 주입한다. 이 경로에서 프로젝트 `.mcp.json`을 읽으면 에이전트별 설정을 가져올 수 있다.

## 포트 결정 우선순위

1. `FAKECHAT_PORT` env (직접 전달, 기존 호환성 유지)
2. `CLAUDE_PROJECT_DIR/.mcp.json` → `mcpServers.sprintable.env.FAKECHAT_PORT`
3. 기본값 `8787`

## 에이전트별 포트 매핑

| 에이전트 | 포트 |
|---------|-----|
| nwachukwu | 8787 |
| qasim | 8788 |
| mirko | 8789 |
| damrong | 8790 |
| ortega | 8791 |

## 변경 파일

- `packages/fakechat/server.ts` — `_portFromProjectDir()` 함수 추가, PID 파일 포트별 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)