### PR TITLE
feat(mcp): S5-2 — SSE parser SseParser 클래스 분리 + 유닛 테스트

### DIFF
--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -1,12 +1,13 @@
 """SSE 브릿지 — /api/v2/events/stream httpx long-lived stream 연결.
 
 REST용 SprintableClient와 완전히 분리된 SSE 전용 httpx.AsyncClient 사용.
-파싱(S5-2), relay(S5-3), backoff 상세(S5-5)는 후속 스토리에서 확장.
+relay(S5-3), backoff 상세(S5-5)는 후속 스토리에서 확장.
 """
 from __future__ import annotations
 
 import asyncio
 import sys
+from dataclasses import dataclass, field
 from typing import Any, Callable
 
 import httpx
@@ -21,6 +22,73 @@ def _log(msg: str) -> None:
     sys.stderr.write(f"[sse-bridge] {msg}\n")
     sys.stderr.flush()
 
+
+# ── SSE Parser ─────────────────────────────────────────────────────────────────
+
+@dataclass
+class SseEvent:
+    event_type: str = "message"
+    data: str = ""
+    last_event_id: str = ""
+
+
+class SseParser:
+    """RFC 8895 SSE 라인 파서.
+
+    `feed(line)` 한 라인씩 공급. 이벤트 완성(blank line) 시 SseEvent 반환.
+    `last_event_id`는 연결 재시도 시 dedup에 사용 (S5-5).
+    """
+
+    def __init__(self) -> None:
+        self._event_type = "message"
+        self._data_lines: list[str] = []
+        self._last_event_id = ""
+
+    @property
+    def last_event_id(self) -> str:
+        return self._last_event_id
+
+    def feed(self, line: str) -> SseEvent | None:
+        """한 라인 처리. 이벤트 완성 시 SseEvent 반환, 미완성이면 None."""
+        line = line.rstrip("\r\n")
+
+        # `:` prefix — heartbeat/comment, skip
+        if line.startswith(":"):
+            return None
+
+        # blank line — dispatch
+        if line == "":
+            if self._data_lines:
+                event = SseEvent(
+                    event_type=self._event_type,
+                    data="\n".join(self._data_lines),
+                    last_event_id=self._last_event_id,
+                )
+                self._event_type = "message"
+                self._data_lines = []
+                return event
+            return None
+
+        # field: value
+        if ":" in line:
+            field_name, _, value = line.partition(":")
+            if value.startswith(" "):
+                value = value[1:]  # SSE spec: strip exactly one leading space
+        else:
+            field_name, value = line, ""
+
+        if field_name == "event":
+            self._event_type = value
+        elif field_name == "data":
+            self._data_lines.append(value)
+        elif field_name == "id":
+            self._last_event_id = value
+        # unknown field — ignore per spec
+
+        return None
+
+
+# ── httpx SSE client ───────────────────────────────────────────────────────────
 
 def make_sse_client(api_url: str, api_key: str) -> httpx.AsyncClient:
     """SSE 전용 httpx.AsyncClient 생성.
@@ -56,24 +124,14 @@ async def _connect_once(
 
         _log("connected")
 
-        event_type = "message"
-        data_lines: list[str] = []
-
+        parser = SseParser()
         async for raw_line in response.aiter_lines():
-            line = raw_line.rstrip()
-            if line.startswith("event:"):
-                event_type = line[6:].strip()
-            elif line.startswith("data:"):
-                data_lines.append(line[5:].strip())
-            elif line == "":
-                if data_lines:
-                    data_str = "\n".join(data_lines)
-                    if event_type != "heartbeat":
-                        _log(f"event={event_type} data={data_str[:200]}")
-                        if on_event is not None:
-                            on_event(event_type, data_str)
-                    event_type = "message"
-                    data_lines = []
+            event = parser.feed(raw_line)
+            if event is not None:
+                if event.event_type != "heartbeat":
+                    _log(f"event={event.event_type} data={event.data[:200]}")
+                    if on_event is not None:
+                        on_event(event.event_type, event.data)
 
         _log("stream ended")
 

--- a/backend/tests/mcp/test_sse_parser.py
+++ b/backend/tests/mcp/test_sse_parser.py
@@ -1,0 +1,122 @@
+"""S5-2: SseParser 유닛 테스트 — synthetic SSE stream으로 파싱 정확성 검증."""
+from __future__ import annotations
+
+import pytest
+
+from sprintable_mcp.sse_bridge import SseEvent, SseParser
+
+
+def _parse(lines: list[str]) -> list[SseEvent]:
+    """헬퍼: 라인 목록을 SseParser에 통과시켜 이벤트 리스트 반환."""
+    parser = SseParser()
+    events: list[SseEvent] = []
+    for line in lines:
+        event = parser.feed(line)
+        if event is not None:
+            events.append(event)
+    return events
+
+
+def test_heartbeat_only_produces_no_event():
+    """`:` prefix 라인(heartbeat/comment)은 이벤트 생성 안 함."""
+    events = _parse([": heartbeat", ": keep-alive", ""])
+    assert events == []
+
+
+def test_single_event_basic():
+    """event: + data: + blank line → 이벤트 1개 생성."""
+    events = _parse([
+        "event: memo_received",
+        "data: hello",
+        "",
+    ])
+    assert len(events) == 1
+    assert events[0].event_type == "memo_received"
+    assert events[0].data == "hello"
+
+
+def test_multiline_data_joined_with_newline():
+    """data: 여러 줄 → '\\n' 결합."""
+    events = _parse([
+        "event: update",
+        "data: line1",
+        "data: line2",
+        "data: line3",
+        "",
+    ])
+    assert len(events) == 1
+    assert events[0].data == "line1\nline2\nline3"
+
+
+def test_id_tracking_persists_across_events():
+    """`id:` 필드가 last_event_id에 추적되고 이후 이벤트에도 유지됨."""
+    parser = SseParser()
+    events = []
+
+    for line in ["id: abc-123", "data: first", ""]:
+        e = parser.feed(line)
+        if e:
+            events.append(e)
+
+    assert events[0].last_event_id == "abc-123"
+    assert parser.last_event_id == "abc-123"
+
+    # id 없는 두 번째 이벤트 — last_event_id 유지
+    for line in ["data: second", ""]:
+        e = parser.feed(line)
+        if e:
+            events.append(e)
+
+    assert events[1].last_event_id == "abc-123"
+
+
+def test_unknown_field_ignored():
+    """알 수 없는 필드는 무시하고 알려진 필드만 처리."""
+    events = _parse([
+        "retry: 3000",
+        "event: ping",
+        "data: pong",
+        "custom-field: value",
+        "",
+    ])
+    assert len(events) == 1
+    assert events[0].event_type == "ping"
+    assert events[0].data == "pong"
+
+
+def test_default_event_type_is_message():
+    """`event:` 없으면 event_type = 'message'."""
+    events = _parse(["data: no event field", ""])
+    assert events[0].event_type == "message"
+
+
+def test_blank_line_without_data_produces_no_event():
+    """data 없이 blank line만 → 이벤트 없음."""
+    events = _parse(["event: empty", ""])
+    assert events == []
+
+
+def test_leading_space_stripped_from_value():
+    """SSE spec: field 값에서 선행 공백 1개 제거."""
+    events = _parse(["event: test", "data: value with space", ""])
+    assert events[0].data == "value with space"
+
+
+def test_multiple_events_sequential():
+    """연속 이벤트 여러 개 순서대로 반환."""
+    events = _parse([
+        "event: first",
+        "data: 1",
+        "",
+        "event: second",
+        "data: 2",
+        "",
+        ": heartbeat",
+        "",
+        "event: third",
+        "data: 3",
+        "",
+    ])
+    assert len(events) == 3
+    assert [e.event_type for e in events] == ["first", "second", "third"]
+    assert [e.data for e in events] == ["1", "2", "3"]


### PR DESCRIPTION
## Summary

- `SseEvent` dataclass 신규: `event_type`, `data`, `last_event_id`
- `SseParser` 클래스 신규: `feed(line) → SseEvent | None`
  - `:` prefix → heartbeat/comment, skip (AC3)
  - `event:`/`data:`/`id:` 필드 추출, 선행 공백 1개 제거 (RFC 8895) (AC1)
  - blank line → `SseEvent` dispatch (AC2)
  - `id:` 누적 → `last_event_id` 유지 (S5-5 dedup 대비)
  - unknown field → ignore per spec
- `_connect_once()`: 인라인 파싱 제거 → `SseParser` 교체

## Test plan

```
tests/mcp/test_sse_parser.py — 9 passed in 0.01s
tests/mcp/test_contract.py   — 31 passed in 0.25s
```

케이스: heartbeat_only, single_event, multiline_data, id_tracking, unknown_field, default_event_type, blank_without_data, leading_space, multiple_events_sequential

🤖 Generated with [Claude Code](https://claude.com/claude-code)