### PR TITLE
[P0 Hotfix] S2-1: migration 0038 FK 방식 수정 — dev bootstrap PK 누락 대응

### DIFF
--- a/backend/alembic/versions/0038_add_presence_columns_to_team_members.py
+++ b/backend/alembic/versions/0038_add_presence_columns_to_team_members.py
@@ -38,8 +38,8 @@ def upgrade() -> None:
         BEGIN
             IF NOT EXISTS (
                 SELECT 1 FROM pg_constraint
-                WHERE conname = 'stories_pkey'
-                  AND conrelid = 'stories'::regclass
+                WHERE conrelid = 'stories'::regclass
+                  AND contype = 'p'
             ) THEN
                 ALTER TABLE stories ADD PRIMARY KEY (id);
             END IF;

--- a/backend/alembic/versions/0038_add_presence_columns_to_team_members.py
+++ b/backend/alembic/versions/0038_add_presence_columns_to_team_members.py
@@ -19,15 +19,10 @@ def upgrade() -> None:
         "team_members",
         sa.Column("last_seen_at", sa.TIMESTAMP(timezone=True), nullable=True),
     )
-    # AC3: active_story_id UUID NULL FK stories(id) ON DELETE SET NULL
+    # AC3: active_story_id UUID NULL — FK는 아래에서 create_foreign_key로 별도 추가
     op.add_column(
         "team_members",
-        sa.Column(
-            "active_story_id",
-            sa.UUID(as_uuid=True),
-            sa.ForeignKey("stories.id", ondelete="SET NULL"),
-            nullable=True,
-        ),
+        sa.Column("active_story_id", sa.UUID(as_uuid=True), nullable=True),
     )
     # AC4: agent_status VARCHAR(20) NULL — online/idle/offline
     op.add_column(
@@ -35,8 +30,36 @@ def upgrade() -> None:
         sa.Column("agent_status", sa.String(20), nullable=True),
     )
 
+    # dev bootstrap 시 stories.id PK constraint가 누락된 환경 대응
+    # prod(Supabase 원본)에는 PK가 존재하므로 DO $$ 블록이 no-op 처리됨
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conname = 'stories_pkey'
+                  AND conrelid = 'stories'::regclass
+            ) THEN
+                ALTER TABLE stories ADD PRIMARY KEY (id);
+            END IF;
+        END $$;
+        """
+    )
+
+    # AC3: active_story_id → stories.id ON DELETE SET NULL
+    op.create_foreign_key(
+        "fk_team_members_active_story_id_stories",
+        "team_members",
+        "stories",
+        ["active_story_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
 
 def downgrade() -> None:
+    op.drop_constraint("fk_team_members_active_story_id_stories", "team_members", type_="foreignkey")
     op.drop_column("team_members", "agent_status")
     op.drop_column("team_members", "active_story_id")
     op.drop_column("team_members", "last_seen_at")


### PR DESCRIPTION
## 장애 원인

PR #815 머지 후 `alembic upgrade head` 실행 시 아래 에러로 migration 0038 실패:

```
psycopg2.errors.InvalidForeignKey: there is no unique constraint matching given keys for referenced table "stories"
[SQL: ALTER TABLE team_members ADD FOREIGN KEY(active_story_id) REFERENCES stories (id) ON DELETE SET NULL]
```

**근본 원인**: `op.add_column`에 인라인 `sa.ForeignKey`를 넣으면 Alembic이 단독 `ALTER TABLE ... ADD FOREIGN KEY` SQL을 생성한다. dev 환경에서 Supabase→FastAPI 전환 bootstrap 시 `stories.id` PK constraint가 누락되어 FK 참조 대상이 없는 상태였다.

## 수정 내용

1. `op.add_column`에서 인라인 FK 제거 → `active_story_id`를 순수 UUID nullable 컬럼으로 추가
2. `DO $$ ... $$` 블록으로 `stories.id` PK 없는 환경 자동 보정 (prod 환경에서는 PK가 이미 존재하므로 no-op)
3. `op.create_foreign_key()`로 FK constraint 명시적 추가
4. `downgrade()`에 `drop_constraint()` 추가

## 테스트

- `test_s2_1_presence_columns.py` + `test_team_members.py`: **23/23 PASS**

## 영향 범위

- dev DB: 0038 재실행 시 stories.id PK 자동 추가 후 FK constraint 정상 적용
- prod DB: stories.id PK 이미 존재 → DO $$ 블록 no-op → FK만 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)