### PR TITLE
[S-C4] feat: EE Audit RBAC 게이팅 — filter_activity_by_role

### DIFF
--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -1,8 +1,9 @@
-"""S-C3: Activity Logs read-only API. CUD 없음."""
+"""S-C3: Activity Logs read-only API. CUD 없음. S-C4: EE RBAC 조건부 게이팅."""
+import logging
 import uuid
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,6 +11,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.activity_log import ActivityLog
+
+logger = logging.getLogger(__name__)
+
+# S-C4: EE RBAC — CE 코드에 top-level import ee 금지. 조건부 로드.
+_ee_rbac_filter = None
+try:
+    from app.core.config import settings as _settings
+    if _settings.is_ee_enabled:
+        from ee.services.audit_rbac import filter_activity_by_role as _ee_rbac_filter  # type: ignore[assignment]
+        logger.info("activity_logs: EE RBAC filter loaded")
+except Exception:
+    pass
 
 router = APIRouter(prefix="/api/v2/activity-logs", tags=["activity-logs"])
 
@@ -51,6 +64,8 @@ async def list_activity_logs(
     org_id: uuid.UUID = Depends(get_verified_org_id),
     _auth: AuthContext = Depends(get_current_user),
 ) -> ActivityLogListResponse:
+    from app.models.team import TeamMember
+
     # AC5: org scope 필터 (외부 접근 불가 — get_verified_org_id가 403 처리)
     q = select(ActivityLog).where(ActivityLog.org_id == org_id)
 
@@ -68,6 +83,26 @@ async def list_activity_logs(
         q = q.where(ActivityLog.created_at >= from_)
     if to:
         q = q.where(ActivityLog.created_at <= to)
+
+    # S-C4: EE RBAC — is_ee_enabled 시 role별 가시성 필터 적용
+    ee_applied = False
+    if _ee_rbac_filter is not None:
+        try:
+            caller_tm = (await db.execute(
+                select(TeamMember).where(
+                    TeamMember.id == uuid.UUID(_auth.user_id),
+                    TeamMember.org_id == org_id,
+                ).limit(1)
+            )).scalar_one_or_none()
+            if caller_tm:
+                q = _ee_rbac_filter(q, caller_tm.role, caller_tm.id)
+                ee_applied = True
+                logger.info(
+                    "activity_logs EE RBAC applied role=%s member_id=%s",
+                    caller_tm.role, caller_tm.id,
+                )
+        except Exception:
+            logger.warning("activity_logs EE RBAC filter failed — fallback to flat log", exc_info=True)
 
     total_result = await db.execute(select(func.count()).select_from(q.subquery()))
     total = total_result.scalar_one()

--- a/backend/ee/services/audit_rbac.py
+++ b/backend/ee/services/audit_rbac.py
@@ -1,0 +1,38 @@
+"""EE: Activity Log RBAC 가시성 필터 (S-C4).
+
+CE fallback: activity_logs.py에서 조건부 import — ee/ 없으면 이 파일 로드 안 됨.
+"""
+from __future__ import annotations
+
+import uuid
+import logging
+
+from sqlalchemy import select
+from sqlalchemy.sql import Select
+
+logger = logging.getLogger(__name__)
+
+_VALID_ROLES = {"owner", "admin", "member"}
+
+
+def filter_activity_by_role(
+    query: Select,
+    member_role: str,
+    member_id: uuid.UUID,
+) -> Select:
+    """role별 가시성 필터 적용.
+
+    - owner: 전체 (필터 없음)
+    - admin: actor_type='agent' 만
+    - member: 본인(member_id)의 actor_id 만 (본인 agent 행위만)
+    """
+    from app.models.activity_log import ActivityLog
+
+    if member_role == "owner":
+        return query
+
+    if member_role == "admin":
+        return query.where(ActivityLog.actor_type == "agent")
+
+    # member 이하: 본인 actor_id만
+    return query.where(ActivityLog.actor_id == member_id)


### PR DESCRIPTION
## Summary
- AC1: `ee/services/audit_rbac.py` 신규 — `filter_activity_by_role(query, member_role, member_id)` 함수
- AC2: CE 코드(`activity_logs.py`) top-level `import ee` 금지 — `try/except` + `is_ee_enabled` 조건부 로드
- AC3: `LICENSE_CONSENT≠agreed` 또는 ee/ 미로드 시 `_ee_rbac_filter=None` → flat log fallback (S-C3 동작 유지)
- AC4: role별 가시성
  - `owner`: 전체 (필터 없음)
  - `admin`: `actor_type='agent'` 만
  - `member`: 본인 `actor_id` 만
- AC5: EE 필터 적용 시 `activity_logs EE RBAC applied role=... member_id=...` structured log

## Test plan
- [ ] `LICENSE_CONSENT=false` 환경 → 필터 없이 전체 log 반환 확인 (flat log)
- [ ] `LICENSE_CONSENT=agreed` + `owner` role → 전체 log 반환
- [ ] `LICENSE_CONSENT=agreed` + `admin` role → `actor_type=agent` 행만 반환
- [ ] `LICENSE_CONSENT=agreed` + `member` role → 본인 actor_id 행만 반환
- [ ] ee/ 없는 OSS 환경 → import 에러 없이 flat log 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)