### PR TITLE
fix(webhook): Discord payload에 memo_id 항상 표시

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -42,10 +42,10 @@ def _to_discord_payload(payload: dict) -> dict:
     discord_content = f"📩 **새 메시지**"
     if content_text:
         discord_content += f"\n{content_text}"
+    if conversation_id:
+        discord_content += f"\n\nmemo_id: {conversation_id}"
     if thread_id:
-        discord_content += f"\n\nreply_id: {thread_id}"
-    elif conversation_id:
-        discord_content += f"\n\nconversation_id: {conversation_id}"
+        discord_content += f"\nreply_id: {thread_id}"
 
     result: dict = {"content": discord_content}
     app_url = __import__("os").environ.get("NEXT_PUBLIC_APP_URL", "")


### PR DESCRIPTION
## 근본 원인

PR #780 `_to_discord_payload`에서 `conversation_id`를 thread_id 없을 때만 `conversation_id:` 로 표시 → 에이전트가 reply_memo 시 필요한 memo_id를 알림에서 확인 불가.

## 수정

```python
# before
if thread_id:
    discord_content += f"\n\nreply_id: {thread_id}"
elif conversation_id:
    discord_content += f"\n\nconversation_id: {conversation_id}"

# after
if conversation_id:
    discord_content += f"\n\nmemo_id: {conversation_id}"
if thread_id:
    discord_content += f"\nreply_id: {thread_id}"
```

- conversation_id = memo_id (동일 UUID) → 항상 `memo_id:` 표시
- thread_id 있으면 `reply_id:`도 추가

## 테스트

- [ ] reply_memo → Discord 알림에 `memo_id: xxx` 표시 확인