### PR TITLE
feat(mcp): S1-4 — ok()/err() 응답 헬퍼 신설 + ping() 적용

### DIFF
--- a/backend/mcp/response.py
+++ b/backend/mcp/response.py
@@ -2,15 +2,29 @@
 from __future__ import annotations
 
 import json
+import uuid
+from datetime import date, datetime
 
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
+
+
+def _default_serializer(obj: object) -> str:
+    """datetime/UUID → JSON 직렬화 가능 타입으로 변환."""
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, uuid.UUID):
+        return str(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def ok(data: object) -> list[TextContent]:
     """성공 응답 — data를 JSON 직렬화해 TextContent 리스트로 반환."""
-    return [TextContent(type="text", text=json.dumps(data, indent=2, ensure_ascii=False))]
+    return [TextContent(type="text", text=json.dumps(data, indent=2, ensure_ascii=False, default=_default_serializer))]
 
 
-def err(msg: str) -> list[TextContent]:
-    """오류 응답 — 'Error: {msg}' 형식의 TextContent 리스트로 반환."""
-    return [TextContent(type="text", text=f"Error: {msg}")]
+def err(msg: str) -> CallToolResult:
+    """오류 응답 — isError=True CallToolResult 반환. 에이전트가 에러로 구분 가능."""
+    return CallToolResult(
+        content=[TextContent(type="text", text=f"Error: {msg}")],
+        isError=True,
+    )

--- a/backend/mcp/response.py
+++ b/backend/mcp/response.py
@@ -1,0 +1,16 @@
+"""공통 응답 헬퍼 — TS ok()/err() 패턴 호환 TextContent 래퍼."""
+from __future__ import annotations
+
+import json
+
+from mcp.types import TextContent
+
+
+def ok(data: object) -> list[TextContent]:
+    """성공 응답 — data를 JSON 직렬화해 TextContent 리스트로 반환."""
+    return [TextContent(type="text", text=json.dumps(data, indent=2, ensure_ascii=False))]
+
+
+def err(msg: str) -> list[TextContent]:
+    """오류 응답 — 'Error: {msg}' 형식의 TextContent 리스트로 반환."""
+    return [TextContent(type="text", text=f"Error: {msg}")]

--- a/backend/mcp/server.py
+++ b/backend/mcp/server.py
@@ -1,6 +1,8 @@
 from mcp.server.fastmcp import FastMCP
+from mcp.types import TextContent
 
 from .config import settings
+from .response import ok
 
 mcp = FastMCP(
     name="sprintable-mcp-python",
@@ -12,6 +14,6 @@ mcp = FastMCP(
 
 
 @mcp.tool()
-def ping() -> str:
+def ping() -> list[TextContent]:
     """서버 생존 확인용 smoke tool."""
-    return "pong"
+    return ok({"status": "pong"})


### PR DESCRIPTION
## 스토리

S1-4: 응답 포맷 — TS ok()/err() 호환 text JSON (E-MCP-PYTHON)

## 구현 내용

### `backend/mcp/response.py` (신설)

```python
def ok(data: object) -> list[TextContent]:
    return [TextContent(type="text", text=json.dumps(data, indent=2, ensure_ascii=False))]

def err(msg: str) -> list[TextContent]:
    return [TextContent(type="text", text=f"Error: {msg}")]
```

- TS `ok()`/`err()` 패턴과 동일한 포맷 — `content[0].type == "text"`, `content[0].text == JSON.stringify(data, null, 2)` 호환
- `ensure_ascii=False` — 한글 등 유니코드 직렬화

### `backend/mcp/server.py` (수정)

- `ping()` 반환 타입 `str` → `list[TextContent]`, `ok({"status": "pong"})` 적용

## 테스트

- [ ] `ping()` 호출 → `content[0].text == '{\n  "status": "pong"\n}'` 확인
- [ ] `err("test error")` → `content[0].text == "Error: test error"` 확인