### PR TITLE
fix(entity-cleanup): project_access permission 값 스펙 정렬 (allowed/denied)

### DIFF
--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -54,10 +54,10 @@ export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSe
   }, [projectId]);
 
   const isBlocked = (orgMemberId: string) =>
-    accessRecords.some((r) => r.org_member_id === orgMemberId && r.permission === 'blocked');
+    accessRecords.some((r) => r.org_member_id === orgMemberId && r.permission === 'denied');
 
   const getRecord = (orgMemberId: string) =>
-    accessRecords.find((r) => r.org_member_id === orgMemberId && r.permission === 'blocked');
+    accessRecords.find((r) => r.org_member_id === orgMemberId && r.permission === 'denied');
 
   const handleToggle = async (member: OrgMember) => {
     if (!canManage || toggling) return;
@@ -78,7 +78,7 @@ export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSe
         const res = await fetch(`/api/projects/${projectId}/access`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ org_member_id: member.id, permission: 'blocked' }),
+          body: JSON.stringify({ org_member_id: member.id, permission: 'denied' }),
         });
         if (res.ok) {
           setMessage({ type: 'success', text: '접근이 차단됐습니다.' });

--- a/backend/alembic/versions/0045_fix_project_access_permission_values.py
+++ b/backend/alembic/versions/0045_fix_project_access_permission_values.py
@@ -1,0 +1,42 @@
+"""fix project_access permission values: member→allowed, blocked→denied (E-ENTITY-CLEANUP S3 spec)
+
+Revision ID: 0045
+Revises: 0044
+Create Date: 2026-05-20
+
+0044에서 permission DEFAULT 'member' / 'blocked' 값을 사용했으나
+S3 전체 스펙 기준은 'allowed' | 'denied' (DEFAULT 'allowed').
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0045"
+down_revision = "0044"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 기존 데이터 변환: member → allowed, blocked → denied
+    op.execute("UPDATE project_access SET permission = 'allowed' WHERE permission = 'member'")
+    op.execute("UPDATE project_access SET permission = 'denied' WHERE permission = 'blocked'")
+    # 컬럼 서버 기본값 변경
+    op.alter_column(
+        "project_access",
+        "permission",
+        server_default="allowed",
+        existing_type=sa.Text,
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.execute("UPDATE project_access SET permission = 'member' WHERE permission = 'allowed'")
+    op.execute("UPDATE project_access SET permission = 'blocked' WHERE permission = 'denied'")
+    op.alter_column(
+        "project_access",
+        "permission",
+        server_default="member",
+        existing_type=sa.Text,
+        existing_nullable=False,
+    )

--- a/backend/app/models/project_access.py
+++ b/backend/app/models/project_access.py
@@ -31,7 +31,7 @@ class ProjectAccess(Base):
         nullable=False,
         index=True,
     )
-    permission: Mapped[str] = mapped_column(Text, nullable=False, default="member", server_default="member")
+    permission: Mapped[str] = mapped_column(Text, nullable=False, default="allowed", server_default="allowed")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/members.py
+++ b/backend/app/routers/members.py
@@ -49,7 +49,7 @@ async def list_members(
                   SELECT 1 FROM project_access pa
                   WHERE pa.org_member_id = om.id
                     AND pa.project_id = :project_id
-                    AND pa.permission = 'blocked'
+                    AND pa.permission = 'denied'
               )
             ORDER BY name
             """

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -74,7 +74,7 @@ async def create_project_access(
     auth: AuthContext = Depends(get_current_user),
     session: AsyncSession = Depends(get_db),
 ) -> ProjectAccessResponse:
-    """프로젝트 접근 제어 레코드 생성 (기본 permission=blocked) — owner/admin만."""
+    """프로젝트 접근 제어 레코드 생성 (permission: 'allowed'|'denied') — owner/admin만."""
     await _require_owner_or_admin(project_id, auth, session)
     if body.permission not in ("allowed", "denied"):
         raise HTTPException(status_code=400, detail="permission must be 'allowed' or 'denied'")

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -17,7 +17,7 @@ router = APIRouter(prefix="/api/v2/projects", tags=["project-access"])
 
 class ProjectAccessCreate(BaseModel):
     org_member_id: uuid.UUID
-    permission: str = "blocked"
+    permission: str = "denied"
 
 
 class ProjectAccessResponse(BaseModel):
@@ -76,8 +76,8 @@ async def create_project_access(
 ) -> ProjectAccessResponse:
     """프로젝트 접근 제어 레코드 생성 (기본 permission=blocked) — owner/admin만."""
     await _require_owner_or_admin(project_id, auth, session)
-    if body.permission not in ("member", "blocked"):
-        raise HTTPException(status_code=400, detail="permission must be 'member' or 'blocked'")
+    if body.permission not in ("allowed", "denied"):
+        raise HTTPException(status_code=400, detail="permission must be 'allowed' or 'denied'")
     existing = await session.execute(
         select(ProjectAccess).where(
             ProjectAccess.project_id == project_id,

--- a/backend/tests/test_e_entity_cleanup_s3_project_access.py
+++ b/backend/tests/test_e_entity_cleanup_s3_project_access.py
@@ -96,12 +96,12 @@ def test_model_docstring_documents_optout():
     assert "opt-out" in source or "레코드 없음" in source
 
 
-def test_permission_default_is_member():
-    """permission 컬럼 기본값 'member'."""
+def test_permission_default_is_allowed():
+    """permission 컬럼 기본값 'allowed' (full spec: 'allowed'|'denied')."""
     from app.models.project_access import ProjectAccess
     perm_col = ProjectAccess.__table__.columns["permission"]
     default = str(perm_col.server_default.arg) if perm_col.server_default else None
-    assert default == "member"
+    assert default == "allowed"
 
 
 # ─── AC5: cascade 삭제 (FK) ──────────────────────────────────────────────────

--- a/backend/tests/test_e_entity_cleanup_s4_members_api.py
+++ b/backend/tests/test_e_entity_cleanup_s4_members_api.py
@@ -60,11 +60,11 @@ def test_project_access_endpoints():
     assert has_get and has_post and has_delete
 
 
-def test_project_access_create_defaults_blocked():
-    """ProjectAccessCreate 기본 permission='blocked'."""
+def test_project_access_create_defaults_denied():
+    """ProjectAccessCreate 기본 permission='denied' (full spec: 'allowed'|'denied')."""
     from app.routers.project_access import ProjectAccessCreate
     obj = ProjectAccessCreate(org_member_id="00000000-0000-0000-0000-000000000001")
-    assert obj.permission == "blocked"
+    assert obj.permission == "denied"
 
 
 def test_project_access_response_schema():


### PR DESCRIPTION
## Background

S3 킥오프 SSE 재전송에서 전체 스펙 확인. SQL 스키마 명시:
```sql
permission VARCHAR(20) NOT NULL DEFAULT 'allowed'  -- 'allowed' | 'denied'
```

0044에서 구현한 값(`'member'`/`'blocked'`)이 스펙과 불일치 → corrective fix.

## Changes

- **0045 migration**: `UPDATE member→allowed`, `UPDATE blocked→denied`, server_default 'allowed'
- **`ProjectAccess` 모델**: `default='allowed'`, `server_default='allowed'`
- **`members.py`**: `pa.permission = 'blocked'` → `'denied'`
- **`project_access.py`**: default `'denied'`, 유효값 `'allowed'|'denied'`
- **S3/S4 테스트**: permission 값 업데이트

## Test Plan

- [x] `pytest tests/test_e_entity_cleanup_s3_project_access.py tests/test_e_entity_cleanup_s4_members_api.py tests/test_e_entity_cleanup_s5_human_cleanup.py` → 37/37 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)