### PR TITLE
[P0 HOTFIX] fix: create_memo conv.id None → conv_id 미리 생성

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -455,7 +455,9 @@ async def create_memo(
     if body.assigned_to_ids:
         participant_ids.update(body.assigned_to_ids)
 
+    conv_id = uuid.uuid4()
     conv = Conversation(
+        id=conv_id,
         project_id=body.project_id,
         org_id=body.org_id,
         type="group",
@@ -465,7 +467,7 @@ async def create_memo(
     )
     session.add(conv)
     for pid in participant_ids:
-        session.add(ConversationParticipant(conversation_id=conv.id, member_id=pid))
+        session.add(ConversationParticipant(conversation_id=conv_id, member_id=pid))
     await session.flush()
 
     # AC2/AC3: entity_links + title → root message metadata 보존 (AC6: link 개수 손실 방지)


### PR DESCRIPTION
## Summary
**P0**: `POST /api/v2/memos` 500 에러 — `NotNullViolation: null value in column "conversation_id"`

**원인**: SQLAlchemy `default=uuid.uuid4`는 INSERT 시점에 평가. `session.flush()` 이전에 `conv.id` 접근 시 `None` → `ConversationParticipant.conversation_id = None`.

**수정**: `conv_id = uuid.uuid4()`로 미리 생성 후 `Conversation(id=conv_id, ...)` + `ConversationParticipant(conversation_id=conv_id, ...)` 명시 지정.

```python
# before (BROKEN)
conv = Conversation(project_id=..., ...)
session.add(conv)
for pid in participant_ids:
    session.add(ConversationParticipant(conversation_id=conv.id, ...))  # conv.id = None!

# after (FIXED)
conv_id = uuid.uuid4()
conv = Conversation(id=conv_id, project_id=..., ...)
session.add(conv)
for pid in participant_ids:
    session.add(ConversationParticipant(conversation_id=conv_id, ...))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)