### PR TITLE
[P5] agent-stats UI — runs → stories 기반 라벨/스키마 변경

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2161,15 +2161,15 @@
   "agentPerformance": {
     "loading": "Loading performance data...",
     "agentStatsTitle": "Agent Stats",
-    "agentStatsDescription": "Completed runs, total executions, and average processing time per agent.",
+    "agentStatsDescription": "Done stories, assigned stories, and average lead time per agent.",
     "velocityTitle": "Team Velocity",
     "velocityDescription": "Story points delivered per sprint (last 5 sprints).",
     "leaderboardTitle": "Leaderboard",
     "leaderboardDescription": "Agents ranked by total reward balance.",
     "noAgents": "No agents deployed yet.",
-    "completed": "Completed",
-    "totalRuns": "Total Runs",
-    "avgDuration": "Avg Time"
+    "doneStories": "Done Stories",
+    "assignedStories": "Assigned",
+    "avgLeadTime": "Avg Lead Time"
   },
   "agentPresence": {
     "title": "Agent Team",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2161,15 +2161,15 @@
   "agentPerformance": {
     "loading": "퍼포먼스 데이터 로딩 중...",
     "agentStatsTitle": "에이전트 통계",
-    "agentStatsDescription": "에이전트별 완료 실행 수, 총 실행 수, 평균 처리 시간입니다.",
+    "agentStatsDescription": "에이전트별 완료 스토리, 배정 스토리, 평균 리드타임입니다.",
     "velocityTitle": "팀 벨로시티",
     "velocityDescription": "스프린트별 완료 스토리 포인트 (최근 5 스프린트).",
     "leaderboardTitle": "리더보드",
     "leaderboardDescription": "보상 잔액 기준 에이전트 순위입니다.",
     "noAgents": "배포된 에이전트가 없습니다.",
-    "completed": "완료",
-    "totalRuns": "총 실행",
-    "avgDuration": "평균 시간"
+    "doneStories": "완료 스토리",
+    "assignedStories": "배정 스토리",
+    "avgLeadTime": "평균 리드타임"
   },
   "agentPresence": {
     "title": "에이전트 팀",

--- a/apps/web/src/components/agents/agent-performance-panel.tsx
+++ b/apps/web/src/components/agents/agent-performance-panel.tsx
@@ -14,12 +14,10 @@ interface AgentMember {
 }
 
 interface AgentStats {
-  total_runs: number;
   completed: number;
-  failed: number;
-  total_tokens: number;
-  total_cost_usd: number;
-  avg_duration_ms: number;
+  total_stories: number;
+  done_story_points: number;
+  avg_lead_time_ms: number;
 }
 
 interface SprintVelocityItem {
@@ -192,21 +190,21 @@ export function AgentPerformancePanel() {
                           <CheckCircle className="size-3" />
                           <span className="text-base font-bold">{agent.stats?.completed ?? 0}</span>
                         </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('completed')}</div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('doneStories')}</div>
                       </div>
                       <div className="rounded-md bg-muted/50 px-2 py-2">
                         <div className="flex items-center justify-center gap-1 text-primary">
                           <Zap className="size-3" />
-                          <span className="text-base font-bold">{agent.stats?.total_runs ?? 0}</span>
+                          <span className="text-base font-bold">{agent.stats?.total_stories ?? 0}</span>
                         </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('totalRuns')}</div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('assignedStories')}</div>
                       </div>
                       <div className="rounded-md bg-muted/50 px-2 py-2">
                         <div className="flex items-center justify-center gap-1 text-muted-foreground">
                           <Clock className="size-3" />
-                          <span className="text-base font-bold">{formatDuration(agent.stats?.avg_duration_ms ?? 0)}</span>
+                          <span className="text-base font-bold">{formatDuration(agent.stats?.avg_lead_time_ms ?? 0)}</span>
                         </div>
-                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('avgDuration')}</div>
+                        <div className="mt-0.5 text-[10px] text-muted-foreground">{t('avgLeadTime')}</div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## 배경

백엔드 PR #830 (`get_agent_stats()` stories 재정의) 프론트엔드 AC5 반영.

## 변경 사항

`AgentStats` 인터페이스 + UI 라벨 업데이트:

| Before | After |
|---|---|
| `total_runs` | `total_stories` |
| `avg_duration_ms` | `avg_lead_time_ms` |
| `failed`, `total_tokens`, `total_cost_usd` | 제거 |
| `done_story_points` | 추가 |

라벨: Completed Runs → Done Stories / Total Runs → Assigned / Avg Time → Avg Lead Time

## Test Plan

- [ ] `/agents` → 퍼포먼스 탭 → 라벨 "완료 스토리 / 배정 스토리 / 평균 리드타임" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)