### PR TITLE
[P0] SSE backfill 폭주 수정 — reconnect 시 last_event_id 전달

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -64,6 +64,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);
+  const lastEventIdRef = useRef<string | null>(null);
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
@@ -87,6 +88,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
 
       const url = new URL('/api/v2/events/memos', window.location.origin);
       if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
+      if (lastEventIdRef.current) url.searchParams.set('last_event_id', lastEventIdRef.current);
 
       const source = new EventSource(url.toString());
       sourceRef.current = source;
@@ -115,6 +117,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
 
       // chat:message — backend _to_chat_message format: { id, thread_id, sender: { id }, ... }
       source.addEventListener('chat:message', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const payload = JSON.parse(e.data as string) as SseChatPayload;
           onNewMessageRef.current?.(normalizeToMessage(payload as unknown as Record<string, unknown>));
@@ -123,6 +126,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
 
       // reply_created — from memos.py publish_event; use as refetch trigger
       source.addEventListener('reply_created', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const payload = JSON.parse(e.data as string) as { id?: string; memo_id?: string };
           if (payload.memo_id) onReplyCreatedRef.current?.(payload.memo_id);
@@ -131,6 +135,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
 
       // conversation:message — realtime update for conversation list
       source.addEventListener('conversation:message', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const payload = JSON.parse(e.data as string) as Record<string, unknown>;
           onConversationMessageRef.current?.(payload);

--- a/apps/web/src/hooks/use-realtime-memos.ts
+++ b/apps/web/src/hooks/use-realtime-memos.ts
@@ -34,6 +34,7 @@ export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, o
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectAttemptsRef = useRef(0);
+  const lastEventIdRef = useRef<string | null>(null);
   const onNewMemoRef = useRef(onNewMemo);
   const onNewReplyRef = useRef(onNewReply);
   const onMemoUpdatedRef = useRef(onMemoUpdated);
@@ -55,6 +56,7 @@ export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, o
 
       const url = new URL('/api/v2/events/memos', window.location.origin);
       if (currentTeamMemberIdRef.current) url.searchParams.set('member_id', currentTeamMemberIdRef.current);
+      if (lastEventIdRef.current) url.searchParams.set('last_event_id', lastEventIdRef.current);
 
       const source = new EventSource(url.toString());
       sourceRef.current = source;
@@ -80,6 +82,7 @@ export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, o
       };
 
       source.addEventListener('memo_created', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const memo = JSON.parse(e.data) as RealtimeMemo;
           const isAssignedToMe = Boolean(currentTeamMemberIdRef.current && memo.assigned_to === currentTeamMemberIdRef.current);
@@ -88,12 +91,14 @@ export function useRealtimeMemos({ currentTeamMemberId, onNewMemo, onNewReply, o
       });
 
       source.addEventListener('memo_updated', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           onMemoUpdatedRef.current?.(JSON.parse(e.data) as RealtimeMemo);
         } catch { /* ignore parse errors */ }
       });
 
       source.addEventListener('reply_created', (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           onNewReplyRef.current?.(JSON.parse(e.data) as RealtimeReply);
         } catch { /* ignore parse errors */ }

--- a/apps/web/src/hooks/use-sse-notifications.ts
+++ b/apps/web/src/hooks/use-sse-notifications.ts
@@ -39,8 +39,10 @@ export function useSseNotifications({ onNotification, memberId, enabled = true }
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let closed = false;
     let reconnectAttempts = 0;
+    let lastEventId: string | null = null;
 
-    const handleData = (raw: string) => {
+    const handleData = (raw: string, eventId?: string) => {
+      if (eventId) lastEventId = eventId;
       if (!raw || raw.trim() === '') return;
       try {
         const parsed = JSON.parse(raw) as SseEventNotification;
@@ -54,16 +56,18 @@ export function useSseNotifications({ onNotification, memberId, enabled = true }
 
       const url = new URL('/api/event-stream', window.location.origin);
       if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
+      if (lastEventId) url.searchParams.set('last_event_id', lastEventId);
 
       es = new EventSource(url.toString(), { withCredentials: true });
 
       es.onopen = () => { reconnectAttempts = 0; };
 
-      es.onmessage = (e: MessageEvent<string>) => handleData(e.data);
+      es.onmessage = (e: MessageEvent<string>) => handleData(e.data, e.lastEventId || undefined);
 
       for (const eventName of ['event_notification', 'notification', 'new_notification']) {
         es.addEventListener(eventName, (e: Event) => {
-          handleData((e as MessageEvent<string>).data);
+          const me = e as MessageEvent<string>;
+          handleData(me.data, me.lastEventId || undefined);
         });
       }
 


### PR DESCRIPTION
## 문제

SSE hooks 3개가 reconnect 시 수동으로 `new EventSource(url)` 호출 → 새 연결에는 브라우저의 `Last-Event-ID` 헤더가 포함되지 않음 → 백엔드가 초기 연결로 인식 → backfill 전량 재전송 폭주.

선생님 직접 목격 이슈. P0.

## 수정

각 훅에 `lastEventId` 추적 변수를 추가하고, 이벤트 수신 시마다 저장 후 reconnect 시 URL에 `?last_event_id={id}` 파라미터로 전달.

| 파일 | 수정 내용 |
|---|---|
| `use-realtime-memos.ts` | `lastEventIdRef` + memo_created/updated/reply_created에 캡처 |
| `use-chat-sse.ts` | `lastEventIdRef` + chat:message/reply_created/conversation:message에 캡처 |
| `use-sse-notifications.ts` | `lastEventId` 클로저 + onmessage + named listeners에 캡처 |

## Before / After

**Before:** `reconnect → new EventSource('/api/v2/events/memos?member_id=X')` → 백엔드 초기 연결 인식 → backfill 전량 재전송

**After:** `reconnect → new EventSource('/api/v2/events/memos?member_id=X&last_event_id=abc123')` → 백엔드 연속 연결 인식 → 놓친 이벤트만 전송

## Test Plan

- [ ] 채팅/메모 SSE 연결 후 네트워크 끊었다 재연결
- [ ] 재연결 시 Request URL에 `last_event_id` 파라미터 확인
- [ ] backfill 폭주 없이 놓친 이벤트만 수신 확인
- [ ] 기존 SSE 기능 (실시간 메모/채팅/알림) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)