### PR TITLE
feat(memos): send_memo conversation find-or-create dedup

### DIFF
--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -6,7 +6,8 @@ import logging
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import func, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 logger = logging.getLogger(__name__)
@@ -463,20 +464,55 @@ async def create_memo(
     if body.assigned_to_ids:
         participant_ids.update(body.assigned_to_ids)
 
-    conv_id = uuid.uuid4()
-    conv = Conversation(
-        id=conv_id,
-        project_id=body.project_id,
-        org_id=org_id,
-        type="group",
-        title=body.title,
-        created_by=body.created_by,
-        status="open",
-    )
-    session.add(conv)
-    for pid in participant_ids:
-        session.add(ConversationParticipant(conversation_id=conv_id, member_id=pid))
-    await session.flush()
+    # find-or-create: 동일 participant 집합의 기존 open conversation 재사용
+    existing_conv: Conversation | None = None
+    if participant_ids:
+        ref_pid = next(iter(participant_ids))
+        candidate_conv_ids = (await session.execute(
+            select(ConversationParticipant.conversation_id)
+            .join(Conversation, Conversation.id == ConversationParticipant.conversation_id)
+            .where(
+                ConversationParticipant.member_id == ref_pid,
+                Conversation.org_id == org_id,
+                Conversation.project_id == body.project_id,
+                Conversation.type == "group",
+                Conversation.status == "open",
+            )
+        )).scalars().all()
+
+        for cid in candidate_conv_ids:
+            members = set((await session.execute(
+                select(ConversationParticipant.member_id)
+                .where(ConversationParticipant.conversation_id == cid)
+            )).scalars().all())
+            if members == participant_ids:
+                existing_conv = (await session.execute(
+                    select(Conversation).where(Conversation.id == cid)
+                )).scalar_one_or_none()
+                break
+
+    if existing_conv is not None:
+        conv = existing_conv
+        await session.execute(
+            sa_update(Conversation)
+            .where(Conversation.id == conv.id)
+            .values(updated_at=func.now())
+        )
+    else:
+        conv_id = uuid.uuid4()
+        conv = Conversation(
+            id=conv_id,
+            project_id=body.project_id,
+            org_id=org_id,
+            type="group",
+            title=body.title,
+            created_by=body.created_by,
+            status="open",
+        )
+        session.add(conv)
+        for pid in participant_ids:
+            session.add(ConversationParticipant(conversation_id=conv_id, member_id=pid))
+        await session.flush()
 
     # AC2/AC3: entity_links + title → root message metadata 보존 (AC6: link 개수 손실 방지)
     parsed_embeds = _parse_entity_embeds(body.content or "")


### PR DESCRIPTION
## Summary

- 동일 sender+recipient 간 `send_memo` 호출 시 매번 새 conversation 생성 → 기존 conversation 재사용으로 전환
- `participant_ids` 집합 exact match로 기존 `open` group conversation 검색
- 있으면: 기존 conversation에 `ConversationMessage`만 추가 + `updated_at` 갱신
- 없으면: 기존과 동일하게 새 conversation 생성

## Logic

```
participant_ids 확정
  → ref_pid 기준 candidate conversations 조회
  → 각 candidate의 participant 집합이 participant_ids와 exact match?
    YES → 기존 conv 재사용 + updated_at 갱신
    NO  → 신규 conv 생성 (기존 플로우)
```

## Test plan

- [ ] A→B 메모 2번 연속 발송 → 동일 conversation에 message 2건 append 확인
- [ ] A→C 다른 recipient 메모 → 별도 conversation 생성 확인
- [ ] 기존 closed conversation 있을 때 → 신규 open conversation 생성 확인

스토리: 61b02e7a-841f-43f1-af31-65537beddcd6

🤖 Generated with [Claude Code](https://claude.com/claude-code)