### PR TITLE
[SID:D3-2] 파일 첨부 블록 — 업로드 + 다운로드

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -546,6 +546,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 editable={selectedDoc.doc_type !== 'sprint_report'}
                 currentDocId={selectedDoc.id}
                 onNavigate={handleSelectDoc}
+                onFileError={(msg) => addToast({ title: msg, type: 'error' })}
                 onChange={setContent}
                 onContentFormatChange={setContentFormat}
                 isDirty={isDirty}

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -102,6 +102,39 @@ export function DocContentRenderer({
       return () => button.removeEventListener('click', handleClick);
     });
 
+    // File attachment download handlers (viewer)
+    const fileBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="fileAttachment"]'));
+    const fileCleanup = fileBlocks.map((block) => {
+      const filename = block.getAttribute('data-filename') ?? 'file';
+      const data = block.getAttribute('data-file-data') ?? '';
+      const size = Number(block.getAttribute('data-size') ?? 0);
+      const sizeLabel = size < 1024 * 1024
+        ? `${(size / 1024).toFixed(1)} KB`
+        : `${(size / (1024 * 1024)).toFixed(1)} MB`;
+
+      block.innerHTML = `
+        <div class="flex items-center gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--muted))]/20 px-4 py-3 cursor-pointer hover:bg-[hsl(var(--muted))]/40 transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-[color:var(--operator-muted)]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">${filename}</p>
+            <p class="text-xs opacity-60">${sizeLabel}</p>
+          </div>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 opacity-50"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        </div>`;
+
+      const handleClick = () => {
+        if (!data) return;
+        const a = document.createElement('a');
+        a.href = data;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      };
+      block.addEventListener('click', handleClick);
+      return () => block.removeEventListener('click', handleClick);
+    });
+
     // Toggle block click handlers (viewer)
     const toggleSummaries = Array.from(root.querySelectorAll<HTMLElement>('[data-type="toggleSummary"]'));
     const toggleCleanup = toggleSummaries.map((summary) => {
@@ -117,6 +150,7 @@ export function DocContentRenderer({
 
     return () => {
       cleanup.forEach((dispose) => dispose());
+      fileCleanup.forEach((dispose) => dispose());
       toggleCleanup.forEach((dispose) => dispose());
     };
   }, [codeCopiedLabel, codeCopyLabel, content, contentFormat]);

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -116,8 +116,8 @@ export function DocContentRenderer({
         <div class="flex items-center gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--muted))]/20 px-4 py-3 cursor-pointer hover:bg-[hsl(var(--muted))]/40 transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-[color:var(--operator-muted)]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
           <div class="min-w-0 flex-1">
-            <p class="truncate text-sm font-medium">${filename}</p>
-            <p class="text-xs opacity-60">${sizeLabel}</p>
+            <p class="truncate text-sm font-medium">${escapeHtmlText(filename)}</p>
+            <p class="text-xs opacity-60">${escapeHtmlText(sizeLabel)}</p>
           </div>
           <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 opacity-50"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
         </div>`;

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -22,6 +22,7 @@ import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
+import { FileAttachmentNode } from './extensions/file-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -33,6 +34,7 @@ export function DocEditor({
   editable = true,
   currentDocId,
   onNavigate,
+  onFileError,
   onChange,
   onSave,
   isDirty = false,
@@ -50,6 +52,7 @@ export function DocEditor({
   editable?: boolean;
   currentDocId?: string;
   onNavigate?: (slug: string) => void;
+  onFileError?: (message: string) => void;
   onChange: (value: string) => void;
   onContentFormatChange?: (format: ContentFormat) => void;
   onSave?: () => Promise<boolean>;
@@ -82,6 +85,16 @@ export function DocEditor({
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
 
+  useEffect(() => {
+    if (!onFileError) return;
+    const handleFileSizeError = (e: Event) => {
+      const msg = (e as CustomEvent<{ message: string }>).detail.message;
+      onFileError(msg);
+    };
+    window.addEventListener('docs:file-size-error', handleFileSizeError);
+    return () => window.removeEventListener('docs:file-size-error', handleFileSizeError);
+  }, [onFileError]);
+
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
@@ -102,6 +115,7 @@ export function DocEditor({
       ToggleBlock,
       ToggleSummary,
       ToggleContent,
+      FileAttachmentNode,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/extensions/file-node.tsx
+++ b/apps/web/src/components/docs/extensions/file-node.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { FileIcon, DownloadIcon } from 'lucide-react';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+export async function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('FileReader 오류'));
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.readAsDataURL(file);
+  });
+}
+
+// ─── File Attachment View ─────────────────────────────────────────────────────
+
+function FileAttachmentView({ node }: ReactNodeViewProps) {
+  const filename = node.attrs.filename as string;
+  const size = node.attrs.size as number;
+  const data = node.attrs.data as string;
+
+  const handleDownload = useCallback(() => {
+    if (!data) return;
+    const a = document.createElement('a');
+    a.href = data;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }, [data, filename]);
+
+  return (
+    <NodeViewWrapper as="div" className="my-3 not-prose">
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]">
+          <FileIcon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[color:var(--operator-foreground)]">{filename}</p>
+          <p className="text-xs text-[color:var(--operator-muted)]">{formatFileSize(size)}</p>
+        </div>
+        <button
+          type="button"
+          contentEditable={false}
+          onClick={handleDownload}
+          className="flex-shrink-0 rounded-lg border border-border p-2 text-[color:var(--operator-muted)] transition-colors hover:border-[color:var(--operator-primary)]/40 hover:text-[color:var(--operator-primary-soft)]"
+          aria-label="파일 다운로드"
+        >
+          <DownloadIcon className="size-4" />
+        </button>
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+
+export const FileAttachmentNode = Node.create({
+  name: 'fileAttachment',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      filename: { default: '' },
+      size: { default: 0 },
+      mimeType: { default: '' },
+      data: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="fileAttachment"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { filename, size, mimeType, data } = HTMLAttributes as Record<string, unknown>;
+    return [
+      'div',
+      mergeAttributes({
+        'data-type': 'fileAttachment',
+        'data-filename': filename,
+        'data-size': String(size),
+        'data-mime-type': mimeType,
+        'data-file-data': data,
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FileAttachmentView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -1,9 +1,30 @@
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
+import { MAX_FILE_BYTES, fileToDataUrl, formatFileSize } from './file-node';
 
-const MAX_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_IMAGE_BYTES = 1 * 1024 * 1024; // 1 MB — images are compressed above this
 const MAX_DIM = 1920;
+
+function dispatchFileSizeError(file: File): void {
+  window.dispatchEvent(new CustomEvent('docs:file-size-error', {
+    detail: { message: `파일 크기가 5MB를 초과합니다. (${formatFileSize(file.size)})` },
+  }));
+}
+
+function insertFileAttachment(view: EditorView, file: File, dataUrl: string, pos?: number): void {
+  const { schema, selection } = view.state;
+  const nodeType = schema.nodes['fileAttachment'];
+  if (!nodeType) return;
+  const node = nodeType.create({
+    filename: file.name,
+    size: file.size,
+    mimeType: file.type,
+    data: dataUrl,
+  });
+  const insertPos = pos ?? selection.anchor;
+  view.dispatch(view.state.tr.insert(insertPos, node));
+}
 
 async function processImageFile(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -11,7 +32,7 @@ async function processImageFile(file: File): Promise<string> {
     reader.onerror = () => reject(new Error('FileReader 오류'));
     reader.onload = (e) => {
       const dataUrl = e.target?.result as string;
-      if (file.size <= MAX_BYTES) {
+      if (file.size <= MAX_IMAGE_BYTES) {
         resolve(dataUrl);
         return;
       }
@@ -34,7 +55,7 @@ async function processImageFile(file: File): Promise<string> {
 
         let quality = 0.85;
         let compressed = canvas.toDataURL('image/jpeg', quality);
-        while (compressed.length * 0.75 > MAX_BYTES && quality > 0.3) {
+        while (compressed.length * 0.75 > MAX_IMAGE_BYTES && quality > 0.3) {
           quality = Math.max(0.3, quality - 0.1);
           compressed = canvas.toDataURL('image/jpeg', quality);
         }
@@ -68,16 +89,24 @@ export const ImageUploadExtension = Extension.create({
             const dragEvent = event as DragEvent;
             const files = dragEvent.dataTransfer?.files;
             if (!files || files.length === 0) return false;
-            const images = Array.from(files).filter((f) => f.type.startsWith('image/'));
-            if (images.length === 0) return false;
 
+            const allFiles = Array.from(files);
+            const images = allFiles.filter((f) => f.type.startsWith('image/'));
+            const nonImages = allFiles.filter((f) => !f.type.startsWith('image/'));
+
+            if (images.length === 0 && nonImages.length === 0) return false;
             dragEvent.preventDefault();
+
             const coords = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
+            const basePos = coords?.pos ?? view.state.selection.anchor;
 
             void Promise.all(images.map(processImageFile)).then((srcs) => {
-              srcs.forEach((src, i) => {
-                insertImageSrc(view, src, (coords?.pos ?? view.state.selection.anchor) + i);
-              });
+              srcs.forEach((src, i) => insertImageSrc(view, src, basePos + i));
+            });
+
+            nonImages.forEach((file) => {
+              if (file.size > MAX_FILE_BYTES) { dispatchFileSizeError(file); return; }
+              void fileToDataUrl(file).then((dataUrl) => insertFileAttachment(view, file, dataUrl, basePos));
             });
 
             return true;

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -28,6 +28,7 @@ import {
   FileText,
   GitBranch,
   ChevronRight,
+  Paperclip,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -148,6 +149,33 @@ export const slashMenuCategories: SlashMenuCategory[] = [
         command: (editor, range) => {
           const url = window.prompt('Image URL:');
           if (url) editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
+        },
+      },
+      {
+        title: 'File',
+        description: '파일 첨부',
+        icon: Paperclip,
+        command: (editor, range) => {
+          editor.chain().focus().deleteRange(range).run();
+          const input = document.createElement('input');
+          input.type = 'file';
+          input.onchange = async () => {
+            const file = input.files?.[0];
+            if (!file) return;
+            const { MAX_FILE_BYTES: maxBytes, fileToDataUrl: toDataUrl, formatFileSize: fmtSize } = await import('./file-node');
+            if (file.size > maxBytes) {
+              window.dispatchEvent(new CustomEvent('docs:file-size-error', {
+                detail: { message: `파일 크기가 5MB를 초과합니다. (${fmtSize(file.size)})` },
+              }));
+              return;
+            }
+            const dataUrl = await toDataUrl(file);
+            editor.commands.insertContent({
+              type: 'fileAttachment',
+              attrs: { filename: file.name, size: file.size, mimeType: file.type, data: dataUrl },
+            });
+          };
+          input.click();
         },
       },
       {

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -67,9 +67,11 @@ turndown.addRule('fileAttachment', {
     (node as HTMLElement).getAttribute('data-type') === 'fileAttachment',
   replacement: (_content, node) => {
     const el = node as HTMLElement;
-    const filename = el.getAttribute('data-filename') ?? '';
-    const size = el.getAttribute('data-size') ?? '0';
-    const mimeType = el.getAttribute('data-mime-type') ?? '';
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const filename = safeAttr(el.getAttribute('data-filename') ?? '');
+    const size = safeAttr(el.getAttribute('data-size') ?? '0');
+    const mimeType = safeAttr(el.getAttribute('data-mime-type') ?? '');
     const data = el.getAttribute('data-file-data') ?? '';
     return `\n<div data-type="fileAttachment" data-filename="${filename}" data-size="${size}" data-mime-type="${mimeType}" data-file-data="${data}"></div>\n`;
   },

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,21 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve file attachment blocks as raw HTML
+turndown.addRule('fileAttachment', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'fileAttachment',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const filename = el.getAttribute('data-filename') ?? '';
+    const size = el.getAttribute('data-size') ?? '0';
+    const mimeType = el.getAttribute('data-mime-type') ?? '';
+    const data = el.getAttribute('data-file-data') ?? '';
+    return `\n<div data-type="fileAttachment" data-filename="${filename}" data-size="${size}" data-mime-type="${mimeType}" data-file-data="${data}"></div>\n`;
+  },
+});
+
 // Preserve toggle blocks as raw HTML — must be before generic block rules
 turndown.addRule('toggleBlock', {
   filter: (node) =>
@@ -169,6 +184,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // File attachment blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="fileAttachment"[^\n]*><\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;


### PR DESCRIPTION
## 변경 사항

### D3-2: 파일 첨부 블록

**신규 파일**
- `extensions/file-node.tsx` — FileAttachmentNode
  - `filename`, `size`, `mimeType`, `data` (base64) attributes
  - UI: 파일 아이콘 + 파일명 + 크기 카드 + 다운로드 버튼
  - 다운로드: `<a href=data download=filename>` 트리거

**수정 파일**
- `image-upload.ts`: DnD에서 非이미지 파일 → 5MB 체크 → FileAttachmentNode 삽입
  - 5MB 초과 시 `docs:file-size-error` CustomEvent dispatch
- `slash-command.tsx`: '미디어' 카테고리에 File 항목 추가 (Paperclip 아이콘, file picker dialog)
- `doc-editor.tsx`: FileAttachmentNode extension 추가 + `docs:file-size-error` event listener + `onFileError` prop
- `docs-shell-client.tsx`: `onFileError → addToast({ type: 'error' })` 연결
- `content-converter.ts`: `fileAttachment` Turndown 룰 + markdownToHtml atom 보호
- `doc-content-renderer.tsx`: 뷰어에서 파일 블록 다운로드 핸들러 (DOM 렌더링)

## AC 체크리스트

- [x] AC1: 슬래시 메뉴 "File" → 파일 선택 → 첨부 블록 삽입
- [x] AC2: 非이미지 파일 DnD → 파일 블록 자동 삽입
- [x] AC3: 파일 아이콘 + 파일명 + 크기 카드 UI
- [x] AC4: 다운로드 버튼 클릭 → base64 data URL 다운로드
- [x] AC5: 5MB 초과 시 에러 토스트
- [x] AC6: doc-content-renderer 뷰어에서 파일 블록 + 다운로드 동작

## 빌드

- `pnpm build` ✅
- TypeScript 에러 없음 ✅
- lint 에러 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)