### PR TITLE
[SID:CB-S9] Chat 스레드 답글 표시 + 진입 UI (우클릭 컨텍스트 메뉴)

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -1,15 +1,24 @@
 'use client';
 
+import { useCallback, useRef, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { Bot, User } from 'lucide-react';
+import { Bot, MessageSquare, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { EntityChip, getEntityHref } from '@/components/memos/embed-card';
+import { MessageContextMenu } from './message-context-menu';
 
 interface ChatBubbleProps {
   message: ChatMessage;
   isMine: boolean;
   isGrouped?: boolean;
+  onOpenThread?: (message: ChatMessage) => void;
+  onDelete?: (messageId: string) => void;
+}
+
+interface ContextMenuState {
+  x: number;
+  y: number;
 }
 
 // Convert @name tokens to markdown links so react-markdown v10 can render them via the `a` component.
@@ -74,80 +83,173 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
   );
 }
 
-export function ChatBubble({ message, isMine, isGrouped = false }: ChatBubbleProps) {
+const LONG_PRESS_MS = 500;
+
+export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete }: ChatBubbleProps) {
   const isAgent = message.sender_type === 'agent';
   const displayName = isMine ? '나' : (message.sender_name || '팀');
   const time = new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(message.created_at));
+  const replyCount = message.reply_count ?? 0;
+  const lastReplyAt = message.last_reply_at;
+
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  // AC1: 우클릭 컨텍스트 메뉴 (데스크톱)
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  // AC2: 롱프레스 컨텍스트 메뉴 (모바일)
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    touchPosRef.current = { x: touch.clientX, y: touch.clientY };
+    longPressTimerRef.current = setTimeout(() => {
+      if (touchPosRef.current) {
+        setContextMenu({ x: touchPosRef.current.x, y: touchPosRef.current.y });
+      }
+    }, LONG_PRESS_MS);
+  }, []);
+
+  const handleTouchEnd = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+    touchPosRef.current = null;
+  }, []);
+
+  const handleTouchMove = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard.writeText(message.content);
+  }, [message.content]);
+
+  const handleDelete = useCallback(() => {
+    onDelete?.(message.id);
+  }, [message.id, onDelete]);
+
+  const handleOpenThread = useCallback(() => {
+    onOpenThread?.(message);
+  }, [message, onOpenThread]);
+
+  const lastReplyTime = lastReplyAt
+    ? new Intl.DateTimeFormat('ko-KR', { hour: '2-digit', minute: '2-digit' }).format(new Date(lastReplyAt))
+    : null;
 
   return (
-    <div className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'} ${isGrouped ? 'mt-0.5' : 'mt-2'}`}>
-      {/* Avatar — hidden when grouped */}
-      {isGrouped ? (
-        <div className="w-7 flex-shrink-0" />
-      ) : (
-        <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-          isAgent
-            ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
-            : isMine
-              ? 'bg-primary/20 text-primary'
-              : 'bg-muted text-muted-foreground'
-        }`}>
-          {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
-        </div>
-      )}
-
-      {/* Bubble + meta */}
-      <div className={`flex max-w-[72%] flex-col gap-0.5 ${isMine ? 'items-end' : 'items-start'}`}>
-        {/* Sender name — hidden when grouped */}
-        {!isGrouped && (
-          <div className="flex items-center gap-1.5">
-            <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
-            {isAgent && (
-              <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
-                AI
-              </span>
-            )}
+    <>
+      <div
+        className={`flex gap-2 ${isMine ? 'flex-row-reverse' : 'flex-row'} ${isGrouped ? 'mt-0.5' : 'mt-2'}`}
+        onContextMenu={handleContextMenu}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={handleTouchMove}
+      >
+        {/* Avatar — hidden when grouped */}
+        {isGrouped ? (
+          <div className="w-7 flex-shrink-0" />
+        ) : (
+          <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
+            isAgent
+              ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+              : isMine
+                ? 'bg-primary/20 text-primary'
+                : 'bg-muted text-muted-foreground'
+          }`}>
+            {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
           </div>
         )}
 
-        {/* Content */}
-        <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words ${
-          isMine
-            ? 'rounded-tr-sm bg-primary text-primary-foreground'
-            : 'rounded-tl-sm bg-muted text-foreground'
-        }`}>
-          <ChatMarkdown content={message.content} isMine={isMine} />
-        </div>
+        {/* Bubble + meta */}
+        <div className={`flex max-w-[72%] flex-col gap-0.5 ${isMine ? 'items-end' : 'items-start'}`}>
+          {/* Sender name — hidden when grouped */}
+          {!isGrouped && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-[11px] font-medium text-muted-foreground">{displayName}</span>
+              {isAgent && (
+                <span className="rounded-sm bg-violet-100 px-1 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-violet-700 dark:bg-violet-900/40 dark:text-violet-300">
+                  AI
+                </span>
+              )}
+            </div>
+          )}
 
-        {/* Attachments */}
-        {message.attachments && message.attachments.length > 0 && (
-          <div className="flex flex-col gap-1.5">
-            {message.attachments.map((att, i) => {
-              const href = att.url;
-              const label = att.name ?? att.filename ?? '첨부파일';
-              const isImage = att.content_type?.startsWith('image/');
-              return (
-                <a
-                  key={href ?? i}
-                  href={href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
-                >
-                  {isImage && href ? (
-                    /* eslint-disable-next-line @next/next/no-img-element */
-                    <img src={href} alt={label} className="max-h-40 max-w-[240px] rounded object-contain" />
-                  ) : (
-                    <span className="truncate text-muted-foreground">{label}</span>
-                  )}
-                </a>
-              );
-            })}
+          {/* Content */}
+          <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words ${
+            isMine
+              ? 'rounded-tr-sm bg-primary text-primary-foreground'
+              : 'rounded-tl-sm bg-muted text-foreground'
+          }`}>
+            <ChatMarkdown content={message.content} isMine={isMine} />
           </div>
-        )}
 
-        <time className="text-[10px] text-muted-foreground/70">{time}</time>
+          {/* Attachments */}
+          {message.attachments && message.attachments.length > 0 && (
+            <div className="flex flex-col gap-1.5">
+              {message.attachments.map((att, i) => {
+                const href = att.url;
+                const label = att.name ?? att.filename ?? '첨부파일';
+                const isImage = att.content_type?.startsWith('image/');
+                return (
+                  <a
+                    key={href ?? i}
+                    href={href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
+                  >
+                    {isImage && href ? (
+                      /* eslint-disable-next-line @next/next/no-img-element */
+                      <img src={href} alt={label} className="max-h-40 max-w-[240px] rounded object-contain" />
+                    ) : (
+                      <span className="truncate text-muted-foreground">{label}</span>
+                    )}
+                  </a>
+                );
+              })}
+            </div>
+          )}
+
+          <time className="text-[10px] text-muted-foreground/70">{time}</time>
+
+          {/* AC5: 답글 수 표시 — reply_count > 0 */}
+          {replyCount > 0 && (
+            <button
+              type="button"
+              onClick={handleOpenThread}
+              className="mt-0.5 flex items-center gap-1.5 rounded-md px-1.5 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/8"
+            >
+              <MessageSquare className="h-3 w-3" />
+              {replyCount}개의 답글
+              {lastReplyTime && (
+                <span className="font-normal text-muted-foreground">{lastReplyTime}</span>
+              )}
+            </button>
+          )}
+        </div>
       </div>
-    </div>
+
+      {/* AC1/AC2: 컨텍스트 메뉴 */}
+      {contextMenu && (
+        <MessageContextMenu
+          x={contextMenu.x}
+          y={contextMenu.y}
+          isMine={isMine}
+          onReply={handleOpenThread}
+          onCopy={handleCopy}
+          onDelete={handleDelete}
+          onClose={() => setContextMenu(null)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -62,7 +62,7 @@ interface EntityResult {
 
 interface ChatInputProps {
   onSend: (content: string, mentionedIds?: string[]) => Promise<void>;
-  onUpload: (file: File) => Promise<void>;
+  onUpload?: (file: File) => Promise<void>;
   disabled?: boolean;
   placeholder?: string;
   projectId?: string;
@@ -184,7 +184,7 @@ export function ChatInput({ onSend, onUpload, disabled, placeholder, projectId, 
 
     setSending(true);
     try {
-      if (pendingFile) {
+      if (pendingFile && onUpload) {
         await onUpload(pendingFile);
         setPendingFile(null);
       }

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -196,6 +196,17 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     setMessages((prev) => prev.filter((m) => m.id !== messageId));
   }, [apiPrefix, threadId]);
 
+  // P2 RC: 자신이 보낸 스레드 답글은 SSE 미수신 → 로컬에서 reply_count +1
+  const handleReplyAdded = useCallback((parentId: string) => {
+    setMessages((prev) =>
+      prev.map((m) =>
+        m.id === parentId
+          ? { ...m, reply_count: (m.reply_count ?? 0) + 1, last_reply_at: new Date().toISOString() }
+          : m,
+      ),
+    );
+  }, []);
+
   const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
     const body: Record<string, unknown> = { content };
     if (mentionedIds && mentionedIds.length > 0) body.mentioned_ids = mentionedIds;
@@ -428,6 +439,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
               projectId={projectId}
               onClose={() => setActiveThread(null)}
               incomingMessage={threadIncoming?.parent_id === activeThread.id ? threadIncoming : null}
+              onReplyAdded={handleReplyAdded}
             />
           </div>
         )}

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, RefreshCw } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { ChatBubble } from './chat-bubble';
 import { ChatInput } from './chat-input';
+import { ThreadPanel } from './thread-panel';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -43,6 +44,9 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
   const [showNewIndicator, setShowNewIndicator] = useState(false);
+  // CB-S9: 스레드 패널 상태
+  const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
+  const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const topSentinelRef = useRef<HTMLDivElement>(null);
@@ -130,7 +134,21 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   const handleConversationMessage = useCallback((payload: Record<string, unknown>) => {
     const conversationId = (payload.conversation_id ?? payload.id) as string | undefined;
     if (conversationId !== threadId) return;
-    addMessage(normalizeToMessage(payload));
+    const msg = normalizeToMessage(payload);
+    // CB-S9: thread reply → inject into thread panel; top-level → add to main + update reply_count
+    if (msg.parent_id) {
+      setThreadIncoming(msg);
+      // Update reply_count on parent message in the main list
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === msg.parent_id
+            ? { ...m, reply_count: (m.reply_count ?? 0) + 1, last_reply_at: msg.created_at }
+            : m,
+        ),
+      );
+    } else {
+      addMessage(msg);
+    }
   }, [threadId, addMessage]);
 
   // AC4: 재연결 시 누락 메시지 backfill
@@ -170,6 +188,13 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     setPullDistance(0);
     touchStartYRef.current = null;
   }, [pullDistance, fetchMessages]);
+
+  // CB-S9: 메시지 삭제 (본인 메시지만)
+  const handleDeleteMessage = useCallback(async (messageId: string) => {
+    const res = await fetch(`${apiPrefix}/${threadId}/messages/${messageId}`, { method: 'DELETE' });
+    if (!res.ok) return;
+    setMessages((prev) => prev.filter((m) => m.id !== messageId));
+  }, [apiPrefix, threadId]);
 
   const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
     const body: Record<string, unknown> = { content };
@@ -254,129 +279,159 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
 
   const groups = groupByDate(messages);
 
+  // CB-S9: 모바일에서 스레드 뷰로 전환 중인지 (< lg)
+  const isMobileThreadView = activeThread !== null;
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Mobile back nav (< lg) — only shown when backRoute is provided */}
-      {backRoute && (
+      {/* Mobile back nav — 스레드 뷰 중이면 스레드 뒤로가기 표시 (AC8) */}
+      {(backRoute || isMobileThreadView) && (
         <div className="flex flex-shrink-0 items-center gap-2 border-b border-border/80 px-3 py-2 lg:hidden">
           <button
             type="button"
-            onClick={() => router.push(backRoute)}
+            onClick={() => {
+              if (isMobileThreadView) { setActiveThread(null); }
+              else if (backRoute) { router.push(backRoute); }
+            }}
             className="flex min-h-[44px] items-center gap-1 px-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <ChevronLeft className="h-4 w-4" />
-            메모
+            {isMobileThreadView ? '대화' : '메모'}
           </button>
-          {threadTitle && (
-            <span className="truncate text-sm font-medium text-foreground">{threadTitle}</span>
-          )}
+          <span className="truncate text-sm font-medium text-foreground">
+            {isMobileThreadView ? '스레드' : (threadTitle ?? '')}
+          </span>
         </div>
       )}
 
-      {/* Desktop thread title (lg+) */}
-      {threadTitle && (
+      {/* Desktop thread title (lg+) — 스레드 패널 없을 때만 표시 */}
+      {threadTitle && !activeThread && (
         <div className="hidden flex-shrink-0 border-b border-border/80 px-4 py-2.5 lg:flex">
           <h2 className="truncate text-sm font-medium text-foreground">{threadTitle}</h2>
         </div>
       )}
 
-      {/* Messages */}
-      <div
-        ref={scrollRef}
-        className="relative flex-1 overflow-y-auto px-4 py-3"
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={() => void handleTouchEnd()}
-      >
-        {/* CB-S8: pull-to-refresh 인디케이터 */}
-        {(pullDistance > 0 || isRefreshing) && (
+      {/* Body: main chat + optional thread panel (side-by-side on desktop) */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+
+        {/* Main chat — AC8: 모바일에서 스레드 뷰 활성 시 hidden */}
+        <div className={`flex min-w-0 flex-1 flex-col overflow-hidden ${isMobileThreadView ? 'hidden lg:flex' : 'flex'}`}>
+          {/* Messages */}
           <div
-            className="pointer-events-none flex justify-center pb-2 transition-all"
-            style={{ height: isRefreshing ? 40 : pullDistance * 0.6 }}
+            ref={scrollRef}
+            className="relative flex-1 overflow-y-auto px-4 py-3"
+            onTouchStart={handleTouchStart}
+            onTouchMove={handleTouchMove}
+            onTouchEnd={() => void handleTouchEnd()}
           >
-            <RefreshCw
-              className={`h-5 w-5 text-muted-foreground transition-transform ${isRefreshing ? 'animate-spin' : ''}`}
-              style={{ transform: `rotate(${(pullDistance / PULL_THRESHOLD) * 180}deg)` }}
-            />
-          </div>
-        )}
-        {loading ? (
-          <div className="flex h-full items-center justify-center">
-            <p className="text-sm text-muted-foreground">불러오는 중…</p>
-          </div>
-        ) : messages.length === 0 ? (
-          <div className="flex h-full items-center justify-center">
-            <EmptyState
-              title="대화를 시작하세요"
-              description="첫 메시지를 보내면 대화가 시작됩니다."
-              className="w-full max-w-xs"
-            />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {/* sentinel: IntersectionObserver triggers auto-load when scrolled to top */}
-            <div ref={topSentinelRef} className="h-px w-full" />
-            {hasMore && (
-              <div className="flex justify-center">
-                <button
-                  type="button"
-                  onClick={() => void handleLoadMore()}
-                  disabled={loadingMore}
-                  className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
-                >
-                  {loadingMore ? '불러오는 중…' : '이전 메시지 보기'}
-                </button>
+            {/* CB-S8: pull-to-refresh 인디케이터 */}
+            {(pullDistance > 0 || isRefreshing) && (
+              <div
+                className="pointer-events-none flex justify-center pb-2 transition-all"
+                style={{ height: isRefreshing ? 40 : pullDistance * 0.6 }}
+              >
+                <RefreshCw
+                  className={`h-5 w-5 text-muted-foreground transition-transform ${isRefreshing ? 'animate-spin' : ''}`}
+                  style={{ transform: `rotate(${(pullDistance / PULL_THRESHOLD) * 180}deg)` }}
+                />
               </div>
             )}
-
-            {groups.map((group) => (
-              <div key={group.date} className="flex flex-col gap-3">
-                <div className="flex items-center gap-3">
-                  <div className="h-px flex-1 bg-border/60" />
-                  <span className="text-[11px] text-muted-foreground">{group.date}</span>
-                  <div className="h-px flex-1 bg-border/60" />
-                </div>
-
-                {group.messages.map((msg, idx) => {
-                  const prev = group.messages[idx - 1];
-                  const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
-                  return (
-                    <ChatBubble
-                      key={msg.id}
-                      message={msg}
-                      isMine={msg.created_by === currentTeamMemberId}
-                      isGrouped={isGrouped}
-                    />
-                  );
-                })}
+            {loading ? (
+              <div className="flex h-full items-center justify-center">
+                <p className="text-sm text-muted-foreground">불러오는 중…</p>
               </div>
-            ))}
+            ) : messages.length === 0 ? (
+              <div className="flex h-full items-center justify-center">
+                <EmptyState
+                  title="대화를 시작하세요"
+                  description="첫 메시지를 보내면 대화가 시작됩니다."
+                  className="w-full max-w-xs"
+                />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-4">
+                {/* sentinel: IntersectionObserver triggers auto-load when scrolled to top */}
+                <div ref={topSentinelRef} className="h-px w-full" />
+                {hasMore && (
+                  <div className="flex justify-center">
+                    <button
+                      type="button"
+                      onClick={() => void handleLoadMore()}
+                      disabled={loadingMore}
+                      className="text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+                    >
+                      {loadingMore ? '불러오는 중…' : '이전 메시지 보기'}
+                    </button>
+                  </div>
+                )}
 
-            <div ref={bottomRef} />
+                {groups.map((group) => (
+                  <div key={group.date} className="flex flex-col gap-3">
+                    <div className="flex items-center gap-3">
+                      <div className="h-px flex-1 bg-border/60" />
+                      <span className="text-[11px] text-muted-foreground">{group.date}</span>
+                      <div className="h-px flex-1 bg-border/60" />
+                    </div>
+
+                    {group.messages.map((msg, idx) => {
+                      const prev = group.messages[idx - 1];
+                      const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
+                      return (
+                        <ChatBubble
+                          key={msg.id}
+                          message={msg}
+                          isMine={msg.created_by === currentTeamMemberId}
+                          isGrouped={isGrouped}
+                          onOpenThread={setActiveThread}
+                          onDelete={handleDeleteMessage}
+                        />
+                      );
+                    })}
+                  </div>
+                ))}
+
+                <div ref={bottomRef} />
+              </div>
+            )}
+          </div>
+
+          {/* AC2(CB-S8): 새 메시지 인디케이터 */}
+          {showNewIndicator && (
+            <div className="flex flex-shrink-0 justify-center py-1">
+              <button
+                type="button"
+                onClick={() => { setShowNewIndicator(false); scrollToBottom(true); }}
+                className="rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-primary shadow-sm transition-colors hover:bg-muted/50"
+              >
+                ↓ 새 메시지
+              </button>
+            </div>
+          )}
+
+          {/* Input */}
+          <ChatInput
+            onSend={handleSend}
+            onUpload={handleUpload}
+            projectId={projectId}
+            placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)"
+          />
+        </div>
+
+        {/* AC7/AC8: 스레드 패널 — 데스크톱 사이드 패널 / 모바일 전체 뷰 */}
+        {activeThread && (
+          <div className={`flex flex-col overflow-hidden ${isMobileThreadView ? 'flex-1' : 'hidden w-80 flex-shrink-0 lg:flex'}`}>
+            <ThreadPanel
+              key={activeThread.id}
+              parentMessage={activeThread}
+              conversationId={threadId}
+              currentTeamMemberId={currentTeamMemberId}
+              projectId={projectId}
+              onClose={() => setActiveThread(null)}
+              incomingMessage={threadIncoming?.parent_id === activeThread.id ? threadIncoming : null}
+            />
           </div>
         )}
       </div>
-
-      {/* AC2: 새 메시지 인디케이터 — 스크롤이 위에 있을 때만 표시 */}
-      {showNewIndicator && (
-        <div className="flex flex-shrink-0 justify-center py-1">
-          <button
-            type="button"
-            onClick={() => { setShowNewIndicator(false); scrollToBottom(true); }}
-            className="rounded-full border border-border bg-background px-3 py-1 text-xs font-medium text-primary shadow-sm transition-colors hover:bg-muted/50"
-          >
-            ↓ 새 메시지
-          </button>
-        </div>
-      )}
-
-      {/* Input */}
-      <ChatInput
-        onSend={handleSend}
-        onUpload={handleUpload}
-        projectId={projectId}
-        placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)"
-      />
     </div>
   );
 }

--- a/apps/web/src/components/chat/message-context-menu.tsx
+++ b/apps/web/src/components/chat/message-context-menu.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { MessageSquareReply, Copy, Trash2 } from 'lucide-react';
+
+interface MessageContextMenuProps {
+  x: number;
+  y: number;
+  isMine: boolean;
+  onReply: () => void;
+  onCopy: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
+
+export function MessageContextMenu({ x, y, isMine, onReply, onCopy, onDelete, onClose }: MessageContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click or Escape
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
+    };
+    const onKeyDown = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
+    document.addEventListener('pointerdown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown);
+    };
+  }, [onClose]);
+
+  // Clamp menu inside viewport
+  const menuW = 160;
+  const menuH = isMine ? 112 : 80;
+  const clampedX = Math.min(x, window.innerWidth - menuW - 8);
+  const clampedY = Math.min(y, window.innerHeight - menuH - 8);
+
+  return (
+    <div
+      ref={menuRef}
+      role="menu"
+      className="fixed z-50 min-w-[160px] overflow-hidden rounded-lg border border-border bg-popover py-1 shadow-md"
+      style={{ left: clampedX, top: clampedY }}
+    >
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => { onReply(); onClose(); }}
+        className="flex w-full items-center gap-2.5 px-3 py-2 text-sm hover:bg-muted"
+      >
+        <MessageSquareReply className="h-3.5 w-3.5 text-muted-foreground" />
+        답글 달기
+      </button>
+      <button
+        type="button"
+        role="menuitem"
+        onClick={() => { onCopy(); onClose(); }}
+        className="flex w-full items-center gap-2.5 px-3 py-2 text-sm hover:bg-muted"
+      >
+        <Copy className="h-3.5 w-3.5 text-muted-foreground" />
+        복사
+      </button>
+      {isMine && (
+        <>
+          <div className="my-1 border-t border-border" />
+          <button
+            type="button"
+            role="menuitem"
+            onClick={() => { onDelete(); onClose(); }}
+            className="flex w-full items-center gap-2.5 px-3 py-2 text-sm text-destructive hover:bg-destructive/10"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+            삭제
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { X } from 'lucide-react';
+import type { ChatMessage } from '@/hooks/use-chat-sse';
+import { normalizeToMessage } from '@/hooks/use-chat-sse';
+import { ChatBubble } from './chat-bubble';
+import { ChatInput } from './chat-input';
+
+interface ThreadPanelProps {
+  parentMessage: ChatMessage;
+  conversationId: string;
+  currentTeamMemberId: string;
+  projectId?: string;
+  onClose: () => void;
+  // Injected by parent SSE to push new thread messages
+  incomingMessage?: ChatMessage | null;
+}
+
+export function ThreadPanel({
+  parentMessage,
+  conversationId,
+  currentTeamMemberId,
+  projectId,
+  onClose,
+  incomingMessage,
+}: ThreadPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  const fetchThreadMessages = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/conversations/${conversationId}/messages?thread_id=${parentMessage.id}`,
+      );
+      if (!res.ok) return;
+      const raw = await res.json() as Record<string, unknown>;
+      const rawData = (Array.isArray(raw) ? raw : (raw.data ?? [])) as Record<string, unknown>[];
+      setMessages(rawData.map(normalizeToMessage));
+    } finally {
+      setLoading(false);
+    }
+  }, [conversationId, parentMessage.id]);
+
+  useEffect(() => {
+    void fetchThreadMessages();
+  }, [fetchThreadMessages]);
+
+  // Scroll to bottom on load
+  useEffect(() => {
+    if (!loading) bottomRef.current?.scrollIntoView({ behavior: 'instant' });
+  }, [loading]);
+
+  // AC10: Inject new messages from parent SSE (parent filters by thread_id)
+  useEffect(() => {
+    if (!incomingMessage) return;
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === incomingMessage.id)) return prev;
+      return [...prev, incomingMessage];
+    });
+    setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+  }, [incomingMessage]);
+
+  const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
+    const body: Record<string, unknown> = { content, thread_id: parentMessage.id };
+    if (mentionedIds && mentionedIds.length > 0) body.mentioned_ids = mentionedIds;
+    const res = await fetch(`/api/conversations/${conversationId}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error('Failed to send thread reply');
+    const raw = await res.json() as Record<string, unknown>;
+    const payload = (raw.data ?? raw) as Record<string, unknown>;
+    const msg = normalizeToMessage(payload);
+    setMessages((prev) => {
+      if (prev.some((m) => m.id === msg.id)) return prev;
+      return [...prev, msg];
+    });
+    setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+  }, [conversationId, parentMessage.id]);
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">
+      {/* Header */}
+      <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-2.5">
+        <span className="text-sm font-medium text-foreground">스레드</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="스레드 닫기"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* AC9: 원본 메시지 */}
+      <div className="flex-shrink-0 border-b border-border/60 bg-muted/30 px-4 py-3">
+        <p className="mb-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">원본 메시지</p>
+        <ChatBubble
+          message={parentMessage}
+          isMine={parentMessage.created_by === currentTeamMemberId}
+          isGrouped={false}
+        />
+      </div>
+
+      {/* Thread messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-3">
+        {loading ? (
+          <p className="text-center text-sm text-muted-foreground">불러오는 중…</p>
+        ) : messages.length === 0 ? (
+          <p className="text-center text-sm text-muted-foreground">아직 답글이 없는.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {messages.map((msg, idx) => {
+              const prev = messages[idx - 1];
+              const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
+              return (
+                <ChatBubble
+                  key={msg.id}
+                  message={msg}
+                  isMine={msg.created_by === currentTeamMemberId}
+                  isGrouped={isGrouped}
+                />
+              );
+            })}
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <ChatInput
+        onSend={handleSend}
+        projectId={projectId}
+        placeholder="답글을 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -15,6 +15,8 @@ interface ThreadPanelProps {
   onClose: () => void;
   // Injected by parent SSE to push new thread messages
   incomingMessage?: ChatMessage | null;
+  // P2 RC: notify parent to increment reply_count when own reply sent
+  onReplyAdded?: (parentId: string) => void;
 }
 
 export function ThreadPanel({
@@ -24,6 +26,7 @@ export function ThreadPanel({
   projectId,
   onClose,
   incomingMessage,
+  onReplyAdded,
 }: ThreadPanelProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
@@ -78,8 +81,10 @@ export function ThreadPanel({
       if (prev.some((m) => m.id === msg.id)) return prev;
       return [...prev, msg];
     });
+    // P2 RC: SSE excludes own messages → manually bump parent reply_count
+    onReplyAdded?.(parentMessage.id);
     setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
-  }, [conversationId, parentMessage.id]);
+  }, [conversationId, parentMessage.id, onReplyAdded]);
 
   return (
     <div className="flex h-full flex-col overflow-hidden border-l border-border bg-background">

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -32,7 +32,8 @@ export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
     content: (raw.content ?? '') as string,
     attachments: (raw.attachments ?? []) as ChatMessage['attachments'],
     created_at: (raw.created_at ?? '') as string,
-    parent_id: (raw.parent_id ?? null) as string | null,
+    // P1 RC: backend sends thread_id as parent pointer; raw.parent_id may be absent
+    parent_id: (raw.parent_id ?? raw.thread_id ?? null) as string | null,
     reply_count: (raw.reply_count ?? 0) as number,
     last_reply_at: (raw.last_reply_at ?? null) as string | null,
   };

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -5,7 +5,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 // Mirrors backend _to_chat_message: { id, thread_id, sender: { id, name, type }, ... }
 export interface ChatMessage {
   id: string;
-  memo_id: string;        // backend: thread_id
+  memo_id: string;        // backend: thread_id (conversation_id for group chats)
   created_by: string;     // backend: sender.id
   sender_name: string;    // backend: sender.name
   sender_type: string;    // backend: sender.type ('human' | 'agent')
@@ -13,6 +13,10 @@ export interface ChatMessage {
   review_type?: string;
   attachments: Array<{ url?: string; name?: string; content_type?: string; filename?: string }>;
   created_at: string;
+  // CB-S9: thread fields
+  parent_id?: string | null;    // null = top-level message; set = this is a thread reply
+  reply_count?: number;
+  last_reply_at?: string | null;
 }
 
 // Normalize backend _to_chat_message format → ChatMessage
@@ -28,6 +32,9 @@ export function normalizeToMessage(raw: Record<string, unknown>): ChatMessage {
     content: (raw.content ?? '') as string,
     attachments: (raw.attachments ?? []) as ChatMessage['attachments'],
     created_at: (raw.created_at ?? '') as string,
+    parent_id: (raw.parent_id ?? null) as string | null,
+    reply_count: (raw.reply_count ?? 0) as number,
+    last_reply_at: (raw.last_reply_at ?? null) as string | null,
   };
 }
 


### PR DESCRIPTION
## 변경 사항

### 신규 컴포넌트

**`message-context-menu.tsx`**
- 우클릭(데스크톱) / 롱프레스 500ms(모바일) 컨텍스트 메뉴
- 항목: 답글 달기 / 복사 / 삭제(본인 메시지만, AC3)
- Escape 키 / 외부 클릭 시 닫힘
- 뷰포트 경계 클램핑 (menu overflow 방지)

**`thread-panel.tsx`**
- 원본 메시지 상단 표시 (AC9)
- `GET /api/conversations/{id}/messages?thread_id=` 로 스레드 메시지 로드
- `POST` with `{ thread_id: parentMessage.id }` 로 답글 전송 (AC10: flat, 중첩 없음)
- 부모 `chat-view`에서 `incomingMessage` prop으로 SSE 실시간 업데이트 주입

### 수정 컴포넌트

**`chat-bubble.tsx`**
- `onContextMenu` (AC1) + 롱프레스 `onTouchStart/End/Move` (AC2) → `contextMenu` state
- `reply_count > 0` 메시지 하단 `"N개의 답글 + last_reply_at"` 버튼 (AC5, AC6)
- `onOpenThread` / `onDelete` prop 추가

**`chat-view.tsx`**
- `activeThread` state: 데스크톱 `w-80` 사이드 패널 (AC7), 모바일 전체 뷰 (AC8)
- 모바일: 스레드 활성 시 main chat `hidden`, 뒤로가기 버튼으로 복귀 (AC8)
- `conversation:message` SSE: `parent_id` 있으면 thread 라우팅, 없으면 main (AC10)
- 스레드 reply_count 실시간 업데이트
- `handleDeleteMessage` 추가 (DELETE API 호출 후 메시지 제거)

**`use-chat-sse.ts`**
- `ChatMessage`에 `parent_id`, `reply_count`, `last_reply_at` 필드 추가

**`chat-input.tsx`**
- `onUpload` optional 처리 (스레드 패널에서 파일 업로드 불필요)

## AC 체크리스트

- [x] AC1: 데스크톱 우클릭 → 컨텍스트 메뉴
- [x] AC2: 모바일 롱프레스 → 동일 컨텍스트 메뉴
- [x] AC3: 삭제 항목은 본인 메시지에만 표시
- [x] AC4: "답글 달기" → 스레드 패널/뷰 오픈
- [x] AC5: reply_count > 0 메시지 하단 "N개의 답글 + last_reply_at"
- [x] AC6: "N개의 답글" 클릭 → 스레드 패널/뷰 오픈
- [x] AC7: 데스크톱 오른쪽 사이드 패널 (w-80, 슬랙 패턴)
- [x] AC8: 모바일 별도 뷰 전환, 뒤로가기 복귀
- [x] AC9: 스레드 뷰 상단 원본 메시지 표시
- [x] AC10: 스레드 내부 답글 → 같은 스레드에 flat 추가 (중첩 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)