### PR TITLE
[S4-1] 파일 단위 충돌 감지 + 경고 알림

### DIFF
--- a/backend/alembic/versions/0040_add_file_locks.py
+++ b/backend/alembic/versions/0040_add_file_locks.py
@@ -1,0 +1,37 @@
+"""add file_locks table (S4-1)
+
+Revision ID: 0040
+Revises: 0039
+Create Date: 2026-05-19
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0040"
+down_revision = "0039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "file_locks",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("member_id", sa.UUID(as_uuid=True),
+                  sa.ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("story_id", sa.UUID(as_uuid=True),
+                  sa.ForeignKey("stories.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("file_path", sa.Text, nullable=False),
+        sa.Column("locked_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("released_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index("ix_file_locks_org_id", "file_locks", ["org_id"])
+    op.create_index("ix_file_locks_project_id", "file_locks", ["project_id"])
+    op.create_index("ix_file_locks_file_path", "file_locks", ["file_path"])
+    op.create_index("ix_file_locks_active", "file_locks", ["file_path", "released_at"])
+
+
+def downgrade() -> None:
+    op.drop_table("file_locks")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -134,6 +134,7 @@ app.include_router(workflow_trigger_types.router)
 app.include_router(workflow_executions.router)
 app.include_router(workflow_templates.router)
 app.include_router(workflow_recipes.router)
+app.include_router(file_locks.router)
 app.include_router(workflow_report.router)
 app.include_router(workflow_trigger.router)
 app.include_router(mockups.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -28,6 +28,7 @@ from app.models.reward import RewardLedger
 from app.models.login_audit_log import LoginAuditLog
 from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
+from app.models.file_lock import FileLock
 
 __all__ = [
     "AgentAuditLog",

--- a/backend/app/models/file_lock.py
+++ b/backend/app/models/file_lock.py
@@ -1,0 +1,31 @@
+"""S4-1: 파일 단위 충돌 감지 — file_locks 모델."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class FileLock(Base):
+    __tablename__ = "file_locks"
+    __table_args__ = (
+        Index("ix_file_locks_active", "file_path", "released_at"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+    )
+    story_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
+    )
+    file_path: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    locked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    released_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -1,0 +1,201 @@
+"""S4-1: 파일 단위 충돌 감지 + 경고 알림."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.file_lock import FileLock
+from app.models.team import TeamMember
+from app.routers.events import publish_event
+from app.services.webhook_dispatch import fire_webhooks
+
+router = APIRouter(tags=["file-locks"])
+
+
+class FileLockBody(BaseModel):
+    file_paths: list[str]
+    story_id: uuid.UUID | None = None
+
+
+class FileUnlockBody(BaseModel):
+    file_paths: list[str]
+
+
+class ConflictInfo(BaseModel):
+    file_path: str
+    locked_by_member_id: str
+    locked_at: datetime
+
+
+# ─── 충돌 감지 헬퍼 ──────────────────────────────────────────────────────────
+
+async def _find_conflicts(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    member_id: uuid.UUID,
+    file_paths: list[str],
+) -> list[ConflictInfo]:
+    """동일 file_path를 다른 멤버가 이미 lock 중인지 확인."""
+    if not file_paths:
+        return []
+    result = await session.execute(
+        select(FileLock).where(
+            FileLock.project_id == project_id,
+            FileLock.file_path.in_(file_paths),
+            FileLock.released_at.is_(None),
+            FileLock.member_id != member_id,
+        )
+    )
+    conflicts = result.scalars().all()
+    return [
+        ConflictInfo(
+            file_path=c.file_path,
+            locked_by_member_id=str(c.member_id),
+            locked_at=c.locked_at,
+        )
+        for c in conflicts
+    ]
+
+
+async def _publish_conflict_event(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    project_id: uuid.UUID,
+    member_id: uuid.UUID,
+    conflicts: list[ConflictInfo],
+) -> None:
+    """AC4: file_conflict 이벤트 발행 → SSE + Discord 웹훅."""
+    event_data: dict[str, Any] = {
+        "event_type": "file_conflict",
+        "severity": "warn",
+        "org_id": str(org_id),
+        "project_id": str(project_id),
+        "member_id": str(member_id),
+        "conflicts": [c.model_dump(mode="json") for c in conflicts],
+    }
+    try:
+        publish_event(str(org_id), "file_conflict", event_data)
+    except Exception:
+        pass
+    try:
+        await fire_webhooks(session, org_id, "file_conflict", event_data)
+    except Exception:
+        pass
+
+
+# ─── AC1: file-lock ──────────────────────────────────────────────────────────
+
+@router.post("/api/v2/team-members/{member_id}/file-lock")
+async def lock_files(
+    member_id: uuid.UUID,
+    body: FileLockBody,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> dict:
+    """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환."""
+    member_result = await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id)
+    )
+    member = member_result.scalar_one_or_none()
+    if member is None:
+        raise HTTPException(status_code=404, detail="Team member not found")
+
+    # AC3: 충돌 체크
+    conflicts = await _find_conflicts(session, member.project_id, member_id, body.file_paths)
+
+    # 새 lock 등록
+    now = datetime.now(timezone.utc)
+    for fp in body.file_paths:
+        session.add(FileLock(
+            org_id=org_id,
+            project_id=member.project_id,
+            member_id=member_id,
+            story_id=body.story_id,
+            file_path=fp,
+            locked_at=now,
+        ))
+    await session.flush()
+
+    # AC4: 충돌 시 이벤트 발행
+    if conflicts:
+        await _publish_conflict_event(session, org_id, member.project_id, member_id, conflicts)
+
+    return {
+        "locked": True,
+        "file_paths": body.file_paths,
+        "warning": [c.model_dump(mode="json") for c in conflicts] if conflicts else None,
+    }
+
+
+# ─── AC2: file-unlock ────────────────────────────────────────────────────────
+
+@router.post("/api/v2/team-members/{member_id}/file-unlock")
+async def unlock_files(
+    member_id: uuid.UUID,
+    body: FileUnlockBody,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> dict:
+    """AC2: 파일 lock 해제."""
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        update(FileLock)
+        .where(
+            FileLock.member_id == member_id,
+            FileLock.file_path.in_(body.file_paths),
+            FileLock.released_at.is_(None),
+        )
+        .values(released_at=now)
+    )
+    await session.flush()
+    return {"unlocked": True, "file_paths": body.file_paths}
+
+
+# ─── AC6: 활성 file lock 목록 ────────────────────────────────────────────────
+
+@router.get("/api/v2/file-locks")
+async def list_file_locks(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> list[dict]:
+    """AC6: 현재 프로젝트 내 활성 file lock 목록."""
+    result = await session.execute(
+        select(FileLock).where(
+            FileLock.org_id == org_id,
+            FileLock.released_at.is_(None),
+        )
+    )
+    locks = result.scalars().all()
+    return [
+        {
+            "id": str(l.id),
+            "member_id": str(l.member_id),
+            "story_id": str(l.story_id) if l.story_id else None,
+            "file_path": l.file_path,
+            "locked_at": l.locked_at.isoformat(),
+        }
+        for l in locks
+    ]
+
+
+# ─── AC7: unclaim 시 file lock 자동 해제 헬퍼 ────────────────────────────────
+
+async def release_all_file_locks(session: AsyncSession, member_id: uuid.UUID) -> None:
+    """AC7: unclaim 시 호출 — 해당 멤버의 모든 file lock 해제."""
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        update(FileLock)
+        .where(FileLock.member_id == member_id, FileLock.released_at.is_(None))
+        .values(released_at=now)
+    )

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -229,12 +229,15 @@ async def unclaim_story(
     session: AsyncSession = Depends(get_db),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    """AC2: active_story_id = NULL."""
+    """AC2: active_story_id = NULL. AC7: file lock 자동 해제."""
     repo = TeamMemberRepository(session, org_id)
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     await repo.update(id, active_story_id=None)
+    # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
+    from app.routers.file_locks import release_all_file_locks
+    await release_all_file_locks(session, id)
     return {"unclaimed": True}
 
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -31,8 +31,9 @@ from .tools.analytics import (
 )
 from .tools.audit import ListAuditLogsInput, list_audit_logs
 from .tools.core import (
-    ClaimStoryInput, DashboardInput,
-    claim_story, get_workflow_guide, list_team_members, my_dashboard, unclaim_story,
+    ClaimStoryInput, DashboardInput, LockFilesInput, UnlockFilesInput,
+    claim_story, get_workflow_guide, list_team_members, lock_files,
+    my_dashboard, unclaim_story, unlock_files,
 )
 from .tools.docs import (
     CreateDocInput, DeleteDocInput, GetDocInput, ListDocsInput,
@@ -317,6 +318,12 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_get_workflow_guide",
      "현재 프로젝트 워크플로우 가이드 텍스트 반환 — 에이전트 system prompt 주입용.",
      SprintableInput, get_workflow_guide),
+    ("sprintable_lock_files",
+     "파일 작업 시작 선언 — 동시 수정 충돌 경고 반환. 작업 완료 후 반드시 unlock_files 호출.",
+     LockFilesInput, lock_files),
+    ("sprintable_unlock_files",
+     "파일 작업 완료 선언 — lock 해제.",
+     UnlockFilesInput, unlock_files),
     # Memos + Chat (10)
     ("sprintable_list_memos",
      "메모 목록 조회.",

--- a/backend/sprintable_mcp/tools/core.py
+++ b/backend/sprintable_mcp/tools/core.py
@@ -16,6 +16,15 @@ class ClaimStoryInput(SprintableInput):
     story_id: str
 
 
+class LockFilesInput(SprintableInput):
+    file_paths: list[str]
+    story_id: str | None = None
+
+
+class UnlockFilesInput(SprintableInput):
+    file_paths: list[str]
+
+
 async def list_team_members(args: SprintableInput) -> list[TextContent]:
     """프로젝트 팀 멤버 목록 조회."""
     params: dict = {"project_id": client.project_id}
@@ -43,6 +52,37 @@ async def claim_story(args: ClaimStoryInput) -> list[TextContent]:
         result = await client.post(
             f"/api/v2/team-members/{client.member_id}/claim",
             json={"story_id": args.story_id},
+        )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def lock_files(args: LockFilesInput) -> list[TextContent]:
+    """파일 작업 시작 선언 — 동시 수정 충돌 경고 반환."""
+    if not client.member_id:
+        return err("member_id not resolved")
+    try:
+        body: dict = {"file_paths": args.file_paths}
+        if args.story_id:
+            body["story_id"] = args.story_id
+        result = await client.post(
+            f"/api/v2/team-members/{client.member_id}/file-lock",
+            json=body,
+        )
+        return ok(result)
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def unlock_files(args: UnlockFilesInput) -> list[TextContent]:
+    """파일 작업 완료 선언 — lock 해제."""
+    if not client.member_id:
+        return err("member_id not resolved")
+    try:
+        result = await client.post(
+            f"/api/v2/team-members/{client.member_id}/file-unlock",
+            json={"file_paths": args.file_paths},
         )
         return ok(result)
     except Exception as exc:

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -1,0 +1,267 @@
+"""S4-1: 파일 단위 충돌 감지 + 경고 알림 검증.
+
+AC1: POST /team-members/{id}/file-lock — 파일 lock 등록
+AC2: POST /team-members/{id}/file-unlock — 파일 lock 해제
+AC3: 동일 파일 다른 멤버 lock 시 conflict warning 반환
+AC4: conflict 시 file_conflict 이벤트 발행
+AC5: MCP 도구 sprintable_lock_files / sprintable_unlock_files 등록
+AC6: GET /api/v2/file-locks — 활성 lock 목록
+AC7: unclaim 시 file lock 자동 해제
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+OTHER_MEMBER_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+
+
+# ─── 충돌 감지 단위 테스트 ────────────────────────────────────────────────────
+
+def test_conflict_info_shape():
+    """AC3: ConflictInfo 모델 필드 확인."""
+    from app.routers.file_locks import ConflictInfo
+    ci = ConflictInfo(
+        file_path="src/foo.py",
+        locked_by_member_id=str(OTHER_MEMBER_ID),
+        locked_at=datetime.now(timezone.utc),
+    )
+    assert ci.file_path == "src/foo.py"
+    assert ci.locked_by_member_id == str(OTHER_MEMBER_ID)
+
+
+def test_release_all_file_locks_exists():
+    """AC7: release_all_file_locks 헬퍼 존재."""
+    from app.routers.file_locks import release_all_file_locks
+    import inspect
+    assert inspect.iscoroutinefunction(release_all_file_locks)
+
+
+# ─── AC5: MCP 도구 등록 확인 ─────────────────────────────────────────────────
+
+def test_mcp_lock_files_in_tool_defs():
+    """AC5: sprintable_lock_files 도구 등록."""
+    from sprintable_mcp.server import _TOOL_DEFS
+    names = [t[0] for t in _TOOL_DEFS]
+    assert "sprintable_lock_files" in names
+
+
+def test_mcp_unlock_files_in_tool_defs():
+    """AC5: sprintable_unlock_files 도구 등록."""
+    from sprintable_mcp.server import _TOOL_DEFS
+    names = [t[0] for t in _TOOL_DEFS]
+    assert "sprintable_unlock_files" in names
+
+
+# ─── migration 확인 ──────────────────────────────────────────────────────────
+
+def test_migration_0040_exists():
+    """file_locks migration 파일 존재."""
+    from pathlib import Path
+    p = Path(__file__).parent.parent / "alembic/versions/0040_add_file_locks.py"
+    assert p.exists()
+
+
+def test_migration_0040_revision():
+    """revision=0040, down_revision=0039."""
+    from pathlib import Path
+    content = (Path(__file__).parent.parent / "alembic/versions/0040_add_file_locks.py").read_text()
+    assert 'revision = "0040"' in content
+    assert 'down_revision = "0039"' in content
+    assert "file_locks" in content
+
+
+# ─── 엔드포인트 통합 테스트 ─────────────────────────────────────────────────
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _mock_member():
+    m = MagicMock()
+    m.id = MEMBER_ID
+    m.org_id = ORG_ID
+    m.project_id = PROJECT_ID
+    m.type = "agent"
+    m.name = "TestAgent"
+    m.role = "member"
+    m.user_id = None
+    m.avatar_url = None
+    m.agent_config = None
+    m.webhook_url = None
+    m.is_active = True
+    m.color = "#3385f8"
+    m.agent_role = None
+    m.created_by = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
+    m.last_seen_at = None
+    m.active_story_id = None
+    m.agent_status = None
+    m.active_story = None
+    return m
+
+
+@pytest.mark.anyio
+async def test_file_lock_no_conflict_200():
+    """AC1: 충돌 없을 때 200 + warning=null."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member  # get member
+            else:
+                result.scalars.return_value.all.return_value = []  # no conflicts
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/team-members/{MEMBER_ID}/file-lock",
+                json={"file_paths": ["src/foo.py"]},
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["locked"] is True
+        assert body["warning"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_file_lock_with_conflict_warning():
+    """AC3: 충돌 있을 때 warning 필드 포함."""
+    client, session, app = await _client()
+    try:
+        member = _mock_member()
+
+        conflict_lock = MagicMock()
+        conflict_lock.file_path = "src/foo.py"
+        conflict_lock.member_id = OTHER_MEMBER_ID
+        conflict_lock.locked_at = datetime(2026, 5, 19, 10, 0, 0, tzinfo=timezone.utc)
+
+        call_count = 0
+
+        async def mock_execute(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = member
+            else:
+                result.scalars.return_value.all.return_value = [conflict_lock]
+            return result
+
+        session.execute = mock_execute
+        session.flush = AsyncMock()
+        session.add = MagicMock()
+
+        with patch("app.routers.file_locks.publish_event"), \
+             patch("app.routers.file_locks.fire_webhooks", new_callable=AsyncMock):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/team-members/{MEMBER_ID}/file-lock",
+                    json={"file_paths": ["src/foo.py"]},
+                )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["locked"] is True
+        assert body["warning"] is not None
+        assert len(body["warning"]) == 1
+        assert body["warning"][0]["file_path"] == "src/foo.py"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_file_unlock_200():
+    """AC2: file-unlock → 200."""
+    client, session, app = await _client()
+    try:
+        mock_result = MagicMock()
+        session.execute = AsyncMock(return_value=mock_result)
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.post(
+                f"/api/v2/team-members/{MEMBER_ID}/file-unlock",
+                json={"file_paths": ["src/foo.py"]},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["unlocked"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_file_locks_200():
+    """AC6: GET /api/v2/file-locks → 목록 반환."""
+    client, session, app = await _client()
+    try:
+        lock = MagicMock()
+        lock.id = uuid.uuid4()
+        lock.member_id = MEMBER_ID
+        lock.story_id = None
+        lock.file_path = "src/foo.py"
+        lock.locked_at = datetime(2026, 5, 19, 10, 0, 0, tzinfo=timezone.utc)
+
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = [lock]
+        session.execute = AsyncMock(return_value=mock_result)
+
+        async with client as c:
+            resp = await c.get("/api/v2/file-locks")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["file_path"] == "src/foo.py"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

에이전트가 파일 작업 시작 시 lock을 등록하고, 동시 수정 충돌을 200+warning으로 경고.
블루프린트 원칙: "성공 지표 — 동시 작업 충돌 발생률 0건"

## AC 체크리스트

- [x] AC1: `POST /api/v2/team-members/{id}/file-lock` — 파일 lock 등록
- [x] AC2: `POST /api/v2/team-members/{id}/file-unlock` — lock 해제
- [x] AC3: 동일 파일 다른 멤버 lock 중이면 `warning` 필드 반환 (200, 블로킹 없음)
- [x] AC4: conflict 시 `file_conflict` 이벤트 SSE + Discord 웹훅 발행
- [x] AC5: MCP `sprintable_lock_files` / `sprintable_unlock_files` 도구 등록
- [x] AC6: `GET /api/v2/file-locks` — 활성 lock 목록 조회
- [x] AC7: unclaim 시 `release_all_file_locks()` 자동 호출

## 변경 파일

- `alembic/versions/0040_add_file_locks.py` — migration (file_locks 테이블)
- `app/models/file_lock.py` — FileLock 모델
- `app/routers/file_locks.py` — 3개 엔드포인트 + release 헬퍼
- `app/routers/team_members.py` — unclaim에 AC7 hook
- `sprintable_mcp/tools/core.py` — lock_files, unlock_files 도구
- `tests/test_s4_1_file_conflict.py` — 10/10 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)