### PR TITLE
[P0] Org Switcher 프론트엔드 context 미갱신 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
@@ -105,6 +106,7 @@ export default function SettingsPage() {
   const tc = useTranslations('common');
   const router = useRouter();
   const searchParamsHook = useSearchParams();
+  const { orgId: ctxOrgId, orgMemberships } = useDashboardContext();
   const [activeTab, setActiveTab] = useState(() => searchParamsHook.get('tab') ?? 'profile');
   const [lnbOpen, setLnbOpen] = useState(false);
   const { toasts, addToast, dismissToast } = useToast();
@@ -186,6 +188,10 @@ export default function SettingsPage() {
   const [webhookEditing, setWebhookEditing] = useState<Record<string, string>>({});
   const [webhookSaving, setWebhookSaving] = useState<string | null>(null);
   const [webhookErrors, setWebhookErrors] = useState<Record<string, string>>({});
+
+  // DashboardCtx에서 현재 org의 role을 derive — fetch 완료 전에도 올바른 role 반영
+  const ctxRole = orgMemberships.find(o => o.orgId === (orgId ?? ctxOrgId))?.role;
+  const currentOrgRole = (orgInfo?.role ?? ctxRole ?? 'member') as string;
 
   const handleOpenDeleteOrg = async () => {
     if (!orgInfo) return;
@@ -1022,7 +1028,7 @@ export default function SettingsPage() {
                       <div className="space-y-4">
                         <div className="space-y-1.5">
                           <label className="text-sm font-medium text-foreground">이름</label>
-                          {(orgInfo.role === 'owner' || orgInfo.role === 'admin') ? (
+                          {(currentOrgRole === 'owner' || currentOrgRole === 'admin') ? (
                             <div className="flex items-center gap-2">
                               <input
                                 className="flex-1 rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
@@ -1058,10 +1064,10 @@ export default function SettingsPage() {
                           </div>
                         )}
 
-                        {orgInfo.role && (
+                        {currentOrgRole && (
                           <div className="space-y-1.5">
                             <label className="text-sm font-medium text-foreground">내 역할</label>
-                            <p className="rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-foreground capitalize">{orgInfo.role}</p>
+                            <p className="rounded-md border border-input bg-muted/30 px-3 py-2 text-sm text-foreground capitalize">{currentOrgRole}</p>
                           </div>
                         )}
                       </div>
@@ -1075,7 +1081,7 @@ export default function SettingsPage() {
                   )}
                 </SectionCardBody>
               </SectionCard>
-              {orgInfo?.role === 'owner' && (
+              {currentOrgRole === 'owner' && (
                 <SectionCard className="border-destructive/20 bg-destructive/10 mt-6">
                   <SectionCardHeader className="border-b border-destructive/20">
                     <div className="space-y-1">
@@ -1094,7 +1100,7 @@ export default function SettingsPage() {
 
             <TabsContent value="org-members">
               {orgId && orgInfo ? (
-                <OrgMembersSection orgId={orgId} currentRole={orgInfo.role ?? 'member'} />
+                <OrgMembersSection orgId={orgId} currentRole={currentOrgRole} />
               ) : (
                 <div className="space-y-3">
                   {[1, 2, 3].map((i) => <div key={i} className="h-12 animate-pulse rounded-md bg-muted" />)}
@@ -1216,7 +1222,7 @@ export default function SettingsPage() {
                 <div className="mt-6">
                   <ProjectAccessSection
                     projectId={currentProjectId}
-                    currentRole={orgInfo.role ?? 'member'}
+                    currentRole={currentOrgRole}
                   />
                 </div>
               )}

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -115,7 +115,8 @@ export function UnifiedSwitcher({
         body: JSON.stringify({ org_id: nextOrgId }),
       });
       if (res.ok) {
-        window.location.href = '/dashboard';
+        router.refresh();
+        router.push('/dashboard');
       }
     } finally {
       setPending(false);
@@ -138,7 +139,8 @@ export function UnifiedSwitcher({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ project_id: projectId }),
       }).catch(() => null);
-      window.location.href = '/dashboard';
+      router.refresh();
+      router.push('/dashboard');
     } finally {
       setPending(false);
     }


### PR DESCRIPTION
## Summary

- `unified-switcher.tsx`: `window.location.href = '/dashboard'` → `router.refresh() + router.push('/dashboard')`
  - `router.refresh()`로 서버 컴포넌트 즉시 재실행 → 사이드바 org명, orgMemberships 즉시 갱신
  - SPA 내 자연스러운 전환 (full reload 없음)

- `settings/page.tsx`: `useDashboardContext()`에서 `orgMemberships` 기반 `currentOrgRole` computed value 추가
  - fetch 완료 전에도 DashboardCtx에서 올바른 role 표시
  - `OrgMembersSection`, `ProjectAccessSection`의 `currentRole` prop도 `currentOrgRole` 사용
  - `orgInfo.role === 'owner'` 조건부 UI도 `currentOrgRole` 기반으로 교체

## AC 체크

- [x] AC-1: 사이드바 org명이 전환된 조직으로 즉시 갱신 (router.refresh로 서버 컴포넌트 재실행)
- [x] AC-2: currentRole이 새 조직 역할로 갱신 (DashboardCtx 기반 currentOrgRole)
- [x] AC-3: Org Members 페이지에서 owner인 경우 초대 폼 표시 (currentOrgRole 사용)
- [x] AC-4: Settings Organization 항목이 새 조직 기준으로 동작 (orgInfo.role → currentOrgRole)
- [x] AC-5: 빠른 연속 전환에도 최종 선택 org context 정확히 반영 (router.refresh 동기화)
- [x] AC-6: full reload 없이 SPA 내 즉시 반영 (router.refresh + router.push)

## Test plan

- [ ] org switcher로 다른 조직으로 전환 → 사이드바 org명 즉시 변경 확인
- [ ] owner 조직으로 전환 후 Settings → Org Members 탭 → 초대 폼 표시 확인
- [ ] member 조직으로 전환 후 Settings → Org Members 탭 → 초대 폼 미표시 확인
- [ ] A→B→A 빠른 연속 전환 시 최종 A org context 정확히 반영 확인
- [ ] `pnpm tsc --noEmit` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)