### PR TITLE
fix: conversation webhook events 필터 backwards compatible 수정

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -72,10 +72,10 @@ async def deliver_conversation_message_webhook(
                 )
             )).scalars().all()
 
-            # conversation.message_created 이벤트 구독 중인 webhook만 필터
+            # events가 NULL/빈 배열이면 전체 이벤트 구독으로 간주 (backwards compatible)
             target_webhooks = [
                 wh for wh in wh_rows
-                if _EVENT_TYPE in (wh.events or [])
+                if not wh.events or _EVENT_TYPE in wh.events
             ]
 
             # AC2: 멘션된 member에 속한 webhook도 추가 조회 (early return 전, participant 여부 무관)


### PR DESCRIPTION
## Summary
- conversation webhook이 events 미등록 WebhookConfig에도 발동되도록 수정
- events 배열 NULL/빈 배열 → 전체 이벤트 구독으로 간주 (backwards compatible)
- 에이전트 간 통신 불통 긴급 수정 (재난복구프로토콜)

## Root Cause
기존 에이전트 WebhookConfig에 `"conversation.message_created"` 이벤트 미등록 → `deliver_conversation_message_webhook()` 필터링에서 전량 제외 → 웹훅 미발동

## Change
```python
# Before
if _EVENT_TYPE in (wh.events or [])
# After  
if not wh.events or _EVENT_TYPE in wh.events
```

## Test plan
- [ ] reply_memo assigned_to=까심군 → Discord 웹훅 수신 확인
- [ ] send_chat_message → 웹훅 발동 확인
- [ ] 기존 events 구독 WebhookConfig 동작 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)