### PR TITLE
[SID:61630405] Settings 메뉴 트리 재편 — 섹션 재그루핑 + 레거시 제거

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -462,7 +462,7 @@
     "usageTab": "Usage",
     "personalSettings": "Personal Settings",
     "projectSettings": "Project Settings",
-    "organizationSettings": "Organization Settings",
+    "organizationSettings": "Organization",
     "billing": "Billing",
     "usage": "Usage",
     "slackIntegration": {

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -462,7 +462,7 @@
     "usageTab": "사용량",
     "personalSettings": "개인 설정",
     "projectSettings": "프로젝트 설정",
-    "organizationSettings": "조직 설정",
+    "organizationSettings": "조직",
     "billing": "결제",
     "usage": "사용량",
     "slackIntegration": {

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -5,7 +5,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Key, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
+import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { OrgMembersSection } from '@/components/settings/org-members-section';
 import { ProjectAccessSection } from '@/components/settings/project-access-section';
@@ -14,7 +14,6 @@ import { AiSettingsSection } from '@/components/settings/ai-settings';
 import { MyProfileSection } from '@/components/settings/my-profile-section';
 import { ByomKeyManagement } from '@/components/settings/byom-key-management';
 import { McpConnectionSettings } from '@/components/settings/mcp-connection-settings';
-import { SlackIntegrationSettingsSection } from '@/components/settings/slack-integration-settings';
 import { WorkflowTriggerTypesSection } from '@/components/settings/workflow-trigger-types-section';
 import { WorkflowExecutionHistorySection } from '@/components/settings/workflow-execution-history-section';
 import { WorkflowTemplateGallerySection } from '@/components/settings/workflow-template-gallery-section';
@@ -765,25 +764,29 @@ export default function SettingsPage() {
               <Palette className="h-4 w-4" />
               {t('tabAppearance')}
             </TabsTrigger>
-            {currentProjectId && isAdmin ? (
-              <TabsTrigger value="api-keys">
-                <Key className="h-4 w-4" />
-                {t('tabApiKeys')}
+            <TabsTrigger value="notifications">
+              <Bell className="h-4 w-4" />
+              {t('tabNotifications')}
+            </TabsTrigger>
+
+            <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('projectSettings')}</span>
+            {currentProjectId ? (
+              <TabsTrigger value="ai">
+                <Bot className="h-4 w-4" />
+                {t('tabAiAgents')}
               </TabsTrigger>
             ) : null}
-
-            {currentProjectId ? (
-              <>
-                <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('projectSettings')}</span>
-                <TabsTrigger value="notifications">
-                  <Bell className="h-4 w-4" />
-                  {t('tabNotifications')}
-                </TabsTrigger>
-                <TabsTrigger value="ai">
-                  <Bot className="h-4 w-4" />
-                  {t('tabAiAgents')}
-                </TabsTrigger>
-              </>
+            {adminChecked ? (
+              <TabsTrigger value="members">
+                <Users className="h-4 w-4" />
+                Team Members
+              </TabsTrigger>
+            ) : null}
+            {adminChecked && isAdmin ? (
+              <TabsTrigger value="workflow">
+                <GitBranch className="h-4 w-4" />
+                {t('tabWorkflow')}
+              </TabsTrigger>
             ) : null}
 
             {adminChecked ? (
@@ -801,36 +804,32 @@ export default function SettingsPage() {
                   <FolderKanban className="h-4 w-4" />
                   {t('tabProjects')}
                 </TabsTrigger>
-                <TabsTrigger value="members">
-                  <Users className="h-4 w-4" />
-                  Team Members
-                </TabsTrigger>
                 {isAdmin ? (
-                  <>
-                    <TabsTrigger value="integrations">
-                      <Zap className="h-4 w-4" />
-                      {t('tabIntegrations')}
-                    </TabsTrigger>
-                    <TabsTrigger value="workflow">
-                      <GitBranch className="h-4 w-4" />
-                      {t('tabWorkflow')}
-                    </TabsTrigger>
-                    <TabsTrigger value="subscription">
-                      <CreditCard className="h-4 w-4" />
-                      {t('tabSubscription')}
-                    </TabsTrigger>
-                    {isEEEnabled() && (
-                      <TabsTrigger value="billing">
-                        <CreditCard className="h-4 w-4" />
-                        Billing
-                      </TabsTrigger>
-                    )}
-                    <TabsTrigger value="usage">
-                      <BarChart2 className="h-4 w-4" />
-                      {t('tabUsage')}
-                    </TabsTrigger>
-                  </>
+                  <TabsTrigger value="webhooks">
+                    <Zap className="h-4 w-4" />
+                    Webhooks
+                  </TabsTrigger>
                 ) : null}
+              </>
+            ) : null}
+
+            {adminChecked && isAdmin ? (
+              <>
+                <span className="truncate px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('billing')}</span>
+                <TabsTrigger value="subscription">
+                  <CreditCard className="h-4 w-4" />
+                  {t('tabSubscription')}
+                </TabsTrigger>
+                {isEEEnabled() && (
+                  <TabsTrigger value="billing">
+                    <CreditCard className="h-4 w-4" />
+                    Billing
+                  </TabsTrigger>
+                )}
+                <TabsTrigger value="usage">
+                  <BarChart2 className="h-4 w-4" />
+                  {t('tabUsage')}
+                </TabsTrigger>
               </>
             ) : null}
 
@@ -1640,65 +1639,62 @@ export default function SettingsPage() {
             </TabsContent>
 
             {adminChecked && isAdmin ? (
-            <TabsContent value="integrations">
-              <div className="space-y-6">
-                <SlackIntegrationSettingsSection />
-                <SectionCard>
-                  <SectionCardHeader>
-                    <div className="space-y-1">
-                      <h2 className="text-base font-semibold text-foreground">{t('webhooks')}</h2>
-                      <p className="text-sm text-muted-foreground">{t('webhookDescription')}</p>
-                    </div>
-                  </SectionCardHeader>
-                  <SectionCardBody className="space-y-4">
-                    <div className="space-y-2">
-                      {webhooks.map((webhook) => (
-                        <div key={webhook.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
-                          <span className="truncate text-foreground">{webhook.url}</span>
-                          <span className="shrink-0 text-muted-foreground">{webhook.projects?.name ?? t('defaultWebhook')}</span>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
-                      <OperatorInput
-                        type="url"
-                        value={newWebhookUrl}
-                        onChange={(e) => setNewWebhookUrl(e.target.value)}
-                        placeholder={t('webhookUrlPlaceholder')}
-                      />
-                      <OperatorDropdownSelect
-                        value={newWebhookProjectId}
-                        onValueChange={(v) => setNewWebhookProjectId(v)}
-                        options={[
-                          { value: '', label: t('defaultWebhook') },
-                          ...projects.map((project) => ({ value: project.id, label: project.name })),
-                        ]}
-                      />
-                      <Button
-                        variant="hero"
-                        size="lg"
-                        onClick={async () => {
-                          if (!newWebhookUrl.trim()) return;
-                          await fetch('/api/webhooks/config', {
-                            method: 'PUT',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ url: newWebhookUrl.trim(), project_id: newWebhookProjectId || null }),
-                          });
-                          setNewWebhookUrl('');
-                          setNewWebhookProjectId('');
-                          const res = await fetch('/api/webhooks/config');
-                          if (res.ok) {
-                            const j = await res.json();
-                            setWebhooks(j.data ?? []);
-                          }
-                        }}
-                      >
-                        {tc('save')}
-                      </Button>
-                    </div>
-                  </SectionCardBody>
-                </SectionCard>
-              </div>
+            <TabsContent value="webhooks">
+              <SectionCard>
+                <SectionCardHeader>
+                  <div className="space-y-1">
+                    <h2 className="text-base font-semibold text-foreground">{t('webhooks')}</h2>
+                    <p className="text-sm text-muted-foreground">{t('webhookDescription')}</p>
+                  </div>
+                </SectionCardHeader>
+                <SectionCardBody className="space-y-4">
+                  <div className="space-y-2">
+                    {webhooks.map((webhook) => (
+                      <div key={webhook.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
+                        <span className="truncate text-foreground">{webhook.url}</span>
+                        <span className="shrink-0 text-muted-foreground">{webhook.projects?.name ?? t('defaultWebhook')}</span>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
+                    <OperatorInput
+                      type="url"
+                      value={newWebhookUrl}
+                      onChange={(e) => setNewWebhookUrl(e.target.value)}
+                      placeholder={t('webhookUrlPlaceholder')}
+                    />
+                    <OperatorDropdownSelect
+                      value={newWebhookProjectId}
+                      onValueChange={(v) => setNewWebhookProjectId(v)}
+                      options={[
+                        { value: '', label: t('defaultWebhook') },
+                        ...projects.map((project) => ({ value: project.id, label: project.name })),
+                      ]}
+                    />
+                    <Button
+                      variant="hero"
+                      size="lg"
+                      onClick={async () => {
+                        if (!newWebhookUrl.trim()) return;
+                        await fetch('/api/webhooks/config', {
+                          method: 'PUT',
+                          headers: { 'Content-Type': 'application/json' },
+                          body: JSON.stringify({ url: newWebhookUrl.trim(), project_id: newWebhookProjectId || null }),
+                        });
+                        setNewWebhookUrl('');
+                        setNewWebhookProjectId('');
+                        const res = await fetch('/api/webhooks/config');
+                        if (res.ok) {
+                          const j = await res.json();
+                          setWebhooks(j.data ?? []);
+                        }
+                      }}
+                    >
+                      {tc('save')}
+                    </Button>
+                  </div>
+                </SectionCardBody>
+              </SectionCard>
             </TabsContent>
             ) : null}
 


### PR DESCRIPTION
## 변경 사항 요약

Settings 페이지 사이드바 메뉴 트리 구조를 재편합니다.

### Before
```
MY ACCOUNT: Profile / Appearance / API Keys
PROJECT SETTINGS: Notifications / AI & Agents
ORGANIZATION SETTINGS: Organization / Org Members / Projects / Team Members / Integrations / Workflow / Subscription / Usage
DANGER ZONE: Delete Account
```

### After
```
MY ACCOUNT: Profile / Appearance / Notifications
PROJECT SETTINGS: AI & Agents / Team Members / Workflow
ORGANIZATION: Organization / Org Members / Projects / Webhooks
BILLING: Subscription / Usage
DANGER ZONE: Delete Account
```

### 주요 변경
- **API Keys 탭 제거** — 사이드바에서 제거, `api-keys` TabsContent는 리다이렉트 로직 유지 (딥링크 호환)
- **Notifications → MY ACCOUNT** — 개인 선호 설정 성격에 맞게 이동
- **Team Members, Workflow → PROJECT SETTINGS** — 프로젝트 단위 관리 항목으로 이동
- **Integrations 제거** — Slack 탭 완전 제거, Webhook 설정은 ORGANIZATION > Webhooks로 독립
- **BILLING 섹션 신설** — Subscription / Usage를 ORGANIZATION에서 분리
- **섹션명 변경** — "ORGANIZATION SETTINGS" → "ORGANIZATION" (ko: 조직 설정 → 조직)

## 테스트 방법
1. `/settings` 접속 후 사이드바 섹션 구조 확인
2. 각 탭 클릭 시 컨텐츠 정상 렌더링 확인
3. `?tab=api-keys` 직접 진입 시 members/agents 리다이렉트 정상 동작 확인
4. 모바일 너비에서 섹션 구분 표시 확인

## AC 체크리스트
- [x] AC1: MY ACCOUNT에 Profile / Appearance / Notifications 3개 항목
- [x] AC2: API Keys 사이드바 탭 제거 (리다이렉트 TabsContent 유지)
- [x] AC3: PROJECT SETTINGS에 AI & Agents / Team Members / Workflow
- [x] AC4: ORGANIZATION에 Organization / Org Members / Projects / Webhooks
- [x] AC5: Integrations 탭 제거, Webhooks 독립 탭
- [x] AC6: BILLING 섹션 신설 (Subscription / Usage)
- [x] AC7: DANGER ZONE 유지
- [x] AC8: 빌드 통과 (lint 에러 0)
- [x] AC9: 반응형 — 기존 lg 브레이크포인트 동일 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)