### PR TITLE
infra: Cloud Run backend 스케일링 설정을 cloudbuild.yaml에 명시

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -45,9 +45,13 @@ jobs:
           if [[ "${{ github.ref_name }}" == "main" ]]; then
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
+            echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
+            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
+            echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
+            echo "backend_max_instances=3" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -55,6 +59,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}" \
             --suppress-logs \
             .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -10,6 +10,8 @@ substitutions:
   _AR_REPO: sprintable
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
+  _BACKEND_MIN_INSTANCES: '1'
+  _BACKEND_MAX_INSTANCES: '3'
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -88,6 +90,8 @@ steps:
       - sprintable-backend-${_DEPLOY_ENV}
       - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
       - --region=${_AR_REGION}
+      - --min-instances=${_BACKEND_MIN_INSTANCES}
+      - --max-instances=${_BACKEND_MAX_INSTANCES}
       - --quiet
     waitFor: [push-backend]
 


### PR DESCRIPTION
## Summary

- P0 대응 중 `gcloud run services update`로 적용한 min/max instances 설정을 IaC에 반영
- 다음 배포 시 `gcloud run deploy`가 스케일링 설정을 덮어쓰는 것을 방지

## 변경 내용

| 환경 | min-instances | max-instances |
|------|--------------|--------------|
| dev  | 1 | 3 |
| prod | 1 | 10 |

**배경:** SSE 장기연결이 `containerConcurrency=80` 슬롯 소진 → 전면 429 발생.
P0 대응으로 dev 서비스에 `min=1, max=3` 수동 적용 완료 (`sprintable-backend-dev-00296-856`).
해당 값을 `cloudbuild.yaml` + `cloud-build.yml`에 명시하여 재배포 시 덮어씌워지지 않도록 코드화.

## 파일 변경

- `cloudbuild.yaml`: `_BACKEND_MIN_INSTANCES`, `_BACKEND_MAX_INSTANCES` substitution 추가 + `deploy-backend` 스텝에 플래그 반영
- `.github/workflows/cloud-build.yml`: 환경별(dev/prod) 인스턴스 값 output 추가 + Cloud Build substitution 전달

## Test plan

- [ ] PR 머지 후 develop push 시 Cloud Build dev 배포에서 `--min-instances=1 --max-instances=3` 적용 확인
- [ ] Cloud Run 콘솔에서 새 리비전 스케일링 설정 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)