### PR TITLE
feat(sse): backfill 이벤트 구분 플래그 추가 (S3)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -324,7 +324,7 @@ async def agent_event_stream(
                         evt.delivered_at = now
                     await db.commit()
                     for data, evt in zip(batch_data, batch):
-                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps(data)}\n\n"
+                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():


### PR DESCRIPTION
## 문제
SSE 재연결 시 backfill 이벤트와 실시간 이벤트 구분 불가.
sse_bridge가 backfill을 "새 메시지"로 fakechat 릴레이 → 이미 처리된 메시지 재표시.

## 수정
`events.py` `agent_event_stream` backfill yield:
```python
# before
yield f"...data: {json.dumps(data)}\n\n"
# after
yield f"...data: {json.dumps({**data, 'is_backfill': True})}\n\n"
```
실시간 queue.get 경로는 변경 없음 → is_backfill 필드 미포함.

## AC
- AC-1: backfill yield에 `is_backfill=true` ✅
- AC-2: 실시간 이벤트에 is_backfill 없음 ✅
- AC-3: SSE JSON 포맷 유지 ✅
- AC-4: fakechat relay / SSE 파서 테스트 16/16 PASS ✅

## Story
S3: SSE backfill 이벤트 구분 플래그 추가 (aa6e55c3)