### PR TITLE
hotfix(P0): switch-org team_member 없을 때 last_project_id fallback 수정

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -51,7 +51,7 @@ from app.core.rate_limit import limiter
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
-from app.models.project import OrgMember
+from app.models.project import OrgMember, Project
 from app.models.team import TeamMember
 from app.models.login_audit_log import LoginAuditLog
 from app.models.user import RefreshToken, User
@@ -1043,6 +1043,17 @@ async def switch_organization(
 
     if team_member is not None:
         user.last_project_id = team_member.project_id
+    else:
+        # team_member 없음 (opt-out 모델) — 대상 org의 첫 project로 last_project_id 갱신.
+        # 미설정 시 _build_app_metadata가 이전 org project_id를 JWT에 심어 context 불일치 발생.
+        first_proj_result = await session.execute(
+            select(Project)
+            .where(Project.org_id == body.org_id, Project.deleted_at.is_(None))
+            .order_by(Project.created_at.asc())
+            .limit(1)
+        )
+        first_proj = first_proj_result.scalar_one_or_none()
+        user.last_project_id = first_proj.id if first_proj else None
 
     # 기존 refresh token 무효화
     await session.execute(


### PR DESCRIPTION
## Problem

Org switcher로 조직 전환 시 사이드바 org명/currentRole 미갱신.

**Root Cause:**
1. `switch_organization`에서 team_member 없으면 `user.last_project_id` = 이전 org 프로젝트 유지
2. `_build_app_metadata` → 이전 org의 project_id로 JWT 빌드
3. `app_metadata["org_id"] = str(body.org_id)` 로 org_id만 덮어씀
4. JWT = { org_id: 새 org, project_id: 이전 org } 불일치 → `/me`가 이전 org 반환

**Trigger:** E-ENTITY-CLEANUP S5에서 human team_member 자동 생성 제거로 새 org에 team_member 없는 경우 발생

## Fix

team_member 없을 때 `else` 블록 추가:
```python
first_proj = await session.execute(
    select(Project).where(Project.org_id == body.org_id, ...).limit(1)
)
user.last_project_id = first_proj.id if first_proj else None
```

→ `_build_app_metadata` 호출 전에 대상 org의 첫 project로 `last_project_id` 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)