### PR TITLE
[SID:D3-3] 외부 임베드 블록 — YouTube, Figma, fallback 링크

### DIFF
--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
 import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
+import { detectEmbedService } from './extensions/embed-node';
 import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
@@ -100,6 +101,46 @@ export function DocContentRenderer({
 
       button.addEventListener('click', handleClick);
       return () => button.removeEventListener('click', handleClick);
+    });
+
+    // Embed block handlers (viewer)
+    const embedBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="embedBlock"]'));
+    embedBlocks.forEach((block) => {
+      const url = block.getAttribute('data-url') ?? '';
+      if (!url) return;
+      const { type, embedUrl } = detectEmbedService(url);
+      block.innerHTML = '';
+      if (type === 'youtube') {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'aspect-video w-full overflow-hidden rounded-xl border border-border';
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.title = 'YouTube video';
+        iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.allowFullscreen = true;
+        iframe.className = 'h-full w-full';
+        wrapper.appendChild(iframe);
+        block.appendChild(wrapper);
+      } else if (type === 'figma') {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'h-[480px] w-full overflow-hidden rounded-xl border border-border';
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.title = 'Figma embed';
+        iframe.allow = 'fullscreen';
+        iframe.allowFullscreen = true;
+        iframe.className = 'h-full w-full';
+        wrapper.appendChild(iframe);
+        block.appendChild(wrapper);
+      } else {
+        const a = document.createElement('a');
+        a.href = url;
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.className = 'flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 text-sm transition-colors hover:bg-muted/40 no-underline';
+        a.textContent = url;
+        block.appendChild(a);
+      }
     });
 
     // File attachment download handlers (viewer)

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -23,6 +23,7 @@ import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { FileAttachmentNode } from './extensions/file-node';
+import { EmbedBlock } from './extensions/embed-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -116,6 +117,7 @@ export function DocEditor({
       ToggleSummary,
       ToggleContent,
       FileAttachmentNode,
+      EmbedBlock,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/extensions/embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/embed-node.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { ExternalLink, Link2 } from 'lucide-react';
+
+// ─── URL Helpers ──────────────────────────────────────────────────────────────
+
+type EmbedService = 'youtube' | 'figma' | 'fallback';
+
+interface EmbedInfo {
+  type: EmbedService;
+  embedUrl: string;
+}
+
+export function detectEmbedService(url: string): EmbedInfo {
+  try {
+    const parsed = new URL(url);
+    if (!['https:', 'http:'].includes(parsed.protocol)) return { type: 'fallback', embedUrl: url };
+
+    // YouTube
+    const ytVideoId =
+      parsed.hostname.includes('youtube.com')
+        ? (parsed.searchParams.get('v') ?? null)
+        : parsed.hostname === 'youtu.be'
+          ? parsed.pathname.slice(1)
+          : null;
+    if (ytVideoId) {
+      return { type: 'youtube', embedUrl: `https://www.youtube.com/embed/${ytVideoId}` };
+    }
+    if (parsed.hostname.includes('youtube.com') && parsed.pathname.startsWith('/embed/')) {
+      return { type: 'youtube', embedUrl: url };
+    }
+
+    // Figma
+    if (
+      parsed.hostname.includes('figma.com') &&
+      /^\/(file|design|proto)\//.test(parsed.pathname)
+    ) {
+      return {
+        type: 'figma',
+        embedUrl: `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`,
+      };
+    }
+  } catch { /* invalid URL */ }
+
+  return { type: 'fallback', embedUrl: url };
+}
+
+// ─── Embed View ───────────────────────────────────────────────────────────────
+
+function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
+  const url = (node.attrs.url as string) ?? '';
+  const [editUrl, setEditUrl] = useState(url);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { setEditUrl(url); }, [url]);
+
+  const applyUrl = useCallback(() => {
+    const trimmed = editUrl.trim();
+    if (trimmed) updateAttributes({ url: trimmed });
+  }, [editUrl, updateAttributes]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') { e.preventDefault(); applyUrl(); }
+    if (e.key === 'Escape') setEditUrl(url);
+  }, [applyUrl, url]);
+
+  const { type, embedUrl } = detectEmbedService(url);
+
+  return (
+    <NodeViewWrapper as="div" className="my-4 not-prose" contentEditable={false}>
+      {/* URL editor — visible when block is selected */}
+      {selected && (
+        <div className="mb-2 flex items-center gap-2 rounded-xl border border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/6 px-3 py-2">
+          <Link2 className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+          <input
+            ref={inputRef}
+            value={editUrl}
+            onChange={(e) => setEditUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={applyUrl}
+            placeholder="URL 입력 후 Enter"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-[color:var(--operator-muted)]/60"
+          />
+        </div>
+      )}
+
+      {/* Embed content */}
+      {url ? (
+        <>
+          {type === 'youtube' && (
+            <div className="aspect-video w-full overflow-hidden rounded-xl border border-border">
+              <iframe
+                src={embedUrl}
+                title="YouTube video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                className="h-full w-full"
+              />
+            </div>
+          )}
+          {type === 'figma' && (
+            <div className="h-[480px] w-full overflow-hidden rounded-xl border border-border">
+              <iframe
+                src={embedUrl}
+                title="Figma embed"
+                allow="fullscreen"
+                allowFullScreen
+                className="h-full w-full"
+              />
+            </div>
+          )}
+          {type === 'fallback' && (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 text-sm transition-colors hover:bg-muted/40"
+            >
+              <ExternalLink className="size-4 flex-shrink-0 text-[color:var(--operator-muted)]" />
+              <span className="min-w-0 flex-1 truncate text-[color:var(--operator-foreground)]/80">{url}</span>
+            </a>
+          )}
+        </>
+      ) : (
+        <div className="flex items-center gap-2 rounded-xl border border-dashed border-border px-4 py-4 text-sm text-[color:var(--operator-muted)]">
+          <Link2 className="size-4" />
+          <span>블록을 선택해 URL을 입력하세요</span>
+        </div>
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+
+export const EmbedBlock = Node.create({
+  name: 'embedBlock',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      url: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="embedBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { url, ...rest } = HTMLAttributes as Record<string, unknown>;
+    return ['div', mergeAttributes({ 'data-type': 'embedBlock', 'data-url': url }, rest)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(EmbedView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -29,6 +29,7 @@ import {
   GitBranch,
   ChevronRight,
   Paperclip,
+  Globe,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -176,6 +177,18 @@ export const slashMenuCategories: SlashMenuCategory[] = [
             });
           };
           input.click();
+        },
+      },
+      {
+        title: 'Embed',
+        description: '외부 URL 임베드',
+        icon: Globe,
+        command: (editor, range) => {
+          const url = window.prompt('임베드할 URL을 입력하세요 (YouTube, Figma 등):');
+          editor.chain().focus().deleteRange(range).run();
+          if (url?.trim()) {
+            editor.commands.insertContent({ type: 'embedBlock', attrs: { url: url.trim() } });
+          }
         },
       },
       {

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,20 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve embed blocks as raw HTML
+turndown.addRule('embedBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'embedBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const url = safeAttr(el.getAttribute('data-url') ?? '');
+    return `\n<div data-type="embedBlock" data-url="${url}"></div>\n`;
+  },
+});
+
 // Preserve file attachment blocks as raw HTML
 turndown.addRule('fileAttachment', {
   filter: (node) =>
@@ -186,6 +200,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Embed blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="embedBlock"[^\n]*><\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;


### PR DESCRIPTION
## 변경 사항

### D3-3: 외부 임베드 블록

**신규 파일**
- `extensions/embed-node.tsx` — EmbedBlock
  - `detectEmbedService(url)`: YouTube / Figma / fallback 감지
  - YouTube: `/embed/VIDEO_ID` iframe (16:9 aspect-video)
  - Figma: `figma.com/embed?...` iframe (480px)
  - Fallback: 링크 카드 (`<a>` + ExternalLink 아이콘)
  - 선택 시 URL 편집 인풋 노출 (Enter 적용, Blur 자동 저장)

**수정 파일**
- `slash-command.tsx`: '미디어' 카테고리에 Embed 항목 추가 (Globe 아이콘, prompt 입력)
- `doc-editor.tsx`: EmbedBlock extension 추가
- `content-converter.ts`: `embedBlock` Turndown 룰 + markdownToHtml atom 보호
- `doc-content-renderer.tsx`: 뷰어에서 `[data-type="embedBlock"]` 쿼리 → DOM 빌드

## AC 체크리스트

- [x] AC1: 슬래시 메뉴 "Embed" → URL 입력 → 임베드 블록 삽입
- [x] AC2: YouTube URL → 16:9 iframe 플레이어
- [x] AC3: Figma URL → 480px iframe 뷰어
- [x] AC4: 지원되지 않는 URL → 링크 카드 fallback
- [x] AC5: 블록 선택 시 URL 편집 인풋 표시 → Enter/Blur 적용
- [x] AC6: doc-content-renderer 뷰어에서 정상 렌더링

## 빌드

- `pnpm build` ✅
- TypeScript 에러 없음 ✅
- lint 에러 0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)