### PR TITLE
[SID:CB-S10] Chat 스레드 자동 스크롤 CB-S8 패턴 + SSE 실시간 업데이트

### DIFF
--- a/apps/web/src/components/chat/thread-panel.tsx
+++ b/apps/web/src/components/chat/thread-panel.tsx
@@ -31,6 +31,8 @@ export function ThreadPanel({
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const bottomRef = useRef<HTMLDivElement>(null);
+  // AC6: CB-S8 패턴 — render 후 DOM 반영된 직후 스크롤 보장
+  const shouldScrollToBottomRef = useRef(false);
 
   const fetchThreadMessages = useCallback(async () => {
     try {
@@ -55,15 +57,23 @@ export function ThreadPanel({
     if (!loading) bottomRef.current?.scrollIntoView({ behavior: 'instant' });
   }, [loading]);
 
-  // AC10: Inject new messages from parent SSE (parent filters by thread_id)
+  // AC4/AC6: SSE 주입 + CB-S8 패턴 스크롤 (setTimeout 제거)
   useEffect(() => {
     if (!incomingMessage) return;
     setMessages((prev) => {
       if (prev.some((m) => m.id === incomingMessage.id)) return prev;
       return [...prev, incomingMessage];
     });
-    setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+    shouldScrollToBottomRef.current = true;
   }, [incomingMessage]);
+
+  // AC6: 매 render 후 플래그 확인 → DOM 업데이트 직후 스크롤 (bare useEffect)
+  useEffect(() => {
+    if (shouldScrollToBottomRef.current) {
+      shouldScrollToBottomRef.current = false;
+      bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }
+  });
 
   const handleSend = useCallback(async (content: string, mentionedIds?: string[]) => {
     const body: Record<string, unknown> = { content, thread_id: parentMessage.id };
@@ -83,7 +93,8 @@ export function ThreadPanel({
     });
     // P2 RC: SSE excludes own messages → manually bump parent reply_count
     onReplyAdded?.(parentMessage.id);
-    setTimeout(() => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }), 50);
+    // AC3/AC6: optimistic update 후 render 완료 시 스크롤
+    shouldScrollToBottomRef.current = true;
   }, [conversationId, parentMessage.id, onReplyAdded]);
 
   return (


### PR DESCRIPTION
## 변경 사항

CB-S9에서 구현된 스레드 패널에 CB-S8의 스크롤 패턴 적용 + SSE 실시간 업데이트 완비.

### `thread-panel.tsx`

**AC6: `setTimeout(50)` 제거 → `shouldScrollToBottomRef` + bare `useEffect` 패턴**

| 위치 | 기존 | 변경 |
|------|------|------|
| SSE incomingMessage 주입 (AC4) | `setTimeout(() => scrollIntoView, 50)` | `shouldScrollToBottomRef.current = true` |
| handleSend 완료 (AC3) | `setTimeout(() => scrollIntoView, 50)` | `shouldScrollToBottomRef.current = true` |
| bare useEffect (신규) | — | 매 render 후 ref 체크 → `scrollIntoView({ behavior: 'smooth' })` |

DOM에 새 메시지 반영된 직후 스크롤 보장 (CB-S8 패턴 동일).

### AC 체크리스트

- [x] AC1: 스레드 오픈 시 thread_id 메시지 목록 로드 (CB-S9 완비)
- [x] AC2: 전송 시 thread_id 포함 API 호출 (CB-S9 완비)
- [x] AC3: 전송 후 즉시 반영 + 자동 스크롤 (optimistic + shouldScrollToBottomRef)
- [x] AC4: SSE conversation:message → thread_id 매칭 → 스레드 패널 실시간 업데이트 (CB-S9 완비)
- [x] AC5: 스레드 답글 수신 시 reply_count 동기 업데이트 (CB-S9 onReplyAdded 완비)
- [x] AC6: 새 메시지 수신 시 자동 스크롤 (shouldScrollToBottomRef + bare useEffect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)