### PR TITLE
fix: send_memo 웹훅 발송 바이패스 복원

### DIFF
--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -41,9 +41,9 @@ export function registerMemosTools(server: McpServer) {
     } catch (e) { return handleError(e); }
   });
 
-  // [DEPRECATED] send_memo — 내부적으로 conversation API로 라우팅됨 (S-B2).
+  // [DEPRECATED] send_memo — /api/v2/memos POST로 라우팅 (웹훅 발송 경로 복원, S-B2 버그 수정).
   // 기존 에이전트 호환성 유지. 스프린터블 운영이 send_memo 없이 검증된 후 제거 예정.
-  server.tool('send_memo', '[DEPRECATED] Send a memo. Internally routes to conversation API. Will be removed after memo-free sprint operation is validated.', {
+  server.tool('send_memo', '[DEPRECATED] Send a memo. Routes to /api/v2/memos which fires webhooks to assigned members. Will be removed after memo-free sprint operation is validated.', {
     project_id: z.string().optional(),
     title: z.string().optional(),
     content: z.string(),
@@ -51,29 +51,21 @@ export function registerMemosTools(server: McpServer) {
     assigned_to: z.string().optional().describe('Single team member ID (legacy, use assigned_to_ids for multiple)'),
     assigned_to_ids: z.array(z.string()).optional().describe('Team member IDs to assign (supports multiple assignees)'),
     trigger_type: z.string().optional().describe('Workflow stage (kickoff, qa_request, review, merge_request)'),
-  }, async ({ assigned_to, assigned_to_ids, project_id, content, title, ...rest }) => {
+  }, async ({ assigned_to, assigned_to_ids, project_id, content, title, memo_type, trigger_type }) => {
     try {
-      const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
-
-      // AC3: conversation + root message 생성으로 라우팅
-      const convPayload: Record<string, unknown> = {
-        type: 'group',
+      const body: Record<string, unknown> = {
+        content,
         title: title ?? '(memo)',
-        participant_ids: resolvedIds ?? [],
         project_id: project_id ?? '',
+        assigned_to,
+        assigned_to_ids,
+        memo_type,
       };
-      const conv = await pmApi('/api/v2/conversations', { method: 'POST', body: JSON.stringify(convPayload) }) as Record<string, unknown>;
-      const conversationId = conv.id as string;
-
-      const msgPayload = { content };
-      const msg = await pmApi(`/api/v2/conversations/${encodeURIComponent(conversationId)}/messages`, {
-        method: 'POST', body: JSON.stringify(msgPayload),
-      }) as Record<string, unknown>;
-      const msgData = (msg.data ?? msg) as Record<string, unknown>;
-      const messageId = msgData.id as string;
-
-      // AC5: 기존 memo_id + 신규 conversation_id/message_id + deprecated
-      return ok({ memo_id: conversationId, conversation_id: conversationId, message_id: messageId, deprecated: true, ...rest });
+      if (trigger_type) {
+        body.memo_metadata = { trigger_type };
+      }
+      const data = await pmApi('/api/v2/memos', { method: 'POST', body: JSON.stringify(body) }) as Record<string, unknown>;
+      return ok({ ...data, deprecated: true, trigger_type });
     } catch (e) { return handleError(e); }
   });
 


### PR DESCRIPTION
## Summary
- S-B2(PR #729)에서 send_memo가 `/api/v2/conversations` 직접 호출로 변경되면서 웹훅 발송 경로(`_fire_webhook`) 바이패스됨
- `/api/v2/memos` POST로 복원하여 백엔드 `create_memo` 엔드포인트의 웹훅 발송 경로 정상 실행
- assigned_to 지정 시 Discord 웹훅 즉시 발송 복원

## Test plan
- [ ] send_memo(assigned_to=까심군) → 까심군 Discord 채널에 웹훅 즉시 도달
- [ ] reply_memo → 기존과 동일하게 웹훅 발송 (변경 없음)
- [ ] send_memo 응답 형태 호환성 유지 (memo_id, conversation_id, message_id, deprecated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**P0 긴급 재난 대응** — PO 직접 수정 (선생님 지시)