### PR TITLE
[CB-S4] feat: 보드 쿼리 정상화 — status별 정렬 + cursor 페이징

### DIFF
--- a/apps/web/src/app/api/stories/route.ts
+++ b/apps/web/src/app/api/stories/route.ts
@@ -55,7 +55,7 @@ export async function GET(request: Request) {
       project_id: searchParams.get('project_id') ?? undefined,
       q: searchParams.get('q') ?? undefined,
       unassigned: searchParams.get('unassigned') === 'true' ? true : undefined,
-      limit: pageInput.limit,
+      limit: pageInput.limit + 1,  // RC3: 오버페치 → buildCursorPageMeta hasMore 판단
       cursor: pageInput.cursor,
     });
     const { page, meta } = buildCursorPageMeta(stories, pageInput.limit, 'created_at');

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -41,6 +41,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
+  const [showNewIndicator, setShowNewIndicator] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -48,6 +49,13 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
 
   const scrollToBottom = useCallback((smooth = false) => {
     bottomRef.current?.scrollIntoView({ behavior: smooth ? 'smooth' : 'instant' });
+  }, []);
+
+  // AC2: 하단 50px 이내인지 판별
+  const isNearBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return true;
+    return el.scrollHeight - el.scrollTop - el.clientHeight <= 50;
   }, []);
 
   const fetchMessages = useCallback(async (before?: string) => {
@@ -90,8 +98,13 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
       if (prev.some((m) => m.id === msg.id)) return prev;
       return [...prev, msg];
     });
-    setTimeout(() => scrollToBottom(true), 50);
-  }, [scrollToBottom]);
+    // AC2: 하단 근처(50px 이내)면 자동 스크롤, 아니면 새 메시지 인디케이터 표시
+    if (isNearBottom()) {
+      setTimeout(() => scrollToBottom(true), 50);
+    } else {
+      setShowNewIndicator(true);
+    }
+  }, [scrollToBottom, isNearBottom]);
 
   const handleNewMessage = useCallback((msg: ChatMessage) => {
     if (msg.memo_id !== threadId) return;
@@ -111,11 +124,17 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     addMessage(normalizeToMessage(payload));
   }, [threadId, addMessage]);
 
+  // AC4: 재연결 시 누락 메시지 backfill
+  const handleReconnect = useCallback(() => {
+    fetchMessages();
+  }, [fetchMessages]);
+
   useChatSse({
     currentTeamMemberId,
     onNewMessage: handleNewMessage,
     onReplyCreated: handleReplyCreated,
     onConversationMessage: handleConversationMessage,
+    onReconnect: handleReconnect,
   });
 
   const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
@@ -156,6 +175,15 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
       scrollEl.scrollTop += scrollEl.scrollHeight - prevScrollHeight;
     }
   }, [hasMore, cursor, loadingMore, fetchMessages]);
+
+  // 스크롤을 직접 내리면 인디케이터 자동 해제
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onScroll = () => { if (isNearBottom()) setShowNewIndicator(false); };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [isNearBottom]);
 
   // Auto-load when scrolled to top (IntersectionObserver watches topSentinelRef inside scrollRef)
   useEffect(() => {
@@ -262,6 +290,19 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
           </div>
         )}
       </div>
+
+      {/* AC2: 새 메시지 인디케이터 — 스크롤이 위에 있을 때만 표시 */}
+      {showNewIndicator && (
+        <div className="flex flex-shrink-0 justify-center py-1">
+          <button
+            type="button"
+            onClick={() => { setShowNewIndicator(false); scrollToBottom(true); }}
+            className="rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-primary shadow-sm transition-colors hover:bg-muted/50"
+          >
+            ↓ 새 메시지
+          </button>
+        </div>
+      )}
 
       {/* Input */}
       <ChatInput

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -163,10 +163,12 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     if (cursor) params.set('cursor', cursor);
     const res = await fetch(`/api/stories?${params}`);
     if (!res.ok) return { stories: [], total: 0, nextCursor: null };
-    const json = await res.json() as { data?: KanbanStory[] };
-    const total = parseInt(res.headers.get('X-Total-Count') ?? '0', 10);
-    const nc = res.headers.get('X-Next-Cursor');
-    return { stories: json.data ?? [], total, nextCursor: nc };
+    // RC: 헤더 대신 JSON body meta에서 cursor/total 읽기 (proxy 헤더 strip 방지)
+    const json = await res.json() as { data?: KanbanStory[]; meta?: { nextCursor?: string | null; hasMore?: boolean; total?: number } };
+    const stories = json.data ?? [];
+    const nextCursor = json.meta?.nextCursor ?? null;
+    const total = json.meta?.total ?? stories.length;
+    return { stories, total, nextCursor };
   }, [projectId, selectedSprintId]);
 
   const fetchData = useCallback(async () => {

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -81,6 +81,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [epics, setEpics] = useState<KanbanEpic[]>([]);
   const [members, setMembers] = useState<KanbanMember[]>([]);
   const [loading, setLoading] = useState(true);
+  // CB-S4: status별 total count + cursor
+  const [columnTotals, setColumnTotals] = useState<Record<string, number>>({});
+  const [columnCursors, setColumnCursors] = useState<Record<string, string | null>>({});
+  const [loadingMoreColumns, setLoadingMoreColumns] = useState<Record<string, boolean>>({});
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
   const [storyTasksNextCursor, setStoryTasksNextCursor] = useState<string | null>(null);
@@ -149,29 +153,53 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     if (userId) memberMap[userId] = m;
   }
 
+  // CB-S4: status별 stories fetch helper
+  const fetchStoriesByStatus = useCallback(async (status: string, cursor?: string): Promise<{ stories: KanbanStory[]; total: number; nextCursor: string | null }> => {
+    const params = new URLSearchParams();
+    if (projectId) params.set('project_id', projectId);
+    if (selectedSprintId) params.set('sprint_id', selectedSprintId);
+    params.set('status', status);
+    params.set('limit', status === 'done' ? '10' : '20');
+    if (cursor) params.set('cursor', cursor);
+    const res = await fetch(`/api/stories?${params}`);
+    if (!res.ok) return { stories: [], total: 0, nextCursor: null };
+    const json = await res.json() as { data?: KanbanStory[] };
+    const total = parseInt(res.headers.get('X-Total-Count') ?? '0', 10);
+    const nc = res.headers.get('X-Next-Cursor');
+    return { stories: json.data ?? [], total, nextCursor: nc };
+  }, [projectId, selectedSprintId]);
+
   const fetchData = useCallback(async () => {
     setLoading(true);
     try {
-      const params = new URLSearchParams();
-      if (selectedSprintId) params.set('sprint_id', selectedSprintId);
-      if (projectId) params.set('project_id', projectId);
-
       const sprintParams = projectId ? `?project_id=${projectId}` : '';
       const epicParams = new URLSearchParams();
       if (projectId) epicParams.set('project_id', projectId);
       epicParams.set('limit', '20');
       const memberParams = projectId ? `?project_id=${projectId}` : '';
 
-      params.set('limit', '20');
-      const [storiesRes, sprintsRes, epicsRes, membersRes] = await Promise.all([
-        fetch(`/api/stories?${params}`),
+      // CB-S4: status별 5회 독립 호출
+      const statuses = COLUMNS.map((c) => c.id);
+      const [storyResults, sprintsRes, epicsRes, membersRes] = await Promise.all([
+        Promise.all(statuses.map((s) => fetchStoriesByStatus(s))),
         fetch(`/api/sprints${sprintParams}`),
         fetch(`/api/epics?${epicParams.toString()}`),
         fetch(`/api/team-members${memberParams}`),
       ]);
 
-      let storyIds: string[] = [];
-      if (storiesRes.ok) { const json = await storiesRes.json(); storyIds = (json.data ?? []).map((s: { id: string }) => s.id); setStories(json.data); setNextCursor(json.meta?.nextCursor ?? null); }
+      const allStories: KanbanStory[] = [];
+      const newTotals: Record<string, number> = {};
+      const newCursors: Record<string, string | null> = {};
+      statuses.forEach((s, i) => {
+        allStories.push(...storyResults[i].stories);
+        newTotals[s] = storyResults[i].total;
+        newCursors[s] = storyResults[i].nextCursor;
+      });
+      setStories(allStories);
+      setColumnTotals(newTotals);
+      setColumnCursors(newCursors);
+
+      let storyIds = allStories.map((s) => s.id);
       if (sprintsRes.ok) { const json = await sprintsRes.json(); setSprints(json.data); }
       if (epicsRes.ok) { const json = await epicsRes.json(); setEpics(json.data); setEpicsNextCursor(json.meta?.nextCursor ?? null); }
       if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data); }
@@ -192,7 +220,21 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     } finally {
       setLoading(false);
     }
-  }, [selectedSprintId, projectId]);
+  }, [selectedSprintId, projectId, fetchStoriesByStatus]);
+
+  // CB-S4: 컬럼별 "더 보기" 핸들러
+  const handleLoadMore = useCallback(async (status: string) => {
+    const cursor = columnCursors[status];
+    if (!cursor) return;
+    setLoadingMoreColumns((prev) => ({ ...prev, [status]: true }));
+    try {
+      const result = await fetchStoriesByStatus(status, cursor);
+      setStories((prev) => [...prev, ...result.stories]);
+      setColumnCursors((prev) => ({ ...prev, [status]: result.nextCursor }));
+    } finally {
+      setLoadingMoreColumns((prev) => ({ ...prev, [status]: false }));
+    }
+  }, [columnCursors, fetchStoriesByStatus]);
 
   useEffect(() => { void fetchData(); }, [fetchData]);
 
@@ -928,6 +970,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onWipDraftChange={(v) => handleWipLimitDraftChange(col.id, v)}
                     onCreateStory={handleCreateStory}
                     executionMap={executionMap}
+                    totalCount={columnTotals[col.id]}
+                    hasMore={!!columnCursors[col.id]}
+                    loadingMore={loadingMoreColumns[col.id] ?? false}
+                    onLoadMore={() => handleLoadMore(col.id)}
                   />
                 );
               })}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -134,7 +134,7 @@ export function KanbanColumn({
             {label}
             {totalCount !== undefined && (
               <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                {totalCount}
+                {hasMore ? `${totalCount}+` : totalCount}
               </span>
             )}
           </h3>

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -56,6 +56,11 @@ interface KanbanColumnProps {
   // Inline create
   onCreateStory?: (columnId: string, title: string) => Promise<void> | void;
   executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
+  // CB-S4: board query
+  totalCount?: number;
+  hasMore?: boolean;
+  loadingMore?: boolean;
+  onLoadMore?: () => void;
 }
 
 export function KanbanColumn({
@@ -64,6 +69,7 @@ export function KanbanColumn({
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
   onCreateStory, projectId, onKickoffStory, executionMap,
+  totalCount, hasMore, loadingMore, onLoadMore,
 }: KanbanColumnProps) {
   const { setNodeRef, isOver } = useDroppable({ id });
   const t = useTranslations('board');
@@ -126,6 +132,11 @@ export function KanbanColumn({
           <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             <span className={`h-2 w-2 rounded-full ${statusColor.dot}`} aria-hidden="true" />
             {label}
+            {totalCount !== undefined && (
+              <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                {totalCount}
+              </span>
+            )}
           </h3>
           <div className="flex items-center gap-1.5">
             {/* AC1: WIP 초과 배지 */}
@@ -264,6 +275,20 @@ export function KanbanColumn({
           ))}
         </div>
       </SortableContextCompat>
+
+      {/* CB-S4: 더 보기 버튼 */}
+      {hasMore && (
+        <div className="mt-2 px-1">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            disabled={loadingMore}
+            className="w-full rounded-md px-3 py-1.5 text-xs text-muted-foreground hover:bg-muted/50 disabled:opacity-50"
+          >
+            {loadingMore ? '불러오는 중...' : '더 보기'}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -46,11 +46,12 @@ interface UseChatSseOptions {
   onNewMessage?: (message: ChatMessage) => void;
   onReplyCreated?: (memoId: string) => void;
   onConversationMessage?: (payload: Record<string, unknown>) => void;
+  onReconnect?: () => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -58,13 +59,15 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
+  const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
 
-  // useLayoutEffect: DOM commit 후 동기적으로 실행 — useEffect(async)보다 먼저 실행되어
-  // SSE 이벤트가 도달하기 전에 ref가 항상 최신 콜백을 가리킴 (stale closure 방지)
+  // useLayoutEffect: DOM commit 후 동기 실행 — useEffect(비동기)보다 먼저 실행되어
+  // SSE 이벤트 도달 전에 ref가 항상 최신 콜백을 가리킴 (stale closure 방지)
   useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
   useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
+  useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   useEffect(() => {
@@ -81,8 +84,11 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current = source;
 
       source.onopen = () => {
+        const isReconnect = reconnectAttemptsRef.current > 0;
         setConnected(true);
         reconnectAttemptsRef.current = 0;
+        // AC4: 재연결 시 backfill 트리거
+        if (isReconnect) onReconnectRef.current?.();
       };
 
       source.onerror = () => {

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 // Mirrors backend _to_chat_message: { id, thread_id, sender: { id, name, type }, ... }
 export interface ChatMessage {
@@ -60,10 +60,12 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onConversationMessageRef = useRef(onConversationMessage);
   const memberIdRef = useRef(currentTeamMemberId);
 
-  useEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
-  useEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
-  useEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
-  useEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
+  // useLayoutEffect: DOM commit 후 동기적으로 실행 — useEffect(async)보다 먼저 실행되어
+  // SSE 이벤트가 도달하기 전에 ref가 항상 최신 콜백을 가리킴 (stale closure 방지)
+  useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
+  useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
+  useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
+  useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
   useEffect(() => {
     if (typeof EventSource === 'undefined') return;

--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -1,18 +1,68 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.pm import Story
 from app.repositories.base import BaseRepository
 from app.schemas.story import STATUS_TRANSITIONS
 
+_PRIORITY_ORDER = case(
+    (Story.priority == "critical", 0),
+    (Story.priority == "high", 1),
+    (Story.priority == "medium", 2),
+    (Story.priority == "low", 3),
+    else_=4,
+)
+
 
 class StoryRepository(BaseRepository[Story]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Story, session, org_id)
+
+    async def list_board(
+        self,
+        project_id: uuid.UUID,
+        status: str,
+        limit: int = 20,
+        cursor: datetime | None = None,
+        sprint_id: uuid.UUID | None = None,
+        assignee_id: uuid.UUID | None = None,
+    ) -> tuple[list[Story], int]:
+        """CB-S4: 보드 상태별 쿼리 — created_at DESC + priority 보조 정렬 + cursor 페이징.
+
+        done: 최근 7일 + limit 10 고정.
+        """
+        q = select(Story).where(
+            self._org_filter(),
+            Story.project_id == project_id,
+            Story.status == status,
+            Story.deleted_at.is_(None),
+        )
+        if sprint_id:
+            q = q.where(Story.sprint_id == sprint_id)
+        if assignee_id:
+            q = q.where(Story.assignee_id == assignee_id)
+
+        # done: 최근 7일 제한
+        if status == "done":
+            cutoff = datetime.now(timezone.utc) - timedelta(days=7)
+            q = q.where(Story.created_at >= cutoff)
+            limit = min(limit, 10)
+
+        # cursor 기반 페이징 (created_at < cursor)
+        if cursor:
+            q = q.where(Story.created_at < cursor)
+
+        count_q = select(func.count()).select_from(q.subquery())
+        total = (await self.session.execute(count_q)).scalar_one()
+
+        q = q.order_by(Story.created_at.desc(), _PRIORITY_ORDER).limit(limit)
+        stories = list((await self.session.execute(q)).scalars().all())
+        return stories, total
 
     async def list_backlog(self, project_id: uuid.UUID, limit: int = 1000) -> list[Story]:
         """sprint 미배정 + 삭제되지 않은 스토리만 서버사이드 필터."""

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query
+from fastapi import APIRouter, BackgroundTasks, Body, Depends, HTTPException, Query, Response
 from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -56,10 +56,31 @@ async def list_stories(
     status_filter: str | None = Query(default=None, alias="status"),
     no_sprint: bool = Query(default=False, description="sprint 미배정 스토리만 반환"),
     limit: int = Query(default=1000, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
+    response: Response = None,  # type: ignore[assignment]
     repo: StoryRepository = Depends(_get_repo),
 ) -> list[StoryResponse]:
+    from datetime import datetime
+
     if no_sprint and project_id:
         stories = await repo.list_backlog(project_id, limit=limit)
+        return [StoryResponse.model_validate(s) for s in stories]
+
+    # CB-S4: status + project_id 조합 시 board 쿼리 (order_by + cursor + done 7일 제한)
+    if status_filter and project_id:
+        cursor_dt = datetime.fromisoformat(cursor) if cursor else None
+        stories, total = await repo.list_board(
+            project_id=project_id,
+            status=status_filter,
+            limit=min(limit, 20) if status_filter == "done" else limit,
+            cursor=cursor_dt,
+            sprint_id=sprint_id,
+            assignee_id=assignee_id,
+        )
+        if response is not None:
+            response.headers["X-Total-Count"] = str(total)
+            if stories:
+                response.headers["X-Next-Cursor"] = stories[-1].created_at.isoformat()
         return [StoryResponse.model_validate(s) for s in stories]
 
     filters: dict = {}

--- a/packages/storage-api/src/SupabaseStoryRepository.ts
+++ b/packages/storage-api/src/SupabaseStoryRepository.ts
@@ -11,7 +11,8 @@ export class SupabaseStoryRepository implements IStoryRepository {
 
   async list(filters: StoryListFilters): Promise<Story[]> {
     return fastapiCall<Story[]>('GET', '/api/v2/stories', this.accessToken, {
-      query: { project_id: filters.project_id, epic_id: filters.epic_id, sprint_id: filters.sprint_id, assignee_id: filters.assignee_id, status: filters.status },
+      // RC1: cursor + limit 전달 (CB-S4 cursor 페이징)
+      query: { project_id: filters.project_id, epic_id: filters.epic_id, sprint_id: filters.sprint_id, assignee_id: filters.assignee_id, status: filters.status, cursor: filters.cursor, limit: filters.limit },
     });
   }
 


### PR DESCRIPTION
## Summary
**문제**: `GET /api/stories?limit=20` 단일 호출로 order_by 없이 heap 순서 20개만 반환 → backlog 20개 차면 다른 상태 스토리 미표시

**수정**:
- `StoryRepository.list_board()` 신규 — `created_at DESC` + `priority` CASE 보조 정렬
- `done` status: 최근 7일 + limit 10 고정
- `cursor` 파라미터: ISO 8601 timestamp → `created_at < cursor` WHERE 조건으로 cursor 기반 페이징
- 응답 헤더: `X-Total-Count` (컬럼 헤더 카운트용) + `X-Next-Cursor` (다음 페이지용)
- `?status=&project_id=` 조합 시 board 쿼리 → 기존 `repo.list()` fallback 유지

## Test plan
- [ ] `GET /stories?project_id=X&status=backlog` → `created_at DESC` 정렬 확인
- [ ] `GET /stories?project_id=X&status=done` → 7일 이내 + 10개 제한 확인
- [ ] `cursor=2026-05-15T00:00:00Z` 지정 → 해당 시간 이전 스토리만 반환
- [ ] `X-Total-Count` 헤더 포함 확인
- [ ] `X-Next-Cursor` 헤더 포함 확인 (마지막 스토리의 created_at)
- [ ] status 없는 기존 호출 (`GET /stories?project_id=X`) → 기존 동작 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)