### PR TITLE
[SID:D2-2] 코드 구문 강조 — Shiki 통합

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
+    "shiki": "^4.1.0",
     "tailwind-merge": "^3.5.0",
     "turndown": "^7.2.4",
     "tw-animate-css": "^1.4.0",

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -51,6 +51,29 @@ export function DocContentRenderer({
       heading.id = seen === 0 ? baseId : `${baseId}-${seen + 1}`;
     });
 
+    // HTML format code blocks: apply Shiki highlighting via DOM
+    if (contentFormat === 'html') {
+      const preTags = Array.from(root.querySelectorAll<HTMLPreElement>('pre'));
+      preTags.forEach((pre) => {
+        const codeEl = pre.querySelector('code');
+        const text = codeEl?.textContent ?? pre.textContent ?? '';
+        if (!text.trim()) return;
+        const lang = codeEl?.className.replace('language-', '').split(' ')[0]
+          ?? pre.getAttribute('data-language')
+          ?? null;
+        void getShikiHighlighter().then((shiki) => {
+          const highlighted = shiki.codeToHtml(text, {
+            lang: resolveLanguage(lang),
+            theme: 'dark-plus',
+          });
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = highlighted;
+          wrapper.className = '[&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:p-4 [&_pre]:text-[13px] [&_pre]:leading-6 [&_code]:!bg-transparent overflow-x-auto';
+          if (pre.parentElement) pre.replaceWith(wrapper);
+        }).catch(() => { /* fallback: keep original pre */ });
+      });
+    }
+
     const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-doc-copy-button="true"]'));
     const cleanup = buttons.map((button) => {
       const handleClick = async () => {

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
+import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
 import remarkGfm from 'remark-gfm';
@@ -148,30 +149,88 @@ export function DocContentRenderer({
               <table>{children}</table>
             </div>
           ),
-          pre: ({ children }) => (
-            <div data-doc-code-shell="true">
-              <div data-doc-code-actions="true">
-                <button
-                  type="button"
-                  data-doc-copy-button="true"
-                  className="transition hover:border-[color:var(--operator-primary)]/35 hover:text-[color:var(--operator-foreground)]"
-                >
-                  {codeCopyLabel}
-                </button>
-              </div>
-              <pre>{children}</pre>
-            </div>
-          ),
+          pre: ({ children }) => <>{children}</>,
           code: (props) => {
             const { children, className: codeClassName } = props as { children?: ReactNode; className?: string };
             const childText = Array.isArray(children) ? children.join('') : String(children ?? '');
             const inline = !String(codeClassName ?? '').includes('language-') && !childText.includes('\n');
-            return inline ? <code>{children}</code> : <code className={codeClassName}>{children}</code>;
+            if (!inline) {
+              const lang = String(codeClassName ?? '').replace('language-', '') || null;
+              return (
+                <ShikiCodeBlock
+                  code={childText}
+                  language={lang}
+                  copyLabel={codeCopyLabel}
+                  copiedLabel={codeCopiedLabel}
+                />
+              );
+            }
+            return <code>{children}</code>;
           },
         }}
       >
         {content}
       </ReactMarkdown>
+    </div>
+  );
+}
+
+function ShikiCodeBlock({
+  code, language, copyLabel, copiedLabel,
+}: {
+  code: string;
+  language: string | null;
+  copyLabel: string;
+  copiedLabel: string;
+}) {
+  const [html, setHtml] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!code.trim()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const shiki = await getShikiHighlighter();
+        if (cancelled) return;
+        const lang = resolveLanguage(language);
+        setHtml(shiki.codeToHtml(code, { lang, theme: 'dark-plus' }));
+      } catch { /* fallback to plain */ }
+    })();
+    return () => { cancelled = true; };
+  }, [code, language]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      }
+    } catch { /* unavailable */ }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }, [code]);
+
+  return (
+    <div data-doc-code-shell="true" className="not-prose my-6 overflow-hidden rounded-2xl border border-slate-700 bg-[#0b1120]">
+      <div data-doc-code-actions="true" className="flex justify-end px-3 pt-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded-full border border-slate-600 bg-slate-700/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300 transition hover:border-slate-400 hover:text-slate-100"
+        >
+          {copied ? copiedLabel : copyLabel}
+        </button>
+      </div>
+      {html ? (
+        <div
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="overflow-x-auto [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:text-[13px] [&_pre]:leading-6 [&_code]:!bg-transparent"
+        />
+      ) : (
+        <pre className="overflow-x-auto p-4 text-[13px] leading-6 text-slate-200">
+          <code>{code}</code>
+        </pre>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -25,15 +25,18 @@ function CodeBlockView({ node, editor, selected }: ReactNodeViewProps) {
   const isEditing = isEditable && selected;
 
   useEffect(() => {
-    if (!code.trim()) { setHighlightedHtml(''); return; }
     let cancelled = false;
     void (async () => {
       try {
-        const shiki = await getShikiHighlighter();
-        if (cancelled) return;
-        const html = shiki.codeToHtml(code, { lang: resolvedLang, theme: 'dark-plus' });
-        setHighlightedHtml(html);
-      } catch { /* fallback to plain */ }
+        const html = code.trim()
+          ? await getShikiHighlighter().then((shiki) =>
+              shiki.codeToHtml(code, { lang: resolvedLang, theme: 'dark-plus' }),
+            )
+          : '';
+        if (!cancelled) setHighlightedHtml(html);
+      } catch {
+        if (!cancelled) setHighlightedHtml('');
+      }
     })();
     return () => { cancelled = true; };
   }, [code, resolvedLang]);

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -1,29 +1,107 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { ChevronDown } from 'lucide-react';
+import {
+  getShikiHighlighter,
+  resolveLanguage,
+  SUPPORTED_LANGUAGES,
+  LANGUAGE_LABELS,
+} from '../lib/shiki-highlighter';
 
-function CodeBlockView({ node }: ReactNodeViewProps) {
+function CodeBlockView({ node, editor, selected }: ReactNodeViewProps) {
   const [copied, setCopied] = useState(false);
+  const [highlightedHtml, setHighlightedHtml] = useState('');
+  const [showLangMenu, setShowLangMenu] = useState(false);
+  const langMenuRef = useRef<HTMLDivElement>(null);
+
+  const language = (node.attrs as { language?: string }).language ?? null;
+  const resolvedLang = resolveLanguage(language);
+  const langLabel = language ? (LANGUAGE_LABELS[language] ?? language) : 'text';
+  const code = node.textContent;
+  const isEditable = editor?.isEditable ?? false;
+  const isEditing = isEditable && selected;
+
+  useEffect(() => {
+    if (!code.trim()) { setHighlightedHtml(''); return; }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const shiki = await getShikiHighlighter();
+        if (cancelled) return;
+        const html = shiki.codeToHtml(code, { lang: resolvedLang, theme: 'dark-plus' });
+        setHighlightedHtml(html);
+      } catch { /* fallback to plain */ }
+    })();
+    return () => { cancelled = true; };
+  }, [code, resolvedLang]);
 
   const handleCopy = useCallback(async () => {
-    const text = node.textContent;
     try {
       if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
+        await navigator.clipboard.writeText(code);
       }
-    } catch {
-      // clipboard unavailable — still show feedback
-    }
+    } catch { /* clipboard unavailable */ }
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
-  }, [node.textContent]);
+  }, [code]);
+
+  const handleLangSelect = useCallback((lang: string) => {
+    editor?.commands.updateAttributes('codeBlock', { language: lang });
+    setShowLangMenu(false);
+  }, [editor]);
+
+  useEffect(() => {
+    if (!showLangMenu) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (langMenuRef.current && !langMenuRef.current.contains(e.target as HTMLElement)) {
+        setShowLangMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showLangMenu]);
 
   return (
     <NodeViewWrapper className="my-4 not-prose">
       <div className="rounded-2xl border border-slate-700 bg-[#0b1120]">
-        <div className="flex justify-end px-3 pt-2">
+        {/* Header: language selector + copy button */}
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          {/* Language dropdown */}
+          <div ref={langMenuRef} className="relative" contentEditable={false}>
+            <button
+              type="button"
+              onClick={() => isEditable && setShowLangMenu((v) => !v)}
+              className={`flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-[0.12em] transition ${
+                isEditable
+                  ? 'text-slate-400 hover:bg-slate-700/50 hover:text-slate-200 cursor-pointer'
+                  : 'text-slate-500 cursor-default'
+              }`}
+            >
+              {langLabel}
+              {isEditable && <ChevronDown className="size-3" />}
+            </button>
+            {showLangMenu && (
+              <div className="absolute left-0 top-full z-50 mt-1 max-h-52 w-36 overflow-y-auto rounded-xl border border-slate-700 bg-slate-900 py-1 shadow-xl">
+                {SUPPORTED_LANGUAGES.map((lang) => (
+                  <button
+                    key={lang}
+                    type="button"
+                    onClick={() => handleLangSelect(lang)}
+                    className={`flex w-full items-center px-3 py-1.5 text-left text-xs transition hover:bg-slate-700/60 ${
+                      lang === language ? 'text-blue-400' : 'text-slate-300'
+                    }`}
+                  >
+                    {LANGUAGE_LABELS[lang] ?? lang}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Copy button */}
           <button
             type="button"
             contentEditable={false}
@@ -33,9 +111,26 @@ function CodeBlockView({ node }: ReactNodeViewProps) {
             {copied ? '복사됨' : '복사'}
           </button>
         </div>
-        <pre className="overflow-x-auto p-4 text-[13px] leading-6 text-slate-200">
-          <NodeViewContent />
-        </pre>
+
+        {/* Code area */}
+        <div className="overflow-x-auto px-4 pb-4">
+          {/* Editing mode: show plain NodeViewContent */}
+          <pre
+            className={`text-[13px] leading-6 text-slate-200 ${isEditing || !highlightedHtml ? '' : 'hidden'}`}
+          >
+            <NodeViewContent />
+          </pre>
+
+          {/* Display mode: Shiki highlighted HTML */}
+          {!isEditing && highlightedHtml && (
+            <div
+              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              className="shiki-block [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:text-[13px] [&_pre]:leading-6 [&_pre]:!p-0 [&_code]:!bg-transparent"
+              onClick={() => isEditable && editor?.commands.focus()}
+              style={{ cursor: isEditable ? 'text' : 'default' }}
+            />
+          )}
+        </div>
       </div>
     </NodeViewWrapper>
   );

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -128,9 +128,11 @@ export function markdownToHtml(rawMd: string): string {
   // Extract fenced code blocks first to prevent other transforms from modifying their content.
   // Subsequent regex passes use gm flags which would otherwise corrupt multi-line code blocks.
   const codeBlockPlaceholders: string[] = [];
-  let html = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+  let html = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, lang, code) => {
     const idx = codeBlockPlaceholders.length;
-    codeBlockPlaceholders.push(`<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`);
+    const langAttrs = lang ? ` data-language="${lang}" class="language-${lang}"` : '';
+    const codeClass = lang ? ` class="language-${lang}"` : '';
+    codeBlockPlaceholders.push(`<pre${langAttrs}><code${codeClass}>${escapeHtml(code.trimEnd())}</code></pre>`);
     return `\x00CODEBLOCK${idx}\x00`;
   });
 

--- a/apps/web/src/components/docs/lib/shiki-highlighter.ts
+++ b/apps/web/src/components/docs/lib/shiki-highlighter.ts
@@ -1,0 +1,48 @@
+import type { HighlighterGeneric } from 'shiki';
+
+export const SUPPORTED_LANGUAGES = [
+  'javascript', 'typescript', 'python', 'go', 'rust', 'sql', 'json', 'yaml',
+  'bash', 'html', 'css', 'java', 'c', 'cpp', 'ruby', 'php', 'swift', 'kotlin',
+  'dart', 'markdown', 'docker', 'terraform', 'graphql', 'shell', 'powershell',
+  'lua', 'r', 'scala', 'elixir', 'haskell',
+] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const LANGUAGE_LABELS: Record<string, string> = {
+  javascript: 'JS', typescript: 'TS', python: 'Python', go: 'Go', rust: 'Rust',
+  sql: 'SQL', json: 'JSON', yaml: 'YAML', bash: 'Bash', html: 'HTML', css: 'CSS',
+  java: 'Java', c: 'C', cpp: 'C++', ruby: 'Ruby', php: 'PHP', swift: 'Swift',
+  kotlin: 'Kotlin', dart: 'Dart', markdown: 'Markdown', docker: 'Docker',
+  terraform: 'Terraform', graphql: 'GraphQL', shell: 'Shell', powershell: 'PS',
+  lua: 'Lua', r: 'R', scala: 'Scala', elixir: 'Elixir', haskell: 'Haskell',
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHighlighter = HighlighterGeneric<any, any>;
+
+let highlighterPromise: Promise<AnyHighlighter> | null = null;
+
+export async function getShikiHighlighter(): Promise<AnyHighlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const { createHighlighter } = await import('shiki');
+      return createHighlighter({
+        themes: ['dark-plus'],
+        langs: [...SUPPORTED_LANGUAGES],
+      });
+    })();
+  }
+  return highlighterPromise;
+}
+
+export function resolveLanguage(lang: string | null | undefined): string {
+  if (!lang) return 'text';
+  const lower = lang.toLowerCase();
+  if ((SUPPORTED_LANGUAGES as readonly string[]).includes(lower)) return lower;
+  const aliases: Record<string, string> = {
+    js: 'javascript', ts: 'typescript', py: 'python', sh: 'bash', yml: 'yaml',
+    'c++': 'cpp', 'c#': 'csharp', jsx: 'javascript', tsx: 'typescript',
+  };
+  return aliases[lower] ?? 'text';
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       shadcn:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.37)(typescript@5.9.3)
+      shiki:
+        specifier: ^4.1.0
+        version: 4.1.0
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1589,6 +1592,37 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shikijs/core@4.1.0':
+    resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.1.0':
+    resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    resolution: {integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.1.0':
+    resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.1.0':
+    resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.1.0':
+    resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.1.0':
+    resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -3457,6 +3491,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -4324,6 +4361,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -4604,6 +4647,15 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4772,6 +4824,10 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shiki@4.1.0:
+    resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -6572,6 +6628,46 @@ snapshots:
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shikijs/core@4.1.0':
+    dependencies:
+      '@shikijs/primitive': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/primitive@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -8696,6 +8792,20 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -9783,6 +9893,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -10125,6 +10243,16 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -10461,6 +10589,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shiki@4.1.0:
+    dependencies:
+      '@shikijs/core': 4.1.0
+      '@shikijs/engine-javascript': 4.1.0
+      '@shikijs/engine-oniguruma': 4.1.0
+      '@shikijs/langs': 4.1.0
+      '@shikijs/themes': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Shiki** WASM lazy load singleton (`shiki-highlighter.ts`) — 초기 페이지 로드 영향 없음
- **30개 언어** 지원 (JS/TS/Python/Go/Rust/SQL/JSON/YAML/Bash/HTML/CSS/Java/C/C++/Ruby/PHP/Swift/Kotlin/Dart/Markdown/Docker/Terraform/GraphQL/Shell/PowerShell/Lua/R/Scala/Elixir/Haskell)
- **code-block-copy.tsx** 개편 — 편집 모드(NodeViewContent) ↔ 표시 모드(Shiki HTML) 전환
- **언어 선택 드롭다운** — 코드 블록 좌측 상단 라벨 클릭 시 표시
- **doc-content-renderer.tsx** — ShikiCodeBlock 컴포넌트로 읽기전용 뷰 Shiki 적용
- `dark-plus` 테마 (`#0b1120` 배경 호환), 복사 버튼 기능 유지

## AC 체크리스트

- [x] AC1: Shiki 기반 언어별 구문 강조
- [x] AC2: 30개 언어 지원
- [x] AC3: 언어 선택 드롭다운 (코드 블록 좌측 상단)
- [x] AC4: 복사 버튼 기능 유지
- [x] AC5: `dark-plus` 테마 (`#0b1120` 배경 호환)
- [x] AC6: WASM lazy load (`await import('shiki')` singleton)
- [x] AC7: 읽기전용 뷰 `ShikiCodeBlock` 동일 Shiki 적용

## 빌드 결과

- `pnpm build` ✅ PASS