### PR TITLE
feat(auth): SS-1 POST 엔드포인트 auth context 강제

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -324,6 +324,19 @@ def require_project_access(
     return project_id
 
 
+def enforce_body_context(
+    auth_org_id: uuid.UUID,
+    body_org_id: uuid.UUID | None = None,
+    body_project_id: uuid.UUID | None = None,
+    auth_project_id: str | None = None,
+) -> None:
+    """AC6/AC7: body의 org_id/project_id가 auth context와 불일치 시 403."""
+    if body_org_id is not None and body_org_id != auth_org_id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.org_id가 auth context와 불일치인")
+    if auth_project_id and body_project_id is not None and str(body_project_id) != str(auth_project_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.project_id가 auth context와 불일치인")
+
+
 async def _verify_project_in_org(
     project_id: uuid.UUID,
     org_id: uuid.UUID,

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import delete, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
@@ -59,9 +59,16 @@ async def list_docs(
 async def create_doc(
     body: DocCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> DocResponse:
-    repo = DocRepository(session, body.org_id)
+    enforce_body_context(
+        auth_org_id=org_id,
+        body_org_id=body.org_id,
+        body_project_id=body.project_id,
+        auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+    )
+    repo = DocRepository(session, org_id)
     doc = await repo.create(
         project_id=body.project_id,
         title=body.title,

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.epic import EpicRepository
 from app.schemas.epic import EpicCreate, EpicProgressResponse, EpicResponse, EpicUpdate
@@ -37,9 +37,16 @@ async def list_epics(
 async def create_epic(
     body: EpicCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> EpicResponse:
-    repo = EpicRepository(session, body.org_id)
+    enforce_body_context(
+        auth_org_id=org_id,
+        body_org_id=body.org_id,
+        body_project_id=body.project_id,
+        auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+    )
+    repo = EpicRepository(session, org_id)
     epic = await repo.create(
         project_id=body.project_id,
         title=body.title,

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.repositories.meeting import MeetingRepository
 from app.schemas.meeting import MeetingCreate, MeetingResponse, MeetingUpdate
@@ -42,10 +42,14 @@ async def create_meeting(
     body: MeetingCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> MeetingResponse:
-    auth_project_id = auth.claims.get("app_metadata", {}).get("project_id")
-    if auth_project_id and str(body.project_id) != str(auth_project_id):
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.project_id가 auth context와 불일치인")
+    enforce_body_context(
+        auth_org_id=org_id,
+        body_org_id=None,
+        body_project_id=body.project_id,
+        auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+    )
     repo = MeetingRepository(session, body.project_id)
     data = body.model_dump(exclude={"project_id"}, exclude_none=False)
     meeting = await repo.create(**{k: v for k, v in data.items() if v is not None or k in ("participants", "decisions", "action_items")})

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user
 from app.dependencies.database import get_db
 from app.repositories.meeting import MeetingRepository
 from app.schemas.meeting import MeetingCreate, MeetingResponse, MeetingUpdate
@@ -41,8 +41,11 @@ async def list_meetings(
 async def create_meeting(
     body: MeetingCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MeetingResponse:
+    auth_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    if auth_project_id and str(body.project_id) != str(auth_project_id):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.project_id가 auth context와 불일치인")
     repo = MeetingRepository(session, body.project_id)
     data = body.model_dump(exclude={"project_id"}, exclude_none=False)
     meeting = await repo.create(**{k: v for k, v in data.items() if v is not None or k in ("participants", "decisions", "action_items")})

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
 
-from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.memo import Memo, MemoAssignee, MemoReply
 from app.models.team import TeamMember
@@ -442,10 +442,18 @@ async def create_memo(
     body: CreateMemo,
     background_tasks: BackgroundTasks,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
     # AC1: conversation adapter로 라우팅 (memo row 미생성)
     from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
+
+    enforce_body_context(
+        auth_org_id=org_id,
+        body_org_id=body.org_id,
+        body_project_id=body.project_id,
+        auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+    )
 
     participant_ids: set[uuid.UUID] = set()
     if body.created_by:
@@ -459,7 +467,7 @@ async def create_memo(
     conv = Conversation(
         id=conv_id,
         project_id=body.project_id,
-        org_id=body.org_id,
+        org_id=org_id,
         type="group",
         title=body.title,
         created_by=body.created_by,
@@ -499,7 +507,7 @@ async def create_memo(
         "create_memo routed to conversation conversation_id=%s message_id=%s project_id=%s entity_links=%d",
         conv.id, root_msg.id, body.project_id, len(all_embed_list),
     )
-    publish_event(str(body.org_id), "memo_created", {"id": str(conv.id)})
+    publish_event(str(org_id), "memo_created", {"id": str(conv.id)})
 
     # webhook + side effects
     memo_recipient_ids: set[uuid.UUID] = set()
@@ -529,7 +537,7 @@ async def create_memo(
         background_tasks.add_task(
             _memo_side_effects_bg,
             memo_id=conv.id,
-            org_id=body.org_id,
+            org_id=org_id,
             project_id=body.project_id,
             assigned_to=body.assigned_to or (body.assigned_to_ids[0] if body.assigned_to_ids else None),
             created_by=body.created_by,
@@ -546,7 +554,7 @@ async def create_memo(
         "message_id": str(root_msg.id),
         "deprecated": True,
         "project_id": str(body.project_id) if body.project_id else None,
-        "org_id": str(body.org_id),
+        "org_id": str(org_id),
         "memo_type": body.memo_type or "memo",
         "title": body.title,
         "content": body.content,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
@@ -102,9 +102,16 @@ async def list_stories(
 async def create_story(
     body: StoryCreate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StoryResponse:
-    repo = StoryRepository(session, body.org_id)
+    enforce_body_context(
+        auth_org_id=org_id,
+        body_org_id=body.org_id,
+        body_project_id=body.project_id,
+        auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+    )
+    repo = StoryRepository(session, org_id)
     story = await repo.create(
         project_id=body.project_id,
         title=body.title,

--- a/backend/tests/test_meetings.py
+++ b/backend/tests/test_meetings.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+ORG_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
 MEETING_ID = uuid.uuid4()
 
@@ -41,7 +42,7 @@ async def _client():
     ctx = MagicMock()
     ctx.user_id = str(uuid.uuid4())
     ctx.email = "test@example.com"
-    ctx.claims = {}
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}}
 
     mock_session = AsyncMock()
 

--- a/backend/tests/test_ss1_auth_context.py
+++ b/backend/tests/test_ss1_auth_context.py
@@ -1,0 +1,153 @@
+"""SS-1: auth context 강제 — AC6/AC7 mismatch 403 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+OTHER_ORG_ID = uuid.uuid4()
+OTHER_PROJECT_ID = uuid.uuid4()
+
+
+def _mk_ctx(org_id: uuid.UUID = ORG_ID, project_id: uuid.UUID = PROJECT_ID) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}}
+    ctx.org_id = str(org_id)
+    return ctx
+
+
+async def _client(ctx: MagicMock):
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── AC6: body.org_id ≠ auth.org_id → 403 ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_doc_org_id_mismatch_403():
+    """AC6: docs POST — body.org_id ≠ auth.org_id → 403."""
+    ctx = _mk_ctx(org_id=ORG_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/docs", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(OTHER_ORG_ID),
+                "title": "악의적 doc",
+                "slug": "evil-doc",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_story_org_id_mismatch_403():
+    """AC6: stories POST — body.org_id ≠ auth.org_id → 403."""
+    ctx = _mk_ctx(org_id=ORG_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/stories", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(OTHER_ORG_ID),
+                "title": "악의적 스토리",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_epic_org_id_mismatch_403():
+    """AC6: epics POST — body.org_id ≠ auth.org_id → 403."""
+    ctx = _mk_ctx(org_id=ORG_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/epics", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(OTHER_ORG_ID),
+                "title": "악의적 에픽",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_memo_org_id_mismatch_403():
+    """AC6: memos POST — body.org_id ≠ auth.org_id → 403."""
+    ctx = _mk_ctx(org_id=ORG_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/memos", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(OTHER_ORG_ID),
+                "title": "악의적 메모",
+                "content": "test",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC7: body.project_id ≠ auth.project_id → 403 ───────────────────────────
+
+@pytest.mark.anyio
+async def test_create_doc_project_id_mismatch_403():
+    """AC7: docs POST — body.project_id ≠ auth.project_id → 403."""
+    ctx = _mk_ctx(project_id=PROJECT_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/docs", json={
+                "project_id": str(OTHER_PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "title": "교차 프로젝트 doc",
+                "slug": "cross-project-doc",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_meeting_project_id_mismatch_403():
+    """AC7: meetings POST — body.project_id ≠ auth.project_id → 403."""
+    ctx = _mk_ctx(project_id=PROJECT_ID)
+    client, app = await _client(ctx)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/meetings", json={
+                "project_id": str(OTHER_PROJECT_ID),
+                "title": "교차 프로젝트 미팅",
+                "meeting_type": "general",
+            })
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- `create_doc`, `create_story`, `create_epic`, `create_meeting`, `create_memo` 전량에 `get_verified_org_id` dependency 주입
- `body.org_id` 대신 auth context의 org_id로 Repository 초기화 (AC1~AC5)
- `enforce_body_context()` 헬퍼 신설 → body.org_id ≠ auth.org_id 시 403 (AC6)
- body.project_id ≠ auth.project_id 시 403 (AC7)
- `conversations.py:create_conversation` 은 기존에 이미 `get_verified_org_id` 사용 중 (AC5 부분 완료)

## Test plan
- [ ] AC1: `POST /api/v2/docs` — API Key로 다른 org_id body 전송 → 403
- [ ] AC2: `POST /api/v2/stories` — 동일 검증
- [ ] AC3: `POST /api/v2/epics` — 동일 검증
- [ ] AC4: `POST /api/v2/meetings` — body.project_id 불일치 → 403
- [ ] AC5: `POST /api/v2/memos` — body.org_id 불일치 → 403
- [ ] AC6: body.org_id ≠ auth.org_id → 403
- [ ] AC7: body.project_id ≠ auth.project_id → 403
- [ ] AC8: 기존 에이전트 6명 정상 동작 (올바른 org_id/project_id 전송 시 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)