### PR TITLE
[SID:D3-6] TOC 사이드패널 — 목차 자동 생성 + 스무스 스크롤

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
+import { DocToc } from '@/components/docs/doc-toc';
+import { extractDocHeadings } from '@/components/docs/doc-heading-utils';
 import { Button } from '@/components/ui/button';
 import { Edit2 } from 'lucide-react';
 import { useDocsLayout } from '../../docs-context';
@@ -27,6 +29,11 @@ export default function DocViewPage() {
   const { projectId } = useDocsLayout();
 
   const [doc, setDoc] = useState<DocState>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollToHeading = useCallback((id: string) => {
+    contentRef.current?.querySelector<HTMLElement>(`#${CSS.escape(id)}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   useEffect(() => {
     if (!projectId || !slug) return;
@@ -62,16 +69,23 @@ export default function DocViewPage() {
           {/* Inline title (Notion style — same layout as editor) */}
           <div className="mb-6 flex items-start justify-between gap-4">
             <h1 className="flex-1 break-words text-4xl font-bold leading-tight">{doc.title}</h1>
-            <Button asChild size="sm" variant="ghost" className="mt-1 flex-shrink-0">
-              <Link href={`/docs/${slug}`}>
-                <Edit2 className="mr-1.5 h-3.5 w-3.5" />
-                {t('editDoc')}
-              </Link>
-            </Button>
+            <div className="mt-1 flex flex-shrink-0 items-center gap-2">
+              <DocToc
+                headings={extractDocHeadings(doc.content, doc.content_format ?? 'markdown')}
+                onHeadingClick={scrollToHeading}
+              />
+              <Button asChild size="sm" variant="ghost">
+                <Link href={`/docs/${slug}`}>
+                  <Edit2 className="mr-1.5 h-3.5 w-3.5" />
+                  {t('editDoc')}
+                </Link>
+              </Button>
+            </div>
           </div>
           <DocContentRenderer
             content={doc.content}
             contentFormat={doc.content_format ?? 'markdown'}
+            contentRef={contentRef}
             codeCopyLabel={t('codeCopy')}
             codeCopiedLabel={t('codeCopied')}
           />

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useCallback, useRef, useState } from 'react';
-import React from 'react';
+import React, { type RefObject } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
@@ -26,6 +26,8 @@ import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
 import { MathBlockNode, MathInlineNode } from './extensions/math-node';
 import { ColumnsBlock, ColumnBlock } from './extensions/column-layout';
+import { DocToc } from './doc-toc';
+import { type DocHeading, slugifyHeading } from './doc-heading-utils';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -87,6 +89,8 @@ export function DocEditor({
 }) {
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
+  const [tocHeadings, setTocHeadings] = useState<DocHeading[]>([]);
+  const editorContentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!onFileError) return;
@@ -145,6 +149,49 @@ export function DocEditor({
     editor.setEditable(editable);
   }, [editor, editable]);
 
+  // Extract TOC headings from editor + assign IDs to heading DOM elements
+  useEffect(() => {
+    if (!editor) return;
+
+    const update = () => {
+      const counts = new Map<string, number>();
+      const headings: DocHeading[] = [];
+
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'heading') {
+          const text = node.textContent.trim();
+          if (!text) return true;
+          const baseId = slugifyHeading(text);
+          const seen = counts.get(baseId) ?? 0;
+          counts.set(baseId, seen + 1);
+          headings.push({
+            level: node.attrs.level as 1 | 2 | 3,
+            text,
+            id: seen === 0 ? baseId : `${baseId}-${seen + 1}`,
+          });
+        }
+        return true;
+      });
+
+      setTocHeadings(headings);
+
+      // Assign IDs to heading DOM elements
+      const root = editorContentRef.current;
+      if (!root) return;
+      const idCounts = new Map<string, number>();
+      root.querySelectorAll<HTMLElement>('h1, h2, h3').forEach((el) => {
+        const baseId = slugifyHeading(el.textContent ?? '');
+        const seen2 = idCounts.get(baseId) ?? 0;
+        idCounts.set(baseId, seen2 + 1);
+        el.id = seen2 === 0 ? baseId : `${baseId}-${seen2 + 1}`;
+      });
+    };
+
+    update();
+    editor.on('update', update);
+    return () => { editor.off('update', update); };
+  }, [editor]);
+
   useEffect(() => {
     if (!editor) return;
     const currentHtml = editor.getHTML();
@@ -173,6 +220,12 @@ export function DocEditor({
     },
     [contentFormat, onChange],
   );
+
+  const scrollToHeading = useCallback((id: string) => {
+    const root = editorContentRef.current;
+    const el = root?.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   const addLink = useCallback(() => {
     if (!editor) return;
@@ -306,6 +359,8 @@ export function DocEditor({
             </ToolbarButton>
           </div>
         ) : null}
+        {/* TOC — always in toolbar when ≥3 headings */}
+        <DocToc headings={tocHeadings} onHeadingClick={scrollToHeading} />
       </div>
 
       {/* Floating bubble toolbar — visible on text selection in preview mode */}
@@ -377,7 +432,7 @@ export function DocEditor({
           placeholder={labels.placeholder}
         />
       ) : (
-        <div className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3">
+        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3">
           <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
         </div>
       )}

--- a/apps/web/src/components/docs/doc-toc.tsx
+++ b/apps/web/src/components/docs/doc-toc.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { List, X } from 'lucide-react';
+import type { DocHeading } from './doc-heading-utils';
+import { cn } from '@/lib/utils';
+
+interface DocTocProps {
+  headings: DocHeading[];
+  onHeadingClick: (id: string) => void;
+  className?: string;
+}
+
+export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const handleClick = useCallback((id: string) => {
+    onHeadingClick(id);
+    setOpen(false);
+  }, [onHeadingClick]);
+
+  // AC5: 3개 미만이면 숨김
+  if (headings.length < 3) return null;
+
+  return (
+    <div ref={panelRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
+          open
+            ? 'border-[color:var(--operator-primary)]/50 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+            : 'border-border/60 bg-card text-foreground hover:border-[color:var(--operator-primary)]/50 hover:text-[color:var(--operator-primary-soft)]'
+        }`}
+        title="목차"
+      >
+        <List className="size-3.5" />
+        <span>목차</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1.5 w-64 overflow-hidden rounded-xl border border-border bg-background shadow-lg">
+          <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
+            <span className="text-xs font-semibold text-[color:var(--operator-foreground)]">목차</span>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded p-0.5 text-[color:var(--operator-muted)] hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+          <nav className="max-h-72 overflow-y-auto py-1.5">
+            {headings.map((heading) => (
+              <button
+                key={heading.id}
+                type="button"
+                onClick={() => handleClick(heading.id)}
+                className={`flex w-full items-start px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted/60 ${
+                  heading.level === 1
+                    ? 'font-semibold text-[color:var(--operator-foreground)]'
+                    : heading.level === 2
+                      ? 'pl-5 text-[color:var(--operator-foreground)]/80'
+                      : 'pl-7 text-[color:var(--operator-muted)]'
+                }`}
+              >
+                <span className="mr-1.5 mt-px flex-shrink-0 text-[color:var(--operator-muted)]">
+                  {heading.level === 1 ? '◆' : heading.level === 2 ? '◇' : '·'}
+                </span>
+                <span className="truncate">{heading.text}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
D3-6: H1/H2/H3 TOC 드롭다운. DocToc 컴포넌트(3개 미만 자동 숨김), 에디터 editor.state에서 실시간 추출, 뷰어(/docs/slug/view) contentRef 연결. 스무스 스크롤. 빌드/lint ✅