### PR TITLE
[fix] /api/v2/events/memos SSE 엔드포인트 제거

### DIFF
--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -133,63 +133,6 @@ def _event_to_payload(event: "Event") -> dict:
 
 # ─── SSE endpoint ─────────────────────────────────────────────────────────────
 
-@router.get("/memos")
-async def memo_event_stream(
-    request: Request,
-    auth: AuthContext = Depends(get_current_user),
-    member_id: str | None = Query(default=None),
-    last_event_id: str | None = Query(default=None),  # AC2: reconnect 판별
-):
-    """GET /api/v2/events/memos — SSE 스트림.
-
-    이벤트:
-    - heartbeat: 30초마다 연결 유지
-    - memo_created: 새 메모 INSERT
-    - memo_updated: 메모 UPDATE
-    - reply_created: 새 메모 답글 INSERT
-
-    AC1: 모든 이벤트에 id: 필드 발행 → 브라우저 Last-Event-ID 자동 추적
-    AC2: last_event_id 파라미터 또는 Last-Event-ID 헤더로 재연결 판별
-    """
-    org_id = auth.claims.get("app_metadata", {}).get("org_id", auth.user_id)
-
-    # Last-Event-ID 헤더도 지원 (브라우저 EventSource 자동 전달)
-    _last_eid = last_event_id or request.headers.get("last-event-id")
-    _is_reconnect = _last_eid is not None
-
-    queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
-    _subscribers[org_id].add(queue)
-
-    async def generate():
-        try:
-            # 초기 heartbeat — HTTP 응답 헤더 즉시 플러시, 재연결 여부 client에 알림
-            reconnect_flag = "true" if _is_reconnect else "false"
-            yield f"event: heartbeat\ndata: {{\"reconnect\":{reconnect_flag}}}\n\n"
-
-            while not await request.is_disconnected():
-                try:
-                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
-                    event_type = event.get("type", "message")
-                    data = {k: v for k, v in event.items() if k != "type"}
-                    # AC1: event_id 우선, 없으면 uuid 생성
-                    eid = data.get("event_id") or str(uuid.uuid4())
-                    yield f"event: {event_type}\nid: {eid}\ndata: {json.dumps(data)}\n\n"
-                except asyncio.TimeoutError:
-                    yield "event: heartbeat\ndata: {}\n\n"
-        except (asyncio.CancelledError, GeneratorExit):
-            pass
-        finally:
-            _subscribers[org_id].discard(queue)
-
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
-        },
-    )
 
 
 # ─── Pydantic schemas ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `app/routers/events.py`의 `GET /api/v2/events/memos` SSE 엔드포인트 제거 (-59줄)
- 프론트에서 해당 엔드포인트 호출 시 401 반복 발생하는 레거시 코드
- `publish_event`, `_subscribers`는 conversations/stories/file_locks에서 사용 중 → 보존

## Test plan

- [ ] `/api/v2/events/memos` → 404 확인
- [ ] `/api/v2/events/agent` (에이전트 SSE) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)