### PR TITLE
[S-B2] feat: MCP memo 도구 어댑터 — conversation API 내부 라우팅

### DIFF
--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -124,9 +124,9 @@ export function registerMemosTools(server: McpServer) {
       // AC4: memo_id = conversation_id (S-B1 패턴). top-level root message 조회 → thread reply 생성
       let rootMsgId: string | undefined;
       try {
-        const msgs = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages?limit=1`) as Record<string, unknown>;
-        const data = (msgs.data ?? []) as Array<Record<string, unknown>>;
-        rootMsgId = data[0]?.id as string | undefined;
+        // pmApi already unwraps {data: [...]} → returns array directly
+        const msgs = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages?limit=1`) as Array<Record<string, unknown>>;
+        rootMsgId = msgs[0]?.id as string | undefined;
       } catch {
         // conversation 없음 → 기존 memos API fallback
       }

--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -41,7 +41,9 @@ export function registerMemosTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  server.tool('send_memo', 'Send a memo', {
+  // [DEPRECATED] send_memo — 내부적으로 conversation API로 라우팅됨 (S-B2).
+  // 기존 에이전트 호환성 유지. 스프린터블 운영이 send_memo 없이 검증된 후 제거 예정.
+  server.tool('send_memo', '[DEPRECATED] Send a memo. Internally routes to conversation API. Will be removed after memo-free sprint operation is validated.', {
     project_id: z.string().optional(),
     title: z.string().optional(),
     content: z.string(),
@@ -49,12 +51,29 @@ export function registerMemosTools(server: McpServer) {
     assigned_to: z.string().optional().describe('Single team member ID (legacy, use assigned_to_ids for multiple)'),
     assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to assign (supports multiple assignees)'),
     trigger_type: z.string().optional().describe('Workflow stage (kickoff, qa_request, review, merge_request)'),
-  }, async ({ assigned_to, assigned_to_ids, ...rest }) => {
+  }, async ({ assigned_to, assigned_to_ids, project_id, content, title, ...rest }) => {
     try {
       const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
-      const payload = { ...rest, ...(resolvedIds ? { assigned_to_ids: resolvedIds } : {}) };
-      const data = await pmApi('/api/v2/memos', { method: 'POST', body: JSON.stringify(payload) });
-      return ok(data);
+
+      // AC3: conversation + root message 생성으로 라우팅
+      const convPayload: Record<string, unknown> = {
+        type: 'group',
+        title: title ?? '(memo)',
+        participant_ids: resolvedIds ?? [],
+        project_id: project_id ?? '',
+      };
+      const conv = await pmApi('/api/v2/conversations', { method: 'POST', body: JSON.stringify(convPayload) }) as Record<string, unknown>;
+      const conversationId = conv.id as string;
+
+      const msgPayload = { content };
+      const msg = await pmApi(`/api/v2/conversations/${encodeURIComponent(conversationId)}/messages`, {
+        method: 'POST', body: JSON.stringify(msgPayload),
+      }) as Record<string, unknown>;
+      const msgData = (msg.data ?? msg) as Record<string, unknown>;
+      const messageId = msgData.id as string;
+
+      // AC5: 기존 memo_id + 신규 conversation_id/message_id + deprecated
+      return ok({ memo_id: conversationId, conversation_id: conversationId, message_id: messageId, deprecated: true, ...rest });
     } catch (e) { return handleError(e); }
   });
 
@@ -76,22 +95,53 @@ export function registerMemosTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  server.tool('read_memo', 'Read memo with replies', {
-    memo_id: z.string().describe('Memo ID'),
+  // AC6: read_memo — conversation 우선, 없으면 memos fallback
+  server.tool('read_memo', 'Read memo with replies (reads from conversation if migrated)', {
+    memo_id: z.string().describe('Memo ID (also accepts conversation ID)'),
   }, async ({ memo_id }) => {
     try {
+      // conversation 존재 여부 확인
+      try {
+        const msgs = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages`) as Record<string, unknown>;
+        const convData = { id: memo_id, conversation_id: memo_id, replies: msgs };
+        return ok(convData);
+      } catch {
+        // fallback to memos API
+      }
       const data = await pmApi(`/api/v2/memos/${encodeURIComponent(memo_id)}`);
       return ok(data);
     } catch (e) { return handleError(e); }
   });
 
-  server.tool('reply_memo', 'Reply to a memo', {
+  // [DEPRECATED] reply_memo — 내부적으로 conversation thread reply로 라우팅됨 (S-B2).
+  server.tool('reply_memo', '[DEPRECATED] Reply to a memo. Internally routes to conversation thread reply. Will be removed after memo-free sprint operation is validated.', {
     memo_id: z.string(),
     content: z.string(),
     assigned_to: z.string().optional().describe('Single team member ID to explicitly notify via webhook (legacy, use assigned_to_ids for multiple)'),
     assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to explicitly notify via webhook on this reply'),
   }, async ({ memo_id, content, assigned_to, assigned_to_ids }) => {
     try {
+      // AC4: memo_id = conversation_id (S-B1 패턴). top-level root message 조회 → thread reply 생성
+      let rootMsgId: string | undefined;
+      try {
+        const msgs = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages?limit=1`) as Record<string, unknown>;
+        const data = (msgs.data ?? []) as Array<Record<string, unknown>>;
+        rootMsgId = data[0]?.id as string | undefined;
+      } catch {
+        // conversation 없음 → 기존 memos API fallback
+      }
+
+      if (rootMsgId) {
+        // conversation thread reply
+        const msgPayload: Record<string, unknown> = { content, thread_id: rootMsgId };
+        const msg = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages`, {
+          method: 'POST', body: JSON.stringify(msgPayload),
+        }) as Record<string, unknown>;
+        const msgData = (msg.data ?? msg) as Record<string, unknown>;
+        return ok({ memo_id, conversation_id: memo_id, message_id: msgData.id, deprecated: true });
+      }
+
+      // fallback: 기존 memos reply API
       const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
       const payload: Record<string, unknown> = { content };
       if (resolvedIds) payload.assigned_to_ids = resolvedIds;
@@ -114,15 +164,24 @@ export function registerMemosTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  // S41: conversations API로 라우팅 전환 (thread_id = conversation_id = memo.id)
+  // AC7: send_chat_message — optional thread_id(reply), message_type, review_type, metadata 추가
   server.tool('send_chat_message', 'Send a chat message to a thread (conversation). Triggers real-time SSE delivery to all participants.', {
-    thread_id: z.string().describe('Thread ID (memo ID = conversation ID)'),
+    thread_id: z.string().describe('Conversation/Thread ID (memo ID = conversation ID)'),
     content: z.string().describe('Message content'),
-  }, async ({ thread_id, content }) => {
+    reply_thread_id: z.string().optional().describe('Optional: message ID to reply to within the thread (creates sub-thread)'),
+    message_type: z.string().optional().describe('Optional: message type hint (e.g. kickoff, qa, review)'),
+    review_type: z.string().optional().describe('Optional: review type (approve, request_changes, comment)'),
+    metadata: z.record(z.string(), z.unknown()).optional().describe('Optional: extra metadata attached to the message'),
+  }, async ({ thread_id, content, reply_thread_id, message_type, review_type, metadata }) => {
     try {
+      const payload: Record<string, unknown> = { content };
+      if (reply_thread_id) payload.thread_id = reply_thread_id;
+      if (message_type || review_type || metadata) {
+        payload.metadata = { ...(metadata ?? {}), ...(message_type ? { message_type } : {}), ...(review_type ? { review_type } : {}) };
+      }
       const data = await pmApi(`/api/v2/conversations/${encodeURIComponent(thread_id)}/messages`, {
         method: 'POST',
-        body: JSON.stringify({ content }),
+        body: JSON.stringify(payload),
       });
       return ok(data);
     } catch (e) { return handleError(e); }


### PR DESCRIPTION
## Summary
- `send_memo`: [DEPRECATED] 마킹, 내부적으로 POST /conversations + POST /conversations/{id}/messages 라우팅. Response에 `memo_id`/`conversation_id`/`message_id`/`deprecated: true` 포함 (S-B2 AC5)
- `reply_memo`: [DEPRECATED] 마킹, GET top-level message → thread_id 획득 → thread reply POST 라우팅. conversation 없으면 기존 memos API fallback (S-B2 AC4)
- `read_memo`: conversation 우선 조회, 없으면 memos fallback (S-B2 AC6)
- `send_chat_message`: optional `reply_thread_id`, `message_type`, `review_type`, `metadata` 파라미터 추가 (S-B2 AC7)
- TS 에러 수정: `z.record(z.unknown())` → `z.record(z.string(), z.unknown())`

## Test plan
- [ ] `send_memo` 호출 시 conversation + root message 생성됨
- [ ] `reply_memo` 호출 시 conversation thread reply 생성됨
- [ ] `reply_memo` — 존재하지 않는 conversation ID → memos API fallback 동작 확인
- [ ] `read_memo` — migrated memo ID → conversation messages 반환
- [ ] `read_memo` — 미이관 memo ID → memos API fallback 동작 확인
- [ ] `send_chat_message` — `reply_thread_id` 지정 시 thread reply 생성됨
- [ ] TypeScript 빌드 에러 없음 (`pnpm build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)