### PR TITLE
[S-D2] feat: 인바운드 Bridge → Conversation 확장

### DIFF
--- a/backend/app/routers/bridge.py
+++ b/backend/app/routers/bridge.py
@@ -192,6 +192,8 @@ async def slack_events(request: Request, session: AsyncSession = Depends(get_db)
                 norm_event.get("threadTs"),
                 message_ts=norm_event.get("messageTs"),
             )
+            if result.get("action") == "error":
+                raise ValueError(result["detail"])
             await session.commit()
             return _ok(result)
         except Exception:
@@ -381,6 +383,8 @@ async def teams_events(request: Request, session: AsyncSession = Depends(get_db)
                 norm_event.get("threadTs"),
                 message_ts=norm_event.get("messageTs"),
             )
+            if result.get("action") == "error":
+                raise ValueError(result["detail"])
             await session.commit()
             return JSONResponse({"ok": True, "result": result})
         except Exception:

--- a/backend/app/routers/bridge.py
+++ b/backend/app/routers/bridge.py
@@ -21,6 +21,71 @@ from app.utils.teams_verify import verify_teams_request
 router = APIRouter(prefix="/api/v2/bridge", tags=["bridge"])
 
 
+# ─── S-D2: conversation inbound helper ────────────────────────────────────────
+
+async def _inbound_to_conversation(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    author_id: uuid.UUID,
+    content: str,
+    external_thread_ts: str | None,
+) -> dict:
+    """external inbound → ConversationMessage 생성.
+
+    thread_ts 있으면 metadata.external_thread_ts 매핑으로 thread reply.
+    없으면 top-level message 생성.
+    """
+    from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+
+    conv = await session.get(Conversation, conversation_id)
+    if conv is None:
+        return {"action": "error", "detail": "conversation_not_found"}
+
+    # 참여자 등록 (없으면 추가)
+    existing_participant = (await session.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == author_id,
+        )
+    )).scalar_one_or_none()
+    if existing_participant is None:
+        session.add(ConversationParticipant(conversation_id=conversation_id, member_id=author_id))
+        await session.flush()
+
+    thread_id: uuid.UUID | None = None
+    if external_thread_ts:
+        # msg_metadata->>'external_thread_ts' 매핑으로 root message 탐색
+        from sqlalchemy import cast, String
+        from sqlalchemy.dialects.postgresql import JSONB
+        root_candidate = (await session.execute(
+            select(ConversationMessage).where(
+                ConversationMessage.conversation_id == conversation_id,
+                ConversationMessage.thread_id.is_(None),
+                ConversationMessage.msg_metadata["external_thread_ts"].as_string() == external_thread_ts,
+            ).limit(1)
+        )).scalar_one_or_none()
+        if root_candidate:
+            thread_id = root_candidate.id
+
+    msg = ConversationMessage(
+        conversation_id=conversation_id,
+        sender_id=author_id,
+        content=content,
+        mentioned_ids=[],
+        thread_id=thread_id,
+        msg_metadata={"external_thread_ts": external_thread_ts} if external_thread_ts and not thread_id else None,
+    )
+    session.add(msg)
+    await session.flush()
+
+    return {
+        "action": "conversation_message_created",
+        "conversation_id": str(conversation_id),
+        "message_id": str(msg.id),
+        "thread_id": str(thread_id) if thread_id else None,
+    }
+
+
 # ─── helpers ──────────────────────────────────────────────────────────────────
 
 def _ok(data: object) -> JSONResponse:
@@ -109,14 +174,31 @@ async def slack_events(request: Request, session: AsyncSession = Depends(get_db)
         return _ok({"action": "ignored"})
 
     label = None if user_mapping else "Slack 연동 미설정 사용자"
-    metadata = build_bridge_metadata("slack", norm_event)
+    content = _memo_content("slack", norm_event, label)
 
+    # S-D2: conversation mapping 있으면 → ConversationMessage 생성 (fallback: memo)
+    conv_id_str = (mapping.config or {}).get("conversation_id")
+    if conv_id_str:
+        try:
+            result = await _inbound_to_conversation(
+                session,
+                uuid.UUID(conv_id_str),
+                author_id,
+                content,
+                norm_event.get("threadTs"),
+            )
+            await session.commit()
+            return _ok(result)
+        except Exception:
+            pass  # conversation 실패 시 memo fallback
+
+    metadata = build_bridge_metadata("slack", norm_event)
     memo_id = await repo.create_memo(
         org_id=org_id,
         project_id=project_id,
         created_by=author_id,
         title=_memo_title(norm_event["messageText"], label),
-        content=_memo_content("slack", norm_event, label),
+        content=content,
         memo_type="memo",
         metadata=metadata,
         assigned_to=None,
@@ -280,14 +362,31 @@ async def teams_events(request: Request, session: AsyncSession = Depends(get_db)
     }
 
     label = None if user_mapping else "Microsoft Teams 연동 미설정 사용자"
-    metadata = build_bridge_metadata("teams", norm_event)
+    content = _memo_content("teams", norm_event, label)
 
+    # S-D2: conversation mapping 있으면 → ConversationMessage 생성 (fallback: memo)
+    conv_id_str = (mapping.config or {}).get("conversation_id")
+    if conv_id_str:
+        try:
+            result = await _inbound_to_conversation(
+                session,
+                uuid.UUID(conv_id_str),
+                author_id,
+                content,
+                norm_event.get("threadTs"),
+            )
+            await session.commit()
+            return JSONResponse({"ok": True, "result": result})
+        except Exception:
+            pass  # conversation 실패 시 memo fallback
+
+    metadata = build_bridge_metadata("teams", norm_event)
     memo_id = await repo.create_memo(
         org_id=org_id,
         project_id=project_id,
         created_by=author_id,
         title=_memo_title(message_text, label),
-        content=_memo_content("teams", norm_event, label),
+        content=content,
         memo_type="memo",
         metadata=metadata,
         assigned_to=None,

--- a/backend/app/routers/bridge.py
+++ b/backend/app/routers/bridge.py
@@ -29,11 +29,11 @@ async def _inbound_to_conversation(
     author_id: uuid.UUID,
     content: str,
     external_thread_ts: str | None,
+    message_ts: str | None = None,
 ) -> dict:
     """external inbound → ConversationMessage 생성.
 
-    thread_ts 있으면 metadata.external_thread_ts 매핑으로 thread reply.
-    없으면 top-level message 생성.
+    RC1: root 저장 시 external_message_ts=message_ts, reply 탐색 시 동일 키로 root 검색.
     """
     from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 
@@ -54,18 +54,22 @@ async def _inbound_to_conversation(
 
     thread_id: uuid.UUID | None = None
     if external_thread_ts:
-        # msg_metadata->>'external_thread_ts' 매핑으로 root message 탐색
-        from sqlalchemy import cast, String
-        from sqlalchemy.dialects.postgresql import JSONB
+        # RC1: external_message_ts == threadTs로 root 탐색
         root_candidate = (await session.execute(
             select(ConversationMessage).where(
                 ConversationMessage.conversation_id == conversation_id,
                 ConversationMessage.thread_id.is_(None),
-                ConversationMessage.msg_metadata["external_thread_ts"].as_string() == external_thread_ts,
+                ConversationMessage.msg_metadata["external_message_ts"].as_string() == external_thread_ts,
             ).limit(1)
         )).scalar_one_or_none()
         if root_candidate:
             thread_id = root_candidate.id
+
+    # RC1: root message에 external_message_ts 저장 (threadTs 없을 때만)
+    if thread_id is None and message_ts:
+        msg_metadata_val: dict | None = {"external_message_ts": message_ts}
+    else:
+        msg_metadata_val = None
 
     msg = ConversationMessage(
         conversation_id=conversation_id,
@@ -73,7 +77,7 @@ async def _inbound_to_conversation(
         content=content,
         mentioned_ids=[],
         thread_id=thread_id,
-        msg_metadata={"external_thread_ts": external_thread_ts} if external_thread_ts and not thread_id else None,
+        msg_metadata=msg_metadata_val,
     )
     session.add(msg)
     await session.flush()
@@ -186,11 +190,12 @@ async def slack_events(request: Request, session: AsyncSession = Depends(get_db)
                 author_id,
                 content,
                 norm_event.get("threadTs"),
+                message_ts=norm_event.get("messageTs"),
             )
             await session.commit()
             return _ok(result)
         except Exception:
-            pass  # conversation 실패 시 memo fallback
+            await session.rollback()  # RC2: dirty session 복구 후 memo fallback
 
     metadata = build_bridge_metadata("slack", norm_event)
     memo_id = await repo.create_memo(
@@ -374,11 +379,12 @@ async def teams_events(request: Request, session: AsyncSession = Depends(get_db)
                 author_id,
                 content,
                 norm_event.get("threadTs"),
+                message_ts=norm_event.get("messageTs"),
             )
             await session.commit()
             return JSONResponse({"ok": True, "result": result})
         except Exception:
-            pass  # conversation 실패 시 memo fallback
+            await session.rollback()  # RC2: dirty session 복구 후 memo fallback
 
     metadata = build_bridge_metadata("teams", norm_event)
     memo_id = await repo.create_memo(


### PR DESCRIPTION
## Summary
- AC1: `mapping.config.conversation_id` 있으면 `_inbound_to_conversation()` 호출 (slack/teams 양쪽)
- AC2: `external_channel_id`, `external_user_id`, `content`, `thread_ts` → `ConversationMessage` 변환
- AC3: `bridge_user_mappings` 매핑 실패 시 `fallback_author` 사용 (기존 패턴 유지)
- AC4: `external_thread_ts` → `msg_metadata` 저장 + 다음 inbound에서 root message 탐색 → thread reply
- AC5: `conversation_id` 없으면 기존 memo inbound fallback 유지
- AC6: response `conversation_id` + `message_id` + `thread_id` 반환
- AC7: `_inbound_to_conversation` 실패 시 memo fallback (long-lived connection 없음, DB 점유 없음)

## Key design
- `mapping.config` JSONB에 `{"conversation_id": "uuid"}` 저장으로 conversation mapping 표현 (migration 불필요)
- thread mapping: `msg_metadata.external_thread_ts` 필드로 Slack thread_ts ↔ Sprintable root message 연결

## Test plan
- [ ] `mapping.config.conversation_id` 있는 채널 inbound → `ConversationMessage` 생성, `conversation_message_created` 응답 확인
- [ ] Slack thread_ts 있는 inbound → 기존 root message에 thread reply 생성 확인
- [ ] `conversation_id` 없는 채널 inbound → 기존 memo 생성 fallback 동작 확인
- [ ] conversation 없는 UUID 지정 → fallback memo 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)