### PR TITLE
feat(entity-cleanup): Members API OrgMember 기반 통합 (E-ENTITY-CLEANUP S4)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,7 +12,7 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
-from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, policy_documents, presence, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -95,6 +95,7 @@ app.include_router(docs.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)
+app.include_router(project_access.router)
 app.include_router(team_members.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -1,9 +1,8 @@
 import uuid
-from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
@@ -30,11 +29,45 @@ async def list_members(
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> list[MemberResponse]:
-    result = await session.execute(
+    """프로젝트 멤버 목록.
+
+    Human: org_members + project_access JOIN (opt-out 모델 — 레코드 없음 = 접근 허용).
+    Agent: team_members(type=agent) 그대로 유지.
+    """
+    result: list[MemberResponse] = []
+
+    # Human members — org_members에 속하고 project_access 'blocked' 제외
+    human_rows = await session.execute(
+        text(
+            """
+            SELECT om.id, COALESCE(u.email, '') AS name, om.role
+            FROM org_members om
+            JOIN users u ON u.id = om.user_id
+            JOIN projects p ON p.org_id = om.org_id AND p.id = :project_id
+            WHERE om.deleted_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM project_access pa
+                  WHERE pa.org_member_id = om.id
+                    AND pa.project_id = :project_id
+                    AND pa.permission = 'blocked'
+              )
+            ORDER BY name
+            """
+        ),
+        {"project_id": str(project_id)},
+    )
+    for row in human_rows:
+        result.append(MemberResponse(id=row[0], name=row[1], type="human", role=row[2], is_active=True))
+
+    # Agent members — team_members(type=agent)은 기존 그대로
+    agent_result = await session.execute(
         select(TeamMember).where(
             TeamMember.project_id == project_id,
+            TeamMember.type == "agent",
             TeamMember.is_active.is_(True),
         ).order_by(TeamMember.name)
     )
-    members = result.scalars().all()
-    return [MemberResponse.model_validate(m) for m in members]
+    for agent in agent_result.scalars().all():
+        result.append(MemberResponse.model_validate(agent))
+
+    return result

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -1,0 +1,120 @@
+"""project_access CRUD API — 프로젝트별 접근 제어 (E-ENTITY-CLEANUP S4)."""
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.database import get_db
+from app.models.project_access import ProjectAccess
+from app.repositories.organization import OrganizationRepository
+
+router = APIRouter(prefix="/api/v2/projects", tags=["project-access"])
+
+
+class ProjectAccessCreate(BaseModel):
+    org_member_id: uuid.UUID
+    permission: str = "blocked"
+
+
+class ProjectAccessResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_member_id: uuid.UUID
+    permission: str
+    created_at: datetime
+
+
+def _get_org_repo(session: AsyncSession = Depends(get_db)) -> OrganizationRepository:
+    return OrganizationRepository(session)
+
+
+async def _require_owner_or_admin(
+    project_id: uuid.UUID, auth: AuthContext, session: AsyncSession
+) -> None:
+    """project_id → org_id 역추적 후 owner/admin 확인."""
+    from sqlalchemy import text
+    result = await session.execute(
+        text("SELECT org_id FROM projects WHERE id = :pid AND deleted_at IS NULL"),
+        {"pid": str(project_id)},
+    )
+    row = result.first()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    org_id = row[0]
+    repo = OrganizationRepository(session)
+    role = await repo.get_member_role(org_id=org_id, user_id=uuid.UUID(auth.user_id))
+    if role not in ("owner", "admin"):
+        raise HTTPException(status_code=403, detail="owner or admin role required")
+
+
+@router.get("/{project_id}/access", response_model=list[ProjectAccessResponse])
+async def list_project_access(
+    project_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> list[ProjectAccessResponse]:
+    """프로젝트 접근 제어 레코드 목록 — owner/admin만."""
+    await _require_owner_or_admin(project_id, auth, session)
+    result = await session.execute(
+        select(ProjectAccess).where(ProjectAccess.project_id == project_id)
+    )
+    return [ProjectAccessResponse.model_validate(r) for r in result.scalars().all()]
+
+
+@router.post("/{project_id}/access", response_model=ProjectAccessResponse, status_code=201)
+async def create_project_access(
+    project_id: uuid.UUID,
+    body: ProjectAccessCreate,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> ProjectAccessResponse:
+    """프로젝트 접근 제어 레코드 생성 (기본 permission=blocked) — owner/admin만."""
+    await _require_owner_or_admin(project_id, auth, session)
+    if body.permission not in ("member", "blocked"):
+        raise HTTPException(status_code=400, detail="permission must be 'member' or 'blocked'")
+    existing = await session.execute(
+        select(ProjectAccess).where(
+            ProjectAccess.project_id == project_id,
+            ProjectAccess.org_member_id == body.org_member_id,
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="Access record already exists")
+    record = ProjectAccess(
+        project_id=project_id,
+        org_member_id=body.org_member_id,
+        permission=body.permission,
+    )
+    session.add(record)
+    await session.commit()
+    await session.refresh(record)
+    return ProjectAccessResponse.model_validate(record)
+
+
+@router.delete("/{project_id}/access/{record_id}", status_code=200)
+async def delete_project_access(
+    project_id: uuid.UUID,
+    record_id: uuid.UUID,
+    auth: AuthContext = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db),
+) -> dict:
+    """프로젝트 접근 제한 해제 — owner/admin만."""
+    await _require_owner_or_admin(project_id, auth, session)
+    result = await session.execute(
+        select(ProjectAccess).where(
+            ProjectAccess.id == record_id,
+            ProjectAccess.project_id == project_id,
+        )
+    )
+    record = result.scalar_one_or_none()
+    if record is None:
+        raise HTTPException(status_code=404, detail="Access record not found")
+    await session.delete(record)
+    await session.commit()
+    return {"ok": True}

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -84,6 +84,12 @@ async def create_team_member(
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
+    # Human member 생성은 org invite 플로우로 이전 (E-ENTITY-CLEANUP S4)
+    if body.type == "human":
+        raise HTTPException(
+            status_code=410,
+            detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
+        )
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 

--- a/backend/tests/test_e_entity_cleanup_s4_members_api.py
+++ b/backend/tests/test_e_entity_cleanup_s4_members_api.py
@@ -1,0 +1,141 @@
+"""E-ENTITY-CLEANUP S4: Members API OrgMember 기반 통합 테스트.
+
+AC1: GET 프로젝트 멤버 → org_members + project_access JOIN 쿼리
+AC2: 조직 멤버 = 전체 프로젝트 접근 (project_access 레코드 없으면 허용)
+AC3: project_access CRUD API (프로젝트별 접근 차단/허용)
+AC4: 조직 탈퇴 시 project_access cascade 삭제 (FK)
+AC5: team_members human 생성 API deprecated (410)
+AC6: 기존 invite 플로우: 조직 초대만 (project_access 기반)
+AC7: 에이전트(type=agent) team_members 영향 없음
+"""
+from __future__ import annotations
+
+import inspect
+
+
+# ─── AC1: GET /api/v2/members 쿼리 변경 ──────────────────────────────────────
+
+def test_members_endpoint_uses_org_members_join():
+    """list_members 소스에 org_members JOIN 쿼리 존재."""
+    from app.routers import members
+    source = inspect.getsource(members.list_members)
+    assert "org_members" in source
+    assert "project_access" in source
+
+
+def test_members_endpoint_opt_out_logic():
+    """list_members 소스에 'blocked' 제외 opt-out 로직 존재."""
+    from app.routers import members
+    source = inspect.getsource(members.list_members)
+    assert "blocked" in source
+    assert "NOT EXISTS" in source or "not exists" in source.lower()
+
+
+# ─── AC2: 레코드 없음 = 접근 허용 ────────────────────────────────────────────
+
+def test_members_includes_all_org_members_by_default():
+    """list_members 쿼리에서 project_access 없는 org_member는 기본 포함됨."""
+    from app.routers import members
+    source = inspect.getsource(members.list_members)
+    # opt-out: NOT EXISTS(blocked) → 허용. blocked 레코드 없으면 포함
+    assert "NOT EXISTS" in source or "blocked" in source
+
+
+# ─── AC3: project_access CRUD ────────────────────────────────────────────────
+
+def test_project_access_router_exists():
+    """project_access 라우터 존재."""
+    from app.routers import project_access
+    paths = [r.path for r in project_access.router.routes]
+    assert any("access" in p for p in paths)
+
+
+def test_project_access_endpoints():
+    """GET, POST, DELETE /projects/{project_id}/access 엔드포인트 존재."""
+    from app.routers import project_access
+    methods_paths = [(list(r.methods or []), r.path) for r in project_access.router.routes]
+    has_get = any("GET" in m for m, _ in methods_paths)
+    has_post = any("POST" in m for m, _ in methods_paths)
+    has_delete = any("DELETE" in m for m, _ in methods_paths)
+    assert has_get and has_post and has_delete
+
+
+def test_project_access_create_defaults_blocked():
+    """ProjectAccessCreate 기본 permission='blocked'."""
+    from app.routers.project_access import ProjectAccessCreate
+    obj = ProjectAccessCreate(org_member_id="00000000-0000-0000-0000-000000000001")
+    assert obj.permission == "blocked"
+
+
+def test_project_access_response_schema():
+    """ProjectAccessResponse에 id, project_id, org_member_id, permission, created_at 존재."""
+    from app.routers.project_access import ProjectAccessResponse
+    fields = set(ProjectAccessResponse.model_fields.keys())
+    assert {"id", "project_id", "org_member_id", "permission", "created_at"}.issubset(fields)
+
+
+# ─── AC4: cascade 삭제 (FK 정의) ─────────────────────────────────────────────
+
+def test_project_access_org_member_cascade_defined():
+    """ProjectAccess.org_member_id FK ON DELETE CASCADE 정의 존재."""
+    from app.models.project_access import ProjectAccess
+    for fk in ProjectAccess.__table__.foreign_keys:
+        if "org_members" in str(fk.target_fullname):
+            assert fk.ondelete == "CASCADE"
+            return
+    assert False, "org_members cascade FK not found"
+
+
+# ─── AC5: team_members human 생성 deprecated ─────────────────────────────────
+
+def test_create_team_member_deprecates_human():
+    """create_team_member 소스에 human type → 410 deprecated 처리 존재."""
+    from app.routers import team_members
+    source = inspect.getsource(team_members.create_team_member)
+    assert "human" in source
+    assert "410" in source or "deprecated" in source.lower()
+
+
+def test_create_team_member_human_blocked():
+    """create_team_member 에 type=human → HTTPException 발생 확인 (소스 검증)."""
+    from app.routers import team_members
+    source = inspect.getsource(team_members.create_team_member)
+    # 410 또는 deprecated 메시지 포함
+    assert "410" in source
+
+
+# ─── AC6: 조직 초대 플로우 유지 ──────────────────────────────────────────────
+
+def test_org_invite_router_still_exists():
+    """org_invites 라우터 변경 없이 유지됨."""
+    from app.routers import org_invites
+    paths = [r.path for r in org_invites.router.routes]
+    assert any("invites" in p for p in paths)
+
+
+def test_project_access_registered_in_main():
+    """project_access 라우터가 main.py에 등록됨."""
+    import inspect
+    from app import main
+    source = inspect.getsource(main)
+    assert "project_access" in source
+    assert "project_access.router" in source
+
+
+# ─── AC7: agent team_members 영향 없음 ───────────────────────────────────────
+
+def test_members_endpoint_still_returns_agents():
+    """list_members 소스에 agent type=agent team_members 쿼리 유지됨."""
+    from app.routers import members
+    source = inspect.getsource(members.list_members)
+    assert "agent" in source
+    assert "TeamMember" in source
+
+
+def test_team_members_agent_creation_unaffected():
+    """create_team_member 소스에서 agent 타입은 기존 로직 유지됨."""
+    from app.routers import team_members
+    source = inspect.getsource(team_members.create_team_member)
+    # agent 경로는 여전히 존재
+    assert "agent" in source
+    assert "fakechat_port" in source


### PR DESCRIPTION
## Summary

- `GET /api/v2/members?project_id=...`: `org_members + project_access JOIN` 쿼리로 전환
  - opt-out 모델: `project_access(permission='blocked')` 레코드 없는 org_member → 자동 허용
  - agent members: `team_members(type=agent)` 그대로 유지
- `project_access` CRUD API 신설: `GET/POST/DELETE /api/v2/projects/{id}/access`
  - `POST` 기본 `permission='blocked'`, owner/admin 전용
- `POST /api/v2/team-members` with `type=human` → **410 Gone** (org invite 플로우로 이전)
- `project_access.router` main.py 등록

## AC Checklist

- [x] AC1: GET 프로젝트 멤버 → `org_members + project_access JOIN` 쿼리
- [x] AC2: 조직 멤버 기본 전체 접근 (blocked 레코드 없으면 허용)
- [x] AC3: `project_access` CRUD API (GET/POST/DELETE)
- [x] AC4: `org_members.id` ON DELETE CASCADE (migration 0044에서 정의)
- [x] AC5: `team_members` human 생성 → 410 deprecated
- [x] AC6: org_invites 라우터 유지 — 조직 초대만
- [x] AC7: agent(type=agent) team_members 변경 없음

## Test Plan

- [x] `pytest tests/test_e_entity_cleanup_s4_members_api.py -v` → 14/14 PASS
- [x] `pytest tests/test_e_entity_cleanup_s3_project_access.py -v` → 12/12 PASS (회귀)

## Changed Files

| 파일 | 변경 내용 |
|------|----------|
| `app/routers/members.py` | org_members + project_access JOIN 쿼리로 전환 |
| `app/routers/project_access.py` | 신설 — project_access CRUD |
| `app/routers/team_members.py` | human 생성 → 410 deprecated |
| `app/main.py` | `project_access.router` 등록 |
| `tests/test_e_entity_cleanup_s4_members_api.py` | AC1~AC7 테스트 14건 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)