### PR TITLE
[SS-3] GET /api/v2/auth/me + MCP env var 정리

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1016,3 +1016,24 @@ async def switch_project(
 
     await session.commit()
     return _ok(tokens)
+
+
+# ─── GET /api/v2/auth/me ─────────────────────────────────────────────────────
+
+class AuthMeResponse(BaseModel):
+    member_id: str
+    org_id: str | None
+    project_id: str | None
+
+
+@router.get("/me", response_model=AuthMeResponse)
+async def get_auth_me(
+    auth: AuthContext = Depends(get_current_user),
+) -> AuthMeResponse:
+    """API Key Bearer 인증으로 바인딩된 member_id, org_id, project_id 반환."""
+    meta = auth.claims.get("app_metadata", {})
+    return AuthMeResponse(
+        member_id=auth.user_id,
+        org_id=auth.org_id or meta.get("org_id"),
+        project_id=meta.get("project_id"),
+    )

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -9,7 +9,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import { configurePmApi } from './pm-api.js';
+import { configurePmApi, resolveAuthContext } from './pm-api.js';
 import { startSseBridge } from './sse-bridge.js';
 import { registerCoreTools } from './tools/core.js';
 import { registerRetroTools } from './tools/retro.js';
@@ -33,7 +33,6 @@ import { registerAuditTools } from './tools/audit.js';
 const PM_API_URL = process.env['PM_API_URL'] ?? '';
 const AGENT_API_KEY = process.env['AGENT_API_KEY'] ?? '';
 const MCP_API_KEY = process.env['MCP_API_KEY'] ?? '';
-const MEMBER_ID = process.env['CURRENT_MEMBER_ID'] ?? process.env['MEMBER_ID'] ?? '';
 const SSE_BACKEND_URL = process.env['SSE_BACKEND_URL'] ?? '';
 const MODE = process.env['MCP_MODE'] ?? 'stdio'; // 'stdio' | 'sse'
 const PORT = Number(process.env['MCP_PORT'] ?? '3100');
@@ -112,9 +111,19 @@ async function main() {
     await server.connect(transport);
     console.error('Sprintable MCP Server (stdio) connected');
 
-    // FastAPI SSE 자동 연결 — MEMBER_ID 있을 때만
-    if (MEMBER_ID) {
-      startSseBridge(PM_API_URL, AGENT_API_KEY, MEMBER_ID, SSE_BACKEND_URL || undefined,
+    // /api/v2/auth/me 로 context 자동 resolve
+    let memberId = '';
+    try {
+      const ctx = await resolveAuthContext();
+      memberId = ctx.memberId;
+      console.error(`Auth context resolved: member=${memberId}`);
+    } catch (err) {
+      console.error('Warning: auth/me resolve failed — SSE bridge disabled:', err);
+    }
+
+    // FastAPI SSE 자동 연결 — memberId 있을 때만
+    if (memberId) {
+      startSseBridge(PM_API_URL, AGENT_API_KEY, memberId, SSE_BACKEND_URL || undefined,
         // S32: notifications/claude/channel → conversation turn 자동 주입
         (eventType, data) => {
           server.server.notification({

--- a/packages/mcp-server/src/pm-api.ts
+++ b/packages/mcp-server/src/pm-api.ts
@@ -18,6 +18,9 @@ export class PmApiError extends Error {
 
 let _pmApiUrl: string;
 let _agentApiKey: string;
+let _memberId: string = '';
+let _orgId: string = '';
+let _projectId: string = '';
 
 /**
  * Call once at startup to configure the module-level credentials.
@@ -28,6 +31,18 @@ export function configurePmApi(pmApiUrl: string, agentApiKey: string): void {
   if (!agentApiKey) throw new Error('AGENT_API_KEY is required');
   _pmApiUrl = pmApiUrl.replace(/\/$/, ''); // strip trailing slash
   _agentApiKey = agentApiKey;
+}
+
+/**
+ * Call after configurePmApi() to resolve member_id/org_id/project_id from the API Key.
+ * Caches the result in module-level variables for use in request body injection.
+ */
+export async function resolveAuthContext(): Promise<{ memberId: string; orgId: string; projectId: string }> {
+  const res = await pmApi<{ member_id: string; org_id: string | null; project_id: string | null }>('/api/v2/auth/me');
+  _memberId = res.member_id ?? '';
+  _orgId = res.org_id ?? '';
+  _projectId = res.project_id ?? '';
+  return { memberId: _memberId, orgId: _orgId, projectId: _projectId };
 }
 
 export type PmApiInit = Omit<RequestInit, 'headers'> & {
@@ -59,9 +74,9 @@ export async function pmApi<T = unknown>(path: string, init: PmApiInit = {}): Pr
   ) {
     try {
       const parsed = JSON.parse(init.body);
-      if (!parsed.project_id && process.env.PROJECT_ID) parsed.project_id = process.env.PROJECT_ID;
-      if (!parsed.created_by && process.env.CURRENT_MEMBER_ID) parsed.created_by = process.env.CURRENT_MEMBER_ID;
-      if (!parsed.org_id && process.env.ORG_ID) parsed.org_id = process.env.ORG_ID;
+      if (!parsed.project_id && _projectId) parsed.project_id = _projectId;
+      if (!parsed.created_by && _memberId) parsed.created_by = _memberId;
+      if (!parsed.org_id && _orgId) parsed.org_id = _orgId;
       init = { ...init, body: JSON.stringify(parsed) };
     } catch { /* body가 JSON이 아닌 경우 원본 유지 */ }
   }


### PR DESCRIPTION
## Summary

- `GET /api/v2/auth/me` 엔드포인트 추가 (`backend/app/routers/auth.py`)
  - Bearer API Key 인증으로 호출 → 바인딩된 `member_id`, `org_id`, `project_id` 반환
  - 유효하지 않은/만료/revoke된 API Key → 401 (기존 `get_current_user` dependency가 처리)
- MCP 서버 env var 정리 (`packages/mcp-server/src/`)
  - `pm-api.ts`: `resolveAuthContext()` 추가 — 부팅 시 `/api/v2/auth/me` 자동 호출, 결과를 모듈 변수에 캐싱. body 주입에서 `process.env.PROJECT_ID` 등 제거
  - `index.ts`: `CURRENT_MEMBER_ID` env var 제거, `resolveAuthContext()` 호출로 대체

## AC Checklist

- [x] AC1: GET /api/v2/auth/me 엔드포인트 존재 + Bearer API Key 인증
- [x] AC2: 응답에 member_id, org_id, project_id 포함
- [x] AC3: 유효하지 않은 API Key → 401 (get_current_user)
- [x] AC4: 만료된 API Key → 401 (get_current_user)
- [x] AC5: revoke된 API Key → 401 (get_current_user)
- [ ] AC6: 오르테가 API Key로 호출 시 올바른 값 반환 — dev 배포 후 확인 필요

## Test plan

- [ ] dev 배포 후 `curl -H "Authorization: Bearer sk_live_9e269a6y..." https://sprintable-backend-dev.../api/v2/auth/me` 로 AC6 확인
- [ ] MCP 서버 재시작 시 `CURRENT_MEMBER_ID` 없이 SSE bridge 정상 연결 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)