### PR TITLE
[SID:44840ade] S6 Members UI OrgMember 기반 재구성

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { OrgMembersSection } from '@/components/settings/org-members-section';
+import { ProjectAccessSection } from '@/components/settings/project-access-section';
 
 import { AiSettingsSection } from '@/components/settings/ai-settings';
 import { MyProfileSection } from '@/components/settings/my-profile-section';
@@ -1210,6 +1211,15 @@ export default function SettingsPage() {
                   ) : null}
                 </SectionCardBody>
               </SectionCard>
+
+              {currentProjectId && orgInfo && (
+                <div className="mt-6">
+                  <ProjectAccessSection
+                    projectId={currentProjectId}
+                    currentRole={orgInfo.role ?? 'member'}
+                  />
+                </div>
+              )}
             </TabsContent>
 
             <TabsContent value="members">

--- a/apps/web/src/app/api/org-members/[id]/route.ts
+++ b/apps/web/src/app/api/org-members/[id]/route.ts
@@ -1,0 +1,19 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/org-members/[id]', { id });
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/org-members/[id]', { id });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/org-members/route.ts
+++ b/apps/web/src/app/api/org-members/route.ts
@@ -1,0 +1,9 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request) {
+  const _r = await proxyToFastapi(request, '/api/v2/org-members');
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/projects/[id]/access/[recordId]/route.ts
+++ b/apps/web/src/app/api/projects/[id]/access/[recordId]/route.ts
@@ -1,0 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; recordId: string }> };
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id, recordId } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/access/[recordId]', { id, recordId });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/projects/[id]/access/route.ts
+++ b/apps/web/src/app/api/projects/[id]/access/route.ts
@@ -1,0 +1,20 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/access', { id });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess([]);
+  return apiSuccess(await _r.json());
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/projects/[id]/access', { id });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -52,12 +52,18 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
 
   const refreshData = async () => {
     const [membersRes, invitesRes] = await Promise.all([
-      fetch(`/api/organizations/${orgId}/members`).catch(() => null),
+      fetch('/api/org-members').catch(() => null),
       fetch(`/api/organizations/${orgId}/invites`).catch(() => null),
     ]);
     if (membersRes?.ok) {
-      const json = await membersRes.json() as { data?: OrgMember[] };
-      setMembers(json.data ?? []);
+      const raw = await membersRes.json() as { data?: Array<{ id: string; user_id: string; role: 'owner' | 'admin' | 'member'; created_at: string }> };
+      setMembers((raw.data ?? []).map((m) => ({
+        id: m.id,
+        user_id: m.user_id,
+        name: m.user_id.slice(0, 8),
+        role: m.role,
+        joined_at: m.created_at,
+      })));
     }
     if (invitesRes?.ok) {
       const json = await invitesRes.json() as { data?: OrgInvite[] };
@@ -94,7 +100,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
   const handleChangeRole = async (memberId: string, newRole: 'admin' | 'member') => {
     setChangingRoleId(memberId);
     setActionMessage(null);
-    const res = await fetch(`/api/organizations/${orgId}/members/${memberId}`, {
+    const res = await fetch(`/api/org-members/${memberId}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ role: newRole }),
@@ -112,7 +118,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
   const handleRemove = async (memberId: string) => {
     setRemovingId(memberId);
     setActionMessage(null);
-    const res = await fetch(`/api/organizations/${orgId}/members/${memberId}`, { method: 'DELETE' });
+    const res = await fetch(`/api/org-members/${memberId}`, { method: 'DELETE' });
     if (res.ok) {
       setActionMessage({ type: 'success', text: '멤버가 제거됐습니다.' });
       setShowRemoveConfirm(null);

--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { Badge } from '@/components/ui/badge';
+
+interface OrgMember {
+  id: string;
+  user_id: string;
+  role: 'owner' | 'admin' | 'member';
+  created_at: string;
+}
+
+interface AccessRecord {
+  id: string;
+  org_member_id: string;
+  project_id: string;
+  permission: string;
+}
+
+interface ProjectAccessSectionProps {
+  projectId: string;
+  currentRole: string;
+}
+
+export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSectionProps) {
+  const [orgMembers, setOrgMembers] = useState<OrgMember[]>([]);
+  const [accessRecords, setAccessRecords] = useState<AccessRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [toggling, setToggling] = useState<string | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const canManage = currentRole === 'owner' || currentRole === 'admin';
+
+  const refreshData = async () => {
+    const [membersRes, accessRes] = await Promise.all([
+      fetch('/api/org-members').catch(() => null),
+      fetch(`/api/projects/${projectId}/access`).catch(() => null),
+    ]);
+    if (membersRes?.ok) {
+      const json = await membersRes.json() as OrgMember[] | { data?: OrgMember[] };
+      setOrgMembers(Array.isArray(json) ? json : (json.data ?? []));
+    }
+    if (accessRes?.ok) {
+      const json = await accessRes.json() as AccessRecord[] | { data?: AccessRecord[] };
+      setAccessRecords(Array.isArray(json) ? json : (json.data ?? []));
+    }
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    void refreshData();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [projectId]);
+
+  const isBlocked = (orgMemberId: string) =>
+    accessRecords.some((r) => r.org_member_id === orgMemberId && r.permission === 'blocked');
+
+  const getRecord = (orgMemberId: string) =>
+    accessRecords.find((r) => r.org_member_id === orgMemberId && r.permission === 'blocked');
+
+  const handleToggle = async (member: OrgMember) => {
+    if (!canManage || toggling) return;
+    setToggling(member.id);
+    setMessage(null);
+    try {
+      if (isBlocked(member.id)) {
+        const record = getRecord(member.id);
+        if (!record) return;
+        const res = await fetch(`/api/projects/${projectId}/access/${record.id}`, { method: 'DELETE' });
+        if (res.ok) {
+          setMessage({ type: 'success', text: '접근 허용으로 변경됐습니다.' });
+          await refreshData();
+        } else {
+          setMessage({ type: 'error', text: '변경에 실패했습니다.' });
+        }
+      } else {
+        const res = await fetch(`/api/projects/${projectId}/access`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ org_member_id: member.id, permission: 'blocked' }),
+        });
+        if (res.ok) {
+          setMessage({ type: 'success', text: '접근이 차단됐습니다.' });
+          await refreshData();
+        } else {
+          setMessage({ type: 'error', text: '변경에 실패했습니다.' });
+        }
+      }
+    } finally {
+      setToggling(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="space-y-2">
+        {[1, 2, 3].map((i) => <div key={i} className="h-10 animate-pulse rounded-md bg-muted" />)}
+      </div>
+    );
+  }
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold text-foreground">프로젝트 접근 권한</h2>
+          <p className="text-sm text-muted-foreground">
+            조직 멤버별 이 프로젝트 접근 권한을 관리합니다. 차단된 멤버는 이 프로젝트를 볼 수 없습니다.
+          </p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-3">
+        {message && (
+          <div className={`rounded-md border p-2 text-xs ${message.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
+            {message.text}
+          </div>
+        )}
+        {orgMembers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">조직 멤버가 없습니다.</p>
+        ) : (
+          orgMembers.map((member) => {
+            const blocked = isBlocked(member.id);
+            const isOwner = member.role === 'owner';
+            return (
+              <div key={member.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+                <div className="min-w-0">
+                  <div className="font-mono text-xs text-muted-foreground truncate">{member.user_id}</div>
+                  <Badge variant={isOwner ? 'info' : 'secondary'} className="capitalize mt-0.5">{member.role}</Badge>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  {blocked ? (
+                    <Badge variant="destructive" className="text-[10px]">차단됨</Badge>
+                  ) : (
+                    <Badge variant="secondary" className="text-[10px]">허용</Badge>
+                  )}
+                  {canManage && !isOwner && (
+                    <button
+                      type="button"
+                      disabled={toggling === member.id}
+                      onClick={() => void handleToggle(member)}
+                      className={`rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${blocked ? 'bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400' : 'bg-destructive/10 text-destructive hover:bg-destructive/20'} disabled:opacity-50`}
+                    >
+                      {toggling === member.id ? '...' : blocked ? '허용' : '차단'}
+                    </button>
+                  )}
+                </div>
+              </div>
+            );
+          })
+        )}
+      </SectionCardBody>
+    </SectionCard>
+  );
+}


### PR DESCRIPTION
## 변경 사항

E-ENTITY-CLEANUP S6 — Members UI OrgMember 기반 재구성 + 프로젝트별 접근 권한 토글.

### 신규 API 라우트
- `GET /api/org-members` → `/api/v2/org-members`
- `PATCH/DELETE /api/org-members/[id]` → `/api/v2/org-members/{id}`
- `GET/POST /api/projects/[id]/access` → `/api/v2/projects/{id}/access`
- `DELETE /api/projects/[id]/access/[recordId]` → `/api/v2/projects/{id}/access/{recordId}`

### 컴포넌트
**`OrgMembersSection`** — `/api/org-members` 기반으로 전환 (목록/PATCH/DELETE)
**`ProjectAccessSection`** (신규) — org_member별 프로젝트 접근 차단/허용 토글, Settings > Projects 탭

### AC
- [x] AC1: OrgMember 기반 멤버 목록
- [x] AC2: 프로젝트별 접근 권한 토글
- [x] AC3: 초대 플로우 유지
- [x] AC4: 역할 변경 org-members API
- [x] AC5: 에이전트 별도 섹션 유지
- [x] AC6: 빌드 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)