### PR TITLE
[P5 FIX] get_agent_stats() — agent_runs → stories 기반 지표 재정의

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -206,26 +206,47 @@ class AnalyticsRepository:
         if member_r.scalar_one_or_none() is None:
             return None  # type: ignore[return-value]
 
-        runs_r = await self.session.execute(
-            text(
-                "SELECT status, input_tokens, output_tokens, cost_usd, duration_ms"
-                " FROM agent_runs WHERE agent_id = :agent_id"
-                " ORDER BY created_at DESC LIMIT 1000"
-            ),
-            {"agent_id": str(agent_id)},
+        # AC1/2/3/4: stories 기반 실제 기여 지표로 재정의
+        stories_r = await self.session.execute(
+            select(Story.status, Story.story_points, Story.created_at, Story.updated_at)
+            .where(
+                Story.assignee_id == agent_id,
+                Story.org_id == self.org_id,
+            )
         )
-        rows = runs_r.all()
-        completed = [r for r in rows if r[0] == "completed"]
-        total_tokens = sum((r[1] or 0) + (r[2] or 0) for r in completed)
-        total_cost = sum((r[3] or 0) for r in completed)
-        avg_dur = round(sum((r[4] or 0) for r in completed) / len(completed)) if completed else 0
+        all_stories = stories_r.all()
+        done_stories = [s for s in all_stories if s[0] == "done"]
+
+        # AC3: done 스토리 story_points 합계
+        done_sp = sum((s[1] or 0) for s in done_stories)
+
+        # AC4: done 스토리 평균 리드타임 (updated_at - created_at 근사값)
+        lead_times_ms: list[int] = []
+        for s in done_stories:
+            created = s[2]
+            updated = s[3]
+            if created and updated:
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                if updated.tzinfo is None:
+                    updated = updated.replace(tzinfo=timezone.utc)
+                delta_ms = int((updated - created).total_seconds() * 1000)
+                if delta_ms > 0:
+                    lead_times_ms.append(delta_ms)
+        avg_lead_time_ms = round(sum(lead_times_ms) / len(lead_times_ms)) if lead_times_ms else 0
+
         return {
-            "total_runs": len(rows),
-            "completed": len(completed),
-            "failed": sum(1 for r in rows if r[0] == "failed"),
-            "total_tokens": total_tokens,
-            "total_cost_usd": total_cost,
-            "avg_duration_ms": avg_dur,
+            # AC1: done 스토리 수
+            "completed": len(done_stories),
+            # AC2: 전체 배정 스토리 수
+            "total_stories": len(all_stories),
+            # AC3: done 스토리 SP 합계
+            "done_story_points": done_sp,
+            # AC4: 평균 리드타임 (ms)
+            "avg_lead_time_ms": avg_lead_time_ms,
+            # 하위 호환 필드 유지 (프론트 라벨 변경 전까지)
+            "total_runs": len(all_stories),
+            "failed": sum(1 for s in all_stories if s[0] not in ("done", "in-progress", "in-review", "ready-for-dev", "backlog")),
         }
 
     async def get_project_health(self, project_id: uuid.UUID) -> dict:


### PR DESCRIPTION
## 문제

`get_agent_stats()`가 `agent_runs`(MCP 실행 횟수) 기반 → 미르코군 PR 2개인데 Completed 0, 댄어윈군 방치인데 4개.

## 수정

`stories WHERE assignee_id=agent` 기반으로 전환:

- **AC1**: `completed` = done 스토리 수
- **AC2**: `total_stories` = 전체 배정 스토리 수  
- **AC3**: `done_story_points` = done SP 합계
- **AC4**: `avg_lead_time_ms` = updated_at - created_at 평균

프론트엔드 AC5는 미르코군 처리 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)