### PR TITLE
[SID:S8] Next.js 프록시 라우트 누락 3건 추가

### DIFF
--- a/apps/web/src/app/api/organizations/[id]/invites/[inviteId]/route.ts
+++ b/apps/web/src/app/api/organizations/[id]/invites/[inviteId]/route.ts
@@ -1,0 +1,12 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string; inviteId: string }> };
+
+export async function DELETE(request: Request, { params }: RouteParams) {
+  const { id, inviteId } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/organizations/[id]/invites/[inviteId]', { id, inviteId });
+  if (!_r.ok) return _r;
+  if (_r.status === 204) return apiSuccess({ ok: true });
+  return apiSuccess(await _r.json());
+}

--- a/apps/web/src/app/api/team-members/[id]/api-key/route.ts
+++ b/apps/web/src/app/api/team-members/[id]/api-key/route.ts
@@ -1,0 +1,29 @@
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+import { handleApiError } from '@/lib/api-error';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]/api-key', { id });
+    if (!_r.ok) return _r;
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    const _r = await proxyToFastapiWithParams(request, '/api/v2/team-members/[id]/api-key', { id });
+    if (!_r.ok) return _r;
+    if (_r.status === 204) return apiSuccess({ ok: true });
+    return apiSuccess(await _r.json());
+  } catch (err: unknown) { return handleApiError(err); }
+}

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -56,11 +56,11 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
       fetch(`/api/organizations/${orgId}/invites`).catch(() => null),
     ]);
     if (membersRes?.ok) {
-      const raw = await membersRes.json() as { data?: Array<{ id: string; user_id: string; role: 'owner' | 'admin' | 'member'; created_at: string }> };
+      const raw = await membersRes.json() as { data?: Array<{ id: string; user_id: string; email?: string | null; role: 'owner' | 'admin' | 'member'; created_at: string }> };
       setMembers((raw.data ?? []).map((m) => ({
         id: m.id,
         user_id: m.user_id,
-        name: m.user_id.slice(0, 8),
+        name: m.email || m.user_id.slice(0, 8),
         role: m.role,
         joined_at: m.created_at,
       })));


### PR DESCRIPTION
## Summary

- **BUG-3**: `DELETE /api/organizations/{id}/invites/{inviteId}` — 라우트 파일 누락으로 404 HTML 반환 수정
- **BUG-5**: `GET /api/team-members/{id}/api-key` — 라우트 파일 누락으로 404 HTML 반환 수정 (POST도 함께 추가)
- **AC-7**: Org Members 탭 멤버 이름을 email 우선 표시 (`email || user_id.slice(0,8)` fallback)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `apps/web/src/app/api/organizations/[id]/invites/[inviteId]/route.ts` | 신규 — DELETE handler |
| `apps/web/src/app/api/team-members/[id]/api-key/route.ts` | 신규 — GET/POST handler |
| `apps/web/src/components/settings/org-members-section.tsx` | 수정 — email 필드 표시 |

## Test plan

- [ ] `DELETE /api/organizations/{id}/invites/{inviteId}` 호출 시 204/200 정상 응답 확인
- [ ] `GET /api/team-members/{id}/api-key` 호출 시 200 정상 응답 확인
- [ ] Org Members 탭에서 멤버 이름이 email로 표시됨 (UUID prefix 아닌)
- [ ] email 없는 멤버는 UUID prefix fallback 확인
- [ ] `pnpm tsc --noEmit` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)