### PR TITLE
fix(webhook): P0 — reply_memo 중복 발송 + channel_router 미적용 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/memos/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -22,21 +22,21 @@ export default function MemoDetailPage() {
 
   const [memo, setMemo] = useState<MemoSummary | null>(null);
 
-  const fetchMemoTitle = useCallback(async () => {
-    try {
-      const res = await fetch(`/api/memos/${id}`);
-      if (!res.ok) return;
-      const { data } = await res.json();
-      setMemo({ id: data.id, title: data.title });
-      await fetch(`/api/memos/${id}/read`, { method: 'PATCH' }).catch(() => null);
-    } catch {
-      // non-critical — ChatView will still render
-    }
-  }, [id]);
-
   useEffect(() => {
-    void fetchMemoTitle();
-  }, [fetchMemoTitle]);
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/api/memos/${id}`);
+        if (!res.ok || cancelled) return;
+        const { data } = await res.json();
+        if (!cancelled) setMemo({ id: data.id, title: data.title });
+        await fetch(`/api/memos/${id}/read`, { method: 'PATCH' }).catch(() => null);
+      } catch {
+        // non-critical — ChatView will still render
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [id]);
 
   if (!currentTeamMemberId) {
     return (

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -201,7 +201,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       setColumnTotals(newTotals);
       setColumnCursors(newCursors);
 
-      let storyIds = allStories.map((s) => s.id);
+      const storyIds = allStories.map((s) => s.id);
       if (sprintsRes.ok) { const json = await sprintsRes.json(); setSprints(json.data); }
       if (epicsRes.ok) { const json = await epicsRes.json(); setEpics(json.data); setEpicsNextCursor(json.meta?.nextCursor ?? null); }
       if (membersRes.ok) { const json = await membersRes.json(); setMembers(json.data); }

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -74,7 +74,7 @@ async def _collect_reply_webhook_urls(
             WebhookConfig.is_active.is_(True),
         )
     )
-    return [row[0] for row in rows if row[0]]
+    return list({row[0] for row in rows if row[0]})
 
 
 def _fire_webhook(url: str, content: str, title: str, memo_url: str, memo_id: str = "") -> None:
@@ -714,7 +714,14 @@ async def add_reply(
             if sender_member:
                 try:
                     from app.routers.conversations import _dispatch_conversation_event
-                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member)
+                    from app.services.channel_router import ChannelRouterError, route_message as _route
+                    discord_exclude_ids: set[uuid.UUID] = set()
+                    try:
+                        decisions = await _route(reply_msg.id, db)
+                        discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
+                    except Exception:
+                        logger.warning("channel_router pre-check failed reply_msg_id=%s", reply_msg.id)
+                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
                 except Exception:
                     logger.warning("conversation event dispatch failed memo_id=%s", id, exc_info=True)
 

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -124,9 +124,12 @@ async def deliver_conversation_message_webhook(
                     )
                 )).scalars().all()
                 existing_ids = {wh.id for wh in target_webhooks}
+                existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.id not in existing_ids:
+                    if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
+                        existing_ids.add(wh.id)
+                        existing_urls.add(wh.url)
 
             if not target_webhooks:
                 return


### PR DESCRIPTION
## 수정 3건

### 1. `memos.py` add_reply — channel_router exclude_ids 전달

`_dispatch_conversation_event()` 호출 전 `channel_router.route_message()` 로 Discord 수신자 파악 → SSE에서 exclude. `conversations.py` L635 패턴과 동일.

### 2. `_collect_reply_webhook_urls()` — URL set 중복제거

```python
# before
return [row[0] for row in rows if row[0]]
# after
return list({row[0] for row in rows if row[0]})
```

동일 URL이 여러 member_id에 등록된 경우 중복 발송 방지.

### 3. `conversation_webhook.py` — extra_wh_rows URL 기준 이중 dedup

```python
existing_ids = {wh.id for wh in target_webhooks}
existing_urls = {wh.url for wh in target_webhooks}
for wh in extra_wh_rows:
    if wh.id not in existing_ids and wh.url not in existing_urls:
        target_webhooks.append(wh)
        existing_ids.add(wh.id)
        existing_urls.add(wh.url)
```

## 선행 PR

PR #777 (Discord webhook 포맷) 머지 + Cloud Build SUCCESS 위에 쌓는 패치.

## 테스트

- [ ] reply_memo 발송 → Discord 수신 1건 확인 (중복 없음)
- [ ] channel_router Discord 수신자 SSE 미발송 확인