### PR TITLE
fix(sse): push-before-commit race condition 해소 — SSE 리얼타임 이벤트 drop 수정

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -75,13 +75,14 @@ async def _dispatch_conversation_event(
     org_id: uuid.UUID,
     sender: TeamMember,
     exclude_ids: set[uuid.UUID] | None = None,
-) -> None:
-    """conversation:message → 전 참여자 SSE dispatch + Event INSERT.
+) -> list[tuple[str, dict]]:
+    """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
     exclude_ids: SSE 발송에서 제외할 member_id 집합 (Discord 수신자 등).
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
 
@@ -93,7 +94,7 @@ async def _dispatch_conversation_event(
     participant_ids = {r[0] for r in rows} - {sender.id} - (exclude_ids or set())
 
     if not participant_ids:
-        return
+        return []
 
     member_rows = (await db.execute(
         select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(participant_ids))
@@ -118,10 +119,10 @@ async def _dispatch_conversation_event(
         db.add(event)
         events_to_push.append((str(pid), event))
 
-    # flush 후 event.id 확보 → event_id 포함 push (dedup 동작 보장)
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_mention_events(
@@ -131,10 +132,13 @@ async def _dispatch_mention_events(
     org_id: uuid.UUID,
     sender: TeamMember,
     mention_targets: set[uuid.UUID],
-) -> None:
-    """AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)."""
+) -> list[tuple[str, dict]]:
+    """AC1: 멘션 대상에게 conversation:mention Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
+
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
+    """
     if not conversation.project_id or not mention_targets:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
     member_rows = (await db.execute(
@@ -160,9 +164,10 @@ async def _dispatch_mention_events(
         db.add(event)
         events_to_push.append((str(pid), event))
 
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_discord_outbound(
@@ -677,9 +682,10 @@ async def send_message(
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
+    pending_sse_pushes: list[tuple[str, dict]] = []
     try:
         async with db.begin_nested():
-            await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
+            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
     except Exception:
         logger.exception("conversation event dispatch failed conversation_id=%s", conversation_id)
 
@@ -689,7 +695,7 @@ async def send_message(
         if mention_targets:
             try:
                 async with db.begin_nested():
-                    await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
+                    pending_sse_pushes += await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
             except Exception:
                 logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
 
@@ -698,6 +704,10 @@ async def send_message(
 
     await db.commit()
     await db.refresh(msg)
+
+    # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
+    for pid_str, sse_payload in pending_sse_pushes:
+        _push_to_agent(pid_str, sse_payload)
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -743,6 +743,7 @@ async def add_reply(
         )
         # CB-S7: SSE conversation:message 발행 (P0 — 수신자 화면 실시간 갱신)
         conv = await db.get(Conversation, id)
+        pending_sse_pushes: list[tuple[str, dict]] = []
         if conv:
             sender_member = (await db.execute(
                 select(TeamMember).where(TeamMember.id == body.created_by)
@@ -757,9 +758,15 @@ async def add_reply(
                         discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
                     except Exception:
                         logger.warning("channel_router pre-check failed reply_msg_id=%s", reply_msg.id)
-                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
+                    pending_sse_pushes = await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
                 except Exception:
                     logger.warning("conversation event dispatch failed memo_id=%s", id, exc_info=True)
+
+        # commit 후 SSE push — Event 커밋 완료 상태에서 push해야 race condition 없음
+        await db.commit()
+        from app.routers.events import _push_to_agent
+        for pid_str, sse_payload in pending_sse_pushes:
+            _push_to_agent(pid_str, sse_payload)
 
         # webhook 발송 (기존 참여자 수집)
         if conv:


### PR DESCRIPTION
## 문제
답신(reply) 메시지의 SSE 리얼타임 이벤트가 거의 항상 누락됨.

## 근본 원인
`conversations.py` send_message 흐름:
1. `_dispatch_conversation_event()` → `db.flush()` → **`_push_to_agent()` 호출** (SSE 큐에 event_id 투입)
2. 이 시점 `db.commit()` 전
3. `agent_event_stream`이 큐에서 event_id를 받아 **새 DB 세션**으로 Event 조회
4. PostgreSQL READ COMMITTED 격리 → 미커밋 Event 불가시 → `live_evt is None` → drop

## 수정
`_dispatch_conversation_event` / `_dispatch_mention_events` 리턴 타입 변경:
- 기존: `None` (내부에서 직접 `_push_to_agent()` 호출)
- 변경: `list[tuple[str, dict]]` (push 페이로드 반환)

`send_message`에서 `db.commit()` 완료 후 반환된 페이로드로 `_push_to_agent()` 일괄 호출.
flush()는 그대로 유지 → event.id 확보(dedup 보장)는 변함없음.

## 검증
- `test_send_message_201` 포함 send_message 관련 테스트 2/2 PASS
- 기존 실패 테스트(`test_list_conversations`)는 pre-existing mock 문제로 변경과 무관

## Story
S0: SSE 리얼타임 이벤트 race condition 수정 (7adad22e)