### PR TITLE
[E-ORG-MULTI S4.1] PATCH /api/v2/organizations/{id} — Organization 이름 수정 API

### DIFF
--- a/backend/app/repositories/organization.py
+++ b/backend/app/repositories/organization.py
@@ -76,6 +76,27 @@ class OrganizationRepository:
             for row in result.all()
         ]
 
+    async def get_member_role(self, org_id: uuid.UUID, user_id: uuid.UUID) -> str | None:
+        """org_members에서 user의 role 반환. 미소속 시 None."""
+        result = await self.session.execute(
+            select(OrgMember.role).where(
+                OrgMember.org_id == org_id,
+                OrgMember.user_id == user_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def update_name(self, org_id: uuid.UUID, name: str) -> Organization | None:
+        """Organization 이름 수정 후 갱신된 객체 반환. 미존재 시 None."""
+        org = await self.get(org_id)
+        if org is None:
+            return None
+        org.name = name
+        await self.session.flush()
+        await self.session.refresh(org)
+        return org
+
     async def delete(self, org_id: uuid.UUID, requester_member_id: uuid.UUID) -> dict:
         org = await self.get(org_id)
         if org is None:

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -8,7 +8,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.user import User
 from app.repositories.organization import OrganizationRepository
-from app.schemas.organization import CreateOrganization, MyOrganizationResponse, OrganizationResponse
+from app.schemas.organization import CreateOrganization, MyOrganizationResponse, OrganizationResponse, UpdateOrganization
 
 router = APIRouter(prefix="/api/v2/organizations", tags=["organizations"])
 
@@ -59,6 +59,29 @@ async def create_organization(
         )
         await session.commit()
 
+    return OrganizationResponse.model_validate(org)
+
+
+@router.patch("/{id}", response_model=OrganizationResponse)
+async def update_organization(
+    id: uuid.UUID,
+    body: UpdateOrganization,
+    auth: AuthContext = Depends(get_current_user),
+    repo: OrganizationRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+) -> OrganizationResponse:
+    """Organization 이름 수정 — owner/admin만 가능."""
+    role = await repo.get_member_role(org_id=id, user_id=uuid.UUID(auth.user_id))
+    if role is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="owner or admin role required")
+
+    org = await repo.update_name(org_id=id, name=body.name)
+    if org is None:
+        raise HTTPException(status_code=404, detail="Organization not found")
+
+    await session.commit()
     return OrganizationResponse.model_validate(org)
 
 

--- a/backend/app/schemas/organization.py
+++ b/backend/app/schemas/organization.py
@@ -31,3 +31,7 @@ class MyOrganizationResponse(BaseModel):
     slug: str
     plan: str
     role: str
+
+
+class UpdateOrganization(BaseModel):
+    name: str

--- a/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
+++ b/backend/tests/test_e_org_multi_s4_1_org_settings_be.py
@@ -1,0 +1,201 @@
+"""E-ORG-MULTI S4.1: PATCH /api/v2/organizations/{id} — Organization Settings 백엔드 API.
+
+AC1: PATCH /api/v2/organizations/{id} 진입점 제공
+AC2: owner/admin만 수정 가능
+AC3: member role 403
+AC4: 존재하지 않는 org_id 404
+AC5: 수정 성공 시 갱신된 organization 반환
+AC6: 테스트 작성
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+
+
+def _mock_org(name: str = "Test Org") -> MagicMock:
+    o = MagicMock()
+    o.id = ORG_ID
+    o.name = name
+    o.slug = "test-org"
+    o.plan = "free"
+    o.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    o.updated_at = datetime(2026, 5, 20, tzinfo=timezone.utc)
+    return o
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client(user_id: uuid.UUID = USER_ID):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(user_id)
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+# ─── AC1: 진입점 존재 ────────────────────────────────────────────────────────
+
+def test_patch_org_endpoint_exists():
+    """PATCH /api/v2/organizations/{id} 라우트가 등록됨."""
+    from app.main import app
+    paths = {getattr(r, "path", "") for r in app.routes}
+    assert "/api/v2/organizations/{id}" in paths
+
+
+# ─── AC2 + AC5: owner 수정 성공 ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_owner_can_update_org_name():
+    """owner role → 200 + 갱신된 org 반환."""
+    client, session, app = await _client()
+    try:
+        updated_org = _mock_org(name="New Name")
+
+        from app.repositories.organization import OrganizationRepository
+        from app.dependencies.database import get_db as _get_db
+
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="owner")
+        mock_repo.update_name = AsyncMock(return_value=updated_org)
+
+        from app.routers.organizations import _get_repo
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+        session.commit = AsyncMock()
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/organizations/{ORG_ID}", json={"name": "New Name"})
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "New Name"
+        assert data["id"] == str(ORG_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_admin_can_update_org_name():
+    """admin role → 200."""
+    client, session, app = await _client()
+    try:
+        updated_org = _mock_org(name="Admin Updated")
+
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="admin")
+        mock_repo.update_name = AsyncMock(return_value=updated_org)
+
+        from app.routers.organizations import _get_repo
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+        session.commit = AsyncMock()
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/organizations/{ORG_ID}", json={"name": "Admin Updated"})
+
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC3: member 403 ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_member_role_returns_403():
+    """member role → 403."""
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value="member")
+
+        from app.routers.organizations import _get_repo
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/organizations/{ORG_ID}", json={"name": "Hacked"})
+
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC4: 비존재 org 404 ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_nonexistent_org_returns_404():
+    """미소속 org_id → get_member_role=None → 404."""
+    client, session, app = await _client()
+    try:
+        mock_repo = MagicMock()
+        mock_repo.get_member_role = AsyncMock(return_value=None)
+
+        from app.routers.organizations import _get_repo
+        app.dependency_overrides[_get_repo] = lambda: mock_repo
+
+        async with client as c:
+            resp = await c.patch(f"/api/v2/organizations/{uuid.uuid4()}", json={"name": "Ghost"})
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ─── AC2: 미인증 401 ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_unauthenticated_returns_401():
+    """Authorization 없으면 401."""
+    from app.main import app
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        resp = await c.patch(f"/api/v2/organizations/{ORG_ID}", json={"name": "X"})
+    assert resp.status_code in (401, 403)
+
+
+# ─── Schema 검증 ─────────────────────────────────────────────────────────────
+
+def test_update_organization_schema():
+    """UpdateOrganization에 name 필드 존재."""
+    from app.schemas.organization import UpdateOrganization
+    fields = set(UpdateOrganization.model_fields.keys())
+    assert "name" in fields
+
+
+# ─── Repository 메서드 검증 ──────────────────────────────────────────────────
+
+def test_repo_has_get_member_role():
+    """OrganizationRepository.get_member_role 메서드 존재."""
+    from app.repositories.organization import OrganizationRepository
+    assert callable(getattr(OrganizationRepository, "get_member_role", None))
+
+
+def test_repo_has_update_name():
+    """OrganizationRepository.update_name 메서드 존재."""
+    from app.repositories.organization import OrganizationRepository
+    assert callable(getattr(OrganizationRepository, "update_name", None))


### PR DESCRIPTION
## 요약
- `PATCH /api/v2/organizations/{id}` 엔드포인트 신설
- `{ name: string }` 수정 가능
- `org_members.role` 기반 권한 체크: owner/admin만 수정, member는 403

## 처리 흐름
```
PATCH /api/v2/organizations/{id} { name }
  ↓ get_member_role(org_id, user_id) — None → 404, member → 403
  ↓ update_name(org_id, name)
  → 200 OrganizationResponse
```

## 변경 파일
| 파일 | 내용 |
|------|------|
| `app/schemas/organization.py` | `UpdateOrganization` 스키마 추가 |
| `app/repositories/organization.py` | `get_member_role()` + `update_name()` 추가 |
| `app/routers/organizations.py` | `PATCH /{id}` 엔드포인트 추가 |
| `tests/test_e_org_multi_s4_1_org_settings_be.py` | AC1~AC6 테스트 9건 |

## AC 체크리스트
- [x] AC1: PATCH /api/v2/organizations/{id} 진입점 제공
- [x] AC2: owner/admin만 수정 가능
- [x] AC3: member role 403
- [x] AC4: 미존재 org 404
- [x] AC5: 수정 성공 시 갱신 org 반환
- [x] AC6: 테스트 9/9 PASS

pnpm build 5 tasks 성공.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)