### PR TITLE
feat(conversations): list pagination limit/offset 추가 (BE+FE)

### DIFF
--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -147,6 +147,8 @@ function applyConversationMessageUpdate(
   return [item, ...updated];
 }
 
+const PAGE_LIMIT = 30;
+
 export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewProps) {
   const t = useTranslations('chats');
   const router = useRouter();
@@ -154,6 +156,11 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
   const [allConversations, setAllConversations] = useState<ConversationItem[]>([]);
   const [isAdminOrOwner, setIsAdminOrOwner] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [myOffset, setMyOffset] = useState(0);
+  const [myTotal, setMyTotal] = useState(0);
+  const [agentOffset, setAgentOffset] = useState(0);
+  const [agentTotal, setAgentTotal] = useState(0);
   const [showModal, setShowModal] = useState(false);
 
   const convsRef = useRef(conversations);
@@ -170,33 +177,44 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
     void checkRole();
   }, []);
 
-  const fetchConversations = useCallback(async () => {
+  const fetchConversations = useCallback(async (nextOffset = 0, append = false) => {
     try {
-      const res = await fetch(`/api/conversations?project_id=${projectId}`);
+      const res = await fetch(
+        `/api/conversations?project_id=${projectId}&limit=${PAGE_LIMIT}&offset=${nextOffset}`
+      );
       if (!res.ok) return;
-      const json = await res.json() as { data: ConversationItem[] };
-      setConversations(json.data ?? []);
+      const json = await res.json() as { data: ConversationItem[]; total: number };
+      const items = json.data ?? [];
+      setConversations((prev) => append ? [...prev, ...items] : items);
+      setMyOffset(nextOffset + items.length);
+      setMyTotal(json.total ?? 0);
     } finally {
       setLoading(false);
+      setLoadingMore(false);
     }
   }, [projectId]);
 
-  const fetchAllConversations = useCallback(async () => {
-    const res = await fetch(`/api/conversations?project_id=${projectId}&include_agent_conversations=true`);
+  const fetchAllConversations = useCallback(async (nextOffset = 0, append = false) => {
+    const res = await fetch(
+      `/api/conversations?project_id=${projectId}&include_agent_conversations=true&limit=${PAGE_LIMIT}&offset=${nextOffset}`
+    );
     if (!res.ok) return;
-    const json = await res.json() as { data: ConversationItem[] };
-    setAllConversations(json.data ?? []);
+    const json = await res.json() as { data: ConversationItem[]; total: number };
+    const items = json.data ?? [];
+    setAllConversations((prev) => append ? [...prev, ...items] : items);
+    setAgentOffset(nextOffset + items.length);
+    setAgentTotal(json.total ?? 0);
   }, [projectId]);
 
-  useEffect(() => { void fetchConversations(); }, [fetchConversations]);
+  useEffect(() => { void fetchConversations(0, false); }, [fetchConversations]);
 
   useEffect(() => {
-    if (isAdminOrOwner) void fetchAllConversations();
+    if (isAdminOrOwner) void fetchAllConversations(0, false);
   }, [isAdminOrOwner, fetchAllConversations]);
 
   const handleConversationMessage = useCallback((payload: { conversation_id?: string; content?: string; created_at?: string }) => {
-    setConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchConversations()));
-    setAllConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchAllConversations()));
+    setConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchConversations(0, false)));
+    setAllConversations((prev) => applyConversationMessageUpdate(prev, payload, () => void fetchAllConversations(0, false)));
   }, [fetchConversations, fetchAllConversations]);
 
   useChatSse({
@@ -245,6 +263,16 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
           ))}
         </div>
       )}
+      {conversations.length < myTotal && (
+        <button
+          type="button"
+          onClick={() => { setLoadingMore(true); void fetchConversations(myOffset, true); }}
+          disabled={loadingMore}
+          className="w-full rounded-lg py-2 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-50"
+        >
+          {loadingMore ? '불러오는 중…' : `더 보기 (${myTotal - conversations.length}건)`}
+        </button>
+      )}
     </div>
   );
 
@@ -260,6 +288,15 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
       {agentOnlyConvs.map((conv) => (
         <ConversationRow key={conv.id} conv={conv} currentMemberId={currentTeamMemberId} isAgentConv onClick={() => router.push(`/chats/${conv.id}`)} />
       ))}
+      {allConversations.length < agentTotal && (
+        <button
+          type="button"
+          onClick={() => void fetchAllConversations(agentOffset, true)}
+          className="w-full rounded-lg py-2 text-xs text-muted-foreground transition hover:text-foreground"
+        >
+          더 보기 ({agentTotal - allConversations.length}건)
+        </button>
+      )}
     </div>
   );
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import and_, select, update
+from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -311,6 +311,8 @@ async def create_conversation(
 async def list_conversations(
     project_id: uuid.UUID = Query(...),
     include_agent_conversations: bool = Query(default=False),
+    limit: int = Query(default=30, ge=1, le=100),
+    offset: int = Query(default=0, ge=0),
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -349,12 +351,22 @@ async def list_conversations(
             conv_ids.update(r[0] for r in agent_conv_result.all())
 
     if not conv_ids:
-        return {"data": []}
+        return {"data": [], "total": 0, "limit": limit, "offset": offset}
+
+    conv_filter = (
+        Conversation.id.in_(conv_ids),
+        Conversation.org_id == org_id,
+        Conversation.project_id == project_id,
+    )
+    total = (await db.execute(
+        select(func.count()).select_from(Conversation).where(*conv_filter)
+    )).scalar_one()
 
     convs = (await db.execute(
         select(Conversation)
-        .where(Conversation.id.in_(conv_ids), Conversation.org_id == org_id, Conversation.project_id == project_id)
+        .where(*conv_filter)
         .order_by(Conversation.updated_at.desc())
+        .limit(limit).offset(offset)
     )).scalars().all()
 
     # participants 배치 조회 (N+1 방지)
@@ -404,7 +416,7 @@ async def list_conversations(
             "updated_at": conv.updated_at.isoformat(),
         })
 
-    return {"data": result}
+    return {"data": result, "total": total, "limit": limit, "offset": offset}
 
 
 @router.get("/{conversation_id}/messages")


### PR DESCRIPTION
## Summary

- `GET /api/v2/conversations` 1988건 일괄 반환 → limit/offset pagination으로 해결
- **BE**: `limit`(default:30, max:100) / `offset` 파라미터 추가. `{data, total, limit, offset}` 반환
- **FE**: `PAGE_LIMIT=30` load more 패턴. 내 대화 / 에이전트 대화 각각 offset 추적. SSE 실시간 업데이트 호환

## Test plan

- [ ] 초기 로드: 최신 30건만 반환 확인
- [ ] "더 보기" 버튼 클릭 시 다음 30건 append 확인
- [ ] 30건 미만 시 "더 보기" 버튼 미노출 확인
- [ ] SSE conversation:message 수신 시 목록 상단 이동 정상 동작
- [ ] `total`, `limit`, `offset` 응답 필드 정상 포함 확인

스토리: c4f391ac-9151-40a7-bef1-e58515a3069a

🤖 Generated with [Claude Code](https://claude.com/claude-code)