### PR TITLE
fix(activity-log): Pydantic v2 model_validate update 파라미터 500 핫픽스

### DIFF
--- a/backend/app/routers/activity_logs.py
+++ b/backend/app/routers/activity_logs.py
@@ -159,15 +159,13 @@ async def list_activity_logs(
                 entity_title_map[(etype, row.id)] = row.title
 
     def _enrich(log: ActivityLog) -> ActivityLogItem:
-        return ActivityLogItem.model_validate(
-            log,
-            update={
-                "actor_name": actor_name_map.get(log.actor_id) if log.actor_id else None,
-                "entity_title": entity_title_map.get((log.entity_type, log.entity_id))
-                if log.entity_type and log.entity_id
-                else None,
-            },
-        )
+        base = ActivityLogItem.model_validate(log)
+        return base.model_copy(update={
+            "actor_name": actor_name_map.get(log.actor_id) if log.actor_id else None,
+            "entity_title": entity_title_map.get((log.entity_type, log.entity_id))
+            if log.entity_type and log.entity_id
+            else None,
+        })
 
     return ActivityLogListResponse(
         items=[_enrich(item) for item in items],


### PR DESCRIPTION
## Summary

- PR #834 squash merge 후 배포에서 `TypeError: model_validate() got an unexpected keyword argument 'update'` 500 발생
- Pydantic v2에서 `model_validate()`는 `update` 파라미터 없음
- `model_validate(log)` → `model_copy(update={...})` 2단계로 수정

## Test plan

- [ ] `GET /api/v2/activity-logs` 500 없이 200 반환 확인
- [ ] `actor_name`, `entity_title` 필드 정상 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)