### PR TITLE
[S-C2] feat: 에이전트 액션 자동 기록 — BackgroundTask activity log hooks

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -593,6 +593,21 @@ async def send_message(
         org_id=org_id,
     )
 
+    # S-C2: agent sender인 경우에만 message_sent 기록 (AC2, AC4, AC5, AC6)
+    if sender.type == "agent":
+        from app.services.activity_log import record_activity_bg
+        background_tasks.add_task(
+            record_activity_bg,
+            org_id=org_id,
+            action="message_sent",
+            actor_id=sender.id,
+            actor_type="agent",
+            project_id=conv.project_id,
+            entity_type="conversation",
+            entity_id=conversation_id,
+            context={"message_id": str(msg.id)},
+        )
+
     return {"data": _msg_payload(msg, sender)}
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -116,6 +116,7 @@ async def get_story(
 async def update_story(
     id: uuid.UUID,
     body: StoryUpdate,
+    background_tasks: BackgroundTasks,
     repo: StoryRepository = Depends(_get_repo),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
@@ -204,6 +205,20 @@ async def update_story(
             except Exception:
                 pass
 
+    # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
+    if actor_id:
+        from app.services.activity_log import record_activity_bg
+        background_tasks.add_task(
+            record_activity_bg,
+            org_id=repo.org_id,
+            action="story_updated",
+            actor_id=actor_id,
+            project_id=story.project_id,
+            entity_type="story",
+            entity_id=id,
+            context={"fields": list(data.keys()), "story_title": story.title},
+        )
+
     return StoryResponse.model_validate(story)
 
 
@@ -222,6 +237,7 @@ async def delete_story(
 async def update_story_status(
     id: uuid.UUID,
     body: StoryStatusUpdate,
+    background_tasks: BackgroundTasks,
     repo: StoryRepository = Depends(_get_repo),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
@@ -313,6 +329,20 @@ async def update_story_status(
                 await db.flush()
             except Exception:
                 pass
+
+    # S-C2: story_updated — actor가 agent인 경우 기록 (AC2, AC6)
+    if actor_id:
+        from app.services.activity_log import record_activity_bg
+        background_tasks.add_task(
+            record_activity_bg,
+            org_id=repo.org_id,
+            action="story_updated",
+            actor_id=actor_id,
+            project_id=story.project_id,
+            entity_type="story",
+            entity_id=id,
+            context={"old_status": old_status, "new_status": story.status, "story_title": story.title},
+        )
 
     return StoryResponse.model_validate(story)
 

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -5,6 +5,7 @@ import uuid
 import logging
 from typing import Literal
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity_log import ActivityLog
@@ -12,6 +13,46 @@ from app.models.activity_log import ActivityLog
 logger = logging.getLogger(__name__)
 
 ActorType = Literal["agent", "human"]
+
+
+async def record_activity_bg(
+    *,
+    org_id: uuid.UUID,
+    action: str,
+    actor_id: uuid.UUID | None = None,
+    actor_type: ActorType | None = None,
+    project_id: uuid.UUID | None = None,
+    entity_type: str | None = None,
+    entity_id: uuid.UUID | None = None,
+    context: dict | None = None,
+) -> None:
+    """BackgroundTask용 activity log 기록. 실패해도 caller에 영향 없음 (AC6)."""
+    from app.core.database import async_session_factory
+    from app.models.team import TeamMember
+
+    try:
+        async with async_session_factory() as db:
+            resolved_type: ActorType = actor_type or "human"
+            if actor_type is None and actor_id is not None:
+                tm = (await db.execute(
+                    select(TeamMember).where(TeamMember.id == actor_id).limit(1)
+                )).scalar_one_or_none()
+                if tm and tm.type in ("agent", "human"):
+                    resolved_type = tm.type  # type: ignore[assignment]
+
+            await ActivityLogService(db).record(
+                org_id=org_id,
+                action=action,
+                actor_id=actor_id,
+                actor_type=resolved_type,
+                project_id=project_id,
+                entity_type=entity_type,
+                entity_id=entity_id,
+                context=context,
+            )
+            await db.commit()
+    except Exception:
+        logger.warning("record_activity_bg failed action=%s actor_id=%s", action, actor_id, exc_info=True)
 
 
 class ActivityLogService:

--- a/backend/app/services/dispatch_router.py
+++ b/backend/app/services/dispatch_router.py
@@ -109,3 +109,21 @@ async def route_dispatch_event(
     else:
         # in_app, telegram 등 — 현재 in_app은 SSE로 처리
         _push_to_agent(str(recipient_id), payload)
+
+    # S-C2: dispatch_triggered — agent recipient인 경우 기록 (AC2, AC6)
+    if recipient_type == "agent":
+        try:
+            from app.services.activity_log import record_activity_bg
+            import asyncio
+            asyncio.ensure_future(record_activity_bg(
+                org_id=event.org_id,
+                action="dispatch_triggered",
+                actor_id=recipient_id,
+                actor_type="agent",
+                project_id=getattr(event, "project_id", None),
+                entity_type="event",
+                entity_id=event_id,
+                context={"event_type": event.event_type, "channel": channel},
+            ))
+        except Exception:
+            logger.warning("dispatch record_activity_bg setup failed event_id=%s", event_id, exc_info=True)


### PR DESCRIPTION
## Summary
S-C1 ActivityLogService 위에 실제 기록 훅 구현. S-C1 (`feature/e-eventbus-s-c1`) 머지 후 rebase 예정.

- AC1: `record_activity_bg()` helper — 새 session으로 비동기 기록, 실패 시 warning만 (메인 응답 지연 없음)
- AC2: 기록 포인트 3개
  - `conversations.py send_message`: `sender.type == 'agent'` → `message_sent` BackgroundTask
  - `stories.py update_story / update_story_status`: `actor_id` 존재 시 `story_updated` BackgroundTask
  - `dispatch_router.py`: `recipient_type == 'agent'` → `dispatch_triggered` asyncio.ensure_future
- AC3: `record_activity_bg`에서 `actor_id`로 `TeamMember.type` 자동 조회 → agent/human 판별
- AC4: `message_sent` context에 `message_id`만 포함 — content 저장 금지
- AC5: read API (`list_messages`, `get_story` 등)에 hook 없음
- AC6: `record_activity_bg` try/except 전체 감싸 — 기록 실패 시 원 요청 HTTP status 미영향
- AC7: response schema 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)