### PR TITLE
[S-D3] feat: fakechat_port 자동 할당 + agent 설정 API response 확장

### DIFF
--- a/backend/alembic/versions/0037_add_fakechat_port_to_team_members.py
+++ b/backend/alembic/versions/0037_add_fakechat_port_to_team_members.py
@@ -1,0 +1,30 @@
+"""add fakechat_port to team_members (S-D3)
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("team_members", sa.Column("fakechat_port", sa.Integer(), nullable=True))
+    # AC2: project 내 중복 port 방지 (agent type + non-null port)
+    op.create_index(
+        "uq_team_members_project_fakechat_port",
+        "team_members",
+        ["project_id", "fakechat_port"],
+        unique=True,
+        postgresql_where=sa.text("fakechat_port IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_team_members_project_fakechat_port", table_name="team_members")
+    op.drop_column("team_members", "fakechat_port")

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -25,6 +25,7 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8")
     agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    fakechat_port: Mapped[int | None] = mapped_column(nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -1,13 +1,18 @@
+import os
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import assert_agent_owner
+from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
+
+_FAKECHAT_BASE_PORT = 8787
 
 router = APIRouter(prefix="/api/v2/team-members", tags=["team-members"])
 
@@ -40,14 +45,32 @@ async def list_team_members(
     return [TeamMemberResponse.model_validate(m) for m in members]
 
 
-@router.post("", response_model=TeamMemberResponse, status_code=201)
+@router.post("", status_code=201)
 async def create_team_member(
     body: TeamMemberCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-) -> TeamMemberResponse:
+) -> dict:
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
+
+    # AC1/AC2: agent 생성 시 fakechat_port 자동 할당 (project 내 중복 방지)
+    fakechat_port: int | None = None
+    if body.type == "agent":
+        existing_ports = {
+            r[0] for r in (await session.execute(
+                select(TeamMember.fakechat_port).where(
+                    TeamMember.project_id == body.project_id,
+                    TeamMember.type == "agent",
+                    TeamMember.fakechat_port.isnot(None),
+                )
+            )).all()
+        }
+        port = _FAKECHAT_BASE_PORT
+        while port in existing_ports:
+            port += 1
+        fakechat_port = port
+
     member = await repo.create(
         project_id=body.project_id,
         type=body.type,
@@ -60,10 +83,38 @@ async def create_team_member(
         color=body.color,
         agent_role=body.agent_role,
         created_by=created_by,
+        fakechat_port=fakechat_port,
     )
+
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
-    return TeamMemberResponse.model_validate(member)
+
+    # AC3: agent 생성 시 API key 자동 생성 + response에 포함
+    api_key_plaintext: str | None = None
+    if body.type == "agent":
+        from app.repositories.api_key import ApiKeyRepository
+        api_key_repo = ApiKeyRepository(session)
+        _api_key_obj, api_key_plaintext = await api_key_repo.create(team_member_id=member.id)
+
+    # AC3: agent 응답에 fakechat_port + mcp_config 포함
+    response = TeamMemberResponse.model_validate(member).model_dump()
+    if body.type == "agent":
+        # AC6: FAKECHAT_PORT 환경변수 호환 — DB 포트 우선, 없으면 환경변수 fallback
+        effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
+        response["fakechat_port"] = effective_port
+        response["api_key_created"] = bool(api_key_plaintext)
+        response["mcp_config"] = {
+            "mcpServers": {
+                "sprintable": {
+                    "type": "sse",
+                    "url": f"http://localhost:{effective_port}/sse",
+                }
+            }
+        }
+        if api_key_plaintext:
+            response["api_key"] = api_key_plaintext
+
+    return response
 
 
 @router.get("/{id}", response_model=TeamMemberResponse)

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -99,6 +99,7 @@ async def create_team_member(
     # AC3: agent 응답에 fakechat_port + mcp_config 포함
     response = TeamMemberResponse.model_validate(member).model_dump()
     if body.type == "agent":
+        response["member_id"] = str(member.id)
         # AC6: FAKECHAT_PORT 환경변수 호환 — DB 포트 우선, 없으면 환경변수 fallback
         effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
         response["fakechat_port"] = effective_port


### PR DESCRIPTION
## Summary
- AC1: agent 생성 시 `8787 + agent_index` 포트 자동 할당 (project 내 기존 포트 스캔 후 가용 포트 할당)
- AC2: migration `0037` — `team_members.fakechat_port INTEGER NULL` + partial unique index `(project_id, fakechat_port) WHERE fakechat_port IS NOT NULL`
- AC3: agent `POST /api/v2/team-members` response에 `member_id`, `api_key_created`, `fakechat_port`, `mcp_config`, `api_key`(최초 1회) 포함
- AC6: `FAKECHAT_PORT` 환경변수 호환 — DB 포트 우선, 없으면 env fallback
- AC7: 서버 사이드 fakechat hosting API 없음 (클라이언트 로컬 실행 가정)

## Test plan
- [ ] agent 생성 → response `fakechat_port=8787` 확인
- [ ] 같은 project에 agent 2번째 생성 → `fakechat_port=8788` 확인
- [ ] 같은 port 중복 생성 시도 → 자동으로 다음 포트 할당 확인
- [ ] `mcp_config.mcpServers.sprintable.url` = `http://localhost:8787/sse` 확인
- [ ] `api_key` 필드 최초 응답에 포함 확인
- [ ] human member 생성 → `fakechat_port`/`mcp_config` 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)