### PR TITLE
[P0] wiki-link Suggestion pluginKey 충돌 해소 — 에디터 크래시 수정

### DIFF
--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import { PluginKey } from '@tiptap/pm/state';
 import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
 import { createRoot, type Root } from 'react-dom/client';
 import { FileText, AlertCircle } from 'lucide-react';
@@ -121,6 +122,7 @@ export const WikiLinkNode = Node.create<WikiLinkOptions>({
     return [
       Suggestion({
         editor: this.editor,
+        pluginKey: new PluginKey('wikiLinkSuggestion'),
         ...this.options.suggestion,
       }),
     ];


### PR DESCRIPTION
P0: wiki-link.tsx Suggestion에 pluginKey 지정 미기로 SlashCommand와 충돌 → 에디터 크래시. new PluginKey('wikiLinkSuggestion') 지정. 빌드 ✅