### PR TITLE
[S-A5] feat: Conversation webhook + Discord 트리거 + 재시도

### DIFF
--- a/backend/alembic/versions/0034_add_conversation_webhook_deliveries.py
+++ b/backend/alembic/versions/0034_add_conversation_webhook_deliveries.py
@@ -1,0 +1,50 @@
+"""add conversation_webhook_deliveries table
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0034"
+down_revision = "0033"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversation_webhook_deliveries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "message_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("conversation_messages.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column(
+            "webhook_config_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("webhook_configs.id", ondelete="SET NULL"),
+            nullable=True,
+            index=True,
+        ),
+        sa.Column("status", sa.Text, nullable=False, server_default="pending"),  # pending | delivered | failed
+        sa.Column("attempt_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("last_error", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+    )
+    op.create_index(
+        "ix_conv_wh_deliveries_status",
+        "conversation_webhook_deliveries",
+        ["status", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conv_wh_deliveries_status", table_name="conversation_webhook_deliveries")
+    op.drop_table("conversation_webhook_deliveries")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -16,6 +16,7 @@ from app.models.doc import Doc
 from app.models.invitation import Invitation
 from app.models.meeting import Meeting
 from app.models.memo import Memo, MemoDocLink, MemoRead, MemoReply
+from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.models.notification import InboxItem, Notification, NotificationSetting
 from app.models.notification_preference import NotificationPreference
 from app.models.organization import Organization
@@ -59,6 +60,7 @@ __all__ = [
     "MemoRead",
     "MemoReply",
     "Notification",
+    "ConversationWebhookDelivery",
     "NotificationPreference",
     "NotificationSetting",
     "OrgMember",

--- a/backend/app/models/conversation_webhook_delivery.py
+++ b/backend/app/models/conversation_webhook_delivery.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import TimestampMixin
+
+
+class ConversationWebhookDelivery(Base, TimestampMixin):
+    __tablename__ = "conversation_webhook_deliveries"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    message_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("conversation_messages.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    webhook_config_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("webhook_configs.id", ondelete="SET NULL"), nullable=True
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="pending")  # pending | delivered | failed
+    attempt_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -74,8 +74,12 @@ async def _dispatch_conversation_event(
     msg: ConversationMessage,
     org_id: uuid.UUID,
     sender: TeamMember,
+    exclude_ids: set[uuid.UUID] | None = None,
 ) -> None:
-    """conversation:message → 전 참여자 SSE dispatch + Event INSERT."""
+    """conversation:message → 전 참여자 SSE dispatch + Event INSERT.
+
+    exclude_ids: SSE 발송에서 제외할 member_id 집합 (Discord 수신자 등).
+    """
     if not conversation.project_id:
         return
 
@@ -86,7 +90,7 @@ async def _dispatch_conversation_event(
         select(ConversationParticipant.member_id)
         .where(ConversationParticipant.conversation_id == conversation.id)
     )).all()
-    participant_ids = {r[0] for r in rows} - {sender.id}
+    participant_ids = {r[0] for r in rows} - {sender.id} - (exclude_ids or set())
 
     if not participant_ids:
         return
@@ -548,9 +552,18 @@ async def send_message(
 
     await db.flush()
 
+    # AC10: Discord 수신자 파악 → SSE dispatch에서 제외 (동일 db 세션, flush 완료 상태)
+    discord_exclude_ids: set[uuid.UUID] = set()
+    try:
+        from app.services.channel_router import ChannelRouterError, route_message as _route
+        decisions = await _route(msg.id, db)
+        discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
+    except Exception:
+        logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
+
     try:
         async with db.begin_nested():
-            await _dispatch_conversation_event(db, conv, msg, org_id, sender)
+            await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
     except Exception:
         logger.exception("conversation event dispatch failed conversation_id=%s", conversation_id)
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -164,15 +164,20 @@ async def _dispatch_discord_outbound(
                 )
                 continue
 
-            # AC10: Discord 전달 (SSE는 이미 발송됨. Discord 결정 시 SSE 중복 방지는
-            # 향후 _dispatch_conversation_event 통합 시 처리. 현재는 Discord 추가 발송)
-            payload = {
-                "event_type": "conversation.message_created",
-                "message_id": str(message_id),
-            }
+            # Discord URL이면 content/embeds 포맷, 아니면 generic JSON
+            is_discord_url = (
+                "discord.com/api/webhooks" in wh.url
+                or "discordapp.com/api/webhooks" in wh.url
+            )
+            content_text = f"[conversation:message] message_id: {message_id}"
+            if is_discord_url:
+                discord_payload: dict = {"content": content_text}
+            else:
+                discord_payload = {"event_type": "conversation.message_created", "message_id": str(message_id)}
+
             try:
                 async with httpx.AsyncClient(timeout=10.0) as client:
-                    await client.post(wh.url, json=payload)
+                    await client.post(wh.url, json=discord_payload)
             except Exception:
                 logger.warning(
                     "Discord outbound failed member_id=%s url=%s", decision.member_id, wh.url, exc_info=True
@@ -562,6 +567,7 @@ async def send_message(
         message_id=msg.id,
         conversation_id=conversation_id,
         org_id=org_id,
+        project_id=conv.project_id,
         sender_id=sender.id,
         thread_id=msg.thread_id,
         created_at=msg.created_at,

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -6,7 +6,7 @@ import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import and_, select, update
 from sqlalchemy.exc import IntegrityError
@@ -17,6 +17,7 @@ from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
 from app.models.team import TeamMember
+from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent
 
 logger = logging.getLogger(__name__)
@@ -117,6 +118,65 @@ async def _dispatch_conversation_event(
     await db.flush()
     for pid_str, event in events_to_push:
         _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+
+
+async def _dispatch_discord_outbound(
+    message_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> None:
+    """Discord 아웃바운드 (AC9~11).
+
+    ChannelRouter가 discord 선택한 수신자 → webhook_configs Discord endpoint 발송.
+    Discord 선택 시 SSE 동시 발송 금지 (AC10).
+    Discord endpoint 미설정 시 sse fallback (AC11).
+    """
+    from app.core.database import async_session_factory
+    from app.services.channel_router import ChannelRouterError, route_message
+    from sqlalchemy import select
+
+    async with async_session_factory() as db:
+        try:
+            decisions = await route_message(message_id, db)
+        except ChannelRouterError:
+            logger.exception("ChannelRouter failed message_id=%s — skipping discord outbound", message_id)
+            return
+
+        discord_members = [d for d in decisions if d.channel == "discord"]
+        if not discord_members:
+            return
+
+        import httpx
+        for decision in discord_members:
+            # discord channel WebhookConfig 조회
+            wh = (await db.execute(
+                select(WebhookConfig).where(
+                    WebhookConfig.member_id == decision.member_id,
+                    WebhookConfig.channel == "discord",
+                    WebhookConfig.is_active.is_(True),
+                )
+            )).scalars().first()
+
+            if wh is None:
+                # AC11: Discord endpoint 미설정 → sse fallback (SSE는 이미 _dispatch_conversation_event에서 처리)
+                logger.info(
+                    "Discord endpoint not configured for member %s — SSE fallback already dispatched",
+                    decision.member_id,
+                )
+                continue
+
+            # AC10: Discord 전달 (SSE는 이미 발송됨. Discord 결정 시 SSE 중복 방지는
+            # 향후 _dispatch_conversation_event 통합 시 처리. 현재는 Discord 추가 발송)
+            payload = {
+                "event_type": "conversation.message_created",
+                "message_id": str(message_id),
+            }
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    await client.post(wh.url, json=payload)
+            except Exception:
+                logger.warning(
+                    "Discord outbound failed member_id=%s url=%s", decision.member_id, wh.url, exc_info=True
+                )
 
 
 # ─── Schemas ──────────────────────────────────────────────────────────────────
@@ -423,6 +483,7 @@ async def add_participant(
 async def send_message(
     conversation_id: uuid.UUID,
     body: SendMessageRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -493,6 +554,26 @@ async def send_message(
 
     await db.commit()
     await db.refresh(msg)
+
+    # webhook delivery BackgroundTask (AC1~8)
+    from app.services.conversation_webhook import deliver_conversation_message_webhook
+    background_tasks.add_task(
+        deliver_conversation_message_webhook,
+        message_id=msg.id,
+        conversation_id=conversation_id,
+        org_id=org_id,
+        sender_id=sender.id,
+        thread_id=msg.thread_id,
+        created_at=msg.created_at,
+    )
+
+    # Discord 아웃바운드 (AC9~11)
+    background_tasks.add_task(
+        _dispatch_discord_outbound,
+        message_id=msg.id,
+        org_id=org_id,
+    )
+
     return {"data": _msg_payload(msg, sender)}
 
 

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -1,0 +1,159 @@
+"""S-A5: Conversation webhook delivery 서비스.
+
+send_message BackgroundTask에서 호출.
+webhook_configs.events에 'conversation.message_created' 포함 시 발송.
+최대 3회 retry + backoff, 실패 시 failed 상태 + last_error 저장.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import json
+import logging
+import uuid
+from datetime import datetime, timezone
+
+import httpx
+
+from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
+from app.models.webhook_config import WebhookConfig
+
+logger = logging.getLogger(__name__)
+
+_EVENT_TYPE = "conversation.message_created"
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.0  # seconds
+
+
+def _sign_payload(secret: str, body: bytes) -> str:
+    """HMAC-SHA256 서명 — X-Hub-Signature-256 헤더용."""
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+async def _attempt_delivery(url: str, secret: str | None, payload: dict) -> None:
+    """단일 webhook HTTP POST 시도. 실패 시 예외 raise."""
+    body = json.dumps(payload, default=str).encode()
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if secret:
+        headers["X-Hub-Signature-256"] = _sign_payload(secret, body)
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.post(url, content=body, headers=headers)
+        resp.raise_for_status()
+
+
+async def deliver_conversation_message_webhook(
+    message_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+    org_id: uuid.UUID,
+    sender_id: uuid.UUID | None,
+    thread_id: uuid.UUID | None,
+    created_at: datetime,
+) -> None:
+    """BackgroundTask 진입점.
+
+    webhook_configs에서 conversation.message_created 이벤트 구독 중인
+    활성 webhook을 조회하고 delivery attempt 기록 후 발송.
+    """
+    from app.core.database import async_session_factory
+    from sqlalchemy import select
+
+    async with async_session_factory() as db:
+        try:
+            wh_rows = (await db.execute(
+                select(WebhookConfig).where(
+                    WebhookConfig.org_id == org_id,
+                    WebhookConfig.is_active.is_(True),
+                )
+            )).scalars().all()
+
+            # conversation.message_created 이벤트 구독 중인 webhook만 필터
+            target_webhooks = [
+                wh for wh in wh_rows
+                if _EVENT_TYPE in (wh.events or [])
+            ]
+            if not target_webhooks:
+                return
+
+            payload = {
+                "event_type": _EVENT_TYPE,
+                "message_id": str(message_id),
+                "conversation_id": str(conversation_id),
+                "sender_id": str(sender_id) if sender_id else None,
+                "thread_id": str(thread_id) if thread_id else None,
+                "created_at": created_at.isoformat(),
+            }
+
+            for wh in target_webhooks:
+                delivery = ConversationWebhookDelivery(
+                    id=uuid.uuid4(),
+                    message_id=message_id,
+                    webhook_config_id=wh.id,
+                    status="pending",
+                    attempt_count=0,
+                )
+                db.add(delivery)
+                await db.flush()
+                delivery_id = delivery.id
+                await db.commit()
+
+                # 별도 세션에서 retry 루프
+                asyncio.ensure_future(
+                    _retry_deliver(delivery_id, wh.url, wh.secret, payload)
+                )
+
+        except Exception:
+            logger.exception("conversation webhook schedule failed message_id=%s", message_id)
+
+
+async def _retry_deliver(
+    delivery_id: uuid.UUID,
+    url: str,
+    secret: str | None,
+    payload: dict,
+) -> None:
+    """최대 3회 retry + exponential backoff."""
+    from app.core.database import async_session_factory
+    from sqlalchemy import select
+
+    for attempt in range(1, _MAX_RETRIES + 1):
+        try:
+            await _attempt_delivery(url, secret, payload)
+
+            async with async_session_factory() as db:
+                delivery = (await db.execute(
+                    select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.id == delivery_id)
+                )).scalar_one_or_none()
+                if delivery:
+                    delivery.status = "delivered"
+                    delivery.attempt_count = attempt
+                    delivery.updated_at = datetime.now(timezone.utc)
+                    await db.commit()
+            return
+
+        except Exception as exc:
+            error_msg = str(exc)[:500]
+            if attempt < _MAX_RETRIES:
+                backoff = _BACKOFF_BASE * (2 ** (attempt - 1))
+                logger.warning(
+                    "webhook delivery attempt %d/%d failed delivery_id=%s: %s — retry in %.1fs",
+                    attempt, _MAX_RETRIES, delivery_id, error_msg, backoff,
+                )
+                await asyncio.sleep(backoff)
+            else:
+                logger.error(
+                    "webhook delivery failed permanently delivery_id=%s: %s",
+                    delivery_id, error_msg,
+                )
+                async with async_session_factory() as db:
+                    delivery = (await db.execute(
+                        select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.id == delivery_id)
+                    )).scalar_one_or_none()
+                    if delivery:
+                        delivery.status = "failed"
+                        delivery.attempt_count = attempt
+                        delivery.last_error = error_msg
+                        delivery.updated_at = datetime.now(timezone.utc)
+                        await db.commit()

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -48,6 +48,7 @@ async def deliver_conversation_message_webhook(
     message_id: uuid.UUID,
     conversation_id: uuid.UUID,
     org_id: uuid.UUID,
+    project_id: uuid.UUID,
     sender_id: uuid.UUID | None,
     thread_id: uuid.UUID | None,
     created_at: datetime,
@@ -65,6 +66,7 @@ async def deliver_conversation_message_webhook(
             wh_rows = (await db.execute(
                 select(WebhookConfig).where(
                     WebhookConfig.org_id == org_id,
+                    WebhookConfig.project_id == project_id,
                     WebhookConfig.is_active.is_(True),
                 )
             )).scalars().all()


### PR DESCRIPTION
## 링크
- Story: S-A5 Conversation webhook + Discord 트리거 + 재시도

## 변경 내용

### Migration 0034
- `conversation_webhook_deliveries` 신규:
  - `message_id UUID FK(CASCADE)`, `webhook_config_id UUID FK(SET NULL)`
  - `status TEXT DEFAULT 'pending'` — pending/delivered/failed
  - `attempt_count INT DEFAULT 0`, `last_error TEXT NULL`
- upgrade/downgrade 로컬 검증 완료

### `app/services/conversation_webhook.py` (신규)
- `deliver_conversation_message_webhook()` — BackgroundTask 진입점
  - `webhook_configs.events`에 `conversation.message_created` 포함 webhook 필터
  - payload: `event_type, message_id, conversation_id, sender_id, thread_id, created_at`
  - secret 있으면 HMAC-SHA256 서명 → `X-Hub-Signature-256` 헤더 (AC4)
  - `_retry_deliver()`: 최대 3회 retry + backoff(1s/2s/4s), failed+last_error (AC5, AC6)
- 기존 memo webhook 하위호환 — WebhookConfig 모델 수정 없음 (AC8)

### `conversations.py` send_message 수정
- `BackgroundTasks` 파라미터 추가
- webhook delivery BackgroundTask (AC1, AC2, AC7)
- `_dispatch_discord_outbound()` 헬퍼 추가:
  - ChannelRouter `route_message()` 호출 → discord 결정 수신자에게 Discord webhook 발송 (AC9)
  - Discord endpoint 미설정 시 SSE fallback 유지 (AC11)
  - ChannelRouterError → SSE 기존 경로 유지 (AC8 fallback)

## AC 체크리스트
- [ ] AC1: conversation_webhook_deliveries 테이블 생성
- [ ] AC2: send_message 성공 후 BackgroundTask 예약
- [ ] AC3: webhook payload 필드 포함
- [ ] AC4: HMAC-SHA256 서명 (secret 있을 때)
- [ ] AC5: 3회 retry
- [ ] AC6: 최종 실패 시 failed + last_error
- [ ] AC7: BackgroundTask로 비동기 처리
- [ ] AC8: 기존 memo webhook 하위호환 유지
- [ ] AC9: Discord channel 선택 시 Discord webhook 발송
- [ ] AC10: Discord 선택 시 SSE 중복 미발송 (현재 _dispatch_conversation_event와 병행)
- [ ] AC11: Discord endpoint 미설정 시 SSE fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)