### PR TITLE
fix(mcp): err() 반환 타입 list[TextContent]로 통일 [P0]

### DIFF
--- a/backend/sprintable_mcp/response.py
+++ b/backend/sprintable_mcp/response.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from datetime import date, datetime
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import TextContent
 
 
 def _default_serializer(obj: object) -> str:
@@ -22,9 +22,6 @@ def ok(data: object) -> list[TextContent]:
     return [TextContent(type="text", text=json.dumps(data, indent=2, ensure_ascii=False, default=_default_serializer))]
 
 
-def err(msg: str) -> CallToolResult:
-    """오류 응답 — isError=True CallToolResult 반환. 에이전트가 에러로 구분 가능."""
-    return CallToolResult(
-        content=[TextContent(type="text", text=f"Error: {msg}")],
-        isError=True,
-    )
+def err(msg: str) -> list[TextContent]:
+    """오류 응답 — ok()와 동일한 list[TextContent] 반환. 에러 prefix로 에이전트 구분."""
+    return [TextContent(type="text", text=f"Error: {msg}")]


### PR DESCRIPTION
## Summary

- `err()` 반환 타입이 `CallToolResult`인데 `ok()`는 `list[TextContent]` → 타입 불일치로 MCP 툴 핸들러 에러
- `err()` → `list[TextContent]` 통일. 불필요한 `CallToolResult` import 제거

## Root Cause

```python
# Before: 타입 불일치
def ok(msg) -> list[TextContent]: ...
def err(msg) -> CallToolResult: ...   # ← 불일치

# After: 통일
def ok(msg) -> list[TextContent]: ...
def err(msg) -> list[TextContent]: ...  # ← 통일
```

## Test plan

- [ ] MCP 서버 재시작 후 툴 호출 정상 동작
- [ ] err() 반환값이 텍스트로 정상 수신

🤖 Generated with [Claude Code](https://claude.com/claude-code)