### PR TITLE
[CB-S2] feat: DM @멘션 → 그룹 conversation 자동 fork

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft } from 'lucide-react';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
@@ -36,6 +36,7 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
 
 export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos' }: ChatViewProps) {
   const router = useRouter();
+  const pathname = usePathname();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -146,11 +147,17 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
       body: JSON.stringify(body),
     });
     if (!res.ok) throw new Error('Failed to send message');
-    // Backend: { data: _to_chat_message }
+    // Backend: { data: _to_chat_message } or { forked: true, forked_conversation_id, data }
     const raw = await res.json() as Record<string, unknown>;
+    // AC3: DM fork 응답 감지 → 새 그룹 conversation으로 자동 네비게이션
+    if (raw.forked === true && typeof raw.forked_conversation_id === 'string') {
+      const newPath = pathname.replace(threadId, raw.forked_conversation_id);
+      router.push(newPath);
+      return;
+    }
     const payload = (raw.data ?? raw) as Record<string, unknown>;
     addMessage(normalizeToMessage(payload));
-  }, [threadId, addMessage, apiPrefix]);
+  }, [threadId, addMessage, apiPrefix, pathname, router]);
 
   const handleUpload = useCallback(async (file: File) => {
     const formData = new FormData();

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -560,12 +560,20 @@ async def send_message(
     # CB-S2: DM + 비참여자 멘션 → 자동 그룹 conversation fork (AC1, AC2)
     fork_info: dict | None = None
     if conv.type == "dm" and body.mentioned_ids:
+        # cross-org 차단: mentioned_ids를 현재 org 소속 member로 필터링
+        valid_member_ids = set((await db.execute(
+            select(TeamMember.id).where(
+                TeamMember.id.in_(body.mentioned_ids),
+                TeamMember.org_id == org_id,
+            )
+        )).scalars().all())
+
         current_participant_ids = set((await db.execute(
             select(ConversationParticipant.member_id)
             .where(ConversationParticipant.conversation_id == conversation_id)
         )).scalars().all())
 
-        non_participants = [mid for mid in body.mentioned_ids if mid not in current_participant_ids]
+        non_participants = [mid for mid in valid_member_ids if mid not in current_participant_ids]
         if non_participants:
             fork_conv_id = uuid.uuid4()
             fork_conv = Conversation(
@@ -578,7 +586,7 @@ async def send_message(
             db.add(fork_conv)
             await db.flush()
 
-            all_participant_ids = current_participant_ids | set(body.mentioned_ids)
+            all_participant_ids = current_participant_ids | valid_member_ids
             for mid in all_participant_ids:
                 db.add(ConversationParticipant(conversation_id=fork_conv_id, member_id=mid))
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -557,6 +557,36 @@ async def send_message(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    # CB-S2: DM + 비참여자 멘션 → 자동 그룹 conversation fork (AC1, AC2)
+    fork_info: dict | None = None
+    if conv.type == "dm" and body.mentioned_ids:
+        current_participant_ids = set((await db.execute(
+            select(ConversationParticipant.member_id)
+            .where(ConversationParticipant.conversation_id == conversation_id)
+        )).scalars().all())
+
+        non_participants = [mid for mid in body.mentioned_ids if mid not in current_participant_ids]
+        if non_participants:
+            fork_conv_id = uuid.uuid4()
+            fork_conv = Conversation(
+                id=fork_conv_id,
+                project_id=conv.project_id,
+                org_id=org_id,
+                type="group",
+                created_by=sender.id,
+            )
+            db.add(fork_conv)
+            await db.flush()
+
+            all_participant_ids = current_participant_ids | set(body.mentioned_ids)
+            for mid in all_participant_ids:
+                db.add(ConversationParticipant(conversation_id=fork_conv_id, member_id=mid))
+
+            fork_info = {"forked_conversation_id": str(fork_conv_id)}
+            # 메시지를 fork된 group conversation에 저장
+            conversation_id = fork_conv_id
+            conv = fork_conv
+
     # thread_id 유효성 검증 — 같은 conversation의 top-level message만 허용
     root_msg: ConversationMessage | None = None
     if body.thread_id is not None:
@@ -660,7 +690,11 @@ async def send_message(
             context={"message_id": str(msg.id)},
         )
 
-    return {"data": _msg_payload(msg, sender)}
+    response: dict = {"data": _msg_payload(msg, sender)}
+    if fork_info:
+        response["forked"] = True
+        response["forked_conversation_id"] = fork_info["forked_conversation_id"]
+    return response
 
 
 @router.patch("/{conversation_id}/status", status_code=200)


### PR DESCRIPTION
## Summary

- `send_message` 시점에 DM + 비참여자 멘션 감지 → 자동 group conversation fork (AC1)
- 기존 DM 참여자 + 멘션 대상 전원 새 conversation 참여자로 추가, 원본 DM 유지 (AC2)
- 응답에 `forked: true` + `forked_conversation_id` 포함, chat-view.tsx 자동 navigate (AC3)
- fork된 group conversation에 메시지 저장 → 새 참여자 SSE dispatch 자동 포함 (AC4)

## Changed files

- `backend/app/routers/conversations.py` — send_message DM fork 로직 + 응답 확장
- `apps/web/src/components/chat/chat-view.tsx` — forked 응답 감지 + router.push

## Test plan

- [ ] DM에서 비참여자 @멘션 메시지 전송 → 응답 `forked: true` + `forked_conversation_id`
- [ ] 새 group conversation에 기존 DM 참여자 2명 + 멘션된 유저 전원 포함 확인
- [ ] 원본 DM conversation 유지 확인
- [ ] 프론트 자동으로 새 group conversation으로 navigate
- [ ] fork된 conversation에 메시지 존재 확인
- [ ] 비참여자 없는 DM 메시지 → fork 없음, 정상 응답

🤖 Generated with [Claude Code](https://claude.com/claude-code)