### PR TITLE
fix(conversations): list_messages owner/admin 참여자 검증 예외 (F7 BE gap)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -430,15 +430,16 @@ async def list_messages(
 
     sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
 
-    # 참여자 검증
-    participant = (await db.execute(
-        select(ConversationParticipant.id).where(
-            ConversationParticipant.conversation_id == conversation_id,
-            ConversationParticipant.member_id == sender.id,
-        )
-    )).scalar_one_or_none()
-    if participant is None:
-        raise HTTPException(status_code=403, detail="Not a participant")
+    # 참여자 검증 — owner/admin은 에이전트 대화 열람 허용
+    if sender.role not in ("owner", "admin"):
+        participant = (await db.execute(
+            select(ConversationParticipant.id).where(
+                ConversationParticipant.conversation_id == conversation_id,
+                ConversationParticipant.member_id == sender.id,
+            )
+        )).scalar_one_or_none()
+        if participant is None:
+            raise HTTPException(status_code=403, detail="Not a participant")
 
     if thread_id is None:
         thread_filter = ConversationMessage.thread_id.is_(None)


### PR DESCRIPTION
## Summary

- PR #835 (include_agent_conversations) 이후 FE 검증에서 발견된 BE 갭
- admin/owner가 에이전트 대화 목록은 볼 수 있지만 클릭 시 `GET /{id}/messages`에서 403 발생
- `list_messages` 참여자 검증을 `member` role에만 적용 — owner/admin은 bypass

## Test plan

- [ ] owner/admin으로 에이전트 conversation 클릭 → 메시지 정상 반환
- [ ] member role로 타인 conversation 접근 → 403 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)