### PR TITLE
feat(mcp): S5-1 — SSE 브릿지 httpx long-lived stream 연결

### DIFF
--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -1,11 +1,13 @@
 """python -m backend.mcp — Sprintable Python MCP server entry point."""
 
 import asyncio
+import contextlib
 import sys
 
 from .api_client import SprintableApiError, client
 from .config import settings
 from .server import mcp
+from .sse_bridge import start_sse_bridge
 
 
 def main() -> None:
@@ -29,7 +31,24 @@ def main() -> None:
         print(f"Error: auth context resolve failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    mcp.run(transport="stdio")
+    asyncio.run(_run())
+
+
+async def _run() -> None:
+    """MCP stdio 서버 + SSE 브릿지를 동일 이벤트 루프에서 실행."""
+    sse_task = asyncio.create_task(
+        start_sse_bridge(
+            settings.sprintable_api_url,
+            settings.agent_api_key,
+            client.member_id,
+        )
+    )
+    try:
+        await mcp.run_stdio_async()
+    finally:
+        sse_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await sse_task
 
 
 if __name__ == "__main__":

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -1,0 +1,106 @@
+"""SSE 브릿지 — /api/v2/events/stream httpx long-lived stream 연결.
+
+REST용 SprintableClient와 완전히 분리된 SSE 전용 httpx.AsyncClient 사용.
+파싱(S5-2), relay(S5-3), backoff 상세(S5-5)는 후속 스토리에서 확장.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Any, Callable
+
+import httpx
+
+SseBridgeEventHandler = Callable[[str, Any], None]
+
+_BASE_DELAY = 1.0
+_MAX_DELAY = 10.0
+
+
+def _log(msg: str) -> None:
+    sys.stderr.write(f"[sse-bridge] {msg}\n")
+    sys.stderr.flush()
+
+
+def make_sse_client(api_url: str, api_key: str) -> httpx.AsyncClient:
+    """SSE 전용 httpx.AsyncClient 생성.
+
+    REST SprintableClient와 connection pool 완전 분리.
+    max_connections=1: SSE는 단일 장기 연결 전용.
+    """
+    return httpx.AsyncClient(
+        base_url=api_url.rstrip("/"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "x-agent-api-key": api_key,
+        },
+        limits=httpx.Limits(max_connections=1, max_keepalive_connections=1),
+        timeout=httpx.Timeout(connect=10.0, read=None, write=None, pool=None),
+    )
+
+
+async def _connect_once(
+    client: httpx.AsyncClient,
+    member_id: str,
+    on_event: SseBridgeEventHandler | None = None,
+) -> None:
+    """SSE 스트림에 한 번 연결해서 이벤트 수신. 스트림 종료 시 반환."""
+    async with client.stream(
+        "GET",
+        "/api/v2/events/stream",
+        params={"member_id": member_id},
+        headers={"Accept": "text/event-stream", "Cache-Control": "no-cache"},
+    ) as response:
+        if response.status_code != 200:
+            raise RuntimeError(f"SSE connect failed: HTTP {response.status_code}")
+
+        _log("connected")
+
+        event_type = "message"
+        data_lines: list[str] = []
+
+        async for raw_line in response.aiter_lines():
+            line = raw_line.rstrip()
+            if line.startswith("event:"):
+                event_type = line[6:].strip()
+            elif line.startswith("data:"):
+                data_lines.append(line[5:].strip())
+            elif line == "":
+                if data_lines:
+                    data_str = "\n".join(data_lines)
+                    if event_type != "heartbeat":
+                        _log(f"event={event_type} data={data_str[:200]}")
+                        if on_event is not None:
+                            on_event(event_type, data_str)
+                    event_type = "message"
+                    data_lines = []
+
+        _log("stream ended")
+
+
+async def start_sse_bridge(
+    api_url: str,
+    api_key: str,
+    member_id: str,
+    on_event: SseBridgeEventHandler | None = None,
+) -> None:
+    """SSE 브릿지 시작. 연결 실패 시 에러 로그 + 재연결 루프 진입.
+
+    MCP stdio 서버와 동일한 이벤트 루프에서 asyncio.create_task()로 실행.
+    """
+    _log(f"starting bridge for member_id={member_id}")
+    client = make_sse_client(api_url, api_key)
+    attempt = 0
+    try:
+        while True:
+            try:
+                await _connect_once(client, member_id, on_event)
+                attempt = 0
+            except Exception as exc:
+                _log(f"error: {exc}")
+            attempt += 1
+            wait = min(_BASE_DELAY * 2 ** (attempt - 1), _MAX_DELAY)
+            _log(f"reconnecting in {wait:.1f}s (attempt {attempt})")
+            await asyncio.sleep(wait)
+    finally:
+        await client.aclose()


### PR DESCRIPTION
## Summary

- `backend/sprintable_mcp/sse_bridge.py` 신규 생성
- `make_sse_client()`: SSE 전용 `httpx.AsyncClient(limits=httpx.Limits(max_connections=1))` — REST `SprintableClient`와 connection pool 완전 분리
- `_connect_once()`: `/api/v2/events/stream?member_id=` SSE 파싱, heartbeat silent, 비-heartbeat `[sse-bridge]` stderr 로그
- `start_sse_bridge()`: 연결 실패 시 에러 로그 + 지수 backoff 재연결 루프
- `__main__.py`: `mcp.run()` → `asyncio.run(_run())` 교체. MCP stdio + SSE 브릿지 동일 이벤트 루프 실행, MCP 종료 시 SSE 태스크 cancel 보장

## AC 검증

| AC | 결과 |
|---|---|
| AC1: `sse_bridge.py` 생성, SSE 전용 httpx client 분리 | ✅ |
| AC2: `/api/v2/events/stream?member_id=` 연결+heartbeat 수신 로직 | ✅ (`_connect_once` 구현) |
| AC3: REST/SSE 별도 pool (`max_connections=1` 분리) | ✅ 코드 리뷰 확인 |
| AC4: 연결 실패 에러 로그 + 재연결 진입 | ✅ `except Exception → _log + reconnecting` |

## Test plan

- [x] `test_contract.py` 31 passed — 기존 테스트 무회귀
- [x] `sse_bridge` import 정상 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)