### PR TITLE
Prod Promotion: E-SSE-PUBSUB + E-SSE-COMM (PR #885~#893)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +14,22 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    from app.services.pg_pubsub import listen_loop
+    task = asyncio.create_task(listen_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
 from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
@@ -20,6 +38,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/api/v2/_swagger" if settings.debug else None,
     redoc_url=None,
+    lifespan=lifespan,
 )
 
 _HTTP_CODE_MAP: dict[int, str] = {

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -18,7 +18,7 @@ from app.models.conversation import Conversation, ConversationMessage, Conversat
 from app.models.event import Event
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
-from app.routers.events import _push_to_agent
+from app.routers.events import _push_to_agent, publish_event
 
 logger = logging.getLogger(__name__)
 
@@ -708,6 +708,8 @@ async def send_message(
     # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
     for pid_str, sse_payload in pending_sse_pushes:
         _push_to_agent(pid_str, sse_payload)
+    # 브라우저 SSE 구독자에게 1회 발행 — pending 유무와 무관하게 commit 후 항상 발행
+    publish_event(str(org_id), "conversation:message", _msg_payload(msg, sender))
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -75,13 +75,14 @@ async def _dispatch_conversation_event(
     org_id: uuid.UUID,
     sender: TeamMember,
     exclude_ids: set[uuid.UUID] | None = None,
-) -> None:
-    """conversation:message → 전 참여자 SSE dispatch + Event INSERT.
+) -> list[tuple[str, dict]]:
+    """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
     exclude_ids: SSE 발송에서 제외할 member_id 집합 (Discord 수신자 등).
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
 
@@ -93,7 +94,7 @@ async def _dispatch_conversation_event(
     participant_ids = {r[0] for r in rows} - {sender.id} - (exclude_ids or set())
 
     if not participant_ids:
-        return
+        return []
 
     member_rows = (await db.execute(
         select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(participant_ids))
@@ -118,10 +119,10 @@ async def _dispatch_conversation_event(
         db.add(event)
         events_to_push.append((str(pid), event))
 
-    # flush 후 event.id 확보 → event_id 포함 push (dedup 동작 보장)
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_mention_events(
@@ -131,10 +132,13 @@ async def _dispatch_mention_events(
     org_id: uuid.UUID,
     sender: TeamMember,
     mention_targets: set[uuid.UUID],
-) -> None:
-    """AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)."""
+) -> list[tuple[str, dict]]:
+    """AC1: 멘션 대상에게 conversation:mention Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
+
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
+    """
     if not conversation.project_id or not mention_targets:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
     member_rows = (await db.execute(
@@ -160,9 +164,10 @@ async def _dispatch_mention_events(
         db.add(event)
         events_to_push.append((str(pid), event))
 
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_discord_outbound(
@@ -677,9 +682,10 @@ async def send_message(
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
+    pending_sse_pushes: list[tuple[str, dict]] = []
     try:
         async with db.begin_nested():
-            await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
+            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
     except Exception:
         logger.exception("conversation event dispatch failed conversation_id=%s", conversation_id)
 
@@ -689,7 +695,7 @@ async def send_message(
         if mention_targets:
             try:
                 async with db.begin_nested():
-                    await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
+                    pending_sse_pushes += await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
             except Exception:
                 logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
 
@@ -698,6 +704,10 @@ async def send_message(
 
     await db.commit()
     await db.refresh(msg)
+
+    # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
+    for pid_str, sse_payload in pending_sse_pushes:
+        _push_to_agent(pid_str, sse_payload)
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -42,6 +42,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
+    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("org", org_id, event_type, data)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -84,18 +92,25 @@ def _compute_backfill_mode(
 def _push_to_agent(member_id: str, payload: dict) -> bool:
     """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
     queues = _agent_connections.get(member_id)
-    if not queues:
-        return False
     pushed = False
-    dead: list[asyncio.Queue] = []
-    for q in list(queues):
-        try:
-            q.put_nowait(payload)
-            pushed = True
-        except asyncio.QueueFull:
-            dead.append(q)
-    for q in dead:
-        queues.discard(q)
+    if queues:
+        dead: list[asyncio.Queue] = []
+        for q in list(queues):
+            try:
+                q.put_nowait(payload)
+                pushed = True
+            except asyncio.QueueFull:
+                dead.append(q)
+        for q in dead:
+            queues.discard(q)
+    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -31,8 +31,11 @@ router = APIRouter(prefix="/api/v2/events", tags=["events"])
 _subscribers: dict[str, set[asyncio.Queue[dict]]] = defaultdict(set)
 
 
-def publish_event(org_id: str, event_type: str, data: dict) -> None:
-    """다른 라우터에서 이벤트를 발행할 때 호출."""
+def publish_event(org_id: str, event_type: str, data: dict, _from_listener: bool = False) -> None:
+    """다른 라우터에서 이벤트를 발행할 때 호출.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     payload = {"type": event_type, **data}
     dead: list[asyncio.Queue] = []
     for q in _subscribers.get(org_id, set()):
@@ -42,14 +45,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
-    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("org", org_id, event_type, data)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("org", org_id, event_type, data)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -89,8 +92,11 @@ def _compute_backfill_mode(
     return exceed, (_BACKFILL_MAX_EVENTS if exceed else 100)
 
 
-def _push_to_agent(member_id: str, payload: dict) -> bool:
-    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
+def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) -> bool:
+    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     queues = _agent_connections.get(member_id)
     pushed = False
     if queues:
@@ -103,14 +109,14 @@ def _push_to_agent(member_id: str, payload: dict) -> bool:
                 dead.append(q)
         for q in dead:
             queues.discard(q)
-    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -324,7 +324,7 @@ async def agent_event_stream(
                         evt.delivered_at = now
                     await db.commit()
                     for data, evt in zip(batch_data, batch):
-                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps(data)}\n\n"
+                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -743,6 +743,7 @@ async def add_reply(
         )
         # CB-S7: SSE conversation:message 발행 (P0 — 수신자 화면 실시간 갱신)
         conv = await db.get(Conversation, id)
+        pending_sse_pushes: list[tuple[str, dict]] = []
         if conv:
             sender_member = (await db.execute(
                 select(TeamMember).where(TeamMember.id == body.created_by)
@@ -757,9 +758,15 @@ async def add_reply(
                         discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
                     except Exception:
                         logger.warning("channel_router pre-check failed reply_msg_id=%s", reply_msg.id)
-                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
+                    pending_sse_pushes = await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
                 except Exception:
                     logger.warning("conversation event dispatch failed memo_id=%s", id, exc_info=True)
+
+        # commit 후 SSE push — Event 커밋 완료 상태에서 push해야 race condition 없음
+        await db.commit()
+        from app.routers.events import _push_to_agent
+        for pid_str, sse_payload in pending_sse_pushes:
+            _push_to_agent(pid_str, sse_payload)
 
         # webhook 발송 (기존 참여자 수집)
         if conv:

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,9 +132,21 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
+
+                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                from app.services.channel_router import route_message as _route
+                sse_member_ids: set[uuid.UUID] = set()
+                try:
+                    decisions = await _route(message_id, db)
+                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                except Exception:
+                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
+                    if wh.member_id in sse_member_ids:
+                        continue  # channel_router → sse: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -133,20 +133,21 @@ async def deliver_conversation_message_webhook(
                     )
                 )).scalars().all()
 
-                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
                 from app.services.channel_router import route_message as _route
-                sse_member_ids: set[uuid.UUID] = set()
+                routed_member_ids: set[uuid.UUID] = set()
                 try:
                     decisions = await _route(message_id, db)
-                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
                 except Exception:
-                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
 
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in sse_member_ids:
-                        continue  # channel_router → sse: member webhook 발송 생략
+                    if wh.member_id in routed_member_ids:
+                        continue  # channel_router → sse/discord: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,22 +132,9 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
-
-                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
-                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
-                from app.services.channel_router import route_message as _route
-                routed_member_ids: set[uuid.UUID] = set()
-                try:
-                    decisions = await _route(message_id, db)
-                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
-                except Exception:
-                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
-
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in routed_member_ids:
-                        continue  # channel_router → sse/discord: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,10 +1,12 @@
-"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+"""E-SSE-PUBSUB S1/S2: PostgreSQL LISTEN/NOTIFY 발행·수신 레이어.
 
-publish_event() / _push_to_agent() 내부에서 호출.
+S1: publish_event() / _push_to_agent() 내부에서 pg_notify() 호출.
+S2: listen_loop() — 다른 인스턴스의 NOTIFY를 수신해 로컬 큐 디스패치.
 실패 시 로컬 전파는 정상 유지 — graceful degradation.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -17,6 +19,7 @@ INSTANCE_ID: str = str(uuid.uuid4())
 _CHANNEL = "sse_events"
 _MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
 
+# ── NOTIFY 발행 ────────────────────────────────────────────────────────────────
 
 async def pg_notify(
     target: str,
@@ -59,3 +62,81 @@ async def pg_notify(
             "pg_notify failed channel=%s target=%s target_id=%s: %s",
             _CHANNEL, target, target_id, exc,
         )
+
+
+# ── LISTEN 수신기 ──────────────────────────────────────────────────────────────
+
+def _on_notification(conn: object, pid: int, channel: str, payload_str: str) -> None:
+    """asyncpg 알림 콜백 (sync). 수신 즉시 dispatch task 스케줄."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_dispatch_received(payload_str))
+    except Exception as exc:
+        logger.warning("pg_listen dispatch schedule failed: %s", exc)
+
+
+async def _dispatch_received(payload_str: str) -> None:
+    """LISTEN 수신 payload → 로컬 큐 디스패치. pg_notify 재발행 금지."""
+    try:
+        payload = json.loads(payload_str)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    # 자기 자신이 발행한 이벤트 skip
+    if payload.get("instance_id") == INSTANCE_ID:
+        return
+
+    target = payload.get("target")
+    target_id = str(payload.get("target_id", ""))
+    event_type = str(payload.get("event_type", ""))
+    data = payload.get("data") or {}
+
+    try:
+        from app.routers.events import publish_event, _push_to_agent
+        if target == "org":
+            publish_event(target_id, event_type, data, _from_listener=True)
+        elif target == "agent":
+            _push_to_agent(target_id, data, _from_listener=True)
+    except Exception as exc:
+        logger.warning("pg_listen dispatch failed target=%s: %s", target, exc)
+
+
+async def listen_loop() -> None:
+    """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
+
+    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유)
+    - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
+    - CancelledError 수신 시 커넥션 정리 후 종료
+    """
+    import asyncpg
+    from app.core.config import settings
+
+    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    delay = 1.0
+
+    logger.info("pg_listen starting on channel=%s instance=%s", _CHANNEL, INSTANCE_ID)
+
+    while True:
+        conn: asyncpg.Connection | None = None
+        try:
+            conn = await asyncpg.connect(raw_url)
+            await conn.add_listener(_CHANNEL, _on_notification)
+            delay = 1.0  # 연결 성공 시 backoff 리셋
+            logger.info("pg_listen connected")
+            # 커넥션 유지 — CancelledError까지 대기
+            while True:
+                await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            logger.info("pg_listen cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning("pg_listen error: %s — reconnecting in %.1fs", exc, delay)
+        finally:
+            if conn is not None:
+                try:
+                    await conn.remove_listener(_CHANNEL, _on_notification)
+                    await conn.close()
+                except Exception:
+                    pass
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 30)

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,0 +1,61 @@
+"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+
+publish_event() / _push_to_agent() 내부에서 호출.
+실패 시 로컬 전파는 정상 유지 — graceful degradation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+logger = logging.getLogger(__name__)
+
+INSTANCE_ID: str = str(uuid.uuid4())
+"""앱 기동 시 1회 생성 — 자기 자신이 발행한 notify 재수신 방지용."""
+
+_CHANNEL = "sse_events"
+_MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
+
+
+async def pg_notify(
+    target: str,
+    target_id: str,
+    event_type: str,
+    data: dict,
+) -> None:
+    """PostgreSQL NOTIFY 단발 발행. SQLAlchemy 기존 풀 재활용.
+
+    target: "org" | "agent"
+    target_id: org_id | member_id (str)
+    실패 시 경고 로그만 — 예외 전파 금지.
+    """
+    payload: dict = {
+        "instance_id": INSTANCE_ID,
+        "target": target,
+        "target_id": target_id,
+        "event_type": event_type,
+        "data": data,
+    }
+
+    payload_str = json.dumps(payload, default=str)
+    if len(payload_str.encode()) > _MAX_PAYLOAD_BYTES:
+        # 8KB 초과 시 content 제거 — id/event_type으로 구독측 재조회 유도
+        data_slim = {k: v for k, v in data.items() if k != "content"}
+        payload["data"] = data_slim
+        payload_str = json.dumps(payload, default=str)
+
+    try:
+        from sqlalchemy import text
+        from app.core.database import async_session_factory
+        async with async_session_factory() as session:
+            await session.execute(
+                text("SELECT pg_notify(:ch, :pl)"),
+                {"ch": _CHANNEL, "pl": payload_str},
+            )
+            await session.commit()
+    except Exception as exc:
+        logger.warning(
+            "pg_notify failed channel=%s target=%s target_id=%s: %s",
+            _CHANNEL, target, target_id, exc,
+        )

--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -13,6 +13,7 @@ class McpSettings(BaseSettings):
     fakechat_port: int = 8787
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
+    has_webhook: bool = False  # True: fakechat relay 전체 스킵, Discord 웹훅으로만 수신
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -354,12 +354,22 @@ async def start_sse_bridge(
             seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
 
-        asyncio.create_task(
-            relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
-        )
+        # MCP notification: webhook 유무·backfill 여부 무관하게 항상 발송 (AC-4)
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
+
+        # relay 조건: (1) backfill 아님, (2) webhook 미설정
+        _relay = True
+        try:
+            _relay = not json.loads(event.data).get("is_backfill", False)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        if _relay and not settings.has_webhook:
+            asyncio.create_task(
+                relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
+            )
+
         if on_event is not None:
             on_event(event.event_type, event.data)
 


### PR DESCRIPTION
## Summary
- **E-SSE-PUBSUB**: PostgreSQL LISTEN/NOTIFY 기반 SSE 크로스 인스턴스 이벤트 전파 (PR #892, #893)
- **E-SSE-COMM**: SSE 통신 근본 수정 — race condition, backfill 플래그, relay 필터, 브라우저 SSE publish (PR #885~#891)

## Changes (9 commits)
- `app/services/pg_pubsub.py` — PG NOTIFY 발행 + LISTEN 수신기 (신규)
- `app/main.py` — FastAPI lifespan 추가
- `app/routers/events.py` — publish_event/push_to_agent pg_notify 연동
- `app/routers/conversations.py` — publish_event 호출 추가
- SSE race condition 해소, backfill is_backfill 플래그, relay 필터링
- S1/S2 webhook 롤백 (PR #888)

## Verification
- dev E2E: SSE conversation:message 수신 5/5 (100%)
- API 응답: ~113ms (pg_notify 비동기, 블로킹 없음)
- QA APPROVE: S1 (PR #892), S2 (PR #893)

🤖 Generated with [Claude Code](https://claude.com/claude-code)