### PR TITLE
[SID:D2-1] 체크리스트 블록 — TaskList/TaskItem 도입

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,8 @@
     "@tiptap/extension-table-cell": "^3.22.3",
     "@tiptap/extension-table-header": "^3.22.3",
     "@tiptap/extension-table-row": "^3.22.3",
+    "@tiptap/extension-task-item": "3.22.3",
+    "@tiptap/extension-task-list": "3.22.3",
     "@tiptap/pm": "^3.22.3",
     "@tiptap/react": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -315,6 +315,12 @@
 .tiptap-content .tiptap .ProseMirror-selectednode { outline: 2px solid var(--tiptap-selection); border-radius: 4px; }
 .tiptap-content .tiptap a { color: var(--tiptap-link); text-decoration: underline; }
 .tiptap-content .tiptap div[data-callout] { border-left: 3px solid var(--tiptap-callout-border); background: var(--tiptap-callout-bg); padding: 12px 16px; border-radius: 0 6px 6px 0; margin: 8px 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] { list-style: none; padding-left: 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] { display: flex; align-items: flex-start; gap: 8px; margin: 2px 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > label { flex-shrink: 0; padding-top: 3px; cursor: pointer; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > label input[type="checkbox"] { cursor: pointer; width: 15px; height: 15px; accent-color: var(--tiptap-link); }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
 /* ─── Typography utilities ─── */
 .text-display {

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -8,6 +8,8 @@ import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
 import Highlight from '@tiptap/extension-highlight';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
 import { Table } from '@tiptap/extension-table';
 import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
@@ -86,6 +88,8 @@ export function DocEditor({
       Link.configure({ openOnClick: false }),
       Image,
       Highlight,
+      TaskList,
+      TaskItem.configure({ nested: true }),
       Table.configure({ resizable: true }),
       TableRow,
       TableCell,

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -18,6 +18,7 @@ import {
   Heading3,
   List,
   ListOrdered,
+  ListTodo,
   Code,
   Quote,
   Lightbulb,
@@ -82,6 +83,13 @@ export const slashMenuCategories: SlashMenuCategory[] = [
         icon: ListOrdered,
         command: (editor, range) =>
           editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+      },
+      {
+        title: 'Checklist',
+        description: '체크리스트',
+        icon: ListTodo,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleTaskList().run(),
       },
     ],
   },

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -13,6 +13,19 @@ const turndown = new TurndownService({
 // TipTap handles structural formatting; no inline text escaping is needed.
 (turndown as unknown as { escape: (str: string) => string }).escape = (str: string) => str;
 
+// TaskList item rule — converts Tiptap taskItem nodes to GFM task list syntax (- [x] / - [ ])
+// Must be registered before the generic compactListItem rule so it wins for taskItem elements.
+turndown.addRule('taskListItem', {
+  filter: (node) =>
+    node.nodeName === 'LI' &&
+    (node as HTMLElement).getAttribute('data-type') === 'taskItem',
+  replacement: (content, node) => {
+    const checked = (node as HTMLElement).getAttribute('data-checked') === 'true';
+    const clean = content.replace(/^\n+/, '').replace(/\n\s*\n/g, '\n').trimEnd();
+    return `- [${checked ? 'x' : ' '}] ${clean}\n`;
+  },
+});
+
 // Custom list item rule — produces compact format regardless of whether
 // TipTap wrapped the content in <p> tags (which it always does via schema normalization).
 // Without this, Turndown outputs "loose" lists with blank lines between items:
@@ -207,6 +220,19 @@ export function markdownToHtml(rawMd: string): string {
     }
 
     return `<ol>${items.map((item) => `<li><p>${item}</p></li>`).join('')}</ol>`;
+  });
+
+  // Task lists (GFM: - [ ] / - [x]) — must be before unordered list rule
+  html = html.replace(/(?:^-\s+\[[ x]\]\s+.+(?:\n|$))+/gm, (listBlock) => {
+    const items = listBlock.trim().split('\n').filter(Boolean);
+    const listItems = items.map((line) => {
+      const match = line.match(/^-\s+\[([ x])\]\s+(.+)$/);
+      if (!match) return '';
+      const checked = match[1] === 'x';
+      const text = match[2] ?? '';
+      return `<li data-type="taskItem" data-checked="${checked}"><label><input type="checkbox"${checked ? ' checked' : ''}></label><div><p>${text}</p></div></li>`;
+    }).filter(Boolean).join('');
+    return `<ul data-type="taskList">${listItems}</ul>`;
   });
 
   // Unordered lists

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,12 @@ importers:
       '@tiptap/extension-table-row':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/extension-table@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-task-item':
+        specifier: 3.22.3
+        version: 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-task-list':
+        specifier: 3.22.3
+        version: 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
       '@tiptap/pm':
         specifier: ^3.22.3
         version: 3.22.3
@@ -1954,6 +1960,16 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.22.3
       '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-task-item@3.22.3':
+    resolution: {integrity: sha512-bUxP6fmlrF4sbpHnkm0nTKNVmtQXNnhrbWsUt0MCnvAd9y5Nq3ohpOzMOCL71AEHfmeV1kEkPbpdwKb1R7XDbg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-task-list@3.22.3':
+    resolution: {integrity: sha512-ze/DNj7Uq/Xjo+t8UuumnvJcmGVrVvLar11nFxobgpij21ja6XiUNMZ+BywvFurWbh5NrHeSYV07vFOWWf5Cpg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
 
   '@tiptap/extension-text@3.22.3':
     resolution: {integrity: sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==}
@@ -6867,6 +6883,14 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
       '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-task-item@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-task-list@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
 
   '@tiptap/extension-text@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
     dependencies:


### PR DESCRIPTION
## Summary

- **슬래시 메뉴 Checklist 항목** — 리스트 카테고리에 추가 (ListTodo 아이콘, "체크리스트")
- **Tiptap TaskList/TaskItem** — `nested: true`로 중첩 지원
- **Markdown 변환** — `- [x]`/`- [ ]` GFM 양방향 변환 (content-converter.ts)
- **CSS 스타일** — 체크박스 레이아웃 + 완료 항목 취소선

## AC 체크리스트

- [x] AC1: 슬래시 메뉴 "Checklist" 항목 추가
- [x] AC2: 체크박스 클릭 토글 (TaskItem 기본 동작)
- [x] AC3: `- [x]` / `- [ ]` markdown 양방향 변환 (htmlToMarkdown + markdownToHtml)
- [x] AC4: Enter 새 항목 / 빈 항목 Enter → paragraph 전환 (TaskItem 기본)
- [x] AC5: Tab/Shift+Tab 중첩 (`nested: true`)
- [x] AC6: 읽기전용 뷰 — ReactMarkdown + remarkGfm 기본 `<input disabled>` 렌더링
- [x] AC7: `@tiptap/extension-task-list@3.22.3`, `@tiptap/extension-task-item@3.22.3` 설치

## 빌드 결과

- `pnpm build` ✅ PASS