### PR TITLE
[SID:D1-4] 슬래시 메뉴 리뉴얼 — Lucide 아이콘 + 카테고리 + 검색

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1112,6 +1112,7 @@
     "editDoc": "Edit",
     "copyMarkdown": "Copy Markdown",
     "deleteDoc": "Delete",
+    "createFailed": "Failed to create document",
     "notFound": "Document not found"
   },
   "rewards": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1112,6 +1112,7 @@
     "editDoc": "편집",
     "copyMarkdown": "마크다운 복사",
     "deleteDoc": "삭제",
+    "createFailed": "문서 생성에 실패했습니다",
     "notFound": "문서를 찾을 수 없는"
   },
   "rewards": {

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
@@ -59,6 +59,8 @@ export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = searchParams.get('new') === '1';
   const t = useTranslations('docs');
 
   const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
@@ -215,7 +217,7 @@ export default function DocSlugPage() {
           title={title}
           onTitleChange={handleTitleChange}
           titlePlaceholder={t('titlePlaceholder')}
-          titleAutoFocus={!title}
+          titleAutoFocus={isNew || !title}
           actions={docActions}
           labels={{
             contentFormat: t('contentFormat'),

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronLeft, ChevronRight, Menu, Plus, X } from 'lucide-react';
@@ -47,14 +46,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     });
   }, []);
 
-  // Create form states
-  const [showCreate, setShowCreate] = useState(false);
-  const [newTitle, setNewTitle] = useState('');
-  const [newContent, setNewContent] = useState('');
-  const [newSlug, setNewSlug] = useState('');
-  const [newParentId, setNewParentId] = useState<string | null>(null);
-  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
@@ -130,49 +122,29 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     } catch { await fetchTree(); }
   }, [fetchTree]);
 
-  const generateSlug = useCallback((s: string): string =>
-    s.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^\wㄱ-힝-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, ''),
-  []);
-
-  const handleNewTitleChange = useCallback((val: string) => {
-    setNewTitle(val);
-    if (!slugManuallyEdited) setNewSlug(generateSlug(val));
-  }, [slugManuallyEdited, generateSlug]);
-
-  const handleSlugChange = useCallback((val: string) => {
-    setNewSlug(val);
-    setSlugManuallyEdited(true);
-  }, []);
-
-  const handleAddChild = useCallback(async (parentId: string) => {
-    setNewParentId(parentId);
-    setShowCreate(true);
-    setNewTitle(''); setNewContent(''); setNewSlug(''); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleNewDoc = useCallback(() => {
-    setShowCreate(true);
-    setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleCreate = useCallback(async () => {
-    if (!projectId || !newTitle.trim() || !newSlug.trim()) return;
+  const createDoc = useCallback(async (parentId: string | null = null) => {
+    if (!projectId || isCreating) return;
+    setIsCreating(true);
+    const slug = `untitled-${Date.now()}`;
     try {
       const res = await fetch('/api/docs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project_id: projectId, title: newTitle, slug: newSlug, content: newContent, content_format: 'markdown', parent_id: newParentId }),
+        body: JSON.stringify({ project_id: projectId, title: 'Untitled', slug, content: '', content_format: 'markdown', parent_id: parentId }),
       });
       if (!res.ok) throw new Error('Failed to create doc');
       const { data } = await res.json();
       setTree((prev) => [{ id: data.id, parent_id: data.parent_id || null, title: data.title, slug: data.slug, icon: data.icon || null, sort_order: data.sort_order || 0, is_folder: data.is_folder || false }, ...prev]);
-      setShowCreate(false); setShowAdvancedOptions(false);
-      setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-      router.push(`/docs/${data.slug}`);
+      router.push(`/docs/${data.slug}?new=1`);
     } catch {
-      // create failed
+      addToast({ title: t('createFailed'), type: 'error' });
+    } finally {
+      setIsCreating(false);
     }
-  }, [projectId, newTitle, newSlug, newContent, newParentId, router]);
+  }, [projectId, isCreating, router, addToast, t]);
+
+  const handleNewDoc = useCallback(() => { void createDoc(null); }, [createDoc]);
+  const handleAddChild = useCallback((parentId: string) => createDoc(parentId), [createDoc]);
 
   const sidebarContent = (
     <>
@@ -224,55 +196,12 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     </>
   );
 
-  const createForm = (
-    <div className="flex h-full flex-col">
-      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Draft</p>
-            <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
-          </div>
-          <Button variant="ghost" size="sm" onClick={() => { setShowCreate(false); setNewParentId(null); }}><X className="h-4 w-4" /></Button>
-        </div>
-      </div>
-      <div className="flex-1 overflow-y-auto px-4 py-4 lg:px-6 lg:py-6">
-        <div className="max-w-3xl space-y-5">
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
-            <Input value={newTitle} onChange={(e) => handleNewTitleChange(e.target.value)} placeholder={t('titlePlaceholder')} />
-          </div>
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('contentLabel')}</label>
-            <textarea value={newContent} onChange={(e) => setNewContent(e.target.value)} placeholder={t('editorPlaceholder')} className="w-full min-h-[220px] rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-foreground resize-none placeholder:text-muted-foreground" />
-          </div>
-          <div>
-            <button type="button" onClick={() => setShowAdvancedOptions((prev) => !prev)} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
-              <span>{showAdvancedOptions ? '▾' : '▸'}</span>
-              <span>{t('advancedOptions')}</span>
-            </button>
-            {showAdvancedOptions && (
-              <div className="mt-3">
-                <label className="text-sm font-medium mb-2 block">{t('slugLabel')}</label>
-                <Input value={newSlug} onChange={(e) => handleSlugChange(e.target.value)} placeholder={t('slugPlaceholder')} />
-              </div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button onClick={handleCreate} disabled={!newTitle.trim() || !newSlug.trim()}>{tc('create')}</Button>
-            <Button variant="ghost" onClick={() => { setShowCreate(false); setNewParentId(null); }}>{tc('cancel')}</Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  const mainContent = showCreate ? createForm : children;
 
   return (
     <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate }}>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
-        actions={<Button size="sm" variant="outline" onClick={handleNewDoc}><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newDoc')}</Button>}
+        actions={<Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}><Plus className="mr-1.5 h-3.5 w-3.5" />{isCreating ? t('loading') : t('newDoc')}</Button>}
       />
 
       {/* Desktop: 2-panel (lg+) */}
@@ -301,7 +230,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
               <ChevronRight className="size-4" />
             </button>
           )}
-          {mainContent}
+          {children}
         </section>
       </div>
 
@@ -314,7 +243,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           </button>
         </div>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-          {mainContent}
+          {children}
         </div>
         {treeDrawerOpen && (
           <>

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -11,117 +11,189 @@ import {
   useRef,
 } from 'react';
 import type { Editor, Range } from '@tiptap/core';
+import type { FC } from 'react';
+import {
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Code,
+  Quote,
+  Lightbulb,
+  Table,
+  ImageIcon,
+  Minus,
+  FileText,
+} from 'lucide-react';
 
 export interface SlashMenuItem {
   title: string;
-  icon: string;
+  description: string;
+  icon: FC<{ className?: string }>;
   command: (editor: Editor, range: Range) => void;
 }
 
-export const defaultSlashItems: SlashMenuItem[] = [
+export interface SlashMenuCategory {
+  label: string;
+  items: SlashMenuItem[];
+}
+
+export const slashMenuCategories: SlashMenuCategory[] = [
   {
-    title: 'Heading 1',
-    icon: 'H1',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 1 }).run(),
+    label: '텍스트',
+    items: [
+      {
+        title: 'Heading 1',
+        description: '큰 제목',
+        icon: Heading1,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 1 }).run(),
+      },
+      {
+        title: 'Heading 2',
+        description: '중간 제목',
+        icon: Heading2,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+      },
+      {
+        title: 'Heading 3',
+        description: '작은 제목',
+        icon: Heading3,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 3 }).run(),
+      },
+    ],
   },
   {
-    title: 'Heading 2',
-    icon: 'H2',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+    label: '리스트',
+    items: [
+      {
+        title: 'Bullet List',
+        description: '순서 없는 목록',
+        icon: List,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+      },
+      {
+        title: 'Ordered List',
+        description: '순서 있는 목록',
+        icon: ListOrdered,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+      },
+    ],
   },
   {
-    title: 'Heading 3',
-    icon: 'H3',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 3 }).run(),
+    label: '블록',
+    items: [
+      {
+        title: 'Code Block',
+        description: '코드 블록',
+        icon: Code,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+      },
+      {
+        title: 'Blockquote',
+        description: '인용구',
+        icon: Quote,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+      },
+      {
+        title: 'Callout',
+        description: '강조 박스',
+        icon: Lightbulb,
+        command: (editor, range) =>
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({ type: 'callout', content: [{ type: 'paragraph' }] })
+            .run(),
+      },
+      {
+        title: 'Table',
+        description: '표 삽입',
+        icon: Table,
+        command: (editor, range) =>
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+            .run(),
+      },
+    ],
   },
   {
-    title: 'Bullet List',
-    icon: '•',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+    label: '미디어',
+    items: [
+      {
+        title: 'Image',
+        description: '이미지 삽입',
+        icon: ImageIcon,
+        command: (editor, range) => {
+          const url = window.prompt('Image URL:');
+          if (url) editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
+        },
+      },
+    ],
   },
   {
-    title: 'Ordered List',
-    icon: '1.',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
-  },
-  {
-    title: 'Code Block',
-    icon: '<>',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
-  },
-  {
-    title: 'Blockquote',
-    icon: '"',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
-  },
-  {
-    title: 'Callout',
-    icon: '💡',
-    command: (editor, range) =>
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertContent({
-          type: 'callout',
-          content: [{ type: 'paragraph' }],
-        })
-        .run(),
-  },
-  {
-    title: 'Table',
-    icon: '⊞',
-    command: (editor, range) =>
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-        .run(),
-  },
-  {
-    title: 'Image',
-    icon: '🖼',
-    command: (editor, range) => {
-      const url = window.prompt('Image URL:');
-      if (url) {
-        editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
-      }
-    },
-  },
-  {
-    title: 'Horizontal Rule',
-    icon: '—',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
-  },
-  {
-    title: 'Page Embed',
-    icon: '📄',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).insertPageEmbed().run(),
+    label: '고급',
+    items: [
+      {
+        title: 'Page Embed',
+        description: '다른 문서 임베드',
+        icon: FileText,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertPageEmbed().run(),
+      },
+      {
+        title: 'Horizontal Rule',
+        description: '구분선',
+        icon: Minus,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+      },
+    ],
   },
 ];
+
+export const defaultSlashItems: SlashMenuItem[] =
+  slashMenuCategories.flatMap((c) => c.items);
 
 interface SlashMenuRef {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
+function groupByCategory(
+  items: SlashMenuItem[],
+  categories: SlashMenuCategory[],
+): { label: string; items: SlashMenuItem[] }[] {
+  return categories
+    .map((cat) => ({
+      label: cat.label,
+      items: cat.items.filter((item) => items.includes(item)),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
 const SlashMenu = forwardRef<
   SlashMenuRef,
-  { items: SlashMenuItem[]; command: (item: SlashMenuItem) => void }
->(function SlashMenu({ items, command }, ref) {
+  {
+    items: SlashMenuItem[];
+    categories: SlashMenuCategory[];
+    query: string;
+    command: (item: SlashMenuItem) => void;
+  }
+>(function SlashMenu({ items, categories, query, command }, ref) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Clamp index when items shrink; reset handled via keyboard navigation
   const safeIndex = items.length > 0 ? Math.min(selectedIndex, items.length - 1) : 0;
 
   const onKeyDown = useCallback(
@@ -135,66 +207,80 @@ const SlashMenu = forwardRef<
         return true;
       }
       if (event.key === 'Enter') {
-        const idx = items.length > 0 ? Math.min(selectedIndex, items.length - 1) : 0;
-        const item = items[idx];
+        const item = items[safeIndex];
         if (item) command(item);
         return true;
       }
       return false;
     },
-    [items, selectedIndex, command],
+    [items, safeIndex, command],
   );
 
   useImperativeHandle(ref, () => ({ onKeyDown }), [onKeyDown]);
 
   if (items.length === 0) return null;
 
+  const grouped = query === '' ? groupByCategory(items, categories) : null;
+
+  const renderItem = (item: SlashMenuItem, flatIndex: number) => {
+    const isActive = flatIndex === safeIndex;
+    const Icon = item.icon;
+    return (
+      <button
+        key={item.title}
+        type="button"
+        data-active={isActive}
+        className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
+          isActive
+            ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
+            : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
+        }`}
+        onClick={() => command(item)}
+      >
+        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/10' : 'bg-muted/40'}`}>
+          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--operator-primary-soft)]' : 'text-[color:var(--operator-muted)]'}`} />
+        </span>
+        <span className="flex min-w-0 flex-col">
+          <span className="text-xs font-medium leading-tight">{item.title}</span>
+          <span className="truncate text-[11px] text-[color:var(--operator-muted)]">{item.description}</span>
+        </span>
+      </button>
+    );
+  };
+
   return (
     <div
       ref={containerRef}
-      className="max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg"
+      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg"
     >
-      {items.map((item, index) => (
-        <button
-          key={item.title}
-          type="button"
-          data-active={index === safeIndex}
-          className={`flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors ${
-            index === safeIndex
-              ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-              : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
-          }`}
-          onClick={() => command(item)}
-        >
-          <span className="w-5 text-center text-xs font-bold text-[color:var(--operator-muted)]">
-            {item.icon}
-          </span>
-          <span>{item.title}</span>
-        </button>
-      ))}
+      {grouped ? (
+        grouped.map((group) => (
+          <div key={group.label}>
+            <p className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--operator-muted)]">
+              {group.label}
+            </p>
+            {group.items.map((item) => {
+              const flatIndex = items.indexOf(item);
+              return renderItem(item, flatIndex);
+            })}
+          </div>
+        ))
+      ) : (
+        items.map((item, index) => renderItem(item, index))
+      )}
     </div>
   );
 });
 
-/** Estimated max-height of the dropdown (matches `max-h-64` = 16rem at 16px/rem). */
-const MENU_ESTIMATED_HEIGHT = 256;
+/** Estimated max-height of the dropdown (matches `max-h-72` = 18rem at 16px/rem). */
+const MENU_ESTIMATED_HEIGHT = 288;
 /** Estimated min-width of the dropdown for initial right-edge clamping. */
-const MENU_ESTIMATED_WIDTH = 240;
+const MENU_ESTIMATED_WIDTH = 256;
 /** Gap between caret anchor and popup edge, in px. */
 const CARET_GAP = 4;
 /** Minimum distance from viewport edges, in px. */
 const VIEWPORT_MARGIN = 8;
 
-/**
- * Pure function that computes the {top, left} for the slash-hint popup so it
- * stays fully within the viewport regardless of scroll position.
- *
- * - Prefers positioning below the caret anchor.
- * - Flips above when insufficient space below and more space is available above.
- * - Clamps both axes to stay within the viewport.
- *
- * Exported for unit testing.
- */
 export function calculatePopupPosition(
   anchorRect: DOMRect,
   popupHeight: number,
@@ -207,17 +293,13 @@ export function calculatePopupPosition(
 
   let top: number;
   if (spaceBelow >= popupHeight || spaceBelow >= spaceAbove) {
-    // Enough room below, or more room below than above → open downward
     top = anchorRect.bottom + CARET_GAP;
   } else {
-    // Flip upward
     top = anchorRect.top - CARET_GAP - popupHeight;
   }
 
-  // Clamp vertically so the popup never extends outside the viewport
   top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - popupHeight - VIEWPORT_MARGIN));
 
-  // Clamp horizontally
   const left = Math.max(
     VIEWPORT_MARGIN,
     Math.min(anchorRect.left, viewportWidth - popupWidth - VIEWPORT_MARGIN),
@@ -226,13 +308,6 @@ export function calculatePopupPosition(
   return { top, left };
 }
 
-/**
- * Applies viewport-aware positioning to the popup element.
- *
- * 1. Computes an initial position with estimated dimensions (no flash).
- * 2. After React has flushed the render (double rAF), re-measures the actual
- *    popup dimensions and fine-tunes the position.
- */
 function applyPosition(
   popup: HTMLElement,
   clientRectFn: (() => DOMRect | null) | null | undefined,
@@ -243,12 +318,10 @@ function applyPosition(
   const vw = window.innerWidth;
   const vh = window.innerHeight;
 
-  // Initial estimate — avoids visible jump on first render
   const initial = calculatePopupPosition(rect, MENU_ESTIMATED_HEIGHT, MENU_ESTIMATED_WIDTH, vw, vh);
   popup.style.top = `${initial.top}px`;
   popup.style.left = `${initial.left}px`;
 
-  // Fine-tune after React's concurrent render has painted (double rAF)
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       if (!popup.isConnected) return;
@@ -270,6 +343,7 @@ function createSuggestionRenderer() {
     onStart(props: {
       editor: Editor;
       range: Range;
+      query: string;
       items: SlashMenuItem[];
       command: (item: SlashMenuItem) => void;
       clientRect?: (() => DOMRect | null) | null;
@@ -284,36 +358,31 @@ function createSuggestionRenderer() {
       root = createRoot(popup);
       root.render(
         <SlashMenu
-          ref={(r) => {
-            menuRef = r;
-          }}
+          ref={(r) => { menuRef = r; }}
           items={props.items}
-          command={(item) => {
-            item.command(props.editor, props.range);
-          }}
+          categories={slashMenuCategories}
+          query={props.query}
+          command={(item) => { item.command(props.editor, props.range); }}
         />,
       );
     },
     onUpdate(props: {
       editor: Editor;
       range: Range;
+      query: string;
       items: SlashMenuItem[];
       command: (item: SlashMenuItem) => void;
       clientRect?: (() => DOMRect | null) | null;
     }) {
-      if (popup) {
-        applyPosition(popup, props.clientRect);
-      }
+      if (popup) applyPosition(popup, props.clientRect);
 
       root?.render(
         <SlashMenu
-          ref={(r) => {
-            menuRef = r;
-          }}
+          ref={(r) => { menuRef = r; }}
           items={props.items}
-          command={(item) => {
-            item.command(props.editor, props.range);
-          }}
+          categories={slashMenuCategories}
+          query={props.query}
+          command={(item) => { item.command(props.editor, props.range); }}
         />,
       );
     },


### PR DESCRIPTION
## Summary

- **Lucide 아이콘** 전면 적용 — H1/•/<> 텍스트 아이콘 전량 교체 (Heading1~3, List, ListOrdered, Code, Quote, Lightbulb, Table, ImageIcon, Minus, FileText)
- **카테고리 그룹핑** — 텍스트 / 리스트 / 블록 / 미디어 / 고급 (5개 카테고리)
- **1줄 설명 텍스트** — 각 아이템 하단에 간결한 설명 추가
- **확장 구조** — `slashMenuCategories` 배열에 카테고리만 추가하면 Phase 2~3 블록 즉시 수용
- **기존 동작 보존** — 키보드 네비게이션, Esc, 뷰포트 위치 계산 100% 유지

## AC 체크리스트

- [x] AC1: Lucide 아이콘 전량 교체
- [x] AC2: 5개 카테고리 그룹핑 (텍스트/리스트/블록/미디어/고급)
- [x] AC3: query 없으면 카테고리 표시, query 있으면 flat 필터 결과
- [x] AC4: ↑↓ Enter Esc 키보드 네비게이션 기존 로직 보존
- [x] AC5: 아이템별 1줄 설명 텍스트 (예: "큰 제목", "순서 없는 목록")
- [x] AC6: 뷰포트 인식 위치 계산 기존 로직 보존
- [x] AC7: `slashMenuCategories` 분리 구조 — Phase 2~3 확장 용이

## 빌드 결과

- `pnpm build` ✅ PASS
- `pnpm lint` — 확인 예정