### PR TITLE
[S6-2] SeenIdsCache LRU+TTL eviction 정책 + config 외부화

### DIFF
--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -11,6 +11,8 @@ class McpSettings(BaseSettings):
     sprintable_api_url: str = ""
     agent_api_key: str = ""
     fakechat_port: int = 8787
+    sse_seen_ids_max_size: int = 10000
+    sse_seen_ids_ttl_seconds: int = 3600
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import sys
 import time
+from collections import OrderedDict
 from dataclasses import dataclass
 from random import randint, uniform
 from typing import TYPE_CHECKING, Any, Callable
@@ -25,10 +26,58 @@ _SseInternalHandler = Callable[["SseEvent"], None]
 _BASE_DELAY = 1.0
 _MAX_DELAY = 10.0
 _JITTER_FACTOR = 0.5    # wait * uniform(0, 0.5) jitter
-_SEEN_IDS_MAX = 1000    # dedup window 크기
 
 # relay 대상 이벤트 타입
 _RELAY_EVENT_TYPES = frozenset(["conversation:message", "conversation:mention"])
+
+
+# ── SeenIdsCache: LRU + TTL dedup 캐시 (S6-2) ────────────────────────────────
+
+class SeenIdsCache:
+    """LRU + TTL 기반 SSE dedup 캐시.
+
+    - max_size 초과: LRU eviction (가장 오래 미사용 항목 제거)
+    - TTL 만료: __contains__ 접근 시 lazy 제거 + add() 시 배치 정리
+    - eviction 발동 시 DEBUG 로그 출력
+    """
+
+    def __init__(self, max_size: int, ttl_seconds: float) -> None:
+        self._max_size = max_size
+        self._ttl = ttl_seconds
+        self._store: OrderedDict[str, float] = OrderedDict()
+
+    def __contains__(self, event_id: str) -> bool:
+        if event_id not in self._store:
+            return False
+        added_at = self._store[event_id]
+        if time.monotonic() - added_at > self._ttl:
+            del self._store[event_id]
+            _log(f"[debug] ttl-evict event_id={event_id}")
+            return False
+        self._store.move_to_end(event_id)
+        return True
+
+    def add(self, event_id: str) -> None:
+        """event_id 추가. 이미 존재하면 LRU 갱신."""
+        if event_id in self._store:
+            self._store.move_to_end(event_id)
+            return
+        self._evict_expired()
+        self._store[event_id] = time.monotonic()
+        while len(self._store) > self._max_size:
+            oldest_id, _ = self._store.popitem(last=False)
+            _log(f"[debug] lru-evict max_size={self._max_size} event_id={oldest_id}")
+
+    def _evict_expired(self) -> None:
+        now = time.monotonic()
+        expired = [k for k, v in self._store.items() if now - v > self._ttl]
+        for k in expired:
+            del self._store[k]
+        if expired:
+            _log(f"[debug] ttl-batch-evict count={len(expired)}")
+
+    def __len__(self) -> int:
+        return len(self._store)
 
 
 def _log(msg: str) -> None:
@@ -279,7 +328,7 @@ async def start_sse_bridge(
     """SSE 브릿지 시작. 연결 실패 시 에러 로그 + jitter exponential backoff 재연결.
 
     - backoff: BASE * 2^attempt (max MAX_DELAY) + uniform(0, wait * JITTER_FACTOR)
-    - dedup: last_event_id 기반 최근 SEEN_IDS_MAX 건 중복 skip
+    - dedup: SeenIdsCache (LRU + TTL) 기반 중복 skip
     - MCP stdio 서버와 동일 이벤트 루프에서 asyncio.create_task()로 실행
     - graceful shutdown: CancelledError → finally: client.aclose()
     """
@@ -287,8 +336,11 @@ async def start_sse_bridge(
     client = make_sse_client(api_url, api_key)
     port = settings.fakechat_port
 
-    # dedup window — reconnect 시 중복 이벤트 skip (insertion-order dict)
-    seen_ids: dict[str, None] = {}
+    # S6-2: LRU + TTL dedup 캐시 (환경변수 기반 설정)
+    seen_ids = SeenIdsCache(
+        max_size=settings.sse_seen_ids_max_size,
+        ttl_seconds=settings.sse_seen_ids_ttl_seconds,
+    )
     # S6-1: 마지막 수신 event_id — 재연결 시 backfill 기준점으로 전달
     _current_last_event_id: str = ""
 
@@ -299,9 +351,7 @@ async def start_sse_bridge(
             if event.last_event_id in seen_ids:
                 _log(f"dedup: skip event_id={event.last_event_id}")
                 return
-            seen_ids[event.last_event_id] = None
-            if len(seen_ids) > _SEEN_IDS_MAX:
-                del seen_ids[next(iter(seen_ids))]  # 가장 오래된 항목 제거
+            seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
 
         asyncio.create_task(

--- a/backend/tests/mcp/test_backoff_dedup.py
+++ b/backend/tests/mcp/test_backoff_dedup.py
@@ -10,7 +10,7 @@ from sprintable_mcp.sse_bridge import (
     _BASE_DELAY,
     _JITTER_FACTOR,
     _MAX_DELAY,
-    _SEEN_IDS_MAX,
+    SeenIdsCache,
     SseEvent,
     start_sse_bridge,
 )
@@ -54,22 +54,21 @@ async def test_dedup_passes_new_event_id():
 
 @pytest.mark.asyncio
 async def test_dedup_evicts_oldest_when_full():
-    """seen_ids가 SEEN_IDS_MAX 초과 시 가장 오래된 항목 제거."""
-    seen_ids: dict[str, None] = {}
-    for i in range(_SEEN_IDS_MAX):
-        seen_ids[f"eid-{i}"] = None
+    """SeenIdsCache: max_size 초과 시 가장 오래된 항목 LRU eviction."""
+    max_size = 10
+    cache = SeenIdsCache(max_size=max_size, ttl_seconds=3600)
+    for i in range(max_size):
+        cache.add(f"eid-{i}")
 
-    assert len(seen_ids) == _SEEN_IDS_MAX
+    assert len(cache) == max_size
 
-    # 새 항목 추가 → 가장 오래된 eid-0 제거
-    new_id = f"eid-{_SEEN_IDS_MAX}"
-    seen_ids[new_id] = None
-    if len(seen_ids) > _SEEN_IDS_MAX:
-        del seen_ids[next(iter(seen_ids))]
+    # 새 항목 추가 → "eid-0"(LRU 최고령) 제거
+    new_id = f"eid-{max_size}"
+    cache.add(new_id)
 
-    assert len(seen_ids) == _SEEN_IDS_MAX
-    assert "eid-0" not in seen_ids
-    assert new_id in seen_ids
+    assert len(cache) == max_size
+    assert "eid-0" not in cache
+    assert new_id in cache
 
 
 @pytest.mark.asyncio

--- a/backend/tests/mcp/test_seen_ids_eviction.py
+++ b/backend/tests/mcp/test_seen_ids_eviction.py
@@ -1,0 +1,204 @@
+"""S6-2: SeenIdsCache LRU + TTL eviction 정책 테스트.
+
+AC1: SSE_SEEN_IDS_MAX_SIZE 환경변수 (default 10000)
+AC2: SSE_SEEN_IDS_TTL_SECONDS 환경변수 (default 3600초)
+AC3: max_size 초과 시 LRU eviction
+AC4: TTL 만료 항목 자동 제거
+AC5: 환경변수 오버라이드 동작 검증
+AC6: eviction 발동 시 DEBUG 로그 출력
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+import pytest
+
+from sprintable_mcp.sse_bridge import SeenIdsCache
+
+
+# ─── AC1/AC2: 환경변수 기본값 ────────────────────────────────────────────────
+
+def test_config_defaults():
+    """SSE_SEEN_IDS_MAX_SIZE=10000, SSE_SEEN_IDS_TTL_SECONDS=3600 기본값."""
+    from sprintable_mcp.config import settings
+    assert settings.sse_seen_ids_max_size == 10000
+    assert settings.sse_seen_ids_ttl_seconds == 3600
+
+
+# ─── AC5: 환경변수 오버라이드 ────────────────────────────────────────────────
+
+def test_config_env_override(monkeypatch):
+    """환경변수 오버라이드 시 settings에 반영됨."""
+    monkeypatch.setenv("SSE_SEEN_IDS_MAX_SIZE", "500")
+    monkeypatch.setenv("SSE_SEEN_IDS_TTL_SECONDS", "60")
+
+    from sprintable_mcp.config import McpSettings
+    overridden = McpSettings()
+    assert overridden.sse_seen_ids_max_size == 500
+    assert overridden.sse_seen_ids_ttl_seconds == 60
+
+
+# ─── SeenIdsCache 기본 동작 ──────────────────────────────────────────────────
+
+def test_add_and_contains():
+    """add() 후 __contains__가 True 반환."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=3600)
+    cache.add("evt-1")
+    assert "evt-1" in cache
+    assert "evt-2" not in cache
+
+
+def test_unknown_id_not_in_cache():
+    """추가하지 않은 ID는 __contains__에서 False."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=3600)
+    assert "never-added" not in cache
+
+
+def test_len_reflects_count():
+    """__len__이 실제 저장 건수를 반환."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=3600)
+    for i in range(5):
+        cache.add(f"evt-{i}")
+    assert len(cache) == 5
+
+
+# ─── AC3: max_size 초과 시 LRU eviction ──────────────────────────────────────
+
+def test_lru_eviction_on_max_size_exceeded():
+    """max_size=3 → 4번째 add 시 가장 오래된 항목 제거."""
+    cache = SeenIdsCache(max_size=3, ttl_seconds=3600)
+    cache.add("a")
+    cache.add("b")
+    cache.add("c")
+    cache.add("d")  # "a"가 LRU eviction 대상
+
+    assert len(cache) == 3
+    assert "a" not in cache  # 가장 오래된 항목 제거됨
+    assert "b" in cache
+    assert "c" in cache
+    assert "d" in cache
+
+
+def test_lru_access_promotes_entry():
+    """access된 항목은 LRU 우선순위가 높아져 eviction에서 보호됨."""
+    cache = SeenIdsCache(max_size=3, ttl_seconds=3600)
+    cache.add("a")
+    cache.add("b")
+    cache.add("c")
+    # "a" access → 최근 사용으로 갱신
+    _ = "a" in cache
+    # "d" 추가 → "b"가 LRU (가장 오래 미사용)
+    cache.add("d")
+
+    assert "a" in cache  # 보호됨
+    assert "b" not in cache  # eviction 대상
+    assert "c" in cache
+    assert "d" in cache
+
+
+def test_lru_eviction_logs_debug(capsys):
+    """LRU eviction 시 [debug] lru-evict 로그 출력."""
+    cache = SeenIdsCache(max_size=2, ttl_seconds=3600)
+    cache.add("x")
+    cache.add("y")
+    cache.add("z")  # "x" eviction → 로그 발생
+
+    import sys
+    captured = capsys.readouterr()
+    assert "lru-evict" in captured.err
+
+
+# ─── AC4: TTL 만료 항목 자동 제거 ────────────────────────────────────────────
+
+def test_ttl_expired_returns_false(monkeypatch):
+    """TTL 만료된 항목은 __contains__에서 False + 제거됨."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=10)
+    cache.add("old-event")
+
+    # time.monotonic()을 100초 이후로 offset
+    original = time.monotonic()
+    monkeypatch.setattr("sprintable_mcp.sse_bridge.time.monotonic", lambda: original + 100)
+
+    assert "old-event" not in cache
+    assert len(cache) == 0
+
+
+def test_ttl_not_expired_remains(monkeypatch):
+    """TTL 미만인 항목은 __contains__에서 True."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=3600)
+    cache.add("recent-event")
+
+    original = time.monotonic()
+    monkeypatch.setattr("sprintable_mcp.sse_bridge.time.monotonic", lambda: original + 5)
+
+    assert "recent-event" in cache
+
+
+def test_ttl_batch_evict_on_add(monkeypatch):
+    """add() 호출 시 만료 항목 배치 제거 + 로그 출력."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=10)
+    cache.add("old-1")
+    cache.add("old-2")
+
+    original = time.monotonic()
+    monkeypatch.setattr("sprintable_mcp.sse_bridge.time.monotonic", lambda: original + 100)
+
+    cache.add("new-event")
+
+    assert len(cache) == 1  # 만료 2건 제거 후 새 항목 1건
+
+
+def test_ttl_batch_evict_logs_debug(monkeypatch, capsys):
+    """TTL 배치 eviction 시 [debug] ttl-batch-evict 로그 출력."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=10)
+    cache.add("exp-1")
+    cache.add("exp-2")
+
+    original = time.monotonic()
+    monkeypatch.setattr("sprintable_mcp.sse_bridge.time.monotonic", lambda: original + 100)
+
+    cache.add("trigger")
+    captured = capsys.readouterr()
+    assert "ttl-batch-evict" in captured.err
+
+
+def test_ttl_single_expire_logs_debug(monkeypatch, capsys):
+    """단건 TTL 만료 시 [debug] ttl-evict 로그 출력."""
+    cache = SeenIdsCache(max_size=100, ttl_seconds=10)
+    cache.add("single-exp")
+
+    original = time.monotonic()
+    monkeypatch.setattr("sprintable_mcp.sse_bridge.time.monotonic", lambda: original + 100)
+
+    result = "single-exp" in cache
+    assert result is False
+    captured = capsys.readouterr()
+    assert "ttl-evict" in captured.err
+
+
+# ─── AC6: start_sse_bridge SeenIdsCache 사용 확인 ────────────────────────────
+
+def test_start_sse_bridge_uses_seen_ids_cache():
+    """start_sse_bridge 소스에 SeenIdsCache 사용 확인."""
+    import inspect
+    from sprintable_mcp import sse_bridge
+    source = inspect.getsource(sse_bridge.start_sse_bridge)
+    assert "SeenIdsCache" in source
+    assert "sse_seen_ids_max_size" in source
+    assert "sse_seen_ids_ttl_seconds" in source
+
+
+def test_seen_ids_add_called_instead_of_dict_assign():
+    """seen_ids.add() 호출 방식으로 교체됨 (dict 직접 할당 방식 제거)."""
+    import inspect
+    from sprintable_mcp import sse_bridge
+    source = inspect.getsource(sse_bridge.start_sse_bridge)
+    assert "seen_ids.add(" in source
+    assert "seen_ids[event.last_event_id] = None" not in source
+
+
+def test_old_seen_ids_max_constant_removed():
+    """_SEEN_IDS_MAX 상수가 sse_bridge 모듈에서 제거됨."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert not hasattr(bridge, "_SEEN_IDS_MAX"), "_SEEN_IDS_MAX 상수는 SeenIdsCache로 대체됨"


### PR DESCRIPTION
## Summary
- `SeenIdsCache` 클래스 신설 — `OrderedDict` 기반 LRU + lazy TTL eviction
- `config.py`에 `SSE_SEEN_IDS_MAX_SIZE`(default 10000), `SSE_SEEN_IDS_TTL_SECONDS`(default 3600) 환경변수 추가
- `start_sse_bridge` → 기존 insertion-order dict + `_SEEN_IDS_MAX` 상수 제거, `SeenIdsCache` 교체
- eviction 발동 시 `[debug]` 로그 출력 (lru-evict / ttl-evict / ttl-batch-evict)

## AC 체크리스트
- [x] AC1: SSE_SEEN_IDS_MAX_SIZE 환경변수 (default 10000)
- [x] AC2: SSE_SEEN_IDS_TTL_SECONDS 환경변수 (default 3600초)
- [x] AC3: max_size 초과 시 LRU eviction
- [x] AC4: TTL 만료 항목 자동 제거 (lazy + 배치)
- [x] AC5: 환경변수 오버라이드 동작 검증 테스트
- [x] AC6: eviction 발동 시 DEBUG 로그 출력

## Test plan
- `tests/mcp/test_seen_ids_eviction.py` — 16 cases 전량 PASS
- `tests/mcp/test_backoff_dedup.py` — SeenIdsCache 호환성 수정 후 PASS
- 기존 MCP 테스트 회귀 없음 (e2e_dev 제외, DNS 환경 이슈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)