### PR TITLE
[P3 FIX] set_status() violation_level 파라미터 — warn 모드 hard block 우회

### DIFF
--- a/backend/app/repositories/story.py
+++ b/backend/app/repositories/story.py
@@ -87,7 +87,9 @@ class StoryRepository(BaseRepository[Story]):
         assert updated is not None
         return updated
 
-    async def set_status(self, id: uuid.UUID, new_status: str) -> Story:
+    async def set_status(
+        self, id: uuid.UUID, new_status: str, violation_level: str = "block"
+    ) -> Story:
         story = await self.get(id)
         if story is None:
             raise ValueError(f"Story {id} not found")
@@ -102,9 +104,11 @@ class StoryRepository(BaseRepository[Story]):
         current_idx = list(STORY_STATUSES).index(story.status)
         new_idx = list(STORY_STATUSES).index(new_status)
         if new_idx != current_idx + 1:
-            raise ValueError(
-                f"Non-sequential transition not allowed: {story.status} → {new_status}"
-            )
+            # AC1: warn 모드이면 hard block 우회 → 전이 허용 (violation 이벤트는 caller에서 발행)
+            if violation_level != "warn":
+                raise ValueError(
+                    f"Non-sequential transition not allowed: {story.status} → {new_status}"
+                )
 
         updated = await self.update(id, status=new_status)
         assert updated is not None

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -287,7 +287,8 @@ async def update_story_status(
         raise HTTPException(status_code=400, detail=_violation.reason or "워크플로우 위반으로 상태 전이가 거부되었습니다.")
 
     try:
-        story = await repo.set_status(id, body.status)
+        # AC2: violation_level 전달 → warn 모드이면 set_status hard block 우회
+        story = await repo.set_status(id, body.status, violation_level=_violation_level)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 


### PR DESCRIPTION
## 문제

`story.py:104` `set_status()`의 hard block (`new_idx != current_idx + 1`) 이 `stories.py:301` violation warn 이벤트 발행보다 먼저 실행됨. warn 모드에서도 `ValueError`로 전이 거부 → violation warn 코드 전체 데드코드화.

## 수정

**`story.py`**: `set_status(id, new_status, violation_level="block")` 파라미터 추가
- `violation_level="warn"` 이면 비순차 전이 hard block 우회 → 전이 허용
- `violation_level="block"` (기본값) 이면 기존 동작 유지

**`stories.py`**: `set_status()` 호출 시 `_violation_level` 전달

## 흐름 (수정 후)

```
1. violation 체크 → violated=True, warn 모드
2. block 모드 → HTTPException(400) 반환  ← 기존 유지
   warn 모드 → 통과
3. set_status(violation_level="warn") → hard block 우회, 전이 성공
4. workflow_violation 이벤트 발행 + 웹훅
```

## 테스트

37/37 PASS (`test_s3_2_violation_warn.py` + `test_rule_evaluator.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)