### PR TITLE
fix(webhook): P0 — Discord payload에 메시지 본문 + embeds 포함

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -674,6 +674,7 @@ async def send_message(
         thread_id=msg.thread_id,
         created_at=msg.created_at,
         mentioned_ids=list(msg.mentioned_ids) if msg.mentioned_ids else None,
+        content=msg.content,
     )
 
     # Discord 아웃바운드 (AC9~11)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -34,16 +34,24 @@ def _is_discord_url(url: str) -> bool:
 
 
 def _to_discord_payload(payload: dict) -> dict:
-    """Sprintable webhook payload → Discord content 포맷 변환."""
-    event_type = payload.get("event_type", "event")
+    """Sprintable webhook payload → Discord content 포맷 변환 (_fire_webhook 스타일)."""
+    content_text = (payload.get("content") or "")[:500]
     conversation_id = payload.get("conversation_id", "")
-    sender_id = payload.get("sender_id") or ""
-    lines = [f"[{event_type}]"]
-    if conversation_id:
-        lines.append(f"conversation_id: {conversation_id}")
-    if sender_id:
-        lines.append(f"sender_id: {sender_id}")
-    return {"content": "\n".join(lines)}
+    thread_id = payload.get("thread_id") or ""
+
+    discord_content = f"📩 **새 메시지**"
+    if content_text:
+        discord_content += f"\n{content_text}"
+    if thread_id:
+        discord_content += f"\n\nreply_id: {thread_id}"
+    elif conversation_id:
+        discord_content += f"\n\nconversation_id: {conversation_id}"
+
+    result: dict = {"content": discord_content}
+    app_url = __import__("os").environ.get("NEXT_PUBLIC_APP_URL", "")
+    if app_url and conversation_id:
+        result["embeds"] = [{"title": "대화 보기", "url": f"{app_url}/memos?id={conversation_id}"}]
+    return result
 
 
 def _sign_payload(secret: str, body: bytes) -> str:
@@ -75,6 +83,7 @@ async def deliver_conversation_message_webhook(
     thread_id: uuid.UUID | None,
     created_at: datetime,
     mentioned_ids: list[uuid.UUID] | None = None,
+    content: str | None = None,
 ) -> None:
     """BackgroundTask 진입점.
 
@@ -143,6 +152,7 @@ async def deliver_conversation_message_webhook(
                 "thread_id": str(thread_id) if thread_id else None,
                 "created_at": created_at.isoformat(),
                 "mentioned_ids": mentioned_id_strs,
+                "content": content,
             }
 
             for wh in target_webhooks:


### PR DESCRIPTION
## 배경

PR #777(Discord 포맷), PR #778(중복 dedup) 이후 3번째 단추.
conversation_webhook Discord payload에 메시지 본문이 없어 수신자가 내용을 볼 수 없는 상태.

## 수정 내용

### `conversation_webhook.py`

**`_to_discord_payload()` 업그레이드:**
```python
# before: [event_type]\nconversation_id: ...\nsender_id: ...
# after: 📩 새 메시지\n{content[:500]}\n\nreply_id/conversation_id + embeds 링크
```

**`deliver_conversation_message_webhook()` — `content` 파라미터 추가:**
```python
content: str | None = None  # 메시지 본문 (Discord 포맷에 포함)
```

### `conversations.py`

```python
background_tasks.add_task(
    deliver_conversation_message_webhook,
    ...
    content=msg.content,  # ← 추가
)
```

## 테스트

- [ ] reply_memo 발송 → Discord에 "📩 새 메시지\n{본문}" 표시 확인
- [ ] send_message → Discord에 메시지 본문 표시 확인
- [ ] embeds 대화 링크 정상 동작 확인