### PR TITLE
feat(mcp): S3-1 — analytics 11개 + core 2개 = 13개 도구

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -3,6 +3,15 @@ from mcp.types import TextContent
 
 from .config import settings
 from .response import ok
+from .tools.analytics import (
+    ActivityInput, AgentStatsInput, EpicProgressInput, OverdueMemberInput,
+    SearchStoriesInput, SprintFilterInput, WorkloadInput,
+    get_agent_stats, get_blocked_stories, get_epic_progress,
+    get_member_workload, get_overdue_tasks, get_project_health,
+    get_project_overview, get_recent_activity, get_sprint_velocity_history,
+    get_unassigned_stories, search_stories,
+)
+from .tools.core import DashboardInput, list_team_members, my_dashboard
 from .tools.epics import (
     AddEpicInput, DeleteEpicInput, ListEpicsInput, UpdateEpicInput,
     add_epic, delete_epic, list_epics, update_epic,
@@ -254,3 +263,85 @@ async def sprintable_update_doc(args: UpdateDocInput) -> list[TextContent]:
 async def sprintable_delete_doc(args: DeleteDocInput) -> list[TextContent]:
     """문서 소프트 삭제."""
     return await delete_doc(args)
+
+
+# ── Analytics (11개) ───────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def sprintable_get_project_overview(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 개요 통계 조회."""
+    return await get_project_overview(args)
+
+
+@mcp.tool()
+async def sprintable_get_member_workload(args: WorkloadInput) -> list[TextContent]:
+    """팀원 워크로드 조회."""
+    return await get_member_workload(args)
+
+
+@mcp.tool()
+async def sprintable_get_sprint_velocity_history(args: SprintableInput) -> list[TextContent]:
+    """스프린트 벨로시티 히스토리 조회."""
+    return await get_sprint_velocity_history(args)
+
+
+@mcp.tool()
+async def sprintable_search_stories(args: SearchStoriesInput) -> list[TextContent]:
+    """스토리 제목 검색."""
+    return await search_stories(args)
+
+
+@mcp.tool()
+async def sprintable_get_blocked_stories(args: SprintFilterInput) -> list[TextContent]:
+    """in-review 상태 스토리 목록 (블로킹 스토리)."""
+    return await get_blocked_stories(args)
+
+
+@mcp.tool()
+async def sprintable_get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
+    """담당자 미지정 스토리 목록."""
+    return await get_unassigned_stories(args)
+
+
+@mcp.tool()
+async def sprintable_get_overdue_tasks(args: OverdueMemberInput) -> list[TextContent]:
+    """미완료 태스크 목록."""
+    return await get_overdue_tasks(args)
+
+
+@mcp.tool()
+async def sprintable_get_recent_activity(args: ActivityInput) -> list[TextContent]:
+    """최근 프로젝트 활동 조회."""
+    return await get_recent_activity(args)
+
+
+@mcp.tool()
+async def sprintable_get_epic_progress(args: EpicProgressInput) -> list[TextContent]:
+    """에픽 진행 현황 조회."""
+    return await get_epic_progress(args)
+
+
+@mcp.tool()
+async def sprintable_get_agent_stats(args: AgentStatsInput) -> list[TextContent]:
+    """에이전트 성과 통계 조회."""
+    return await get_agent_stats(args)
+
+
+@mcp.tool()
+async def sprintable_get_project_health(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 전체 건강도 조회."""
+    return await get_project_health(args)
+
+
+# ── Core (2개) ─────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def sprintable_list_team_members(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 팀 멤버 목록 조회."""
+    return await list_team_members(args)
+
+
+@mcp.tool()
+async def sprintable_my_dashboard(args: DashboardInput) -> list[TextContent]:
+    """팀원 대시보드 요약 조회."""
+    return await my_dashboard(args)

--- a/backend/sprintable_mcp/tools/analytics.py
+++ b/backend/sprintable_mcp/tools/analytics.py
@@ -1,0 +1,140 @@
+"""분석 관련 MCP 도구 (11개)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class MemberIdInput(SprintableInput):
+    member_id: str
+
+
+class WorkloadInput(SprintableInput):
+    member_id: str
+
+
+class SprintFilterInput(SprintableInput):
+    sprint_id: str | None = None
+
+
+class OverdueMemberInput(SprintableInput):
+    member_id: str | None = None
+
+
+class ActivityInput(SprintableInput):
+    limit: int | None = None
+
+
+class EpicProgressInput(SprintableInput):
+    epic_id: str
+
+
+class AgentStatsInput(SprintableInput):
+    agent_id: str
+
+
+class SearchStoriesInput(SprintableInput):
+    query: str
+
+
+async def get_project_overview(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 개요 통계 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/overview", params={"project_id": client.project_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_member_workload(args: WorkloadInput) -> list[TextContent]:
+    """팀원 워크로드 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/workload", params={"project_id": client.project_id, "member_id": args.member_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_sprint_velocity_history(args: SprintableInput) -> list[TextContent]:
+    """스프린트 벨로시티 히스토리 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/velocity-history", params={"project_id": client.project_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def search_stories(args: SearchStoriesInput) -> list[TextContent]:
+    """스토리 제목 검색."""
+    try:
+        return ok(await client.get("/api/v2/stories", params={"project_id": client.project_id, "q": args.query}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_blocked_stories(args: SprintFilterInput) -> list[TextContent]:
+    """in-review 상태 스토리 목록 (블로킹 스토리)."""
+    params: dict = {"project_id": client.project_id, "status": "in-review"}
+    if args.sprint_id:
+        params["sprint_id"] = args.sprint_id
+    try:
+        return ok(await client.get("/api/v2/stories", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_unassigned_stories(args: SprintFilterInput) -> list[TextContent]:
+    """담당자 미지정 스토리 목록."""
+    params: dict = {"project_id": client.project_id, "unassigned": "true"}
+    if args.sprint_id:
+        params["sprint_id"] = args.sprint_id
+    try:
+        return ok(await client.get("/api/v2/stories", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_overdue_tasks(args: OverdueMemberInput) -> list[TextContent]:
+    """미완료 태스크 목록."""
+    params: dict = {"project_id": client.project_id, "status_ne": "done"}
+    if args.member_id:
+        params["assignee_id"] = args.member_id
+    try:
+        return ok(await client.get("/api/v2/tasks", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_recent_activity(args: ActivityInput) -> list[TextContent]:
+    """최근 프로젝트 활동 조회."""
+    params: dict = {"project_id": client.project_id}
+    if args.limit is not None:
+        params["limit"] = str(args.limit)
+    try:
+        return ok(await client.get("/api/v2/analytics/activity", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_epic_progress(args: EpicProgressInput) -> list[TextContent]:
+    """에픽 진행 현황 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/epic-progress", params={"project_id": client.project_id, "epic_id": args.epic_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_agent_stats(args: AgentStatsInput) -> list[TextContent]:
+    """에이전트 성과 통계 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/agent-stats", params={"project_id": client.project_id, "agent_id": args.agent_id}))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def get_project_health(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 전체 건강도 조회."""
+    try:
+        return ok(await client.get("/api/v2/analytics/health", params={"project_id": client.project_id}))
+    except Exception as exc:
+        return err(str(exc))

--- a/backend/sprintable_mcp/tools/core.py
+++ b/backend/sprintable_mcp/tools/core.py
@@ -1,0 +1,31 @@
+"""코어 유틸리티 MCP 도구 (2개)."""
+from __future__ import annotations
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class DashboardInput(SprintableInput):
+    member_id: str | None = None
+
+
+async def list_team_members(args: SprintableInput) -> list[TextContent]:
+    """프로젝트 팀 멤버 목록 조회."""
+    params: dict = {"project_id": client.project_id}
+    try:
+        return ok(await client.get("/api/v2/members", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def my_dashboard(args: DashboardInput) -> list[TextContent]:
+    """팀원 대시보드 요약 조회."""
+    member = args.member_id or client.member_id
+    params: dict = {"member_id": member, "project_id": client.project_id}
+    try:
+        return ok(await client.get("/api/v2/dashboard", params=params))
+    except Exception as exc:
+        return err(str(exc))


### PR DESCRIPTION
## 스토리

S3-1: 분석+코어 시스템 콜 (E-MCP-PYTHON Phase 3)

## 구현 내용

### `tools/analytics.py` (신설) — 11개

get_project_overview, get_member_workload, get_sprint_velocity_history, search_stories, get_blocked_stories, get_unassigned_stories, get_overdue_tasks, get_recent_activity, get_epic_progress, get_agent_stats, get_project_health

### `tools/core.py` (신설) — 2개

list_team_members, my_dashboard (member_id 미지정 시 `client.member_id` 자동)

### `server.py` — 13개 등록 → 총 **47개**