### PR TITLE
[S-A3] feat: Notification Preferences 테이블 + CRUD API

### DIFF
--- a/backend/alembic/versions/0033_add_notification_preferences.py
+++ b/backend/alembic/versions/0033_add_notification_preferences.py
@@ -1,0 +1,63 @@
+"""add notification_preferences table
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0033"
+down_revision = "0032"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_preferences",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "member_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("team_members.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("scope_type", sa.Text, nullable=False),  # global | project | conversation | thread
+        sa.Column("scope_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("channel", sa.Text, nullable=False),  # sse | discord | telegram | in_app
+        sa.Column("level", sa.Text, nullable=False),  # all | mentions | mute
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+
+    # scope_id IS NULL (global scope) — partial unique
+    op.create_index(
+        "uq_notif_pref_global",
+        "notification_preferences",
+        ["member_id", "scope_type", "channel"],
+        unique=True,
+        postgresql_where=sa.text("scope_id IS NULL"),
+    )
+    # scope_id IS NOT NULL (project/conversation/thread) — partial unique
+    op.create_index(
+        "uq_notif_pref_scoped",
+        "notification_preferences",
+        ["member_id", "scope_type", "scope_id", "channel"],
+        unique=True,
+        postgresql_where=sa.text("scope_id IS NOT NULL"),
+    )
+    # 조회 최적화
+    op.create_index(
+        "ix_notif_pref_member",
+        "notification_preferences",
+        ["member_id", "scope_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_notif_pref_member", table_name="notification_preferences")
+    op.drop_index("uq_notif_pref_scoped", table_name="notification_preferences")
+    op.drop_index("uq_notif_pref_global", table_name="notification_preferences")
+    op.drop_table("notification_preferences")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -102,6 +102,7 @@ app.include_router(memos.router)
 app.include_router(entities.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)
+app.include_router(notification_preferences.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)
 app.include_router(rewards.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -17,6 +17,7 @@ from app.models.invitation import Invitation
 from app.models.meeting import Meeting
 from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
 from app.models.notification import InboxItem, Notification, NotificationSetting
+from app.models.notification_preference import NotificationPreference
 from app.models.organization import Organization
 from app.models.pm import Epic, Sprint, Story, Task
 from app.models.project import OrgMember, Project
@@ -58,6 +59,7 @@ __all__ = [
     "MemoRead",
     "MemoReply",
     "Notification",
+    "NotificationPreference",
     "NotificationSetting",
     "OrgMember",
     "Organization",

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -1,0 +1,22 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+
+class NotificationPreference(Base, TimestampMixin):
+    __tablename__ = "notification_preferences"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    scope_type: Mapped[str] = mapped_column(Text, nullable=False)  # global | project | conversation | thread
+    scope_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    channel: Mapped[str] = mapped_column(Text, nullable=False)  # sse | discord | telegram | in_app
+    level: Mapped[str] = mapped_column(Text, nullable=False)  # all | mentions | mute

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -299,6 +299,9 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
                         role=inv.role,
                     )
                     session.add(new_member)
+                    await session.flush()
+                    from app.services.notification_preference_defaults import insert_default_preferences
+                    await insert_default_preferences(session, new_member.id, "human")
             await session.flush()
             return {
                 "org_id": str(inv.org_id),

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -119,6 +119,9 @@ async def accept_invitation(
                 role=inv.role,
             )
             session.add(new_member)
+            await session.flush()
+            from app.services.notification_preference_defaults import insert_default_preferences
+            await insert_default_preferences(session, new_member.id, "human")
 
     await session.flush()
     return {"ok": True, "org_id": str(inv.org_id), "project_id": str(inv.project_id) if inv.project_id else None}

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -1,0 +1,138 @@
+"""S-A3: Notification Preferences CRUD API."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.notification_preference import NotificationPreference
+from app.models.team import TeamMember
+
+router = APIRouter(prefix="/api/v2/notification-preferences", tags=["notification-preferences"])
+
+_VALID_CHANNELS = {"sse", "discord", "telegram", "in_app"}
+_VALID_LEVELS = {"all", "mentions", "mute"}
+_VALID_SCOPE_TYPES = {"global", "project", "conversation", "thread"}
+
+
+# ─── Schemas ──────────────────────────────────────────────────────────────────
+
+class PreferenceItem(BaseModel):
+    scope_type: str
+    scope_id: uuid.UUID | None = None
+    channel: str
+    level: str
+
+
+class UpsertPreferencesRequest(BaseModel):
+    preferences: list[PreferenceItem]
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async def _get_member(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> TeamMember:
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+    else:
+        stmt = select(TeamMember).where(
+            TeamMember.user_id == uuid.UUID(auth.user_id),
+            TeamMember.org_id == org_id,
+        )
+    member = (await db.execute(stmt)).scalars().first()
+    if member is None:
+        raise HTTPException(status_code=400, detail="Team member not found")
+    return member
+
+
+def _pref_to_dict(p: NotificationPreference) -> dict:
+    return {
+        "id": str(p.id),
+        "member_id": str(p.member_id),
+        "scope_type": p.scope_type,
+        "scope_id": str(p.scope_id) if p.scope_id else None,
+        "channel": p.channel,
+        "level": p.level,
+        "updated_at": p.updated_at.isoformat(),
+    }
+
+
+# ─── Endpoints ────────────────────────────────────────────────────────────────
+
+@router.get("")
+async def get_preferences(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/notification-preferences — 현재 멤버의 전체 preference 조회."""
+    member = await _get_member(auth, org_id, db)
+    rows = (await db.execute(
+        select(NotificationPreference).where(NotificationPreference.member_id == member.id)
+    )).scalars().all()
+    return {"data": [_pref_to_dict(p) for p in rows]}
+
+
+@router.put("")
+async def upsert_preferences(
+    body: UpsertPreferencesRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """PUT /api/v2/notification-preferences — upsert (INSERT ON CONFLICT UPDATE)."""
+    member = await _get_member(auth, org_id, db)
+
+    results = []
+    for item in body.preferences:
+        if item.channel not in _VALID_CHANNELS:
+            raise HTTPException(status_code=422, detail=f"Invalid channel '{item.channel}'. Must be one of: {sorted(_VALID_CHANNELS)}")
+        if item.level not in _VALID_LEVELS:
+            raise HTTPException(status_code=422, detail=f"Invalid level '{item.level}'. Must be one of: {sorted(_VALID_LEVELS)}")
+        if item.scope_type not in _VALID_SCOPE_TYPES:
+            raise HTTPException(status_code=422, detail=f"Invalid scope_type '{item.scope_type}'.")
+
+        # agent는 assigned conversation/thread에 mute 설정 불가
+        if member.type == "agent" and item.level == "mute" and item.scope_type in ("conversation", "thread"):
+            raise HTTPException(status_code=400, detail="Agent cannot mute assigned conversation or thread")
+
+        now = datetime.now(timezone.utc)
+        stmt = (
+            pg_insert(NotificationPreference)
+            .values(
+                id=uuid.uuid4(),
+                member_id=member.id,
+                scope_type=item.scope_type,
+                scope_id=item.scope_id,
+                channel=item.channel,
+                level=item.level,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        # partial unique index에 맞는 conflict target 선택
+        if item.scope_id is None:
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["member_id", "scope_type", "channel"],
+                index_where=NotificationPreference.scope_id.is_(None),
+                set_={"level": item.level, "updated_at": now},
+            )
+        else:
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["member_id", "scope_type", "scope_id", "channel"],
+                index_where=NotificationPreference.scope_id.isnot(None),
+                set_={"level": item.level, "updated_at": now},
+            )
+        result = await db.execute(stmt.returning(NotificationPreference))
+        row = result.scalar_one()
+        results.append(_pref_to_dict(row))
+
+    await db.commit()
+    return {"data": results}

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -61,6 +61,8 @@ async def create_team_member(
         agent_role=body.agent_role,
         created_by=created_by,
     )
+    from app.services.notification_preference_defaults import insert_default_preferences
+    await insert_default_preferences(session, member.id, body.type)
     return TeamMemberResponse.model_validate(member)
 
 

--- a/backend/app/services/notification_preference_defaults.py
+++ b/backend/app/services/notification_preference_defaults.py
@@ -1,0 +1,33 @@
+"""member 생성 시 기본 NotificationPreference 자동 삽입 헬퍼."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.notification_preference import NotificationPreference
+
+_HUMAN_DEFAULTS = [("global", "in_app", "all")]
+_AGENT_DEFAULTS = [("global", "sse", "all")]
+
+
+async def insert_default_preferences(
+    db: AsyncSession,
+    member_id: uuid.UUID,
+    member_type: str,
+) -> None:
+    """human → global/in_app/all, agent → global/sse/all 기본 preference 삽입."""
+    defaults = _HUMAN_DEFAULTS if member_type == "human" else _AGENT_DEFAULTS
+    now = datetime.now(timezone.utc)
+    for scope_type, channel, level in defaults:
+        db.add(NotificationPreference(
+            id=uuid.uuid4(),
+            member_id=member_id,
+            scope_type=scope_type,
+            scope_id=None,
+            channel=channel,
+            level=level,
+            created_at=now,
+            updated_at=now,
+        ))


### PR DESCRIPTION
## 링크
- Story: S-A3 Notification Preferences 테이블 + CRUD API

## 변경 내용

### Migration 0033
- `notification_preferences` 신규 테이블:
  - `member_id UUID FK(team_members.id, CASCADE)`
  - `scope_type TEXT` — global/project/conversation/thread
  - `scope_id UUID NULL`
  - `channel TEXT` — sse/discord/telegram/in_app
  - `level TEXT` — all/mentions/mute
- Partial unique index 2개 (PostgreSQL NULL != NULL 처리):
  - `uq_notif_pref_global`: `(member_id, scope_type, channel) WHERE scope_id IS NULL`
  - `uq_notif_pref_scoped`: `(member_id, scope_type, scope_id, channel) WHERE scope_id IS NOT NULL`
- **notification_settings 테이블 미변경**
- upgrade/downgrade 로컬 검증 완료

### Model
- `NotificationPreference` 신규, `__init__.py` 등록

### API (`notification_preferences.py`)
- `GET /api/v2/notification-preferences` — 현재 멤버 preference 전체 조회
- `PUT /api/v2/notification-preferences` — upsert (INSERT ON CONFLICT UPDATE)
  - channel 허용값 외 422, level 허용값 외 422
  - agent가 conversation/thread에 mute 설정 시 400

### AC7 — member 생성 기본값
- `notification_preference_defaults.insert_default_preferences()` 헬퍼
  - human: `global/in_app/all`, agent: `global/sse/all`
- `auth.py` + `invitations.py` 에 후크 추가 (TeamMember 생성 직후 flush → default insert)

## AC 체크리스트
- [ ] AC1: notification_preferences 테이블 생성, UNIQUE 제약 동작
- [ ] AC2: notification_settings 테이블 미변경
- [ ] AC3: GET 응답 정상
- [ ] AC4: PUT upsert — 동일 scope+channel 재PUT 시 level만 갱신
- [ ] AC5: channel 허용값 외 422
- [ ] AC6: level 허용값 외 422
- [ ] AC7: member 생성 시 기본 preference 자동 삽입
- [ ] AC8: agent conversation/thread mute 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)