### PR TITLE
feat(pubsub): pg_notify 발행 레이어 — Cloud Run 인스턴스 간 SSE 전파 (E-SSE-PUBSUB S1)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -42,6 +42,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
+    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("org", org_id, event_type, data)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -84,18 +92,25 @@ def _compute_backfill_mode(
 def _push_to_agent(member_id: str, payload: dict) -> bool:
     """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
     queues = _agent_connections.get(member_id)
-    if not queues:
-        return False
     pushed = False
-    dead: list[asyncio.Queue] = []
-    for q in list(queues):
-        try:
-            q.put_nowait(payload)
-            pushed = True
-        except asyncio.QueueFull:
-            dead.append(q)
-    for q in dead:
-        queues.discard(q)
+    if queues:
+        dead: list[asyncio.Queue] = []
+        for q in list(queues):
+            try:
+                q.put_nowait(payload)
+                pushed = True
+            except asyncio.QueueFull:
+                dead.append(q)
+        for q in dead:
+            queues.discard(q)
+    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,0 +1,62 @@
+"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+
+publish_event() / _push_to_agent() 내부에서 호출.
+실패 시 로컬 전파는 정상 유지 — graceful degradation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+logger = logging.getLogger(__name__)
+
+INSTANCE_ID: str = str(uuid.uuid4())
+"""앱 기동 시 1회 생성 — 자기 자신이 발행한 notify 재수신 방지용."""
+
+_CHANNEL = "sse_events"
+_MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
+
+
+async def pg_notify(
+    target: str,
+    target_id: str,
+    event_type: str,
+    data: dict,
+) -> None:
+    """PostgreSQL NOTIFY 단발 발행. 실패 시 경고 로그만 — 예외 전파 금지.
+
+    target: "org" | "agent"
+    target_id: org_id | member_id (str)
+    """
+    import asyncpg
+    from app.core.config import settings
+
+    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+    payload: dict = {
+        "instance_id": INSTANCE_ID,
+        "target": target,
+        "target_id": target_id,
+        "event_type": event_type,
+        "data": data,
+    }
+
+    payload_str = json.dumps(payload, default=str)
+    if len(payload_str.encode()) > _MAX_PAYLOAD_BYTES:
+        # 8KB 초과 시 content 제거 — id/event_type으로 구독측 재조회 유도
+        data_slim = {k: v for k, v in data.items() if k != "content"}
+        payload["data"] = data_slim
+        payload_str = json.dumps(payload, default=str)
+
+    try:
+        conn = await asyncpg.connect(raw_url)
+        try:
+            await conn.execute("SELECT pg_notify($1, $2)", _CHANNEL, payload_str)
+        finally:
+            await conn.close()
+    except Exception as exc:
+        logger.warning(
+            "pg_notify failed channel=%s target=%s target_id=%s: %s",
+            _CHANNEL, target, target_id, exc,
+        )

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -24,16 +24,12 @@ async def pg_notify(
     event_type: str,
     data: dict,
 ) -> None:
-    """PostgreSQL NOTIFY 단발 발행. 실패 시 경고 로그만 — 예외 전파 금지.
+    """PostgreSQL NOTIFY 단발 발행. SQLAlchemy 기존 풀 재활용.
 
     target: "org" | "agent"
     target_id: org_id | member_id (str)
+    실패 시 경고 로그만 — 예외 전파 금지.
     """
-    import asyncpg
-    from app.core.config import settings
-
-    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
-
     payload: dict = {
         "instance_id": INSTANCE_ID,
         "target": target,
@@ -50,11 +46,14 @@ async def pg_notify(
         payload_str = json.dumps(payload, default=str)
 
     try:
-        conn = await asyncpg.connect(raw_url)
-        try:
-            await conn.execute("SELECT pg_notify($1, $2)", _CHANNEL, payload_str)
-        finally:
-            await conn.close()
+        from sqlalchemy import text
+        from app.core.database import async_session_factory
+        async with async_session_factory() as session:
+            await session.execute(
+                text("SELECT pg_notify(:ch, :pl)"),
+                {"ch": _CHANNEL, "pl": payload_str},
+            )
+            await session.commit()
     except Exception as exc:
         logger.warning(
             "pg_notify failed channel=%s target=%s target_id=%s: %s",


### PR DESCRIPTION
## 문제
Cloud Run max_instances=3에서 `_subscribers`/`_agent_connections`가 프로세스 로컬 메모리 → 인스턴스 간 SSE 이벤트 미전파.

## 수정
**신규 `app/services/pg_pubsub.py`:**
- `INSTANCE_ID = str(uuid.uuid4())` — 앱 기동 시 1회
- `pg_notify(target, target_id, event_type, data)`: asyncpg 직접 connect → `SELECT pg_notify('sse_events', payload)`
- 8KB 초과 시 `data.content` 제거, id만 전달
- 실패 시 warning log만, 예외 전파 금지

**수정 `events.py`:**
- `publish_event()`: 로컬 push 후 `pg_notify("org", org_id, ...)` task 생성
- `_push_to_agent()`: 로컬 큐 유무 무관하게 `pg_notify("agent", member_id, ...)` task 생성
- `RuntimeError`(루프 없음) graceful skip

## 검증
- 대화 테스트 7/9 PASS (2개 pre-existing StopAsyncIteration)
- webhook 테스트 35/35 PASS

## Story
S1: pg_notify 발행 레이어 (56e20023)