### PR TITLE
[SID:CB-S5] GNB 사이드바 Epics 진입점 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -50,7 +50,8 @@
     "search": "Search…",
     "help": "Help",
     "chats": "Chats",
-    "activity": "Activity Log"
+    "activity": "Activity Log",
+    "epics": "Epics"
   },
   "commandPalette": {
     "title": "Command palette",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -50,7 +50,8 @@
     "search": "검색…",
     "help": "도움말",
     "chats": "채팅",
-    "activity": "활동 로그"
+    "activity": "활동 로그",
+    "epics": "에픽"
   },
   "commandPalette": {
     "title": "커맨드 팔레트",

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   FolderKanban,
   Gauge,
   Inbox,
+  Layers,
   LayoutDashboard,
   MessageSquare,
   MessageSquareMore,
@@ -215,6 +216,16 @@ export function AppSidebar({
                   <FolderKanban />
                   <span>{t('board')}</span>
                   <KbdHint>B</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/epics" />}
+                  isActive={isActive('/epics')}
+                  tooltip={t('epics')}
+                >
+                  <Layers />
+                  <span>{t('epics')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>


### PR DESCRIPTION
## Summary

- GNB 사이드바 Sprint 그룹에 **Epics** 메뉴 항목 추가 (Board 바로 아래)
- `Layers` 아이콘, `/epics` 링크, `isActive('/epics')` 활성화 처리
- `nav.epics` 번역 추가 (en: "Epics", ko: "에픽")

## 기존 구현 확인 (신규 작업 불필요)

| AC | 기존 상태 |
|---|---|
| AC2: 이름, 상태, ProgressBar, target_date | `EpicRow` 컴포넌트에 이미 구현 ✅ |
| AC3: status 필터 (all/active/completed/draft/archived) | `statusFilter` state 이미 존재 ✅ |
| AC4: 모바일 반응형 | lg:flex/lg:hidden 레이아웃 이미 구현 ✅ |

## Test plan

- [ ] 사이드바에 Epics 메뉴 항목 표시 확인 (Board 아래)
- [ ] `/epics` 클릭 시 에픽 목록 렌더링 확인
- [ ] 에픽 선택 시 active 스타일 적용 확인
- [ ] status 필터 (all/active/done 등) 동작 확인
- [ ] 모바일(< lg)에서 목록 → 상세 전환 확인
- [ ] `pnpm build` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)