### PR TITLE
feat(webhook): discord 멤버 member webhook 이중 발송 제거 (S2)

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -133,20 +133,21 @@ async def deliver_conversation_message_webhook(
                     )
                 )).scalars().all()
 
-                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
                 from app.services.channel_router import route_message as _route
-                sse_member_ids: set[uuid.UUID] = set()
+                routed_member_ids: set[uuid.UUID] = set()
                 try:
                     decisions = await _route(message_id, db)
-                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
                 except Exception:
-                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
 
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in sse_member_ids:
-                        continue  # channel_router → sse: member webhook 발송 생략
+                    if wh.member_id in routed_member_ids:
+                        continue  # channel_router → sse/discord: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)


### PR DESCRIPTION
## 문제
Discord preference 멤버에게 동일 Discord URL로 2회 POST:
1. `conversation_webhook` → `_to_discord_payload` 포맷 (member webhook)
2. `discord_outbound` BackgroundTask → 별도 포맷

## 수정
S1의 `sse_member_ids` → `routed_member_ids`로 확장:
- `channel in ("sse", "discord")` 모두 member webhook skip
- org/project-level webhook(member_id=NULL)은 기존 동작 유지
- channel_router 호출 실패 시 fallback(전량 발송) 유지

## 검증
- webhook 테스트 35/35 PASS

## Story
S2: discord_outbound + conversation_webhook 중복 제거 (e03210a4)