### PR TITLE
[SID:799a81a9] S2 Members 사이드바 중복 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -788,7 +788,7 @@ export default function SettingsPage() {
                 </TabsTrigger>
                 <TabsTrigger value="org-members">
                   <Users className="h-4 w-4" />
-                  Members
+                  Org Members
                 </TabsTrigger>
                 <TabsTrigger value="projects">
                   <FolderKanban className="h-4 w-4" />
@@ -796,7 +796,7 @@ export default function SettingsPage() {
                 </TabsTrigger>
                 <TabsTrigger value="members">
                   <Users className="h-4 w-4" />
-                  {t('tabMembers')}
+                  Team Members
                 </TabsTrigger>
                 {isAdmin ? (
                   <>


### PR DESCRIPTION
## 변경 사항

E-ENTITY-CLEANUP S2 — Organization Settings 사이드바 "Members" 중복 제거.

### 문제
Settings 탭 목록: `Organization → Members → Projects → Members → Integrations`
두 "Members" 탭이 동일 이름으로 중복 노출.

### 수정
| 탭 value | 기존 라벨 | 수정 라벨 |
|---------|--------|--------|
| `org-members` | Members | **Org Members** |
| `members` | Members (t('tabMembers')) | **Team Members** |

### AC 체크리스트
- [x] org-members 탭: "Org Members" (조직 멤버 + 초대)
- [x] members 탭: "Team Members" (프로젝트 팀 + 에이전트)
- [x] 중복 "Members" 항목 없음
- [x] 빌드 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)