### PR TITLE
[SID:S5-1] Agent Performance Dashboard tab on /agents page

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1859,7 +1859,9 @@
     "workflowVersionPreviewTitle": "Version {version} snapshot",
     "workflowVersionAddedRules": "+{count}",
     "workflowVersionRemovedRules": "-{count}",
-    "workflowVersionChangedRules": "~{count}"
+    "workflowVersionChangedRules": "~{count}",
+    "tabDeployments": "Deployments",
+    "tabPerformance": "Performance"
   },
   "agentRuns": {
     "eyebrow": "RUN HISTORY",
@@ -2155,6 +2157,19 @@
     "forbiddenTitle": "Access denied",
     "forbiddenDescription": "You do not have permission to view the activity log.",
     "noProject": "No project selected."
+  },
+  "agentPerformance": {
+    "loading": "Loading performance data...",
+    "agentStatsTitle": "Agent Stats",
+    "agentStatsDescription": "Completed runs, total executions, and average processing time per agent.",
+    "velocityTitle": "Team Velocity",
+    "velocityDescription": "Story points delivered per sprint (last 5 sprints).",
+    "leaderboardTitle": "Leaderboard",
+    "leaderboardDescription": "Agents ranked by total reward balance.",
+    "noAgents": "No agents deployed yet.",
+    "completed": "Completed",
+    "totalRuns": "Total Runs",
+    "avgDuration": "Avg Time"
   },
   "agentPresence": {
     "title": "Agent Team",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1859,7 +1859,9 @@
     "workflowVersionPreviewTitle": "버전 {version} 스냅샷",
     "workflowVersionAddedRules": "추가 {count}",
     "workflowVersionRemovedRules": "삭제 {count}",
-    "workflowVersionChangedRules": "변경 {count}"
+    "workflowVersionChangedRules": "변경 {count}",
+    "tabDeployments": "배포",
+    "tabPerformance": "퍼포먼스"
   },
   "agentRuns": {
     "eyebrow": "실행 기록",
@@ -2155,6 +2157,19 @@
     "forbiddenTitle": "접근 권한 없음",
     "forbiddenDescription": "활동 로그를 조회할 권한이 없습니다.",
     "noProject": "선택된 프로젝트가 없습니다."
+  },
+  "agentPerformance": {
+    "loading": "퍼포먼스 데이터 로딩 중...",
+    "agentStatsTitle": "에이전트 통계",
+    "agentStatsDescription": "에이전트별 완료 실행 수, 총 실행 수, 평균 처리 시간입니다.",
+    "velocityTitle": "팀 벨로시티",
+    "velocityDescription": "스프린트별 완료 스토리 포인트 (최근 5 스프린트).",
+    "leaderboardTitle": "리더보드",
+    "leaderboardDescription": "보상 잔액 기준 에이전트 순위입니다.",
+    "noAgents": "배포된 에이전트가 없습니다.",
+    "completed": "완료",
+    "totalRuns": "총 실행",
+    "avgDuration": "평균 시간"
   },
   "agentPresence": {
     "title": "에이전트 팀",

--- a/apps/web/src/app/(authenticated)/agents/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/page.tsx
@@ -1,5 +1,5 @@
-import { AgentsDashboard } from '@/components/agents/agents-dashboard';
+import { AgentsPageTabs } from '@/components/agents/agents-page-tabs';
 
 export default async function AgentsPage() {
-  return <AgentsDashboard deployments={[]} />;
+  return <AgentsPageTabs deployments={[]} />;
 }

--- a/apps/web/src/components/agents/agent-performance-panel.tsx
+++ b/apps/web/src/components/agents/agent-performance-panel.tsx
@@ -1,0 +1,271 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Bot, TrendingUp, Trophy, Zap, Clock, CheckCircle } from 'lucide-react';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { Badge } from '@/components/ui/badge';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+
+interface AgentMember {
+  id: string;
+  name: string;
+  type: string;
+}
+
+interface AgentStats {
+  total_runs: number;
+  completed: number;
+  failed: number;
+  total_tokens: number;
+  total_cost_usd: number;
+  avg_duration_ms: number;
+}
+
+interface SprintVelocityItem {
+  id: string;
+  title: string;
+  velocity: number | null;
+  status: string;
+  start_date: string | null;
+  end_date: string | null;
+}
+
+interface LeaderboardEntry {
+  member_id: string;
+  balance: number;
+}
+
+interface AgentRow extends AgentMember {
+  stats: AgentStats | null;
+  rank: number | null;
+  balance: number;
+}
+
+function VelocityChart({ items }: { items: SprintVelocityItem[] }) {
+  const recent = items.slice(-5);
+  const maxV = Math.max(...recent.map((s) => s.velocity ?? 0), 1);
+
+  return (
+    <div className="space-y-2">
+      {recent.map((sprint) => {
+        const v = sprint.velocity ?? 0;
+        const pct = Math.round((v / maxV) * 100);
+        return (
+          <div key={sprint.id} className="flex items-center gap-3">
+            <span className="w-28 shrink-0 truncate text-xs text-muted-foreground" title={sprint.title}>
+              {sprint.title}
+            </span>
+            <div className="flex-1 overflow-hidden rounded-full bg-muted/50 h-2">
+              <div
+                className="h-2 rounded-full bg-primary transition-all duration-500"
+                style={{ width: `${pct}%` }}
+              />
+            </div>
+            <span className="w-8 shrink-0 text-right text-xs font-medium text-foreground">{v}</span>
+          </div>
+        );
+      })}
+      {recent.length === 0 && (
+        <p className="py-4 text-center text-sm text-muted-foreground">스프린트 데이터가 없습니다.</p>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(ms: number): string {
+  if (ms <= 0) return '—';
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.round(m / 60)}h`;
+}
+
+export function AgentPerformancePanel() {
+  const t = useTranslations('agentPerformance');
+  const { projectId } = useDashboardContext();
+  const [agents, setAgents] = useState<AgentRow[]>([]);
+  const [velocity, setVelocity] = useState<SprintVelocityItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    try {
+      const [membersRes, velocityRes, lbRes] = await Promise.all([
+        fetch(`/api/team-members?project_id=${projectId}&type=agent`),
+        fetch(`/api/analytics/velocity-history?project_id=${projectId}`),
+        fetch(`/api/rewards/leaderboard?project_id=${projectId}&period=all`),
+      ]);
+
+      const membersJson = membersRes.ok ? (await membersRes.json() as { data: AgentMember[] | null }) : null;
+      const velocityJson = velocityRes.ok ? (await velocityRes.json() as { data: SprintVelocityItem[] | null }) : null;
+      const lbJson = lbRes.ok ? (await lbRes.json() as { data: LeaderboardEntry[] | null }) : null;
+
+      const agentMembers = (membersJson?.data ?? []).filter((m) => m.type === 'agent');
+      const leaderboard: LeaderboardEntry[] = lbJson?.data ?? [];
+      const balanceMap: Record<string, number> = {};
+      leaderboard.forEach((e, i) => { balanceMap[e.member_id] = e.balance ?? 0; void i; });
+
+      const sorted = [...leaderboard].sort((a, b) => (b.balance ?? 0) - (a.balance ?? 0));
+      const rankMap: Record<string, number> = {};
+      sorted.forEach((e, i) => { rankMap[e.member_id] = i + 1; });
+
+      const statsResults = await Promise.allSettled(
+        agentMembers.map((m) =>
+          fetch(`/api/analytics/agent-stats?project_id=${projectId}&agent_id=${m.id}`)
+            .then(async (r) => {
+              if (!r.ok) return null;
+              const j = await r.json() as { data: AgentStats | null };
+              return j.data;
+            })
+            .catch(() => null),
+        ),
+      );
+
+      setAgents(
+        agentMembers.map((m, i) => ({
+          ...m,
+          stats: statsResults[i]?.status === 'fulfilled' ? (statsResults[i] as PromiseFulfilledResult<AgentStats | null>).value : null,
+          rank: rankMap[m.id] ?? null,
+          balance: balanceMap[m.id] ?? 0,
+        })),
+      );
+      setVelocity(velocityJson?.data ?? []);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">
+        <div className="flex items-center justify-center py-20 text-muted-foreground text-sm">
+          {t('loading')}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">
+      <div className="mx-auto w-full max-w-5xl space-y-6">
+
+        {/* Agent stat cards */}
+        <SectionCard>
+          <SectionCardHeader>
+            <div className="flex items-center gap-2">
+              <Bot className="size-4 text-primary" />
+              <span className="text-sm font-semibold text-foreground">{t('agentStatsTitle')}</span>
+            </div>
+            <p className="mt-0.5 text-xs text-muted-foreground">{t('agentStatsDescription')}</p>
+          </SectionCardHeader>
+          <SectionCardBody>
+            {agents.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">{t('noAgents')}</p>
+            ) : (
+              <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                {agents.map((agent) => (
+                  <div key={agent.id} className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <div className="truncate text-sm font-semibold text-foreground">{agent.name}</div>
+                        {agent.rank != null && (
+                          <div className="flex items-center gap-1 mt-0.5">
+                            <Trophy className="size-3 text-amber-400" />
+                            <span className="text-xs text-muted-foreground">#{agent.rank}</span>
+                          </div>
+                        )}
+                      </div>
+                      <Badge variant="chip" className="shrink-0 text-xs">
+                        {agent.balance} TJSB
+                      </Badge>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2 text-center">
+                      <div className="rounded-md bg-muted/50 px-2 py-2">
+                        <div className="flex items-center justify-center gap-1 text-emerald-500">
+                          <CheckCircle className="size-3" />
+                          <span className="text-base font-bold">{agent.stats?.completed ?? 0}</span>
+                        </div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('completed')}</div>
+                      </div>
+                      <div className="rounded-md bg-muted/50 px-2 py-2">
+                        <div className="flex items-center justify-center gap-1 text-primary">
+                          <Zap className="size-3" />
+                          <span className="text-base font-bold">{agent.stats?.total_runs ?? 0}</span>
+                        </div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('totalRuns')}</div>
+                      </div>
+                      <div className="rounded-md bg-muted/50 px-2 py-2">
+                        <div className="flex items-center justify-center gap-1 text-muted-foreground">
+                          <Clock className="size-3" />
+                          <span className="text-base font-bold">{formatDuration(agent.stats?.avg_duration_ms ?? 0)}</span>
+                        </div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('avgDuration')}</div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </SectionCardBody>
+        </SectionCard>
+
+        <div className="grid gap-6 lg:grid-cols-2">
+          {/* Velocity chart */}
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="flex items-center gap-2">
+                <TrendingUp className="size-4 text-primary" />
+                <span className="text-sm font-semibold text-foreground">{t('velocityTitle')}</span>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{t('velocityDescription')}</p>
+            </SectionCardHeader>
+            <SectionCardBody>
+              <VelocityChart items={velocity} />
+            </SectionCardBody>
+          </SectionCard>
+
+          {/* Leaderboard */}
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="flex items-center gap-2">
+                <Trophy className="size-4 text-amber-400" />
+                <span className="text-sm font-semibold text-foreground">{t('leaderboardTitle')}</span>
+              </div>
+              <p className="mt-0.5 text-xs text-muted-foreground">{t('leaderboardDescription')}</p>
+            </SectionCardHeader>
+            <SectionCardBody className="space-y-2">
+              {agents.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">{t('noAgents')}</p>
+              ) : (
+                [...agents]
+                  .sort((a, b) => b.balance - a.balance)
+                  .map((agent, idx) => (
+                    <div
+                      key={agent.id}
+                      className="flex items-center gap-3 rounded-md border border-border bg-muted/30 px-3 py-2.5"
+                    >
+                      <span className={`w-6 shrink-0 text-center text-sm font-bold ${idx === 0 ? 'text-amber-400' : idx === 1 ? 'text-slate-400' : idx === 2 ? 'text-amber-600' : 'text-muted-foreground'}`}>
+                        {idx + 1}
+                      </span>
+                      <span className="flex-1 truncate text-sm font-medium text-foreground">{agent.name}</span>
+                      <Badge variant={idx === 0 ? 'success' : 'chip'} className="shrink-0 text-xs">
+                        {agent.balance} TJSB
+                      </Badge>
+                    </div>
+                  ))
+              )}
+            </SectionCardBody>
+          </SectionCard>
+        </div>
+
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -120,7 +120,7 @@ function getFailureHeadline(failure: AgentDeploymentCard['latest_failed_run']) {
 
 const AUTO_REFRESH_INTERVAL = 30_000;
 
-export function AgentsDashboard({ deployments: initialDeployments }: { deployments: AgentDeploymentCard[] }) {
+export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = false }: { deployments: AgentDeploymentCard[]; hideTopBar?: boolean }) {
   const locale = useLocale();
   const t = useTranslations('agents');
   const tr = useTranslations('agentRuns');
@@ -233,15 +233,17 @@ export function AgentsDashboard({ deployments: initialDeployments }: { deploymen
 
   return (
     <>
-      <TopBarSlot
-          title={<h1 className="text-sm font-medium">{t('statusTitle')}</h1>}
-          actions={
-            <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
-              <Rocket className="mr-1.5 size-3.5" />
-              {t('openWizard')}
-            </Link>
-          }
-        />
+      {!hideTopBar && (
+        <TopBarSlot
+            title={<h1 className="text-sm font-medium">{t('statusTitle')}</h1>}
+            actions={
+              <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
+                <Rocket className="mr-1.5 size-3.5" />
+                {t('openWizard')}
+              </Link>
+            }
+          />
+      )}
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto p-6">
         <div className="rounded-xl border border-border bg-background">
           <div className="flex flex-col gap-3 border-b border-border/60 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">

--- a/apps/web/src/components/agents/agents-page-tabs.tsx
+++ b/apps/web/src/components/agents/agents-page-tabs.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import Link from 'next/link';
+import { Rocket } from 'lucide-react';
+import { buttonVariants } from '@/components/ui/button';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { AgentsDashboard, type AgentDeploymentCard } from '@/components/agents/agents-dashboard';
+import { AgentPerformancePanel } from '@/components/agents/agent-performance-panel';
+
+type Tab = 'deployments' | 'performance';
+
+interface AgentsPageTabsProps {
+  deployments: AgentDeploymentCard[];
+}
+
+export function AgentsPageTabs({ deployments }: AgentsPageTabsProps) {
+  const t = useTranslations('agents');
+  const [activeTab, setActiveTab] = useState<Tab>('deployments');
+
+  return (
+    <>
+      <TopBarSlot
+        title={
+          <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/30 p-0.5">
+            <button
+              onClick={() => setActiveTab('deployments')}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                activeTab === 'deployments'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('tabDeployments')}
+            </button>
+            <button
+              onClick={() => setActiveTab('performance')}
+              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+                activeTab === 'performance'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {t('tabPerformance')}
+            </button>
+          </div>
+        }
+        actions={
+          activeTab === 'deployments' ? (
+            <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
+              <Rocket className="mr-1.5 size-3.5" />
+              {t('openWizard')}
+            </Link>
+          ) : null
+        }
+      />
+      {activeTab === 'deployments' ? (
+        <AgentsDashboard deployments={deployments} hideTopBar />
+      ) : (
+        <AgentPerformancePanel />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- **Performance tab** added to `/agents` page alongside existing Deployments tab
- Pill-style tab switcher rendered in TopBar (`AgentsPageTabs` wrapper)
- `AgentPerformancePanel` fetches 3 APIs concurrently: team-members, velocity-history, rewards/leaderboard
- Per-agent `agent-stats` fetched in parallel (Promise.allSettled)
- No new backend endpoints — frontend-only change

## Features

| Section | Data Source | Notes |
|---|---|---|
| Agent Stat Cards | `/api/analytics/agent-stats` | completed runs, total runs, avg duration per agent |
| Team Velocity Chart | `/api/analytics/velocity-history` | CSS bar chart, last 5 sprints |
| Leaderboard | `/api/rewards/leaderboard` | ranked by TJSB balance |

## Screenshots

### Desktop — Deployments tab (before / after tabs added)
Tab switcher visible in top bar. Deploy wizard CTA hidden on Performance tab.

### Desktop — Performance tab
Agent stat cards (3-col grid), velocity chart + leaderboard side by side.

### Mobile 390px — Performance tab
Agent cards stack to single column, sections stack vertically.

## Test Plan

- [ ] Navigate to `/agents`
- [ ] Verify "배포 / 퍼포먼스" tab switcher in top bar
- [ ] Deployments tab: existing behavior unchanged
- [ ] Performance tab: Agent stat cards, velocity chart, leaderboard render
- [ ] Mobile: layout doesn't break at 390px viewport
- [ ] No console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)