### PR TITLE
[SID:S2-5] Agent Team Presence Panel on Dashboard

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2155,5 +2155,14 @@
     "forbiddenTitle": "Access denied",
     "forbiddenDescription": "You do not have permission to view the activity log.",
     "noProject": "No project selected."
+  },
+  "agentPresence": {
+    "title": "Agent Team",
+    "description": "Live presence status of your AI agents.",
+    "liveLabel": "Live",
+    "empty": "No agents deployed yet.",
+    "status_online": "Online",
+    "status_idle": "Idle",
+    "status_offline": "Offline"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2155,5 +2155,14 @@
     "forbiddenTitle": "접근 권한 없음",
     "forbiddenDescription": "활동 로그를 조회할 권한이 없습니다.",
     "noProject": "선택된 프로젝트가 없습니다."
+  },
+  "agentPresence": {
+    "title": "에이전트 팀",
+    "description": "AI 에이전트의 실시간 활동 상태입니다.",
+    "liveLabel": "실시간",
+    "empty": "배포된 에이전트가 없습니다.",
+    "status_online": "온라인",
+    "status_idle": "유휴",
+    "status_offline": "오프라인"
   }
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/button';
 import { OperatorStatCard } from '@/components/ui/operator-stat-card';
 import { formatLocaleDateOnly, formatLocaleDateTime } from '@/lib/i18n';
 import { WidgetRefreshTime } from '@/components/ui/widget-refresh-time';
+import { AgentPresencePanel, type AgentPresenceMember } from '@/components/agents/agent-presence-panel';
 
 export default async function DashboardPage() {
   const fetchedAt = new Date().toISOString();
@@ -40,6 +41,12 @@ export default async function DashboardPage() {
     { query: { project_id: projectId, member_type: 'agent' } },
   ).catch(() => null);
   const hasActiveAgent = (agentsData ?? []).some((a) => a.is_active);
+
+  // Agent presence panel: initial SSR data
+  const agentPresenceData = await fastapiCall<AgentPresenceMember[]>(
+    'GET', '/api/v2/team-members', session.access_token,
+    { query: { project_id: projectId, type: 'agent' } },
+  ).catch(() => null);
 
   interface DashboardData {
     my_stories: Array<{ id: string; title: string; status: string; story_points: number | null }>;
@@ -247,6 +254,11 @@ export default async function DashboardPage() {
               <div className="pt-1"><WidgetRefreshTime fetchedAt={fetchedAt} /></div>
             </SectionCardBody>
           </SectionCard>
+
+          <AgentPresencePanel
+            initialMembers={agentPresenceData ?? []}
+            projectId={projectId}
+          />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/agents/agent-presence-panel.tsx
+++ b/apps/web/src/components/agents/agent-presence-panel.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Bot, Clock } from 'lucide-react';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { Badge } from '@/components/ui/badge';
+
+export interface AgentPresenceMember {
+  id: string;
+  name: string;
+  type: string;
+  presence_status: 'online' | 'idle' | 'offline' | null;
+  active_story: { id: string; title: string; status: string } | null;
+  last_seen_at: string | null;
+}
+
+interface AgentPresencePanelProps {
+  initialMembers: AgentPresenceMember[];
+  projectId: string;
+}
+
+const POLL_INTERVAL = 30_000;
+
+function presenceDotClass(status: AgentPresenceMember['presence_status']): string {
+  switch (status) {
+    case 'online': return 'bg-emerald-500';
+    case 'idle': return 'bg-amber-400';
+    default: return 'bg-muted-foreground/40';
+  }
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text;
+}
+
+export function AgentPresencePanel({ initialMembers, projectId }: AgentPresencePanelProps) {
+  const t = useTranslations('agentPresence');
+  const [members, setMembers] = useState<AgentPresenceMember[]>(initialMembers);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/team-members?project_id=${encodeURIComponent(projectId)}&type=agent`);
+      if (!res.ok) return;
+      const json = await res.json() as { data: AgentPresenceMember[] | null };
+      if (Array.isArray(json.data)) {
+        setMembers(json.data.filter((m) => m.type === 'agent'));
+      }
+    } catch {
+      // Silently skip poll failures
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    const start = () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      intervalRef.current = setInterval(fetchMembers, POLL_INTERVAL);
+    };
+    const stop = () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    const handleVisibility = () => {
+      if (document.hidden) {
+        stop();
+      } else {
+        fetchMembers();
+        start();
+      }
+    };
+
+    start();
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchMembers]);
+
+  const agentMembers = members.filter((m) => m.type === 'agent');
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-sm font-semibold text-foreground">{t('title')}</div>
+          <Badge variant="chip" className="inline-flex items-center gap-1 text-xs">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" aria-hidden="true" />
+            {t('liveLabel')}
+          </Badge>
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">{t('description')}</p>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-2">
+        {agentMembers.length === 0 ? (
+          <div className="flex flex-col items-center gap-2 py-6 text-center">
+            <Bot className="size-8 text-muted-foreground/50" />
+            <p className="text-sm text-muted-foreground">{t('empty')}</p>
+          </div>
+        ) : (
+          agentMembers.map((member) => (
+            <div
+              key={member.id}
+              className="flex items-start gap-3 rounded-md border border-border bg-muted/30 px-3 py-2.5"
+            >
+              <span
+                className={`mt-1 h-2 w-2 shrink-0 rounded-full ${presenceDotClass(member.presence_status)}`}
+                aria-label={t(`status_${member.presence_status ?? 'offline'}`)}
+              />
+              <div className="min-w-0 flex-1 space-y-0.5">
+                <div className="text-sm font-medium text-foreground leading-snug">{member.name}</div>
+                {member.active_story ? (
+                  <div className="text-xs text-muted-foreground truncate">
+                    {truncate(member.active_story.title, 40)}
+                  </div>
+                ) : (
+                  <div className="text-xs text-muted-foreground">{t(`status_${member.presence_status ?? 'offline'}`)}</div>
+                )}
+              </div>
+              {member.active_story && (
+                <Badge variant="chip" className="shrink-0 text-[10px]">
+                  {member.active_story.status}
+                </Badge>
+              )}
+              {!member.active_story && member.last_seen_at && member.presence_status !== 'online' && (
+                <Clock className="mt-0.5 size-3 shrink-0 text-muted-foreground/50" aria-hidden="true" />
+              )}
+            </div>
+          ))
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -3,15 +3,46 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.dependencies.ownership import assert_agent_owner
+from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.team_member import TeamMemberRepository
-from app.schemas.team_member import TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate
+from app.schemas.team_member import (
+    ActiveStorySummary, TeamMemberCreate, TeamMemberResponse, TeamMemberUpdate,
+)
+
+
+class ClaimBody(BaseModel):
+    story_id: uuid.UUID
+
+
+async def _inject_active_stories(
+    members: list, session: AsyncSession
+) -> list[TeamMemberResponse]:
+    """AC6: active_story_id → stories batch 조회 후 inject."""
+    ids = {m.active_story_id for m in members if m.active_story_id}
+    stories: dict[uuid.UUID, Story] = {}
+    if ids:
+        result = await session.execute(select(Story).where(Story.id.in_(ids)))
+        for s in result.scalars().all():
+            stories[s.id] = s
+
+    out = []
+    for m in members:
+        resp = TeamMemberResponse.model_validate(m)
+        if m.active_story_id and m.active_story_id in stories:
+            s = stories[m.active_story_id]
+            resp = resp.model_copy(update={
+                "active_story": ActiveStorySummary(id=s.id, title=s.title, status=s.status)
+            })
+        out.append(resp)
+    return out
 
 _FAKECHAT_BASE_PORT = 8787
 
@@ -32,6 +63,7 @@ async def list_team_members(
     is_active: bool | None = Query(default=True),
     user_id: uuid.UUID | None = Query(default=None),
     repo: TeamMemberRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
 ) -> list[TeamMemberResponse]:
     filters: dict = {}
     if project_id:
@@ -43,7 +75,7 @@ async def list_team_members(
     if user_id:
         filters["user_id"] = user_id
     members = await repo.list(**filters)
-    return [TeamMemberResponse.model_validate(m) for m in members]
+    return await _inject_active_stories(members, session)
 
 
 @router.post("", status_code=201)
@@ -163,6 +195,47 @@ async def heartbeat(
     now = datetime.now(timezone.utc)
     await repo.update(id, last_seen_at=now, agent_status="online")
     return {"ok": True, "last_seen_at": now.isoformat()}
+
+
+@router.post("/{id}/claim")
+async def claim_story(
+    id: uuid.UUID,
+    body: ClaimBody,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """AC1/3: active_story_id 갱신 + story 존재 검증."""
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+
+    # AC3: story가 해당 project에 존재하는지 검증
+    story_result = await session.execute(
+        select(Story).where(Story.id == body.story_id, Story.project_id == member.project_id)
+    )
+    story = story_result.scalar_one_or_none()
+    if story is None:
+        raise HTTPException(status_code=400, detail="Story not found in this project")
+
+    now = datetime.now(timezone.utc)
+    await repo.update(id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
+    return {"claimed": True, "story_id": str(body.story_id)}
+
+
+@router.post("/{id}/unclaim")
+async def unclaim_story(
+    id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """AC2: active_story_id = NULL."""
+    repo = TeamMemberRepository(session, org_id)
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+    await repo.update(id, active_story_id=None)
+    return {"unclaimed": True}
 
 
 @router.delete("/{id}", status_code=200)

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -8,6 +8,12 @@ _ONLINE_THRESHOLD = timedelta(minutes=5)
 _IDLE_THRESHOLD = timedelta(minutes=30)
 
 
+class ActiveStorySummary(BaseModel):
+    id: uuid.UUID
+    title: str
+    status: str
+
+
 class TeamMemberCreate(BaseModel):
     project_id: uuid.UUID
     org_id: uuid.UUID
@@ -56,6 +62,8 @@ class TeamMemberResponse(BaseModel):
     last_seen_at: datetime | None = None
     active_story_id: uuid.UUID | None = None
     agent_status: str | None = None
+    # S2-4: active_story 요약 — router에서 inject
+    active_story: ActiveStorySummary | None = None
 
     # S2-3: computed presence_status — 조회 시점 실시간 계산
     @computed_field
@@ -72,5 +80,8 @@ class TeamMemberResponse(BaseModel):
         if delta <= _ONLINE_THRESHOLD:
             return "online"
         if delta <= _IDLE_THRESHOLD:
+            return "idle"
+        # AC7: claim 중이면 offline 강등 방지 → idle 유지
+        if self.active_story_id is not None:
             return "idle"
         return "offline"

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -30,7 +30,10 @@ from .tools.analytics import (
     get_unassigned_stories, search_stories,
 )
 from .tools.audit import ListAuditLogsInput, list_audit_logs
-from .tools.core import DashboardInput, list_team_members, my_dashboard
+from .tools.core import (
+    ClaimStoryInput, DashboardInput,
+    claim_story, list_team_members, my_dashboard, unclaim_story,
+)
 from .tools.docs import (
     CreateDocInput, DeleteDocInput, GetDocInput, ListDocsInput,
     SearchDocsInput, UpdateDocInput,
@@ -298,13 +301,19 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_project_health",
      "프로젝트 전체 건강도 조회.",
      SprintableInput, get_project_health),
-    # Core (2)
+    # Core (4)
     ("sprintable_list_team_members",
      "프로젝트 팀 멤버 목록 조회.",
      SprintableInput, list_team_members),
     ("sprintable_my_dashboard",
      "팀원 대시보드 요약 조회.",
      DashboardInput, my_dashboard),
+    ("sprintable_claim_story",
+     "현재 작업 중인 스토리를 claim — active_story_id 갱신, 중복 배정 방지.",
+     ClaimStoryInput, claim_story),
+    ("sprintable_unclaim_story",
+     "작업 중인 스토리 claim 해제 — active_story_id = NULL.",
+     SprintableInput, unclaim_story),
     # Memos + Chat (10)
     ("sprintable_list_memos",
      "메모 목록 조회.",

--- a/backend/sprintable_mcp/tools/core.py
+++ b/backend/sprintable_mcp/tools/core.py
@@ -1,4 +1,4 @@
-"""코어 유틸리티 MCP 도구 (2개)."""
+"""코어 유틸리티 MCP 도구 (4개)."""
 from __future__ import annotations
 
 from mcp.types import TextContent
@@ -10,6 +10,10 @@ from ..schemas import SprintableInput
 
 class DashboardInput(SprintableInput):
     member_id: str | None = None
+
+
+class ClaimStoryInput(SprintableInput):
+    story_id: str
 
 
 async def list_team_members(args: SprintableInput) -> list[TextContent]:
@@ -27,5 +31,33 @@ async def my_dashboard(args: DashboardInput) -> list[TextContent]:
     params: dict = {"member_id": member, "project_id": client.project_id}
     try:
         return ok(await client.get("/api/v2/dashboard", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def claim_story(args: ClaimStoryInput) -> list[TextContent]:
+    """현재 작업 중인 스토리를 claim — active_story_id 갱신."""
+    if not client.member_id:
+        return err("member_id not resolved")
+    try:
+        result = await client.post(
+            f"/api/v2/team-members/{client.member_id}/claim",
+            json={"story_id": args.story_id},
+        )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def unclaim_story(args: SprintableInput) -> list[TextContent]:
+    """작업 중인 스토리 claim 해제 — active_story_id = NULL."""
+    if not client.member_id:
+        return err("member_id not resolved")
+    try:
+        result = await client.post(
+            f"/api/v2/team-members/{client.member_id}/unclaim",
+            json={},
+        )
+        return ok(result)
     except Exception as exc:
         return err(str(exc))

--- a/backend/tests/test_s2_3_presence_status.py
+++ b/backend/tests/test_s2_3_presence_status.py
@@ -43,6 +43,7 @@ def _mock_member(type_: str = "agent", last_seen_at=None):
     m.last_seen_at = last_seen_at
     m.active_story_id = None
     m.agent_status = None
+    m.active_story = None
     return m
 
 

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -1,0 +1,316 @@
+"""S2-4: story claim/unclaim MCP 도구 + 현재 작업 가시화 검증.
+
+AC1: POST /api/v2/team-members/{id}/claim → 200 + {claimed, story_id}
+AC2: POST /api/v2/team-members/{id}/unclaim → 200 + {unclaimed}
+AC3: claim 시 story가 project에 없으면 400
+AC4: MCP claim_story 도구 존재
+AC5: MCP unclaim_story 도구 존재
+AC6: GET /api/v2/team-members 응답에 active_story {id, title, status} 포함
+AC7: claim 중 last_seen_at 30분 초과여도 presence_status = idle
+AC8: active_story schema 필드 존재
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+NOW = datetime.now(timezone.utc)
+
+
+def _mock_member(active_story_id=None, last_seen_at=None, type_="agent"):
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.user_id = None
+    m.type = type_
+    m.name = "TestAgent"
+    m.role = "member"
+    m.avatar_url = None
+    m.agent_config = None
+    m.webhook_url = None
+    m.is_active = True
+    m.color = "#3385f8"
+    m.agent_role = None
+    m.created_by = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    m.last_seen_at = last_seen_at
+    m.active_story_id = active_story_id
+    m.agent_status = None
+    m.active_story = None  # from_attributes 시 MagicMock 반환 방지
+    return m
+
+
+def _mock_story(id=None, title="Test Story", status="in-progress"):
+    s = MagicMock()
+    s.id = id or STORY_ID
+    s.title = title
+    s.status = status
+    s.project_id = PROJECT_ID
+    return s
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ─── AC1: claim 엔드포인트 ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_claim_story_200():
+    """AC1: POST /claim → 200 + {claimed: true, story_id}."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+        story = _mock_story()
+        updated = _mock_member(active_story_id=STORY_ID)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member  # get member
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = story   # story 존재 확인
+            else:
+                result.scalar_one_or_none.return_value = updated  # update
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/team-members/{MEMBER_ID}/claim",
+                json={"story_id": str(STORY_ID)},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["claimed"] is True
+        assert body["story_id"] == str(STORY_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC2: unclaim 엔드포인트 ─────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_unclaim_story_200():
+    """AC2: POST /unclaim → 200 + {unclaimed: true}."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member(active_story_id=STORY_ID)
+        updated = _mock_member(active_story_id=None)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            result.scalar_one_or_none.return_value = member if call_count == 1 else updated
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.refresh = AsyncMock()
+
+        async with client as c:
+            resp = await c.post(f"/api/v2/team-members/{MEMBER_ID}/unclaim")
+
+        assert resp.status_code == 200
+        assert resp.json()["unclaimed"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC3: story 없으면 400 ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_claim_story_400_if_story_not_in_project():
+    """AC3: story가 project에 없으면 400."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member
+            else:
+                result.scalar_one_or_none.return_value = None  # story 없음
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/team-members/{MEMBER_ID}/claim",
+                json={"story_id": str(uuid.uuid4())},
+            )
+
+        assert resp.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC4/5: MCP 도구 존재 확인 ───────────────────────────────────────────────
+
+def test_mcp_claim_story_tool_in_tool_defs():
+    """AC4: sprintable_claim_story 도구가 _TOOL_DEFS에 등록됨."""
+    from sprintable_mcp.server import _TOOL_DEFS
+    names = [t[0] for t in _TOOL_DEFS]
+    assert "sprintable_claim_story" in names
+
+
+def test_mcp_unclaim_story_tool_in_tool_defs():
+    """AC5: sprintable_unclaim_story 도구가 _TOOL_DEFS에 등록됨."""
+    from sprintable_mcp.server import _TOOL_DEFS
+    names = [t[0] for t in _TOOL_DEFS]
+    assert "sprintable_unclaim_story" in names
+
+
+# ─── AC6/AC8: active_story 필드 ──────────────────────────────────────────────
+
+def test_schema_has_active_story_field():
+    """AC8: TeamMemberResponse에 active_story 필드 존재."""
+    from app.schemas.team_member import TeamMemberResponse
+    assert "active_story" in TeamMemberResponse.model_fields
+
+
+@pytest.mark.anyio
+async def test_list_members_active_story_injected():
+    """AC6: GET /team-members 응답에 active_story {id, title, status} 포함."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story(id=STORY_ID, title="Fix Bug", status="in-progress")
+        member = _mock_member(active_story_id=STORY_ID)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                # list members
+                result.scalars.return_value.all.return_value = [member]
+            else:
+                # stories batch 조회
+                result.scalars.return_value.all.return_value = [story]
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["active_story"] is not None
+        assert body[0]["active_story"]["id"] == str(STORY_ID)
+        assert body[0]["active_story"]["title"] == "Fix Bug"
+        assert body[0]["active_story"]["status"] == "in-progress"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_members_active_story_null_when_no_claim():
+    """AC6: active_story_id 없으면 active_story=null."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member(active_story_id=None)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalars.return_value.all.return_value = [member]
+            else:
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = mock_execute
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/team-members?project_id={PROJECT_ID}")
+
+        assert resp.status_code == 200
+        assert resp.json()[0]["active_story"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC7: claim 중 offline 강등 방지 ─────────────────────────────────────────
+
+def test_presence_status_idle_when_claimed_over_30min():
+    """AC7: claim 중이고 last_seen_at 60분 초과 → presence_status = idle (offline 아님)."""
+    from app.schemas.team_member import TeamMemberResponse
+
+    m = _mock_member(
+        active_story_id=STORY_ID,
+        last_seen_at=NOW - timedelta(hours=1),
+    )
+    resp = TeamMemberResponse.model_validate(m)
+    assert resp.presence_status == "idle"
+
+
+def test_presence_status_offline_when_unclaimed_over_30min():
+    """AC7 반증: unclaim 상태이고 30분 초과 → offline."""
+    from app.schemas.team_member import TeamMemberResponse
+
+    m = _mock_member(
+        active_story_id=None,
+        last_seen_at=NOW - timedelta(hours=1),
+    )
+    resp = TeamMemberResponse.model_validate(m)
+    assert resp.presence_status == "offline"

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -33,6 +33,8 @@ def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
     m.last_seen_at = None
     m.active_story_id = None
     m.agent_status = None
+    # S2-4: active_story inject용 (None으로 고정)
+    m.active_story = None
     return m
 
 


### PR DESCRIPTION
## Summary

- `AgentPresencePanel` component added to Dashboard page
- 30-second auto-polling from `/api/v2/team-members?project_id={id}&type=agent`
- Tab visibility-aware polling (pauses when hidden, resumes on focus)
- Presence dot indicators: online=emerald, idle=amber, offline=gray
- Active story title displayed with 40-char truncate
- Human-type members excluded via `type=agent` query param
- i18n added for `ko` + `en` (`agentPresence` namespace)

## AC Checklist

- [x] AC1: Team Presence section displayed in Dashboard route
- [x] AC2: Presence dot indicators per status (online/idle/offline)
- [x] AC3: active_story title shown, max 40 chars truncate
- [x] AC4: 30-second auto-polling with visibility-aware pause
- [x] AC5: `type=human` members excluded via API query param
- [ ] AC6: E2E — agent heartbeat → 30s UI update (requires live agent + QA env)
- [x] AC7: Panel renders in existing grid without breaking layout

## Screenshots

### Before (Dashboard without panel)
Previous grid ended at "Unread Memos" card.

### After (Dashboard with Agent Team Presence Panel)
"에이전트 팀 / Agent Team" section with Live badge, presence dots, agent cards confirmed rendering at localhost:3001.

Agents shown: Lucas Kim (SDR), Sofia Chen (AE), James Park (CS) — all offline (gray dot).

## Test Plan

- [ ] Navigate to `/dashboard`
- [ ] Verify "에이전트 팀" section visible at bottom of grid
- [ ] Verify presence dot colors (green/amber/gray) per status
- [ ] Wait 30s — confirm polling updates without manual refresh
- [ ] Trigger agent heartbeat → verify `online` dot within 30s (AC6)
- [ ] Mobile viewport: confirm layout not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)