### PR TITLE
[S-A1] feat: ConversationMessage single-level thread 지원

### DIFF
--- a/backend/alembic/versions/0031_add_thread_support_to_conversation_messages.py
+++ b/backend/alembic/versions/0031_add_thread_support_to_conversation_messages.py
@@ -1,0 +1,57 @@
+"""add thread_id, reply_count, last_reply_at to conversation_messages
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversation_messages",
+        sa.Column(
+            "thread_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("conversation_messages.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "conversation_messages",
+        sa.Column("reply_count", sa.Integer, nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "conversation_messages",
+        sa.Column("last_reply_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # top-level 메시지 조회 최적화 (기본 list 경로)
+    op.create_index(
+        "ix_conversation_messages_top_level",
+        "conversation_messages",
+        ["conversation_id", "created_at"],
+        postgresql_where=sa.text("thread_id IS NULL"),
+    )
+    # reply 조회 최적화
+    op.create_index(
+        "ix_conversation_messages_thread",
+        "conversation_messages",
+        ["thread_id", "created_at"],
+        postgresql_where=sa.text("thread_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversation_messages_thread", table_name="conversation_messages")
+    op.drop_index("ix_conversation_messages_top_level", table_name="conversation_messages")
+    op.drop_column("conversation_messages", "last_reply_at")
+    op.drop_column("conversation_messages", "reply_count")
+    op.drop_column("conversation_messages", "thread_id")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -64,5 +64,15 @@ class ConversationMessage(Base, TimestampMixin):
     mentioned_ids: Mapped[list[uuid.UUID]] = mapped_column(
         ARRAY(UUID(as_uuid=True)), nullable=False, default=list
     )
+    thread_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("conversation_messages.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    reply_count: Mapped[int] = mapped_column(nullable=False, default=0)
+    last_reply_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     conversation: Mapped[Conversation] = relationship("Conversation", back_populates="messages")

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -53,6 +53,9 @@ def _msg_payload(msg: ConversationMessage, sender: TeamMember | None) -> dict:
     return {
         "id": str(msg.id),
         "conversation_id": str(msg.conversation_id),
+        "thread_id": str(msg.thread_id) if msg.thread_id else None,
+        "reply_count": msg.reply_count,
+        "last_reply_at": msg.last_reply_at.isoformat() if msg.last_reply_at else None,
         "content": msg.content,
         "mentioned_ids": [str(m) for m in (msg.mentioned_ids or [])],
         "sender": {
@@ -128,6 +131,7 @@ class CreateConversationRequest(BaseModel):
 class SendMessageRequest(BaseModel):
     content: str
     mentioned_ids: list[uuid.UUID] = []
+    thread_id: uuid.UUID | None = None
 
 
 class AddParticipantRequest(BaseModel):
@@ -267,11 +271,16 @@ async def list_messages(
     conversation_id: uuid.UUID,
     limit: int = Query(default=30, le=200),
     before: str | None = Query(default=None),
+    thread_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """GET /api/v2/conversations/{id}/messages — cursor 기반 페이지네이션."""
+    """GET /api/v2/conversations/{id}/messages — cursor 기반 페이지네이션.
+
+    thread_id 미지정: top-level 메시지만 반환 (thread_id IS NULL).
+    thread_id 지정: 해당 thread의 reply 목록 반환.
+    """
     conv_project_id = (await db.execute(
         select(Conversation.project_id).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
     )).scalar_one_or_none()
@@ -290,9 +299,14 @@ async def list_messages(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    if thread_id is None:
+        thread_filter = ConversationMessage.thread_id.is_(None)
+    else:
+        thread_filter = ConversationMessage.thread_id == thread_id
+
     stmt = (
         select(ConversationMessage)
-        .where(ConversationMessage.conversation_id == conversation_id)
+        .where(ConversationMessage.conversation_id == conversation_id, thread_filter)
         .order_by(ConversationMessage.created_at.desc())
         .limit(limit + 1)
     )
@@ -425,13 +439,35 @@ async def send_message(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    # thread_id 유효성 검증 — 같은 conversation의 top-level message만 허용
+    root_msg: ConversationMessage | None = None
+    if body.thread_id is not None:
+        root_msg = (await db.execute(
+            select(ConversationMessage).where(
+                ConversationMessage.id == body.thread_id,
+                ConversationMessage.conversation_id == conversation_id,
+            )
+        )).scalar_one_or_none()
+        if root_msg is None:
+            raise HTTPException(status_code=400, detail="Thread root not found in this conversation")
+        if root_msg.thread_id is not None:
+            raise HTTPException(status_code=400, detail="Cannot reply to a reply (single-level thread only)")
+
     msg = ConversationMessage(
         conversation_id=conversation_id,
         sender_id=sender.id,
         content=body.content,
         mentioned_ids=body.mentioned_ids,
+        thread_id=body.thread_id,
     )
     db.add(msg)
+
+    # reply인 경우 root message의 reply_count / last_reply_at 업데이트
+    if root_msg is not None:
+        now = datetime.now(timezone.utc)
+        root_msg.reply_count = (root_msg.reply_count or 0) + 1
+        root_msg.last_reply_at = now
+
     await db.flush()
 
     try:

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import and_, select
+from sqlalchemy import and_, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -462,11 +462,16 @@ async def send_message(
     )
     db.add(msg)
 
-    # reply인 경우 root message의 reply_count / last_reply_at 업데이트
+    # reply인 경우 root message의 reply_count / last_reply_at 원자 업데이트
     if root_msg is not None:
-        now = datetime.now(timezone.utc)
-        root_msg.reply_count = (root_msg.reply_count or 0) + 1
-        root_msg.last_reply_at = now
+        await db.execute(
+            update(ConversationMessage)
+            .where(ConversationMessage.id == body.thread_id)
+            .values(
+                reply_count=ConversationMessage.reply_count + 1,
+                last_reply_at=datetime.now(timezone.utc),
+            )
+        )
 
     await db.flush()
 


### PR DESCRIPTION
## 링크
- Story: S-A1 ConversationMessage 스레드 지원

## 변경 내용

### Migration 0031
- `conversation_messages`에 컬럼 3개 추가:
  - `thread_id UUID NULL` — self-referential FK (`ON DELETE SET NULL`)
  - `reply_count INTEGER NOT NULL DEFAULT 0`
  - `last_reply_at TIMESTAMP WITH TIME ZONE NULL`
- partial index `ix_conversation_messages_top_level`: `WHERE thread_id IS NULL` (top-level 조회)
- partial index `ix_conversation_messages_thread`: `WHERE thread_id IS NOT NULL` (reply 조회)
- upgrade/downgrade 로컬 검증 완료

### Model (`conversation.py`)
- `ConversationMessage`에 `thread_id`, `reply_count`, `last_reply_at` 필드 추가

### API (`conversations.py`)
- `_msg_payload`: `thread_id`, `reply_count`, `last_reply_at` 응답에 포함
- `SendMessageRequest`: `thread_id: uuid.UUID | None = None` 추가
- `GET /{conversation_id}/messages`:
  - `?thread_id` 쿼리 파라미터 추가
  - 미지정 → `thread_id IS NULL` (top-level only, 기존 동작 유지)
  - 지정 → 해당 thread의 reply 목록
- `POST /{conversation_id}/messages`:
  - `thread_id` 유효성 검증: 같은 conversation의 top-level message만 허용
  - reply-to-reply 시 400
  - reply 전송 시 root message의 `reply_count +1`, `last_reply_at` 업데이트 (동일 트랜잭션)

## AC 체크리스트
- [ ] AC1: thread_id=NULL 메시지 전송 정상 (기존 flat 동작 유지)
- [ ] AC2: thread_id 지정 시 reply 전송 + root reply_count/last_reply_at 갱신
- [ ] AC3: 다른 conversation의 message_id로 thread_id 지정 → 400
- [ ] AC4: 이미 reply인 message를 thread root로 지정 → 400
- [ ] AC5: GET ?thread_id 미지정 → top-level only 반환
- [ ] AC6: GET ?thread_id={id} → reply 목록 반환
- [ ] AC7: alembic downgrade → upgrade 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)