### PR TITLE
[SID:D3-5] 컬럼 레이아웃 — 2/3단 분할 블록

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -322,6 +322,17 @@
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
+/* ─── Column layout ─── */
+[data-type="columnsBlock"] > [data-type="columnBlock"],
+.tiptap [data-type="columnsBlock"] > .contents > [data-type="columnBlock"] { min-width: 0; }
+[data-type="columnBlock"] { min-width: 0; padding: 0.5rem; border-radius: 0.5rem; border: 1px solid transparent; }
+[data-type="columnBlock"]:focus-within { border-color: hsl(var(--border)); }
+/* Viewer grid (no NodeViewContent wrapper) */
+[data-type="columnsBlock"] { display: grid; gap: 1rem; }
+[data-type="columnsBlock"][data-cols="2"] { grid-template-columns: repeat(2, 1fr); }
+[data-type="columnsBlock"][data-cols="3"] { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 640px) { [data-type="columnsBlock"] { grid-template-columns: 1fr !important; } }
+
 /* ─── Toggle block ─── */
 [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"],
 .tiptap [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"] { display: none; }

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -25,6 +25,7 @@ import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-b
 import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
 import { MathBlockNode, MathInlineNode } from './extensions/math-node';
+import { ColumnsBlock, ColumnBlock } from './extensions/column-layout';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -121,6 +122,8 @@ export function DocEditor({
       EmbedBlock,
       MathBlockNode,
       MathInlineNode,
+      ColumnsBlock,
+      ColumnBlock,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/extensions/column-layout.tsx
+++ b/apps/web/src/components/docs/extensions/column-layout.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { Columns2, Columns3 } from 'lucide-react';
+
+// ─── Columns Block View ───────────────────────────────────────────────────────
+
+function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeViewProps) {
+  const cols = (node.attrs.columns as number) ?? 2;
+
+  const switchTo = useCallback((target: 2 | 3) => {
+    if (typeof getPos !== 'function') return;
+    const pos = getPos();
+    if (pos === undefined) return;
+
+    if (target === 3 && cols === 2) {
+      // Add a new column at the end
+      editor.commands.command(({ tr }) => {
+        const { schema } = editor;
+        const insertPos = pos + node.nodeSize - 1;
+        const colNode = schema.nodes['columnBlock']?.create(null, schema.nodes['paragraph']?.create());
+        if (!colNode) return false;
+        tr.insert(insertPos, colNode);
+        tr.setNodeMarkup(pos, undefined, { columns: 3 });
+        return true;
+      });
+    } else if (target === 2 && cols === 3) {
+      // Remove last column
+      editor.commands.command(({ tr }) => {
+        const lastChild = node.lastChild;
+        if (!lastChild) return false;
+        const lastColEnd = pos + node.nodeSize - 1;
+        const lastColStart = lastColEnd - lastChild.nodeSize;
+        tr.delete(lastColStart, lastColEnd);
+        tr.setNodeMarkup(pos, undefined, { columns: 2 });
+        return true;
+      });
+    } else {
+      updateAttributes({ columns: target });
+    }
+  }, [cols, editor, getPos, node, updateAttributes]);
+
+  const gridClass = cols === 3
+    ? 'grid grid-cols-1 sm:grid-cols-3 gap-4'
+    : 'grid grid-cols-1 sm:grid-cols-2 gap-4';
+
+  return (
+    <NodeViewWrapper as="div" className="not-prose my-4 group">
+      {/* Column switcher — visible on hover */}
+      <div
+        contentEditable={false}
+        className="mb-1.5 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+      >
+        <span className="text-[10px] uppercase tracking-widest text-[color:var(--operator-muted)] mr-1">컬럼</span>
+        <button
+          type="button"
+          onClick={() => switchTo(2)}
+          className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
+            cols === 2
+              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+          }`}
+        >
+          <Columns2 className="size-3" />2단
+        </button>
+        <button
+          type="button"
+          onClick={() => switchTo(3)}
+          className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
+            cols === 3
+              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+          }`}
+        >
+          <Columns3 className="size-3" />3단
+        </button>
+      </div>
+
+      {/* Grid wrapper — NodeViewContent renders columnBlock children directly */}
+      <div className={gridClass}>
+        <NodeViewContent as="div" className="contents" />
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definitions ─────────────────────────────────────────────────────────
+
+export const ColumnBlock = Node.create({
+  name: 'columnBlock',
+  content: 'block+',
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="columnBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'columnBlock' }, HTMLAttributes), 0];
+  },
+});
+
+export const ColumnsBlock = Node.create({
+  name: 'columnsBlock',
+  group: 'block',
+  content: 'columnBlock+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      columns: {
+        default: 2,
+        parseHTML: (el) => Number(el.getAttribute('data-cols') ?? 2),
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          'data-cols': String(attributes['columns'] ?? 2),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="columnsBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'columnsBlock' }, HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ColumnsBlockView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -31,6 +31,7 @@ import {
   Paperclip,
   Globe,
   Sigma,
+  Columns2,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -213,6 +214,20 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Columns',
+        description: '2단/3단 컬럼 레이아웃',
+        icon: Columns2,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'columnsBlock',
+            attrs: { columns: 2 },
+            content: [
+              { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+              { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+            ],
+          }).run(),
+      },
       {
         title: 'Math Block',
         description: 'LaTeX 블록 수식',

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,21 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve columns block as raw HTML
+turndown.addRule('columnsBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'columnsBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const cols = el.getAttribute('data-cols') ?? '2';
+    const columnsHtml = Array.from(el.querySelectorAll('[data-type="columnBlock"]'))
+      .map((col) => `<div data-type="columnBlock">${(col as HTMLElement).innerHTML}</div>`)
+      .join('');
+    return `\n<div data-type="columnsBlock" data-cols="${cols}">${columnsHtml}</div>\n`;
+  },
+});
+
 // Preserve math block nodes as raw HTML
 turndown.addRule('mathBlock', {
   filter: (node) =>
@@ -228,6 +243,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Columns blocks — may span multiple lines, protect by start tag
+  html = html.replace(/^<div data-type="columnsBlock"[\s\S]*?<\/div>\s*<\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;


### PR DESCRIPTION
D3-5: 2/3단 컬럼 레이아웃. ColumnsBlock(ReactNodeView, hover UI) + ColumnBlock(block+). CSS grid, 반응형(sm:grid-cols-1), round-trip 보존. 빌드/lint ✅