### PR TITLE
[P1 FIX] GET /api/v2/ping 엔드포인트 추가

### DIFF
--- a/backend/app/routers/health.py
+++ b/backend/app/routers/health.py
@@ -7,6 +7,12 @@ from app.dependencies.database import get_db
 router = APIRouter(prefix="/api/v2", tags=["health"])
 
 
+@router.get("/ping")
+async def ping():
+    """인증 불필요 생존 확인 — CLI npx sprintable connect 호환."""
+    return {"ok": True}
+
+
 @router.get("/health")
 async def health_check(db: AsyncSession = Depends(get_db)):
     """AC2: GET /api/v2/health — DB 연결 포함 헬스체크 (AC3)."""


### PR DESCRIPTION
## 문제

`npx sprintable connect` CLI가 연결 검증 시 `GET /api/v2/ping`을 호출하는데, 이 엔드포인트가 백엔드에 없어서 404 → CLI 즉사.

## 수정

`backend/app/routers/health.py`에 인증 불필요 ping 라우트 추가:

```
GET /api/v2/ping → 200 {"ok": true}
```

## 검증

```
200 {'ok': True}
```

smoke test PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)