### PR TITLE
feat(entity-cleanup): project_access 테이블 신설 + migration (E-ENTITY-CLEANUP S3)

### DIFF
--- a/backend/alembic/versions/0044_add_project_access.py
+++ b/backend/alembic/versions/0044_add_project_access.py
@@ -1,0 +1,58 @@
+"""add project_access table for per-project permission control (E-ENTITY-CLEANUP S3)
+
+Revision ID: 0044
+Revises: 0043
+Create Date: 2026-05-20
+
+기본 정책: 레코드 없음 = 접근 허용 (opt-out 모델).
+기존 team_members(type=human) 데이터를 project_access로 변환.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0044"
+down_revision = "0043"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_access",
+        sa.Column("id", sa.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("project_id", sa.UUID(as_uuid=True), sa.ForeignKey("projects.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("org_member_id", sa.UUID(as_uuid=True), sa.ForeignKey("org_members.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("permission", sa.Text, nullable=False, server_default="member"),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_index("ix_project_access_project_id", "project_access", ["project_id"])
+    op.create_index("ix_project_access_org_member_id", "project_access", ["org_member_id"])
+    op.create_unique_constraint(
+        "uq_project_access_project_member", "project_access", ["project_id", "org_member_id"]
+    )
+
+    # 기존 team_members(type=human) → project_access 데이터 변환
+    op.execute(
+        """
+        INSERT INTO project_access (project_id, org_member_id, permission, created_at)
+        SELECT DISTINCT
+            tm.project_id,
+            om.id,
+            'member',
+            NOW()
+        FROM team_members tm
+        JOIN org_members om
+            ON om.user_id = tm.user_id
+            AND om.org_id = tm.org_id
+            AND om.deleted_at IS NULL
+        WHERE tm.type = 'human'
+          AND tm.project_id IS NOT NULL
+          AND tm.user_id IS NOT NULL
+          AND tm.is_active = TRUE
+        ON CONFLICT (project_id, org_member_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("project_access")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -30,6 +30,7 @@ from app.models.standup import StandupEntry, StandupFeedback
 from app.models.team import TeamMember
 from app.models.file_lock import FileLock
 from app.models.org_invite import OrgInvite
+from app.models.project_access import ProjectAccess
 
 __all__ = [
     "AgentAuditLog",
@@ -67,6 +68,7 @@ __all__ = [
     "NotificationSetting",
     "OrgInvite",
     "OrgMember",
+    "ProjectAccess",
     "Organization",
     "Project",
     "ProjectSetting",

--- a/backend/app/models/project_access.py
+++ b/backend/app/models/project_access.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ProjectAccess(Base):
+    """프로젝트별 접근 제어 (opt-out 모델: 레코드 없음 = 접근 허용).
+
+    OrgMember가 특정 프로젝트에 대해 명시적 권한이 필요할 때만 레코드 생성.
+    """
+    __tablename__ = "project_access"
+    __table_args__ = (
+        UniqueConstraint("project_id", "org_member_id", name="uq_project_access_project_member"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("projects.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    org_member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("org_members.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    permission: Mapped[str] = mapped_column(Text, nullable=False, default="member", server_default="member")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/tests/test_e_entity_cleanup_s3_project_access.py
+++ b/backend/tests/test_e_entity_cleanup_s3_project_access.py
@@ -1,0 +1,139 @@
+"""E-ENTITY-CLEANUP S3: project_access 테이블 신설 + migration 테스트.
+
+AC1: project_access 테이블 생성 (project_id, org_member_id, permission, created_at)
+AC2: Alembic migration 존재 (0044)
+AC3: 기존 team_members(type=human) → project_access 데이터 변환 로직 포함
+AC4: 기본 정책: 레코드 없음 = 접근 허용 (opt-out 모델)
+AC5: org_member 삭제 시 project_access cascade 삭제 (FK 정의)
+AC6: 롤백 migration(downgrade) 포함
+"""
+from __future__ import annotations
+
+import os
+
+
+# ─── AC1: 모델 필드 검증 ─────────────────────────────────────────────────────
+
+def test_project_access_model_exists():
+    """ProjectAccess 모델 존재."""
+    from app.models.project_access import ProjectAccess
+    assert ProjectAccess.__tablename__ == "project_access"
+
+
+def test_project_access_model_fields():
+    """ProjectAccess에 project_id, org_member_id, permission, created_at 필드 존재."""
+    from app.models.project_access import ProjectAccess
+    cols = {c.name for c in ProjectAccess.__table__.columns}
+    assert "id" in cols
+    assert "project_id" in cols
+    assert "org_member_id" in cols
+    assert "permission" in cols
+    assert "created_at" in cols
+
+
+def test_project_access_unique_constraint():
+    """(project_id, org_member_id) unique constraint 존재."""
+    from app.models.project_access import ProjectAccess
+    constraint_names = {c.name for c in ProjectAccess.__table__.constraints}
+    assert "uq_project_access_project_member" in constraint_names
+
+
+# ─── AC2: migration 존재 ─────────────────────────────────────────────────────
+
+def test_migration_0044_exists():
+    """0044_add_project_access.py migration 파일 존재."""
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions", "0044_add_project_access.py"
+    )
+    assert os.path.exists(path)
+
+
+def test_migration_0044_revision():
+    """0044 migration revision=0044, down_revision=0043."""
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions", "0044_add_project_access.py"
+    )
+    with open(path) as f:
+        content = f.read()
+    assert 'revision = "0044"' in content
+    assert 'down_revision = "0043"' in content
+
+
+def test_migration_creates_project_access():
+    """0044 migration 소스에 project_access 테이블 생성 존재."""
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions", "0044_add_project_access.py"
+    )
+    with open(path) as f:
+        content = f.read()
+    assert "project_access" in content
+    assert "project_id" in content
+    assert "org_member_id" in content
+    assert "permission" in content
+
+
+# ─── AC3: 데이터 변환 로직 ───────────────────────────────────────────────────
+
+def test_migration_has_data_conversion():
+    """0044 migration 소스에 team_members → project_access 데이터 변환 SQL 존재."""
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions", "0044_add_project_access.py"
+    )
+    with open(path) as f:
+        content = f.read()
+    assert "team_members" in content
+    assert "INSERT INTO project_access" in content
+    assert "type" in content and ("human" in content)
+
+
+# ─── AC4: opt-out 모델 검증 ─────────────────────────────────────────────────
+
+def test_model_docstring_documents_optout():
+    """ProjectAccess 모델에 opt-out 정책 문서화."""
+    from app.models.project_access import ProjectAccess
+    import inspect
+    source = inspect.getsource(ProjectAccess)
+    assert "opt-out" in source or "레코드 없음" in source
+
+
+def test_permission_default_is_member():
+    """permission 컬럼 기본값 'member'."""
+    from app.models.project_access import ProjectAccess
+    perm_col = ProjectAccess.__table__.columns["permission"]
+    default = str(perm_col.server_default.arg) if perm_col.server_default else None
+    assert default == "member"
+
+
+# ─── AC5: cascade 삭제 (FK) ──────────────────────────────────────────────────
+
+def test_project_access_org_member_fk_cascade():
+    """org_member_id FK에 ON DELETE CASCADE 설정."""
+    from app.models.project_access import ProjectAccess
+    for fk in ProjectAccess.__table__.foreign_keys:
+        if "org_members" in str(fk.target_fullname):
+            assert fk.ondelete == "CASCADE", f"org_member FK ondelete={fk.ondelete}, expected CASCADE"
+            return
+    assert False, "org_members FK not found"
+
+
+def test_project_access_project_fk_cascade():
+    """project_id FK에 ON DELETE CASCADE 설정."""
+    from app.models.project_access import ProjectAccess
+    for fk in ProjectAccess.__table__.foreign_keys:
+        if "projects" in str(fk.target_fullname):
+            assert fk.ondelete == "CASCADE", f"project FK ondelete={fk.ondelete}, expected CASCADE"
+            return
+    assert False, "projects FK not found"
+
+
+# ─── AC6: 롤백 migration ─────────────────────────────────────────────────────
+
+def test_migration_has_downgrade():
+    """0044 migration 소스에 downgrade 함수 + drop_table 존재."""
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "alembic", "versions", "0044_add_project_access.py"
+    )
+    with open(path) as f:
+        content = f.read()
+    assert "def downgrade" in content
+    assert "drop_table" in content


### PR DESCRIPTION
## Summary

- `project_access` 테이블 신설 — 프로젝트별 접근 권한 제어 (opt-out 모델)
- `ProjectAccess` SQLAlchemy 모델: `project_id`, `org_member_id`, `permission`, `created_at`
- Alembic migration 0044: 테이블 생성 + `team_members(type=human)` → `project_access` 데이터 변환
- **기본 정책: 레코드 없음 = 접근 허용** (조직 소속이면 모든 프로젝트 접근 가능)

## AC Checklist

- [x] AC1: `project_access(project_id, org_member_id, permission, created_at)` 테이블 생성
- [x] AC2: Alembic migration 0044 존재 (dev 환경 적용 가능)
- [x] AC3: `team_members(type=human)` → `project_access` 데이터 변환 SQL 포함
- [x] AC4: 기본 정책 opt-out 모델 문서화
- [x] AC5: `org_members.id` ON DELETE CASCADE + `projects.id` ON DELETE CASCADE
- [x] AC6: `downgrade()` → `drop_table("project_access")` 롤백 포함

## Test Plan

- [x] `pytest tests/test_e_entity_cleanup_s3_project_access.py -v` → 12/12 PASS

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `app/models/project_access.py` | `ProjectAccess` 모델 신설 |
| `alembic/versions/0044_add_project_access.py` | 테이블 생성 + 데이터 변환 migration |
| `tests/test_e_entity_cleanup_s3_project_access.py` | AC1~AC6 테스트 12건 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)