### PR TITLE
feat(mcp): S5-4 — MCP notification 전송 (session.send_log_message)

### DIFF
--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -3,11 +3,27 @@
 import asyncio
 import contextlib
 import sys
+import types as _types
 
 from .api_client import SprintableApiError, client
 from .config import settings
 from .server import mcp
-from .sse_bridge import start_sse_bridge
+from .sse_bridge import register_session, start_sse_bridge
+
+
+def _patch_session_capture() -> None:
+    """lowlevel _handle_message를 패치해서 ServerSession을 register_session에 주입.
+
+    MCP 클라이언트가 첫 메시지(initialize)를 보내면 세션이 캡처됨.
+    이후 SSE 이벤트 → _send_mcp_notification에서 session.send_log_message 사용 가능.
+    """
+    orig = mcp._mcp_server._handle_message.__func__  # type: ignore[attr-defined]
+
+    async def _capturing(self, message, session, lifespan_ctx, raise_exc=False):
+        register_session(session)
+        return await orig(self, message, session, lifespan_ctx, raise_exc)
+
+    mcp._mcp_server._handle_message = _types.MethodType(_capturing, mcp._mcp_server)
 
 
 def main() -> None:
@@ -31,6 +47,7 @@ def main() -> None:
         print(f"Error: auth context resolve failed: {exc}", file=sys.stderr)
         sys.exit(1)
 
+    _patch_session_capture()
     asyncio.run(_run())
 
 

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -11,11 +11,14 @@ import sys
 import time
 from dataclasses import dataclass
 from random import randint
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
 
 from .config import settings
+
+if TYPE_CHECKING:
+    from mcp.server.session import ServerSession
 
 SseBridgeEventHandler = Callable[[str, Any], None]
 
@@ -29,6 +32,34 @@ _RELAY_EVENT_TYPES = frozenset(["conversation:message", "conversation:mention"])
 def _log(msg: str) -> None:
     sys.stderr.write(f"[sse-bridge] {msg}\n")
     sys.stderr.flush()
+
+
+# ── MCP Session Registry ───────────────────────────────────────────────────────
+
+_active_session: ServerSession | None = None
+
+
+def register_session(session: ServerSession) -> None:
+    """활성 MCP ServerSession 등록. __main__.py _handle_message 패치에서 호출."""
+    global _active_session
+    _active_session = session
+
+
+async def _send_mcp_notification(event_type: str, data_str: str) -> None:
+    """SSE 이벤트를 MCP log notification으로 클라이언트에 전송.
+
+    세션 미등록 또는 에러 시 조용히 skip — MCP 도구 호출에 영향 없음.
+    """
+    if _active_session is None:
+        return
+    try:
+        await _active_session.send_log_message(
+            level="info",
+            data={"event_type": event_type, "data": data_str},
+            logger="sprintable.sse",
+        )
+    except Exception as exc:
+        _log(f"notification error: {exc}")
 
 
 # ── SSE Parser ─────────────────────────────────────────────────────────────────
@@ -237,7 +268,7 @@ async def start_sse_bridge(
     """SSE 브릿지 시작. 연결 실패 시 에러 로그 + 재연결 루프 진입.
 
     MCP stdio 서버와 동일한 이벤트 루프에서 asyncio.create_task()로 실행.
-    수신 이벤트는 fakechat relay (fire-and-forget) + on_event 콜백으로 전달.
+    수신 이벤트는 fakechat relay + MCP notification + on_event 콜백으로 전달.
     """
     _log(f"starting bridge for member_id={member_id}")
     client = make_sse_client(api_url, api_key)
@@ -246,6 +277,9 @@ async def start_sse_bridge(
     def _relay_and_dispatch(event_type: str, data: Any) -> None:
         asyncio.create_task(
             relay_to_fakechat(event_type, str(data), api_url, api_key, port)
+        )
+        asyncio.create_task(
+            _send_mcp_notification(event_type, str(data))
         )
         if on_event is not None:
             on_event(event_type, data)

--- a/backend/tests/mcp/test_mcp_notification.py
+++ b/backend/tests/mcp/test_mcp_notification.py
@@ -1,0 +1,96 @@
+"""S5-4: MCP notification 전송 유닛 테스트."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import sprintable_mcp.sse_bridge as bridge
+from sprintable_mcp.sse_bridge import _send_mcp_notification, register_session
+
+
+def _make_mock_session() -> MagicMock:
+    session = MagicMock()
+    session.send_log_message = AsyncMock()
+    return session
+
+
+def setup_function():
+    """각 테스트 전 세션 레지스트리 초기화."""
+    bridge._active_session = None
+
+
+@pytest.mark.asyncio
+async def test_notification_not_sent_without_session():
+    """세션 미등록 시 send_log_message 호출 없음."""
+    assert bridge._active_session is None
+    await _send_mcp_notification("memo_received", '{"data": "test"}')
+    # 예외 없이 통과 (세션 없어도 조용히 skip)
+
+
+@pytest.mark.asyncio
+async def test_notification_sent_to_registered_session():
+    """세션 등록 후 SSE 이벤트 → send_log_message 호출."""
+    session = _make_mock_session()
+    register_session(session)
+
+    await _send_mcp_notification("memo_received", '{"title": "킥오프"}')
+
+    session.send_log_message.assert_called_once()
+    call_kwargs = session.send_log_message.call_args[1]
+    assert call_kwargs["level"] == "info"
+    assert call_kwargs["data"]["event_type"] == "memo_received"
+    assert '킥오프' in call_kwargs["data"]["data"]
+    assert call_kwargs["logger"] == "sprintable.sse"
+
+
+@pytest.mark.asyncio
+async def test_notification_swallows_session_error():
+    """session.send_log_message 에러 시 예외 전파 없음."""
+    session = _make_mock_session()
+    session.send_log_message = AsyncMock(side_effect=Exception("connection closed"))
+    register_session(session)
+
+    await _send_mcp_notification("test_event", "data")  # 예외 전파 없음
+
+
+@pytest.mark.asyncio
+async def test_register_session_replaces_previous():
+    """register_session 재호출 시 이전 세션 교체."""
+    session1 = _make_mock_session()
+    session2 = _make_mock_session()
+
+    register_session(session1)
+    register_session(session2)
+
+    await _send_mcp_notification("event", "data")
+
+    session1.send_log_message.assert_not_called()
+    session2.send_log_message.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_relay_and_notification_both_triggered():
+    """SSE 이벤트 수신 시 relay + notification 양쪽 태스크 생성 확인."""
+    import asyncio as _asyncio
+
+    session = _make_mock_session()
+    register_session(session)
+
+    created: list[str] = []
+    orig_create = _asyncio.create_task
+
+    def _mock_create(coro, **kwargs):
+        created.append(coro.__name__ if hasattr(coro, "__name__") else str(type(coro)))
+        return orig_create(coro, **kwargs)
+
+    with patch("sprintable_mcp.sse_bridge.asyncio.create_task", side_effect=_mock_create):
+        # _relay_and_dispatch을 직접 호출할 수 없으므로 두 함수가 모두 호출되는지 확인
+        tasks = [
+            bridge.relay_to_fakechat("conversation:message", '{}', "http://api", "key", 8787),
+            bridge._send_mcp_notification("conversation:message", '{}'),
+        ]
+        await _asyncio.gather(*tasks)
+
+    # send_log_message가 실제로 호출됐는지 확인
+    session.send_log_message.assert_called_once()


### PR DESCRIPTION
## Summary

- `_active_session` 글로벌 레지스트리 + `register_session()` 공개 함수
- `_send_mcp_notification(event_type, data_str)`: `session.send_log_message(level="info", data={"event_type":..., "data":...})` — 에러 삼키기
- `_relay_and_dispatch`: relay + notification 두 fire-and-forget task
- `__main__.py` `_patch_session_capture()`: lowlevel `_handle_message` monkey-patch로 초기화 메시지 수신 시 세션 캡처 → `register_session` 주입

## 세션 캡처 흐름

```
MCP client → initialize → _capturing._handle_message
                           → register_session(session)
SSE event → _relay_and_dispatch
           → asyncio.create_task(_send_mcp_notification)
              → session.send_log_message(level="info", ...)
              → MCP client receives notifications/message
```

## Test plan

```
test_mcp_notification.py  — 5 passed
test_contract.py          — 31 passed
Total: 36 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)