### PR TITLE
[SID:DEL-S1] 에픽 삭제 UI — 리스트 + 상세 페이지

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2076,7 +2076,11 @@
     "notAssigned": "Not assigned",
     "spExceeded": "SP Over",
     "spExceededDetail": "{total}SP / target {target}SP exceeded",
-    "noStories": "No stories linked to this epic."
+    "noStories": "No stories linked to this epic.",
+    "deleteEpic": "Delete Epic",
+    "deleteConfirmTitle": "Delete Epic?",
+    "deleteConfirmDescription": "This is permanent and cannot be undone. All stories in this epic will be unlinked.",
+    "deleteConfirmButton": "Delete permanently"
   },
   "sprints": {
     "title": "Sprints",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2076,7 +2076,11 @@
     "notAssigned": "미지정",
     "spExceeded": "SP 초과",
     "spExceededDetail": "{total}SP / 목표 {target}SP 초과",
-    "noStories": "이 에픽에 연결된 스토리가 없습니다."
+    "noStories": "이 에픽에 연결된 스토리가 없습니다.",
+    "deleteEpic": "에픽 삭제",
+    "deleteConfirmTitle": "에픽을 삭제하시겠습니까?",
+    "deleteConfirmDescription": "이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.",
+    "deleteConfirmButton": "영구 삭제"
   },
   "sprints": {
     "title": "스프린트",

--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
+import { ToastContainer, useToast } from '@/components/ui/toast';
 
 type EpicStatus = 'draft' | 'active' | 'done' | 'archived';
 type EpicPriority = 'critical' | 'high' | 'medium' | 'low';
@@ -209,6 +210,7 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
 export default function EpicDetailPage() {
   const { id } = useParams<{ id: string }>();
   const router = useRouter();
+  const { toasts, addToast, dismissToast } = useToast();
   const [epic, setEpic] = useState<Epic | null>(null);
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
@@ -221,13 +223,19 @@ export default function EpicDetailPage() {
     setDeleting(true);
     try {
       const res = await fetch(`/api/epics/${epic.id}`, { method: 'DELETE' });
-      if (!res.ok) throw new Error();
+      if (!res.ok) {
+        const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+        addToast({ type: 'error', title: json?.error?.message ?? '에픽 삭제에 실패했습니다.' });
+        return;
+      }
       router.replace('/epics');
+    } catch {
+      addToast({ type: 'error', title: '에픽 삭제에 실패했습니다.' });
     } finally {
       setDeleting(false);
       setShowDeleteConfirm(false);
     }
-  }, [epic, router]);
+  }, [epic, router, addToast]);
 
   useEffect(() => {
     fetch(`/api/epics/${id}`)
@@ -438,6 +446,8 @@ export default function EpicDetailPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </>
   );
 }

--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -5,9 +5,13 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { ArrowLeft, Pencil, X } from 'lucide-react';
+import { ArrowLeft, Pencil, Trash2, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog, DialogContent, DialogDescription,
+  DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 
@@ -209,6 +213,21 @@ export default function EpicDetailPage() {
   const [loading, setLoading] = useState(true);
   const [isEditing, setIsEditing] = useState(false);
   const [epicAssigneeId, setEpicAssigneeId] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+
+  const handleDelete = useCallback(async () => {
+    if (!epic) return;
+    setDeleting(true);
+    try {
+      const res = await fetch(`/api/epics/${epic.id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error();
+      router.replace('/epics');
+    } finally {
+      setDeleting(false);
+      setShowDeleteConfirm(false);
+    }
+  }, [epic, router]);
 
   useEffect(() => {
     fetch(`/api/epics/${id}`)
@@ -253,14 +272,25 @@ export default function EpicDetailPage() {
         <div className="space-y-3">
           <div className="flex items-start justify-between gap-4">
             <h1 className="text-xl font-bold leading-tight">{epic.title}</h1>
-            <button
-              type="button"
-              onClick={() => setIsEditing((v) => !v)}
-              className="shrink-0 flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
-            >
-              {isEditing ? <X className="h-3.5 w-3.5" /> : <Pencil className="h-3.5 w-3.5" />}
-              {isEditing ? '취소' : '편집'}
-            </button>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setIsEditing((v) => !v)}
+                className="flex items-center gap-1.5 rounded-lg border border-border px-2.5 py-1.5 text-xs font-medium hover:bg-muted transition-colors"
+              >
+                {isEditing ? <X className="h-3.5 w-3.5" /> : <Pencil className="h-3.5 w-3.5" />}
+                {isEditing ? '취소' : '편집'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowDeleteConfirm(true)}
+                className="flex items-center gap-1.5 rounded-lg border border-destructive/40 px-2.5 py-1.5 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors"
+                aria-label="에픽 삭제"
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                삭제
+              </button>
+            </div>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant={statusBadgeVariant(epic.status)}>{epic.status}</Badge>
@@ -383,6 +413,31 @@ export default function EpicDetailPage() {
           )}
         </section>
       </div>
+
+      {/* Delete confirm dialog */}
+      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>에픽을 삭제하시겠습니까?</DialogTitle>
+            <DialogDescription>
+              이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setShowDeleteConfirm(false)} disabled={deleting}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => void handleDelete()}
+              disabled={deleting}
+            >
+              {deleting ? '삭제 중…' : '영구 삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -3,11 +3,15 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronLeft, Plus, X } from 'lucide-react';
+import { ChevronLeft, Plus, Trash2, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
 import { EmptyState } from '@/components/ui/empty-state';
+import {
+  Dialog, DialogContent, DialogDescription,
+  DialogFooter, DialogHeader, DialogTitle,
+} from '@/components/ui/dialog';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -390,9 +394,10 @@ interface EpicRowProps {
   epic: Epic;
   isSelected: boolean;
   onClick: () => void;
+  onDeleteRequest: (id: string) => void;
 }
 
-function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
+function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
   const t = useTranslations('epics');
   const stories = epic.stories ?? [];
   const { done, total } = calcStoryProgress(stories);
@@ -415,14 +420,16 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
   };
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`w-full rounded-2xl border px-4 py-3.5 text-left transition-all duration-150 ${
+    <div
+      className={`group relative w-full rounded-2xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
         isSelected
           ? 'border-primary/40 bg-primary/5'
           : 'border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] hover:border-primary/30 hover:bg-primary/5'
       }`}
+      onClick={onClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClick(); }}
     >
       <div className="space-y-2.5">
         <div className="flex items-start justify-between gap-2">
@@ -430,6 +437,14 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
           <div className="flex shrink-0 items-center gap-1.5">
             <Badge variant={statusBadgeVariant(epic.status)}>{statusLabel[epic.status]}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{priorityLabel[epic.priority]}</Badge>
+            <button
+              type="button"
+              aria-label={t('deleteEpic')}
+              onClick={(e) => { e.stopPropagation(); onDeleteRequest(epic.id); }}
+              className="hidden group-hover:flex items-center justify-center rounded-md p-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
           </div>
         </div>
 
@@ -458,7 +473,7 @@ function EpicRow({ epic, isSelected, onClick }: EpicRowProps) {
           </div>
         ) : null}
       </div>
-    </button>
+    </div>
   );
 }
 
@@ -688,6 +703,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
   const [epicsLoadingMore, setEpicsLoadingMore] = useState(false);
   const [statusFilter, setStatusFilter] = useState<EpicStatus | 'all'>('all');
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   const fetchEpics = useCallback(async (cursor?: string | null) => {
     try {
@@ -733,6 +750,20 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
     // AC5: 모든 디바이스에서 /epics/[id] 딥링크로 이동
     router.push(`/epics/${epic.id}`);
   }, [router]);
+
+  const handleDeleteEpic = useCallback(async (id: string) => {
+    setDeleting(true);
+    setEpics((prev) => prev.filter((e) => e.id !== id));
+    setSelectedEpic((prev) => prev?.id === id ? null : prev);
+    try {
+      await fetch(`/api/epics/${id}`, { method: 'DELETE' });
+    } catch {
+      void fetchEpics();
+    } finally {
+      setDeleting(false);
+      setDeleteConfirmId(null);
+    }
+  }, [fetchEpics]);
 
   const handleCreated = useCallback((epic: Epic) => {
     setEpics((prev) => [epic, ...prev]);
@@ -804,6 +835,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
                 epic={epic}
                 isSelected={selectedEpic?.id === epic.id}
                 onClick={() => { void handleSelectEpic(epic); }}
+                onDeleteRequest={(id) => setDeleteConfirmId(id)}
               />
             ))}
             {epicsHasMore && (
@@ -871,6 +903,31 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
           onClose={() => setShowCreate(false)}
         />
       ) : null}
+
+      {/* Delete confirm dialog */}
+      <Dialog open={!!deleteConfirmId} onOpenChange={(open) => { if (!open) setDeleteConfirmId(null); }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>에픽을 삭제하시겠습니까?</DialogTitle>
+            <DialogDescription>
+              이 작업은 되돌릴 수 없습니다. 에픽에 포함된 스토리는 연결이 해제됩니다.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="ghost" size="sm" onClick={() => setDeleteConfirmId(null)} disabled={deleting}>
+              취소
+            </Button>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => { if (deleteConfirmId) void handleDeleteEpic(deleteConfirmId); }}
+              disabled={deleting}
+            >
+              {deleting ? '삭제 중…' : '영구 삭제'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -12,6 +12,7 @@ import {
   Dialog, DialogContent, DialogDescription,
   DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
+import { ToastContainer, useToast } from '@/components/ui/toast';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -694,6 +695,7 @@ interface EpicsClientProps {
 export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const t = useTranslations('epics');
   const router = useRouter();
+  const { toasts, addToast, dismissToast } = useToast();
   const [epics, setEpics] = useState<Epic[]>([]);
   const [selectedEpic, setSelectedEpic] = useState<Epic | null>(null);
   const [loading, setLoading] = useState(true);
@@ -756,14 +758,20 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
     setEpics((prev) => prev.filter((e) => e.id !== id));
     setSelectedEpic((prev) => prev?.id === id ? null : prev);
     try {
-      await fetch(`/api/epics/${id}`, { method: 'DELETE' });
+      const res = await fetch(`/api/epics/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+        addToast({ type: 'error', title: json?.error?.message ?? '에픽 삭제에 실패했습니다.' });
+        void fetchEpics();
+      }
     } catch {
+      addToast({ type: 'error', title: '에픽 삭제에 실패했습니다.' });
       void fetchEpics();
     } finally {
       setDeleting(false);
       setDeleteConfirmId(null);
     }
-  }, [fetchEpics]);
+  }, [fetchEpics, addToast]);
 
   const handleCreated = useCallback((epic: Epic) => {
     setEpics((prev) => [epic, ...prev]);
@@ -928,6 +936,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

백엔드 DELETE API + Next.js route는 기존 존재. 프론트엔드 UI만 추가.

### 상세 페이지 (`/epics/[id]/page.tsx`)
- 편집 버튼 옆 **Trash2 삭제 버튼** 추가 (destructive 스타일)
- `Dialog` 확인 다이얼로그 — hard delete 경고 문구 필수 반영
- DELETE 호출 성공 → `/epics` 복귀

### 리스트 페이지 (`epics-client.tsx`)
- `EpicRow`를 `<div role="button">`으로 변경 → 내부 삭제 버튼 중첩 허용
- 각 카드 hover 시 우측에 **Trash2 아이콘** 표시 (`stopPropagation`)
- **Optimistic remove**: 삭제 즉시 목록에서 제거, 실패 시 `fetchEpics()` 복구
- 확인 다이얼로그 공유

### 번역
- `deleteEpic`, `deleteConfirmTitle`, `deleteConfirmDescription`, `deleteConfirmButton` en/ko 추가

## Test plan

- [ ] 에픽 상세 페이지에서 삭제 버튼 표시 확인
- [ ] 삭제 버튼 클릭 → 확인 다이얼로그 표시 (hard delete 경고 포함)
- [ ] 확인 클릭 → 에픽 삭제 + `/epics` 복귀 확인
- [ ] 에픽 리스트 카드 hover 시 Trash2 아이콘 표시 확인
- [ ] 리스트에서 삭제 → optimistic remove (즉시 목록에서 제거) 확인
- [ ] 비admin 계정에서 삭제 시도 → 403 처리 확인 (API 레벨)
- [ ] `pnpm build` 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)