### PR TITLE
[P0] fix: /chats 대화 클릭 진입 불가 리그레션 수정

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -47,18 +47,21 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
   const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
-  // fix: 스레드 열기 — 브라우저 히스토리에 entry 추가 → 뒤로가기 시 스레드 닫힘
+  // activeThread 열림 여부를 ref로 추적 — popstate 핸들러 stale closure 방지
+  const activeThreadRef = useRef(false);
+
+  // 스레드 열기: 현재 URL 유지한 채 history entry 추가
   const openThread = useCallback((message: ChatMessage) => {
     setActiveThread(message);
-    window.history.pushState({ _sprintableThread: true }, '');
+    activeThreadRef.current = true;
+    const url = window.location.pathname + window.location.search;
+    window.history.pushState({ _sprintableThread: true }, '', url);
   }, []);
-  // fix: 스레드 닫기 — history.back()으로 pushState entry 제거 (popstate가 setActiveThread(null) 처리)
+
+  // 스레드 닫기: history.back() 제거 — Next.js router와 충돌 방지 (P0 리그레션 원인)
   const closeThread = useCallback(() => {
-    if ((window.history.state as Record<string, unknown> | null)?._sprintableThread) {
-      window.history.back();
-    } else {
-      setActiveThread(null);
-    }
+    activeThreadRef.current = false;
+    setActiveThread(null);
   }, []);
   const bottomRef = useRef<HTMLDivElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -177,9 +180,15 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     onReconnect: handleReconnect,
   });
 
-  // fix: popstate — 뒤로가기 시 스레드 패널 닫기 (채팅 화면 유지)
+  // fix: popstate — 스레드 열린 상태에서만 가로채기 (Next.js 네비게이션 비간섭)
   useEffect(() => {
-    const handlePopState = () => setActiveThread(null);
+    const handlePopState = (e: PopStateEvent) => {
+      if (!activeThreadRef.current) return; // 스레드 없으면 Next.js가 처리
+      // 스레드 닫기 + 현재 URL 재push → 실제 뒤로가기 취소, 채팅 화면 유지
+      activeThreadRef.current = false;
+      setActiveThread(null);
+      window.history.pushState(e.state ?? null, '', window.location.pathname + window.location.search);
+    };
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
   }, []);


### PR DESCRIPTION
## 🚨 P0 리그레션 수정

**증상**: PR #756 머지 후 `/chats` 목록에서 대화 클릭해도 채팅 상세 진입 불가

## 원인 분석

PR #756의 `closeThread()`에서 `window.history.back()` 호출이 Next.js App Router history 스택을 오염시킴.

Next.js App Router는 내부적으로 `history.pushState`를 사용해 클라이언트 네비게이션을 관리하는데, 우리 `closeThread()`의 `history.back()` 호출이 Next.js router의 navigation queue에 간섭 → `router.push()` 실패.

## 수정 내용

**`chat-view.tsx`**

| | PR #756 (버그 있음) | 이번 수정 |
|--|---|---|
| `closeThread` | `history.back()` 호출 | `setActiveThread(null)` 만 |
| `openThread` | `pushState(state, '')` URL 누락 | `pushState(state, '', pathname+search)` URL 명시 |
| `popstate` 핸들러 | 항상 `setActiveThread(null)` | `activeThreadRef` 조건부 처리 |
| 스레드 없을 때 popstate | setActiveThread(null) 호출 (불필요) | 통과 (Next.js 처리) ✅ |
| 스레드 있을 때 popstate | setActiveThread(null) | 닫기 + URL re-push (뒤로가기 취소) ✅ |

## AC 검증

- [x] AC1: `/chats` 대화 클릭 → 채팅 상세 정상 진입
- [x] AC2: 스레드 열고 뒤로가기 → 스레드 닫힘, 채팅 화면 유지
- [x] AC3 (암묵적): X버튼/모바일 뒤로가기 → closeThread → 스레드 닫힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)