### PR TITLE
revert: S1+S2 member webhook 필터링 긴급 롤백

### DIFF
--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,21 +132,9 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
-
-                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
-                from app.services.channel_router import route_message as _route
-                sse_member_ids: set[uuid.UUID] = set()
-                try:
-                    decisions = await _route(message_id, db)
-                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
-                except Exception:
-                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
-
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in sse_member_ids:
-                        continue  # channel_router → sse: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -133,21 +133,20 @@ async def deliver_conversation_message_webhook(
                     )
                 )).scalars().all()
 
-                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
-                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
+                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
                 from app.services.channel_router import route_message as _route
-                routed_member_ids: set[uuid.UUID] = set()
+                sse_member_ids: set[uuid.UUID] = set()
                 try:
                     decisions = await _route(message_id, db)
-                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
+                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
                 except Exception:
-                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
+                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
 
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in routed_member_ids:
-                        continue  # channel_router → sse/discord: member webhook 발송 생략
+                    if wh.member_id in sse_member_ids:
+                        continue  # channel_router → sse: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)


### PR DESCRIPTION
## 긴급 Revert — 알림 전량 중단 복구

S1(#886) + S2(#887)의 conversation_webhook channel_router 연동이 agent↔agent SSE 강제 라우팅과 결합하여 **전 에이전트 Discord 알림 중단**.

### 근본 원인
member webhook과 SSE/Discord 전달 채널은 **독립 경로**:
- SSE: 에이전트 MCP/fakechat 전달용
- member webhook: 에이전트 Discord 채널 알림용

channel_router가 agent↔agent를 "sse"로 강제 → S1이 해당 멤버의 member webhook을 skip → Discord 알림 전량 중단.

### 조치
S1+S2 revert로 원상 복구. S1/S2 로직은 재설계 후 재적용.