### PR TITLE
fix(docker): packages/cli/package.json COPY 추가 — @inquirer/* Docker 빌드 누락 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY packages/shared/package.json packages/shared/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/storage-api/package.json packages/storage-api/package.json
+COPY packages/cli/package.json packages/cli/package.json
 COPY ee/packages/storage-saas/package.json ee/packages/storage-saas/package.json
 RUN pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary
- Dockerfile deps stage에 `packages/cli/package.json` COPY 1줄 추가
- `pnpm install` 시 cli 워크스페이스를 인식하지 못해 `@inquirer/*` 미설치 → Docker Publish TS2307 오류 원인

## Test plan
- [ ] Docker Publish workflow CI 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)