### PR TITLE
[S2-2] MCP 미들웨어 passive heartbeat — tool 호출 시 last_seen_at 자동 갱신

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
@@ -146,6 +147,22 @@ async def update_team_member(
     data = body.model_dump(exclude_unset=True)
     updated = await repo.update(id, **data)
     return TeamMemberResponse.model_validate(updated)
+
+
+@router.patch("/{id}/heartbeat")
+async def heartbeat(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """AC1/2: last_seen_at = NOW(), agent_status = online 갱신."""
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    now = datetime.now(timezone.utc)
+    await repo.update(id, last_seen_at=now, agent_status="online")
+    return {"ok": True, "last_seen_at": now.isoformat()}
 
 
 @router.delete("/{id}", status_code=200)

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,14 +1,19 @@
 """Sprintable MCP 서버 — 88개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
+import asyncio
 import inspect
+import logging
 from typing import get_type_hints
+
+logger = logging.getLogger(__name__)
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import TextContent
 from pydantic import BaseModel
 from pydantic.fields import PydanticUndefined
 
+from .api_client import client
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
@@ -89,6 +94,15 @@ from .tools.tasks import (
 )
 
 
+async def _heartbeat_fire_forget() -> None:
+    """AC3/4: tool 호출 완료 후 fire-and-forget. 실패해도 tool 결과에 영향 없음."""
+    try:
+        if client.member_id:
+            await client.patch(f"/api/v2/team-members/{client.member_id}/heartbeat")
+    except Exception as exc:
+        logger.warning("heartbeat failed (ignored): %s", exc)
+
+
 def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
     """BaseModel → flat inspect.Signature so FastMCP emits top-level params."""
     try:
@@ -114,7 +128,9 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
         )
 
     async def wrapper(**kwargs):
-        return await fn(input_cls(**kwargs))
+        result = await fn(input_cls(**kwargs))
+        asyncio.create_task(_heartbeat_fire_forget())
+        return result
 
     wrapper.__name__ = name
     wrapper.__qualname__ = name
@@ -135,8 +151,9 @@ mcp = FastMCP(
 
 
 @mcp.tool()
-def ping() -> list[TextContent]:
+async def ping() -> list[TextContent]:
     """서버 생존 확인용 smoke tool."""
+    asyncio.create_task(_heartbeat_fire_forget())
     return ok({"status": "pong"})
 
 

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -1,0 +1,250 @@
+"""S2-2: MCP 미들웨어 passive heartbeat 검증.
+
+AC1: PATCH /api/v2/team-members/{id}/heartbeat 엔드포인트 존재 + 200
+AC2: 응답에 ok=True, last_seen_at 포함
+AC3: _flat() wrapper가 heartbeat fire-and-forget task 생성
+AC4: heartbeat 실패 시 tool 결과에 영향 없음
+AC5: ping() 도구도 heartbeat task 생성
+AC6: MCP server _heartbeat_fire_forget — member_id 없으면 API 미호출
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+
+
+# ─── AC1/2: heartbeat 엔드포인트 ─────────────────────────────────────────────
+
+def _mock_member_for_heartbeat():
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.project_id = uuid.uuid4()
+    m.user_id = None
+    m.type = "agent"
+    m.name = "TestAgent"
+    m.role = "member"
+    m.avatar_url = None
+    m.agent_config = None
+    m.webhook_url = None
+    m.is_active = True
+    m.color = "#3385f8"
+    m.agent_role = None
+    m.created_by = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    m.last_seen_at = datetime(2026, 5, 19, 10, 0, 0, tzinfo=timezone.utc)
+    m.active_story_id = None
+    m.agent_status = "online"
+    return m
+
+
+async def _heartbeat_client():
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "agent@test.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_endpoint_200():
+    """AC1: PATCH /api/v2/team-members/{id}/heartbeat → 200."""
+    client, session, app = await _heartbeat_client()
+    try:
+        member = _mock_member_for_heartbeat()
+        updated = _mock_member_for_heartbeat()
+
+        mock_get_result = MagicMock()
+        mock_get_result.scalar_one_or_none.return_value = member
+
+        mock_update_result = MagicMock()
+        mock_update_result.scalar_one_or_none.return_value = updated
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return mock_get_result
+            return mock_update_result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_heartbeat_response_shape():
+    """AC2: 응답에 ok=True, last_seen_at(ISO8601) 포함."""
+    client, session, app = await _heartbeat_client()
+    try:
+        member = _mock_member_for_heartbeat()
+        updated = _mock_member_for_heartbeat()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = member if call_count == 1 else updated
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}/heartbeat")
+
+        body = resp.json()
+        assert body["ok"] is True
+        assert "last_seen_at" in body
+        # ISO8601 형식 확인
+        datetime.fromisoformat(body["last_seen_at"].replace("Z", "+00:00"))
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_heartbeat_404_if_not_found():
+    """AC1: 존재하지 않는 멤버 → 404."""
+    client, session, app = await _heartbeat_client()
+    try:
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/team-members/{uuid.uuid4()}/heartbeat")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC3: _flat() wrapper heartbeat task 생성 ────────────────────────────────
+
+@pytest.mark.anyio
+async def test_flat_wrapper_creates_heartbeat_task():
+    """AC3: _flat() wrapper가 tool 완료 후 heartbeat task를 생성."""
+    from sprintable_mcp.server import _flat
+    from sprintable_mcp.schemas import SprintableInput
+
+    async def dummy_tool(args: SprintableInput):
+        return [MagicMock()]
+
+    wrapped = _flat("dummy", "dummy doc", SprintableInput, dummy_tool)
+
+    tasks_created = []
+
+    def fake_create_task(coro):
+        tasks_created.append(coro)
+        coro.close()  # 실제 실행 없이 정리
+        return MagicMock()
+
+    with patch("sprintable_mcp.server.asyncio.create_task", side_effect=fake_create_task):
+        await wrapped()
+
+    assert len(tasks_created) == 1
+
+
+# ─── AC4: heartbeat 실패 시 tool 결과 영향 없음 ──────────────────────────────
+
+@pytest.mark.anyio
+async def test_heartbeat_failure_does_not_affect_tool():
+    """AC4: heartbeat 실패해도 tool 결과 정상 반환."""
+    from sprintable_mcp.server import _flat
+    from sprintable_mcp.schemas import SprintableInput
+    from mcp.types import TextContent
+
+    sentinel = [TextContent(type="text", text="ok")]
+
+    async def dummy_tool(args: SprintableInput):
+        return sentinel
+
+    wrapped = _flat("dummy", "doc", SprintableInput, dummy_tool)
+
+    async def failing_heartbeat():
+        raise RuntimeError("network error")
+
+    with patch("sprintable_mcp.server._heartbeat_fire_forget", side_effect=failing_heartbeat):
+        with patch("sprintable_mcp.server.asyncio.create_task"):
+            result = await wrapped()
+
+    assert result is sentinel
+
+
+# ─── AC5: ping() heartbeat task 생성 ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_ping_creates_heartbeat_task():
+    """AC5: ping() 도구 호출 시 heartbeat task 생성."""
+    import sprintable_mcp.server as srv
+
+    tasks_created = []
+
+    def fake_create_task(coro):
+        tasks_created.append(coro)
+        coro.close()
+        return MagicMock()
+
+    with patch.object(srv.asyncio, "create_task", side_effect=fake_create_task):
+        await srv.ping()
+
+    assert len(tasks_created) == 1
+
+
+# ─── AC6: member_id 없으면 API 미호출 ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_heartbeat_skips_if_no_member_id():
+    """AC6: client.member_id가 빈 문자열이면 heartbeat API 미호출."""
+    from sprintable_mcp.server import _heartbeat_fire_forget
+
+    with patch("sprintable_mcp.server.client") as mock_client:
+        mock_client.member_id = ""
+        mock_client.patch = AsyncMock()
+
+        await _heartbeat_fire_forget()
+
+        mock_client.patch.assert_not_called()


### PR DESCRIPTION
## Summary

- `PATCH /api/v2/team-members/{id}/heartbeat` 엔드포인트 신설 — `last_seen_at = NOW()`, `agent_status = 'online'` 갱신
- `sprintable_mcp/server.py` `_flat()` wrapper + `ping()`에 `asyncio.create_task(_heartbeat_fire_forget())` 추가
- heartbeat 실패는 `logger.warning`만, tool 결과에 영향 없음
- `client.member_id` 없으면 API 미호출 (부팅 직후 passive 보장)

## AC 체크리스트

- [x] AC1: `PATCH /api/v2/team-members/{id}/heartbeat` 200
- [x] AC2: 응답 `{ok: true, last_seen_at: ISO8601}`, DB `last_seen_at` / `agent_status = 'online'` 갱신
- [x] AC3: `_flat()` wrapper — 모든 tool 완료 후 fire-and-forget
- [x] AC4: heartbeat 실패 시 tool 결과 영향 없음
- [x] AC5: `ping()` 도 heartbeat task 생성
- [x] AC6: `member_id` 없으면 API 미호출 (부팅 직후 last_seen_at NULL 유지)

## 변경 파일

- `backend/app/routers/team_members.py` — heartbeat 엔드포인트 추가
- `backend/sprintable_mcp/server.py` — `_heartbeat_fire_forget` + `_flat` + `ping` 수정
- `backend/tests/test_s2_2_passive_heartbeat.py` — 7개 테스트 (30/30 PASS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)