### PR TITLE
feat(sse_bridge): backfill 스킵 + webhook exclusive OR relay 필터 (S4)

### DIFF
--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -13,6 +13,7 @@ class McpSettings(BaseSettings):
     fakechat_port: int = 8787
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
+    has_webhook: bool = False  # True: fakechat relay 전체 스킵, Discord 웹훅으로만 수신
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -354,12 +354,22 @@ async def start_sse_bridge(
             seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
 
-        asyncio.create_task(
-            relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
-        )
+        # MCP notification: webhook 유무·backfill 여부 무관하게 항상 발송 (AC-4)
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
+
+        # relay 조건: (1) backfill 아님, (2) webhook 미설정
+        _relay = True
+        try:
+            _relay = not json.loads(event.data).get("is_backfill", False)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        if _relay and not settings.has_webhook:
+            asyncio.create_task(
+                relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
+            )
+
         if on_event is not None:
             on_event(event.event_type, event.data)
 


### PR DESCRIPTION
## 문제
1. SSE 재연결 시 backfill 이벤트가 fakechat "새 메시지"로 릴레이 → 재표시
2. webhook 설정 에이전트에게도 fakechat relay → Discord + fakechat 이중 수신

## 수정
`sse_bridge.py` `_handle()` relay 조건:
- `is_backfill=true` → `relay_to_fakechat` skip (S3 플래그 활용)
- `settings.has_webhook=True` → `relay_to_fakechat` 전체 skip
- `_send_mcp_notification` 은 두 조건 모두 항상 발송 유지

`config.py`: `has_webhook: bool = False` 추가 (환경변수 `HAS_WEBHOOK=true`)

## AC
- AC-1: is_backfill=true 이벤트 → relay 스킵 ✅
- AC-2: has_webhook=True → relay 전체 스킵 ✅
- AC-3: has_webhook=False → relay 정상 ✅
- AC-4: MCP notification 항상 발송 ✅
- AC-5: SSE 수신 자체 스킵 없음 ✅

## 검증
MCP 테스트 87/90 PASS (3개 실패는 네트워크 e2e + tool count pre-existing)

## Story
S4: sse_bridge fakechat relay 필터링 (9e636dce)