### PR TITLE
[CB-S1] feat: @멘션 백엔드 알림 + 웹훅 연동 완성

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -124,6 +124,47 @@ async def _dispatch_conversation_event(
         _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
 
 
+async def _dispatch_mention_events(
+    db: AsyncSession,
+    conversation: Conversation,
+    msg: ConversationMessage,
+    org_id: uuid.UUID,
+    sender: TeamMember,
+    mention_targets: set[uuid.UUID],
+) -> None:
+    """AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)."""
+    if not conversation.project_id or not mention_targets:
+        return
+
+    payload = _msg_payload(msg, sender)
+    member_rows = (await db.execute(
+        select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(mention_targets))
+    )).all()
+    member_type_map = {r[0]: r[1] for r in member_rows}
+
+    events_to_push: list[tuple[str, Event]] = []
+    for pid in mention_targets:
+        m_type = member_type_map.get(pid, "human")
+        event = Event(
+            project_id=conversation.project_id,
+            org_id=org_id,
+            event_type="conversation:mention",
+            source_entity_type="conversation_message",
+            source_entity_id=msg.id,
+            sender_id=sender.id,
+            recipient_id=pid,
+            recipient_type=m_type,
+            payload=payload,
+            status="pending",
+        )
+        db.add(event)
+        events_to_push.append((str(pid), event))
+
+    await db.flush()
+    for pid_str, event in events_to_push:
+        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+
+
 async def _dispatch_discord_outbound(
     message_id: uuid.UUID,
     org_id: uuid.UUID,
@@ -567,6 +608,16 @@ async def send_message(
     except Exception:
         logger.exception("conversation event dispatch failed conversation_id=%s", conversation_id)
 
+    # AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)
+    if msg.mentioned_ids:
+        mention_targets = set(msg.mentioned_ids) - {sender.id} - discord_exclude_ids
+        if mention_targets:
+            try:
+                async with db.begin_nested():
+                    await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
+            except Exception:
+                logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
+
     # conversation updated_at 갱신
     conv.updated_at = datetime.now(timezone.utc)
 
@@ -584,6 +635,7 @@ async def send_message(
         sender_id=sender.id,
         thread_id=msg.thread_id,
         created_at=msg.created_at,
+        mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
     )
 
     # Discord 아웃바운드 (AC9~11)

--- a/backend/app/services/channel_router.py
+++ b/backend/app/services/channel_router.py
@@ -4,7 +4,6 @@
 """
 from __future__ import annotations
 
-import re
 import uuid
 from dataclasses import dataclass, field
 from typing import Sequence
@@ -127,10 +126,9 @@ async def route_message(
             if level == "mute":
                 continue
 
-            # mentions → @{member_id} 포함 여부 체크 (AC4)
+            # CB-S1 AC3: mentioned_ids 배열 기반 mentions 판단 (content regex 폐기)
             if level == "mentions":
-                pattern = rf"@{re.escape(str(rid))}"
-                if not re.search(pattern, msg.content or ""):
+                if not (msg.mentioned_ids and rid in msg.mentioned_ids):
                     continue
 
             decisions.append(DeliveryDecision(

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -52,6 +52,7 @@ async def deliver_conversation_message_webhook(
     sender_id: uuid.UUID | None,
     thread_id: uuid.UUID | None,
     created_at: datetime,
+    mentioned_ids: list[uuid.UUID] | None = None,
 ) -> None:
     """BackgroundTask 진입점.
 
@@ -79,6 +80,8 @@ async def deliver_conversation_message_webhook(
             if not target_webhooks:
                 return
 
+            # AC2: mentioned_ids를 payload + 멘션 대상 에이전트 webhook 포함
+            mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
             payload = {
                 "event_type": _EVENT_TYPE,
                 "message_id": str(message_id),
@@ -86,7 +89,21 @@ async def deliver_conversation_message_webhook(
                 "sender_id": str(sender_id) if sender_id else None,
                 "thread_id": str(thread_id) if thread_id else None,
                 "created_at": created_at.isoformat(),
+                "mentioned_ids": mentioned_id_strs,
             }
+
+            # 멘션된 member에 속한 webhook도 추가 조회 (participant 여부 무관)
+            if mentioned_ids:
+                extra_wh_rows = (await db.execute(
+                    select(WebhookConfig).where(
+                        WebhookConfig.member_id.in_(mentioned_ids),
+                        WebhookConfig.is_active.is_(True),
+                    )
+                )).scalars().all()
+                existing_ids = {wh.id for wh in target_webhooks}
+                for wh in extra_wh_rows:
+                    if wh.id not in existing_ids:
+                        target_webhooks.append(wh)
 
             for wh in target_webhooks:
                 delivery = ConversationWebhookDelivery(

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -77,22 +77,8 @@ async def deliver_conversation_message_webhook(
                 wh for wh in wh_rows
                 if _EVENT_TYPE in (wh.events or [])
             ]
-            if not target_webhooks:
-                return
 
-            # AC2: mentioned_ids를 payload + 멘션 대상 에이전트 webhook 포함
-            mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
-            payload = {
-                "event_type": _EVENT_TYPE,
-                "message_id": str(message_id),
-                "conversation_id": str(conversation_id),
-                "sender_id": str(sender_id) if sender_id else None,
-                "thread_id": str(thread_id) if thread_id else None,
-                "created_at": created_at.isoformat(),
-                "mentioned_ids": mentioned_id_strs,
-            }
-
-            # 멘션된 member에 속한 webhook도 추가 조회 (participant 여부 무관)
+            # AC2: 멘션된 member에 속한 webhook도 추가 조회 (early return 전, participant 여부 무관)
             if mentioned_ids:
                 extra_wh_rows = (await db.execute(
                     select(WebhookConfig).where(
@@ -104,6 +90,20 @@ async def deliver_conversation_message_webhook(
                 for wh in extra_wh_rows:
                     if wh.id not in existing_ids:
                         target_webhooks.append(wh)
+
+            if not target_webhooks:
+                return
+
+            mentioned_id_strs = [str(m) for m in (mentioned_ids or [])]
+            payload = {
+                "event_type": _EVENT_TYPE,
+                "message_id": str(message_id),
+                "conversation_id": str(conversation_id),
+                "sender_id": str(sender_id) if sender_id else None,
+                "thread_id": str(thread_id) if thread_id else None,
+                "created_at": created_at.isoformat(),
+                "mentioned_ids": mentioned_id_strs,
+            }
 
             for wh in target_webhooks:
                 delivery = ConversationWebhookDelivery(


### PR DESCRIPTION
## Summary
`mentioned_ids`가 DB에 저장만 되고 어떤 알림도 발송되지 않는 문제 해결.

- AC1: `_dispatch_mention_events()` 신규 — 멘션 대상에게 `conversation:mention` SSE 이벤트 발송 (conversation participant 여부 무관)
- AC2: `deliver_conversation_message_webhook()` — `mentioned_ids` 파라미터 추가. payload에 `mentioned_ids` 포함 + 멘션된 member의 webhook config도 추가 delivery
- AC3: `channel_router.py` mentions level 판단 — content `@{member_id}` regex → `mentioned_ids` 배열 기반으로 전환 (`import re` 제거)

## Test plan
- [ ] 메시지 발송 시 `mentioned_ids` 있으면 대상에게 `conversation:mention` SSE 이벤트 수신 확인
- [ ] 멘션 대상이 conversation participant가 아니어도 SSE 수신 확인
- [ ] webhook payload에 `mentioned_ids` 배열 포함 확인
- [ ] 멘션 대상 에이전트의 webhook config로 delivery 전송 확인
- [ ] NotificationPreference `level=mentions`인 멘버에게 멘션 시 정상 delivery 확인
- [ ] `level=mentions`이지만 mentioned_ids에 없으면 delivery 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)