### PR TITLE
[SID:D2-4] 토글/디테일 블록 — 접기/펼치기

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -322,6 +322,14 @@
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
+/* ─── Toggle block ─── */
+[data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"],
+.tiptap [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"] { display: none; }
+[data-type="toggleContent"],
+.tiptap [data-type="toggleContent"] { padding-left: 1.25rem; margin-left: 0.875rem; border-left: 2px solid hsl(var(--border)); margin-top: 0.25rem; }
+[data-type="toggleSummary"],
+.tiptap [data-type="toggleSummary"] { cursor: pointer; }
+
 /* ─── Typography utilities ─── */
 .text-display {
   font-size: 2rem;

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -102,8 +102,22 @@ export function DocContentRenderer({
       return () => button.removeEventListener('click', handleClick);
     });
 
+    // Toggle block click handlers (viewer)
+    const toggleSummaries = Array.from(root.querySelectorAll<HTMLElement>('[data-type="toggleSummary"]'));
+    const toggleCleanup = toggleSummaries.map((summary) => {
+      const handleClick = () => {
+        const block = summary.closest<HTMLElement>('[data-type="toggleBlock"]');
+        if (!block) return;
+        const isOpen = block.getAttribute('data-open') === 'true';
+        block.setAttribute('data-open', String(!isOpen));
+      };
+      summary.addEventListener('click', handleClick);
+      return () => summary.removeEventListener('click', handleClick);
+    });
+
     return () => {
       cleanup.forEach((dispose) => dispose());
+      toggleCleanup.forEach((dispose) => dispose());
     };
   }, [codeCopiedLabel, codeCopyLabel, content, contentFormat]);
 

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -20,6 +20,7 @@ import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
+import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -96,6 +97,9 @@ export function DocEditor({
       TableHeader,
       Placeholder.configure({ placeholder: labels.placeholder }),
       CalloutNode,
+      ToggleBlock,
+      ToggleSummary,
+      ToggleContent,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -27,6 +27,7 @@ import {
   Minus,
   FileText,
   GitBranch,
+  ChevronRight,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -170,6 +171,20 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Toggle',
+        description: '접기/펼치기 블록',
+        icon: ChevronRight,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'toggleBlock',
+            attrs: { open: false },
+            content: [
+              { type: 'toggleSummary', content: [{ type: 'text', text: '토글 제목' }] },
+              { type: 'toggleContent', content: [{ type: 'paragraph' }] },
+            ],
+          }).run(),
+      },
       {
         title: 'Page Embed',
         description: '다른 문서 임베드',

--- a/apps/web/src/components/docs/extensions/toggle-block.tsx
+++ b/apps/web/src/components/docs/extensions/toggle-block.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+
+// ─── Toggle Summary View ──────────────────────────────────────────────────────
+
+function ToggleSummaryView({ getPos, editor }: ReactNodeViewProps) {
+  const readParentOpen = useCallback((): boolean => {
+    if (typeof getPos !== 'function') return false;
+    try {
+      const pos = getPos();
+      if (pos === undefined) return false;
+      const $pos = editor.state.doc.resolve(pos);
+      if ($pos.depth >= 1) {
+        const parent = $pos.node($pos.depth - 1);
+        if (parent.type.name === 'toggleBlock') return Boolean(parent.attrs.open);
+      }
+    } catch { /* node may be deleted */ }
+    return false;
+  }, [editor, getPos]);
+
+  const [isOpen, setIsOpen] = useState(() => readParentOpen());
+
+  useEffect(() => {
+    const updateOpen = () => { setIsOpen(readParentOpen()); };
+    editor.on('update', updateOpen);
+    return () => { editor.off('update', updateOpen); };
+  }, [editor, readParentOpen]);
+
+  const handleToggle = useCallback(() => {
+    if (typeof getPos !== 'function') return;
+    try {
+      const pos = getPos();
+      if (pos === undefined) return;
+      const $pos = editor.state.doc.resolve(pos);
+      if ($pos.depth < 1) return;
+      const parentPos = $pos.before($pos.depth);
+      const parent = $pos.node($pos.depth - 1);
+      if (parent.type.name !== 'toggleBlock') return;
+      editor.commands.command(({ tr }) => {
+        tr.setNodeMarkup(parentPos, undefined, { open: !parent.attrs.open });
+        return true;
+      });
+    } catch { /* node may be deleted */ }
+  }, [editor, getPos]);
+
+  return (
+    <NodeViewWrapper as="div" className="flex items-center gap-1.5">
+      <button
+        type="button"
+        contentEditable={false}
+        onClick={handleToggle}
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-[color:var(--operator-muted)] transition-colors hover:bg-muted hover:text-[color:var(--operator-foreground)]"
+        aria-label={isOpen ? '접기' : '펼치기'}
+      >
+        {isOpen
+          ? <ChevronDown className="size-3.5" />
+          : <ChevronRight className="size-3.5" />}
+      </button>
+      <NodeViewContent as="div" className="flex-1 font-medium leading-6 outline-none" />
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Nodes ────────────────────────────────────────────────────────────────────
+
+export const ToggleSummary = Node.create({
+  name: 'toggleSummary',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleSummary"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleSummary' }, HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ToggleSummaryView);
+  },
+});
+
+export const ToggleContent = Node.create({
+  name: 'toggleContent',
+  content: 'block+',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleContent"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleContent' }, HTMLAttributes), 0];
+  },
+});
+
+export const ToggleBlock = Node.create({
+  name: 'toggleBlock',
+  group: 'block',
+  content: 'toggleSummary toggleContent',
+  defining: true,
+
+  addAttributes() {
+    return {
+      open: {
+        default: false,
+        parseHTML: (element) => element.getAttribute('data-open') === 'true',
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          'data-open': String(attributes['open'] ?? false),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleBlock' }, HTMLAttributes), 0];
+  },
+});

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -47,6 +47,22 @@ turndown.addRule('compactListItem', {
   },
 });
 
+// Preserve toggle blocks as raw HTML — must be before generic block rules
+turndown.addRule('toggleBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'toggleBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const isOpen = el.getAttribute('data-open') === 'true';
+    const summaryEl = el.querySelector('[data-type="toggleSummary"]');
+    const contentEl = el.querySelector('[data-type="toggleContent"]');
+    const summaryHtml = summaryEl ? summaryEl.innerHTML : '';
+    const contentHtml = contentEl ? contentEl.innerHTML : '';
+    return `\n<div data-type="toggleBlock" data-open="${isOpen}"><div data-type="toggleSummary">${summaryHtml}</div><div data-type="toggleContent">${contentHtml}</div></div>\n`;
+  },
+});
+
 // Preserve page-embed atoms — must be before the generic block rule
 turndown.addRule('pageEmbed', {
   filter: (node) => node.nodeName === 'DIV' && node.hasAttribute('data-page-embed'),
@@ -136,10 +152,16 @@ export function markdownToHtml(rawMd: string): string {
     return `\x00CODEBLOCK${idx}\x00`;
   });
 
-  // Protect page-embed atoms — they are written as raw HTML by htmlToMarkdown() and
-  // must survive the HTML-escape pass below intact.
+  // Protect page-embed and toggle atoms — written as raw HTML by htmlToMarkdown()
+  // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Toggle blocks are stored as single-line raw HTML by the Turndown rule above
+  html = html.replace(/^<div data-type="toggleBlock"[^\n]*<\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;


### PR DESCRIPTION
## 변경 사항

### D2-4: 토글/디테일 블록

**신규 파일**
- `apps/web/src/components/docs/extensions/toggle-block.tsx`
  - `ToggleBlock` 노드: `content: 'toggleSummary toggleContent'`, `open` attribute (기본: false)
  - `ToggleSummary` 노드: ReactNodeViewRenderer — ChevronRight/ChevronDown 토글 버튼 + NodeViewContent
  - `ToggleContent` 노드: block+ content, `data-type="toggleContent"` attribute

**수정 파일**
- `doc-editor.tsx`: ToggleBlock / ToggleSummary / ToggleContent extensions 추가
- `slash-command.tsx`: '고급' 카테고리에 Toggle 항목 추가 (ChevronRight 아이콘)
- `globals.css`: `[data-open="false"] [data-type="toggleContent"] { display: none }` + content indent 스타일
- `content-converter.ts`: Turndown 룰 추가 (toggle → raw HTML 보존), markdownToHtml atom 보호
- `doc-content-renderer.tsx`: 뷰어에서 toggle summary 클릭 핸들러 (DOM attribute 토글)

## AC 체크리스트

- [x] AC1: 슬래시 메뉴 '고급' 카테고리 → "Toggle" 선택 시 블록 삽입
- [x] AC2: summary 클릭으로 접기/펼치기 토글
- [x] AC3: summary 영역 편집 가능 (NodeViewContent inline)
- [x] AC4: content 영역 block+ nested 가능
- [x] AC5: ▶/▼ 아이콘 (ChevronRight/ChevronDown)
- [x] AC6: open attribute 저장 — HTML format 그대로, Markdown format raw HTML 보존

## 빌드

- `pnpm build` ✅
- TypeScript 에러 없음 ✅
- lint 에러 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)