### PR TITLE
[P0] docs fetchDoc 방어 코드 — 422 시 크래시 차단

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
@@ -59,13 +59,15 @@ export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const isNew = searchParams.get('new') === '1';
   const t = useTranslations('docs');
+  // 신규 문서 자동 포커스: URL ?new=1 파라미터를 ref로 처리 (useSearchParams Suspense 이슈 방지)
+  const isNewRef = useRef(typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('new') === '1');
+  const isNew = isNewRef.current;
 
   const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
 
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
+  const [docLoading, setDocLoading] = useState(true);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [contentFormat, setContentFormat] = useState<'markdown' | 'html'>('markdown');
@@ -94,16 +96,27 @@ export default function DocSlugPage() {
 
   const fetchDoc = useCallback(async () => {
     if (!projectId || !slug) return;
+    setDocLoading(true);
     try {
       const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`);
-      if (!res.ok) throw new Error('Failed to fetch doc');
-      const { data } = await res.json();
+      if (!res.ok) {
+        setSelectedDoc(null);
+        return;
+      }
+      const json = await res.json();
+      const data = json?.data ?? null;
+      if (!data) {
+        setSelectedDoc(null);
+        return;
+      }
       setSelectedDoc(data);
-      setTitle(data.title);
-      setContent(data.content);
-      setContentFormat(data.content_format || 'markdown');
+      setTitle(data.title ?? '');
+      setContent(data.content ?? '');
+      setContentFormat(data.content_format ?? 'markdown');
     } catch {
       setSelectedDoc(null);
+    } finally {
+      setDocLoading(false);
     }
   }, [projectId, slug]);
 
@@ -142,10 +155,18 @@ export default function DocSlugPage() {
     router.push(`/docs/${targetSlug}`);
   }, [router]);
 
-  if (!selectedDoc) {
+  if (docLoading) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (!selectedDoc) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">{t('notFound')}</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Phase 1 머지 후 dev 환경에서 `/docs/[slug]` 진입 시 크래시 발생 회귀 수정.

**원인:** API 422 응답 시 `data`가 null인데 `data.title` 접근 → TypeError 크래시.

**수정 내용:**
- `useSearchParams` 제거 → `window.location.search` 직접 읽기 (Next.js Suspense 이슈 차단)
- `fetchDoc`: `res.ok` false 시 즉시 return, `json?.data ?? null` null-safe 처리
- `setTitle(data.title ?? '')`, `setContent(data.content ?? '')` 방어 추가
- `docLoading` state 추가 → 로딩 중 / 에러(notFound) 상태 분기 표시

## 변경 파일

| 파일 | 변경 내용 |
|------|---------|
| `[slug]/page.tsx` | fetchDoc 방어 코드, docLoading state, useSearchParams 제거 |

## 빌드 결과

- `pnpm build` ✅ PASS
- develop 최신 (`991b9292`) 기준 단독 커밋