### PR TITLE
[SID:CB-S6] Epics 상세 페이지 — objective/성공기준 + 스토리 그룹핑 + 딥링크

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -19,27 +19,61 @@ interface Story {
   title: string;
   status: string;
   story_points?: number;
-  assignee_id?: string;
+  assignee_id?: string | null;
+  assignee_name?: string | null;
 }
 
 interface Epic {
   id: string;
   title: string;
-  description?: string;
+  description?: string | null;
+  objective?: string | null;
+  success_criteria?: string | null;
   status: EpicStatus;
   priority: EpicPriority;
-  target_date?: string;
-  target_sp?: number;
+  target_date?: string | null;
+  target_sp?: number | null;
   assignee_id?: string | null;
   project_id?: string;
   created_at: string;
   stories?: Story[];
 }
 
+// ─── Story status order for grouping ─────────────────────────────────────────
+
+const STATUS_ORDER = ['in-progress', 'in-review', 'ready-for-dev', 'backlog', 'done', 'blocked'];
+
+function groupByStatus(stories: Story[]): { status: string; items: Story[] }[] {
+  const map = new Map<string, Story[]>();
+  for (const s of stories) {
+    const g = map.get(s.status) ?? [];
+    g.push(s);
+    map.set(s.status, g);
+  }
+  const ordered: { status: string; items: Story[] }[] = [];
+  for (const st of STATUS_ORDER) {
+    const items = map.get(st);
+    if (items?.length) { ordered.push({ status: st, items }); map.delete(st); }
+  }
+  for (const [status, items] of map) {
+    if (items.length) ordered.push({ status, items });
+  }
+  return ordered;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
 function statusBadgeVariant(s: EpicStatus) {
   if (s === 'active') return 'info' as const;
   if (s === 'done') return 'success' as const;
   return 'secondary' as const;
+}
+
+function storyStatusVariant(s: string): 'success' | 'info' | 'destructive' | 'secondary' {
+  if (s === 'done') return 'success';
+  if (s === 'in-progress' || s === 'in-review') return 'info';
+  if (s === 'blocked') return 'destructive';
+  return 'secondary';
 }
 
 function priorityBadgeVariant(p: EpicPriority) {
@@ -49,10 +83,12 @@ function priorityBadgeVariant(p: EpicPriority) {
   return 'chip' as const;
 }
 
-function formatDate(d?: string) {
+function formatDate(d?: string | null) {
   if (!d) return '—';
   return new Date(d).toLocaleDateString('ko-KR', { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
+
+// ─── UI components ────────────────────────────────────────────────────────────
 
 function ProgressBar({ done, total }: { done: number; total: number }) {
   const pct = total > 0 ? Math.round((done / total) * 100) : 0;
@@ -91,13 +127,17 @@ function MdBody({ content }: { content: string }) {
   );
 }
 
+// ─── Inline edit form ─────────────────────────────────────────────────────────
+
 function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: Epic) => void; onCancel: () => void }) {
   const [title, setTitle] = useState(epic.title);
   const [description, setDescription] = useState(epic.description ?? '');
+  const [objective, setObjective] = useState(epic.objective ?? '');
+  const [successCriteria, setSuccessCriteria] = useState(epic.success_criteria ?? '');
   const [status, setStatus] = useState<EpicStatus>(epic.status);
   const [priority, setPriority] = useState<EpicPriority>(epic.priority);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
-  const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined ? String(epic.target_sp) : '');
+  const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined && epic.target_sp !== null ? String(epic.target_sp) : '');
   const [saving, setSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
@@ -110,6 +150,8 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
         body: JSON.stringify({
           title: title.trim(),
           description: description.trim() || undefined,
+          objective: objective.trim() || undefined,
+          success_criteria: successCriteria.trim() || undefined,
           status,
           priority,
           ...(targetDate ? { target_date: targetDate } : {}),
@@ -122,14 +164,16 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
     } finally {
       setSaving(false);
     }
-  }, [title, description, status, priority, targetDate, targetSp, epic, onSaved]);
+  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, epic, onSaved]);
 
   const inputCls = 'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
 
   return (
     <div className="space-y-4">
       <input type="text" value={title} onChange={(e) => setTitle(e.target.value)} className={inputCls} placeholder="제목" />
-      <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={5} className={`${inputCls} resize-none`} placeholder="설명 (마크다운)" />
+      <textarea value={description} onChange={(e) => setDescription(e.target.value)} rows={4} className={`${inputCls} resize-none`} placeholder="설명 (마크다운)" />
+      <textarea value={objective} onChange={(e) => setObjective(e.target.value)} rows={3} className={`${inputCls} resize-none`} placeholder="목표 (Objective)" />
+      <textarea value={successCriteria} onChange={(e) => setSuccessCriteria(e.target.value)} rows={3} className={`${inputCls} resize-none`} placeholder="성공 기준 (Success Criteria)" />
       <div className="grid grid-cols-2 gap-3">
         <select value={status} onChange={(e) => setStatus(e.target.value as EpicStatus)} className={inputCls}>
           <option value="draft">Draft</option>
@@ -155,6 +199,8 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
     </div>
   );
 }
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default function EpicDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -185,6 +231,7 @@ export default function EpicDetailPage() {
   const done = stories.filter((s) => s.status === 'done').length;
   const spDone = stories.filter((s) => s.status === 'done').reduce((a, s) => a + (s.story_points ?? 0), 0);
   const spTotal = stories.reduce((a, s) => a + (s.story_points ?? 0), 0);
+  const storyGroups = groupByStatus(stories);
 
   return (
     <>
@@ -215,7 +262,7 @@ export default function EpicDetailPage() {
               {isEditing ? '취소' : '편집'}
             </button>
           </div>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <Badge variant={statusBadgeVariant(epic.status)}>{epic.status}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{epic.priority}</Badge>
             {epic.target_date && <span className="text-xs text-muted-foreground">마감: {formatDate(epic.target_date)}</span>}
@@ -248,20 +295,38 @@ export default function EpicDetailPage() {
           </div>
         )}
 
-        {/* Description */}
         {!isEditing && (
-          <div className="space-y-2">
-            <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">설명</h2>
-            {epic.description?.trim() ? (
-              <MdBody content={epic.description} />
-            ) : (
-              <p className="text-sm italic text-muted-foreground">설명이 없는.</p>
+          <>
+            {/* Description */}
+            <section className="space-y-2">
+              <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">설명</h2>
+              {epic.description?.trim() ? (
+                <MdBody content={epic.description} />
+              ) : (
+                <p className="text-sm italic text-muted-foreground">설명이 없는.</p>
+              )}
+            </section>
+
+            {/* Objective */}
+            {epic.objective?.trim() && (
+              <section className="space-y-2">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">목표 (Objective)</h2>
+                <MdBody content={epic.objective} />
+              </section>
             )}
-          </div>
+
+            {/* Success criteria */}
+            {epic.success_criteria?.trim() && (
+              <section className="space-y-2">
+                <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">성공 기준</h2>
+                <MdBody content={epic.success_criteria} />
+              </section>
+            )}
+          </>
         )}
 
         {/* Progress */}
-        <div className="space-y-4">
+        <section className="space-y-4">
           <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">진행 상황</h2>
           <div>
             <p className="mb-1 text-xs text-muted-foreground">스토리 완료</p>
@@ -273,36 +338,50 @@ export default function EpicDetailPage() {
               <ProgressBar done={spDone} total={spTotal} />
             </div>
           )}
-        </div>
+        </section>
 
-        {/* Stories */}
-        <div className="space-y-2">
-          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">스토리 ({stories.length})</h2>
-          {stories.length > 0 ? (
-            <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
-              {stories.map((story) => (
-                <button
-                  key={story.id}
-                  type="button"
-                  onClick={() => router.push(`/board?story=${story.id}`)}
-                  className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
-                >
-                  <span className="text-sm">{story.title}</span>
-                  <div className="flex shrink-0 items-center gap-2">
-                    {story.story_points != null && (
-                      <span className="text-xs text-muted-foreground">{story.story_points} SP</span>
-                    )}
-                    <Badge variant={story.status === 'done' ? 'success' : 'secondary'} className="text-[10px]">
-                      {story.status}
+        {/* Stories — grouped by status */}
+        <section className="space-y-4">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">
+            스토리 ({stories.length})
+          </h2>
+          {stories.length === 0 ? (
+            <p className="text-sm italic text-muted-foreground">스토리가 없는.</p>
+          ) : (
+            <div className="space-y-4">
+              {storyGroups.map(({ status: groupStatus, items }) => (
+                <div key={groupStatus}>
+                  <div className="mb-1.5 flex items-center gap-2">
+                    <Badge variant={storyStatusVariant(groupStatus)} className="text-[10px]">
+                      {groupStatus}
                     </Badge>
+                    <span className="text-xs text-muted-foreground">{items.length}건</span>
                   </div>
-                </button>
+                  <div className="divide-y divide-border rounded-xl border border-border overflow-hidden">
+                    {items.map((story) => (
+                      <button
+                        key={story.id}
+                        type="button"
+                        onClick={() => router.push(`/board?story=${story.id}`)}
+                        className="flex w-full items-center justify-between px-4 py-3 text-left hover:bg-muted/50 transition-colors"
+                      >
+                        <span className="flex-1 truncate text-sm">{story.title}</span>
+                        <div className="ml-3 flex shrink-0 items-center gap-2">
+                          {story.assignee_name && (
+                            <span className="text-xs text-muted-foreground truncate max-w-[80px]">{story.assignee_name}</span>
+                          )}
+                          {story.story_points != null && (
+                            <span className="text-xs text-muted-foreground">{story.story_points} SP</span>
+                          )}
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                </div>
               ))}
             </div>
-          ) : (
-            <p className="text-sm italic text-muted-foreground">스토리가 없는.</p>
           )}
-        </div>
+        </section>
       </div>
     </>
   );

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -729,16 +729,10 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
     }
   }, []);
 
-  const handleSelectEpic = useCallback(async (epic: Epic) => {
-    // 모바일: 상세 페이지 직접 이동
-    if (typeof window !== 'undefined' && window.innerWidth < 1024) {
-      router.push(`/epics/${epic.id}`);
-      return;
-    }
-    setSelectedEpic(epic);
-    setMobileView('detail');
-    await fetchEpicDetail(epic.id);
-  }, [fetchEpicDetail, router]);
+  const handleSelectEpic = useCallback((epic: Epic) => {
+    // AC5: 모든 디바이스에서 /epics/[id] 딥링크로 이동
+    router.push(`/epics/${epic.id}`);
+  }, [router]);
 
   const handleCreated = useCallback((epic: Epic) => {
     setEpics((prev) => [epic, ...prev]);


### PR DESCRIPTION
## Summary

### AC2 — 에픽 메타 (읽기 전용)
- `Epic` 인터페이스에 `objective`, `success_criteria` 필드 추가
- 상세 페이지에 **목표 (Objective)** / **성공 기준** 섹션 렌더링 (마크다운)
- `EpicEditInline`에 objective/success_criteria 입력 필드 추가 (편집 가능)

### AC3 — 소속 스토리 목록
- **status별 그룹핑** (`in-progress → in-review → ready-for-dev → backlog → done → 기타`)
- 그룹 헤더: 상태 배지 + 건수
- `assignee_name` 표시 (API 반환 시)
- SP 표시 유지

### AC4 — 스토리 클릭
- `/board?story={id}` 이동 (기존 동작 유지)

### AC5 — 에픽 리스트 → 상세 딥링크
- `epics-client.tsx` `handleSelectEpic` — 모든 디바이스에서 `/epics/[id]` 네비게이션 (기존: 데스크톱은 사이드패널)

## Test plan

- [ ] `/epics/{id}` 직접 URL 입력 → 정상 렌더 확인 (AC1)
- [ ] objective, success_criteria 있는 에픽 → 해당 섹션 표시 확인 (AC2)
- [ ] 스토리 목록 status별 그룹핑 확인 (AC3)
- [ ] 스토리 행 클릭 → `/board?story=...` 이동 확인 (AC4)
- [ ] `/epics` 목록에서 에픽 행 클릭 → `/epics/{id}` 이동 확인 (AC5)
- [ ] `pnpm build` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)