### PR TITLE
[S0-1] fakechat backfill 교정 + conversations 웹훅 검증

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -58,16 +58,24 @@ _sse_connection_count: int = 0
 # ─── S6-1: Backfill 볼륨 제어 ─────────────────────────────────────────────────
 _BACKFILL_THRESHOLD_SECONDS: int = int(_os.getenv("BACKFILL_THRESHOLD_SECONDS", "300"))
 _BACKFILL_MAX_EVENTS: int = int(_os.getenv("BACKFILL_MAX_EVENTS", "50"))
+# S0-1: 초기 연결(last_event_id=None) 시 backfill 상한 — 재연결과 구분하여 중복 방지
+_BACKFILL_INITIAL_EVENTS: int = int(_os.getenv("BACKFILL_INITIAL_EVENTS", "5"))
 
 
-def _compute_backfill_mode(ref_ts: "datetime | None", now: "datetime") -> tuple[bool, int]:
+def _compute_backfill_mode(
+    ref_ts: "datetime | None",
+    now: "datetime",
+    initial: bool = False,
+) -> tuple[bool, int]:
     """(exceed_threshold, limit) — threshold 초과 여부와 사용할 LIMIT 반환.
 
     exceed_threshold=True  → DESC 최신 N건 조회
     exceed_threshold=False → ASC 전량 조회 (max 100)
+    initial=True: last_event_id=None 초기 연결 — BACKFILL_INITIAL_EVENTS 상한 적용
     """
     if ref_ts is None:
-        return True, _BACKFILL_MAX_EVENTS
+        limit = _BACKFILL_INITIAL_EVENTS if initial else _BACKFILL_MAX_EVENTS
+        return True, limit
     _ref = ref_ts if ref_ts.tzinfo else ref_ts.replace(tzinfo=timezone.utc)
     exceed = (now - _ref) > timedelta(seconds=_BACKFILL_THRESHOLD_SECONDS)
     return exceed, (_BACKFILL_MAX_EVENTS if exceed else 100)
@@ -239,7 +247,9 @@ async def agent_event_stream(
                         ref_ts = ts if ts.tzinfo else ts.replace(tzinfo=timezone.utc)
 
                 _ref = ref_ts if ref_ts is None or ref_ts.tzinfo else ref_ts.replace(tzinfo=timezone.utc)
-                exceed, limit = _compute_backfill_mode(_ref, now)
+                # S0-1: 초기 연결(last_event_id=None, since_timestamp=None)은 INITIAL 상한 적용
+                is_initial = last_event_id is None and since_timestamp is None
+                exceed, limit = _compute_backfill_mode(_ref, now, initial=is_initial)
                 if exceed:
                     # threshold 초과: 최근 N건만 (최신순 → 역순 전달로 시간 순서 보존)
                     result = await db.execute(

--- a/backend/tests/test_s0_1_backfill_webhook.py
+++ b/backend/tests/test_s0_1_backfill_webhook.py
@@ -1,0 +1,169 @@
+"""S0-1: fakechat backfill 교정 + conversations 웹훅 검증.
+
+AC1: SSE reconnect 시 sse_bridge가 last_event_id 전달 (S6-1 이미 구현, 소스 검증)
+AC2: last_event_id=None (초기 연결) 시 backfill 상한 BACKFILL_INITIAL_EVENTS (default 5)
+AC3: conversations send_message 시 webhook BackgroundTask 추가됨
+AC4: conversation:message 이벤트가 sse_bridge relay 대상
+AC5: memo 경로(send_memo/reply_memo) 기능 영향 없음
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.events import (
+    _BACKFILL_INITIAL_EVENTS,
+    _BACKFILL_MAX_EVENTS,
+    _BACKFILL_THRESHOLD_SECONDS,
+    _compute_backfill_mode,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── AC2: 초기 연결 backfill 상한 ────────────────────────────────────────────
+
+def test_initial_events_default():
+    """BACKFILL_INITIAL_EVENTS 기본값 5건."""
+    assert _BACKFILL_INITIAL_EVENTS == 5
+
+
+def test_initial_connect_uses_initial_limit():
+    """initial=True + ref_ts=None → BACKFILL_INITIAL_EVENTS 상한."""
+    now = datetime.now(timezone.utc)
+    exceed, limit = _compute_backfill_mode(None, now, initial=True)
+    assert exceed is True
+    assert limit == _BACKFILL_INITIAL_EVENTS
+
+
+def test_reconnect_uses_max_events_limit():
+    """initial=False + ref_ts=None → BACKFILL_MAX_EVENTS 상한 (재연결 fallback)."""
+    now = datetime.now(timezone.utc)
+    exceed, limit = _compute_backfill_mode(None, now, initial=False)
+    assert exceed is True
+    assert limit == _BACKFILL_MAX_EVENTS
+
+
+def test_initial_within_threshold_uses_asc():
+    """initial=True라도 ref_ts가 threshold 이내 → ASC 전량 (initial 무관)."""
+    now = datetime.now(timezone.utc)
+    ref = now - timedelta(seconds=10)
+    exceed, limit = _compute_backfill_mode(ref, now, initial=True)
+    assert exceed is False
+    assert limit == 100
+
+
+def test_initial_connect_source_in_generate():
+    """generate() 소스에 is_initial 분기가 포함됨."""
+    from app.routers.events import agent_event_stream
+    source = inspect.getsource(agent_event_stream)
+    assert "is_initial" in source
+    assert "last_event_id is None and since_timestamp is None" in source
+    assert "initial=is_initial" in source
+
+
+# ─── AC1: SSE reconnect last_event_id 전달 ───────────────────────────────────
+
+def test_sse_bridge_stores_last_event_id_on_reconnect():
+    """_current_last_event_id가 갱신되어 재연결 시 _connect_once에 전달됨."""
+    from sprintable_mcp import sse_bridge
+    source = inspect.getsource(sse_bridge.start_sse_bridge)
+    assert "_current_last_event_id" in source
+    assert "nonlocal _current_last_event_id" in source
+    assert "_current_last_event_id = event.last_event_id" in source
+
+
+def test_connect_once_passes_last_event_id_param():
+    """_connect_once가 last_event_id를 SSE 쿼리 파라미터에 포함."""
+    from sprintable_mcp import sse_bridge
+    source = inspect.getsource(sse_bridge._connect_once)
+    assert 'params["last_event_id"] = last_event_id' in source
+
+
+def test_backfill_yields_sse_id_field():
+    """SSE backfill yield에 id: 필드 포함 → bridge가 last_event_id 파싱 가능."""
+    from app.routers.events import agent_event_stream
+    source = inspect.getsource(agent_event_stream)
+    assert "id: {evt.id}" in source
+
+
+def test_live_sse_always_yields_id_field():
+    """live SSE yield에 event_id 없어도 uuid4()로 id: 보장."""
+    from app.routers.events import agent_event_stream
+    source = inspect.getsource(agent_event_stream)
+    assert "_live_id = eid or str(uuid.uuid4())" in source
+
+
+# ─── AC3: conversations webhook BackgroundTask 검증 ──────────────────────────
+
+def test_send_message_webhook_background_task_in_source():
+    """send_message 소스에 deliver_conversation_message_webhook BackgroundTask 추가 확인."""
+    import inspect
+    from app.routers import conversations as cv
+    source = inspect.getsource(cv.send_message)
+    assert "deliver_conversation_message_webhook" in source
+    assert "background_tasks.add_task" in source
+    # webhook에 필수 파라미터 전달 확인
+    assert "message_id=msg.id" in source
+    assert "conversation_id=conversation_id" in source
+    assert "content=msg.content" in source
+
+
+# ─── AC4: conversation:message SSE relay 대상 확인 ───────────────────────────
+
+def test_conversation_message_in_relay_event_types():
+    """sse_bridge._RELAY_EVENT_TYPES에 conversation:message 포함."""
+    from sprintable_mcp.sse_bridge import _RELAY_EVENT_TYPES
+    assert "conversation:message" in _RELAY_EVENT_TYPES
+
+
+def test_conversation_mention_in_relay_event_types():
+    """sse_bridge._RELAY_EVENT_TYPES에 conversation:mention 포함."""
+    from sprintable_mcp.sse_bridge import _RELAY_EVENT_TYPES
+    assert "conversation:mention" in _RELAY_EVENT_TYPES
+
+
+def test_relay_filters_non_conversation_events():
+    """chat:message 같은 비대상 이벤트는 relay 대상 외."""
+    from sprintable_mcp.sse_bridge import _RELAY_EVENT_TYPES
+    assert "chat:message" not in _RELAY_EVENT_TYPES
+    assert "memo_created" not in _RELAY_EVENT_TYPES
+
+
+# ─── AC5: memo 경로 기능 영향 없음 ───────────────────────────────────────────
+
+def test_send_memo_tool_still_registered():
+    """send_memo 도구가 MCP 서버에 등록되어 있음."""
+    import os
+    os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+    os.environ.setdefault("AGENT_API_KEY", "sk_test")
+    from sprintable_mcp.server import mcp
+    tools = mcp._tool_manager._tools
+    assert "sprintable_send_memo" in tools
+
+
+def test_reply_memo_tool_still_registered():
+    """reply_memo 도구가 MCP 서버에 등록되어 있음."""
+    import os
+    os.environ.setdefault("SPRINTABLE_API_URL", "http://test")
+    os.environ.setdefault("AGENT_API_KEY", "sk_test")
+    from sprintable_mcp.server import mcp
+    tools = mcp._tool_manager._tools
+    assert "sprintable_reply_memo" in tools
+
+
+def test_backfill_threshold_unchanged():
+    """S6-1 backfill threshold 기본값 300초 유지."""
+    assert _BACKFILL_THRESHOLD_SECONDS == 300
+
+
+def test_backfill_max_events_unchanged():
+    """S6-1 BACKFILL_MAX_EVENTS 기본값 50건 유지 (재연결 시 기준)."""
+    assert _BACKFILL_MAX_EVENTS == 50


### PR DESCRIPTION
## Summary
- `BACKFILL_INITIAL_EVENTS` (default 5) 환경변수 추가 — 초기 연결 backfill 상한
- `_compute_backfill_mode(initial=True)`: `last_event_id=None` 초기 연결 시 50건 → 5건
- `generate()`: `is_initial_connect = last_event_id is None and since_timestamp is None` 분기
- 재연결 시 `_current_last_event_id` 전달로 threshold 이내 전량 / 초과 50건 유지 (S6-1)

## AC 체크리스트
- [x] AC1: SSE reconnect 시 sse_bridge last_event_id 전달 (S6-1 구현 소스 검증)
- [x] AC2: 초기 연결(last_event_id=None) backfill 상한 5건
- [x] AC3: conversations send_message webhook BackgroundTask 소스 검증
- [x] AC4: conversation:message sse_bridge relay 대상 확인
- [x] AC5: send_memo/reply_memo 도구 등록 유지, threshold/max_events 기본값 불변

## Test plan
- `tests/test_s0_1_backfill_webhook.py` — 17/17 PASS
- `tests/test_s6_1_sse_backfill.py` — 23/23 PASS (회귀 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)