### PR TITLE
feat(webhook): conversation_webhook channel_router 연동 — sse 결정 멤버 이중 발송 제거

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,9 +132,21 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
+
+                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                from app.services.channel_router import route_message as _route
+                sse_member_ids: set[uuid.UUID] = set()
+                try:
+                    decisions = await _route(message_id, db)
+                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                except Exception:
+                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
+                    if wh.member_id in sse_member_ids:
+                        continue  # channel_router → sse: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)


### PR DESCRIPTION
## 문제
`conversation_webhook.py`가 channel_router 결정을 무시하고 member webhook 전량 POST.
channel_router가 "sse"로 결정한 멤버도 member-level webhook이 있으면 이중 수신됨.

## 수정
`deliver_conversation_message_webhook` member webhook 병합 시:
1. `channel_router.route_message()` 호출 → `sse_member_ids` 수집
2. `extra_wh_rows` 순회 중 `wh.member_id in sse_member_ids` → `continue` (발송 생략)
3. org/project-level webhook(member_id=NULL)은 channel_router 결정 무관하게 항상 발송 유지
4. channel_router 호출 실패 시 기존 동작(전량 발송) fallback

## 검증
- webhook 테스트 35/35 PASS

## Story
S1: conversation_webhook channel_router 연동 (0a6c137e)