### PR TITLE
[S-A2] feat: Conversation 상태 관리 — status/resolved_by/resolved_at + PATCH endpoint

### DIFF
--- a/backend/alembic/versions/0032_add_status_to_conversations.py
+++ b/backend/alembic/versions/0032_add_status_to_conversations.py
@@ -1,0 +1,47 @@
+"""add status, resolved_by, resolved_at to conversations
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0032"
+down_revision = "0031"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversations",
+        sa.Column("status", sa.Text, nullable=False, server_default="open"),
+    )
+    op.add_column(
+        "conversations",
+        sa.Column(
+            "resolved_by",
+            UUID(as_uuid=True),
+            sa.ForeignKey("team_members.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "conversations",
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # 상태별 조회 최적화
+    op.create_index(
+        "ix_conversations_status",
+        "conversations",
+        ["org_id", "project_id", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_status", table_name="conversations")
+    op.drop_column("conversations", "resolved_at")
+    op.drop_column("conversations", "resolved_by")
+    op.drop_column("conversations", "status")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -21,6 +21,13 @@ class Conversation(Base, OrgScopedMixin, TimestampMixin):
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
     )
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="open")  # open | resolved
+    resolved_by: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     participants: Mapped[list["ConversationParticipant"]] = relationship(
         "ConversationParticipant", back_populates="conversation", lazy="select"

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -134,6 +134,10 @@ class SendMessageRequest(BaseModel):
     thread_id: uuid.UUID | None = None
 
 
+class UpdateStatusRequest(BaseModel):
+    status: str  # open | resolved
+
+
 class AddParticipantRequest(BaseModel):
     member_id: uuid.UUID
 
@@ -487,3 +491,55 @@ async def send_message(
     await db.commit()
     await db.refresh(msg)
     return {"data": _msg_payload(msg, sender)}
+
+
+@router.patch("/{conversation_id}/status", status_code=200)
+async def update_conversation_status(
+    conversation_id: uuid.UUID,
+    body: UpdateStatusRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """PATCH /api/v2/conversations/{id}/status — open/resolved 전환."""
+    if body.status not in ("open", "resolved"):
+        raise HTTPException(status_code=400, detail="Invalid status. Must be 'open' or 'resolved'")
+
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    requester = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+
+    # 참여자 검증
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == requester.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    now = datetime.now(timezone.utc)
+    if body.status == "resolved":
+        conv.status = "resolved"
+        conv.resolved_by = requester.id
+        conv.resolved_at = now
+    else:
+        conv.status = "open"
+        conv.resolved_by = None
+        conv.resolved_at = None
+
+    conv.updated_at = now
+    await db.commit()
+    await db.refresh(conv)
+
+    return {
+        "id": str(conv.id),
+        "status": conv.status,
+        "resolved_by": str(conv.resolved_by) if conv.resolved_by else None,
+        "resolved_at": conv.resolved_at.isoformat() if conv.resolved_at else None,
+    }

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -259,6 +259,9 @@ async def list_conversations(
             "id": str(conv.id),
             "type": conv.type,
             "title": conv.title,
+            "status": conv.status,
+            "resolved_by": str(conv.resolved_by) if conv.resolved_by else None,
+            "resolved_at": conv.resolved_at.isoformat() if conv.resolved_at else None,
             "participants": conv_participants.get(conv.id, []),
             "latest_message": {
                 "content": latest_msg.content,


### PR DESCRIPTION
## 링크
- Story: S-A2 Conversation 상태 관리

## 변경 내용

### Migration 0032
- `conversations`에 컬럼 3개 추가:
  - `status TEXT NOT NULL DEFAULT 'open'` — 기존 row 전부 'open' 보장
  - `resolved_by UUID NULL FK(team_members.id, SET NULL)`
  - `resolved_at TIMESTAMP WITH TIME ZONE NULL`
- 인덱스 `ix_conversations_status(org_id, project_id, status)` — 상태별 조회 최적화
- upgrade/downgrade 로컬 검증 완료

### Model (`conversation.py`)
- `Conversation`에 `status`, `resolved_by`, `resolved_at` 필드 추가

### API (`conversations.py`)
- `UpdateStatusRequest` 스키마 추가
- `PATCH /api/v2/conversations/{id}/status` 신규:
  - `status = 'resolved'` → `resolved_by = 요청자.id`, `resolved_at = now`
  - `status = 'open'` → `resolved_by = NULL`, `resolved_at = NULL`
  - 비참여자 → 403
  - 유효하지 않은 status → 400
  - `conversation.updated_at` 갱신

## AC 체크리스트
- [ ] AC1: 기존 conversation row status='open' 보장 (migration upgrade)
- [ ] AC2: PATCH resolved → resolved_by/resolved_at 설정
- [ ] AC3: PATCH open → resolved_by/resolved_at NULL 초기화
- [ ] AC4: 비참여자 403
- [ ] AC5: 유효하지 않은 status 400
- [ ] AC6: agent type participant 정상 동작
- [ ] AC7: alembic downgrade → upgrade 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)