### PR TITLE
[SID:D1-3] 즉시 문서 생성 — 빈 문서에서 바로 편집 시작

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1112,6 +1112,7 @@
     "editDoc": "Edit",
     "copyMarkdown": "Copy Markdown",
     "deleteDoc": "Delete",
+    "createFailed": "Failed to create document",
     "notFound": "Document not found"
   },
   "rewards": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1112,6 +1112,7 @@
     "editDoc": "편집",
     "copyMarkdown": "마크다운 복사",
     "deleteDoc": "삭제",
+    "createFailed": "문서 생성에 실패했습니다",
     "notFound": "문서를 찾을 수 없는"
   },
   "rewards": {

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
@@ -59,6 +59,8 @@ export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = searchParams.get('new') === '1';
   const t = useTranslations('docs');
 
   const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
@@ -215,7 +217,7 @@ export default function DocSlugPage() {
           title={title}
           onTitleChange={handleTitleChange}
           titlePlaceholder={t('titlePlaceholder')}
-          titleAutoFocus={!title}
+          titleAutoFocus={isNew || !title}
           actions={docActions}
           labels={{
             contentFormat: t('contentFormat'),

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronLeft, ChevronRight, Menu, Plus, X } from 'lucide-react';
@@ -47,14 +46,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     });
   }, []);
 
-  // Create form states
-  const [showCreate, setShowCreate] = useState(false);
-  const [newTitle, setNewTitle] = useState('');
-  const [newContent, setNewContent] = useState('');
-  const [newSlug, setNewSlug] = useState('');
-  const [newParentId, setNewParentId] = useState<string | null>(null);
-  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
@@ -130,49 +122,29 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     } catch { await fetchTree(); }
   }, [fetchTree]);
 
-  const generateSlug = useCallback((s: string): string =>
-    s.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^\wㄱ-힝-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, ''),
-  []);
-
-  const handleNewTitleChange = useCallback((val: string) => {
-    setNewTitle(val);
-    if (!slugManuallyEdited) setNewSlug(generateSlug(val));
-  }, [slugManuallyEdited, generateSlug]);
-
-  const handleSlugChange = useCallback((val: string) => {
-    setNewSlug(val);
-    setSlugManuallyEdited(true);
-  }, []);
-
-  const handleAddChild = useCallback(async (parentId: string) => {
-    setNewParentId(parentId);
-    setShowCreate(true);
-    setNewTitle(''); setNewContent(''); setNewSlug(''); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleNewDoc = useCallback(() => {
-    setShowCreate(true);
-    setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleCreate = useCallback(async () => {
-    if (!projectId || !newTitle.trim() || !newSlug.trim()) return;
+  const createDoc = useCallback(async (parentId: string | null = null) => {
+    if (!projectId || isCreating) return;
+    setIsCreating(true);
+    const slug = `untitled-${Date.now()}`;
     try {
       const res = await fetch('/api/docs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project_id: projectId, title: newTitle, slug: newSlug, content: newContent, content_format: 'markdown', parent_id: newParentId }),
+        body: JSON.stringify({ project_id: projectId, title: 'Untitled', slug, content: '', content_format: 'markdown', parent_id: parentId }),
       });
       if (!res.ok) throw new Error('Failed to create doc');
       const { data } = await res.json();
       setTree((prev) => [{ id: data.id, parent_id: data.parent_id || null, title: data.title, slug: data.slug, icon: data.icon || null, sort_order: data.sort_order || 0, is_folder: data.is_folder || false }, ...prev]);
-      setShowCreate(false); setShowAdvancedOptions(false);
-      setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-      router.push(`/docs/${data.slug}`);
+      router.push(`/docs/${data.slug}?new=1`);
     } catch {
-      // create failed
+      addToast({ title: t('createFailed'), type: 'error' });
+    } finally {
+      setIsCreating(false);
     }
-  }, [projectId, newTitle, newSlug, newContent, newParentId, router]);
+  }, [projectId, isCreating, router, addToast, t]);
+
+  const handleNewDoc = useCallback(() => { void createDoc(null); }, [createDoc]);
+  const handleAddChild = useCallback((parentId: string) => createDoc(parentId), [createDoc]);
 
   const sidebarContent = (
     <>
@@ -224,55 +196,12 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     </>
   );
 
-  const createForm = (
-    <div className="flex h-full flex-col">
-      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Draft</p>
-            <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
-          </div>
-          <Button variant="ghost" size="sm" onClick={() => { setShowCreate(false); setNewParentId(null); }}><X className="h-4 w-4" /></Button>
-        </div>
-      </div>
-      <div className="flex-1 overflow-y-auto px-4 py-4 lg:px-6 lg:py-6">
-        <div className="max-w-3xl space-y-5">
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
-            <Input value={newTitle} onChange={(e) => handleNewTitleChange(e.target.value)} placeholder={t('titlePlaceholder')} />
-          </div>
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('contentLabel')}</label>
-            <textarea value={newContent} onChange={(e) => setNewContent(e.target.value)} placeholder={t('editorPlaceholder')} className="w-full min-h-[220px] rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-foreground resize-none placeholder:text-muted-foreground" />
-          </div>
-          <div>
-            <button type="button" onClick={() => setShowAdvancedOptions((prev) => !prev)} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
-              <span>{showAdvancedOptions ? '▾' : '▸'}</span>
-              <span>{t('advancedOptions')}</span>
-            </button>
-            {showAdvancedOptions && (
-              <div className="mt-3">
-                <label className="text-sm font-medium mb-2 block">{t('slugLabel')}</label>
-                <Input value={newSlug} onChange={(e) => handleSlugChange(e.target.value)} placeholder={t('slugPlaceholder')} />
-              </div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button onClick={handleCreate} disabled={!newTitle.trim() || !newSlug.trim()}>{tc('create')}</Button>
-            <Button variant="ghost" onClick={() => { setShowCreate(false); setNewParentId(null); }}>{tc('cancel')}</Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  const mainContent = showCreate ? createForm : children;
 
   return (
     <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate }}>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
-        actions={<Button size="sm" variant="outline" onClick={handleNewDoc}><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newDoc')}</Button>}
+        actions={<Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}><Plus className="mr-1.5 h-3.5 w-3.5" />{isCreating ? t('loading') : t('newDoc')}</Button>}
       />
 
       {/* Desktop: 2-panel (lg+) */}
@@ -301,7 +230,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
               <ChevronRight className="size-4" />
             </button>
           )}
-          {mainContent}
+          {children}
         </section>
       </div>
 
@@ -314,7 +243,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           </button>
         </div>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-          {mainContent}
+          {children}
         </div>
         {treeDrawerOpen && (
           <>


### PR DESCRIPTION
## Summary

- **+ New Document 클릭 → 즉시 생성**: API POST(`title='Untitled'`, `slug=untitled-{timestamp}`) 후 에디터 바로 navigate
- **생성 폼 완전 제거**: `showCreate` 상태, `createForm` JSX, 관련 state 7개·함수 3개 모두 삭제 (-90줄)
- **제목 자동 포커스**: `?new=1` query param → `page.tsx`에서 `titleAutoFocus` 활성화 (D1-1 연동)
- **에러 처리**: API 실패 시 toast + 버튼 재활성화

## AC 체크리스트

- [x] AC1: + New Document 클릭 → 즉시 `title='Untitled'` POST
- [x] AC2: 생성 직후 `/docs/{slug}?new=1`으로 자동 navigate
- [x] AC3: `isNew || !title` 조건으로 인라인 H1 제목 autoFocus (D1-1 연동)
- [x] AC4: `showCreate` state·createForm·관련 UI 완전 제거
- [x] AC5: `untitled-${Date.now()}` slug 자동 생성
- [x] AC6: `setTree` optimistic update → 사이드바 즉시 반영
- [x] AC7: API 실패 시 `createFailed` toast + `isCreating=false` 버튼 재활성화

## 변경 파일

| 파일 | 변경 내용 |
|------|---------|
| `docs/layout.tsx` | createDoc 즉시 생성, createForm 제거, isCreating state |
| `[slug]/page.tsx` | useSearchParams, isNew flag, titleAutoFocus 확장 |
| `messages/ko.json` | createFailed 키 추가 |
| `messages/en.json` | createFailed 키 추가 |

## 빌드 결과

- `pnpm build` ✅ PASS
- `pnpm lint` ✅ 0 errors