### PR TITLE
[CB-S7] fix: Chat 대화 답신 시 SSE 이벤트 미발행 수정 (P0)

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -697,8 +697,20 @@ async def add_reply(
             "add_reply routed to conversation thread conversation_id=%s message_id=%s",
             id, reply_msg.id,
         )
-        # webhook 발송 (기존 참여자 수집)
+        # CB-S7: SSE conversation:message 발행 (P0 — 수신자 화면 실시간 갱신)
         conv = await db.get(Conversation, id)
+        if conv:
+            sender_member = (await db.execute(
+                select(TeamMember).where(TeamMember.id == body.created_by)
+            )).scalar_one_or_none()
+            if sender_member:
+                try:
+                    from app.routers.conversations import _dispatch_conversation_event
+                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member)
+                except Exception:
+                    logger.warning("conversation event dispatch failed memo_id=%s", id, exc_info=True)
+
+        # webhook 발송 (기존 참여자 수집)
         if conv:
             webhook_urls = await _collect_reply_webhook_urls(
                 db, id, None, conv.created_by, body.created_by, body.assigned_to_ids


### PR DESCRIPTION
## Summary

- `memos.py` conversation reply 경로에서 `_dispatch_conversation_event` 미호출로 수신자 화면 실시간 갱신이 되지 않던 P0 버그 수정
- `reply_msg` 저장 + flush 직후 sender_member 조회 → lazy import `_dispatch_conversation_event` 호출
- SSE 발행 실패 시 `logger.warning` 처리 (non-blocking — 메시지 저장/웹훅은 영향 없음)

## Changed files

- `backend/app/routers/memos.py` — conversation reply 경로 `_dispatch_conversation_event` 추가 (13줄)

## Test plan

- [ ] DM/그룹 chat에서 메시지 전송 → 수신자 화면 새로고침 없이 실시간 갱신 확인
- [ ] 기존 webhook 발송 정상 동작 확인
- [ ] legacy memo path(fallback) 영향 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)