### PR TITLE
feat(pubsub): LISTEN 수신기 + 로컬 디스패치 (E-SSE-PUBSUB S2)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +14,22 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    from app.services.pg_pubsub import listen_loop
+    task = asyncio.create_task(listen_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
 from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
@@ -20,6 +38,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/api/v2/_swagger" if settings.debug else None,
     redoc_url=None,
+    lifespan=lifespan,
 )
 
 _HTTP_CODE_MAP: dict[int, str] = {

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -31,8 +31,11 @@ router = APIRouter(prefix="/api/v2/events", tags=["events"])
 _subscribers: dict[str, set[asyncio.Queue[dict]]] = defaultdict(set)
 
 
-def publish_event(org_id: str, event_type: str, data: dict) -> None:
-    """다른 라우터에서 이벤트를 발행할 때 호출."""
+def publish_event(org_id: str, event_type: str, data: dict, _from_listener: bool = False) -> None:
+    """다른 라우터에서 이벤트를 발행할 때 호출.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     payload = {"type": event_type, **data}
     dead: list[asyncio.Queue] = []
     for q in _subscribers.get(org_id, set()):
@@ -42,14 +45,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
-    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("org", org_id, event_type, data)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("org", org_id, event_type, data)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -89,8 +92,11 @@ def _compute_backfill_mode(
     return exceed, (_BACKFILL_MAX_EVENTS if exceed else 100)
 
 
-def _push_to_agent(member_id: str, payload: dict) -> bool:
-    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
+def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) -> bool:
+    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     queues = _agent_connections.get(member_id)
     pushed = False
     if queues:
@@ -103,14 +109,14 @@ def _push_to_agent(member_id: str, payload: dict) -> bool:
                 dead.append(q)
         for q in dead:
             queues.discard(q)
-    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,10 +1,12 @@
-"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+"""E-SSE-PUBSUB S1/S2: PostgreSQL LISTEN/NOTIFY 발행·수신 레이어.
 
-publish_event() / _push_to_agent() 내부에서 호출.
+S1: publish_event() / _push_to_agent() 내부에서 pg_notify() 호출.
+S2: listen_loop() — 다른 인스턴스의 NOTIFY를 수신해 로컬 큐 디스패치.
 실패 시 로컬 전파는 정상 유지 — graceful degradation.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -17,6 +19,7 @@ INSTANCE_ID: str = str(uuid.uuid4())
 _CHANNEL = "sse_events"
 _MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
 
+# ── NOTIFY 발행 ────────────────────────────────────────────────────────────────
 
 async def pg_notify(
     target: str,
@@ -59,3 +62,81 @@ async def pg_notify(
             "pg_notify failed channel=%s target=%s target_id=%s: %s",
             _CHANNEL, target, target_id, exc,
         )
+
+
+# ── LISTEN 수신기 ──────────────────────────────────────────────────────────────
+
+def _on_notification(conn: object, pid: int, channel: str, payload_str: str) -> None:
+    """asyncpg 알림 콜백 (sync). 수신 즉시 dispatch task 스케줄."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_dispatch_received(payload_str))
+    except Exception as exc:
+        logger.warning("pg_listen dispatch schedule failed: %s", exc)
+
+
+async def _dispatch_received(payload_str: str) -> None:
+    """LISTEN 수신 payload → 로컬 큐 디스패치. pg_notify 재발행 금지."""
+    try:
+        payload = json.loads(payload_str)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    # 자기 자신이 발행한 이벤트 skip
+    if payload.get("instance_id") == INSTANCE_ID:
+        return
+
+    target = payload.get("target")
+    target_id = str(payload.get("target_id", ""))
+    event_type = str(payload.get("event_type", ""))
+    data = payload.get("data") or {}
+
+    try:
+        from app.routers.events import publish_event, _push_to_agent
+        if target == "org":
+            publish_event(target_id, event_type, data, _from_listener=True)
+        elif target == "agent":
+            _push_to_agent(target_id, data, _from_listener=True)
+    except Exception as exc:
+        logger.warning("pg_listen dispatch failed target=%s: %s", target, exc)
+
+
+async def listen_loop() -> None:
+    """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
+
+    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유)
+    - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
+    - CancelledError 수신 시 커넥션 정리 후 종료
+    """
+    import asyncpg
+    from app.core.config import settings
+
+    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    delay = 1.0
+
+    logger.info("pg_listen starting on channel=%s instance=%s", _CHANNEL, INSTANCE_ID)
+
+    while True:
+        conn: asyncpg.Connection | None = None
+        try:
+            conn = await asyncpg.connect(raw_url)
+            await conn.add_listener(_CHANNEL, _on_notification)
+            delay = 1.0  # 연결 성공 시 backoff 리셋
+            logger.info("pg_listen connected")
+            # 커넥션 유지 — CancelledError까지 대기
+            while True:
+                await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            logger.info("pg_listen cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning("pg_listen error: %s — reconnecting in %.1fs", exc, delay)
+        finally:
+            if conn is not None:
+                try:
+                    await conn.remove_listener(_CHANNEL, _on_notification)
+                    await conn.close()
+                except Exception:
+                    pass
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 30)


### PR DESCRIPTION
## 변경 내용

### pg_pubsub.py
- **`listen_loop()`**: raw asyncpg 전용 커넥션 1개로 `LISTEN 'sse_events'`
  - 자기 자신 발행 재수신 방지: `instance_id == INSTANCE_ID` skip
  - exponential backoff 1s→2s→4s→max 30s
  - `CancelledError` 수신 시 listener 제거 + conn close
- **`_dispatch_received()`**: `target=org` → `publish_event(_from_listener=True)` / `target=agent` → `_push_to_agent(_from_listener=True)`

### events.py
- `publish_event(_from_listener=False)`: 리스너 경로에서 호출 시 `pg_notify` 재발행 skip → 무한 루프 차단
- `_push_to_agent(_from_listener=False)`: 동일

### main.py
- `lifespan` context manager 추가 → startup: `listen_loop()` task 기동, shutdown: cancel + await

## 검증
- webhook 35/35 + send_message 2/2 = 37/37 PASS
- pre-existing 실패 2건 미포함

## Story
S2: LISTEN 수신기 + 로컬 디스패치 (29b14957)