### PR TITLE
fix(mcp): SSE 재연결 백오프 축소 — 긴급재난복구

### DIFF
--- a/packages/mcp-server/src/sse-bridge.ts
+++ b/packages/mcp-server/src/sse-bridge.ts
@@ -4,8 +4,8 @@
  * 연결 끊김 시 exponential backoff 재연결.
  */
 
-const BASE_DELAY_MS = 5_000;
-const MAX_DELAY_MS = 60_000;
+const BASE_DELAY_MS = 1_000;
+const MAX_DELAY_MS = 10_000;
 const JITTER_MS = 500;
 
 export type SseBridgeEventHandler = (eventType: string, data: unknown) => void;


### PR DESCRIPTION
## Summary
- `BASE_DELAY_MS` 5000 → 1000 (5초 → 1초)
- `MAX_DELAY_MS` 60000 → 10000 (60초 → 10초)

## Why
Cloud Run 리비전 배포 시 에이전트 SSE 연결 전량 소멸. 재연결 백오프가 5~60초로 그 동안 에이전트 간 실시간 통신 불통. 1~10초로 축소하여 복구 속도 개선.

## Test plan
- [ ] SSE 연결 끊기 → 1초 내 재연결 시도 확인
- [ ] 최대 백오프 10초 내 재연결 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)