### PR TITLE
[S-C1] feat: activity_logs 테이블 + ActivityLogService.record()

### DIFF
--- a/backend/alembic/versions/0036_add_activity_logs.py
+++ b/backend/alembic/versions/0036_add_activity_logs.py
@@ -1,0 +1,47 @@
+"""add activity_logs table (S-C1)
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0036"
+down_revision = "0035"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "activity_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("actor_type", sa.Text(), nullable=False),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("entity_type", sa.Text(), nullable=True),
+        sa.Column("entity_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("context", JSONB(), nullable=False, server_default="{}"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.CheckConstraint("actor_type IN ('agent', 'human')", name="ck_activity_logs_actor_type"),
+    )
+    # AC: 인덱스 3개
+    op.create_index("ix_activity_logs_org_created", "activity_logs", ["org_id", "created_at"])
+    op.create_index("ix_activity_logs_actor_created", "activity_logs", ["actor_id", "created_at"])
+    op.create_index("ix_activity_logs_entity", "activity_logs", ["entity_type", "entity_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_activity_logs_entity", table_name="activity_logs")
+    op.drop_index("ix_activity_logs_actor_created", table_name="activity_logs")
+    op.drop_index("ix_activity_logs_org_created", table_name="activity_logs")
+    op.drop_table("activity_logs")

--- a/backend/app/models/activity_log.py
+++ b/backend/app/models/activity_log.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Text, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ActivityLog(Base):
+    __tablename__ = "activity_logs"
+    __table_args__ = (
+        CheckConstraint("actor_type IN ('agent', 'human')", name="ck_activity_logs_actor_type"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    actor_type: Mapped[str] = mapped_column(Text, nullable=False)
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    entity_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    context: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -1,0 +1,53 @@
+"""ActivityLogService — 내부 서비스 전용. API expose는 S-C3에서."""
+from __future__ import annotations
+
+import uuid
+import logging
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.activity_log import ActivityLog
+
+logger = logging.getLogger(__name__)
+
+ActorType = Literal["agent", "human"]
+
+
+class ActivityLogService:
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+
+    async def record(
+        self,
+        *,
+        org_id: uuid.UUID,
+        action: str,
+        actor_type: ActorType,
+        actor_id: uuid.UUID | None = None,
+        project_id: uuid.UUID | None = None,
+        entity_type: str | None = None,
+        entity_id: uuid.UUID | None = None,
+        context: dict | None = None,
+    ) -> ActivityLog:
+        """activity_logs row 생성. immutable — update/delete 없음. (AC2, AC3, AC4, AC5)"""
+        if actor_type not in ("agent", "human"):
+            raise ValueError(f"actor_type must be 'agent' or 'human', got {actor_type!r}")
+
+        log = ActivityLog(
+            org_id=org_id,
+            project_id=project_id,
+            actor_id=actor_id,
+            actor_type=actor_type,
+            action=action,
+            entity_type=entity_type,
+            entity_id=entity_id,
+            context=context or {},  # AC3: NULL 저장 금지, 기본값 {}
+        )
+        self._db.add(log)
+        await self._db.flush()
+        logger.info(
+            "activity_log recorded action=%s actor_type=%s actor_id=%s entity_type=%s entity_id=%s",
+            action, actor_type, actor_id, entity_type, entity_id,
+        )
+        return log


### PR DESCRIPTION
## Summary
- AC1: Alembic migration `0036` — `activity_logs` 테이블 신규 생성. 인덱스 3개: `(org_id, created_at)`, `(actor_id, created_at)`, `(entity_type, entity_id)`. `actor_type` CHECK constraint.
- AC2: `ActivityLogService.record()` — 내부 서비스 전용 (API expose는 S-C3에서)
- AC3: `context` 기본값 `{}` 보장 — `context or {}` 패턴, NULL 저장 불가
- AC4: `actor_type IN ('agent', 'human')` — Python `Literal` 타입 validation + DB CHECK constraint 이중 보장
- AC5: immutable — `record()` 메서드만 존재, update/delete 메서드 없음
- AC6: `permission_audit_logs` (`audit.py`) 무변경

## Test plan
- [ ] migration `0036` upgrade → `activity_logs` 테이블 생성 확인
- [ ] migration `0036` downgrade → 테이블 삭제 확인
- [ ] `ActivityLogService.record(actor_type="agent", ...)` → row 생성 확인
- [ ] `ActivityLogService.record(actor_type="invalid", ...)` → `ValueError` 발생 확인
- [ ] `context=None` 전달 시 DB에 `{}` 저장 확인 (NULL 아님)
- [ ] `permission_audit_logs` 테이블/모델 무변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)