### PR TITLE
Prod Promotion: E-DOCS-UPGRADE 에픽 전량 완주 (61 SP, 20 PRs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY packages/shared/package.json packages/shared/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/sdk/package.json packages/sdk/package.json
 COPY packages/storage-api/package.json packages/storage-api/package.json
+COPY packages/cli/package.json packages/cli/package.json
 COPY ee/packages/storage-saas/package.json ee/packages/storage-saas/package.json
 RUN pnpm install --frozen-lockfile --ignore-scripts
 

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1110,6 +1110,8 @@
     "advancedOptions": "Advanced options",
     "preview": "Preview",
     "editDoc": "Edit",
+    "copyMarkdown": "Copy Markdown",
+    "deleteDoc": "Delete",
     "notFound": "Document not found"
   },
   "rewards": {

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1112,6 +1112,7 @@
     "editDoc": "Edit",
     "copyMarkdown": "Copy Markdown",
     "deleteDoc": "Delete",
+    "createFailed": "Failed to create document",
     "notFound": "Document not found"
   },
   "rewards": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1112,6 +1112,7 @@
     "editDoc": "편집",
     "copyMarkdown": "마크다운 복사",
     "deleteDoc": "삭제",
+    "createFailed": "문서 생성에 실패했습니다",
     "notFound": "문서를 찾을 수 없는"
   },
   "rewards": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1110,6 +1110,8 @@
     "advancedOptions": "고급 옵션",
     "preview": "미리보기",
     "editDoc": "편집",
+    "copyMarkdown": "마크다운 복사",
+    "deleteDoc": "삭제",
     "notFound": "문서를 찾을 수 없는"
   },
   "rewards": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,7 +24,9 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@sprintable/core-storage": "workspace:*",
     "@sprintable/storage-api": "workspace:*",
-"@tiptap/core": "^3.22.3",
+    "@tiptap/core": "^3.22.3",
+    "@tiptap/extension-bubble-menu": "^3.22.3",
+    "@tiptap/extension-highlight": "3.22.3",
     "@tiptap/extension-image": "^3.22.3",
     "@tiptap/extension-link": "^3.22.3",
     "@tiptap/extension-placeholder": "^3.22.3",
@@ -47,6 +49,7 @@
     "next": "16.2.2",
     "next-intl": "^4.9.0",
     "next-themes": "^0.4.6",
+    "qrcode.react": "^4.2.0",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "react-markdown": "^10.1.0",
@@ -57,7 +60,6 @@
     "tailwind-merge": "^3.5.0",
     "turndown": "^7.2.4",
     "tw-animate-css": "^1.4.0",
-    "qrcode.react": "^4.2.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -34,6 +34,8 @@
     "@tiptap/extension-table-cell": "^3.22.3",
     "@tiptap/extension-table-header": "^3.22.3",
     "@tiptap/extension-table-row": "^3.22.3",
+    "@tiptap/extension-task-item": "3.22.3",
+    "@tiptap/extension-task-list": "3.22.3",
     "@tiptap/pm": "^3.22.3",
     "@tiptap/react": "^3.22.3",
     "@tiptap/starter-kit": "^3.22.3",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -47,6 +47,7 @@
     "dompurify": "^3.3.3",
     "framer-motion": "^12.38.0",
     "jose": "^6.2.3",
+    "katex": "^0.16.47",
     "lucide-react": "^1.7.0",
     "mermaid": "^11.15.0",
     "next": "16.2.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,7 @@
     "framer-motion": "^12.38.0",
     "jose": "^6.2.3",
     "lucide-react": "^1.7.0",
+    "mermaid": "^11.15.0",
     "next": "16.2.2",
     "next-intl": "^4.9.0",
     "next-themes": "^0.4.6",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -59,6 +59,7 @@
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
+    "shiki": "^4.1.0",
     "tailwind-merge": "^3.5.0",
     "turndown": "^7.2.4",
     "tw-animate-css": "^1.4.0",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
@@ -59,13 +59,15 @@ export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const isNew = searchParams.get('new') === '1';
   const t = useTranslations('docs');
+  // 신규 문서 자동 포커스: URL ?new=1 파라미터를 ref로 처리 (useSearchParams Suspense 이슈 방지)
+  const isNewRef = useRef(typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('new') === '1');
+  const isNew = isNewRef.current;
 
   const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
 
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
+  const [docLoading, setDocLoading] = useState(true);
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [contentFormat, setContentFormat] = useState<'markdown' | 'html'>('markdown');
@@ -94,16 +96,27 @@ export default function DocSlugPage() {
 
   const fetchDoc = useCallback(async () => {
     if (!projectId || !slug) return;
+    setDocLoading(true);
     try {
       const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`);
-      if (!res.ok) throw new Error('Failed to fetch doc');
-      const { data } = await res.json();
+      if (!res.ok) {
+        setSelectedDoc(null);
+        return;
+      }
+      const json = await res.json();
+      const data = json?.data ?? null;
+      if (!data) {
+        setSelectedDoc(null);
+        return;
+      }
       setSelectedDoc(data);
-      setTitle(data.title);
-      setContent(data.content);
-      setContentFormat(data.content_format || 'markdown');
+      setTitle(data.title ?? '');
+      setContent(data.content ?? '');
+      setContentFormat(data.content_format ?? 'markdown');
     } catch {
       setSelectedDoc(null);
+    } finally {
+      setDocLoading(false);
     }
   }, [projectId, slug]);
 
@@ -142,10 +155,18 @@ export default function DocSlugPage() {
     router.push(`/docs/${targetSlug}`);
   }, [router]);
 
-  if (!selectedDoc) {
+  if (docLoading) {
     return (
       <div className="flex h-full items-center justify-center">
         <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+      </div>
+    );
+  }
+
+  if (!selectedDoc) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">{t('notFound')}</p>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
@@ -59,6 +59,8 @@ export default function DocSlugPage() {
   const params = useParams();
   const slug = typeof params.slug === 'string' ? params.slug : '';
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const isNew = searchParams.get('new') === '1';
   const t = useTranslations('docs');
 
   const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
@@ -215,7 +217,7 @@ export default function DocSlugPage() {
           title={title}
           onTitleChange={handleTitleChange}
           titlePlaceholder={t('titlePlaceholder')}
-          titleAutoFocus={!title}
+          titleAutoFocus={isNew || !title}
           actions={docActions}
           labels={{
             contentFormat: t('contentFormat'),

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -5,10 +5,15 @@ import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import Link from 'next/link';
-import { Check, Copy, Eye, Trash2 } from 'lucide-react';
+import { Check, Copy, Eye, MoreHorizontal, Trash2 } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { useDocsLayout } from '../docs-context';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 
@@ -69,6 +74,12 @@ export default function DocSlugPage() {
     setSelectedDoc(doc);
     setTree((prev) => prev.map((d) => (d.id === doc.id ? { ...d, title: doc.title } : d)));
   }, [setTree]);
+
+  const handleTitleChange = useCallback((value: string) => {
+    setTitle(value);
+    setSelectedDoc((prev) => (prev ? { ...prev, title: value } : null));
+    setTree((prev) => prev.map((d) => (d.id === selectedDoc?.id ? { ...d, title: value } : d)));
+  }, [selectedDoc?.id, setTree]);
 
   const { status: saveStatus, isDirty, save } = useDocSync<DocDetail>({
     docId: selectedDoc?.id ?? null,
@@ -137,38 +148,43 @@ export default function DocSlugPage() {
     );
   }
 
+  const docActions = (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground">
+        <MoreHorizontal className="h-4 w-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        {saveStatus !== 'idle' && (
+          <>
+            <div className="flex items-center px-2 py-1.5">
+              <SaveStatusIndicator status={saveStatus} t={t} />
+            </div>
+            <DropdownMenuSeparator />
+          </>
+        )}
+        <DropdownMenuItem onClick={handleCopyMarkdown}>
+          {mdCopied ? <Check className="mr-2 h-4 w-4 text-emerald-500" /> : <Copy className="mr-2 h-4 w-4" />}
+          {t('copyMarkdown')}
+        </DropdownMenuItem>
+        <DropdownMenuItem render={<Link href={`/docs/${slug}/view`} />}>
+          <Eye className="mr-2 h-4 w-4" />
+          {t('preview')}
+        </DropdownMenuItem>
+        {selectedDoc.doc_type !== 'sprint_report' && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem onClick={handleDelete} className="text-destructive focus:text-destructive">
+              <Trash2 className="mr-2 h-4 w-4" />
+              {t('deleteDoc')}
+            </DropdownMenuItem>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
-        <div className="flex items-center justify-between gap-4">
-          <div className="flex-1 min-w-0">
-            <Input
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="border-none bg-transparent px-0 text-2xl font-semibold focus-visible:ring-0"
-              placeholder={t('titlePlaceholder')}
-            />
-          </div>
-          <div className="flex items-center gap-3">
-            <SaveStatusIndicator status={saveStatus} t={t} />
-            <Button asChild variant="ghost" size="sm" title={t('preview')}>
-              <Link href={`/docs/${slug}/view`}>
-                <Eye className="h-4 w-4" />
-              </Link>
-            </Button>
-            <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
-              {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-            </Button>
-            {selectedDoc.doc_type !== 'sprint_report' && (
-              <Button variant="ghost" size="sm" onClick={handleDelete}>
-                <Trash2 className="h-4 w-4" />
-              </Button>
-            )}
-          </div>
-        </div>
-      </div>
-
       {/* Dispatch */}
       {projectId && (
         <div className="flex-shrink-0 border-b border-border px-4 py-2 lg:px-6">
@@ -196,6 +212,11 @@ export default function DocSlugPage() {
           onSave={save}
           autosave={autosave}
           onAutosaveToggle={setAutosave}
+          title={title}
+          onTitleChange={handleTitleChange}
+          titlePlaceholder={t('titlePlaceholder')}
+          titleAutoFocus={!title}
+          actions={docActions}
           labels={{
             contentFormat: t('contentFormat'),
             markdown: t('formatMarkdown'),

--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -56,22 +56,19 @@ export default function DocViewPage() {
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Header */}
-      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-4">
-        <div className="flex items-center justify-between gap-4">
-          <h1 className="truncate text-xl font-semibold">{doc.title}</h1>
-          <Button asChild size="sm" variant="outline">
-            <Link href={`/docs/${slug}`}>
-              <Edit2 className="mr-1.5 h-3.5 w-3.5" />
-              {t('editDoc')}
-            </Link>
-          </Button>
-        </div>
-      </div>
-
       {/* Content */}
       <div className="flex-1 overflow-y-auto px-4 py-6 lg:px-8 lg:py-8">
         <div className="mx-auto max-w-3xl">
+          {/* Inline title (Notion style — same layout as editor) */}
+          <div className="mb-6 flex items-start justify-between gap-4">
+            <h1 className="flex-1 break-words text-4xl font-bold leading-tight">{doc.title}</h1>
+            <Button asChild size="sm" variant="ghost" className="mt-1 flex-shrink-0">
+              <Link href={`/docs/${slug}`}>
+                <Edit2 className="mr-1.5 h-3.5 w-3.5" />
+                {t('editDoc')}
+              </Link>
+            </Button>
+          </div>
           <DocContentRenderer
             content={doc.content}
             contentFormat={doc.content_format ?? 'markdown'}

--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { DocContentRenderer } from '@/components/docs/doc-content-renderer';
+import { DocToc } from '@/components/docs/doc-toc';
+import { extractDocHeadings } from '@/components/docs/doc-heading-utils';
 import { Button } from '@/components/ui/button';
 import { Edit2 } from 'lucide-react';
 import { useDocsLayout } from '../../docs-context';
@@ -27,6 +29,11 @@ export default function DocViewPage() {
   const { projectId } = useDocsLayout();
 
   const [doc, setDoc] = useState<DocState>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const scrollToHeading = useCallback((id: string) => {
+    contentRef.current?.querySelector<HTMLElement>(`#${CSS.escape(id)}`)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   useEffect(() => {
     if (!projectId || !slug) return;
@@ -62,16 +69,23 @@ export default function DocViewPage() {
           {/* Inline title (Notion style — same layout as editor) */}
           <div className="mb-6 flex items-start justify-between gap-4">
             <h1 className="flex-1 break-words text-4xl font-bold leading-tight">{doc.title}</h1>
-            <Button asChild size="sm" variant="ghost" className="mt-1 flex-shrink-0">
-              <Link href={`/docs/${slug}`}>
-                <Edit2 className="mr-1.5 h-3.5 w-3.5" />
-                {t('editDoc')}
-              </Link>
-            </Button>
+            <div className="mt-1 flex flex-shrink-0 items-center gap-2">
+              <DocToc
+                headings={extractDocHeadings(doc.content, doc.content_format ?? 'markdown')}
+                onHeadingClick={scrollToHeading}
+              />
+              <Button asChild size="sm" variant="ghost">
+                <Link href={`/docs/${slug}`}>
+                  <Edit2 className="mr-1.5 h-3.5 w-3.5" />
+                  {t('editDoc')}
+                </Link>
+              </Button>
+            </div>
           </div>
           <DocContentRenderer
             content={doc.content}
             contentFormat={doc.content_format ?? 'markdown'}
+            contentRef={contentRef}
             codeCopyLabel={t('codeCopy')}
             codeCopiedLabel={t('codeCopied')}
           />

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -546,6 +546,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 editable={selectedDoc.doc_type !== 'sprint_report'}
                 currentDocId={selectedDoc.id}
                 onNavigate={handleSelectDoc}
+                onFileError={(msg) => addToast({ title: msg, type: 'error' })}
                 onChange={setContent}
                 onContentFormatChange={setContentFormat}
                 isDirty={isDirty}

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -443,6 +443,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
               onRename={handleRename}
               onDelete={handleDeleteDoc}
               onAddChild={handleAddChild}
+              projectId={projectId}
             />
             {docsHasMore && (
               <div className="px-2 py-1">

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { ChevronDown, ChevronRight, Plus, X, Trash2, Copy, Check, Menu } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, X, Menu } from 'lucide-react';
 import { DocsShell } from '@/components/docs/docs-shell';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 
@@ -55,21 +55,6 @@ export function getDocSaveStatusText(status: SaveStatus, t: (key: string) => str
   return map[status] ?? null;
 }
 
-const SAVE_STATUS_CLASS: Partial<Record<SaveStatus, string>> = {
-  saving: 'text-[color:var(--operator-muted)]',
-  saved: 'text-emerald-500/70',
-  unsaved: 'text-amber-500/70',
-  error: 'text-rose-500',
-  conflict: 'text-rose-500',
-  'remote-changed': 'text-amber-500',
-};
-
-function SaveStatusIndicator({ status, t }: { status: SaveStatus; t: ReturnType<typeof useTranslations> }) {
-  const text = getDocSaveStatusText(status, t);
-  if (!text) return null;
-
-  return <span className={`shrink-0 text-xs ${SAVE_STATUS_CLASS[status] ?? ''}`}>{text}</span>;
-}
 
 /**
  * Docs shell with 2-panel layout (tree + content).
@@ -96,20 +81,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [contentFormat, setContentFormat] = useState<'markdown' | 'html'>('markdown');
-  const [mdCopied, setMdCopied] = useState(false);
   const [autosave, setAutosave] = useState(true);
-
-  const handleCopyMarkdown = useCallback(async () => {
-    try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(content);
-      }
-    } catch {
-      // clipboard unavailable
-    }
-    setMdCopied(true);
-    window.setTimeout(() => setMdCopied(false), 1600);
-  }, [content]);
 
   // Create form states
   const [showCreate, setShowCreate] = useState(false);
@@ -367,22 +339,6 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     }
   }, [projectId, newTitle, newSlug, newContent, newParentId, router, searchParams]);
 
-  const handleDelete = useCallback(async () => {
-    if (!selectedDoc || !projectId) return;
-    if (!confirm(t('confirmDelete'))) return;
-
-    try {
-      const res = await fetch(`/api/docs/${selectedDoc.id}`, { method: 'DELETE' });
-
-      if (!res.ok) throw new Error('Failed to delete doc');
-
-      setTree((prev) => prev.filter((doc) => doc.id !== selectedDoc.id));
-      setSelectedDoc(null);
-      router.replace('/docs');
-    } catch (error) {
-      console.error('Failed to delete doc:', error);
-    }
-  }, [selectedDoc, projectId, router, t]);
 
   useEffect(() => {
     void fetchTree(selectedTags.length ? selectedTags : undefined);
@@ -582,31 +538,6 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
           </div>
         ) : selectedDoc ? (
           <div className="flex h-full flex-col overflow-hidden">
-            {/* Header */}
-            <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
-              <div className="flex items-center justify-between gap-4">
-                <div className="flex-1 min-w-0">
-                  <Input
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                    className="border-none bg-transparent px-0 text-2xl font-semibold focus-visible:ring-0"
-                    placeholder={t('titlePlaceholder')}
-                  />
-                </div>
-                <div className="flex items-center gap-3">
-                  <SaveStatusIndicator status={saveStatus} t={t} />
-                  <Button variant="ghost" size="sm" onClick={handleCopyMarkdown} title="마크다운 복사">
-                    {mdCopied ? <Check className="h-4 w-4 text-emerald-500" /> : <Copy className="h-4 w-4" />}
-                  </Button>
-                  {selectedDoc.doc_type !== 'sprint_report' && (
-                    <Button variant="ghost" size="sm" onClick={handleDelete}>
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  )}
-                </div>
-              </div>
-            </div>
-
             {/* Content — fills remaining height */}
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden px-4 py-4 lg:px-6 lg:py-6">
               <DocEditor
@@ -621,6 +552,12 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 onSave={save}
                 autosave={autosave}
                 onAutosaveToggle={setAutosave}
+                title={title}
+                onTitleChange={(v) => {
+                  setTitle(v);
+                  setTree((prev) => prev.map((d) => (d.id === selectedDoc.id ? { ...d, title: v } : d)));
+                }}
+                titlePlaceholder={t('titlePlaceholder')}
                 labels={{
                   contentFormat: t('contentFormat'),
                   markdown: t('formatMarkdown'),

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -547,6 +547,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                 currentDocId={selectedDoc.id}
                 onNavigate={handleSelectDoc}
                 onFileError={(msg) => addToast({ title: msg, type: 'error' })}
+                projectId={projectId}
                 onChange={setContent}
                 onContentFormatChange={setContentFormat}
                 isDirty={isDirty}

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
-import { ChevronDown, ChevronRight, Plus, X, Menu } from 'lucide-react';
+import { ChevronDown, ChevronRight, Plus, X, Menu, Search, FileText } from 'lucide-react';
 import { DocsShell } from '@/components/docs/docs-shell';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 
@@ -76,6 +76,12 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
   const [docsLoadingMore, setDocsLoadingMore] = useState(false);
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Array<{ id: string; title: string; slug: string; snippet?: string }>>([]);
+  const sanitizeSnippet = (html: string) =>
+    html.replace(/<(?!\/?(?:b|mark)\b)[^>]+>/gi, '');
+  const [searchLoading, setSearchLoading] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Always-editable content states
   const [title, setTitle] = useState('');
@@ -134,6 +140,25 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       setDocsLoadingMore(false);
     }
   }, [projectId]);
+
+  // Full-text search with debounce
+  useEffect(() => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    if (!searchQuery.trim() || !projectId) { setSearchResults([]); setSearchLoading(false); return; }
+
+    setSearchLoading(true);
+    searchTimerRef.current = setTimeout(() => {
+      void fetch(`/api/docs?project_id=${projectId}&q=${encodeURIComponent(searchQuery.trim())}&limit=20`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data: { data?: Array<{ id: string; title: string; slug: string; snippet?: string }> } | null) => {
+          setSearchResults(data?.data ?? []);
+        })
+        .catch(() => { setSearchResults([]); })
+        .finally(() => { setSearchLoading(false); });
+    }, 300);
+
+    return () => { if (searchTimerRef.current) clearTimeout(searchTimerRef.current); };
+  }, [searchQuery, projectId]);
 
   const fetchDoc = useCallback(async (slug: string) => {
     if (!projectId) return;
@@ -371,6 +396,29 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
 
   const sidebarContent = (
     <>
+      {/* Full-text search input */}
+      <div className="border-b border-border/60 px-3 py-2">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[color:var(--operator-muted)]" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="문서 검색..."
+            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-[color:var(--operator-muted)] focus:border-[color:var(--operator-primary)]/40 focus:bg-muted/50"
+          />
+          {searchQuery && (
+            <button
+              type="button"
+              onClick={() => setSearchQuery('')}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-[color:var(--operator-muted)] hover:text-foreground"
+            >
+              <X className="size-3" />
+            </button>
+          )}
+        </div>
+      </div>
+
       {/* Tag filter — AC1 접기/펼치기 */}
       {(() => {
         const allTags = [...new Set(tree.flatMap((d) => (d as unknown as { tags?: string[] | null }).tags ?? []))];
@@ -419,7 +467,37 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         );
       })()}
       <div className="flex-1 overflow-y-auto p-2">
-        {tree.length === 0 ? (
+        {/* Search results */}
+        {searchQuery.trim() ? (
+          searchLoading ? (
+            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 중...</p>
+          ) : searchResults.length === 0 ? (
+            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 결과 없음</p>
+          ) : (
+            <ul className="space-y-1">
+              {searchResults.map((result) => (
+                <li key={result.id}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectDoc(result.slug)}
+                    className="flex w-full flex-col items-start gap-1 rounded-xl px-3 py-2 text-left transition-colors hover:bg-muted/60"
+                  >
+                    <span className="flex items-center gap-1.5 text-xs font-medium text-[color:var(--operator-foreground)]">
+                      <FileText className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+                      {result.title}
+                    </span>
+                    {result.snippet && (
+                      <span
+                        className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5 [&_b]:rounded [&_b]:bg-yellow-400/40 [&_b]:font-normal [&_b]:text-[color:var(--operator-foreground)] [&_b]:px-0.5"
+                        dangerouslySetInnerHTML={{ __html: sanitizeSnippet(result.snippet) }}
+                      />
+                    )}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )
+        ) : tree.length === 0 ? (
           <EmptyState
             title={t('title')}
             description={t('selectDoc')}

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
-import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronLeft, ChevronRight, Menu, Plus, X } from 'lucide-react';
@@ -47,14 +46,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     });
   }, []);
 
-  // Create form states
-  const [showCreate, setShowCreate] = useState(false);
-  const [newTitle, setNewTitle] = useState('');
-  const [newContent, setNewContent] = useState('');
-  const [newSlug, setNewSlug] = useState('');
-  const [newParentId, setNewParentId] = useState<string | null>(null);
-  const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
-  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   const fetchTree = useCallback(async (tags?: string[], cursor?: string | null) => {
     if (!projectId) return;
@@ -130,49 +122,29 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     } catch { await fetchTree(); }
   }, [fetchTree]);
 
-  const generateSlug = useCallback((s: string): string =>
-    s.toLowerCase().trim().replace(/\s+/g, '-').replace(/[^\wㄱ-힝-]/g, '').replace(/-+/g, '-').replace(/^-|-$/g, ''),
-  []);
-
-  const handleNewTitleChange = useCallback((val: string) => {
-    setNewTitle(val);
-    if (!slugManuallyEdited) setNewSlug(generateSlug(val));
-  }, [slugManuallyEdited, generateSlug]);
-
-  const handleSlugChange = useCallback((val: string) => {
-    setNewSlug(val);
-    setSlugManuallyEdited(true);
-  }, []);
-
-  const handleAddChild = useCallback(async (parentId: string) => {
-    setNewParentId(parentId);
-    setShowCreate(true);
-    setNewTitle(''); setNewContent(''); setNewSlug(''); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleNewDoc = useCallback(() => {
-    setShowCreate(true);
-    setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-  }, []);
-
-  const handleCreate = useCallback(async () => {
-    if (!projectId || !newTitle.trim() || !newSlug.trim()) return;
+  const createDoc = useCallback(async (parentId: string | null = null) => {
+    if (!projectId || isCreating) return;
+    setIsCreating(true);
+    const slug = `untitled-${Date.now()}`;
     try {
       const res = await fetch('/api/docs', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ project_id: projectId, title: newTitle, slug: newSlug, content: newContent, content_format: 'markdown', parent_id: newParentId }),
+        body: JSON.stringify({ project_id: projectId, title: 'Untitled', slug, content: '', content_format: 'markdown', parent_id: parentId }),
       });
       if (!res.ok) throw new Error('Failed to create doc');
       const { data } = await res.json();
       setTree((prev) => [{ id: data.id, parent_id: data.parent_id || null, title: data.title, slug: data.slug, icon: data.icon || null, sort_order: data.sort_order || 0, is_folder: data.is_folder || false }, ...prev]);
-      setShowCreate(false); setShowAdvancedOptions(false);
-      setNewTitle(''); setNewSlug(''); setNewContent(''); setNewParentId(null); setSlugManuallyEdited(false);
-      router.push(`/docs/${data.slug}`);
+      router.push(`/docs/${data.slug}?new=1`);
     } catch {
-      // create failed
+      addToast({ title: t('createFailed'), type: 'error' });
+    } finally {
+      setIsCreating(false);
     }
-  }, [projectId, newTitle, newSlug, newContent, newParentId, router]);
+  }, [projectId, isCreating, router, addToast, t]);
+
+  const handleNewDoc = useCallback(() => { void createDoc(null); }, [createDoc]);
+  const handleAddChild = useCallback((parentId: string) => createDoc(parentId), [createDoc]);
 
   const sidebarContent = (
     <>
@@ -224,55 +196,12 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
     </>
   );
 
-  const createForm = (
-    <div className="flex h-full flex-col">
-      <div className="flex-shrink-0 border-b border-border px-4 py-3 lg:px-6 lg:py-5">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1">
-            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-muted-foreground">Draft</p>
-            <h2 className="text-2xl font-semibold">{t('newDoc')}</h2>
-          </div>
-          <Button variant="ghost" size="sm" onClick={() => { setShowCreate(false); setNewParentId(null); }}><X className="h-4 w-4" /></Button>
-        </div>
-      </div>
-      <div className="flex-1 overflow-y-auto px-4 py-4 lg:px-6 lg:py-6">
-        <div className="max-w-3xl space-y-5">
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('titleLabel')}</label>
-            <Input value={newTitle} onChange={(e) => handleNewTitleChange(e.target.value)} placeholder={t('titlePlaceholder')} />
-          </div>
-          <div>
-            <label className="text-sm font-medium mb-2 block">{t('contentLabel')}</label>
-            <textarea value={newContent} onChange={(e) => setNewContent(e.target.value)} placeholder={t('editorPlaceholder')} className="w-full min-h-[220px] rounded-xl border border-border bg-muted/30 px-4 py-3 text-sm text-foreground resize-none placeholder:text-muted-foreground" />
-          </div>
-          <div>
-            <button type="button" onClick={() => setShowAdvancedOptions((prev) => !prev)} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors">
-              <span>{showAdvancedOptions ? '▾' : '▸'}</span>
-              <span>{t('advancedOptions')}</span>
-            </button>
-            {showAdvancedOptions && (
-              <div className="mt-3">
-                <label className="text-sm font-medium mb-2 block">{t('slugLabel')}</label>
-                <Input value={newSlug} onChange={(e) => handleSlugChange(e.target.value)} placeholder={t('slugPlaceholder')} />
-              </div>
-            )}
-          </div>
-          <div className="flex gap-2">
-            <Button onClick={handleCreate} disabled={!newTitle.trim() || !newSlug.trim()}>{tc('create')}</Button>
-            <Button variant="ghost" onClick={() => { setShowCreate(false); setNewParentId(null); }}>{tc('cancel')}</Button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-
-  const mainContent = showCreate ? createForm : children;
 
   return (
     <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate }}>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
-        actions={<Button size="sm" variant="outline" onClick={handleNewDoc}><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newDoc')}</Button>}
+        actions={<Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}><Plus className="mr-1.5 h-3.5 w-3.5" />{isCreating ? t('loading') : t('newDoc')}</Button>}
       />
 
       {/* Desktop: 2-panel (lg+) */}
@@ -301,7 +230,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
               <ChevronRight className="size-4" />
             </button>
           )}
-          {mainContent}
+          {children}
         </section>
       </div>
 
@@ -314,7 +243,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           </button>
         </div>
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
-          {mainContent}
+          {children}
         </div>
         {treeDrawerOpen && (
           <>

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -4,13 +4,12 @@ import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
-import { DocsShell } from '@/components/docs/docs-shell';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Input } from '@/components/ui/input';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
-import { ChevronDown, ChevronRight, Menu, Plus, X } from 'lucide-react';
+import { ChevronDown, ChevronLeft, ChevronRight, Menu, Plus, X } from 'lucide-react';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { DocsLayoutContext, type Doc, type DocUpdate } from './docs-context';
 
@@ -34,6 +33,19 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
 
   const [pendingDocUpdate, setPendingDocUpdate] = useState<DocUpdate | null>(null);
   const clearPendingDocUpdate = useCallback(() => setPendingDocUpdate(null), []);
+
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
+    if (typeof window === 'undefined') return false;
+    return localStorage.getItem('docs-sidebar-collapsed') === 'true';
+  });
+
+  const handleToggleSidebar = useCallback(() => {
+    setSidebarCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem('docs-sidebar-collapsed', String(next));
+      return next;
+    });
+  }, []);
 
   // Create form states
   const [showCreate, setShowCreate] = useState(false);
@@ -264,9 +276,34 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
       />
 
       {/* Desktop: 2-panel (lg+) */}
-      <DocsShell sidebar={sidebarContent} className="hidden min-h-0 flex-1 lg:flex">
-        {mainContent}
-      </DocsShell>
+      <div className="hidden min-h-0 flex-1 overflow-hidden lg:flex">
+        {!sidebarCollapsed && (
+          <aside className="relative flex w-[300px] flex-shrink-0 flex-col overflow-y-auto border-r border-border/80 bg-background">
+            <button
+              type="button"
+              onClick={handleToggleSidebar}
+              title={t('hideSidebar')}
+              className="absolute right-2 top-2 z-10 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ChevronLeft className="size-4" />
+            </button>
+            {sidebarContent}
+          </aside>
+        )}
+        <section className="relative flex min-w-0 flex-1 flex-col overflow-hidden bg-background">
+          {sidebarCollapsed && (
+            <button
+              type="button"
+              onClick={handleToggleSidebar}
+              title={t('openSidebar')}
+              className="absolute left-2 top-2 z-10 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              <ChevronRight className="size-4" />
+            </button>
+          )}
+          {mainContent}
+        </section>
+      </div>
 
       {/* Mobile: content + tree drawer (< lg) */}
       <div className="flex flex-1 flex-col overflow-hidden lg:hidden">

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -315,6 +315,12 @@
 .tiptap-content .tiptap .ProseMirror-selectednode { outline: 2px solid var(--tiptap-selection); border-radius: 4px; }
 .tiptap-content .tiptap a { color: var(--tiptap-link); text-decoration: underline; }
 .tiptap-content .tiptap div[data-callout] { border-left: 3px solid var(--tiptap-callout-border); background: var(--tiptap-callout-bg); padding: 12px 16px; border-radius: 0 6px 6px 0; margin: 8px 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] { list-style: none; padding-left: 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] { display: flex; align-items: flex-start; gap: 8px; margin: 2px 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > label { flex-shrink: 0; padding-top: 3px; cursor: pointer; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > label input[type="checkbox"] { cursor: pointer; width: 15px; height: 15px; accent-color: var(--tiptap-link); }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
+.tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
 /* ─── Typography utilities ─── */
 .text-display {

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -322,6 +322,17 @@
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
+/* ─── Column layout ─── */
+[data-type="columnsBlock"] > [data-type="columnBlock"],
+.tiptap [data-type="columnsBlock"] > .contents > [data-type="columnBlock"] { min-width: 0; }
+[data-type="columnBlock"] { min-width: 0; padding: 0.5rem; border-radius: 0.5rem; border: 1px solid transparent; }
+[data-type="columnBlock"]:focus-within { border-color: hsl(var(--border)); }
+/* Viewer grid (no NodeViewContent wrapper) */
+[data-type="columnsBlock"] { display: grid; gap: 1rem; }
+[data-type="columnsBlock"][data-cols="2"] { grid-template-columns: repeat(2, 1fr); }
+[data-type="columnsBlock"][data-cols="3"] { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 640px) { [data-type="columnsBlock"] { grid-template-columns: 1fr !important; } }
+
 /* ─── Toggle block ─── */
 [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"],
 .tiptap [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"] { display: none; }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -322,6 +322,14 @@
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"] > div { flex: 1; min-width: 0; }
 .tiptap-content .tiptap ul[data-type="taskList"] li[data-type="taskItem"][data-checked="true"] > div p { text-decoration: line-through; opacity: 0.55; }
 
+/* ─── Toggle block ─── */
+[data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"],
+.tiptap [data-type="toggleBlock"][data-open="false"] > [data-type="toggleContent"] { display: none; }
+[data-type="toggleContent"],
+.tiptap [data-type="toggleContent"] { padding-left: 1.25rem; margin-left: 0.875rem; border-left: 2px solid hsl(var(--border)); margin-top: 0.25rem; }
+[data-type="toggleSummary"],
+.tiptap [data-type="toggleSummary"] { cursor: pointer; }
+
 /* ─── Typography utilities ─── */
 .text-display {
   font-size: 2rem;

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
 import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
+import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
 import remarkGfm from 'remark-gfm';
@@ -179,6 +180,9 @@ export function DocContentRenderer({
             const inline = !String(codeClassName ?? '').includes('language-') && !childText.includes('\n');
             if (!inline) {
               const lang = String(codeClassName ?? '').replace('language-', '') || null;
+              if (lang === 'mermaid') {
+                return <MermaidReadonlyBlock code={childText} />;
+              }
               return (
                 <ShikiCodeBlock
                   code={childText}
@@ -195,6 +199,35 @@ export function DocContentRenderer({
         {content}
       </ReactMarkdown>
     </div>
+  );
+}
+
+function MermaidReadonlyBlock({ code }: { code: string }) {
+  const [svg, setSvg] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!code.trim()) return;
+    let cancelled = false;
+    void renderMermaid(code).then(({ svg: rendered }) => {
+      if (!cancelled) { setSvg(rendered); setError(''); }
+    }).catch((err: unknown) => {
+      if (!cancelled) { setError(err instanceof Error ? err.message : '렌더링 실패'); setSvg(''); }
+    });
+    return () => { cancelled = true; };
+  }, [code]);
+
+  if (error) {
+    return <div className="not-prose my-4 rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400">{error}</div>;
+  }
+  if (!svg) {
+    return <div className="not-prose my-4 rounded-xl border border-slate-700 bg-[#0b1120] p-4 text-xs text-slate-500">렌더링 중...</div>;
+  }
+  return (
+    <div
+      className="not-prose my-4 flex justify-center rounded-xl border border-slate-700 bg-[#0b1120] p-4 [&_svg]:h-auto [&_svg]:max-w-full"
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
   );
 }
 

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
 import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
+import { detectEmbedService } from './extensions/embed-node';
 import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
@@ -100,6 +101,46 @@ export function DocContentRenderer({
 
       button.addEventListener('click', handleClick);
       return () => button.removeEventListener('click', handleClick);
+    });
+
+    // Embed block handlers (viewer)
+    const embedBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="embedBlock"]'));
+    embedBlocks.forEach((block) => {
+      const url = block.getAttribute('data-url') ?? '';
+      if (!url) return;
+      const { type, embedUrl } = detectEmbedService(url);
+      block.innerHTML = '';
+      if (type === 'youtube') {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'aspect-video w-full overflow-hidden rounded-xl border border-border';
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.title = 'YouTube video';
+        iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture';
+        iframe.allowFullscreen = true;
+        iframe.className = 'h-full w-full';
+        wrapper.appendChild(iframe);
+        block.appendChild(wrapper);
+      } else if (type === 'figma') {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'h-[480px] w-full overflow-hidden rounded-xl border border-border';
+        const iframe = document.createElement('iframe');
+        iframe.src = embedUrl;
+        iframe.title = 'Figma embed';
+        iframe.allow = 'fullscreen';
+        iframe.allowFullscreen = true;
+        iframe.className = 'h-full w-full';
+        wrapper.appendChild(iframe);
+        block.appendChild(wrapper);
+      } else {
+        const a = document.createElement('a');
+        a.href = url;
+        a.target = '_blank';
+        a.rel = 'noopener noreferrer';
+        a.className = 'flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 text-sm transition-colors hover:bg-muted/40 no-underline';
+        a.textContent = url;
+        block.appendChild(a);
+      }
     });
 
     // File attachment download handlers (viewer)

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
+import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
 import remarkGfm from 'remark-gfm';
@@ -49,6 +50,29 @@ export function DocContentRenderer({
       headingCounts.set(baseId, seen + 1);
       heading.id = seen === 0 ? baseId : `${baseId}-${seen + 1}`;
     });
+
+    // HTML format code blocks: apply Shiki highlighting via DOM
+    if (contentFormat === 'html') {
+      const preTags = Array.from(root.querySelectorAll<HTMLPreElement>('pre'));
+      preTags.forEach((pre) => {
+        const codeEl = pre.querySelector('code');
+        const text = codeEl?.textContent ?? pre.textContent ?? '';
+        if (!text.trim()) return;
+        const lang = codeEl?.className.replace('language-', '').split(' ')[0]
+          ?? pre.getAttribute('data-language')
+          ?? null;
+        void getShikiHighlighter().then((shiki) => {
+          const highlighted = shiki.codeToHtml(text, {
+            lang: resolveLanguage(lang),
+            theme: 'dark-plus',
+          });
+          const wrapper = document.createElement('div');
+          wrapper.innerHTML = highlighted;
+          wrapper.className = '[&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:p-4 [&_pre]:text-[13px] [&_pre]:leading-6 [&_code]:!bg-transparent overflow-x-auto';
+          if (pre.parentElement) pre.replaceWith(wrapper);
+        }).catch(() => { /* fallback: keep original pre */ });
+      });
+    }
 
     const buttons = Array.from(root.querySelectorAll<HTMLButtonElement>('[data-doc-copy-button="true"]'));
     const cleanup = buttons.map((button) => {
@@ -148,30 +172,88 @@ export function DocContentRenderer({
               <table>{children}</table>
             </div>
           ),
-          pre: ({ children }) => (
-            <div data-doc-code-shell="true">
-              <div data-doc-code-actions="true">
-                <button
-                  type="button"
-                  data-doc-copy-button="true"
-                  className="transition hover:border-[color:var(--operator-primary)]/35 hover:text-[color:var(--operator-foreground)]"
-                >
-                  {codeCopyLabel}
-                </button>
-              </div>
-              <pre>{children}</pre>
-            </div>
-          ),
+          pre: ({ children }) => <>{children}</>,
           code: (props) => {
             const { children, className: codeClassName } = props as { children?: ReactNode; className?: string };
             const childText = Array.isArray(children) ? children.join('') : String(children ?? '');
             const inline = !String(codeClassName ?? '').includes('language-') && !childText.includes('\n');
-            return inline ? <code>{children}</code> : <code className={codeClassName}>{children}</code>;
+            if (!inline) {
+              const lang = String(codeClassName ?? '').replace('language-', '') || null;
+              return (
+                <ShikiCodeBlock
+                  code={childText}
+                  language={lang}
+                  copyLabel={codeCopyLabel}
+                  copiedLabel={codeCopiedLabel}
+                />
+              );
+            }
+            return <code>{children}</code>;
           },
         }}
       >
         {content}
       </ReactMarkdown>
+    </div>
+  );
+}
+
+function ShikiCodeBlock({
+  code, language, copyLabel, copiedLabel,
+}: {
+  code: string;
+  language: string | null;
+  copyLabel: string;
+  copiedLabel: string;
+}) {
+  const [html, setHtml] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!code.trim()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const shiki = await getShikiHighlighter();
+        if (cancelled) return;
+        const lang = resolveLanguage(language);
+        setHtml(shiki.codeToHtml(code, { lang, theme: 'dark-plus' }));
+      } catch { /* fallback to plain */ }
+    })();
+    return () => { cancelled = true; };
+  }, [code, language]);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(code);
+      }
+    } catch { /* unavailable */ }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1600);
+  }, [code]);
+
+  return (
+    <div data-doc-code-shell="true" className="not-prose my-6 overflow-hidden rounded-2xl border border-slate-700 bg-[#0b1120]">
+      <div data-doc-code-actions="true" className="flex justify-end px-3 pt-2">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="rounded-full border border-slate-600 bg-slate-700/50 px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.18em] text-slate-300 transition hover:border-slate-400 hover:text-slate-100"
+        >
+          {copied ? copiedLabel : copyLabel}
+        </button>
+      </div>
+      {html ? (
+        <div
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="overflow-x-auto [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:p-4 [&_pre]:text-[13px] [&_pre]:leading-6 [&_code]:!bg-transparent"
+        />
+      ) : (
+        <pre className="overflow-x-auto p-4 text-[13px] leading-6 text-slate-200">
+          <code>{code}</code>
+        </pre>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -102,6 +102,39 @@ export function DocContentRenderer({
       return () => button.removeEventListener('click', handleClick);
     });
 
+    // File attachment download handlers (viewer)
+    const fileBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="fileAttachment"]'));
+    const fileCleanup = fileBlocks.map((block) => {
+      const filename = block.getAttribute('data-filename') ?? 'file';
+      const data = block.getAttribute('data-file-data') ?? '';
+      const size = Number(block.getAttribute('data-size') ?? 0);
+      const sizeLabel = size < 1024 * 1024
+        ? `${(size / 1024).toFixed(1)} KB`
+        : `${(size / (1024 * 1024)).toFixed(1)} MB`;
+
+      block.innerHTML = `
+        <div class="flex items-center gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--muted))]/20 px-4 py-3 cursor-pointer hover:bg-[hsl(var(--muted))]/40 transition-colors">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-[color:var(--operator-muted)]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <div class="min-w-0 flex-1">
+            <p class="truncate text-sm font-medium">${escapeHtmlText(filename)}</p>
+            <p class="text-xs opacity-60">${escapeHtmlText(sizeLabel)}</p>
+          </div>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 opacity-50"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+        </div>`;
+
+      const handleClick = () => {
+        if (!data) return;
+        const a = document.createElement('a');
+        a.href = data;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+      };
+      block.addEventListener('click', handleClick);
+      return () => block.removeEventListener('click', handleClick);
+    });
+
     // Toggle block click handlers (viewer)
     const toggleSummaries = Array.from(root.querySelectorAll<HTMLElement>('[data-type="toggleSummary"]'));
     const toggleCleanup = toggleSummaries.map((summary) => {
@@ -117,6 +150,7 @@ export function DocContentRenderer({
 
     return () => {
       cleanup.forEach((dispose) => dispose());
+      fileCleanup.forEach((dispose) => dispose());
       toggleCleanup.forEach((dispose) => dispose());
     };
   }, [codeCopiedLabel, codeCopyLabel, content, contentFormat]);

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -102,8 +102,22 @@ export function DocContentRenderer({
       return () => button.removeEventListener('click', handleClick);
     });
 
+    // Toggle block click handlers (viewer)
+    const toggleSummaries = Array.from(root.querySelectorAll<HTMLElement>('[data-type="toggleSummary"]'));
+    const toggleCleanup = toggleSummaries.map((summary) => {
+      const handleClick = () => {
+        const block = summary.closest<HTMLElement>('[data-type="toggleBlock"]');
+        if (!block) return;
+        const isOpen = block.getAttribute('data-open') === 'true';
+        block.setAttribute('data-open', String(!isOpen));
+      };
+      summary.addEventListener('click', handleClick);
+      return () => summary.removeEventListener('click', handleClick);
+    });
+
     return () => {
       cleanup.forEach((dispose) => dispose());
+      toggleCleanup.forEach((dispose) => dispose());
     };
   }, [codeCopiedLabel, codeCopyLabel, content, contentFormat]);
 

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MutableRefObject, ReactNode, RefObject } from 'react';
 import { getShikiHighlighter, resolveLanguage } from './lib/shiki-highlighter';
 import { detectEmbedService } from './extensions/embed-node';
+import { renderKatex } from './extensions/math-node';
 import { renderMermaid } from './lib/mermaid-renderer';
 import ReactMarkdown from 'react-markdown';
 import DOMPurify from 'dompurify';
@@ -101,6 +102,33 @@ export function DocContentRenderer({
 
       button.addEventListener('click', handleClick);
       return () => button.removeEventListener('click', handleClick);
+    });
+
+    // Math block rendering (viewer)
+    const mathBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="mathBlock"]'));
+    mathBlocks.forEach((block) => {
+      const latex = block.getAttribute('data-latex') ?? block.textContent ?? '';
+      if (!latex.trim()) return;
+      void renderKatex(latex, true).then(({ html: katexHtml, error }) => {
+        if (error) {
+          block.innerHTML = `<div class="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">${escapeHtmlText(error)}</div>`;
+        } else {
+          block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-[color:var(--operator-foreground)]">${katexHtml}</div>`;
+        }
+      });
+    });
+
+    const mathInlines = Array.from(root.querySelectorAll<HTMLElement>('[data-type="mathInline"]'));
+    mathInlines.forEach((span) => {
+      const latex = span.textContent ?? '';
+      if (!latex.trim()) return;
+      void renderKatex(latex, false).then(({ html: katexHtml, error }) => {
+        if (error) {
+          span.className = 'rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono';
+        } else {
+          span.innerHTML = katexHtml;
+        }
+      });
     });
 
     // Embed block handlers (viewer)

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -104,6 +104,18 @@ export function DocContentRenderer({
       return () => button.removeEventListener('click', handleClick);
     });
 
+    // Wiki link click handlers (viewer)
+    const wikiLinks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="wikiLink"]'));
+    const wikiCleanup = wikiLinks.map((span) => {
+      const slug = span.getAttribute('data-slug') ?? '';
+      const title = span.getAttribute('data-title') ?? span.textContent ?? '';
+      span.className = 'inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)] hover:bg-[color:var(--operator-primary)]/20 transition-colors';
+      span.title = title;
+      const handleClick = () => { if (slug) window.location.href = `/docs/${slug}`; };
+      span.addEventListener('click', handleClick);
+      return () => span.removeEventListener('click', handleClick);
+    });
+
     // Math block rendering (viewer)
     const mathBlocks = Array.from(root.querySelectorAll<HTMLElement>('[data-type="mathBlock"]'));
     mathBlocks.forEach((block) => {
@@ -219,6 +231,7 @@ export function DocContentRenderer({
 
     return () => {
       cleanup.forEach((dispose) => dispose());
+      wikiCleanup.forEach((dispose) => dispose());
       fileCleanup.forEach((dispose) => dispose());
       toggleCleanup.forEach((dispose) => dispose());
     };

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useCallback, useRef, useState } from 'react';
-import React from 'react';
+import React, { type RefObject } from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
@@ -26,6 +26,8 @@ import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
 import { MathBlockNode, MathInlineNode } from './extensions/math-node';
 import { ColumnsBlock, ColumnBlock } from './extensions/column-layout';
+import { DocToc } from './doc-toc';
+import { type DocHeading, slugifyHeading } from './doc-heading-utils';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -87,6 +89,8 @@ export function DocEditor({
 }) {
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
+  const [tocHeadings, setTocHeadings] = useState<DocHeading[]>([]);
+  const editorContentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!onFileError) return;
@@ -145,6 +149,49 @@ export function DocEditor({
     editor.setEditable(editable);
   }, [editor, editable]);
 
+  // Extract TOC headings from editor + assign IDs to heading DOM elements
+  useEffect(() => {
+    if (!editor) return;
+
+    const update = () => {
+      const counts = new Map<string, number>();
+      const headings: DocHeading[] = [];
+
+      editor.state.doc.descendants((node) => {
+        if (node.type.name === 'heading') {
+          const text = node.textContent.trim();
+          if (!text) return true;
+          const baseId = slugifyHeading(text);
+          const seen = counts.get(baseId) ?? 0;
+          counts.set(baseId, seen + 1);
+          headings.push({
+            level: node.attrs.level as 1 | 2 | 3,
+            text,
+            id: seen === 0 ? baseId : `${baseId}-${seen + 1}`,
+          });
+        }
+        return true;
+      });
+
+      setTocHeadings(headings);
+
+      // Assign IDs to heading DOM elements
+      const root = editorContentRef.current;
+      if (!root) return;
+      const idCounts = new Map<string, number>();
+      root.querySelectorAll<HTMLElement>('h1, h2, h3').forEach((el) => {
+        const baseId = slugifyHeading(el.textContent ?? '');
+        const seen2 = idCounts.get(baseId) ?? 0;
+        idCounts.set(baseId, seen2 + 1);
+        el.id = seen2 === 0 ? baseId : `${baseId}-${seen2 + 1}`;
+      });
+    };
+
+    update();
+    editor.on('update', update);
+    return () => { editor.off('update', update); };
+  }, [editor]);
+
   useEffect(() => {
     if (!editor) return;
     const currentHtml = editor.getHTML();
@@ -173,6 +220,12 @@ export function DocEditor({
     },
     [contentFormat, onChange],
   );
+
+  const scrollToHeading = useCallback((id: string) => {
+    const root = editorContentRef.current;
+    const el = root?.querySelector<HTMLElement>(`#${CSS.escape(id)}`);
+    el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, []);
 
   const addLink = useCallback(() => {
     if (!editor) return;
@@ -306,6 +359,8 @@ export function DocEditor({
             </ToolbarButton>
           </div>
         ) : null}
+        {/* TOC — always in toolbar when ≥3 headings */}
+        <DocToc headings={tocHeadings} onHeadingClick={scrollToHeading} />
       </div>
 
       {/* Floating bubble toolbar — visible on text selection in preview mode */}
@@ -377,7 +432,7 @@ export function DocEditor({
           placeholder={labels.placeholder}
         />
       ) : (
-        <div className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3">
+        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3">
           <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
         </div>
       )}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -6,7 +6,8 @@ import { useEditor, EditorContent } from '@tiptap/react';
 import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
-import Image from '@tiptap/extension-image';
+import { CustomImageNode } from './extensions/image-node';
+import { ImageUploadExtension } from './extensions/image-upload';
 import Highlight from '@tiptap/extension-highlight';
 import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
@@ -87,7 +88,8 @@ export function DocEditor({
       StarterKit.configure({ codeBlock: false }),
       CodeBlockWithCopy,
       Link.configure({ openOnClick: false }),
-      Image,
+      CustomImageNode,
+      ImageUploadExtension,
       Highlight,
       TaskList,
       TaskItem.configure({ nested: true }),

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -3,14 +3,17 @@
 import { useEffect, useCallback, useRef, useState } from 'react';
 import React from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
+import { BubbleMenu } from '@tiptap/react/menus';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
+import Highlight from '@tiptap/extension-highlight';
 import { Table } from '@tiptap/extension-table';
 import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import Placeholder from '@tiptap/extension-placeholder';
+import { Bold, Italic, Strikethrough, Code, Link2, Highlighter } from 'lucide-react';
 import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
@@ -82,6 +85,7 @@ export function DocEditor({
       CodeBlockWithCopy,
       Link.configure({ openOnClick: false }),
       Image,
+      Highlight,
       Table.configure({ resizable: true }),
       TableRow,
       TableCell,
@@ -272,6 +276,65 @@ export function DocEditor({
         ) : null}
       </div>
 
+      {/* Floating bubble toolbar — visible on text selection in preview mode */}
+      {editor && editable && viewMode === 'preview' && (
+        <BubbleMenu
+          editor={editor}
+          className="flex items-center gap-0.5 rounded-lg border border-border/60 bg-background p-1 shadow-lg"
+        >
+          <BubbleButton
+            active={editor.isActive('bold')}
+            onClick={() => editor.chain().focus().toggleBold().run()}
+            title="굵게 (Ctrl+B)"
+          >
+            <Bold className="size-3.5" />
+          </BubbleButton>
+          <BubbleButton
+            active={editor.isActive('italic')}
+            onClick={() => editor.chain().focus().toggleItalic().run()}
+            title="기울임 (Ctrl+I)"
+          >
+            <Italic className="size-3.5" />
+          </BubbleButton>
+          <BubbleButton
+            active={editor.isActive('strike')}
+            onClick={() => editor.chain().focus().toggleStrike().run()}
+            title="취소선"
+          >
+            <Strikethrough className="size-3.5" />
+          </BubbleButton>
+          <BubbleButton
+            active={editor.isActive('code')}
+            onClick={() => editor.chain().focus().toggleCode().run()}
+            title="인라인 코드"
+          >
+            <Code className="size-3.5" />
+          </BubbleButton>
+          <span className="mx-0.5 h-4 w-px bg-border/60" />
+          <BubbleButton
+            active={editor.isActive('link')}
+            onClick={() => {
+              if (editor.isActive('link')) {
+                editor.chain().focus().unsetLink().run();
+              } else {
+                const url = window.prompt('URL:');
+                if (url) editor.chain().focus().setLink({ href: url }).run();
+              }
+            }}
+            title="링크"
+          >
+            <Link2 className="size-3.5" />
+          </BubbleButton>
+          <BubbleButton
+            active={editor.isActive('highlight')}
+            onClick={() => editor.chain().focus().toggleHighlight().run()}
+            title="형광펜"
+          >
+            <Highlighter className="size-3.5" />
+          </BubbleButton>
+        </BubbleMenu>
+      )}
+
       {/* Editor content — fills remaining height */}
       {viewMode === 'markdown' ? (
         <textarea
@@ -324,6 +387,33 @@ export function DocEditor({
         </div>
       ) : null}
     </div>
+  );
+}
+
+function BubbleButton({
+  active,
+  onClick,
+  title,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      className={`rounded-md p-1.5 transition-colors ${
+        active
+          ? 'bg-primary/14 text-primary'
+          : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -22,6 +22,7 @@ import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
+import { FileAttachmentNode } from './extensions/file-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -33,6 +34,7 @@ export function DocEditor({
   editable = true,
   currentDocId,
   onNavigate,
+  onFileError,
   onChange,
   onSave,
   isDirty = false,
@@ -50,6 +52,7 @@ export function DocEditor({
   editable?: boolean;
   currentDocId?: string;
   onNavigate?: (slug: string) => void;
+  onFileError?: (message: string) => void;
   onChange: (value: string) => void;
   onContentFormatChange?: (format: ContentFormat) => void;
   onSave?: () => Promise<boolean>;
@@ -82,6 +85,16 @@ export function DocEditor({
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
 
+  useEffect(() => {
+    if (!onFileError) return;
+    const handleFileSizeError = (e: Event) => {
+      const msg = (e as CustomEvent<{ message: string }>).detail.message;
+      onFileError(msg);
+    };
+    window.addEventListener('docs:file-size-error', handleFileSizeError);
+    return () => window.removeEventListener('docs:file-size-error', handleFileSizeError);
+  }, [onFileError]);
+
   const editor = useEditor({
     immediatelyRender: false,
     extensions: [
@@ -102,6 +115,7 @@ export function DocEditor({
       ToggleBlock,
       ToggleSummary,
       ToggleContent,
+      FileAttachmentNode,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -26,6 +26,7 @@ import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
 import { MathBlockNode, MathInlineNode } from './extensions/math-node';
 import { ColumnsBlock, ColumnBlock } from './extensions/column-layout';
+import { WikiLinkNode, createWikiLinkSuggestion } from './extensions/wiki-link';
 import { DocToc } from './doc-toc';
 import { type DocHeading, slugifyHeading } from './doc-heading-utils';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
@@ -40,6 +41,7 @@ export function DocEditor({
   currentDocId,
   onNavigate,
   onFileError,
+  projectId,
   onChange,
   onSave,
   isDirty = false,
@@ -58,6 +60,7 @@ export function DocEditor({
   currentDocId?: string;
   onNavigate?: (slug: string) => void;
   onFileError?: (message: string) => void;
+  projectId?: string;
   onChange: (value: string) => void;
   onContentFormatChange?: (format: ContentFormat) => void;
   onSave?: () => Promise<boolean>;
@@ -128,6 +131,11 @@ export function DocEditor({
       MathInlineNode,
       ColumnsBlock,
       ColumnBlock,
+      WikiLinkNode.configure({
+        projectId,
+        onNavigate,
+        suggestion: createWikiLinkSuggestion(projectId),
+      }),
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -23,6 +23,7 @@ import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { FileAttachmentNode } from './extensions/file-node';
+import { EmbedBlock } from './extensions/embed-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -116,6 +117,7 @@ export function DocEditor({
       ToggleSummary,
       ToggleContent,
       FileAttachmentNode,
+      EmbedBlock,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useCallback, useRef, useState } from 'react';
+import React from 'react';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
@@ -30,6 +31,11 @@ export function DocEditor({
   isDirty = false,
   autosave = true,
   onAutosaveToggle,
+  title,
+  onTitleChange,
+  titlePlaceholder,
+  titleAutoFocus,
+  actions,
   labels,
 }: {
   value: string;
@@ -43,6 +49,11 @@ export function DocEditor({
   isDirty?: boolean;
   autosave?: boolean;
   onAutosaveToggle?: (enabled: boolean) => void;
+  title?: string;
+  onTitleChange?: (value: string) => void;
+  titlePlaceholder?: string;
+  titleAutoFocus?: boolean;
+  actions?: React.ReactNode;
   labels: {
     contentFormat: string;
     markdown: string;
@@ -144,8 +155,42 @@ export function DocEditor({
     editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run();
   }, [editor]);
 
+  const titleRef = useRef<HTMLTextAreaElement>(null);
+
+  const autoResizeTitle = useCallback((el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, []);
+
+  useEffect(() => {
+    if (titleRef.current) autoResizeTitle(titleRef.current);
+  }, [title, autoResizeTitle]);
+
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-background">
+      {/* Inline title (Notion style) */}
+      {title !== undefined && (
+        <div className="flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 pt-8">
+          <textarea
+            ref={titleRef}
+            value={title}
+            onChange={(e) => {
+              onTitleChange?.(e.target.value);
+              autoResizeTitle(e.target);
+            }}
+            placeholder={titlePlaceholder ?? 'Untitled'}
+            autoFocus={titleAutoFocus}
+            rows={1}
+            className="w-full resize-none overflow-hidden bg-transparent text-4xl font-bold leading-tight outline-none placeholder:text-muted-foreground/40"
+          />
+          {actions && (
+            <div className="flex flex-shrink-0 items-center gap-1 pt-1">
+              {actions}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Tab bar + toolbar */}
       <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-2 border-b border-border/60 px-3 py-2">
         {/* View mode tabs */}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -24,6 +24,7 @@ import { CodeBlockWithCopy } from './extensions/code-block-copy';
 import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
+import { MathBlockNode, MathInlineNode } from './extensions/math-node';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -118,6 +119,8 @@ export function DocEditor({
       ToggleContent,
       FileAttachmentNode,
       EmbedBlock,
+      MathBlockNode,
+      MathInlineNode,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -25,6 +25,7 @@ import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-b
 import { FileAttachmentNode } from './extensions/file-node';
 import { EmbedBlock } from './extensions/embed-node';
 import { MathBlockNode, MathInlineNode } from './extensions/math-node';
+import { ColumnsBlock, ColumnBlock } from './extensions/column-layout';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -121,6 +122,8 @@ export function DocEditor({
       EmbedBlock,
       MathBlockNode,
       MathInlineNode,
+      ColumnsBlock,
+      ColumnBlock,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -8,6 +8,8 @@ import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import Image from '@tiptap/extension-image';
 import Highlight from '@tiptap/extension-highlight';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
 import { Table } from '@tiptap/extension-table';
 import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
@@ -86,6 +88,8 @@ export function DocEditor({
       Link.configure({ openOnClick: false }),
       Image,
       Highlight,
+      TaskList,
+      TaskItem.configure({ nested: true }),
       Table.configure({ resizable: true }),
       TableRow,
       TableCell,

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -20,6 +20,7 @@ import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
 import { CodeBlockWithCopy } from './extensions/code-block-copy';
+import { ToggleBlock, ToggleSummary, ToggleContent } from './extensions/toggle-block';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
 
 type ContentFormat = 'markdown' | 'html';
@@ -96,6 +97,9 @@ export function DocEditor({
       TableHeader,
       Placeholder.configure({ placeholder: labels.placeholder }),
       CalloutNode,
+      ToggleBlock,
+      ToggleSummary,
+      ToggleContent,
       SlashCommandExtension,
       PageEmbedExtension.configure({ currentDocId, onNavigate }),
     ],

--- a/apps/web/src/components/docs/doc-toc.tsx
+++ b/apps/web/src/components/docs/doc-toc.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import { List, X } from 'lucide-react';
+import type { DocHeading } from './doc-heading-utils';
+import { cn } from '@/lib/utils';
+
+interface DocTocProps {
+  headings: DocHeading[];
+  onHeadingClick: (id: string) => void;
+  className?: string;
+}
+
+export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
+  const [open, setOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [open]);
+
+  const handleClick = useCallback((id: string) => {
+    onHeadingClick(id);
+    setOpen(false);
+  }, [onHeadingClick]);
+
+  // AC5: 3개 미만이면 숨김
+  if (headings.length < 3) return null;
+
+  return (
+    <div ref={panelRef} className={cn('relative', className)}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
+          open
+            ? 'border-[color:var(--operator-primary)]/50 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+            : 'border-border/60 bg-card text-foreground hover:border-[color:var(--operator-primary)]/50 hover:text-[color:var(--operator-primary-soft)]'
+        }`}
+        title="목차"
+      >
+        <List className="size-3.5" />
+        <span>목차</span>
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1.5 w-64 overflow-hidden rounded-xl border border-border bg-background shadow-lg">
+          <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
+            <span className="text-xs font-semibold text-[color:var(--operator-foreground)]">목차</span>
+            <button
+              type="button"
+              onClick={() => setOpen(false)}
+              className="rounded p-0.5 text-[color:var(--operator-muted)] hover:bg-muted hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+          <nav className="max-h-72 overflow-y-auto py-1.5">
+            {headings.map((heading) => (
+              <button
+                key={heading.id}
+                type="button"
+                onClick={() => handleClick(heading.id)}
+                className={`flex w-full items-start px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted/60 ${
+                  heading.level === 1
+                    ? 'font-semibold text-[color:var(--operator-foreground)]'
+                    : heading.level === 2
+                      ? 'pl-5 text-[color:var(--operator-foreground)]/80'
+                      : 'pl-7 text-[color:var(--operator-muted)]'
+                }`}
+              >
+                <span className="mr-1.5 mt-px flex-shrink-0 text-[color:var(--operator-muted)]">
+                  {heading.level === 1 ? '◆' : heading.level === 2 ? '◇' : '·'}
+                </span>
+                <span className="truncate">{heading.text}</span>
+              </button>
+            ))}
+          </nav>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -1,11 +1,49 @@
 'use client';
 
 import { useState, useCallback, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, MoreVertical } from 'lucide-react';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
+
+// ─── Preview Card ─────────────────────────────────────────────────────────────
+
+function extractSnippet(content: string, maxChars = 200): string {
+  return content
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/[#*_`\[\]>~]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, maxChars);
+}
+
+function DocPreviewCard({ title, snippet, x, y }: { title: string; snippet: string; x: number; y: number }) {
+  const CARD_WIDTH = 280;
+  const CARD_EST_HEIGHT = 120;
+  const GAP = 12;
+
+  const left = x + GAP + CARD_WIDTH > window.innerWidth
+    ? Math.max(8, x - GAP - CARD_WIDTH)
+    : x + GAP;
+  const top = Math.min(y, window.innerHeight - CARD_EST_HEIGHT - 8);
+
+  return createPortal(
+    <div
+      style={{ position: 'fixed', left, top, width: CARD_WIDTH, zIndex: 9999, pointerEvents: 'none' }}
+      className="rounded-xl border border-border bg-background p-3 shadow-lg"
+    >
+      <p className="mb-1 text-xs font-semibold text-[color:var(--operator-foreground)] truncate">{title}</p>
+      {snippet ? (
+        <p className="text-[11px] leading-relaxed text-[color:var(--operator-muted)] line-clamp-4">{snippet}</p>
+      ) : (
+        <p className="text-[11px] text-[color:var(--operator-muted)] opacity-60">내용 없음</p>
+      )}
+    </div>,
+    document.body,
+  );
+}
 
 interface Doc {
   id: string;
@@ -46,6 +84,7 @@ interface DocTreeProps {
   onDelete?: (docId: string) => Promise<void>;
   onAddChild?: (parentId: string) => Promise<void>;
   emptyFolderLabel?: string;
+  projectId?: string;
 }
 
 function TreeNode({
@@ -59,6 +98,7 @@ function TreeNode({
   onAddChild,
   depth = 0,
   emptyFolderLabel = 'No child docs',
+  projectId,
 }: {
   doc: Doc;
   allDocs: Doc[];
@@ -70,6 +110,7 @@ function TreeNode({
   onAddChild?: (parentId: string) => Promise<void>;
   depth?: number;
   emptyFolderLabel?: string;
+  projectId?: string;
 }) {
   const childDocs = allDocs.filter((entry) => entry.parent_id === doc.id).sort((a, b) => a.sort_order - b.sort_order);
   const hasChildren = childDocs.length > 0;
@@ -78,6 +119,32 @@ function TreeNode({
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const isSelected = selectedSlug === doc.slug;
   const menuRef = useRef<HTMLDivElement>(null);
+
+  // Preview state
+  const [preview, setPreview] = useState<{ title: string; snippet: string } | null>(null);
+  const [previewPos, setPreviewPos] = useState({ x: 0, y: 0 });
+  const hoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleMouseEnter = useCallback((e: React.MouseEvent) => {
+    const { clientX, clientY } = e;
+    hoverTimerRef.current = setTimeout(() => {
+      if (!projectId) return;
+      void fetch(`/api/docs?project_id=${projectId}&slug=${encodeURIComponent(doc.slug)}&limit=1`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((data: { data?: Array<{ title: string; content?: string }> } | null) => {
+          const d = data?.data?.[0];
+          if (!d) return;
+          setPreview({ title: d.title, snippet: extractSnippet(d.content ?? '') });
+          setPreviewPos({ x: clientX, y: clientY });
+        })
+        .catch(() => { /* ignore */ });
+    }, 300);
+  }, [doc.slug, projectId]);
+
+  const handleMouseLeave = useCallback(() => {
+    if (hoverTimerRef.current) { clearTimeout(hoverTimerRef.current); hoverTimerRef.current = null; }
+    setPreview(null);
+  }, []);
 
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: doc.id,
@@ -138,9 +205,12 @@ function TreeNode({
   return (
     <div ref={setNodeRef} style={style}>
       <div className="group relative">
+        {preview && <DocPreviewCard title={preview.title} snippet={preview.snippet} x={previewPos.x} y={previewPos.y} />}
         <button
           onClick={handleClick}
           onContextMenu={handleContextMenu}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
           className={cn(
             'flex w-full items-center gap-2 rounded-2xl pl-3 pr-7 py-2 text-left text-[13px] transition-all',
             isSelected
@@ -207,6 +277,7 @@ function TreeNode({
                   onAddChild={onAddChild}
                   depth={depth + 1}
                   emptyFolderLabel={emptyFolderLabel}
+                  projectId={projectId}
                 />
               ))}
             </SortableContext>
@@ -224,7 +295,7 @@ function TreeNode({
   );
 }
 
-export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel }: DocTreeProps) {
+export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel, projectId }: DocTreeProps) {
   const rootDocs = docs.filter((entry) => !entry.parent_id).sort((a, b) => a.sort_order - b.sort_order);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
 
@@ -293,7 +364,7 @@ export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMov
       <SortableContext items={rootDocs.map((d) => d.id)} strategy={verticalListSortingStrategy}>
         <nav className="space-y-1">
           {rootDocs.map((doc) => (
-            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} />
+            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} projectId={projectId} />
           ))}
         </nav>
       </SortableContext>

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useEffect, useRef } from 'react';
+import { useState, useCallback, useEffect, useRef, useId } from 'react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
 import { ChevronDown } from 'lucide-react';
@@ -10,8 +10,85 @@ import {
   SUPPORTED_LANGUAGES,
   LANGUAGE_LABELS,
 } from '../lib/shiki-highlighter';
+import { renderMermaid } from '../lib/mermaid-renderer';
 
-function CodeBlockView({ node, editor, selected }: ReactNodeViewProps) {
+// ─── Mermaid Block ───────────────────────────────────────────────────────────
+
+function MermaidBlockView({ node, editor, selected }: ReactNodeViewProps) {
+  const [svg, setSvg] = useState('');
+  const [error, setError] = useState('');
+  const id = useId();
+  const code = node.textContent;
+  const isEditable = editor?.isEditable ?? false;
+  const showCode = isEditable && selected;
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!code.trim()) {
+        setSvg('');
+        setError('');
+        return;
+      }
+      try {
+        const { svg: rendered } = await renderMermaid(code);
+        if (!cancelled) { setSvg(rendered); setError(''); }
+      } catch (err: unknown) {
+        if (!cancelled) { setError(err instanceof Error ? err.message : '렌더링 실패'); setSvg(''); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [code]);
+
+  const handlePreviewClick = useCallback(() => {
+    if (isEditable) editor?.commands.focus();
+  }, [editor, isEditable]);
+
+  return (
+    <NodeViewWrapper className="my-4 not-prose" data-mermaid-id={id}>
+      <div className="rounded-2xl border border-slate-700 bg-[#0b1120]">
+        <div className="flex items-center justify-between px-3 py-2" contentEditable={false}>
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-slate-500">mermaid</span>
+          {isEditable && (
+            <span className="text-[11px] text-slate-600">{showCode ? '코드 편집 중' : '클릭하여 편집'}</span>
+          )}
+        </div>
+
+        {/* Code editor — visible when selected */}
+        <pre className={`border-t border-slate-700/50 p-4 text-[13px] leading-6 text-slate-200 ${showCode ? '' : 'hidden'}`}>
+          <NodeViewContent />
+        </pre>
+
+        {/* SVG preview — click triggers focus + selection to enter edit mode */}
+        {!showCode && (
+          <div
+            className="px-4 pb-4"
+            contentEditable={false}
+            onClick={handlePreviewClick}
+            style={{ cursor: isEditable ? 'pointer' : 'default' }}
+          >
+            {error ? (
+              <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400">
+                {error}
+              </div>
+            ) : svg ? (
+              <div
+                dangerouslySetInnerHTML={{ __html: svg }}
+                className="flex justify-center [&_svg]:max-w-full [&_svg]:h-auto"
+              />
+            ) : (
+              <p className="text-xs text-slate-600">다이어그램을 입력하세요</p>
+            )}
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Shiki Code Block View ────────────────────────────────────────────────────
+
+function ShikiBlockView({ node, editor, selected }: ReactNodeViewProps) {
   const [copied, setCopied] = useState(false);
   const [highlightedHtml, setHighlightedHtml] = useState('');
   const [showLangMenu, setShowLangMenu] = useState(false);
@@ -137,6 +214,14 @@ function CodeBlockView({ node, editor, selected }: ReactNodeViewProps) {
       </div>
     </NodeViewWrapper>
   );
+}
+
+// ─── Dispatcher ───────────────────────────────────────────────────────────────
+
+function CodeBlockView(props: ReactNodeViewProps) {
+  const language = (props.node.attrs as { language?: string }).language ?? null;
+  if (language === 'mermaid') return <MermaidBlockView {...props} />;
+  return <ShikiBlockView {...props} />;
 }
 
 export const CodeBlockWithCopy = Node.create({

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -1,29 +1,110 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { ChevronDown } from 'lucide-react';
+import {
+  getShikiHighlighter,
+  resolveLanguage,
+  SUPPORTED_LANGUAGES,
+  LANGUAGE_LABELS,
+} from '../lib/shiki-highlighter';
 
-function CodeBlockView({ node }: ReactNodeViewProps) {
+function CodeBlockView({ node, editor, selected }: ReactNodeViewProps) {
   const [copied, setCopied] = useState(false);
+  const [highlightedHtml, setHighlightedHtml] = useState('');
+  const [showLangMenu, setShowLangMenu] = useState(false);
+  const langMenuRef = useRef<HTMLDivElement>(null);
+
+  const language = (node.attrs as { language?: string }).language ?? null;
+  const resolvedLang = resolveLanguage(language);
+  const langLabel = language ? (LANGUAGE_LABELS[language] ?? language) : 'text';
+  const code = node.textContent;
+  const isEditable = editor?.isEditable ?? false;
+  const isEditing = isEditable && selected;
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const html = code.trim()
+          ? await getShikiHighlighter().then((shiki) =>
+              shiki.codeToHtml(code, { lang: resolvedLang, theme: 'dark-plus' }),
+            )
+          : '';
+        if (!cancelled) setHighlightedHtml(html);
+      } catch {
+        if (!cancelled) setHighlightedHtml('');
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [code, resolvedLang]);
 
   const handleCopy = useCallback(async () => {
-    const text = node.textContent;
     try {
       if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(text);
+        await navigator.clipboard.writeText(code);
       }
-    } catch {
-      // clipboard unavailable — still show feedback
-    }
+    } catch { /* clipboard unavailable */ }
     setCopied(true);
     window.setTimeout(() => setCopied(false), 1600);
-  }, [node.textContent]);
+  }, [code]);
+
+  const handleLangSelect = useCallback((lang: string) => {
+    editor?.commands.updateAttributes('codeBlock', { language: lang });
+    setShowLangMenu(false);
+  }, [editor]);
+
+  useEffect(() => {
+    if (!showLangMenu) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (langMenuRef.current && !langMenuRef.current.contains(e.target as HTMLElement)) {
+        setShowLangMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [showLangMenu]);
 
   return (
     <NodeViewWrapper className="my-4 not-prose">
       <div className="rounded-2xl border border-slate-700 bg-[#0b1120]">
-        <div className="flex justify-end px-3 pt-2">
+        {/* Header: language selector + copy button */}
+        <div className="flex items-center justify-between px-3 pt-2 pb-1">
+          {/* Language dropdown */}
+          <div ref={langMenuRef} className="relative" contentEditable={false}>
+            <button
+              type="button"
+              onClick={() => isEditable && setShowLangMenu((v) => !v)}
+              className={`flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-medium uppercase tracking-[0.12em] transition ${
+                isEditable
+                  ? 'text-slate-400 hover:bg-slate-700/50 hover:text-slate-200 cursor-pointer'
+                  : 'text-slate-500 cursor-default'
+              }`}
+            >
+              {langLabel}
+              {isEditable && <ChevronDown className="size-3" />}
+            </button>
+            {showLangMenu && (
+              <div className="absolute left-0 top-full z-50 mt-1 max-h-52 w-36 overflow-y-auto rounded-xl border border-slate-700 bg-slate-900 py-1 shadow-xl">
+                {SUPPORTED_LANGUAGES.map((lang) => (
+                  <button
+                    key={lang}
+                    type="button"
+                    onClick={() => handleLangSelect(lang)}
+                    className={`flex w-full items-center px-3 py-1.5 text-left text-xs transition hover:bg-slate-700/60 ${
+                      lang === language ? 'text-blue-400' : 'text-slate-300'
+                    }`}
+                  >
+                    {LANGUAGE_LABELS[lang] ?? lang}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Copy button */}
           <button
             type="button"
             contentEditable={false}
@@ -33,9 +114,26 @@ function CodeBlockView({ node }: ReactNodeViewProps) {
             {copied ? '복사됨' : '복사'}
           </button>
         </div>
-        <pre className="overflow-x-auto p-4 text-[13px] leading-6 text-slate-200">
-          <NodeViewContent />
-        </pre>
+
+        {/* Code area */}
+        <div className="overflow-x-auto px-4 pb-4">
+          {/* Editing mode: show plain NodeViewContent */}
+          <pre
+            className={`text-[13px] leading-6 text-slate-200 ${isEditing || !highlightedHtml ? '' : 'hidden'}`}
+          >
+            <NodeViewContent />
+          </pre>
+
+          {/* Display mode: Shiki highlighted HTML */}
+          {!isEditing && highlightedHtml && (
+            <div
+              dangerouslySetInnerHTML={{ __html: highlightedHtml }}
+              className="shiki-block [&_pre]:!m-0 [&_pre]:!bg-transparent [&_pre]:text-[13px] [&_pre]:leading-6 [&_pre]:!p-0 [&_code]:!bg-transparent"
+              onClick={() => isEditable && editor?.commands.focus()}
+              style={{ cursor: isEditable ? 'text' : 'default' }}
+            />
+          )}
+        </div>
       </div>
     </NodeViewWrapper>
   );

--- a/apps/web/src/components/docs/extensions/column-layout.tsx
+++ b/apps/web/src/components/docs/extensions/column-layout.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { Columns2, Columns3 } from 'lucide-react';
+
+// ─── Columns Block View ───────────────────────────────────────────────────────
+
+function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeViewProps) {
+  const cols = (node.attrs.columns as number) ?? 2;
+
+  const switchTo = useCallback((target: 2 | 3) => {
+    if (typeof getPos !== 'function') return;
+    const pos = getPos();
+    if (pos === undefined) return;
+
+    if (target === 3 && cols === 2) {
+      // Add a new column at the end
+      editor.commands.command(({ tr }) => {
+        const { schema } = editor;
+        const insertPos = pos + node.nodeSize - 1;
+        const colNode = schema.nodes['columnBlock']?.create(null, schema.nodes['paragraph']?.create());
+        if (!colNode) return false;
+        tr.insert(insertPos, colNode);
+        tr.setNodeMarkup(pos, undefined, { columns: 3 });
+        return true;
+      });
+    } else if (target === 2 && cols === 3) {
+      // Remove last column
+      editor.commands.command(({ tr }) => {
+        const lastChild = node.lastChild;
+        if (!lastChild) return false;
+        const lastColEnd = pos + node.nodeSize - 1;
+        const lastColStart = lastColEnd - lastChild.nodeSize;
+        tr.delete(lastColStart, lastColEnd);
+        tr.setNodeMarkup(pos, undefined, { columns: 2 });
+        return true;
+      });
+    } else {
+      updateAttributes({ columns: target });
+    }
+  }, [cols, editor, getPos, node, updateAttributes]);
+
+  const gridClass = cols === 3
+    ? 'grid grid-cols-1 sm:grid-cols-3 gap-4'
+    : 'grid grid-cols-1 sm:grid-cols-2 gap-4';
+
+  return (
+    <NodeViewWrapper as="div" className="not-prose my-4 group">
+      {/* Column switcher — visible on hover */}
+      <div
+        contentEditable={false}
+        className="mb-1.5 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
+      >
+        <span className="text-[10px] uppercase tracking-widest text-[color:var(--operator-muted)] mr-1">컬럼</span>
+        <button
+          type="button"
+          onClick={() => switchTo(2)}
+          className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
+            cols === 2
+              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+          }`}
+        >
+          <Columns2 className="size-3" />2단
+        </button>
+        <button
+          type="button"
+          onClick={() => switchTo(3)}
+          className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
+            cols === 3
+              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+          }`}
+        >
+          <Columns3 className="size-3" />3단
+        </button>
+      </div>
+
+      {/* Grid wrapper — NodeViewContent renders columnBlock children directly */}
+      <div className={gridClass}>
+        <NodeViewContent as="div" className="contents" />
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definitions ─────────────────────────────────────────────────────────
+
+export const ColumnBlock = Node.create({
+  name: 'columnBlock',
+  content: 'block+',
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="columnBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'columnBlock' }, HTMLAttributes), 0];
+  },
+});
+
+export const ColumnsBlock = Node.create({
+  name: 'columnsBlock',
+  group: 'block',
+  content: 'columnBlock+',
+  defining: true,
+
+  addAttributes() {
+    return {
+      columns: {
+        default: 2,
+        parseHTML: (el) => Number(el.getAttribute('data-cols') ?? 2),
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          'data-cols': String(attributes['columns'] ?? 2),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="columnsBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'columnsBlock' }, HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ColumnsBlockView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/embed-node.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { ExternalLink, Link2 } from 'lucide-react';
+
+// ─── URL Helpers ──────────────────────────────────────────────────────────────
+
+type EmbedService = 'youtube' | 'figma' | 'fallback';
+
+interface EmbedInfo {
+  type: EmbedService;
+  embedUrl: string;
+}
+
+export function detectEmbedService(url: string): EmbedInfo {
+  try {
+    const parsed = new URL(url);
+    if (!['https:', 'http:'].includes(parsed.protocol)) return { type: 'fallback', embedUrl: url };
+
+    // YouTube
+    const ytVideoId =
+      parsed.hostname.includes('youtube.com')
+        ? (parsed.searchParams.get('v') ?? null)
+        : parsed.hostname === 'youtu.be'
+          ? parsed.pathname.slice(1)
+          : null;
+    if (ytVideoId) {
+      return { type: 'youtube', embedUrl: `https://www.youtube.com/embed/${ytVideoId}` };
+    }
+    if (parsed.hostname.includes('youtube.com') && parsed.pathname.startsWith('/embed/')) {
+      return { type: 'youtube', embedUrl: url };
+    }
+
+    // Figma
+    if (
+      parsed.hostname.includes('figma.com') &&
+      /^\/(file|design|proto)\//.test(parsed.pathname)
+    ) {
+      return {
+        type: 'figma',
+        embedUrl: `https://www.figma.com/embed?embed_host=share&url=${encodeURIComponent(url)}`,
+      };
+    }
+  } catch { /* invalid URL */ }
+
+  return { type: 'fallback', embedUrl: url };
+}
+
+// ─── Embed View ───────────────────────────────────────────────────────────────
+
+function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
+  const url = (node.attrs.url as string) ?? '';
+  const [editUrl, setEditUrl] = useState(url);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { setEditUrl(url); }, [url]);
+
+  const applyUrl = useCallback(() => {
+    const trimmed = editUrl.trim();
+    if (trimmed) updateAttributes({ url: trimmed });
+  }, [editUrl, updateAttributes]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') { e.preventDefault(); applyUrl(); }
+    if (e.key === 'Escape') setEditUrl(url);
+  }, [applyUrl, url]);
+
+  const { type, embedUrl } = detectEmbedService(url);
+
+  return (
+    <NodeViewWrapper as="div" className="my-4 not-prose" contentEditable={false}>
+      {/* URL editor — visible when block is selected */}
+      {selected && (
+        <div className="mb-2 flex items-center gap-2 rounded-xl border border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/6 px-3 py-2">
+          <Link2 className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+          <input
+            ref={inputRef}
+            value={editUrl}
+            onChange={(e) => setEditUrl(e.target.value)}
+            onKeyDown={handleKeyDown}
+            onBlur={applyUrl}
+            placeholder="URL 입력 후 Enter"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-[color:var(--operator-muted)]/60"
+          />
+        </div>
+      )}
+
+      {/* Embed content */}
+      {url ? (
+        <>
+          {type === 'youtube' && (
+            <div className="aspect-video w-full overflow-hidden rounded-xl border border-border">
+              <iframe
+                src={embedUrl}
+                title="YouTube video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowFullScreen
+                className="h-full w-full"
+              />
+            </div>
+          )}
+          {type === 'figma' && (
+            <div className="h-[480px] w-full overflow-hidden rounded-xl border border-border">
+              <iframe
+                src={embedUrl}
+                title="Figma embed"
+                allow="fullscreen"
+                allowFullScreen
+                className="h-full w-full"
+              />
+            </div>
+          )}
+          {type === 'fallback' && (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 text-sm transition-colors hover:bg-muted/40"
+            >
+              <ExternalLink className="size-4 flex-shrink-0 text-[color:var(--operator-muted)]" />
+              <span className="min-w-0 flex-1 truncate text-[color:var(--operator-foreground)]/80">{url}</span>
+            </a>
+          )}
+        </>
+      ) : (
+        <div className="flex items-center gap-2 rounded-xl border border-dashed border-border px-4 py-4 text-sm text-[color:var(--operator-muted)]">
+          <Link2 className="size-4" />
+          <span>블록을 선택해 URL을 입력하세요</span>
+        </div>
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+
+export const EmbedBlock = Node.create({
+  name: 'embedBlock',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      url: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="embedBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { url, ...rest } = HTMLAttributes as Record<string, unknown>;
+    return ['div', mergeAttributes({ 'data-type': 'embedBlock', 'data-url': url }, rest)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(EmbedView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/file-node.tsx
+++ b/apps/web/src/components/docs/extensions/file-node.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useCallback } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { FileIcon, DownloadIcon } from 'lucide-react';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export const MAX_FILE_BYTES = 5 * 1024 * 1024;
+
+export async function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('FileReader 오류'));
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.readAsDataURL(file);
+  });
+}
+
+// ─── File Attachment View ─────────────────────────────────────────────────────
+
+function FileAttachmentView({ node }: ReactNodeViewProps) {
+  const filename = node.attrs.filename as string;
+  const size = node.attrs.size as number;
+  const data = node.attrs.data as string;
+
+  const handleDownload = useCallback(() => {
+    if (!data) return;
+    const a = document.createElement('a');
+    a.href = data;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  }, [data, filename]);
+
+  return (
+    <NodeViewWrapper as="div" className="my-3 not-prose">
+      <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]">
+          <FileIcon className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-[color:var(--operator-foreground)]">{filename}</p>
+          <p className="text-xs text-[color:var(--operator-muted)]">{formatFileSize(size)}</p>
+        </div>
+        <button
+          type="button"
+          contentEditable={false}
+          onClick={handleDownload}
+          className="flex-shrink-0 rounded-lg border border-border p-2 text-[color:var(--operator-muted)] transition-colors hover:border-[color:var(--operator-primary)]/40 hover:text-[color:var(--operator-primary-soft)]"
+          aria-label="파일 다운로드"
+        >
+          <DownloadIcon className="size-4" />
+        </button>
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+
+export const FileAttachmentNode = Node.create({
+  name: 'fileAttachment',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      filename: { default: '' },
+      size: { default: 0 },
+      mimeType: { default: '' },
+      data: { default: '' },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="fileAttachment"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { filename, size, mimeType, data } = HTMLAttributes as Record<string, unknown>;
+    return [
+      'div',
+      mergeAttributes({
+        'data-type': 'fileAttachment',
+        'data-filename': filename,
+        'data-size': String(size),
+        'data-mime-type': mimeType,
+        'data-file-data': data,
+      }),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FileAttachmentView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/image-node.tsx
+++ b/apps/web/src/components/docs/extensions/image-node.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState, useCallback, useRef } from 'react';
+import Image from '@tiptap/extension-image';
+import { mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+
+// ─── Resize Handle ────────────────────────────────────────────────────────────
+
+function ImageView({ node, updateAttributes, selected }: ReactNodeViewProps) {
+  const [isResizing, setIsResizing] = useState(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  const src = node.attrs.src as string;
+  const alt = (node.attrs.alt as string) ?? '';
+  const width = node.attrs.width as number | null;
+
+  const handleResizeStart = useCallback((e: React.MouseEvent, side: 'left' | 'right') => {
+    e.preventDefault();
+    e.stopPropagation();
+    setIsResizing(true);
+    startXRef.current = e.clientX;
+    startWidthRef.current = imgRef.current?.offsetWidth ?? 300;
+
+    const onMouseMove = (me: MouseEvent) => {
+      const delta = me.clientX - startXRef.current;
+      const newWidth = Math.max(80, startWidthRef.current + (side === 'right' ? delta : -delta));
+      updateAttributes({ width: Math.round(newWidth) });
+    };
+
+    const onMouseUp = () => {
+      setIsResizing(false);
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [updateAttributes]);
+
+  return (
+    <NodeViewWrapper as="div" className="relative my-4 inline-block max-w-full">
+      <img
+        ref={imgRef}
+        src={src}
+        alt={alt}
+        draggable={false}
+        style={{ width: width ? `${width}px` : undefined, maxWidth: '100%', height: 'auto', display: 'block' }}
+        className={`rounded-xl border border-border object-contain transition-shadow ${
+          selected ? 'ring-2 ring-[color:var(--operator-primary)] ring-offset-1' : ''
+        } ${isResizing ? 'select-none' : ''}`}
+      />
+      {selected && (
+        <>
+          <div
+            role="separator"
+            aria-label="왼쪽 리사이즈 핸들"
+            onMouseDown={(e) => handleResizeStart(e, 'left')}
+            className="absolute left-0 top-1/2 -translate-x-1/2 -translate-y-1/2 h-8 w-3 cursor-ew-resize rounded-sm border border-border bg-background shadow-md hover:bg-muted"
+          />
+          <div
+            role="separator"
+            aria-label="오른쪽 리사이즈 핸들"
+            onMouseDown={(e) => handleResizeStart(e, 'right')}
+            className="absolute right-0 top-1/2 translate-x-1/2 -translate-y-1/2 h-8 w-3 cursor-ew-resize rounded-sm border border-border bg-background shadow-md hover:bg-muted"
+          />
+        </>
+      )}
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definition ──────────────────────────────────────────────────────────
+// Extend the built-in Image node to add width attribute + resize NodeView
+
+export const CustomImageNode = Image.extend({
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      width: {
+        default: null,
+        parseHTML: (el) => {
+          const style = (el as HTMLElement).style.width;
+          if (style) return parseInt(style, 10) || null;
+          return (el as HTMLElement).getAttribute('width') ? Number((el as HTMLElement).getAttribute('width')) : null;
+        },
+        renderHTML: (attributes: Record<string, unknown>) => {
+          if (!attributes['width']) return {};
+          return { style: `width:${attributes['width']}px;max-width:100%;height:auto` };
+        },
+      },
+    };
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['img', mergeAttributes(HTMLAttributes)];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ImageView);
+  },
+});

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -1,9 +1,30 @@
 import { Extension } from '@tiptap/core';
 import { Plugin, PluginKey } from '@tiptap/pm/state';
 import type { EditorView } from '@tiptap/pm/view';
+import { MAX_FILE_BYTES, fileToDataUrl, formatFileSize } from './file-node';
 
-const MAX_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_IMAGE_BYTES = 1 * 1024 * 1024; // 1 MB — images are compressed above this
 const MAX_DIM = 1920;
+
+function dispatchFileSizeError(file: File): void {
+  window.dispatchEvent(new CustomEvent('docs:file-size-error', {
+    detail: { message: `파일 크기가 5MB를 초과합니다. (${formatFileSize(file.size)})` },
+  }));
+}
+
+function insertFileAttachment(view: EditorView, file: File, dataUrl: string, pos?: number): void {
+  const { schema, selection } = view.state;
+  const nodeType = schema.nodes['fileAttachment'];
+  if (!nodeType) return;
+  const node = nodeType.create({
+    filename: file.name,
+    size: file.size,
+    mimeType: file.type,
+    data: dataUrl,
+  });
+  const insertPos = pos ?? selection.anchor;
+  view.dispatch(view.state.tr.insert(insertPos, node));
+}
 
 async function processImageFile(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -11,7 +32,7 @@ async function processImageFile(file: File): Promise<string> {
     reader.onerror = () => reject(new Error('FileReader 오류'));
     reader.onload = (e) => {
       const dataUrl = e.target?.result as string;
-      if (file.size <= MAX_BYTES) {
+      if (file.size <= MAX_IMAGE_BYTES) {
         resolve(dataUrl);
         return;
       }
@@ -34,7 +55,7 @@ async function processImageFile(file: File): Promise<string> {
 
         let quality = 0.85;
         let compressed = canvas.toDataURL('image/jpeg', quality);
-        while (compressed.length * 0.75 > MAX_BYTES && quality > 0.3) {
+        while (compressed.length * 0.75 > MAX_IMAGE_BYTES && quality > 0.3) {
           quality = Math.max(0.3, quality - 0.1);
           compressed = canvas.toDataURL('image/jpeg', quality);
         }
@@ -68,16 +89,24 @@ export const ImageUploadExtension = Extension.create({
             const dragEvent = event as DragEvent;
             const files = dragEvent.dataTransfer?.files;
             if (!files || files.length === 0) return false;
-            const images = Array.from(files).filter((f) => f.type.startsWith('image/'));
-            if (images.length === 0) return false;
 
+            const allFiles = Array.from(files);
+            const images = allFiles.filter((f) => f.type.startsWith('image/'));
+            const nonImages = allFiles.filter((f) => !f.type.startsWith('image/'));
+
+            if (images.length === 0 && nonImages.length === 0) return false;
             dragEvent.preventDefault();
+
             const coords = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
+            const basePos = coords?.pos ?? view.state.selection.anchor;
 
             void Promise.all(images.map(processImageFile)).then((srcs) => {
-              srcs.forEach((src, i) => {
-                insertImageSrc(view, src, (coords?.pos ?? view.state.selection.anchor) + i);
-              });
+              srcs.forEach((src, i) => insertImageSrc(view, src, basePos + i));
+            });
+
+            nonImages.forEach((file) => {
+              if (file.size > MAX_FILE_BYTES) { dispatchFileSizeError(file); return; }
+              void fileToDataUrl(file).then((dataUrl) => insertFileAttachment(view, file, dataUrl, basePos));
             });
 
             return true;

--- a/apps/web/src/components/docs/extensions/image-upload.ts
+++ b/apps/web/src/components/docs/extensions/image-upload.ts
@@ -1,0 +1,106 @@
+import { Extension } from '@tiptap/core';
+import { Plugin, PluginKey } from '@tiptap/pm/state';
+import type { EditorView } from '@tiptap/pm/view';
+
+const MAX_BYTES = 1 * 1024 * 1024; // 1 MB
+const MAX_DIM = 1920;
+
+async function processImageFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(new Error('FileReader 오류'));
+    reader.onload = (e) => {
+      const dataUrl = e.target?.result as string;
+      if (file.size <= MAX_BYTES) {
+        resolve(dataUrl);
+        return;
+      }
+      // Compress via canvas
+      const img = new Image();
+      img.onerror = () => reject(new Error('이미지 로드 오류'));
+      img.onload = () => {
+        let { naturalWidth: w, naturalHeight: h } = img;
+        if (w > MAX_DIM || h > MAX_DIM) {
+          const ratio = Math.min(MAX_DIM / w, MAX_DIM / h);
+          w = Math.round(w * ratio);
+          h = Math.round(h * ratio);
+        }
+        const canvas = document.createElement('canvas');
+        canvas.width = w;
+        canvas.height = h;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) { resolve(dataUrl); return; }
+        ctx.drawImage(img, 0, 0, w, h);
+
+        let quality = 0.85;
+        let compressed = canvas.toDataURL('image/jpeg', quality);
+        while (compressed.length * 0.75 > MAX_BYTES && quality > 0.3) {
+          quality = Math.max(0.3, quality - 0.1);
+          compressed = canvas.toDataURL('image/jpeg', quality);
+        }
+        resolve(compressed);
+      };
+      img.src = dataUrl;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+function insertImageSrc(view: EditorView, src: string, pos?: number): void {
+  const { schema, selection } = view.state;
+  const imageType = schema.nodes['image'];
+  if (!imageType) return;
+  const node = imageType.create({ src });
+  const insertPos = pos ?? selection.anchor;
+  const tr = view.state.tr.insert(insertPos, node);
+  view.dispatch(tr);
+}
+
+export const ImageUploadExtension = Extension.create({
+  name: 'imageUpload',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('imageUpload'),
+        props: {
+          handleDrop(view: EditorView, event: Event) {
+            const dragEvent = event as DragEvent;
+            const files = dragEvent.dataTransfer?.files;
+            if (!files || files.length === 0) return false;
+            const images = Array.from(files).filter((f) => f.type.startsWith('image/'));
+            if (images.length === 0) return false;
+
+            dragEvent.preventDefault();
+            const coords = view.posAtCoords({ left: dragEvent.clientX, top: dragEvent.clientY });
+
+            void Promise.all(images.map(processImageFile)).then((srcs) => {
+              srcs.forEach((src, i) => {
+                insertImageSrc(view, src, (coords?.pos ?? view.state.selection.anchor) + i);
+              });
+            });
+
+            return true;
+          },
+
+          handlePaste(view: EditorView, event: Event) {
+            const clipboardEvent = event as ClipboardEvent;
+            const items = clipboardEvent.clipboardData?.items;
+            if (!items) return false;
+            const imageItems = Array.from(items).filter((item) => item.type.startsWith('image/'));
+            if (imageItems.length === 0) return false;
+
+            clipboardEvent.preventDefault();
+            const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
+
+            void Promise.all(files.map(processImageFile)).then((srcs) => {
+              srcs.forEach((src) => insertImageSrc(view, src));
+            });
+
+            return true;
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/apps/web/src/components/docs/extensions/math-node.tsx
+++ b/apps/web/src/components/docs/extensions/math-node.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { Node, Mark, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+
+// ─── KaTeX Renderer ───────────────────────────────────────────────────────────
+
+async function renderKatex(latex: string, displayMode: boolean): Promise<{ html: string; error?: string }> {
+  try {
+    const katex = await import('katex');
+    const html = katex.default.renderToString(latex, {
+      displayMode,
+      throwOnError: true,
+      output: 'html',
+    });
+    return { html };
+  } catch (err) {
+    return { html: '', error: err instanceof Error ? err.message : 'KaTeX 렌더링 실패' };
+  }
+}
+
+// ─── Math Block View (display mode) ──────────────────────────────────────────
+
+function MathBlockView({ node, selected }: ReactNodeViewProps) {
+  const latex = node.textContent;
+  const [html, setHtml] = useState('');
+  const [error, setError] = useState('');
+  const showEdit = selected;
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!latex.trim()) {
+        setHtml('');
+        setError('');
+        return;
+      }
+      const { html: rendered, error: err } = await renderKatex(latex, true);
+      if (cancelled) return;
+      if (err) { setError(err); setHtml(''); } else { setHtml(rendered); setError(''); }
+    })();
+    return () => { cancelled = true; };
+  }, [latex]);
+
+  return (
+    <NodeViewWrapper as="div" className="my-4 not-prose">
+      <div className="rounded-xl border border-border bg-muted/10">
+        {/* Header */}
+        <div className="flex items-center justify-between px-3 py-2" contentEditable={false}>
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[color:var(--operator-muted)]">math</span>
+          {selected && (
+            <span className="text-[11px] text-[color:var(--operator-muted)]">LaTeX 편집 중</span>
+          )}
+        </div>
+
+        {/* LaTeX editor — visible when selected */}
+        <pre className={`border-t border-border/50 p-4 text-[13px] leading-6 text-[color:var(--operator-foreground)] font-mono ${showEdit ? '' : 'hidden'}`}>
+          <NodeViewContent />
+        </pre>
+
+        {/* KaTeX preview */}
+        {!showEdit && (
+          <div className="px-4 pb-4" contentEditable={false}>
+            {error ? (
+              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">{error}</div>
+            ) : html ? (
+              <div
+                dangerouslySetInnerHTML={{ __html: html }}
+                className="flex justify-center overflow-x-auto [&_.katex]:text-[color:var(--operator-foreground)]"
+              />
+            ) : (
+              <p className="text-xs text-[color:var(--operator-muted)] text-center">수식을 입력하세요 (LaTeX)</p>
+            )}
+          </div>
+        )}
+      </div>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Math Inline View ────────────────────────────────────────────────────────
+
+function MathInlineView({ node }: ReactNodeViewProps) {
+  const latex = node.textContent;
+  const [html, setHtml] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!latex.trim()) return;
+    let cancelled = false;
+    void renderKatex(latex, false).then(({ html: rendered, error: err }) => {
+      if (cancelled) return;
+      if (err) { setError(err); setHtml(''); } else { setHtml(rendered); setError(''); }
+    });
+    return () => { cancelled = true; };
+  }, [latex]);
+
+  if (error) {
+    return (
+      <NodeViewWrapper as="span" className="rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono">
+        {latex}
+      </NodeViewWrapper>
+    );
+  }
+
+  if (html) {
+    return (
+      <NodeViewWrapper as="span" contentEditable={false}>
+        <span
+          dangerouslySetInnerHTML={{ __html: html }}
+          className="[&_.katex]:text-[color:var(--operator-foreground)]"
+        />
+      </NodeViewWrapper>
+    );
+  }
+
+  return (
+    <NodeViewWrapper as="span" className="rounded bg-muted/40 px-1 font-mono text-[0.9em]">
+      <NodeViewContent />
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Node Definitions ─────────────────────────────────────────────────────────
+
+export const MathBlockNode = Node.create({
+  name: 'mathBlock',
+  group: 'block',
+  content: 'text*',
+  marks: '',
+  code: true,
+  defining: true,
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="mathBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const latex = (HTMLAttributes as Record<string, unknown>)['data-latex'] as string ?? '';
+    return ['div', mergeAttributes({ 'data-type': 'mathBlock', 'data-latex': latex }, HTMLAttributes), 0];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-m': () => this.editor.commands.insertContent({
+        type: this.name,
+        content: [{ type: 'text', text: '' }],
+      }),
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathBlockView);
+  },
+});
+
+export const MathInlineNode = Node.create({
+  name: 'mathInline',
+  group: 'inline',
+  inline: true,
+  atom: true,
+  content: 'text*',
+  marks: '',
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="mathInline"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['span', mergeAttributes({ 'data-type': 'mathInline' }, HTMLAttributes), 0];
+  },
+
+  addKeyboardShortcuts() {
+    return {
+      'Mod-Shift-e': () => this.editor.commands.insertContent({
+        type: this.name,
+        content: [{ type: 'text', text: '' }],
+      }),
+    };
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(MathInlineView);
+  },
+});
+
+// ─── Viewer helper ────────────────────────────────────────────────────────────
+
+export { renderKatex };

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -27,6 +27,7 @@ import {
   Minus,
   FileText,
   GitBranch,
+  ChevronRight,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -170,6 +171,20 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Toggle',
+        description: '접기/펼치기 블록',
+        icon: ChevronRight,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'toggleBlock',
+            attrs: { open: false },
+            content: [
+              { type: 'toggleSummary', content: [{ type: 'text', text: '토글 제목' }] },
+              { type: 'toggleContent', content: [{ type: 'paragraph' }] },
+            ],
+          }).run(),
+      },
       {
         title: 'Page Embed',
         description: '다른 문서 임베드',

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -30,6 +30,7 @@ import {
   ChevronRight,
   Paperclip,
   Globe,
+  Sigma,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -212,6 +213,26 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Math Block',
+        description: 'LaTeX 블록 수식',
+        icon: Sigma,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'mathBlock',
+            content: [{ type: 'text', text: 'E = mc^2' }],
+          }).run(),
+      },
+      {
+        title: 'Math Inline',
+        description: 'LaTeX 인라인 수식',
+        icon: Sigma,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'mathInline',
+            content: [{ type: 'text', text: 'x^2' }],
+          }).run(),
+      },
       {
         title: 'Toggle',
         description: '접기/펼치기 블록',

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -11,117 +11,189 @@ import {
   useRef,
 } from 'react';
 import type { Editor, Range } from '@tiptap/core';
+import type { FC } from 'react';
+import {
+  Heading1,
+  Heading2,
+  Heading3,
+  List,
+  ListOrdered,
+  Code,
+  Quote,
+  Lightbulb,
+  Table,
+  ImageIcon,
+  Minus,
+  FileText,
+} from 'lucide-react';
 
 export interface SlashMenuItem {
   title: string;
-  icon: string;
+  description: string;
+  icon: FC<{ className?: string }>;
   command: (editor: Editor, range: Range) => void;
 }
 
-export const defaultSlashItems: SlashMenuItem[] = [
+export interface SlashMenuCategory {
+  label: string;
+  items: SlashMenuItem[];
+}
+
+export const slashMenuCategories: SlashMenuCategory[] = [
   {
-    title: 'Heading 1',
-    icon: 'H1',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 1 }).run(),
+    label: '텍스트',
+    items: [
+      {
+        title: 'Heading 1',
+        description: '큰 제목',
+        icon: Heading1,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 1 }).run(),
+      },
+      {
+        title: 'Heading 2',
+        description: '중간 제목',
+        icon: Heading2,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+      },
+      {
+        title: 'Heading 3',
+        description: '작은 제목',
+        icon: Heading3,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleHeading({ level: 3 }).run(),
+      },
+    ],
   },
   {
-    title: 'Heading 2',
-    icon: 'H2',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+    label: '리스트',
+    items: [
+      {
+        title: 'Bullet List',
+        description: '순서 없는 목록',
+        icon: List,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+      },
+      {
+        title: 'Ordered List',
+        description: '순서 있는 목록',
+        icon: ListOrdered,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+      },
+    ],
   },
   {
-    title: 'Heading 3',
-    icon: 'H3',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleHeading({ level: 3 }).run(),
+    label: '블록',
+    items: [
+      {
+        title: 'Code Block',
+        description: '코드 블록',
+        icon: Code,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
+      },
+      {
+        title: 'Blockquote',
+        description: '인용구',
+        icon: Quote,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+      },
+      {
+        title: 'Callout',
+        description: '강조 박스',
+        icon: Lightbulb,
+        command: (editor, range) =>
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({ type: 'callout', content: [{ type: 'paragraph' }] })
+            .run(),
+      },
+      {
+        title: 'Table',
+        description: '표 삽입',
+        icon: Table,
+        command: (editor, range) =>
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+            .run(),
+      },
+    ],
   },
   {
-    title: 'Bullet List',
-    icon: '•',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+    label: '미디어',
+    items: [
+      {
+        title: 'Image',
+        description: '이미지 삽입',
+        icon: ImageIcon,
+        command: (editor, range) => {
+          const url = window.prompt('Image URL:');
+          if (url) editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
+        },
+      },
+    ],
   },
   {
-    title: 'Ordered List',
-    icon: '1.',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
-  },
-  {
-    title: 'Code Block',
-    icon: '<>',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleCodeBlock().run(),
-  },
-  {
-    title: 'Blockquote',
-    icon: '"',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
-  },
-  {
-    title: 'Callout',
-    icon: '💡',
-    command: (editor, range) =>
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertContent({
-          type: 'callout',
-          content: [{ type: 'paragraph' }],
-        })
-        .run(),
-  },
-  {
-    title: 'Table',
-    icon: '⊞',
-    command: (editor, range) =>
-      editor
-        .chain()
-        .focus()
-        .deleteRange(range)
-        .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
-        .run(),
-  },
-  {
-    title: 'Image',
-    icon: '🖼',
-    command: (editor, range) => {
-      const url = window.prompt('Image URL:');
-      if (url) {
-        editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
-      }
-    },
-  },
-  {
-    title: 'Horizontal Rule',
-    icon: '—',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
-  },
-  {
-    title: 'Page Embed',
-    icon: '📄',
-    command: (editor, range) =>
-      editor.chain().focus().deleteRange(range).insertPageEmbed().run(),
+    label: '고급',
+    items: [
+      {
+        title: 'Page Embed',
+        description: '다른 문서 임베드',
+        icon: FileText,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertPageEmbed().run(),
+      },
+      {
+        title: 'Horizontal Rule',
+        description: '구분선',
+        icon: Minus,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).setHorizontalRule().run(),
+      },
+    ],
   },
 ];
+
+export const defaultSlashItems: SlashMenuItem[] =
+  slashMenuCategories.flatMap((c) => c.items);
 
 interface SlashMenuRef {
   onKeyDown: (event: KeyboardEvent) => boolean;
 }
 
+function groupByCategory(
+  items: SlashMenuItem[],
+  categories: SlashMenuCategory[],
+): { label: string; items: SlashMenuItem[] }[] {
+  return categories
+    .map((cat) => ({
+      label: cat.label,
+      items: cat.items.filter((item) => items.includes(item)),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
 const SlashMenu = forwardRef<
   SlashMenuRef,
-  { items: SlashMenuItem[]; command: (item: SlashMenuItem) => void }
->(function SlashMenu({ items, command }, ref) {
+  {
+    items: SlashMenuItem[];
+    categories: SlashMenuCategory[];
+    query: string;
+    command: (item: SlashMenuItem) => void;
+  }
+>(function SlashMenu({ items, categories, query, command }, ref) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Clamp index when items shrink; reset handled via keyboard navigation
   const safeIndex = items.length > 0 ? Math.min(selectedIndex, items.length - 1) : 0;
 
   const onKeyDown = useCallback(
@@ -135,66 +207,80 @@ const SlashMenu = forwardRef<
         return true;
       }
       if (event.key === 'Enter') {
-        const idx = items.length > 0 ? Math.min(selectedIndex, items.length - 1) : 0;
-        const item = items[idx];
+        const item = items[safeIndex];
         if (item) command(item);
         return true;
       }
       return false;
     },
-    [items, selectedIndex, command],
+    [items, safeIndex, command],
   );
 
   useImperativeHandle(ref, () => ({ onKeyDown }), [onKeyDown]);
 
   if (items.length === 0) return null;
 
+  const grouped = query === '' ? groupByCategory(items, categories) : null;
+
+  const renderItem = (item: SlashMenuItem, flatIndex: number) => {
+    const isActive = flatIndex === safeIndex;
+    const Icon = item.icon;
+    return (
+      <button
+        key={item.title}
+        type="button"
+        data-active={isActive}
+        className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
+          isActive
+            ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
+            : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
+        }`}
+        onClick={() => command(item)}
+      >
+        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/10' : 'bg-muted/40'}`}>
+          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--operator-primary-soft)]' : 'text-[color:var(--operator-muted)]'}`} />
+        </span>
+        <span className="flex min-w-0 flex-col">
+          <span className="text-xs font-medium leading-tight">{item.title}</span>
+          <span className="truncate text-[11px] text-[color:var(--operator-muted)]">{item.description}</span>
+        </span>
+      </button>
+    );
+  };
+
   return (
     <div
       ref={containerRef}
-      className="max-h-64 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg"
+      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg"
     >
-      {items.map((item, index) => (
-        <button
-          key={item.title}
-          type="button"
-          data-active={index === safeIndex}
-          className={`flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm transition-colors ${
-            index === safeIndex
-              ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-              : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
-          }`}
-          onClick={() => command(item)}
-        >
-          <span className="w-5 text-center text-xs font-bold text-[color:var(--operator-muted)]">
-            {item.icon}
-          </span>
-          <span>{item.title}</span>
-        </button>
-      ))}
+      {grouped ? (
+        grouped.map((group) => (
+          <div key={group.label}>
+            <p className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--operator-muted)]">
+              {group.label}
+            </p>
+            {group.items.map((item) => {
+              const flatIndex = items.indexOf(item);
+              return renderItem(item, flatIndex);
+            })}
+          </div>
+        ))
+      ) : (
+        items.map((item, index) => renderItem(item, index))
+      )}
     </div>
   );
 });
 
-/** Estimated max-height of the dropdown (matches `max-h-64` = 16rem at 16px/rem). */
-const MENU_ESTIMATED_HEIGHT = 256;
+/** Estimated max-height of the dropdown (matches `max-h-72` = 18rem at 16px/rem). */
+const MENU_ESTIMATED_HEIGHT = 288;
 /** Estimated min-width of the dropdown for initial right-edge clamping. */
-const MENU_ESTIMATED_WIDTH = 240;
+const MENU_ESTIMATED_WIDTH = 256;
 /** Gap between caret anchor and popup edge, in px. */
 const CARET_GAP = 4;
 /** Minimum distance from viewport edges, in px. */
 const VIEWPORT_MARGIN = 8;
 
-/**
- * Pure function that computes the {top, left} for the slash-hint popup so it
- * stays fully within the viewport regardless of scroll position.
- *
- * - Prefers positioning below the caret anchor.
- * - Flips above when insufficient space below and more space is available above.
- * - Clamps both axes to stay within the viewport.
- *
- * Exported for unit testing.
- */
 export function calculatePopupPosition(
   anchorRect: DOMRect,
   popupHeight: number,
@@ -207,17 +293,13 @@ export function calculatePopupPosition(
 
   let top: number;
   if (spaceBelow >= popupHeight || spaceBelow >= spaceAbove) {
-    // Enough room below, or more room below than above → open downward
     top = anchorRect.bottom + CARET_GAP;
   } else {
-    // Flip upward
     top = anchorRect.top - CARET_GAP - popupHeight;
   }
 
-  // Clamp vertically so the popup never extends outside the viewport
   top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - popupHeight - VIEWPORT_MARGIN));
 
-  // Clamp horizontally
   const left = Math.max(
     VIEWPORT_MARGIN,
     Math.min(anchorRect.left, viewportWidth - popupWidth - VIEWPORT_MARGIN),
@@ -226,13 +308,6 @@ export function calculatePopupPosition(
   return { top, left };
 }
 
-/**
- * Applies viewport-aware positioning to the popup element.
- *
- * 1. Computes an initial position with estimated dimensions (no flash).
- * 2. After React has flushed the render (double rAF), re-measures the actual
- *    popup dimensions and fine-tunes the position.
- */
 function applyPosition(
   popup: HTMLElement,
   clientRectFn: (() => DOMRect | null) | null | undefined,
@@ -243,12 +318,10 @@ function applyPosition(
   const vw = window.innerWidth;
   const vh = window.innerHeight;
 
-  // Initial estimate — avoids visible jump on first render
   const initial = calculatePopupPosition(rect, MENU_ESTIMATED_HEIGHT, MENU_ESTIMATED_WIDTH, vw, vh);
   popup.style.top = `${initial.top}px`;
   popup.style.left = `${initial.left}px`;
 
-  // Fine-tune after React's concurrent render has painted (double rAF)
   requestAnimationFrame(() => {
     requestAnimationFrame(() => {
       if (!popup.isConnected) return;
@@ -270,6 +343,7 @@ function createSuggestionRenderer() {
     onStart(props: {
       editor: Editor;
       range: Range;
+      query: string;
       items: SlashMenuItem[];
       command: (item: SlashMenuItem) => void;
       clientRect?: (() => DOMRect | null) | null;
@@ -284,36 +358,31 @@ function createSuggestionRenderer() {
       root = createRoot(popup);
       root.render(
         <SlashMenu
-          ref={(r) => {
-            menuRef = r;
-          }}
+          ref={(r) => { menuRef = r; }}
           items={props.items}
-          command={(item) => {
-            item.command(props.editor, props.range);
-          }}
+          categories={slashMenuCategories}
+          query={props.query}
+          command={(item) => { item.command(props.editor, props.range); }}
         />,
       );
     },
     onUpdate(props: {
       editor: Editor;
       range: Range;
+      query: string;
       items: SlashMenuItem[];
       command: (item: SlashMenuItem) => void;
       clientRect?: (() => DOMRect | null) | null;
     }) {
-      if (popup) {
-        applyPosition(popup, props.clientRect);
-      }
+      if (popup) applyPosition(popup, props.clientRect);
 
       root?.render(
         <SlashMenu
-          ref={(r) => {
-            menuRef = r;
-          }}
+          ref={(r) => { menuRef = r; }}
           items={props.items}
-          command={(item) => {
-            item.command(props.editor, props.range);
-          }}
+          categories={slashMenuCategories}
+          query={props.query}
+          command={(item) => { item.command(props.editor, props.range); }}
         />,
       );
     },

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -26,6 +26,7 @@ import {
   ImageIcon,
   Minus,
   FileText,
+  GitBranch,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -147,6 +148,22 @@ export const slashMenuCategories: SlashMenuCategory[] = [
           const url = window.prompt('Image URL:');
           if (url) editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
         },
+      },
+      {
+        title: 'Mermaid Diagram',
+        description: '다이어그램 삽입',
+        icon: GitBranch,
+        command: (editor, range) =>
+          editor
+            .chain()
+            .focus()
+            .deleteRange(range)
+            .insertContent({
+              type: 'codeBlock',
+              attrs: { language: 'mermaid' },
+              content: [{ type: 'text', text: 'flowchart TD\n    A[시작] --> B[끝]' }],
+            })
+            .run(),
       },
     ],
   },

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -28,6 +28,7 @@ import {
   FileText,
   GitBranch,
   ChevronRight,
+  Paperclip,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -148,6 +149,33 @@ export const slashMenuCategories: SlashMenuCategory[] = [
         command: (editor, range) => {
           const url = window.prompt('Image URL:');
           if (url) editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
+        },
+      },
+      {
+        title: 'File',
+        description: '파일 첨부',
+        icon: Paperclip,
+        command: (editor, range) => {
+          editor.chain().focus().deleteRange(range).run();
+          const input = document.createElement('input');
+          input.type = 'file';
+          input.onchange = async () => {
+            const file = input.files?.[0];
+            if (!file) return;
+            const { MAX_FILE_BYTES: maxBytes, fileToDataUrl: toDataUrl, formatFileSize: fmtSize } = await import('./file-node');
+            if (file.size > maxBytes) {
+              window.dispatchEvent(new CustomEvent('docs:file-size-error', {
+                detail: { message: `파일 크기가 5MB를 초과합니다. (${fmtSize(file.size)})` },
+              }));
+              return;
+            }
+            const dataUrl = await toDataUrl(file);
+            editor.commands.insertContent({
+              type: 'fileAttachment',
+              attrs: { filename: file.name, size: file.size, mimeType: file.type, data: dataUrl },
+            });
+          };
+          input.click();
         },
       },
       {

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -29,6 +29,7 @@ import {
   GitBranch,
   ChevronRight,
   Paperclip,
+  Globe,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -176,6 +177,18 @@ export const slashMenuCategories: SlashMenuCategory[] = [
             });
           };
           input.click();
+        },
+      },
+      {
+        title: 'Embed',
+        description: '외부 URL 임베드',
+        icon: Globe,
+        command: (editor, range) => {
+          const url = window.prompt('임베드할 URL을 입력하세요 (YouTube, Figma 등):');
+          editor.chain().focus().deleteRange(range).run();
+          if (url?.trim()) {
+            editor.commands.insertContent({ type: 'embedBlock', attrs: { url: url.trim() } });
+          }
         },
       },
       {

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -18,6 +18,7 @@ import {
   Heading3,
   List,
   ListOrdered,
+  ListTodo,
   Code,
   Quote,
   Lightbulb,
@@ -82,6 +83,13 @@ export const slashMenuCategories: SlashMenuCategory[] = [
         icon: ListOrdered,
         command: (editor, range) =>
           editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+      },
+      {
+        title: 'Checklist',
+        description: '체크리스트',
+        icon: ListTodo,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).toggleTaskList().run(),
       },
     ],
   },

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -31,6 +31,7 @@ import {
   Paperclip,
   Globe,
   Sigma,
+  Columns2,
 } from 'lucide-react';
 
 export interface SlashMenuItem {
@@ -213,6 +214,20 @@ export const slashMenuCategories: SlashMenuCategory[] = [
   {
     label: '고급',
     items: [
+      {
+        title: 'Columns',
+        description: '2단/3단 컬럼 레이아웃',
+        icon: Columns2,
+        command: (editor, range) =>
+          editor.chain().focus().deleteRange(range).insertContent({
+            type: 'columnsBlock',
+            attrs: { columns: 2 },
+            content: [
+              { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+              { type: 'columnBlock', content: [{ type: 'paragraph' }] },
+            ],
+          }).run(),
+      },
       {
         title: 'Math Block',
         description: 'LaTeX 블록 수식',

--- a/apps/web/src/components/docs/extensions/toggle-block.tsx
+++ b/apps/web/src/components/docs/extensions/toggle-block.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState, useCallback, useEffect } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import { ReactNodeViewRenderer, NodeViewWrapper, NodeViewContent, type ReactNodeViewProps } from '@tiptap/react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+
+// ─── Toggle Summary View ──────────────────────────────────────────────────────
+
+function ToggleSummaryView({ getPos, editor }: ReactNodeViewProps) {
+  const readParentOpen = useCallback((): boolean => {
+    if (typeof getPos !== 'function') return false;
+    try {
+      const pos = getPos();
+      if (pos === undefined) return false;
+      const $pos = editor.state.doc.resolve(pos);
+      if ($pos.depth >= 1) {
+        const parent = $pos.node($pos.depth - 1);
+        if (parent.type.name === 'toggleBlock') return Boolean(parent.attrs.open);
+      }
+    } catch { /* node may be deleted */ }
+    return false;
+  }, [editor, getPos]);
+
+  const [isOpen, setIsOpen] = useState(() => readParentOpen());
+
+  useEffect(() => {
+    const updateOpen = () => { setIsOpen(readParentOpen()); };
+    editor.on('update', updateOpen);
+    return () => { editor.off('update', updateOpen); };
+  }, [editor, readParentOpen]);
+
+  const handleToggle = useCallback(() => {
+    if (typeof getPos !== 'function') return;
+    try {
+      const pos = getPos();
+      if (pos === undefined) return;
+      const $pos = editor.state.doc.resolve(pos);
+      if ($pos.depth < 1) return;
+      const parentPos = $pos.before($pos.depth);
+      const parent = $pos.node($pos.depth - 1);
+      if (parent.type.name !== 'toggleBlock') return;
+      editor.commands.command(({ tr }) => {
+        tr.setNodeMarkup(parentPos, undefined, { open: !parent.attrs.open });
+        return true;
+      });
+    } catch { /* node may be deleted */ }
+  }, [editor, getPos]);
+
+  return (
+    <NodeViewWrapper as="div" className="flex items-center gap-1.5">
+      <button
+        type="button"
+        contentEditable={false}
+        onClick={handleToggle}
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-[color:var(--operator-muted)] transition-colors hover:bg-muted hover:text-[color:var(--operator-foreground)]"
+        aria-label={isOpen ? '접기' : '펼치기'}
+      >
+        {isOpen
+          ? <ChevronDown className="size-3.5" />
+          : <ChevronRight className="size-3.5" />}
+      </button>
+      <NodeViewContent as="div" className="flex-1 font-medium leading-6 outline-none" />
+    </NodeViewWrapper>
+  );
+}
+
+// ─── Nodes ────────────────────────────────────────────────────────────────────
+
+export const ToggleSummary = Node.create({
+  name: 'toggleSummary',
+  content: 'inline*',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleSummary"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleSummary' }, HTMLAttributes), 0];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(ToggleSummaryView);
+  },
+});
+
+export const ToggleContent = Node.create({
+  name: 'toggleContent',
+  content: 'block+',
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleContent"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleContent' }, HTMLAttributes), 0];
+  },
+});
+
+export const ToggleBlock = Node.create({
+  name: 'toggleBlock',
+  group: 'block',
+  content: 'toggleSummary toggleContent',
+  defining: true,
+
+  addAttributes() {
+    return {
+      open: {
+        default: false,
+        parseHTML: (element) => element.getAttribute('data-open') === 'true',
+        renderHTML: (attributes: Record<string, unknown>) => ({
+          'data-open': String(attributes['open'] ?? false),
+        }),
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'div[data-type="toggleBlock"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', mergeAttributes({ 'data-type': 'toggleBlock' }, HTMLAttributes), 0];
+  },
+});

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -1,0 +1,263 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Node, mergeAttributes } from '@tiptap/core';
+import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
+import { createRoot, type Root } from 'react-dom/client';
+import { FileText, AlertCircle } from 'lucide-react';
+
+// ─── WikiLink Node View ───────────────────────────────────────────────────────
+
+interface WikiLinkDoc {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+function WikiLinkView({ node, editor }: ReactNodeViewProps) {
+  const title = node.attrs.title as string;
+  const slug = node.attrs.slug as string | null;
+  const [exists, setExists] = useState<boolean | null>(null);
+
+  const { projectId, onNavigate } = (editor.extensionManager.extensions.find(
+    (e) => e.name === 'wikiLink',
+  )?.options ?? {}) as { projectId?: string; onNavigate?: (slug: string) => void };
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      if (!slug || !projectId) { setExists(true); return; }
+      try {
+        const res = await fetch(`/api/docs?project_id=${projectId}&slug=${encodeURIComponent(slug)}&limit=1`);
+        const data = res.ok ? (await res.json() as { data?: unknown[] }) : null;
+        if (!cancelled) setExists(Array.isArray(data?.data) && data.data.length > 0);
+      } catch {
+        if (!cancelled) setExists(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [slug, projectId]);
+
+  const handleClick = useCallback(() => {
+    if (!slug) return;
+    if (onNavigate) { onNavigate(slug); return; }
+    window.location.href = `/docs/${slug}`;
+  }, [slug, onNavigate]);
+
+  const isNotFound = exists === false;
+
+  return (
+    <NodeViewWrapper as="span" contentEditable={false}>
+      <span
+        onClick={handleClick}
+        title={isNotFound ? '문서를 찾을 수 없습니다' : title}
+        className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] transition-colors ${
+          isNotFound
+            ? 'bg-red-500/10 text-red-500 hover:bg-red-500/20'
+            : 'bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)] hover:bg-[color:var(--operator-primary)]/20'
+        }`}
+      >
+        {isNotFound
+          ? <AlertCircle className="size-3 flex-shrink-0" />
+          : <FileText className="size-3 flex-shrink-0" />}
+        {title}
+      </span>
+    </NodeViewWrapper>
+  );
+}
+
+// ─── WikiLink Node ────────────────────────────────────────────────────────────
+
+export interface WikiLinkOptions {
+  projectId?: string;
+  onNavigate?: (slug: string) => void;
+  suggestion: Partial<SuggestionOptions>;
+}
+
+export const WikiLinkNode = Node.create<WikiLinkOptions>({
+  name: 'wikiLink',
+  group: 'inline',
+  inline: true,
+  atom: true,
+
+  addOptions() {
+    return {
+      projectId: undefined,
+      onNavigate: undefined,
+      suggestion: {},
+    };
+  },
+
+  addAttributes() {
+    return {
+      docId: { default: null },
+      title: { default: '' },
+      slug: { default: null },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'span[data-type="wikiLink"]' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const { docId, title, slug, ...rest } = HTMLAttributes as Record<string, unknown>;
+    return [
+      'span',
+      mergeAttributes(
+        { 'data-type': 'wikiLink', 'data-doc-id': docId, 'data-title': title, 'data-slug': slug },
+        rest,
+      ),
+      String(title ?? ''),
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(WikiLinkView);
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ];
+  },
+});
+
+// ─── Search Dropdown ──────────────────────────────────────────────────────────
+
+function WikiLinkMenu({
+  items,
+  command,
+}: {
+  items: WikiLinkDoc[];
+  command: (item: WikiLinkDoc) => void;
+}) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowDown') { setSelectedIndex((i) => (i + 1) % Math.max(items.length, 1)); e.preventDefault(); }
+      if (e.key === 'ArrowUp') { setSelectedIndex((i) => (i - 1 + items.length) % Math.max(items.length, 1)); e.preventDefault(); }
+      if (e.key === 'Enter') { const item = items[selectedIndex]; if (item) { command(item); } e.preventDefault(); }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [items, selectedIndex, command]);
+
+  if (items.length === 0) {
+    return (
+      <div className="w-56 rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-3 text-xs text-[color:var(--operator-muted)] shadow-lg">
+        문서를 찾을 수 없습니다
+      </div>
+    );
+  }
+
+  return (
+    <div ref={menuRef} className="max-h-64 w-56 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg">
+      {items.map((item, i) => (
+        <button
+          key={item.id}
+          type="button"
+          onClick={() => command(item)}
+          className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
+            i === selectedIndex
+              ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
+              : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
+          }`}
+        >
+          <FileText className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+          <span className="truncate text-xs">{item.title}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// ─── Suggestion Factory ───────────────────────────────────────────────────────
+
+export function createWikiLinkSuggestion(projectId: string | undefined): Partial<SuggestionOptions> {
+  let popup: HTMLElement | null = null;
+  let root: Root | null = null;
+
+  return {
+    char: '[[',
+    allowSpaces: true,
+    startOfLine: false,
+
+    items: async ({ query }) => {
+      if (!projectId) return [];
+      try {
+        const params = new URLSearchParams({ project_id: projectId, q: query, limit: '10' });
+        const res = await fetch(`/api/docs?${params.toString()}`);
+        if (!res.ok) return [];
+        const data = await res.json() as { data?: WikiLinkDoc[] };
+        return data.data ?? [];
+      } catch {
+        return [];
+      }
+    },
+
+    render: () => ({
+      onStart(props) {
+        popup = document.createElement('div');
+        popup.style.cssText = 'position:fixed;z-index:9999';
+        document.body.appendChild(popup);
+
+        const rect = props.clientRect?.();
+        if (rect) {
+          popup.style.top = `${rect.bottom + 4}px`;
+          popup.style.left = `${rect.left}px`;
+        }
+
+        root = createRoot(popup);
+        root.render(
+          <WikiLinkMenu
+            items={props.items as WikiLinkDoc[]}
+            command={(item) => {
+              props.command(item);
+            }}
+          />,
+        );
+      },
+
+      onUpdate(props) {
+        const rect = props.clientRect?.();
+        if (rect && popup) {
+          popup.style.top = `${rect.bottom + 4}px`;
+          popup.style.left = `${rect.left}px`;
+        }
+        root?.render(
+          <WikiLinkMenu
+            items={props.items as WikiLinkDoc[]}
+            command={(item) => { props.command(item); }}
+          />,
+        );
+      },
+
+      onKeyDown(props) {
+        if (props.event.key === 'Escape') {
+          popup?.remove(); popup = null; root?.unmount(); root = null;
+          return true;
+        }
+        return false;
+      },
+
+      onExit() {
+        popup?.remove(); popup = null; root?.unmount(); root = null;
+      },
+    }),
+
+    command({ editor, range, props }) {
+      const item = props as WikiLinkDoc;
+      editor.chain().focus().deleteRange(range).insertContent({
+        type: 'wikiLink',
+        attrs: { docId: item.id, title: item.title, slug: item.slug },
+      }).run();
+    },
+  };
+}

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Node, mergeAttributes } from '@tiptap/core';
 import Suggestion, { type SuggestionOptions } from '@tiptap/suggestion';
+import { PluginKey } from '@tiptap/pm/state';
 import { ReactNodeViewRenderer, NodeViewWrapper, type ReactNodeViewProps } from '@tiptap/react';
 import { createRoot, type Root } from 'react-dom/client';
 import { FileText, AlertCircle } from 'lucide-react';
@@ -121,6 +122,7 @@ export const WikiLinkNode = Node.create<WikiLinkOptions>({
     return [
       Suggestion({
         editor: this.editor,
+        pluginKey: new PluginKey('wikiLinkSuggestion'),
         ...this.options.suggestion,
       }),
     ];

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,21 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve columns block as raw HTML
+turndown.addRule('columnsBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'columnsBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const cols = el.getAttribute('data-cols') ?? '2';
+    const columnsHtml = Array.from(el.querySelectorAll('[data-type="columnBlock"]'))
+      .map((col) => `<div data-type="columnBlock">${(col as HTMLElement).innerHTML}</div>`)
+      .join('');
+    return `\n<div data-type="columnsBlock" data-cols="${cols}">${columnsHtml}</div>\n`;
+  },
+});
+
 // Preserve math block nodes as raw HTML
 turndown.addRule('mathBlock', {
   filter: (node) =>
@@ -228,6 +243,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Columns blocks — may span multiple lines, protect by start tag
+  html = html.replace(/^<div data-type="columnsBlock"[\s\S]*?<\/div>\s*<\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -128,9 +128,11 @@ export function markdownToHtml(rawMd: string): string {
   // Extract fenced code blocks first to prevent other transforms from modifying their content.
   // Subsequent regex passes use gm flags which would otherwise corrupt multi-line code blocks.
   const codeBlockPlaceholders: string[] = [];
-  let html = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+  let html = md.replace(/```(\w*)\n([\s\S]*?)```/g, (_m, lang, code) => {
     const idx = codeBlockPlaceholders.length;
-    codeBlockPlaceholders.push(`<pre><code>${escapeHtml(code.trimEnd())}</code></pre>`);
+    const langAttrs = lang ? ` data-language="${lang}" class="language-${lang}"` : '';
+    const codeClass = lang ? ` class="language-${lang}"` : '';
+    codeBlockPlaceholders.push(`<pre${langAttrs}><code${codeClass}>${escapeHtml(code.trimEnd())}</code></pre>`);
     return `\x00CODEBLOCK${idx}\x00`;
   });
 

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,20 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve embed blocks as raw HTML
+turndown.addRule('embedBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'embedBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const url = safeAttr(el.getAttribute('data-url') ?? '');
+    return `\n<div data-type="embedBlock" data-url="${url}"></div>\n`;
+  },
+});
+
 // Preserve file attachment blocks as raw HTML
 turndown.addRule('fileAttachment', {
   filter: (node) =>
@@ -186,6 +200,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Embed blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="embedBlock"[^\n]*><\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,23 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve file attachment blocks as raw HTML
+turndown.addRule('fileAttachment', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'fileAttachment',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const filename = safeAttr(el.getAttribute('data-filename') ?? '');
+    const size = safeAttr(el.getAttribute('data-size') ?? '0');
+    const mimeType = safeAttr(el.getAttribute('data-mime-type') ?? '');
+    const data = el.getAttribute('data-file-data') ?? '';
+    return `\n<div data-type="fileAttachment" data-filename="${filename}" data-size="${size}" data-mime-type="${mimeType}" data-file-data="${data}"></div>\n`;
+  },
+});
+
 // Preserve toggle blocks as raw HTML — must be before generic block rules
 turndown.addRule('toggleBlock', {
   filter: (node) =>
@@ -169,6 +186,12 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // File attachment blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="fileAttachment"[^\n]*><\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,22 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve wiki link inline nodes as raw HTML
+turndown.addRule('wikiLink', {
+  filter: (node) =>
+    node.nodeName === 'SPAN' &&
+    (node as HTMLElement).getAttribute('data-type') === 'wikiLink',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const docId = safeAttr(el.getAttribute('data-doc-id') ?? '');
+    const title = safeAttr(el.getAttribute('data-title') ?? el.textContent ?? '');
+    const slug = safeAttr(el.getAttribute('data-slug') ?? '');
+    return `<span data-type="wikiLink" data-doc-id="${docId}" data-title="${title}" data-slug="${slug}">${title}</span>`;
+  },
+});
+
 // Preserve columns block as raw HTML
 turndown.addRule('columnsBlock', {
   filter: (node) =>
@@ -255,6 +271,12 @@ export function markdownToHtml(rawMd: string): string {
   });
   // Math blocks — stored as single-line raw HTML
   html = html.replace(/^<div data-type="mathBlock"[^\n]*<\/div>$/gm, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Wiki link spans
+  html = html.replace(/<span data-type="wikiLink"[^>]*>[^<]*<\/span>/g, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -47,6 +47,22 @@ turndown.addRule('compactListItem', {
   },
 });
 
+// Preserve toggle blocks as raw HTML — must be before generic block rules
+turndown.addRule('toggleBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'toggleBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const isOpen = el.getAttribute('data-open') === 'true';
+    const summaryEl = el.querySelector('[data-type="toggleSummary"]');
+    const contentEl = el.querySelector('[data-type="toggleContent"]');
+    const summaryHtml = summaryEl ? summaryEl.innerHTML : '';
+    const contentHtml = contentEl ? contentEl.innerHTML : '';
+    return `\n<div data-type="toggleBlock" data-open="${isOpen}"><div data-type="toggleSummary">${summaryHtml}</div><div data-type="toggleContent">${contentHtml}</div></div>\n`;
+  },
+});
+
 // Preserve page-embed atoms — must be before the generic block rule
 turndown.addRule('pageEmbed', {
   filter: (node) => node.nodeName === 'DIV' && node.hasAttribute('data-page-embed'),
@@ -136,10 +152,16 @@ export function markdownToHtml(rawMd: string): string {
     return `\x00CODEBLOCK${idx}\x00`;
   });
 
-  // Protect page-embed atoms — they are written as raw HTML by htmlToMarkdown() and
-  // must survive the HTML-escape pass below intact.
+  // Protect page-embed and toggle atoms — written as raw HTML by htmlToMarkdown()
+  // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Toggle blocks are stored as single-line raw HTML by the Turndown rule above
+  html = html.replace(/^<div data-type="toggleBlock"[^\n]*<\/div>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -47,6 +47,19 @@ turndown.addRule('compactListItem', {
   },
 });
 
+// Preserve image width — Turndown strips style from <img>; serialize as raw HTML for round-trip
+turndown.addRule('imageWithWidth', {
+  filter: (node) =>
+    node.nodeName === 'IMG' && !!(node as HTMLElement).style.width,
+  replacement: (_content, node) => {
+    const el = node as HTMLImageElement;
+    const src = el.getAttribute('src') ?? '';
+    const alt = el.getAttribute('alt') ?? '';
+    const width = el.style.width;
+    return `\n<img src="${src}" alt="${alt}" style="width:${width};max-width:100%;height:auto">\n`;
+  },
+});
+
 // Preserve toggle blocks as raw HTML — must be before generic block rules
 turndown.addRule('toggleBlock', {
   filter: (node) =>
@@ -162,6 +175,12 @@ export function markdownToHtml(rawMd: string): string {
   });
   // Toggle blocks are stored as single-line raw HTML by the Turndown rule above
   html = html.replace(/^<div data-type="toggleBlock"[^\n]*<\/div>$/gm, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Images with width style — serialized as raw HTML by imageWithWidth Turndown rule
+  html = html.replace(/^<img\s[^>]*style="width:[^"]*"[^>]*>$/gm, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -60,6 +60,34 @@ turndown.addRule('imageWithWidth', {
   },
 });
 
+// Preserve math block nodes as raw HTML
+turndown.addRule('mathBlock', {
+  filter: (node) =>
+    node.nodeName === 'DIV' &&
+    (node as HTMLElement).getAttribute('data-type') === 'mathBlock',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const latex = el.textContent ?? '';
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `\n<div data-type="mathBlock" data-latex="${safeAttr(latex)}">${safeAttr(latex)}</div>\n`;
+  },
+});
+
+// Preserve math inline nodes as raw HTML
+turndown.addRule('mathInline', {
+  filter: (node) =>
+    node.nodeName === 'SPAN' &&
+    (node as HTMLElement).getAttribute('data-type') === 'mathInline',
+  replacement: (_content, node) => {
+    const el = node as HTMLElement;
+    const latex = el.textContent ?? '';
+    const safeAttr = (s: string) =>
+      s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `<span data-type="mathInline">${safeAttr(latex)}</span>`;
+  },
+});
+
 // Preserve embed blocks as raw HTML
 turndown.addRule('embedBlock', {
   filter: (node) =>
@@ -200,6 +228,18 @@ export function markdownToHtml(rawMd: string): string {
   // and must survive the HTML-escape pass below intact.
   const atomPlaceholders: string[] = [];
   html = html.replace(/<div\s+data-page-embed[^>]*><\/div>/g, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Math blocks — stored as single-line raw HTML
+  html = html.replace(/^<div data-type="mathBlock"[^\n]*<\/div>$/gm, (m) => {
+    const idx = atomPlaceholders.length;
+    atomPlaceholders.push(m);
+    return `\x00ATOM${idx}\x00`;
+  });
+  // Math inline — protect span tags
+  html = html.replace(/<span data-type="mathInline">[^<]*<\/span>/g, (m) => {
     const idx = atomPlaceholders.length;
     atomPlaceholders.push(m);
     return `\x00ATOM${idx}\x00`;

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -13,6 +13,19 @@ const turndown = new TurndownService({
 // TipTap handles structural formatting; no inline text escaping is needed.
 (turndown as unknown as { escape: (str: string) => string }).escape = (str: string) => str;
 
+// TaskList item rule — converts Tiptap taskItem nodes to GFM task list syntax (- [x] / - [ ])
+// Must be registered before the generic compactListItem rule so it wins for taskItem elements.
+turndown.addRule('taskListItem', {
+  filter: (node) =>
+    node.nodeName === 'LI' &&
+    (node as HTMLElement).getAttribute('data-type') === 'taskItem',
+  replacement: (content, node) => {
+    const checked = (node as HTMLElement).getAttribute('data-checked') === 'true';
+    const clean = content.replace(/^\n+/, '').replace(/\n\s*\n/g, '\n').trimEnd();
+    return `- [${checked ? 'x' : ' '}] ${clean}\n`;
+  },
+});
+
 // Custom list item rule — produces compact format regardless of whether
 // TipTap wrapped the content in <p> tags (which it always does via schema normalization).
 // Without this, Turndown outputs "loose" lists with blank lines between items:
@@ -207,6 +220,19 @@ export function markdownToHtml(rawMd: string): string {
     }
 
     return `<ol>${items.map((item) => `<li><p>${item}</p></li>`).join('')}</ol>`;
+  });
+
+  // Task lists (GFM: - [ ] / - [x]) — must be before unordered list rule
+  html = html.replace(/(?:^-\s+\[[ x]\]\s+.+(?:\n|$))+/gm, (listBlock) => {
+    const items = listBlock.trim().split('\n').filter(Boolean);
+    const listItems = items.map((line) => {
+      const match = line.match(/^-\s+\[([ x])\]\s+(.+)$/);
+      if (!match) return '';
+      const checked = match[1] === 'x';
+      const text = match[2] ?? '';
+      return `<li data-type="taskItem" data-checked="${checked}"><label><input type="checkbox"${checked ? ' checked' : ''}></label><div><p>${text}</p></div></li>`;
+    }).filter(Boolean).join('');
+    return `<ul data-type="taskList">${listItems}</ul>`;
   });
 
   // Unordered lists

--- a/apps/web/src/components/docs/lib/mermaid-renderer.ts
+++ b/apps/web/src/components/docs/lib/mermaid-renderer.ts
@@ -1,0 +1,34 @@
+let initPromise: Promise<void> | null = null;
+
+async function ensureInit() {
+  if (!initPromise) {
+    initPromise = (async () => {
+      const { default: mermaid } = await import('mermaid');
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'dark',
+        themeVariables: {
+          background: '#0b1120',
+          primaryColor: '#1e3a5f',
+          primaryTextColor: '#e2e8f0',
+          lineColor: '#475569',
+          edgeLabelBackground: '#1e293b',
+          clusterBkg: '#1e293b',
+          titleColor: '#e2e8f0',
+        },
+        securityLevel: 'loose',
+      });
+    })();
+  }
+  return initPromise;
+}
+
+let counter = 0;
+
+export async function renderMermaid(code: string): Promise<{ svg: string }> {
+  await ensureInit();
+  const { default: mermaid } = await import('mermaid');
+  const id = `mermaid-${++counter}-${Date.now()}`;
+  const { svg } = await mermaid.render(id, code.trim());
+  return { svg };
+}

--- a/apps/web/src/components/docs/lib/shiki-highlighter.ts
+++ b/apps/web/src/components/docs/lib/shiki-highlighter.ts
@@ -1,0 +1,48 @@
+import type { HighlighterGeneric } from 'shiki';
+
+export const SUPPORTED_LANGUAGES = [
+  'javascript', 'typescript', 'python', 'go', 'rust', 'sql', 'json', 'yaml',
+  'bash', 'html', 'css', 'java', 'c', 'cpp', 'ruby', 'php', 'swift', 'kotlin',
+  'dart', 'markdown', 'docker', 'terraform', 'graphql', 'shell', 'powershell',
+  'lua', 'r', 'scala', 'elixir', 'haskell',
+] as const;
+
+export type SupportedLanguage = (typeof SUPPORTED_LANGUAGES)[number];
+
+export const LANGUAGE_LABELS: Record<string, string> = {
+  javascript: 'JS', typescript: 'TS', python: 'Python', go: 'Go', rust: 'Rust',
+  sql: 'SQL', json: 'JSON', yaml: 'YAML', bash: 'Bash', html: 'HTML', css: 'CSS',
+  java: 'Java', c: 'C', cpp: 'C++', ruby: 'Ruby', php: 'PHP', swift: 'Swift',
+  kotlin: 'Kotlin', dart: 'Dart', markdown: 'Markdown', docker: 'Docker',
+  terraform: 'Terraform', graphql: 'GraphQL', shell: 'Shell', powershell: 'PS',
+  lua: 'Lua', r: 'R', scala: 'Scala', elixir: 'Elixir', haskell: 'Haskell',
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHighlighter = HighlighterGeneric<any, any>;
+
+let highlighterPromise: Promise<AnyHighlighter> | null = null;
+
+export async function getShikiHighlighter(): Promise<AnyHighlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = (async () => {
+      const { createHighlighter } = await import('shiki');
+      return createHighlighter({
+        themes: ['dark-plus'],
+        langs: [...SUPPORTED_LANGUAGES],
+      });
+    })();
+  }
+  return highlighterPromise;
+}
+
+export function resolveLanguage(lang: string | null | undefined): string {
+  if (!lang) return 'text';
+  const lower = lang.toLowerCase();
+  if ((SUPPORTED_LANGUAGES as readonly string[]).includes(lower)) return lower;
+  const aliases: Record<string, string> = {
+    js: 'javascript', ts: 'typescript', py: 'python', sh: 'bash', yml: 'yaml',
+    'c++': 'cpp', 'c#': 'csharp', jsx: 'javascript', tsx: 'typescript',
+  };
+  return aliases[lower] ?? 'text';
+}

--- a/apps/web/src/services/docs.ts
+++ b/apps/web/src/services/docs.ts
@@ -165,8 +165,7 @@ export class DocsService {
       if (error) throw error;
       return data;
     }
-    // OSS: title-only search via list (content search not supported in SQLite repo)
-    const all = await this.repo.list({ project_id: projectId, limit: input?.limit, cursor: input?.cursor ?? undefined });
-    return all.filter((d) => d.title.toLowerCase().includes(query.toLowerCase()));
+    // OSS / API: pass q to repo.list which forwards to FastAPI search_full_text()
+    return this.repo.list({ project_id: projectId, q: query, limit: input?.limit, cursor: input?.cursor ?? undefined, tags: input?.tags });
   }
 }

--- a/backend/alembic/versions/0047_add_docs_tsvector.py
+++ b/backend/alembic/versions/0047_add_docs_tsvector.py
@@ -1,0 +1,32 @@
+"""docs 테이블 tsvector 컬럼 + GIN 인덱스 추가 (D4-2 전문 검색)
+
+Revision ID: 0047
+Revises: 0046
+"""
+from alembic import op
+
+revision = "0047"
+down_revision = "0046"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE docs
+        ADD COLUMN IF NOT EXISTS search_vector TSVECTOR
+        GENERATED ALWAYS AS (
+            to_tsvector('simple',
+                coalesce(title, '') || ' ' || coalesce(content, ''))
+        ) STORED
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_docs_search_vector ON docs USING GIN(search_vector)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_docs_search_vector")
+    op.execute("ALTER TABLE docs DROP COLUMN IF EXISTS search_vector")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,7 @@
+import asyncio
 import logging
 import os
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -12,6 +14,22 @@ from app.core.rate_limit import limiter
 
 configure_logging(json_logs=os.getenv("APP_ENV", "development") != "development")
 _logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    from app.services.pg_pubsub import listen_loop
+    task = asyncio.create_task(listen_loop())
+    try:
+        yield
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
 from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, chats, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, memos, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
@@ -20,6 +38,7 @@ app = FastAPI(
     version="0.1.0",
     docs_url="/api/v2/_swagger" if settings.debug else None,
     redoc_url=None,
+    lifespan=lifespan,
 )
 
 _HTTP_CODE_MAP: dict[int, str] = {

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -1,9 +1,11 @@
 import uuid
 from datetime import datetime
-from typing import List
+from typing import Any, List
 
-from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
-from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from typing import Any
+
+from sqlalchemy import Computed, DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, TSVECTOR, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -34,6 +36,14 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     doc_type: Mapped[str] = mapped_column(Text, nullable=False, default="page")
     content_format: Mapped[str] = mapped_column(Text, nullable=False, default="markdown")
     tags: Mapped[List[str]] = mapped_column(ARRAY(Text), nullable=False, default=list)
+    search_vector: Mapped[Any] = mapped_column(
+        TSVECTOR,
+        Computed(
+            "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(content, ''))",
+            persisted=True,
+        ),
+        nullable=True,
+    )
 
     children: Mapped[list["Doc"]] = relationship("Doc", back_populates="parent", lazy="select")
     parent: Mapped["Doc | None"] = relationship("Doc", back_populates="children", remote_side=[id])

--- a/backend/app/repositories/doc.py
+++ b/backend/app/repositories/doc.py
@@ -62,3 +62,31 @@ class DocRepository(BaseRepository[Doc]):
         ).limit(limit)
         result = await self.session.execute(q)
         return list(result.scalars().all())
+
+    async def search_full_text(
+        self, project_id: uuid.UUID, query: str, limit: int = 50
+    ) -> list[tuple[Doc, str | None]]:
+        """tsvector 기반 전문 검색. ts_rank 내림차순. snippet 포함."""
+        from sqlalchemy import func, literal_column
+
+        tsquery = func.plainto_tsquery("simple", query)
+        snippet_expr = func.ts_headline(
+            "simple",
+            Doc.content,
+            tsquery,
+            literal_column("'MaxWords=30, MinWords=15, ShortWord=3, MaxFragments=1'"),
+        )
+
+        stmt = (
+            select(Doc, snippet_expr.label("snippet"))
+            .where(
+                self._org_filter(),
+                Doc.project_id == project_id,
+                Doc.deleted_at.is_(None),
+                Doc.search_vector.op("@@")(tsquery),
+            )
+            .order_by(func.ts_rank(Doc.search_vector, tsquery).desc())
+            .limit(limit)
+        )
+        result = await self.session.execute(stmt)
+        return [(row.Doc, row.snippet) for row in result]

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -18,7 +18,7 @@ from app.models.conversation import Conversation, ConversationMessage, Conversat
 from app.models.event import Event
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
-from app.routers.events import _push_to_agent
+from app.routers.events import _push_to_agent, publish_event
 
 logger = logging.getLogger(__name__)
 
@@ -708,6 +708,8 @@ async def send_message(
     # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
     for pid_str, sse_payload in pending_sse_pushes:
         _push_to_agent(pid_str, sse_payload)
+    # 브라우저 SSE 구독자에게 1회 발행 — pending 유무와 무관하게 commit 후 항상 발행
+    publish_event(str(org_id), "conversation:message", _msg_payload(msg, sender))
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -75,13 +75,14 @@ async def _dispatch_conversation_event(
     org_id: uuid.UUID,
     sender: TeamMember,
     exclude_ids: set[uuid.UUID] | None = None,
-) -> None:
-    """conversation:message → 전 참여자 SSE dispatch + Event INSERT.
+) -> list[tuple[str, dict]]:
+    """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
 
     exclude_ids: SSE 발송에서 제외할 member_id 집합 (Discord 수신자 등).
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
     """
     if not conversation.project_id:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
 
@@ -93,7 +94,7 @@ async def _dispatch_conversation_event(
     participant_ids = {r[0] for r in rows} - {sender.id} - (exclude_ids or set())
 
     if not participant_ids:
-        return
+        return []
 
     member_rows = (await db.execute(
         select(TeamMember.id, TeamMember.type).where(TeamMember.id.in_(participant_ids))
@@ -118,10 +119,10 @@ async def _dispatch_conversation_event(
         db.add(event)
         events_to_push.append((str(pid), event))
 
-    # flush 후 event.id 확보 → event_id 포함 push (dedup 동작 보장)
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_mention_events(
@@ -131,10 +132,13 @@ async def _dispatch_mention_events(
     org_id: uuid.UUID,
     sender: TeamMember,
     mention_targets: set[uuid.UUID],
-) -> None:
-    """AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)."""
+) -> list[tuple[str, dict]]:
+    """AC1: 멘션 대상에게 conversation:mention Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
+
+    반환값: [(pid_str, payload)] — db.commit() 완료 후 _push_to_agent() 호출용.
+    """
     if not conversation.project_id or not mention_targets:
-        return
+        return []
 
     payload = _msg_payload(msg, sender)
     member_rows = (await db.execute(
@@ -160,9 +164,10 @@ async def _dispatch_mention_events(
         db.add(event)
         events_to_push.append((str(pid), event))
 
+    # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    for pid_str, event in events_to_push:
-        _push_to_agent(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
+            for pid_str, event in events_to_push]
 
 
 async def _dispatch_discord_outbound(
@@ -677,9 +682,10 @@ async def send_message(
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
+    pending_sse_pushes: list[tuple[str, dict]] = []
     try:
         async with db.begin_nested():
-            await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
+            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
     except Exception:
         logger.exception("conversation event dispatch failed conversation_id=%s", conversation_id)
 
@@ -689,7 +695,7 @@ async def send_message(
         if mention_targets:
             try:
                 async with db.begin_nested():
-                    await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
+                    pending_sse_pushes += await _dispatch_mention_events(db, conv, msg, org_id, sender, mention_targets)
             except Exception:
                 logger.warning("mention event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
 
@@ -698,6 +704,10 @@ async def send_message(
 
     await db.commit()
     await db.refresh(msg)
+
+    # commit 완료 후 SSE push — Event가 DB에 커밋된 상태에서 push해야 race condition 없음
+    for pid_str, sse_payload in pending_sse_pushes:
+        _push_to_agent(pid_str, sse_payload)
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -30,9 +30,18 @@ async def list_docs(
     doc_type: str | None = Query(default=None),
     tags: str | None = Query(default=None, description="comma-separated tags"),
     slug: str | None = Query(default=None),
+    q: str | None = Query(default=None, description="전문 검색 — 제목 + 본문"),
     limit: int = Query(default=500, ge=1, le=1000),
     repo: DocRepository = Depends(_get_repo),
 ) -> list[DocSummaryResponse]:
+    # AC1 + AC3: 전문 검색 — project_id 필수
+    if q and project_id:
+        results = await repo.search_full_text(project_id, q.strip(), limit=min(limit, 50))
+        return [
+            DocSummaryResponse.model_validate(doc).model_copy(update={"snippet": snippet})
+            for doc, snippet in results
+        ]
+
     if slug and project_id:
         doc = await repo.get_by_slug(project_id, slug)
         return [DocSummaryResponse.model_validate(doc)] if doc else []

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -42,6 +42,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
+    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("org", org_id, event_type, data)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -84,18 +92,25 @@ def _compute_backfill_mode(
 def _push_to_agent(member_id: str, payload: dict) -> bool:
     """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
     queues = _agent_connections.get(member_id)
-    if not queues:
-        return False
     pushed = False
-    dead: list[asyncio.Queue] = []
-    for q in list(queues):
-        try:
-            q.put_nowait(payload)
-            pushed = True
-        except asyncio.QueueFull:
-            dead.append(q)
-    for q in dead:
-        queues.discard(q)
+    if queues:
+        dead: list[asyncio.Queue] = []
+        for q in list(queues):
+            try:
+                q.put_nowait(payload)
+                pushed = True
+            except asyncio.QueueFull:
+                dead.append(q)
+        for q in dead:
+            queues.discard(q)
+    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
+    try:
+        from app.services.pg_pubsub import pg_notify
+        asyncio.get_running_loop().create_task(
+            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+        )
+    except RuntimeError:
+        pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -373,8 +373,9 @@ async def agent_event_stream(
                         except Exception:
                             pass
                     # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
+                    # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
                     _live_id = eid or str(uuid.uuid4())
-                    yield f"event: {event_type}\nid: {_live_id}\ndata: {json.dumps(event_data)}\n\n"
+                    yield f"event: {event_type}\nid: {_live_id}\ndata: {json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})}\n\n"
                 except asyncio.TimeoutError:
                     # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
                     yield "event: heartbeat\ndata: {}\n\n"

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -31,8 +31,11 @@ router = APIRouter(prefix="/api/v2/events", tags=["events"])
 _subscribers: dict[str, set[asyncio.Queue[dict]]] = defaultdict(set)
 
 
-def publish_event(org_id: str, event_type: str, data: dict) -> None:
-    """다른 라우터에서 이벤트를 발행할 때 호출."""
+def publish_event(org_id: str, event_type: str, data: dict, _from_listener: bool = False) -> None:
+    """다른 라우터에서 이벤트를 발행할 때 호출.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     payload = {"type": event_type, **data}
     dead: list[asyncio.Queue] = []
     for q in _subscribers.get(org_id, set()):
@@ -42,14 +45,14 @@ def publish_event(org_id: str, event_type: str, data: dict) -> None:
             dead.append(q)
     for q in dead:
         _subscribers[org_id].discard(q)
-    # 다른 인스턴스에 전파 — 실패 시 로컬 전파는 정상 유지
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("org", org_id, event_type, data)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("org", org_id, event_type, data)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
 
 
 # ─── Agent connection registry (S2/S3: 에이전트별 SSE) ───────────────────────
@@ -89,8 +92,11 @@ def _compute_backfill_mode(
     return exceed, (_BACKFILL_MAX_EVENTS if exceed else 100)
 
 
-def _push_to_agent(member_id: str, payload: dict) -> bool:
-    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결."""
+def _push_to_agent(member_id: str, payload: dict, _from_listener: bool = False) -> bool:
+    """연결 중인 에이전트 모든 큐에 SSE 페이로드 전송. True=1개 이상 전달, False=미연결.
+
+    _from_listener=True: LISTEN 수신기에서 호출 시 pg_notify 재발행 금지 (무한 루프 차단).
+    """
     queues = _agent_connections.get(member_id)
     pushed = False
     if queues:
@@ -103,14 +109,14 @@ def _push_to_agent(member_id: str, payload: dict) -> bool:
                 dead.append(q)
         for q in dead:
             queues.discard(q)
-    # 로컬 전파 여부와 무관하게 다른 인스턴스에 전파 — 미연결 시에도 필요
-    try:
-        from app.services.pg_pubsub import pg_notify
-        asyncio.get_running_loop().create_task(
-            pg_notify("agent", member_id, payload.get("event_type", ""), payload)
-        )
-    except RuntimeError:
-        pass  # 이벤트 루프 없음 (테스트 등)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("agent", member_id, payload.get("event_type", ""), payload)
+            )
+        except RuntimeError:
+            pass  # 이벤트 루프 없음 (테스트 등)
     return pushed
 
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -324,7 +324,7 @@ async def agent_event_stream(
                         evt.delivered_at = now
                     await db.commit()
                     for data, evt in zip(batch_data, batch):
-                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps(data)}\n\n"
+                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():

--- a/backend/app/routers/memos.py
+++ b/backend/app/routers/memos.py
@@ -743,6 +743,7 @@ async def add_reply(
         )
         # CB-S7: SSE conversation:message 발행 (P0 — 수신자 화면 실시간 갱신)
         conv = await db.get(Conversation, id)
+        pending_sse_pushes: list[tuple[str, dict]] = []
         if conv:
             sender_member = (await db.execute(
                 select(TeamMember).where(TeamMember.id == body.created_by)
@@ -757,9 +758,15 @@ async def add_reply(
                         discord_exclude_ids = {d.member_id for d in decisions if d.channel == "discord"}
                     except Exception:
                         logger.warning("channel_router pre-check failed reply_msg_id=%s", reply_msg.id)
-                    await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
+                    pending_sse_pushes = await _dispatch_conversation_event(db, conv, reply_msg, repo.org_id, sender_member, exclude_ids=discord_exclude_ids)
                 except Exception:
                     logger.warning("conversation event dispatch failed memo_id=%s", id, exc_info=True)
+
+        # commit 후 SSE push — Event 커밋 완료 상태에서 push해야 race condition 없음
+        await db.commit()
+        from app.routers.events import _push_to_agent
+        for pid_str, sse_payload in pending_sse_pushes:
+            _push_to_agent(pid_str, sse_payload)
 
         # webhook 발송 (기존 참여자 수집)
         if conv:

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -47,6 +47,7 @@ class DocSummaryResponse(BaseModel):
     is_folder: bool
     tags: list[str]
     updated_at: datetime
+    snippet: str | None = None
 
 
 class DocResponse(BaseModel):

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,9 +132,21 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
+
+                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                from app.services.channel_router import route_message as _route
+                sse_member_ids: set[uuid.UUID] = set()
+                try:
+                    decisions = await _route(message_id, db)
+                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                except Exception:
+                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
+                    if wh.member_id in sse_member_ids:
+                        continue  # channel_router → sse: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -133,20 +133,21 @@ async def deliver_conversation_message_webhook(
                     )
                 )).scalars().all()
 
-                # channel_router 결정 조회 — sse 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
+                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
                 from app.services.channel_router import route_message as _route
-                sse_member_ids: set[uuid.UUID] = set()
+                routed_member_ids: set[uuid.UUID] = set()
                 try:
                     decisions = await _route(message_id, db)
-                    sse_member_ids = {d.member_id for d in decisions if d.channel == "sse"}
+                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
                 except Exception:
-                    logger.warning("channel_router failed message_id=%s — sse filtering skipped", message_id)
+                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
 
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in sse_member_ids:
-                        continue  # channel_router → sse: member webhook 발송 생략
+                    if wh.member_id in routed_member_ids:
+                        continue  # channel_router → sse/discord: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -132,22 +132,9 @@ async def deliver_conversation_message_webhook(
                         WebhookConfig.is_active.is_(True),
                     )
                 )).scalars().all()
-
-                # channel_router 결정 조회 — sse/discord 결정 멤버의 member webhook 스킵 (이중 발송 방지)
-                # sse: SSE로 이미 전달 / discord: discord_outbound BackgroundTask가 전담
-                from app.services.channel_router import route_message as _route
-                routed_member_ids: set[uuid.UUID] = set()
-                try:
-                    decisions = await _route(message_id, db)
-                    routed_member_ids = {d.member_id for d in decisions if d.channel in ("sse", "discord")}
-                except Exception:
-                    logger.warning("channel_router failed message_id=%s — member webhook dedup skipped", message_id)
-
                 existing_ids = {wh.id for wh in target_webhooks}
                 existing_urls = {wh.url for wh in target_webhooks}
                 for wh in extra_wh_rows:
-                    if wh.member_id in routed_member_ids:
-                        continue  # channel_router → sse/discord: member webhook 발송 생략
                     if wh.id not in existing_ids and wh.url not in existing_urls:
                         target_webhooks.append(wh)
                         existing_ids.add(wh.id)

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,10 +1,12 @@
-"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+"""E-SSE-PUBSUB S1/S2: PostgreSQL LISTEN/NOTIFY 발행·수신 레이어.
 
-publish_event() / _push_to_agent() 내부에서 호출.
+S1: publish_event() / _push_to_agent() 내부에서 pg_notify() 호출.
+S2: listen_loop() — 다른 인스턴스의 NOTIFY를 수신해 로컬 큐 디스패치.
 실패 시 로컬 전파는 정상 유지 — graceful degradation.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -17,6 +19,7 @@ INSTANCE_ID: str = str(uuid.uuid4())
 _CHANNEL = "sse_events"
 _MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
 
+# ── NOTIFY 발행 ────────────────────────────────────────────────────────────────
 
 async def pg_notify(
     target: str,
@@ -59,3 +62,81 @@ async def pg_notify(
             "pg_notify failed channel=%s target=%s target_id=%s: %s",
             _CHANNEL, target, target_id, exc,
         )
+
+
+# ── LISTEN 수신기 ──────────────────────────────────────────────────────────────
+
+def _on_notification(conn: object, pid: int, channel: str, payload_str: str) -> None:
+    """asyncpg 알림 콜백 (sync). 수신 즉시 dispatch task 스케줄."""
+    try:
+        loop = asyncio.get_running_loop()
+        loop.create_task(_dispatch_received(payload_str))
+    except Exception as exc:
+        logger.warning("pg_listen dispatch schedule failed: %s", exc)
+
+
+async def _dispatch_received(payload_str: str) -> None:
+    """LISTEN 수신 payload → 로컬 큐 디스패치. pg_notify 재발행 금지."""
+    try:
+        payload = json.loads(payload_str)
+    except (json.JSONDecodeError, ValueError):
+        return
+
+    # 자기 자신이 발행한 이벤트 skip
+    if payload.get("instance_id") == INSTANCE_ID:
+        return
+
+    target = payload.get("target")
+    target_id = str(payload.get("target_id", ""))
+    event_type = str(payload.get("event_type", ""))
+    data = payload.get("data") or {}
+
+    try:
+        from app.routers.events import publish_event, _push_to_agent
+        if target == "org":
+            publish_event(target_id, event_type, data, _from_listener=True)
+        elif target == "agent":
+            _push_to_agent(target_id, data, _from_listener=True)
+    except Exception as exc:
+        logger.warning("pg_listen dispatch failed target=%s: %s", target, exc)
+
+
+async def listen_loop() -> None:
+    """PG LISTEN 수신 루프. lifespan startup에서 background task로 실행.
+
+    - raw asyncpg 전용 커넥션 1개 (SQLAlchemy pool 미점유)
+    - 연결 실패 시 exponential backoff 1s→2s→4s→max 30s
+    - CancelledError 수신 시 커넥션 정리 후 종료
+    """
+    import asyncpg
+    from app.core.config import settings
+
+    raw_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    delay = 1.0
+
+    logger.info("pg_listen starting on channel=%s instance=%s", _CHANNEL, INSTANCE_ID)
+
+    while True:
+        conn: asyncpg.Connection | None = None
+        try:
+            conn = await asyncpg.connect(raw_url)
+            await conn.add_listener(_CHANNEL, _on_notification)
+            delay = 1.0  # 연결 성공 시 backoff 리셋
+            logger.info("pg_listen connected")
+            # 커넥션 유지 — CancelledError까지 대기
+            while True:
+                await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            logger.info("pg_listen cancelled — shutting down")
+            break
+        except Exception as exc:
+            logger.warning("pg_listen error: %s — reconnecting in %.1fs", exc, delay)
+        finally:
+            if conn is not None:
+                try:
+                    await conn.remove_listener(_CHANNEL, _on_notification)
+                    await conn.close()
+                except Exception:
+                    pass
+        await asyncio.sleep(delay)
+        delay = min(delay * 2, 30)

--- a/backend/app/services/pg_pubsub.py
+++ b/backend/app/services/pg_pubsub.py
@@ -1,0 +1,61 @@
+"""E-SSE-PUBSUB S1: PostgreSQL LISTEN/NOTIFY 발행 레이어.
+
+publish_event() / _push_to_agent() 내부에서 호출.
+실패 시 로컬 전파는 정상 유지 — graceful degradation.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+logger = logging.getLogger(__name__)
+
+INSTANCE_ID: str = str(uuid.uuid4())
+"""앱 기동 시 1회 생성 — 자기 자신이 발행한 notify 재수신 방지용."""
+
+_CHANNEL = "sse_events"
+_MAX_PAYLOAD_BYTES = 7500  # 8KB PG 제한 대비 여유
+
+
+async def pg_notify(
+    target: str,
+    target_id: str,
+    event_type: str,
+    data: dict,
+) -> None:
+    """PostgreSQL NOTIFY 단발 발행. SQLAlchemy 기존 풀 재활용.
+
+    target: "org" | "agent"
+    target_id: org_id | member_id (str)
+    실패 시 경고 로그만 — 예외 전파 금지.
+    """
+    payload: dict = {
+        "instance_id": INSTANCE_ID,
+        "target": target,
+        "target_id": target_id,
+        "event_type": event_type,
+        "data": data,
+    }
+
+    payload_str = json.dumps(payload, default=str)
+    if len(payload_str.encode()) > _MAX_PAYLOAD_BYTES:
+        # 8KB 초과 시 content 제거 — id/event_type으로 구독측 재조회 유도
+        data_slim = {k: v for k, v in data.items() if k != "content"}
+        payload["data"] = data_slim
+        payload_str = json.dumps(payload, default=str)
+
+    try:
+        from sqlalchemy import text
+        from app.core.database import async_session_factory
+        async with async_session_factory() as session:
+            await session.execute(
+                text("SELECT pg_notify(:ch, :pl)"),
+                {"ch": _CHANNEL, "pl": payload_str},
+            )
+            await session.commit()
+    except Exception as exc:
+        logger.warning(
+            "pg_notify failed channel=%s target=%s target_id=%s: %s",
+            _CHANNEL, target, target_id, exc,
+        )

--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -13,6 +13,7 @@ class McpSettings(BaseSettings):
     fakechat_port: int = 8787
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
+    has_webhook: bool = False  # True: fakechat relay 전체 스킵, Discord 웹훅으로만 수신
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -346,13 +346,24 @@ async def start_sse_bridge(
 
     def _handle(event: SseEvent) -> None:
         nonlocal _current_last_event_id
-        # event_id dedup
+        # id: 필드 우선 dedup
         if event.last_event_id:
             if event.last_event_id in seen_ids:
                 _log(f"dedup: skip event_id={event.last_event_id}")
                 return
             seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
+        else:
+            # id: 필드 없을 때 data.event_id fallback dedup — 백필/live id 불일치 방어
+            try:
+                _data_eid = json.loads(event.data).get("event_id") if event.data else None
+                if _data_eid:
+                    if _data_eid in seen_ids:
+                        _log(f"dedup(data): skip event_id={_data_eid}")
+                        return
+                    seen_ids.add(_data_eid)
+            except (json.JSONDecodeError, AttributeError):
+                pass
 
         # MCP notification: webhook 유무·backfill 여부 무관하게 항상 발송 (AC-4)
         asyncio.create_task(

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -354,12 +354,22 @@ async def start_sse_bridge(
             seen_ids.add(event.last_event_id)
             _current_last_event_id = event.last_event_id
 
-        asyncio.create_task(
-            relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
-        )
+        # MCP notification: webhook 유무·backfill 여부 무관하게 항상 발송 (AC-4)
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
+
+        # relay 조건: (1) backfill 아님, (2) webhook 미설정
+        _relay = True
+        try:
+            _relay = not json.loads(event.data).get("is_backfill", False)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        if _relay and not settings.has_webhook:
+            asyncio.create_task(
+                relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
+            )
+
         if on_event is not None:
             on_event(event.event_type, event.data)
 

--- a/packages/cli/src/commands/connect.ts
+++ b/packages/cli/src/commands/connect.ts
@@ -22,12 +22,12 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
   const apiUrl = await input({
     message: "Sprintable API URL",
     default: "https://app.sprintable.ai",
-    validate: (v) => (v.startsWith("http") ? true : "http(s):// 로 시작해야 합니다"),
+    validate: (v: string) => (v.startsWith("http") ? true : "http(s):// 로 시작해야 합니다"),
   });
 
   const adminKey = await password({
     message: "Admin API Key (팀 관리자 권한)",
-    validate: (v) => (v.trim().length > 0 ? true : "API Key를 입력하세요"),
+    validate: (v: string) => (v.trim().length > 0 ? true : "API Key를 입력하세요"),
   });
 
   // ── 2. 연결 확인 ─────────────────────────────────────────────────────────
@@ -67,7 +67,7 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
   } catch {
     projectId = await input({
       message: "Project ID (UUID)",
-      validate: (v) => (v.trim().length > 0 ? true : "Project ID를 입력하세요"),
+      validate: (v: string) => (v.trim().length > 0 ? true : "Project ID를 입력하세요"),
     });
   }
 
@@ -75,7 +75,7 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
   const agentName = await input({
     message: "에이전트 이름",
     default: "My Agent",
-    validate: (v) => (v.trim().length > 0 ? true : "이름을 입력하세요"),
+    validate: (v: string) => (v.trim().length > 0 ? true : "이름을 입력하세요"),
   });
 
   // ── 6. AC6: 이미 등록된 member 확인 ─────────────────────────────────────
@@ -94,7 +94,7 @@ export async function connectCommand(opts: ConnectOptions = {}): Promise<void> {
         console.log("\n기존 에이전트를 사용합니다. API key를 직접 입력하세요.");
         finalApiKey = await password({
           message: "기존 Agent API Key",
-          validate: (v) => (v.trim().length > 0 ? true : "API Key를 입력하세요"),
+          validate: (v: string) => (v.trim().length > 0 ? true : "API Key를 입력하세요"),
         });
         adapter.writeConfig(apiUrl, finalApiKey.trim());
         _printSuccess(adapter.configPath, agent);

--- a/packages/core-storage/src/interfaces/IDocRepository.ts
+++ b/packages/core-storage/src/interfaces/IDocRepository.ts
@@ -61,6 +61,7 @@ export interface UpdateDocInput {
 export interface DocListFilters extends PaginationOptions {
   project_id: string;
   tags?: string[];
+  q?: string;
 }
 
 export interface IDocRepository {

--- a/packages/storage-api/src/SupabaseDocRepository.ts
+++ b/packages/storage-api/src/SupabaseDocRepository.ts
@@ -11,6 +11,7 @@ export class SupabaseDocRepository implements IDocRepository {
         limit: filters.limit,
         cursor: filters.cursor ?? undefined,
         tags: filters.tags?.join(','),
+        q: filters.q,
       },
     });
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,12 @@ importers:
       '@tiptap/extension-table-row':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/extension-table@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-task-item':
+        specifier: 3.22.3
+        version: 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
+      '@tiptap/extension-task-list':
+        specifier: 3.22.3
+        version: 3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))
       '@tiptap/pm':
         specifier: ^3.22.3
         version: 3.22.3
@@ -1954,6 +1960,16 @@ packages:
     peerDependencies:
       '@tiptap/core': ^3.22.3
       '@tiptap/pm': ^3.22.3
+
+  '@tiptap/extension-task-item@3.22.3':
+    resolution: {integrity: sha512-bUxP6fmlrF4sbpHnkm0nTKNVmtQXNnhrbWsUt0MCnvAd9y5Nq3ohpOzMOCL71AEHfmeV1kEkPbpdwKb1R7XDbg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
+
+  '@tiptap/extension-task-list@3.22.3':
+    resolution: {integrity: sha512-ze/DNj7Uq/Xjo+t8UuumnvJcmGVrVvLar11nFxobgpij21ja6XiUNMZ+BywvFurWbh5NrHeSYV07vFOWWf5Cpg==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.22.3
 
   '@tiptap/extension-text@3.22.3':
     resolution: {integrity: sha512-Q9R7JsTdomP5uUjtPjNKxHT1xoh/i9OJZnmgJLe7FcgZEaPOQ3bWxmKZoLZQfDfZjyB8BtH+Hc7nUvhCMOePxw==}
@@ -6867,6 +6883,14 @@ snapshots:
     dependencies:
       '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
       '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-task-item@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-task-list@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/extension-list': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
 
   '@tiptap/extension-text@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
       '@tiptap/core':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/extension-bubble-menu':
+        specifier: ^3.22.3
+        version: 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-highlight':
+        specifier: 3.22.3
+        version: 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
       '@tiptap/extension-image':
         specifier: ^3.22.3
         version: 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))
@@ -1811,6 +1817,12 @@ packages:
       '@tiptap/core': ^3.22.3
       '@tiptap/pm': ^3.22.3
 
+  '@tiptap/extension-bubble-menu@3.23.5':
+    resolution: {integrity: sha512-otcGwyVO6OfxdDPnbooZxYGrb+6q5WYmS+g2V+XGGNRn5oJgyY5pW0dqELIUJ66dosIIXXPyw2XqBDpMMY2kyQ==}
+    peerDependencies:
+      '@tiptap/core': 3.23.5
+      '@tiptap/pm': 3.23.5
+
   '@tiptap/extension-bullet-list@3.22.3':
     resolution: {integrity: sha512-xOmW/b1hgECIE6r3IeZvKn4VVlG3+dfTjCWE6lnnyLaqdNkNhKS1CwUmDZdYNLUS2ryIUtgz5ID1W/8A3PhbiA==}
     peerDependencies:
@@ -1856,6 +1868,11 @@ packages:
 
   '@tiptap/extension-heading@3.22.3':
     resolution: {integrity: sha512-XBHuhiEV2EEhZHpOLcplLqAmBIhJciU3I6AtwmqeEqDC0P114uMEfAO7JGlbBZdCYotNer26PKnu44TBTeNtkw==}
+    peerDependencies:
+      '@tiptap/core': ^3.22.3
+
+  '@tiptap/extension-highlight@3.22.3':
+    resolution: {integrity: sha512-iGDzQ3IuVQpfQcWsMEQ0B8q3R83bZZH6l6O2MuCmWbzm/p7mMi5vQwRCMLAbM9xFELq8KjDMHOWeER4fozp/Sg==}
     peerDependencies:
       '@tiptap/core': ^3.22.3
 
@@ -6734,6 +6751,12 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
       '@tiptap/pm': 3.22.3
+
+  '@tiptap/extension-bubble-menu@3.23.5(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+      '@tiptap/pm': 3.22.3
     optional: true
 
   '@tiptap/extension-bullet-list@3.22.3(@tiptap/extension-list@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3))':
@@ -6773,6 +6796,10 @@ snapshots:
       '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
 
   '@tiptap/extension-heading@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
+    dependencies:
+      '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
+
+  '@tiptap/extension-highlight@3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))':
     dependencies:
       '@tiptap/core': 3.22.3(@tiptap/pm@3.22.3)
 
@@ -6887,7 +6914,7 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
-      '@tiptap/extension-bubble-menu': 3.22.3(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
+      '@tiptap/extension-bubble-menu': 3.23.5(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
       '@tiptap/extension-floating-menu': 3.22.3(@floating-ui/dom@1.7.6)(@tiptap/core@3.22.3(@tiptap/pm@3.22.3))(@tiptap/pm@3.22.3)
     transitivePeerDependencies:
       - '@floating-ui/dom'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
+      mermaid:
+        specifier: ^11.15.0
+        version: 11.15.0
       next:
         specifier: 16.2.2
         version: 16.2.2(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -323,6 +326,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -476,6 +482,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -921,6 +933,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1135,6 +1153,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -2089,23 +2110,98 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
 
   '@types/d3-drag@3.0.7':
     resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
 
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
   '@types/d3-interpolate@3.0.4':
     resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
 
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
   '@types/d3-selection@3.0.11':
     resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
   '@types/d3-transition@3.0.9':
     resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
 
   '@types/d3-zoom@3.0.8':
     resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -2122,6 +2218,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -2348,6 +2447,9 @@ packages:
     resolution: {integrity: sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==}
     cpu: [x64]
     os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
@@ -2711,6 +2813,14 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -2746,6 +2856,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig@9.0.1:
     resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
@@ -2770,8 +2886,49 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.4:
+    resolution: {integrity: sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
   d3-color@3.1.0:
     resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
     engines: {node: '>=12'}
 
   d3-dispatch@3.0.1:
@@ -2782,16 +2939,86 @@ packages:
     resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
     engines: {node: '>=12'}
 
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   d3-ease@3.0.1:
     resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
     engines: {node: '>=12'}
 
   d3-interpolate@3.0.1:
     resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
     engines: {node: '>=12'}
 
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
   d3-selection@3.0.0:
     resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
     engines: {node: '>=12'}
 
   d3-timer@3.0.1:
@@ -2807,6 +3034,13 @@ packages:
   d3-zoom@3.0.0:
     resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
     engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -2826,6 +3060,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -2885,6 +3122,9 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -3012,6 +3252,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -3452,6 +3695,9 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3556,6 +3802,10 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -3578,6 +3828,9 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -3591,6 +3844,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.2.0:
     resolution: {integrity: sha512-IhghAA8n4KSlXuWKzYsWyWb82JoYTzShfyvdSF85oJPnNOjvv4kAo7S7Jtkm3/vJ53C7dQNRO+Gpnj3iWgTjBQ==}
@@ -3857,8 +4117,15 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3874,6 +4141,12 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -3962,6 +4235,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -3996,6 +4272,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -4063,6 +4344,9 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -4397,6 +4681,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4421,6 +4708,9 @@ packages:
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4484,6 +4774,12 @@ packages:
 
   po-parser@2.1.1:
     resolution: {integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4725,6 +5021,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4738,6 +5037,9 @@ packages:
   rope-sequence@1.3.4:
     resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
@@ -4748,6 +5050,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -4992,6 +5297,9 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -5095,6 +5403,10 @@ packages:
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   ts-morph@26.0.0:
     resolution: {integrity: sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==}
@@ -5232,6 +5544,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -5543,6 +5859,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.0.4
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5754,6 +6075,10 @@ snapshots:
       use-sync-external-store: 1.6.0(react@19.2.4)
     optionalDependencies:
       '@types/react': 19.2.14
+
+  '@braintree/sanitize-url@7.1.2': {}
+
+  '@chevrotain/types@11.1.2': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -6090,6 +6415,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -6282,6 +6615,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@mixmark-io/domino@2.2.0': {}
 
@@ -7109,17 +7446,80 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
   '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
 
   '@types/d3-drag@3.0.7':
     dependencies:
       '@types/d3-selection': 3.0.11
 
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
   '@types/d3-interpolate@3.0.4':
     dependencies:
       '@types/d3-color': 3.1.3
 
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
   '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
 
   '@types/d3-transition@3.0.9':
     dependencies:
@@ -7129,6 +7529,39 @@ snapshots:
     dependencies:
       '@types/d3-interpolate': 3.0.4
       '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
 
   '@types/debug@4.1.13':
     dependencies:
@@ -7145,6 +7578,8 @@ snapshots:
       '@types/estree': 1.0.8
 
   '@types/estree@1.0.8': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -7364,6 +7799,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitest/expect@2.1.9':
     dependencies:
@@ -7783,6 +8223,10 @@ snapshots:
 
   commander@14.0.3: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   concat-map@0.0.1: {}
 
   concurrently@9.2.1:
@@ -7811,6 +8255,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -7832,7 +8284,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.4
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.4
+
+  cytoscape@3.33.4: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
   d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
 
   d3-dispatch@3.0.1: {}
 
@@ -7841,13 +8335,81 @@ snapshots:
       d3-dispatch: 3.0.1
       d3-selection: 3.0.0
 
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
   d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
 
   d3-interpolate@3.0.1:
     dependencies:
       d3-color: 3.1.0
 
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
   d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
 
@@ -7867,6 +8429,44 @@ snapshots:
       d3-interpolate: 3.0.1
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   damerau-levenshtein@1.0.8: {}
 
@@ -7889,6 +8489,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.20: {}
 
   debug@3.2.7:
     dependencies:
@@ -7930,6 +8532,10 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -8115,6 +8721,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es-toolkit@1.46.1: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -8733,6 +9341,8 @@ snapshots:
       - encoding
       - supports-color
 
+  hachure-fill@0.5.2: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -8900,6 +9510,10 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -8920,6 +9534,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
@@ -8931,6 +9547,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.2.0:
     dependencies:
@@ -9174,9 +9794,15 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kleur@3.0.3: {}
 
@@ -9187,6 +9813,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   levn@0.4.1:
     dependencies:
@@ -9254,6 +9884,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash-es@4.18.1: {}
+
   lodash.merge@4.6.2: {}
 
   log-symbols@6.0.0:
@@ -9291,6 +9923,8 @@ snapshots:
       uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -9456,6 +10090,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.4
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.4)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.4)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.3.3
+      es-toolkit: 1.46.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -9949,6 +10607,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-manager-detector@1.6.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9979,6 +10639,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
 
@@ -10017,6 +10679,13 @@ snapshots:
       fsevents: 2.3.2
 
   po-parser@2.1.1: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -10352,6 +11021,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
       '@oxc-project/types': 0.122.0
@@ -10409,6 +11080,13 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -10424,6 +11102,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -10780,6 +11460,8 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.29.0
 
+  stylis@4.4.0: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -10859,6 +11541,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-dedent@2.2.0: {}
 
   ts-morph@26.0.0:
     dependencies:
@@ -11061,6 +11745,8 @@ snapshots:
       react: 19.2.4
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.0: {}
 
   uuid@8.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       jose:
         specifier: ^6.2.3
         version: 6.2.3
+      katex:
+        specifier: ^0.16.47
+        version: 0.16.47
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       shadcn:
         specifier: ^4.1.2
         version: 4.1.2(@types/node@20.19.37)(typescript@5.9.3)
+      shiki:
+        specifier: ^4.1.0
+        version: 4.1.0
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -1589,6 +1592,37 @@ packages:
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@shikijs/core@4.1.0':
+    resolution: {integrity: sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.1.0':
+    resolution: {integrity: sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    resolution: {integrity: sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.1.0':
+    resolution: {integrity: sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.1.0':
+    resolution: {integrity: sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.1.0':
+    resolution: {integrity: sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.1.0':
+    resolution: {integrity: sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
@@ -3457,6 +3491,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -4324,6 +4361,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
     engines: {node: '>=20'}
@@ -4604,6 +4647,15 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4772,6 +4824,10 @@ packages:
   shell-quote@1.8.3:
     resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
     engines: {node: '>= 0.4'}
+
+  shiki@4.1.0:
+    resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -6572,6 +6628,46 @@ snapshots:
   '@schummar/icu-type-parser@1.21.5': {}
 
   '@sec-ant/readable-stream@0.4.1': {}
+
+  '@shikijs/core@4.1.0':
+    dependencies:
+      '@shikijs/primitive': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/primitive@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/themes@4.1.0':
+    dependencies:
+      '@shikijs/types': 4.1.0
+
+  '@shikijs/types@4.1.0':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
+
+  '@shikijs/vscode-textmate@10.0.2': {}
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
@@ -8696,6 +8792,20 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -9783,6 +9893,14 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
   open@11.0.0:
     dependencies:
       default-browser: 5.5.0
@@ -10125,6 +10243,16 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -10461,6 +10589,17 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   shell-quote@1.8.3: {}
+
+  shiki@4.1.0:
+    dependencies:
+      '@shikijs/core': 4.1.0
+      '@shikijs/engine-javascript': 4.1.0
+      '@shikijs/engine-oniguruma': 4.1.0
+      '@shikijs/langs': 4.1.0
+      '@shikijs/themes': 4.1.0
+      '@shikijs/types': 4.1.0
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.4
 
   side-channel-list@1.0.0:
     dependencies:


### PR DESCRIPTION
## Summary
- E-DOCS-UPGRADE 에픽 전량 완주 (61/61 SP, 18 stories, 20 PRs)
- Phase 1: 기반 (인라인 제목, 반응형 사이드바, 즉시 생성, 슬래시 메뉴, 플로팅 툴바)
- Phase 2: 블록 확장 (체크리스트, Shiki 코드, Mermaid, 토글)
- Phase 3: 고급 확장 (이미지 D&D, 파일 첨부, 외부 임베드, KaTeX, 컬럼 레이아웃, TOC, 위키링크)
- Phase 4: UX (호버 카드, 전문 검색 tsvector)
- P0 hotfix: wiki-link pluginKey collision
- dev UI Puppeteer 검증 완료

## Migration
- **0047_add_docs_tsvector**: search_vector TSVECTOR GENERATED ALWAYS AS STORED + GIN index
- prod DB migration 적용 필요: `gcloud run jobs execute sprintable-migrate-prod --region asia-northeast3 --wait`

## Test plan
- [x] dev UI Puppeteer 검증: 문서 트리, 에디터, 슬래시 메뉴, TOC, 백엔드 search API
- [x] dev CB SUCCESS 전 PR 확인
- [ ] prod CB SUCCESS 확인
- [ ] prod migration 적용
- [ ] prod UI smoke 검증