### PR TITLE
fix(sse-bridge): conversation:message relay threadId fallback + callback URL 수정

### DIFF
--- a/packages/mcp-server/src/sse-bridge.ts
+++ b/packages/mcp-server/src/sse-bridge.ts
@@ -24,6 +24,7 @@ async function relayToFakechat(eventType: string, data: unknown): Promise<void> 
 
   let text: string;
   let threadId = '';
+  let isConversationEvent = false;
   if (typeof data === 'object' && data !== null) {
     const d = data as Record<string, unknown>;
     // payload가 중첩된 경우(chat:message 이벤트) payload에서 꺼냄
@@ -35,7 +36,9 @@ async function relayToFakechat(eventType: string, data: unknown): Promise<void> 
         : String(senderRaw);
     const content = payload.content ?? d.content ?? d.message ?? d.text ?? JSON.stringify(data);
     text = senderName ? `[${eventType}] ${senderName}: ${content}` : `[${eventType}] ${content}`;
-    threadId = String(payload.thread_id ?? d.thread_id ?? '');
+    const conversationId = String(payload.conversation_id ?? d.conversation_id ?? '');
+    threadId = String(payload.thread_id ?? d.thread_id ?? conversationId);
+    isConversationEvent = !!conversationId && !payload.thread_id && !d.thread_id;
   } else {
     text = `[${eventType}] ${String(data)}`;
   }
@@ -50,7 +53,10 @@ async function relayToFakechat(eventType: string, data: unknown): Promise<void> 
     const agentApiKey = process.env.AGENT_API_KEY ?? '';
     form.set('thread_id', threadId);
     if (pmApiUrl && agentApiKey) {
-      form.set('reply_callback_url', `${pmApiUrl}/api/v2/chats/${threadId}/messages`);
+      const callbackPath = isConversationEvent
+        ? `/api/v2/conversations/${threadId}/messages`
+        : `/api/v2/chats/${threadId}/messages`;
+      form.set('reply_callback_url', `${pmApiUrl}${callbackPath}`);
       form.set('reply_callback_api_key', agentApiKey);
     }
   }


### PR DESCRIPTION
## Summary
- `relayToFakechat()` line 38: `threadId` 추출 시 `conversation_id` fallback 추가
- `conversation:message` 이벤트 판별 후 callback URL을 `/api/v2/conversations/{id}/messages`로 분기
- 기존 `chat:message` 등 thread_id 기반 이벤트는 기존 경로 유지

## Root Cause
`conversation:message` 이벤트 payload에 `thread_id` 없고 `conversation_id`만 존재 → `threadId = ''` → relay metadata 누락 → 역방향 relay 불가

## Test plan
- [ ] `conversation:message` SSE 이벤트 수신 시 fakechat relay threadId 정상 설정 확인
- [ ] reply_callback_url이 `/api/v2/conversations/{id}/messages`로 설정 확인
- [ ] 기존 chat:message 이벤트 relay 정상 동작 유지 확인
- [ ] tsc --noEmit PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)