### PR TITLE
[S0-2] Sprint CRUD MCP 도구 3건 추가 (create/update/delete)

### DIFF
--- a/packages/mcp-server/src/tools/sprints.ts
+++ b/packages/mcp-server/src/tools/sprints.ts
@@ -54,4 +54,50 @@ export function registerSprintsTools(server: McpServer) {
       return ok(data);
     } catch (e) { return handleError(e); }
   });
+
+  server.tool('create_sprint', 'Create a new sprint', {
+    project_id: z.string().describe('Project ID'),
+    title: z.string().describe('Sprint title'),
+    start_date: z.string().optional().describe('Start date (ISO date, e.g. 2026-05-01)'),
+    end_date: z.string().optional().describe('End date (ISO date, e.g. 2026-05-14)'),
+    team_size: z.number().optional().describe('Team size'),
+  }, async ({ project_id, title, start_date, end_date, team_size }) => {
+    try {
+      const body: Record<string, unknown> = { project_id, title };
+      if (start_date) body.start_date = start_date;
+      if (end_date) body.end_date = end_date;
+      if (team_size !== undefined) body.team_size = team_size;
+      const data = await pmApi('/api/v2/sprints', { method: 'POST', body: JSON.stringify(body) });
+      return ok(data);
+    } catch (e) { return handleError(e); }
+  });
+
+  server.tool('update_sprint', 'Update sprint fields', {
+    sprint_id: z.string().describe('Sprint ID'),
+    title: z.string().optional().describe('Sprint title'),
+    start_date: z.string().optional().describe('Start date (ISO date)'),
+    end_date: z.string().optional().describe('End date (ISO date)'),
+    team_size: z.number().optional().describe('Team size'),
+  }, async ({ sprint_id, title, start_date, end_date, team_size }) => {
+    try {
+      const body: Record<string, unknown> = {};
+      if (title !== undefined) body.title = title;
+      if (start_date !== undefined) body.start_date = start_date;
+      if (end_date !== undefined) body.end_date = end_date;
+      if (team_size !== undefined) body.team_size = team_size;
+      const data = await pmApi(`/api/v2/sprints/${encodeURIComponent(sprint_id)}`, {
+        method: 'PATCH', body: JSON.stringify(body),
+      });
+      return ok(data);
+    } catch (e) { return handleError(e); }
+  });
+
+  server.tool('delete_sprint', 'Delete sprint', {
+    sprint_id: z.string().describe('Sprint ID'),
+  }, async ({ sprint_id }) => {
+    try {
+      const data = await pmApi(`/api/v2/sprints/${encodeURIComponent(sprint_id)}`, { method: 'DELETE' });
+      return ok(data);
+    } catch (e) { return handleError(e); }
+  });
 }


### PR DESCRIPTION
## Summary

- `packages/mcp-server/src/tools/sprints.ts`에 `create_sprint`, `update_sprint`, `delete_sprint` 3개 도구 추가
- 백엔드에 이미 존재하는 POST/PATCH/DELETE 엔드포인트 포팅

## AC Checklist

| AC | 내용 | 상태 |
|----|------|------|
| AC1: create_sprint — POST /api/v2/sprints | project_id, title 필수, start_date/end_date/team_size 선택 | ✅ |
| AC2: update_sprint — PATCH /api/v2/sprints/{id} | sprint_id 필수, 나머지 선택 | ✅ |
| AC3: delete_sprint — DELETE /api/v2/sprints/{id} | sprint_id 필수 | ✅ |
| AC4: 에러 핸들링 — 기존 패턴(PmApiError → err()) 동일 | handleError() 사용 | ✅ |
| AC5: pnpm build 성공 | tsc 에러 없음 | ✅ |
| AC6: 기존 5개 도구 회귀 없음 | list_sprints/activate_sprint/close_sprint 등 변경 없음 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)