### PR TITLE
[S0-H1] reply_memo conversation thread mentioned_ids 전달 누락 수정

### DIFF
--- a/packages/mcp-server/src/tools/memos.ts
+++ b/packages/mcp-server/src/tools/memos.ts
@@ -125,7 +125,9 @@ export function registerMemosTools(server: McpServer) {
 
       if (rootMsgId) {
         // conversation thread reply
+        const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
         const msgPayload: Record<string, unknown> = { content, thread_id: rootMsgId };
+        if (resolvedIds) msgPayload.mentioned_ids = resolvedIds;
         const msg = await pmApi(`/api/v2/conversations/${encodeURIComponent(memo_id)}/messages`, {
           method: 'POST', body: JSON.stringify(msgPayload),
         }) as Record<string, unknown>;


### PR DESCRIPTION
## Summary

- `reply_memo`가 conversation thread 경로로 실행될 때 `assigned_to`/`assigned_to_ids`가 `msgPayload`에 포함되지 않아 수신자 알림 누락 발생
- `resolvedIds` resolved 후 `mentioned_ids`로 conversation message POST body에 추가

## 변경 내용

```typescript
// 수정 전
const msgPayload: Record<string, unknown> = { content, thread_id: rootMsgId };

// 수정 후
const resolvedIds = assigned_to_ids ?? (assigned_to ? [assigned_to] : undefined);
const msgPayload: Record<string, unknown> = { content, thread_id: rootMsgId };
if (resolvedIds) msgPayload.mentioned_ids = resolvedIds;
```

## Test plan

- [ ] `pnpm build` 통과 ✅
- [ ] reply_memo 호출 시 assigned_to 지정한 멤버에게 알림 도달 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)