### PR TITLE
[S-A4] feat: ChannelRouter 서비스 — 메시지 수신자별 전달 채널 결정

### DIFF
--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -1,0 +1,144 @@
+"""S-A4: ChannelRouter — 메시지 수신자별 전달 채널 결정 서비스.
+
+라우팅만 담당. 전달(dispatch)은 caller의 책임.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.conversation import ConversationMessage, ConversationParticipant
+from app.models.notification_preference import NotificationPreference
+from app.models.team import TeamMember
+
+
+class ChannelRouterError(Exception):
+    """ChannelRouter 장애 시 typed exception — caller가 SSE fallback 가능."""
+
+
+@dataclass
+class DeliveryDecision:
+    member_id: uuid.UUID
+    channel: str
+    level: str
+    reason: str
+
+
+async def route_message(
+    message_id: uuid.UUID,
+    db: AsyncSession,
+) -> list[DeliveryDecision]:
+    """메시지 수신자별 DeliveryDecision 목록 반환.
+
+    mute인 경우 해당 수신자 제외 (decision 미생성).
+    mentions level인 경우 message content에 @{member_id} 없으면 제외.
+    agent↔agent: preference 무관 sse 강제.
+    """
+    try:
+        # 1. 메시지 + 발신자 조회
+        msg = (await db.execute(
+            select(ConversationMessage).where(ConversationMessage.id == message_id)
+        )).scalar_one_or_none()
+        if msg is None:
+            raise ChannelRouterError(f"Message {message_id} not found")
+
+        # 2. 발신자 type 확인
+        sender_type: str | None = None
+        if msg.sender_id:
+            sender_type = (await db.execute(
+                select(TeamMember.type).where(TeamMember.id == msg.sender_id)
+            )).scalar_one_or_none()
+
+        # 3. conversation participants (발신자 제외)
+        participant_rows = (await db.execute(
+            select(ConversationParticipant.member_id).where(
+                ConversationParticipant.conversation_id == msg.conversation_id,
+            )
+        )).scalars().all()
+        recipient_ids = [pid for pid in participant_rows if pid != msg.sender_id]
+        if not recipient_ids:
+            return []
+
+        # 4. 수신자 type 배치 조회
+        member_rows = (await db.execute(
+            select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(recipient_ids))
+        )).all()
+        member_type_map: dict[uuid.UUID, str] = {r[0]: r[1] for r in member_rows}
+
+        # 5. preference 배치 조회 — thread/conversation/global 3 scope
+        scope_ids_to_check: list[uuid.UUID | None] = []
+        scope_type_order: list[tuple[str, uuid.UUID | None]] = []
+        if msg.thread_id:
+            scope_type_order.append(("thread", msg.thread_id))
+            scope_ids_to_check.append(msg.thread_id)
+        scope_type_order.append(("conversation", msg.conversation_id))
+        scope_ids_to_check.append(msg.conversation_id)
+        scope_type_order.append(("global", None))
+
+        pref_rows = (await db.execute(
+            select(NotificationPreference).where(
+                NotificationPreference.member_id.in_(recipient_ids),
+            )
+        )).scalars().all()
+
+        # member_id → {(scope_type, scope_id): NotificationPreference}
+        pref_map: dict[uuid.UUID, dict[tuple[str, uuid.UUID | None], NotificationPreference]] = {}
+        for p in pref_rows:
+            pref_map.setdefault(p.member_id, {})[(p.scope_type, p.scope_id)] = p
+
+        # 6. 수신자별 라우팅 결정
+        decisions: list[DeliveryDecision] = []
+        for rid in recipient_ids:
+            recipient_type = member_type_map.get(rid, "human")
+
+            # agent↔agent → sse 강제 (AC5)
+            if sender_type == "agent" and recipient_type == "agent":
+                decisions.append(DeliveryDecision(
+                    member_id=rid,
+                    channel="sse",
+                    level="all",
+                    reason="agent-to-agent forced sse",
+                ))
+                continue
+
+            # preference fallback: thread → conversation → global
+            pref: NotificationPreference | None = None
+            matched_scope = "global"
+            for stype, sid in scope_type_order:
+                candidate = pref_map.get(rid, {}).get((stype, sid))
+                if candidate is not None:
+                    pref = candidate
+                    matched_scope = stype
+                    break
+
+            channel = pref.channel if pref else "sse"
+            level = pref.level if pref else "all"
+
+            # mute → skip (AC3)
+            if level == "mute":
+                continue
+
+            # mentions → @{member_id} 포함 여부 체크 (AC4)
+            if level == "mentions":
+                pattern = rf"@{re.escape(str(rid))}"
+                if not re.search(pattern, msg.content or ""):
+                    continue
+
+            decisions.append(DeliveryDecision(
+                member_id=rid,
+                channel=channel,
+                level=level,
+                reason=f"preference scope={matched_scope}",
+            ))
+
+        return decisions
+
+    except ChannelRouterError:
+        raise
+    except Exception as exc:
+        raise ChannelRouterError(f"ChannelRouter failed for message {message_id}: {exc}") from exc

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -12,7 +12,7 @@ from typing import Sequence
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.conversation import ConversationMessage, ConversationParticipant
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
 
@@ -70,14 +70,18 @@ async def route_message(
         )).all()
         member_type_map: dict[uuid.UUID, str] = {r[0]: r[1] for r in member_rows}
 
-        # 5. preference 배치 조회 — thread/conversation/global 3 scope
-        scope_ids_to_check: list[uuid.UUID | None] = []
+        # 5. preference 배치 조회 — thread/conversation/project/global 4 scope
+        # conversation의 project_id 조회 (project scope fallback용)
+        conv_project_id: uuid.UUID | None = (await db.execute(
+            select(Conversation.project_id).where(Conversation.id == msg.conversation_id)
+        )).scalar_one_or_none()
+
         scope_type_order: list[tuple[str, uuid.UUID | None]] = []
         if msg.thread_id:
             scope_type_order.append(("thread", msg.thread_id))
-            scope_ids_to_check.append(msg.thread_id)
         scope_type_order.append(("conversation", msg.conversation_id))
-        scope_ids_to_check.append(msg.conversation_id)
+        if conv_project_id:
+            scope_type_order.append(("project", conv_project_id))
         scope_type_order.append(("global", None))
 
         pref_rows = (await db.execute(


### PR DESCRIPTION
## 링크
- Story: S-A4 Channel Router 서비스

## 변경 내용

### `app/services/channel_router.py` (신규)

내부 서비스 전용. API endpoint 없음. Migration 없음.

**공개 인터페이스:**
```python
class ChannelRouterError(Exception): ...

@dataclass
class DeliveryDecision:
    member_id: uuid.UUID
    channel: str   # sse | discord | telegram | in_app
    level: str     # all | mentions
    reason: str

async def route_message(message_id, db) -> list[DeliveryDecision]: ...
```

**라우팅 로직:**
1. 메시지 조회 → 발신자 type 확인
2. conversation participants에서 발신자 제외 → 수신자 목록
3. preference 배치 조회 (thread/conversation/global scope)
4. 수신자별 결정:
   - **agent↔agent** → `sse` 강제 (AC5)
   - **preference fallback**: thread → conversation → global (AC2)
   - **mute** → skip, decision 미생성 (AC3)
   - **mentions** → `@{member_id}` content 체크 후 없으면 skip (AC4)
5. `ChannelRouterError` — 장애 시 typed exception, caller SSE fallback 가능 (AC8)

## AC 체크리스트
- [ ] AC1: `route_message()` 존재 + `DeliveryDecision` 반환
- [ ] AC2: preference fallback thread→conversation→global
- [ ] AC3: mute → decision 미생성
- [ ] AC4: mentions → @{member_id} 없으면 제외
- [ ] AC5: agent↔agent → sse 강제
- [ ] AC6: human recipient → preference channel 사용
- [ ] AC7: 1 recipient = 1 decision (중복 없음)
- [ ] AC8: `ChannelRouterError` typed exception

🤖 Generated with [Claude Code](https://claude.com/claude-code)