### PR TITLE
feat(docs): D4-2 전문 검색 — tsvector GIN 인덱스 + 검색 API + ts_headline 스니펫

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { ChevronDown, ChevronRight, Plus, X, Menu } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, X, Menu, Search, FileText } from 'lucide-react';
 import { DocsShell } from '@/components/docs/docs-shell';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 
@@ -76,6 +76,10 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
   const [docsLoadingMore, setDocsLoadingMore] = useState(false);
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Array<{ id: string; title: string; slug: string; snippet?: string }>>([]);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Always-editable content states
   const [title, setTitle] = useState('');
@@ -134,6 +138,25 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       setDocsLoadingMore(false);
     }
   }, [projectId]);
+
+  // Full-text search with debounce
+  useEffect(() => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    if (!searchQuery.trim() || !projectId) { setSearchResults([]); setSearchLoading(false); return; }
+
+    setSearchLoading(true);
+    searchTimerRef.current = setTimeout(() => {
+      void fetch(`/api/docs?project_id=${projectId}&q=${encodeURIComponent(searchQuery.trim())}&limit=20`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data: { data?: Array<{ id: string; title: string; slug: string; snippet?: string }> } | null) => {
+          setSearchResults(data?.data ?? []);
+        })
+        .catch(() => { setSearchResults([]); })
+        .finally(() => { setSearchLoading(false); });
+    }, 300);
+
+    return () => { if (searchTimerRef.current) clearTimeout(searchTimerRef.current); };
+  }, [searchQuery, projectId]);
 
   const fetchDoc = useCallback(async (slug: string) => {
     if (!projectId) return;
@@ -371,6 +394,29 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   const sidebarContent = (
     <>
+      {/* Full-text search input */}
+      <div className="border-b border-border/60 px-3 py-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[color:var(--operator-muted)]" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="문서 검색..."
+            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-[color:var(--operator-muted)] focus:border-[color:var(--operator-primary)]/40 focus:bg-muted/50"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-[color:var(--operator-muted)] hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+
       {/* Tag filter — AC1 접기/펼치기 */}
       {(() => {
         const allTags = [...new Set(tree.flatMap((d) => (d as unknown as { tags?: string[] | null }).tags ?? []))];
@@ -419,7 +465,37 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         );
       })()}
       <div className="flex-1 overflow-y-auto p-2">
-        {tree.length === 0 ? (
+        {/* Search results */}
+        {searchQuery.trim() ? (
+          searchLoading ? (
+            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 중...</p>
+          ) : searchResults.length === 0 ? (
+            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 결과 없음</p>
+          ) : (
+            <ul className="space-y-1">
+              {searchResults.map((result) => (
+                <li key={result.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectDoc(result.slug)}
+                    className="flex w-full flex-col items-start gap-1 rounded-xl px-3 py-2 text-left transition-colors hover:bg-muted/60"
+                  >
+                    <span className="flex items-center gap-1.5 text-xs font-medium text-[color:var(--operator-foreground)]">
+                      <FileText className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+                      {result.title}
+                    </span>
+                    {result.snippet && (
+                      <span
+                        className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5"
+                        dangerouslySetInnerHTML={{ __html: result.snippet }}
+                      />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : tree.length === 0 ? (
           <EmptyState
             title={t('title')}
             description={t('selectDoc')}

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -443,6 +443,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
               onRename={handleRename}
               onDelete={handleDeleteDoc}
               onAddChild={handleAddChild}
+              projectId={projectId}
             />
             {docsHasMore && (
               <div className="px-2 py-1">

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -486,7 +486,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                     </span>
                     {result.snippet && (
                       <span
-                        className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5"
+                        className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5 [&_b]:rounded [&_b]:bg-yellow-400/40 [&_b]:font-normal [&_b]:text-[color:var(--operator-foreground)] [&_b]:px-0.5"
                         dangerouslySetInnerHTML={{ __html: result.snippet }}
                       />
                     )}

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -78,6 +78,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Array<{ id: string; title: string; slug: string; snippet?: string }>>([]);
+  const sanitizeSnippet = (html: string) =>
+    html.replace(/<(?!\/?(?:b|mark)\b)[^>]+>/gi, '');
   const [searchLoading, setSearchLoading] = useState(false);
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -487,7 +489,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                     {result.snippet && (
                       <span
                         className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5 [&_b]:rounded [&_b]:bg-yellow-400/40 [&_b]:font-normal [&_b]:text-[color:var(--operator-foreground)] [&_b]:px-0.5"
-                        dangerouslySetInnerHTML={{ __html: result.snippet }}
+                        dangerouslySetInnerHTML={{ __html: sanitizeSnippet(result.snippet) }}
                       />
                     )}
                   </button>

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -1,11 +1,49 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, MoreVertical } from 'lucide-react';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
+
+// ─── Preview Card ─────────────────────────────────────────────────────────────
+
+function extractSnippet(content: string, maxChars = 200): string {
+  return content
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#*_`\[\]>~]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxChars);
+}
+
+function DocPreviewCard({ title, snippet, x, y }: { title: string; snippet: string; x: number; y: number }) {
+  const CARD_WIDTH = 280;
+  const CARD_EST_HEIGHT = 120;
+  const GAP = 12;
+
+  const left = x + GAP + CARD_WIDTH > window.innerWidth
+    ? Math.max(8, x - GAP - CARD_WIDTH)
+    : x + GAP;
+  const top = Math.min(y, window.innerHeight - CARD_EST_HEIGHT - 8);
+
+  return createPortal(
+    <div
+      style={{ position: 'fixed', left, top, width: CARD_WIDTH, zIndex: 9999, pointerEvents: 'none' }}
+      className="rounded-xl border border-border bg-background p-3 shadow-lg"
+    >
+      <p className="mb-1 text-xs font-semibold text-[color:var(--operator-foreground)] truncate">{title}</p>
+      {snippet ? (
+        <p className="text-[11px] leading-relaxed text-[color:var(--operator-muted)] line-clamp-4">{snippet}</p>
+      ) : (
+        <p className="text-[11px] text-[color:var(--operator-muted)] opacity-60">내용 없음</p>
+      )}
+    </div>,
+    document.body,
+  );
+}
 
 interface Doc {
   id: string;
@@ -46,6 +84,7 @@ interface DocTreeProps {
   onDelete?: (docId: string) => Promise<void>;
   onAddChild?: (parentId: string) => Promise<void>;
   emptyFolderLabel?: string;
+  projectId?: string;
 }
 
 function TreeNode({
@@ -59,6 +98,7 @@ function TreeNode({
   onAddChild,
   depth = 0,
   emptyFolderLabel = 'No child docs',
+  projectId,
 }: {
   doc: Doc;
   allDocs: Doc[];
@@ -70,6 +110,7 @@ function TreeNode({
   onAddChild?: (parentId: string) => Promise<void>;
   depth?: number;
   emptyFolderLabel?: string;
+  projectId?: string;
 }) {
   const childDocs = allDocs.filter((entry) => entry.parent_id === doc.id).sort((a, b) => a.sort_order - b.sort_order);
   const hasChildren = childDocs.length > 0;
@@ -78,6 +119,32 @@ function TreeNode({
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const isSelected = selectedSlug === doc.slug;
   const menuRef = useRef<HTMLDivElement>(null);
+
+  // Preview state
+  const [preview, setPreview] = useState<{ title: string; snippet: string } | null>(null);
+  const [previewPos, setPreviewPos] = useState({ x: 0, y: 0 });
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback((e: React.MouseEvent) => {
+    const { clientX, clientY } = e;
+    hoverTimerRef.current = setTimeout(() => {
+      if (!projectId) return;
+      void fetch(`/api/docs?project_id=${projectId}&slug=${encodeURIComponent(doc.slug)}&limit=1`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data: { data?: Array<{ title: string; content?: string }> } | null) => {
+          const d = data?.data?.[0];
+          if (!d) return;
+          setPreview({ title: d.title, snippet: extractSnippet(d.content ?? '') });
+          setPreviewPos({ x: clientX, y: clientY });
+        })
+        .catch(() => { /* ignore */ });
+    }, 300);
+  }, [doc.slug, projectId]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current) { clearTimeout(hoverTimerRef.current); hoverTimerRef.current = null; }
+    setPreview(null);
+  }, []);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: doc.id,
@@ -138,9 +205,12 @@ function TreeNode({
   return (
     <div ref={setNodeRef} style={style}>
       <div className="group relative">
+        {preview && <DocPreviewCard title={preview.title} snippet={preview.snippet} x={previewPos.x} y={previewPos.y} />}
         <button
           onClick={handleClick}
           onContextMenu={handleContextMenu}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
           className={cn(
             'flex w-full items-center gap-2 rounded-2xl pl-3 pr-7 py-2 text-left text-[13px] transition-all',
             isSelected
@@ -207,6 +277,7 @@ function TreeNode({
                   onAddChild={onAddChild}
                   depth={depth + 1}
                   emptyFolderLabel={emptyFolderLabel}
+                  projectId={projectId}
                 />
               ))}
             </SortableContext>
@@ -224,7 +295,7 @@ function TreeNode({
   );
 }
 
-export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel }: DocTreeProps) {
+export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel, projectId }: DocTreeProps) {
   const rootDocs = docs.filter((entry) => !entry.parent_id).sort((a, b) => a.sort_order - b.sort_order);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
@@ -293,7 +364,7 @@ export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMov
       <SortableContext items={rootDocs.map((d) => d.id)} strategy={verticalListSortingStrategy}>
         <nav className="space-y-1">
           {rootDocs.map((doc) => (
-            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} />
+            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} projectId={projectId} />
           ))}
         </nav>
       </SortableContext>

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -165,8 +165,7 @@ export class DocsService {
       if (error) throw error;
       return data;
     }
-    // OSS: title-only search via list (content search not supported in SQLite repo)
-    const all = await this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined });
-    return all.filter((d) => d.title.toLowerCase().includes(query.toLowerCase()));
+    // OSS / API: pass q to repo.list which forwards to FastAPI search_full_text()
+    return this.repo.list({ project_id: projectId, q: query, limit: input?.limit, cursor: input?.cursor ?? undefined, tags: input?.tags });
   }
 }

--- a/backend/alembic/versions/0047_add_docs_tsvector.py
+++ b/backend/alembic/versions/0047_add_docs_tsvector.py
@@ -1,0 +1,32 @@
+"""docs 테이블 tsvector 컬럼 + GIN 인덱스 추가 (D4-2 전문 검색)
+
+Revision ID: 0047
+Revises: 0046
+"""
+from alembic import op
+
+revision = "0047"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE docs
+        ADD COLUMN IF NOT EXISTS search_vector TSVECTOR
+        GENERATED ALWAYS AS (
+            to_tsvector('simple',
+                coalesce(title, '') || ' ' || coalesce(content, ''))
+        ) STORED
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_docs_search_vector ON docs USING GIN(search_vector)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_docs_search_vector")
+    op.execute("ALTER TABLE docs DROP COLUMN IF EXISTS search_vector")

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -1,9 +1,11 @@
 import uuid
 from datetime import datetime
-from typing import List
+from typing import Any, List
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from typing import Any
+
+from sqlalchemy import Computed, DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -34,6 +36,14 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     doc_type: Mapped[str] = mapped_column(Text, nullable=False, default="page")
     content_format: Mapped[str] = mapped_column(Text, nullable=False, default="markdown")
     tags: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    search_vector: Mapped[Any] = mapped_column(
+        TSVECTOR,
+        Computed(
+            "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(content, ''))",
+            persisted=True,
+        ),
+        nullable=True,
+    )
 
     children: Mapped[list["Doc"]] = relationship("Doc", back_populates="parent", lazy="select")
     parent: Mapped["Doc | None"] = relationship("Doc", back_populates="children", remote_side=[id])

--- a/backend/app/repositories/doc.py
+++ b/backend/app/repositories/doc.py
@@ -62,3 +62,31 @@ class DocRepository(BaseRepository[Doc]):
         ).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
+
+    async def search_full_text(
+        self, project_id: uuid.UUID, query: str, limit: int = 50
+    ) -> list[tuple[Doc, str | None]]:
+        """tsvector 기반 전문 검색. ts_rank 내림차순. snippet 포함."""
+        from sqlalchemy import func, literal_column
+
+        tsquery = func.plainto_tsquery("simple", query)
+        snippet_expr = func.ts_headline(
+            "simple",
+            Doc.content,
+            tsquery,
+            literal_column("'MaxWords=30, MinWords=15, ShortWord=3, MaxFragments=1'"),
+        )
+
+        stmt = (
+            select(Doc, snippet_expr.label("snippet"))
+            .where(
+                self._org_filter(),
+                Doc.project_id == project_id,
+                Doc.deleted_at.is_(None),
+                Doc.search_vector.op("@@")(tsquery),
+            )
+            .order_by(func.ts_rank(Doc.search_vector, tsquery).desc())
+            .limit(limit)
+        )
+        result = await self.session.execute(stmt)
+        return [(row.Doc, row.snippet) for row in result]

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -30,9 +30,18 @@ async def list_docs(
     doc_type: str | None = Query(default=None),
     tags: str | None = Query(default=None, description="comma-separated tags"),
     slug: str | None = Query(default=None),
+    q: str | None = Query(default=None, description="전문 검색 — 제목 + 본문"),
     limit: int = Query(default=500, ge=1, le=1000),
     repo: DocRepository = Depends(_get_repo),
 ) -> list[DocSummaryResponse]:
+    # AC1 + AC3: 전문 검색 — project_id 필수
+    if q and project_id:
+        results = await repo.search_full_text(project_id, q.strip(), limit=min(limit, 50))
+        return [
+            DocSummaryResponse.model_validate(doc).model_copy(update={"snippet": snippet})
+            for doc, snippet in results
+        ]
+
     if slug and project_id:
         doc = await repo.get_by_slug(project_id, slug)
         return [DocSummaryResponse.model_validate(doc)] if doc else []

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -47,6 +47,7 @@ class DocSummaryResponse(BaseModel):
     is_folder: bool
     tags: list[str]
     updated_at: datetime
+    snippet: str | None = None
 
 
 class DocResponse(BaseModel):

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -61,6 +61,7 @@ export interface UpdateDocInput {
 export interface DocListFilters extends PaginationOptions {
   project_id: string;
   tags?: string[];
+  q?: string;
 }
 
 export interface IDocRepository {

--- a/packages/storage-api/src/SupabaseDocRepository.ts
+++ b/packages/storage-api/src/SupabaseDocRepository.ts
@@ -11,6 +11,7 @@ export class SupabaseDocRepository implements IDocRepository {
         limit: filters.limit,
         cursor: filters.cursor ?? undefined,
         tags: filters.tags?.join(','),
+        q: filters.q,
       },
     });
   }


### PR DESCRIPTION
## Summary
- Alembic migration 0047: `docs.search_vector` TSVECTOR GENERATED ALWAYS STORED + GIN 인덱스
- `GET /api/v2/docs?q=검색어&project_id=...` 전문 검색 지원 (기존 `q` 파라미터 확장)
- `DocSummaryResponse.snippet` 추가 — `ts_headline` 기반 매칭 스니펫 반환
- dev 환경 migration 0047 적용 완료 ✅

## AC 체크
- [x] AC2: docs 테이블 search_vector TSVECTOR GENERATED STORED + idx_docs_search_vector GIN 인덱스
- [x] AC1: `/api/v2/docs?q=` 전문 검색 파라미터 추가 (plainto_tsquery, ts_rank 정렬)
- [x] AC3: `snippet` 필드 ts_headline 기반 스니펫 반환

## Test plan
- [ ] `GET /api/v2/docs?q=<검색어>&project_id=<uuid>` 검색 결과 + snippet 확인
- [ ] 기존 목록/태그/슬러그 조회 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)