### PR TITLE
[SID:d937bc26] S2.2 Organization Switcher UI

### DIFF
--- a/apps/web/src/components/nav/organization-switcher.tsx
+++ b/apps/web/src/components/nav/organization-switcher.tsx
@@ -37,16 +37,27 @@ interface OrganizationSwitcherProps {
 }
 
 export function OrganizationSwitcher({ orgs, currentOrgId, className }: OrganizationSwitcherProps) {
+  const [pending, setPending] = useState(false);
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const currentOrg = orgs.find((o) => o.orgId === currentOrgId);
   const displayName = currentOrg?.orgName ?? 'Organization';
 
-  // switch-org 백엔드 API는 S2.1에서 구현 예정.
-  // 현재는 SSR layout이 새 Org를 반영하도록 /dashboard 풀 리로드로 전환.
-  function switchOrg(nextOrgId: string) {
-    if (!nextOrgId || nextOrgId === currentOrgId) return;
-    window.location.href = '/dashboard';
+  async function switchOrg(nextOrgId: string) {
+    if (!nextOrgId || nextOrgId === currentOrgId || pending) return;
+    setPending(true);
+    try {
+      const res = await fetch('/api/switch-org', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ org_id: nextOrgId }),
+      });
+      if (res.ok) {
+        window.location.href = '/dashboard';
+      }
+    } finally {
+      setPending(false);
+    }
   }
 
   function handleCreated(orgId: string) {
@@ -57,6 +68,7 @@ export function OrganizationSwitcher({ orgs, currentOrgId, className }: Organiza
     <>
       <DropdownMenu>
         <DropdownMenuTrigger
+          disabled={pending}
           render={
             <SidebarMenuButton className={cn('w-full', className)}>
               <OrgInitial name={displayName} />
@@ -75,6 +87,7 @@ export function OrganizationSwitcher({ orgs, currentOrgId, className }: Organiza
             {orgs.map((org) => (
               <DropdownMenuItem
                 key={org.orgId}
+                disabled={pending}
                 onClick={() => void switchOrg(org.orgId)}
               >
                 <OrgInitial name={org.orgName} />


### PR DESCRIPTION
## 변경 사항

`organization-switcher.tsx` — S1.2에서 임시로 적용했던 `window.location.href` 우회를 제거하고 `POST /api/switch-org` 정식 연동.

### 변경 내용

**`organization-switcher.tsx`**
- `switchOrg` 함수: `window.location.href` 우회 → `POST /api/switch-org` 실제 호출
- `pending` state 복원: API 호출 중 드롭다운/메뉴 아이템 disabled
- 응답 ok 시 `window.location.href = '/dashboard'` full reload (SSR이 새 토큰 반영)
- `DropdownMenuTrigger` + `DropdownMenuItem` 모두 `disabled={pending}` 처리

### API 흐름

```
POST /api/switch-org { org_id }
  → FastAPI POST /api/v2/auth/switch-org
  → { access_token, refresh_token, project_id }
  → 쿠키 갱신 (SP_AT, SP_RT, CURRENT_PROJECT)
  → window.location.href = '/dashboard'
  → layout.tsx SSR이 새 org/project 컨텍스트로 렌더
```

## AC 검증

- [x] AC1: GNB 현재 Org 이름 표시 (기존 구현 유지)
- [x] AC2: 드롭다운 소속 Org 목록 표시 (기존 구현 유지)
- [x] AC3: 현재 Org 체크마크 구분 (기존 구현 유지)
- [x] AC4: Org 선택 → `POST /api/switch-org` → 토큰 갱신 → 페이지 리로드
- [x] AC5: 전환 후 Project Switcher는 새 Org의 Project 표시 (SSR layout)
- [x] AC6: owner/admin/member 모두 전환 가능 (권한 검증은 FastAPI)
- [x] AC7: pending 중 드롭다운 disabled → 중복 클릭 방지

## 빌드

- `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)