### PR TITLE
[SID:S-D3] 에이전트 설정 UI — fakechat 포트 + SSE 채널 표시

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { ArrowLeft, Check, Pencil, Plus, X } from 'lucide-react';
+import { ArrowLeft, Check, Copy, Pencil, Plus, X } from 'lucide-react';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -28,6 +28,7 @@ interface AgentMember {
   is_active: boolean;
   webhook_url: string | null;
   created_by: string | null;
+  fakechat_port: number | null;
 }
 
 interface WebhookConfig {
@@ -100,6 +101,7 @@ export default function AgentDetailPage() {
   const [freshApiKey, setFreshApiKey] = useState<string | null>(null);
   const [hasActiveKey, setHasActiveKey] = useState(false);
   const [mcpCopied, setMcpCopied] = useState(false);
+  const [fakechatMcpCopied, setFakechatMcpCopied] = useState(false);
 
   const [projects, setProjects] = useState<ProjectOption[]>([]);
   const [sameNameAgents, setSameNameAgents] = useState<AgentMember[]>([]);
@@ -315,6 +317,21 @@ export default function AgentDetailPage() {
     }
   };
 
+  const handleCopyFakechatMcp = async () => {
+    if (!agent?.fakechat_port) return;
+    const config = JSON.stringify(
+      { mcpServers: { sprintable: { type: 'sse', url: `http://localhost:${agent.fakechat_port}/sse` } } },
+      null, 2,
+    );
+    try {
+      await navigator.clipboard.writeText(config);
+      setFakechatMcpCopied(true);
+      setTimeout(() => setFakechatMcpCopied(false), 2000);
+    } catch {
+      addToast({ type: 'error', title: tc('error') });
+    }
+  };
+
   if (loading) {
     return (
       <div className="w-full max-w-3xl mx-auto p-6 space-y-4">
@@ -489,6 +506,52 @@ export default function AgentDetailPage() {
             <p className="text-xs text-amber-400">API Key를 먼저 발급하세요. 발급 직후 실제 키가 이 블록에 자동으로 포함됩니다.</p>
           ) : (
             <p className="text-xs text-muted-foreground">보안상 기존 키는 재표시되지 않습니다. 위 API Keys 섹션에서 새 키를 발급하면 실제 키가 포함된 Config가 여기에 자동으로 나타납니다.</p>
+          )}
+        </SectionCardBody>
+      </SectionCard>
+
+      {/* Fakechat 채널 (SSE) */}
+      <SectionCard>
+        <SectionCardHeader>
+          <div className="flex items-center justify-between w-full">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2">
+                <h2 className="text-base font-semibold text-foreground">Fakechat 채널</h2>
+                <Badge variant="info">SSE</Badge>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                이 에이전트의 로컬 SSE 채널 설정입니다. fakechat 서버가 해당 포트에서 실행되어야 합니다.
+              </p>
+            </div>
+            {agent.fakechat_port ? (
+              <Button variant="glass" size="sm" onClick={() => void handleCopyFakechatMcp()}>
+                {fakechatMcpCopied ? <Check className="h-3.5 w-3.5" /> : <><Copy className="h-3.5 w-3.5 mr-1" />Copy SSE Config</>}
+              </Button>
+            ) : null}
+          </div>
+        </SectionCardHeader>
+        <SectionCardBody className="space-y-3">
+          {agent.fakechat_port ? (
+            <>
+              <div className="flex items-center gap-3 text-sm">
+                <span className="text-muted-foreground">Port</span>
+                <code className="rounded bg-muted px-2 py-0.5 font-mono text-foreground">{agent.fakechat_port}</code>
+                <span className="text-muted-foreground">SSE URL</span>
+                <code className="rounded bg-muted px-2 py-0.5 font-mono text-xs text-foreground">
+                  http://localhost:{agent.fakechat_port}/sse
+                </code>
+              </div>
+              <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
+                {JSON.stringify(
+                  { mcpServers: { sprintable: { type: 'sse', url: `http://localhost:${agent.fakechat_port}/sse` } } },
+                  null, 2,
+                )}
+              </pre>
+            </>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              fakechat 포트 정보가 없습니다. 에이전트를 재생성하거나 관리자에게 문의하세요.
+            </p>
           )}
         </SectionCardBody>
       </SectionCard>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, CreditCard, FolderKanban, GitBranch, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
+import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { AiSettingsSection } from '@/components/settings/ai-settings';
 import { MyProfileSection } from '@/components/settings/my-profile-section';
@@ -69,6 +69,14 @@ interface ProjectMember {
   is_active: boolean;
   webhook_url?: string | null;
   created_by?: string | null;
+  fakechat_port?: number | null;
+}
+
+interface NewAgentResult {
+  name: string;
+  fakechat_port: number | null;
+  mcp_config: Record<string, unknown> | null;
+  api_key: string | null;
 }
 
 const NOTIFICATION_CATEGORIES = [
@@ -153,6 +161,8 @@ export default function SettingsPage() {
   const [addingAgent, setAddingAgent] = useState(false);
   const [deactivatingAgentId, setDeactivatingAgentId] = useState<string | null>(null);
   const [agentActionMessage, setAgentActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+  const [newAgentResult, setNewAgentResult] = useState<NewAgentResult | null>(null);
+  const [newAgentMcpCopied, setNewAgentMcpCopied] = useState(false);
   const [webhookEditing, setWebhookEditing] = useState<Record<string, string>>({});
   const [webhookSaving, setWebhookSaving] = useState<string | null>(null);
   const [webhookErrors, setWebhookErrors] = useState<Record<string, string>>({});
@@ -219,21 +229,37 @@ export default function SettingsPage() {
     if (!newAgentName.trim() || !newAgentProjectId || !orgId) return;
     setAddingAgent(true);
     setAgentActionMessage(null);
+    setNewAgentResult(null);
     const res = await fetch('/api/team-members', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ org_id: orgId, project_id: newAgentProjectId, name: newAgentName.trim(), type: 'agent', role: 'member' }),
     });
     if (res.ok) {
+      const json = await res.json() as { data?: { fakechat_port?: number | null; mcp_config?: Record<string, unknown> | null; api_key?: string | null } };
+      setNewAgentResult({
+        name: newAgentName.trim(),
+        fakechat_port: json.data?.fakechat_port ?? null,
+        mcp_config: json.data?.mcp_config ?? null,
+        api_key: json.data?.api_key ?? null,
+      });
       setNewAgentName('');
       setNewAgentProjectId('');
-      setAgentActionMessage({ type: 'success', text: t('agentAdded') });
       await refreshOrgAgents();
     } else {
-      const json = await res.json().catch(() => null);
+      const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
       setAgentActionMessage({ type: 'error', text: json?.error?.message ?? t('agentActionFailed') });
     }
     setAddingAgent(false);
+  };
+
+  const handleCopyNewAgentMcp = async () => {
+    if (!newAgentResult?.mcp_config) return;
+    try {
+      await navigator.clipboard.writeText(JSON.stringify(newAgentResult.mcp_config, null, 2));
+      setNewAgentMcpCopied(true);
+      setTimeout(() => setNewAgentMcpCopied(false), 2000);
+    } catch { /* noop */ }
   };
 
   const handleToggleAgentActive = async (agent: ProjectMember) => {
@@ -1021,6 +1047,47 @@ export default function SettingsPage() {
                         </div>
                       ) : null}
 
+                      {newAgentResult ? (
+                        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-4 space-y-3">
+                          <div className="flex items-center justify-between">
+                            <p className="text-sm font-semibold text-emerald-500">
+                              {newAgentResult.name} 생성 완료
+                            </p>
+                            <button type="button" onClick={() => setNewAgentResult(null)} className="text-muted-foreground hover:text-foreground">
+                              <X className="size-3.5" />
+                            </button>
+                          </div>
+                          {newAgentResult.fakechat_port ? (
+                            <div className="flex items-center gap-2 text-xs">
+                              <Badge variant="info">SSE</Badge>
+                              <span className="font-mono text-foreground">Port: {newAgentResult.fakechat_port}</span>
+                              <span className="text-muted-foreground">— fakechat http://localhost:{newAgentResult.fakechat_port}/sse</span>
+                            </div>
+                          ) : null}
+                          {newAgentResult.api_key ? (
+                            <div className="space-y-1">
+                              <p className="text-xs font-medium text-foreground">API Key — 지금만 표시됩니다.</p>
+                              <code className="block break-all rounded bg-background border border-border p-2 text-xs font-mono text-foreground/80">
+                                {newAgentResult.api_key}
+                              </code>
+                            </div>
+                          ) : null}
+                          {newAgentResult.mcp_config ? (
+                            <div className="space-y-1">
+                              <div className="flex items-center justify-between">
+                                <p className="text-xs font-medium text-foreground">MCP Config (SSE)</p>
+                                <Button variant="glass" size="sm" onClick={() => void handleCopyNewAgentMcp()}>
+                                  {newAgentMcpCopied ? <Check className="size-3" /> : 'Copy'}
+                                </Button>
+                              </div>
+                              <pre className="overflow-x-auto rounded-md border border-border bg-muted/30 p-3 text-xs text-foreground/80">
+                                {JSON.stringify(newAgentResult.mcp_config, null, 2)}
+                              </pre>
+                            </div>
+                          ) : null}
+                        </div>
+                      ) : null}
+
                       {orgAgents.length > 0 ? (
                         <div className="space-y-2">
                           {orgAgents.map((agent) => {
@@ -1032,6 +1099,8 @@ export default function SettingsPage() {
                                   <div className="mt-1 flex flex-wrap items-center gap-2">
                                     <Badge variant="secondary">{t('agentMember')}</Badge>
                                     <Badge variant="outline">{agent.role}</Badge>
+                                    <Badge variant="info">SSE</Badge>
+                                    {agent.fakechat_port ? <span className="font-mono text-[11px] text-muted-foreground">:{agent.fakechat_port}</span> : null}
                                     <span className="text-xs text-muted-foreground">{projectName}</span>
                                     {currentUserId && agent.created_by === currentUserId ? <Badge variant="outline" className="border-primary/40 text-primary text-[10px]">{t('agentOwner')}</Badge> : null}
                                     {!agent.is_active ? <Badge variant="destructive">inactive</Badge> : null}

--- a/backend/alembic/versions/0037_add_fakechat_port_to_team_members.py
+++ b/backend/alembic/versions/0037_add_fakechat_port_to_team_members.py
@@ -1,0 +1,30 @@
+"""add fakechat_port to team_members (S-D3)
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-05-15
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0037"
+down_revision = "0036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("team_members", sa.Column("fakechat_port", sa.Integer(), nullable=True))
+    # AC2: project 내 중복 port 방지 (agent type + non-null port)
+    op.create_index(
+        "uq_team_members_project_fakechat_port",
+        "team_members",
+        ["project_id", "fakechat_port"],
+        unique=True,
+        postgresql_where=sa.text("fakechat_port IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_team_members_project_fakechat_port", table_name="team_members")
+    op.drop_column("team_members", "fakechat_port")

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -25,6 +25,7 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8")
     agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    fakechat_port: Mapped[int | None] = mapped_column(nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -1,13 +1,18 @@
+import os
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import assert_agent_owner
+from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
 from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
+
+_FAKECHAT_BASE_PORT = 8787
 
 router = APIRouter(prefix="/api/v2/team-members", tags=["team-members"])
 
@@ -40,14 +45,32 @@ async def list_team_members(
     return [TeamMemberResponse.model_validate(m) for m in members]
 
 
-@router.post("", response_model=TeamMemberResponse, status_code=201)
+@router.post("", status_code=201)
 async def create_team_member(
     body: TeamMemberCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
-) -> TeamMemberResponse:
+) -> dict:
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
+
+    # AC1/AC2: agent 생성 시 fakechat_port 자동 할당 (project 내 중복 방지)
+    fakechat_port: int | None = None
+    if body.type == "agent":
+        existing_ports = {
+            r[0] for r in (await session.execute(
+                select(TeamMember.fakechat_port).where(
+                    TeamMember.project_id == body.project_id,
+                    TeamMember.type == "agent",
+                    TeamMember.fakechat_port.isnot(None),
+                )
+            )).all()
+        }
+        port = _FAKECHAT_BASE_PORT
+        while port in existing_ports:
+            port += 1
+        fakechat_port = port
+
     member = await repo.create(
         project_id=body.project_id,
         type=body.type,
@@ -60,10 +83,38 @@ async def create_team_member(
         color=body.color,
         agent_role=body.agent_role,
         created_by=created_by,
+        fakechat_port=fakechat_port,
     )
+
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
-    return TeamMemberResponse.model_validate(member)
+
+    # AC3: agent 생성 시 API key 자동 생성 + response에 포함
+    api_key_plaintext: str | None = None
+    if body.type == "agent":
+        from app.repositories.api_key import ApiKeyRepository
+        api_key_repo = ApiKeyRepository(session)
+        _api_key_obj, api_key_plaintext = await api_key_repo.create(team_member_id=member.id)
+
+    # AC3: agent 응답에 fakechat_port + mcp_config 포함
+    response = TeamMemberResponse.model_validate(member).model_dump()
+    if body.type == "agent":
+        # AC6: FAKECHAT_PORT 환경변수 호환 — DB 포트 우선, 없으면 환경변수 fallback
+        effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
+        response["fakechat_port"] = effective_port
+        response["api_key_created"] = bool(api_key_plaintext)
+        response["mcp_config"] = {
+            "mcpServers": {
+                "sprintable": {
+                    "type": "sse",
+                    "url": f"http://localhost:{effective_port}/sse",
+                }
+            }
+        }
+        if api_key_plaintext:
+            response["api_key"] = api_key_plaintext
+
+    return response
 
 
 @router.get("/{id}", response_model=TeamMemberResponse)

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -99,6 +99,7 @@ async def create_team_member(
     # AC3: agent 응답에 fakechat_port + mcp_config 포함
     response = TeamMemberResponse.model_validate(member).model_dump()
     if body.type == "agent":
+        response["member_id"] = str(member.id)
         # AC6: FAKECHAT_PORT 환경변수 호환 — DB 포트 우선, 없으면 환경변수 fallback
         effective_port = fakechat_port or int(os.environ.get("FAKECHAT_PORT", _FAKECHAT_BASE_PORT))
         response["fakechat_port"] = effective_port


### PR DESCRIPTION
## Summary

- **AC4**: `/settings/members/agents/[id]` 페이지에 Fakechat 채널 섹션 추가
  - `AgentMember` 인터페이스에 `fakechat_port: number | null` 추가
  - fakechat_port가 있으면 Port + SSE URL 표시
  - SSE MCP Config (`{ type: "sse", url: "http://localhost:{port}/sse" }`) Copy 버튼
  - 포트 없으면 안내 문구 표시
- **AC5**: 에이전트 목록 + 상세 페이지에 `SSE` 채널 배지 표시
  - 설정 페이지 agent 목록: `SSE` info 배지 + `:PORT` 표시
  - 에이전트 상세 페이지: Fakechat 채널 섹션 헤더에 `SSE` 배지
- **agent 생성 결과 패널**: POST 응답의 `fakechat_port` + `mcp_config` + `api_key` 캡처 및 표시
  - 생성 직후 SSE Port / API Key / SSE MCP Config 원클릭 복사 제공

## Test plan

- [ ] `/settings?tab=members` → Agents 탭에서 agent 생성 → 결과 패널에 Port + API Key + SSE MCP Config 표시 확인
- [ ] agent 목록에 `SSE` 배지 + `:PORT` 표시 확인
- [ ] `/settings/members/agents/[id]` → Fakechat 채널 섹션 표시 확인
- [ ] Copy SSE Config 버튼 클릭 → 클립보드에 SSE config 복사 확인
- [ ] fakechat_port 없는 기존 에이전트 → 안내 문구 표시 확인
- [ ] `pnpm build` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)