### PR TITLE
hotfix: 0044 migration org_members PK 추가 (FK 실패 수정)

### DIFF
--- a/backend/alembic/versions/0044_add_project_access.py
+++ b/backend/alembic/versions/0044_add_project_access.py
@@ -17,6 +17,23 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # org_members.id에 PK constraint가 없으면 추가 (Supabase 생성 테이블 보정)
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'org_members'::regclass
+                  AND contype = 'p'
+            ) THEN
+                ALTER TABLE org_members ADD PRIMARY KEY (id);
+            END IF;
+        END
+        $$;
+        """
+    )
+
     op.create_table(
         "project_access",
         sa.Column("id", sa.UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),


### PR DESCRIPTION
## Problem

dev DB에서 `alembic upgrade head` 실행 시 0044 migration 실패:
```
psycopg2.errors.InvalidForeignKey: there is no unique constraint matching given keys for referenced table "org_members"
```

`org_members` 테이블이 Supabase에서 생성됐고 `id` 컬럼에 PRIMARY KEY constraint가 없는 상태.
→ `project_access.org_member_id` → `org_members.id` FK 생성 불가.

## Fix

0044 upgrade() 앞에 조건부 PK 추가 구문 삽입:
```sql
DO $$
BEGIN
    IF NOT EXISTS (
        SELECT 1 FROM pg_constraint
        WHERE conrelid = 'org_members'::regclass AND contype = 'p'
    ) THEN
        ALTER TABLE org_members ADD PRIMARY KEY (id);
    END IF;
END
$$;
```
이미 PK가 있으면 스킵.

## Notes
- DB는 현재 revision 0043 (0044 미적용 상태)
- 이 PR 머지 후 `sprintable-migrate-dev` job 재실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)