### PR TITLE
feat(mcp): S2-3 — 스프린트 생명주기 8개 도구

### DIFF
--- a/backend/sprintable_mcp/schemas.py
+++ b/backend/sprintable_mcp/schemas.py
@@ -44,6 +44,12 @@ class StoryPoints(int, Enum):
     twenty_one = 21
 
 
+class SprintStatus(str, Enum):
+    planning = "planning"
+    active = "active"
+    closed = "closed"
+
+
 class SprintableInput(BaseModel):
     """모든 Sprintable 도구 입력 공통 베이스.
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -22,6 +22,11 @@ from .tools.tasks import (
     update_task, update_task_status,
 )
 from .schemas import SprintableInput
+from .tools.sprints import (
+    CreateSprintInput, ListSprintsInput, SprintIdInput, UpdateSprintInput,
+    activate_sprint, close_sprint, create_sprint, delete_sprint,
+    get_velocity, list_sprints, sprint_summary, update_sprint,
+)
 
 mcp = FastMCP(
     name="sprintable-mcp-python",
@@ -156,3 +161,53 @@ async def sprintable_update_epic(args: UpdateEpicInput) -> list[TextContent]:
 async def sprintable_delete_epic(args: DeleteEpicInput) -> list[TextContent]:
     """에픽 삭제."""
     return await delete_epic(args)
+
+
+# ── Sprints (8개) ──────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def sprintable_list_sprints(args: ListSprintsInput) -> list[TextContent]:
+    """스프린트 목록 조회."""
+    return await list_sprints(args)
+
+
+@mcp.tool()
+async def sprintable_sprint_summary(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 스토리 상태별 요약."""
+    return await sprint_summary(args)
+
+
+@mcp.tool()
+async def sprintable_activate_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 활성화 (planning → active)."""
+    return await activate_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_close_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 종료 (active → closed)."""
+    return await close_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_get_velocity(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 벨로시티 조회."""
+    return await get_velocity(args)
+
+
+@mcp.tool()
+async def sprintable_create_sprint(args: CreateSprintInput) -> list[TextContent]:
+    """스프린트 생성."""
+    return await create_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_update_sprint(args: UpdateSprintInput) -> list[TextContent]:
+    """스프린트 수정."""
+    return await update_sprint(args)
+
+
+@mcp.tool()
+async def sprintable_delete_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 삭제."""
+    return await delete_sprint(args)

--- a/backend/sprintable_mcp/tools/sprints.py
+++ b/backend/sprintable_mcp/tools/sprints.py
@@ -1,0 +1,114 @@
+"""스프린트 관련 MCP 도구 (8개)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintStatus, SprintableInput
+
+
+class ListSprintsInput(SprintableInput):
+    status: SprintStatus | None = None
+
+
+class SprintIdInput(SprintableInput):
+    sprint_id: str
+
+
+class CreateSprintInput(SprintableInput):
+    title: str
+    start_date: str | None = None
+    end_date: str | None = None
+    team_size: int | None = None
+
+
+class UpdateSprintInput(SprintableInput):
+    sprint_id: str
+    title: str | None = None
+    start_date: str | None = None
+    end_date: str | None = None
+    team_size: int | None = None
+
+
+async def list_sprints(args: ListSprintsInput) -> list[TextContent]:
+    """스프린트 목록 조회."""
+    params: dict = {"project_id": client.project_id}
+    if args.status:
+        params["status"] = args.status.value
+    try:
+        return ok(await client.get("/api/v2/sprints", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def sprint_summary(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 스토리 상태별 요약."""
+    try:
+        return ok(await client.get(f"/api/v2/sprints/{args.sprint_id}/summary"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def activate_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 활성화 (planning → active)."""
+    try:
+        return ok(await client.post(f"/api/v2/sprints/{args.sprint_id}/activate"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def close_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 종료 (active → closed)."""
+    try:
+        return ok(await client.post(f"/api/v2/sprints/{args.sprint_id}/close"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_velocity(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 벨로시티 조회."""
+    try:
+        return ok(await client.get(f"/api/v2/sprints/{args.sprint_id}/velocity"))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def create_sprint(args: CreateSprintInput) -> list[TextContent]:
+    """스프린트 생성."""
+    body: dict = {"title": args.title, "project_id": client.project_id}
+    if args.start_date:
+        body["start_date"] = args.start_date
+    if args.end_date:
+        body["end_date"] = args.end_date
+    if args.team_size is not None:
+        body["team_size"] = args.team_size
+    try:
+        return ok(await client.post("/api/v2/sprints", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def update_sprint(args: UpdateSprintInput) -> list[TextContent]:
+    """스프린트 수정."""
+    updates: dict = {}
+    if args.title is not None:
+        updates["title"] = args.title
+    if args.start_date is not None:
+        updates["start_date"] = args.start_date
+    if args.end_date is not None:
+        updates["end_date"] = args.end_date
+    if args.team_size is not None:
+        updates["team_size"] = args.team_size
+    try:
+        return ok(await client.patch(f"/api/v2/sprints/{args.sprint_id}", json=updates))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_sprint(args: SprintIdInput) -> list[TextContent]:
+    """스프린트 삭제."""
+    try:
+        return ok(await client.delete(f"/api/v2/sprints/{args.sprint_id}"))
+    except Exception as exc:
+        return err(str(exc))


### PR DESCRIPTION
## 스토리

S2-3: 스프린트 생명주기 시스템 콜 (E-MCP-PYTHON Phase 2)

## 구현 내용

### `schemas.py` — SprintStatus Enum 추가

### `tools/sprints.py` (신설) — 8개

| 도구 | 설명 |
|---|---|
| list_sprints | 목록 (status 필터) |
| sprint_summary | 상태별 요약 |
| activate_sprint | planning → active |
| close_sprint | active → closed |
| get_velocity | 벨로시티 조회 |
| create_sprint | 신규 생성 |
| update_sprint | 수정 |
| delete_sprint | 삭제 |

### `server.py` — 8개 `sprintable_*` 도구 등록