### PR TITLE
feat(mcp): S2-2 — stories/tasks/epics 19개 도구 포팅

### DIFF
--- a/backend/sprintable_mcp/schemas.py
+++ b/backend/sprintable_mcp/schemas.py
@@ -21,6 +21,29 @@ class StoryPriority(str, Enum):
     low = "low"
 
 
+class TaskStatus(str, Enum):
+    todo = "todo"
+    in_progress = "in-progress"
+    done = "done"
+
+
+class EpicStatus(str, Enum):
+    draft = "draft"
+    active = "active"
+    done = "done"
+    archived = "archived"
+
+
+class StoryPoints(int, Enum):
+    one = 1
+    two = 2
+    three = 3
+    five = 5
+    eight = 8
+    thirteen = 13
+    twenty_one = 21
+
+
 class SprintableInput(BaseModel):
     """모든 Sprintable 도구 입력 공통 베이스.
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -3,7 +3,25 @@ from mcp.types import TextContent
 
 from .config import settings
 from .response import ok
-from .tools.stories import ListStoriesInput, list_stories
+from .tools.epics import (
+    AddEpicInput, DeleteEpicInput, ListEpicsInput, UpdateEpicInput,
+    add_epic, delete_epic, list_epics, update_epic,
+)
+from .tools.stories import (
+    AddStoryInput, AssignStoryToSprintInput, DeleteStoryInput,
+    ListStoriesInput, UnassignStoryFromSprintInput, UpdateStoryInput,
+    UpdateStoryStatusInput,
+    add_story, assign_story_to_sprint, delete_story,
+    list_backlog, list_stories, unassign_story_from_sprint,
+    update_story, update_story_status,
+)
+from .tools.tasks import (
+    AddTaskInput, DeleteTaskInput, GetTaskInput, ListMyTasksInput,
+    ListTasksInput, UpdateTaskInput, UpdateTaskStatusInput,
+    add_task, delete_task, get_task, list_my_tasks, list_tasks,
+    update_task, update_task_status,
+)
+from .schemas import SprintableInput
 
 mcp = FastMCP(
     name="sprintable-mcp-python",
@@ -20,7 +38,121 @@ def ping() -> list[TextContent]:
     return ok({"status": "pong"})
 
 
+# ── Stories (8개) ──────────────────────────────────────────────────────────────
+
 @mcp.tool()
 async def sprintable_list_stories(args: ListStoriesInput) -> list[TextContent]:
-    """프로젝트 스토리 목록 조회. project_id/org_id는 context에서 자동 주입."""
+    """프로젝트 스토리 목록 조회. project_id/org_id context 자동 주입."""
     return await list_stories(args)
+
+
+@mcp.tool()
+async def sprintable_list_backlog(args: SprintableInput) -> list[TextContent]:
+    """백로그 스토리 목록 (스프린트 미배정)."""
+    return await list_backlog(args)
+
+
+@mcp.tool()
+async def sprintable_add_story(args: AddStoryInput) -> list[TextContent]:
+    """스토리 생성."""
+    return await add_story(args)
+
+
+@mcp.tool()
+async def sprintable_update_story(args: UpdateStoryInput) -> list[TextContent]:
+    """스토리 수정."""
+    return await update_story(args)
+
+
+@mcp.tool()
+async def sprintable_delete_story(args: DeleteStoryInput) -> list[TextContent]:
+    """스토리 삭제."""
+    return await delete_story(args)
+
+
+@mcp.tool()
+async def sprintable_assign_story_to_sprint(args: AssignStoryToSprintInput) -> list[TextContent]:
+    """스토리를 스프린트에 배정."""
+    return await assign_story_to_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_unassign_story_from_sprint(args: UnassignStoryFromSprintInput) -> list[TextContent]:
+    """스토리를 스프린트에서 제거."""
+    return await unassign_story_from_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_update_story_status(args: UpdateStoryStatusInput) -> list[TextContent]:
+    """스토리 상태 변경."""
+    return await update_story_status(args)
+
+
+# ── Tasks (7개) ────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def sprintable_list_tasks(args: ListTasksInput) -> list[TextContent]:
+    """태스크 목록 조회."""
+    return await list_tasks(args)
+
+
+@mcp.tool()
+async def sprintable_list_my_tasks(args: ListMyTasksInput) -> list[TextContent]:
+    """내 태스크 목록 조회."""
+    return await list_my_tasks(args)
+
+
+@mcp.tool()
+async def sprintable_get_task(args: GetTaskInput) -> list[TextContent]:
+    """태스크 단건 조회."""
+    return await get_task(args)
+
+
+@mcp.tool()
+async def sprintable_add_task(args: AddTaskInput) -> list[TextContent]:
+    """태스크 생성."""
+    return await add_task(args)
+
+
+@mcp.tool()
+async def sprintable_update_task(args: UpdateTaskInput) -> list[TextContent]:
+    """태스크 수정."""
+    return await update_task(args)
+
+
+@mcp.tool()
+async def sprintable_update_task_status(args: UpdateTaskStatusInput) -> list[TextContent]:
+    """태스크 상태 변경."""
+    return await update_task_status(args)
+
+
+@mcp.tool()
+async def sprintable_delete_task(args: DeleteTaskInput) -> list[TextContent]:
+    """태스크 삭제."""
+    return await delete_task(args)
+
+
+# ── Epics (4개) ────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def sprintable_list_epics(args: ListEpicsInput) -> list[TextContent]:
+    """에픽 목록 조회."""
+    return await list_epics(args)
+
+
+@mcp.tool()
+async def sprintable_add_epic(args: AddEpicInput) -> list[TextContent]:
+    """에픽 생성."""
+    return await add_epic(args)
+
+
+@mcp.tool()
+async def sprintable_update_epic(args: UpdateEpicInput) -> list[TextContent]:
+    """에픽 수정."""
+    return await update_epic(args)
+
+
+@mcp.tool()
+async def sprintable_delete_epic(args: DeleteEpicInput) -> list[TextContent]:
+    """에픽 삭제."""
+    return await delete_epic(args)

--- a/backend/sprintable_mcp/tools/epics.py
+++ b/backend/sprintable_mcp/tools/epics.py
@@ -1,0 +1,93 @@
+"""에픽 관련 MCP 도구 (4개)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import EpicStatus, SprintableInput, StoryPriority
+
+
+class ListEpicsInput(SprintableInput):
+    pass
+
+
+class AddEpicInput(SprintableInput):
+    title: str
+    priority: StoryPriority | None = None
+    description: str | None = None
+    objective: str | None = None
+    success_criteria: str | None = None
+    target_sp: int | None = None
+    target_date: str | None = None
+
+
+class UpdateEpicInput(SprintableInput):
+    epic_id: str
+    title: str | None = None
+    status: EpicStatus | None = None
+    priority: StoryPriority | None = None
+    description: str | None = None
+    objective: str | None = None
+    success_criteria: str | None = None
+    target_sp: int | None = None
+    target_date: str | None = None
+
+
+class DeleteEpicInput(SprintableInput):
+    epic_id: str
+
+
+async def list_epics(args: ListEpicsInput) -> list[TextContent]:
+    """에픽 목록 조회."""
+    try:
+        return ok(await client.get("/api/v2/epics", params={"project_id": client.project_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def add_epic(args: AddEpicInput) -> list[TextContent]:
+    """에픽 생성."""
+    body: dict = {"title": args.title, "project_id": client.project_id}
+    if args.priority:
+        body["priority"] = args.priority.value
+    for field in ("description", "objective", "success_criteria", "target_date"):
+        val = getattr(args, field)
+        if val is not None:
+            body[field] = val
+    if args.target_sp is not None:
+        body["target_sp"] = args.target_sp
+    try:
+        return ok(await client.post("/api/v2/epics", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_epic(args: UpdateEpicInput) -> list[TextContent]:
+    """에픽 수정."""
+    updates: dict = {}
+    if args.title is not None:
+        updates["title"] = args.title
+    if args.status is not None:
+        updates["status"] = args.status.value
+    if args.priority is not None:
+        updates["priority"] = args.priority.value
+    for field in ("description", "objective", "success_criteria", "target_date"):
+        val = getattr(args, field)
+        if val is not None:
+            updates[field] = val
+    if args.target_sp is not None:
+        updates["target_sp"] = args.target_sp
+    try:
+        return ok(await client.patch(f"/api/v2/epics/{args.epic_id}", json=updates))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_epic(args: DeleteEpicInput) -> list[TextContent]:
+    """에픽 삭제."""
+    try:
+        await client.delete(f"/api/v2/epics/{args.epic_id}")
+        return ok({"deleted": True})
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/tools/stories.py
+++ b/backend/sprintable_mcp/tools/stories.py
@@ -1,20 +1,14 @@
-"""스토리 관련 MCP 도구."""
+"""스토리 관련 MCP 도구 (8개)."""
 from __future__ import annotations
 
-from mcp.types import TextContent
+from mcp.types import CallToolResult, TextContent
 
 from ..api_client import client
 from ..response import err, ok
-from ..schemas import SprintableInput, StoryPriority, StoryStatus
+from ..schemas import SprintableInput, StoryPoints, StoryPriority, StoryStatus
 
 
 class ListStoriesInput(SprintableInput):
-    """list_stories 입력 스키마.
-
-    project_id/org_id는 context에서 자동 주입.
-    Optional 필드는 MCP schema required에서 제외.
-    """
-
     sprint_id: str | None = None
     epic_id: str | None = None
     status: StoryStatus | None = None
@@ -22,8 +16,48 @@ class ListStoriesInput(SprintableInput):
     assignee_id: str | None = None
 
 
+class AddStoryInput(SprintableInput):
+    title: str
+    epic_id: str | None = None
+    sprint_id: str | None = None
+    assignee_id: str | None = None
+    priority: StoryPriority | None = None
+    story_points: StoryPoints | None = None
+    description: str | None = None
+    acceptance_criteria: str | None = None
+
+
+class UpdateStoryInput(SprintableInput):
+    story_id: str
+    title: str | None = None
+    priority: StoryPriority | None = None
+    story_points: StoryPoints | None = None
+    description: str | None = None
+    acceptance_criteria: str | None = None
+    assignee_id: str | None = None
+    epic_id: str | None = None
+
+
+class DeleteStoryInput(SprintableInput):
+    story_id: str
+
+
+class AssignStoryToSprintInput(SprintableInput):
+    story_id: str
+    sprint_id: str
+
+
+class UnassignStoryFromSprintInput(SprintableInput):
+    story_id: str
+
+
+class UpdateStoryStatusInput(SprintableInput):
+    story_id: str
+    status: StoryStatus
+
+
 async def list_stories(args: ListStoriesInput) -> list[TextContent]:
-    """프로젝트의 스토리 목록 조회."""
+    """프로젝트 스토리 목록 조회."""
     params: dict = {"project_id": client.project_id}
     if client.org_id:
         params["org_id"] = client.org_id
@@ -37,9 +71,94 @@ async def list_stories(args: ListStoriesInput) -> list[TextContent]:
         params["priority"] = args.priority.value
     if args.assignee_id:
         params["assignee_id"] = args.assignee_id
-
     try:
-        data = await client.get("/api/v2/stories", params=params)
-        return ok(data)
+        return ok(await client.get("/api/v2/stories", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_backlog(args: SprintableInput) -> list[TextContent]:
+    """백로그 스토리 목록 (스프린트 미배정)."""
+    try:
+        return ok(await client.get("/api/v2/stories/backlog", params={"project_id": client.project_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def add_story(args: AddStoryInput) -> list[TextContent]:
+    """스토리 생성."""
+    body: dict = {"title": args.title, "project_id": client.project_id}
+    if args.epic_id:
+        body["epic_id"] = args.epic_id
+    if args.sprint_id:
+        body["sprint_id"] = args.sprint_id
+    if args.assignee_id:
+        body["assignee_id"] = args.assignee_id
+    if args.priority:
+        body["priority"] = args.priority.value
+    if args.story_points:
+        body["story_points"] = args.story_points.value
+    if args.description:
+        body["description"] = args.description
+    if args.acceptance_criteria:
+        body["acceptance_criteria"] = args.acceptance_criteria
+    try:
+        return ok(await client.post("/api/v2/stories", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_story(args: UpdateStoryInput) -> list[TextContent]:
+    """스토리 수정."""
+    updates: dict = {}
+    if args.title is not None:
+        updates["title"] = args.title
+    if args.priority is not None:
+        updates["priority"] = args.priority.value
+    if args.story_points is not None:
+        updates["story_points"] = args.story_points.value
+    if args.description is not None:
+        updates["description"] = args.description
+    if args.acceptance_criteria is not None:
+        updates["acceptance_criteria"] = args.acceptance_criteria
+    if args.assignee_id is not None:
+        updates["assignee_id"] = args.assignee_id
+    if args.epic_id is not None:
+        updates["epic_id"] = args.epic_id
+    try:
+        return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json=updates))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_story(args: DeleteStoryInput) -> list[TextContent]:
+    """스토리 삭제."""
+    try:
+        await client.delete(f"/api/v2/stories/{args.story_id}")
+        return ok({"deleted": True})
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def assign_story_to_sprint(args: AssignStoryToSprintInput) -> list[TextContent]:
+    """스토리를 스프린트에 배정."""
+    try:
+        return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json={"sprint_id": args.sprint_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def unassign_story_from_sprint(args: UnassignStoryFromSprintInput) -> list[TextContent]:
+    """스토리를 스프린트에서 제거."""
+    try:
+        return ok(await client.patch(f"/api/v2/stories/{args.story_id}", json={"sprint_id": None}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_story_status(args: UpdateStoryStatusInput) -> list[TextContent] | CallToolResult:
+    """스토리 상태 변경."""
+    try:
+        return ok(await client.patch(f"/api/v2/stories/{args.story_id}/status", json={"status": args.status.value}))
     except Exception as exc:
         return err(str(exc))

--- a/backend/sprintable_mcp/tools/tasks.py
+++ b/backend/sprintable_mcp/tools/tasks.py
@@ -1,0 +1,126 @@
+"""태스크 관련 MCP 도구 (7개)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput, TaskStatus
+
+
+class ListTasksInput(SprintableInput):
+    story_id: str | None = None
+    assignee_id: str | None = None
+    status: TaskStatus | None = None
+
+
+class ListMyTasksInput(SprintableInput):
+    assignee_id: str | None = None
+
+
+class GetTaskInput(SprintableInput):
+    task_id: str
+
+
+class AddTaskInput(SprintableInput):
+    story_id: str
+    title: str
+    assignee_id: str | None = None
+    story_points: int | None = None
+    status: TaskStatus | None = None
+
+
+class UpdateTaskInput(SprintableInput):
+    task_id: str
+    title: str | None = None
+    assignee_id: str | None = None
+    story_points: int | None = None
+
+
+class UpdateTaskStatusInput(SprintableInput):
+    task_id: str
+    status: TaskStatus
+
+
+class DeleteTaskInput(SprintableInput):
+    task_id: str
+
+
+async def list_tasks(args: ListTasksInput) -> list[TextContent]:
+    """태스크 목록 조회."""
+    params: dict = {"project_id": client.project_id}
+    if args.story_id:
+        params["story_id"] = args.story_id
+    if args.assignee_id:
+        params["assignee_id"] = args.assignee_id
+    if args.status:
+        params["status"] = args.status.value
+    try:
+        return ok(await client.get("/api/v2/tasks", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def list_my_tasks(args: ListMyTasksInput) -> list[TextContent]:
+    """내 태스크 목록 조회."""
+    assignee = args.assignee_id or client.member_id
+    params: dict = {"assignee_id": assignee, "project_id": client.project_id}
+    try:
+        return ok(await client.get("/api/v2/tasks", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_task(args: GetTaskInput) -> list[TextContent]:
+    """태스크 단건 조회."""
+    try:
+        return ok(await client.get(f"/api/v2/tasks/{args.task_id}"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def add_task(args: AddTaskInput) -> list[TextContent]:
+    """태스크 생성."""
+    body: dict = {"story_id": args.story_id, "title": args.title}
+    if args.assignee_id:
+        body["assignee_id"] = args.assignee_id
+    if args.story_points is not None:
+        body["story_points"] = args.story_points
+    if args.status:
+        body["status"] = args.status.value
+    try:
+        return ok(await client.post("/api/v2/tasks", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_task(args: UpdateTaskInput) -> list[TextContent]:
+    """태스크 수정."""
+    updates: dict = {}
+    if args.title is not None:
+        updates["title"] = args.title
+    if args.assignee_id is not None:
+        updates["assignee_id"] = args.assignee_id
+    if args.story_points is not None:
+        updates["story_points"] = args.story_points
+    try:
+        return ok(await client.patch(f"/api/v2/tasks/{args.task_id}", json=updates))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_task_status(args: UpdateTaskStatusInput) -> list[TextContent]:
+    """태스크 상태 변경."""
+    try:
+        return ok(await client.patch(f"/api/v2/tasks/{args.task_id}", json={"status": args.status.value}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_task(args: DeleteTaskInput) -> list[TextContent]:
+    """태스크 삭제."""
+    try:
+        await client.delete(f"/api/v2/tasks/{args.task_id}")
+        return ok({"deleted": True})
+    except Exception as exc:
+        return err(str(exc))


### PR DESCRIPTION
## 스토리

S2-2: 엔티티 CRUD 시스템 콜 (E-MCP-PYTHON Phase 2)
**선행 PR**: #782 (S2-1 패턴 확립)

## 구현 내용

### `schemas.py` 추가 — TaskStatus / EpicStatus / StoryPoints Enum

### `tools/stories.py` — 8개

list_backlog, add_story, update_story, delete_story, assign_story_to_sprint, unassign_story_from_sprint, update_story_status (기존 list_stories 포함)

### `tools/tasks.py` (신설) — 7개

list_tasks, list_my_tasks, get_task, add_task, update_task, update_task_status, delete_task

### `tools/epics.py` (신설) — 4개

list_epics, add_epic, update_epic, delete_epic

### `server.py` — 19개 도구 전량 등록 (`sprintable_` prefix)

## 특이사항

- S2-1 브랜치 위에서 작업한 것이므로 PR #782 머지 후 자동 정리됨
- `list_my_tasks`: assignee_id 미지정 시 `client.member_id` 자동 사용