### PR TITLE
[S-B4 HOTFIX] fix: metadata → msg_metadata — SQLAlchemy 예약 속성명 충돌

### DIFF
--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -82,6 +82,6 @@ class ConversationMessage(Base, TimestampMixin):
         DateTime(timezone=True), nullable=True
     )
     review_type: Mapped[str | None] = mapped_column(Text, nullable=True)
-    metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    msg_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
 
     conversation: Mapped[Conversation] = relationship("Conversation", back_populates="messages")

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -488,7 +488,7 @@ async def create_memo(
         content=body.content or "",
         mentioned_ids=[],
         thread_id=None,
-        metadata=root_metadata,
+        msg_metadata=root_metadata,
     )
     session.add(root_msg)
     await session.flush()
@@ -687,7 +687,7 @@ async def add_reply(
             mentioned_ids=[],
             thread_id=root_msg.id,
             review_type=body.review_type if body.review_type != "comment" else None,
-            metadata={"review_type": body.review_type} if body.review_type else None,
+            msg_metadata={"review_type": body.review_type} if body.review_type else None,
         )
         db.add(reply_msg)
         await db.flush()

--- a/backend/scripts/migrate_memos_to_conversations.py
+++ b/backend/scripts/migrate_memos_to_conversations.py
@@ -185,7 +185,7 @@ async def _migrate_one(db, memo: Memo) -> None:
         mentioned_ids=[],
         thread_id=None,
         reply_count=len(replies),
-        metadata=root_metadata,
+        msg_metadata=root_metadata,
     )
     root_msg.created_at = memo.created_at
     root_msg.updated_at = memo.created_at
@@ -208,7 +208,7 @@ async def _migrate_one(db, memo: Memo) -> None:
             mentioned_ids=[],
             thread_id=root_msg.id,
             review_type=reply.review_type if reply.review_type != "comment" else None,
-            metadata={"review_type": reply.review_type} if reply.review_type else None,
+            msg_metadata={"review_type": reply.review_type} if reply.review_type else None,
         )
         reply_msg.created_at = reply.created_at
         reply_msg.updated_at = reply.created_at


### PR DESCRIPTION
## Summary
Cloud Build FAILED: `sqlalchemy.exc.InvalidRequestError: Attribute name 'metadata' is reserved when using the Declarative API.`

**원인**: `ConversationMessage.metadata`가 SQLAlchemy `DeclarativeBase` 예약 속성명. 컨테이너 임포트 시점 크래시.

**수정**: `Memo.memo_metadata` 패턴 적용
```python
# before (BROKEN)
metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

# after (FIXED)
msg_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
```

DB 컬럼명 `metadata`는 유지 — migration 변경 없음.

## Files changed
- `backend/app/models/conversation.py`
- `backend/app/routers/memos.py`
- `backend/scripts/migrate_memos_to_conversations.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)