### PR TITLE
fix(sse): SSE 재연결 이중 전달 해소 — is_backfill + event_id dedup (S4)

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -373,8 +373,9 @@ async def agent_event_stream(
                         except Exception:
                             pass
                     # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
+                    # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
                     _live_id = eid or str(uuid.uuid4())
-                    yield f"event: {event_type}\nid: {_live_id}\ndata: {json.dumps(event_data)}\n\n"
+                    yield f"event: {event_type}\nid: {_live_id}\ndata: {json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})}\n\n"
                 except asyncio.TimeoutError:
                     # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
                     yield "event: heartbeat\ndata: {}\n\n"

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -346,13 +346,24 @@ async def start_sse_bridge(
 
     def _handle(event: SseEvent) -> None:
         nonlocal _current_last_event_id
-        # event_id dedup
+        # id: 필드 우선 dedup
         if event.last_event_id:
             if event.last_event_id in seen_ids:
                 _log(f"dedup: skip event_id={event.last_event_id}")
                 return
             seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
+        else:
+            # id: 필드 없을 때 data.event_id fallback dedup — 백필/live id 불일치 방어
+            try:
+                _data_eid = json.loads(event.data).get("event_id") if event.data else None
+                if _data_eid:
+                    if _data_eid in seen_ids:
+                        _log(f"dedup(data): skip event_id={_data_eid}")
+                        return
+                    seen_ids.add(_data_eid)
+            except (json.JSONDecodeError, AttributeError):
+                pass
 
         # MCP notification: webhook 유무·backfill 여부 무관하게 항상 발송 (AC-4)
         asyncio.create_task(


### PR DESCRIPTION
## Summary

- **`events.py` L377**: live yield에 `is_backfill: False` + `event_id: _live_id` 명시
  - 백필(`is_backfill: True`) vs live(`is_backfill: False`) 명확 구분 → sse_bridge relay 필터 정합성 확보
  - `_live_id = eid = event_data.get("event_id")`이면 Event.id와 동일 → SeenIdsCache dedup 정상 작동
- **`sse_bridge.py` `_handle`**: `id:` 필드 없을 때 `data.event_id` fallback dedup 추가
  - 백필/live id 불일치 edge case 방어층

## Root Cause

재연결 시 동일 이벤트가 백필(DB) + live queue(PG LISTEN) 두 경로로 수신될 때:
1. 백필: `id: Event.id`, `is_backfill: True` → relay 안 함 ✅
2. live: `id: uuid4()`, `is_backfill` 없음 → relay 실행 ❌
   - SeenIdsCache: 백필 id(Event.id) ≠ live id(uuid4()) → dedup 미작동 → fakechat 이중 전달

## Test plan

- [ ] SSE 재연결 시 fakechat 중복 메시지 0건 확인 (AC-4)
- [ ] 정상 실시간 전달 깨지지 않음 확인 (AC-3)
- [ ] `is_backfill: False` 필드가 live 이벤트 data에 포함 확인
- [ ] `event_id` 필드가 SSE `id:` 와 동일한 값으로 data에 포함 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)