### PR TITLE
[SID:D3-4] KaTeX 수식 블록 — 블록 + 인라인 수식

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
     "jose": "^6.2.3",
+    "katex": "^0.16.47",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.15.0",
     "next": "16.2.2",

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
 import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
 import { detectEmbedService } from './extensions/embed-node';
+import { renderKatex } from './extensions/math-node';
 import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
@@ -101,6 +102,33 @@ export function DocContentRenderer({
 
       button.addEventListener('click', handleClick);
       return () => button.removeEventListener('click', handleClick);
+    });
+
+    // Math block rendering (viewer)
+    const mathBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="mathBlock"]'));
+    mathBlocks.forEach((block) => {
+      const latex = block.getAttribute('data-latex') ?? block.textContent ?? '';
+      if (!latex.trim()) return;
+      void renderKatex(latex, true).then(({ html: katexHtml, error }) => {
+        if (error) {
+          block.innerHTML = `<div class="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">${escapeHtmlText(error)}</div>`;
+        } else {
+          block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-[color:var(--operator-foreground)]">${katexHtml}</div>`;
+        }
+      });
+    });
+
+    const mathInlines = Array.from(root.querySelectorAll<HTMLElement>('[data-type="mathInline"]'));
+    mathInlines.forEach((span) => {
+      const latex = span.textContent ?? '';
+      if (!latex.trim()) return;
+      void renderKatex(latex, false).then(({ html: katexHtml, error }) => {
+        if (error) {
+          span.className = 'rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono';
+        } else {
+          span.innerHTML = katexHtml;
+        }
+      });
     });
 
     // Embed block handlers (viewer)

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -24,6 +24,7 @@ import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
+import { MathBlockNode, MathInlineNode } from './extensions/math-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -118,6 +119,8 @@ export function DocEditor({
       ToggleContent,
       FileAttachmentNode,
       EmbedBlock,
+      MathBlockNode,
+      MathInlineNode,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/extensions/math-node.tsx
+++ b/apps/web/src/components/docs/extensions/math-node.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Node, Mark, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+
+// ─── KaTeX Renderer ───────────────────────────────────────────────────────────
+
+async function renderKatex(latex: string, displayMode: boolean): Promise<{ html: string; error?: string }> {
+  try {
+    const katex = await import('katex');
+    const html = katex.default.renderToString(latex, {
+      displayMode,
+      throwOnError: true,
+      output: 'html',
+    });
+    return { html };
+  } catch (err) {
+    return { html: '', error: err instanceof Error ? err.message : 'KaTeX 렌더링 실패' };
+  }
+}
+
+// ─── Math Block View (display mode) ──────────────────────────────────────────
+
+function MathBlockView({ node, selected }: ReactNodeViewProps) {
+  const latex = node.textContent;
+  const [html, setHtml] = useState('');
+  const [error, setError] = useState('');
+  const showEdit = selected;
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!latex.trim()) {
+        setHtml('');
+        setError('');
+        return;
+      }
+      const { html: rendered, error: err } = await renderKatex(latex, true);
+      if (cancelled) return;
+      if (err) { setError(err); setHtml(''); } else { setHtml(rendered); setError(''); }
+    })();
+    return () => { cancelled = true; };
+  }, [latex]);
+
+  return (
+    <NodeViewWrapper as="div" className="my-4 not-prose">
+      <div className="rounded-xl border border-border bg-muted/10">
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2" contentEditable={false}>
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[color:var(--operator-muted)]">math</span>
+          {selected && (
+            <span className="text-[11px] text-[color:var(--operator-muted)]">LaTeX 편집 중</span>
+          )}
+        </div>
+
+        {/* LaTeX editor — visible when selected */}
+        <pre className={`border-t border-border/50 p-4 text-[13px] leading-6 text-[color:var(--operator-foreground)] font-mono ${showEdit ? '' : 'hidden'}`}>
+          <NodeViewContent />
+        </pre>
+
+        {/* KaTeX preview */}
+        {!showEdit && (
+          <div className="px-4 pb-4" contentEditable={false}>
+            {error ? (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">{error}</div>
+            ) : html ? (
+              <div
+                dangerouslySetInnerHTML={{ __html: html }}
+                className="flex justify-center overflow-x-auto [&_.katex]:text-[color:var(--operator-foreground)]"
+              />
+            ) : (
+              <p className="text-xs text-[color:var(--operator-muted)] text-center">수식을 입력하세요 (LaTeX)</p>
+            )}
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Math Inline View ────────────────────────────────────────────────────────
+
+function MathInlineView({ node }: ReactNodeViewProps) {
+  const latex = node.textContent;
+  const [html, setHtml] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!latex.trim()) return;
+    let cancelled = false;
+    void renderKatex(latex, false).then(({ html: rendered, error: err }) => {
+      if (cancelled) return;
+      if (err) { setError(err); setHtml(''); } else { setHtml(rendered); setError(''); }
+    });
+    return () => { cancelled = true; };
+  }, [latex]);
+
+  if (error) {
+    return (
+      <NodeViewWrapper as="span" className="rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono">
+        {latex}
+      </NodeViewWrapper>
+    );
+  }
+
+  if (html) {
+    return (
+      <NodeViewWrapper as="span" contentEditable={false}>
+        <span
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="[&_.katex]:text-[color:var(--operator-foreground)]"
+        />
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper as="span" className="rounded bg-muted/40 px-1 font-mono text-[0.9em]">
+      <NodeViewContent />
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definitions ─────────────────────────────────────────────────────────
+
+export const MathBlockNode = Node.create({
+  name: 'mathBlock',
+  group: 'block',
+  content: 'text*',
+  marks: '',
+  code: true,
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="mathBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const latex = (HTMLAttributes as Record<string, unknown>)['data-latex'] as string ?? '';
+    return ['div', mergeAttributes({ 'data-type': 'mathBlock', 'data-latex': latex }, HTMLAttributes), 0];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-m': () => this.editor.commands.insertContent({
+        type: this.name,
+        content: [{ type: 'text', text: '' }],
+      }),
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathBlockView);
+  },
+});
+
+export const MathInlineNode = Node.create({
+  name: 'mathInline',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  content: 'text*',
+  marks: '',
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="mathInline"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-type': 'mathInline' }, HTMLAttributes), 0];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-e': () => this.editor.commands.insertContent({
+        type: this.name,
+        content: [{ type: 'text', text: '' }],
+      }),
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathInlineView);
+  },
+});
+
+// ─── Viewer helper ────────────────────────────────────────────────────────────
+
+export { renderKatex };

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -30,6 +30,7 @@ import {
   ChevronRight,
   Paperclip,
   Globe,
+  Sigma,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -212,6 +213,26 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Math Block',
+        description: 'LaTeX 블록 수식',
+        icon: Sigma,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'mathBlock',
+            content: [{ type: 'text', text: 'E = mc^2' }],
+          }).run(),
+      },
+      {
+        title: 'Math Inline',
+        description: 'LaTeX 인라인 수식',
+        icon: Sigma,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'mathInline',
+            content: [{ type: 'text', text: 'x^2' }],
+          }).run(),
+      },
       {
         title: 'Toggle',
         description: '접기/펼치기 블록',

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,34 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve math block nodes as raw HTML
+turndown.addRule('mathBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'mathBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const latex = el.textContent ?? '';
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `\n<div data-type="mathBlock" data-latex="${safeAttr(latex)}">${safeAttr(latex)}</div>\n`;
+  },
+});
+
+// Preserve math inline nodes as raw HTML
+turndown.addRule('mathInline', {
+  filter: (node) =>
+    node.nodeName === 'SPAN' &&
+    (node as HTMLElement).getAttribute('data-type') === 'mathInline',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const latex = el.textContent ?? '';
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `<span data-type="mathInline">${safeAttr(latex)}</span>`;
+  },
+});
+
 // Preserve embed blocks as raw HTML
 turndown.addRule('embedBlock', {
   filter: (node) =>
@@ -200,6 +228,18 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Math blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="mathBlock"[^\n]*<\/div>$/gm, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Math inline — protect span tags
+  html = html.replace(/<span data-type="mathInline">[^<]*<\/span>/g, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      katex:
+        specifier: ^0.16.47
+        version: 0.16.47
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)


### PR DESCRIPTION
D3-4: KaTeX 수식 블록 구현. MathBlockNode + MathInlineNode, 슬래시 메뉴, 뷰어 렌더링, round-trip 보존. 빌드/lint ✅