### PR TITLE
fix(webhook): P0 — Discord webhook URL 감지 + content 포맷 변환

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -26,6 +26,26 @@ _MAX_RETRIES = 3
 _BACKOFF_BASE = 1.0  # seconds
 
 
+_DISCORD_URL_PATTERNS = ("discord.com/api/webhooks", "discordapp.com/api/webhooks")
+
+
+def _is_discord_url(url: str) -> bool:
+    return any(pat in url for pat in _DISCORD_URL_PATTERNS)
+
+
+def _to_discord_payload(payload: dict) -> dict:
+    """Sprintable webhook payload → Discord content 포맷 변환."""
+    event_type = payload.get("event_type", "event")
+    conversation_id = payload.get("conversation_id", "")
+    sender_id = payload.get("sender_id") or ""
+    lines = [f"[{event_type}]"]
+    if conversation_id:
+        lines.append(f"conversation_id: {conversation_id}")
+    if sender_id:
+        lines.append(f"sender_id: {sender_id}")
+    return {"content": "\n".join(lines)}
+
+
 def _sign_payload(secret: str, body: bytes) -> str:
     """HMAC-SHA256 서명 — X-Hub-Signature-256 헤더용."""
     digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -34,9 +54,11 @@ def _sign_payload(secret: str, body: bytes) -> str:
 
 async def _attempt_delivery(url: str, secret: str | None, payload: dict) -> None:
     """단일 webhook HTTP POST 시도. 실패 시 예외 raise."""
-    body = json.dumps(payload, default=str).encode()
+    discord = _is_discord_url(url)
+    delivery_payload = _to_discord_payload(payload) if discord else payload
+    body = json.dumps(delivery_payload, default=str).encode()
     headers: dict[str, str] = {"Content-Type": "application/json"}
-    if secret:
+    if secret and not discord:
         headers["X-Hub-Signature-256"] = _sign_payload(secret, body)
 
     async with httpx.AsyncClient(timeout=10.0) as client:


### PR DESCRIPTION
## 근본 원인

`_attempt_delivery`가 Discord webhook URL에 generic JSON을 POST → Discord 400 거부 → 전량 실패.

## 수정 내용

`_is_discord_url()` + `_to_discord_payload()` 추가:

```python
_DISCORD_URL_PATTERNS = ("discord.com/api/webhooks", "discordapp.com/api/webhooks")

def _to_discord_payload(payload: dict) -> dict:
    # {"content": "[event_type]\nconversation_id: ...\nsender_id: ..."}
```

- Discord URL 감지 시 Discord `content` 포맷으로 변환
- Discord URL에는 HMAC 서명 헤더 미포함 (Discord 검증 불가)
- 일반 URL은 기존 동작 유지

## 참조

`backend/app/routers/memos.py` `_fire_webhook` — 동일 패턴

## 테스트

- [ ] Discord webhook URL로 `reply_memo` 발송 → Discord 채널 수신 확인
- [ ] 일반 URL webhook 기존 동작 유지 확인