### PR TITLE
[SID:D3-1] 이미지 드래그앤드롭 업로드 + 리사이즈 핸들

### DIFF
--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -6,7 +6,8 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
-import Image from '@tiptap/extension-image';
+import { CustomImageNode } from './extensions/image-node';
+import { ImageUploadExtension } from './extensions/image-upload';
 import Highlight from '@tiptap/extension-highlight';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
@@ -87,7 +88,8 @@ export function DocEditor({
       StarterKit.configure({ codeBlock: false }),
       CodeBlockWithCopy,
       Link.configure({ openOnClick: false }),
-      Image,
+      CustomImageNode,
+      ImageUploadExtension,
       Highlight,
       TaskList,
       TaskItem.configure({ nested: true }),

--- a/apps/web/src/components/docs/extensions/image-node.tsx
+++ b/apps/web/src/components/docs/extensions/image-node.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import Image from '@tiptap/extension-image';
+import { mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+
+// ─── Resize Handle ────────────────────────────────────────────────────────────
+
+function ImageView({ node, updateAttributes, selected }: ReactNodeViewProps) {
+  const [isResizing, setIsResizing] = useState(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  const src = node.attrs.src as string;
+  const alt = (node.attrs.alt as string) ?? '';
+  const width = node.attrs.width as number | null;
+
+  const handleResizeStart = useCallback((e: React.MouseEvent, side: 'left' | 'right') => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsResizing(true);
+    startXRef.current = e.clientX;
+    startWidthRef.current = imgRef.current?.offsetWidth ?? 300;
+
+    const onMouseMove = (me: MouseEvent) => {
+      const delta = me.clientX - startXRef.current;
+      const newWidth = Math.max(80, startWidthRef.current + (side === 'right' ? delta : -delta));
+      updateAttributes({ width: Math.round(newWidth) });
+    };
+
+    const onMouseUp = () => {
+      setIsResizing(false);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [updateAttributes]);
+
+  return (
+    <NodeViewWrapper as="div" className="relative my-4 inline-block max-w-full">
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        draggable={false}
+        style={{ width: width ? `${width}px` : undefined, maxWidth: '100%', height: 'auto', display: 'block' }}
+        className={`rounded-xl border border-border object-contain transition-shadow ${
+          selected ? 'ring-2 ring-[color:var(--operator-primary)] ring-offset-1' : ''
+        } ${isResizing ? 'select-none' : ''}`}
+      />
+      {selected && (
+        <>
+          <div
+            role="separator"
+            aria-label="왼쪽 리사이즈 핸들"
+            onMouseDown={(e) => handleResizeStart(e, 'left')}
+            className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 h-8 w-3 cursor-ew-resize rounded-sm border border-border bg-background shadow-md hover:bg-muted"
+          />
+          <div
+            role="separator"
+            aria-label="오른쪽 리사이즈 핸들"
+            onMouseDown={(e) => handleResizeStart(e, 'right')}
+            className="absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 h-8 w-3 cursor-ew-resize rounded-sm border border-border bg-background shadow-md hover:bg-muted"
+          />
+        </>
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+// Extend the built-in Image node to add width attribute + resize NodeView
+
+export const CustomImageNode = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (el) => {
+          const style = (el as HTMLElement).style.width;
+          if (style) return parseInt(style, 10) || null;
+          return (el as HTMLElement).getAttribute('width') ? Number((el as HTMLElement).getAttribute('width')) : null;
+        },
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes['width']) return {};
+          return { style: `width:${attributes['width']}px;max-width:100%;height:auto` };
+        },
+      },
+    };
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(HTMLAttributes)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ImageView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -1,0 +1,106 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+const MAX_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_DIM = 1920;
+
+async function processImageFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('FileReader 오류'));
+    reader.onload = (e) => {
+      const dataUrl = e.target?.result as string;
+      if (file.size <= MAX_BYTES) {
+        resolve(dataUrl);
+        return;
+      }
+      // Compress via canvas
+      const img = new Image();
+      img.onerror = () => reject(new Error('이미지 로드 오류'));
+      img.onload = () => {
+        let { naturalWidth: w, naturalHeight: h } = img;
+        if (w > MAX_DIM || h > MAX_DIM) {
+          const ratio = Math.min(MAX_DIM / w, MAX_DIM / h);
+          w = Math.round(w * ratio);
+          h = Math.round(h * ratio);
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { resolve(dataUrl); return; }
+        ctx.drawImage(img, 0, 0, w, h);
+
+        let quality = 0.85;
+        let compressed = canvas.toDataURL('image/jpeg', quality);
+        while (compressed.length * 0.75 > MAX_BYTES && quality > 0.3) {
+          quality = Math.max(0.3, quality - 0.1);
+          compressed = canvas.toDataURL('image/jpeg', quality);
+        }
+        resolve(compressed);
+      };
+      img.src = dataUrl;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function insertImageSrc(view: EditorView, src: string, pos?: number): void {
+  const { schema, selection } = view.state;
+  const imageType = schema.nodes['image'];
+  if (!imageType) return;
+  const node = imageType.create({ src });
+  const insertPos = pos ?? selection.anchor;
+  const tr = view.state.tr.insert(insertPos, node);
+  view.dispatch(tr);
+}
+
+export const ImageUploadExtension = Extension.create({
+  name: 'imageUpload',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('imageUpload'),
+        props: {
+          handleDrop(view: EditorView, event: Event) {
+            const dragEvent = event as DragEvent;
+            const files = dragEvent.dataTransfer?.files;
+            if (!files || files.length === 0) return false;
+            const images = Array.from(files).filter((f) => f.type.startsWith('image/'));
+            if (images.length === 0) return false;
+
+            dragEvent.preventDefault();
+            const coords = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
+
+            void Promise.all(images.map(processImageFile)).then((srcs) => {
+              srcs.forEach((src, i) => {
+                insertImageSrc(view, src, (coords?.pos ?? view.state.selection.anchor) + i);
+              });
+            });
+
+            return true;
+          },
+
+          handlePaste(view: EditorView, event: Event) {
+            const clipboardEvent = event as ClipboardEvent;
+            const items = clipboardEvent.clipboardData?.items;
+            if (!items) return false;
+            const imageItems = Array.from(items).filter((item) => item.type.startsWith('image/'));
+            if (imageItems.length === 0) return false;
+
+            clipboardEvent.preventDefault();
+            const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
+
+            void Promise.all(files.map(processImageFile)).then((srcs) => {
+              srcs.forEach((src) => insertImageSrc(view, src));
+            });
+
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -47,6 +47,19 @@ turndown.addRule('compactListItem', {
   },
 });
 
+// Preserve image width — Turndown strips style from <img>; serialize as raw HTML for round-trip
+turndown.addRule('imageWithWidth', {
+  filter: (node) =>
+    node.nodeName === 'IMG' && !!(node as HTMLElement).style.width,
+  replacement: (_content, node) => {
+    const el = node as HTMLImageElement;
+    const src = el.getAttribute('src') ?? '';
+    const alt = el.getAttribute('alt') ?? '';
+    const width = el.style.width;
+    return `\n<img src="${src}" alt="${alt}" style="width:${width};max-width:100%;height:auto">\n`;
+  },
+});
+
 // Preserve toggle blocks as raw HTML — must be before generic block rules
 turndown.addRule('toggleBlock', {
   filter: (node) =>
@@ -162,6 +175,12 @@ export function markdownToHtml(rawMd: string): string {
   });
   // Toggle blocks are stored as single-line raw HTML by the Turndown rule above
   html = html.replace(/^<div data-type="toggleBlock"[^\n]*<\/div>$/gm, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Images with width style — serialized as raw HTML by imageWithWidth Turndown rule
+  html = html.replace(/^<img\s[^>]*style="width:[^"]*"[^>]*>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;


### PR DESCRIPTION
## 변경 사항

### D3-1: 이미지 드래그앤드롭 업로드 + 리사이즈

**신규 파일**
- `extensions/image-node.tsx` — `@tiptap/extension-image` extend
  - `width` attribute 추가 (style로 renderHTML)
  - ReactNodeViewRenderer: 선택 시 좌우 리사이즈 핸들 노출
  - 드래그로 width 조절 (mousedown → mousemove → mouseup)
  - 최소 80px 제한

- `extensions/image-upload.ts` — ProseMirror Plugin
  - `handleDrop`: 에디터 영역 파일 드롭 → base64 변환 → 삽입
  - `handlePaste`: 클립보드 이미지 붙여넣기 → base64 변환 → 삽입
  - 1MB 초과 이미지: canvas resize (MAX_DIM: 1920px) + JPEG quality 0.85→0.3 압축

**수정 파일**
- `doc-editor.tsx`: `Image` → `CustomImageNode` + `ImageUploadExtension` 추가

## AC 체크리스트

- [x] AC1: 에디터 드래그앤드롭 → base64 자동 삽입
- [x] AC2: Ctrl+V 클립보드 이미지 → base64 자동 삽입
- [x] AC3: 슬래시 메뉴 "Image" → URL 다이얼로그 (기존 유지)
- [x] AC4: 이미지 클릭 선택 + 좌우 리사이즈 핸들 드래그
- [x] AC5: 1MB 초과 canvas 압축 (1920px + quality 감소)

## 빌드

- `pnpm build` ✅
- TypeScript 에러 없음 ✅
- lint 에러 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)