### PR TITLE
[S0-3] v2 suffix 도구명 정규화 6건 + 최종 87개 검증

### DIFF
--- a/packages/mcp-server/src/tools/smoke.test.ts
+++ b/packages/mcp-server/src/tools/smoke.test.ts
@@ -1067,7 +1067,7 @@ describe('standup-retro tools via pmApi', () => {
     vi.stubGlobal('fetch', (url: string, init?: RequestInit) => Promise.resolve(handler(url, init)));
   }
 
-  it('get_standup_v2 calls GET /api/v2/standup with member_id and date', async () => {
+  it('get_standup calls GET /api/v2/standup with member_id and date', async () => {
     stubFetch((url) => {
       expect(url).toContain('/api/v2/standup?');
       expect(url).toContain('member_id=member-alpha');
@@ -1076,11 +1076,11 @@ describe('standup-retro tools via pmApi', () => {
       return new Response(JSON.stringify({ data: { id: 'standup-1', author_id: 'member-alpha' } }), { status: 200 });
     });
 
-    const result = await harness.invoke('get_standup_v2', { project_id: 'project-alpha', member_id: 'member-alpha', date: '2026-04-06' });
+    const result = await harness.invoke('get_standup', { project_id: 'project-alpha', member_id: 'member-alpha', date: '2026-04-06' });
     expect(result).toEqual({ data: { id: 'standup-1', author_id: 'member-alpha' } });
   });
 
-  it('save_standup_v2 calls POST /api/v2/standup with body fields', async () => {
+  it('save_standup calls POST /api/v2/standup with body fields', async () => {
     stubFetch((url, init) => {
       expect(url).toBe('http://test-pm-api/api/v2/standup');
       expect(init?.method).toBe('POST');
@@ -1089,18 +1089,18 @@ describe('standup-retro tools via pmApi', () => {
       return new Response(JSON.stringify({ data: { id: 'standup-new', author_id: 'member-alpha' } }), { status: 200 });
     });
 
-    const result = await harness.invoke('save_standup_v2', { author_id: 'member-alpha', date: '2026-04-06', done: 'Done', plan: 'Plan' });
+    const result = await harness.invoke('save_standup', { author_id: 'member-alpha', date: '2026-04-06', done: 'Done', plan: 'Plan' });
     expect(result).toEqual({ data: { id: 'standup-new', author_id: 'member-alpha' } });
   });
 
-  it('list_standup_entries_v2 calls GET /api/v2/standup with date param', async () => {
+  it('list_standup_entries calls GET /api/v2/standup with date param', async () => {
     stubFetch((url) => {
       expect(url).toContain('/api/v2/standup?');
       expect(url).toContain('date=2026-04-06');
       return new Response(JSON.stringify({ data: [{ id: 'standup-1' }] }), { status: 200 });
     });
 
-    const result = await harness.invoke('list_standup_entries_v2', { project_id: 'project-alpha', date: '2026-04-06' });
+    const result = await harness.invoke('list_standup_entries', { project_id: 'project-alpha', date: '2026-04-06' });
     expect(result).toEqual({ data: [{ id: 'standup-1' }] });
   });
 
@@ -1151,7 +1151,7 @@ describe('standup-retro tools via pmApi', () => {
     expect(result).toEqual({ data: { id: 'session-new', title: 'Sprint 1 Retro' } });
   });
 
-  it('change_retro_phase_v2 calls PATCH /api/v2/retro-sessions/:id with phase', async () => {
+  it('change_retro_phase calls PATCH /api/v2/retro-sessions/:id with phase', async () => {
     stubFetch((url, init) => {
       expect(url).toContain('/api/v2/retro-sessions/session-1?');
       expect(url).toContain('project_id=project-alpha');
@@ -1161,11 +1161,11 @@ describe('standup-retro tools via pmApi', () => {
       return new Response(JSON.stringify({ data: { id: 'session-1', phase: 'group' } }), { status: 200 });
     });
 
-    const result = await harness.invoke('change_retro_phase_v2', { project_id: 'project-alpha', session_id: 'session-1', phase: 'group' });
+    const result = await harness.invoke('change_retro_phase', { project_id: 'project-alpha', session_id: 'session-1', phase: 'group' });
     expect(result).toEqual({ data: { id: 'session-1', phase: 'group' } });
   });
 
-  it('add_retro_item_v2 calls POST /api/v2/retro-sessions/:id/items', async () => {
+  it('add_retro_item calls POST /api/v2/retro-sessions/:id/items', async () => {
     stubFetch((url, init) => {
       expect(url).toContain('/api/v2/retro-sessions/session-1/items?');
       expect(init?.method).toBe('POST');
@@ -1174,18 +1174,18 @@ describe('standup-retro tools via pmApi', () => {
       return new Response(JSON.stringify({ data: { id: 'item-new', category: 'good' } }), { status: 200 });
     });
 
-    const result = await harness.invoke('add_retro_item_v2', { project_id: 'project-alpha', session_id: 'session-1', category: 'good', text: 'Great work', author_id: 'member-alpha' });
+    const result = await harness.invoke('add_retro_item', { project_id: 'project-alpha', session_id: 'session-1', category: 'good', text: 'Great work', author_id: 'member-alpha' });
     expect(result).toEqual({ data: { id: 'item-new', category: 'good' } });
   });
 
-  it('export_retro_v2 calls GET /api/v2/retro-sessions/:id/export', async () => {
+  it('export_retro calls GET /api/v2/retro-sessions/:id/export', async () => {
     stubFetch((url) => {
       expect(url).toContain('/api/v2/retro-sessions/session-1/export?');
       expect(url).toContain('project_id=project-alpha');
       return new Response(JSON.stringify({ data: { markdown: '# Retro\n' } }), { status: 200 });
     });
 
-    const result = await harness.invoke('export_retro_v2', { project_id: 'project-alpha', session_id: 'session-1' });
+    const result = await harness.invoke('export_retro', { project_id: 'project-alpha', session_id: 'session-1' });
     expect(result).toEqual({ data: { markdown: '# Retro\n' } });
   });
 

--- a/packages/mcp-server/src/tools/standup-retro.ts
+++ b/packages/mcp-server/src/tools/standup-retro.ts
@@ -101,7 +101,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('get_standup_v2', 'Get standup entry for member+date (v2)', {
+  server.tool('get_standup', 'Get standup entry for member+date', {
     project_id: z.string().optional().describe('Explicit project ID'),
     member_id: z.string(),
     date: z.string().describe('YYYY-MM-DD'),
@@ -116,7 +116,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('save_standup_v2', 'Save/update standup entry (v2)', {
+  server.tool('save_standup', 'Save/update standup entry', {
     project_id: z.string().optional(),
     author_id: z.string(),
     date: z.string().describe('YYYY-MM-DD'),
@@ -137,7 +137,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('list_standup_entries_v2', 'List standup entries for date (v2)', {
+  server.tool('list_standup_entries', 'List standup entries for date', {
     project_id: z.string().optional(),
     current_member_id: z.string().optional(),
     date: z.string().describe('YYYY-MM-DD'),
@@ -153,7 +153,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('change_retro_phase_v2', 'Change retro session phase (v2)', {
+  server.tool('change_retro_phase', 'Change retro session phase', {
     project_id: z.string(),
     session_id: z.string(),
     phase: z.enum(['collect', 'group', 'vote', 'discuss', 'action', 'closed']),
@@ -169,7 +169,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('add_retro_item_v2', 'Add retro item (v2)', {
+  server.tool('add_retro_item', 'Add retro item', {
     project_id: z.string(),
     session_id: z.string(),
     category: z.enum(['good', 'bad', 'improve']),
@@ -187,7 +187,7 @@ export function registerStandupRetroTools(server: McpServer) {
     }
   });
 
-  server.tool('export_retro_v2', 'Export retro as markdown (v2)', {
+  server.tool('export_retro', 'Export retro as markdown', {
     project_id: z.string(),
     session_id: z.string(),
   }, async ({ project_id, session_id }) => {


### PR DESCRIPTION
## Summary

- `standup-retro.ts`에서 v2 suffix 도구명 6건을 정식명으로 리네임
- 백엔드 API 경로(`/api/v2/...`)는 그대로 유지
- smoke.test.ts 리네임 반영
- 최종 도구 카운트 **87개** 확인

## 리네임 목록

| 변경 전 | 변경 후 |
|---------|---------|
| `get_standup_v2` | `get_standup` |
| `save_standup_v2` | `save_standup` |
| `list_standup_entries_v2` | `list_standup_entries` |
| `change_retro_phase_v2` | `change_retro_phase` |
| `add_retro_item_v2` | `add_retro_item` |
| `export_retro_v2` | `export_retro` |

## Test plan

- [x] `pnpm build` PASS
- [x] smoke.test.ts 95 passed (기존 실패 4건은 변경 무관)
- [x] 도구 카운트 87개 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)