### PR TITLE
[P2] Org Switcher 사이드바 org명 즉시 갱신 — 레이아웃 캐싱 해소

### DIFF
--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -73,9 +73,17 @@ export function UnifiedSwitcher({
   const [otherOrgProjects, setOtherOrgProjects] = useState<Record<string, ProjectItem[]>>({});
   const [loadingOrgIds, setLoadingOrgIds] = useState<Set<string>>(new Set());
 
-  const currentOrg = orgs.find((o) => o.orgId === currentOrgId);
+  // Optimistic org 상태 — API 성공 즉시 UI에 반영, router.refresh() 완료 후 서버 값과 동기화
+  const [localOrgId, setLocalOrgId] = useState<string | undefined>(currentOrgId);
+
+  // 서버에서 새 currentOrgId가 내려오면 (router.refresh() 완료 후) 로컬 상태 동기화
+  useEffect(() => {
+    setLocalOrgId(currentOrgId);
+  }, [currentOrgId]);
+
+  const currentOrg = orgs.find((o) => o.orgId === localOrgId);
   const currentProject = projects.find((p) => p.projectId === currentProjectId);
-  const otherOrgs = orgs.filter((o) => o.orgId !== currentOrgId);
+  const otherOrgs = orgs.filter((o) => o.orgId !== localOrgId);
 
   const displayOrg = currentOrg?.orgName ?? 'Organization';
   const displayProject = currentProject?.projectName ?? '';
@@ -106,8 +114,10 @@ export function UnifiedSwitcher({
   }, [open]);
 
   async function switchOrg(nextOrgId: string) {
-    if (!nextOrgId || nextOrgId === currentOrgId || pending) return;
+    if (!nextOrgId || nextOrgId === localOrgId || pending) return;
+    const prevOrgId = localOrgId;
     setPending(true);
+    setLocalOrgId(nextOrgId); // optimistic: 즉시 사이드바 org명 갱신
     try {
       const res = await fetch('/api/switch-org', {
         method: 'POST',
@@ -116,7 +126,8 @@ export function UnifiedSwitcher({
       });
       if (res.ok) {
         router.refresh();
-        router.push('/dashboard');
+      } else {
+        setLocalOrgId(prevOrgId); // API 실패 시 롤백
       }
     } finally {
       setPending(false);
@@ -125,14 +136,19 @@ export function UnifiedSwitcher({
 
   async function switchOrgAndProject(nextOrgId: string, projectId: string) {
     if (pending) return;
+    const prevOrgId = localOrgId;
     setPending(true);
+    setLocalOrgId(nextOrgId); // optimistic: 즉시 사이드바 org명 갱신
     try {
       const orgRes = await fetch('/api/switch-org', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ org_id: nextOrgId }),
       });
-      if (!orgRes.ok) return;
+      if (!orgRes.ok) {
+        setLocalOrgId(prevOrgId);
+        return;
+      }
       // org 전환 후 project 전환 (쿠키는 Set-Cookie로 이미 갱신됨)
       await fetch('/api/switch-project', {
         method: 'POST',
@@ -140,7 +156,6 @@ export function UnifiedSwitcher({
         body: JSON.stringify({ project_id: projectId }),
       }).catch(() => null);
       router.refresh();
-      router.push('/dashboard');
     } finally {
       setPending(false);
     }


### PR DESCRIPTION
## 변경 사항 요약

Org 전환 후 사이드바 org명이 새로고침 없이 즉시 반영되지 않던 버그 수정.

### 근본 원인

`router.refresh()` + `router.push('/dashboard')` 동시 호출 시 race condition 발생.  
이미 `/dashboard`에 있을 때 `push`가 새 navigation을 시작하면서 `refresh` 결과가 무효화되어 layout 재실행이 이뤄지지 않음.

### 수정 내용 (`unified-switcher.tsx`)

| 항목 | Before | After |
|------|--------|-------|
| Org 전환 UI 갱신 | router.refresh() 완료 후 (느림) | API 성공 즉시 optimistic update |
| router.push 호출 | `/dashboard`로 push | 제거 (race condition 원인) |
| 실패 처리 | 없음 | prevOrgId 자동 롤백 |

**핵심 변경:**
- `localOrgId` 클라이언트 state 추가 — API 성공 직후 `setLocalOrgId(nextOrgId)` 호출로 즉시 UI 반영
- `router.push('/dashboard')` 제거 — same-route navigation race condition 원인 제거  
- `router.refresh()` 단독 호출 — layout.tsx 서버 컴포넌트 재실행으로 서버 데이터 동기화
- `useEffect([currentOrgId])` — refresh 완료 후 서버에서 내려온 값으로 localOrgId 동기화

### 테스트 방법

1. E2E TEST CORP → 뭉클랩 전환 → 사이드바 즉시 "뭉클랩" 표시 확인
2. 뭉클랩 → E2E TEST CORP 전환 → 사이드바 즉시 "E2E Test Corp" 표시 확인
3. 새로고침 없이 페이지 컨텐츠도 전환된 org 기준으로 변경되는지 확인

### 체크리스트

- [x] 기능 구현 완료
- [x] `pnpm build` 통과
- [x] `pnpm lint` 0 errors
- [ ] 까심 아르야 QA 검수