### PR TITLE
[SID:65445ab1] fix: events/memos SSE 호출부 제거 — /api/event-stream 전환

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -86,7 +86,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current?.close();
       sourceRef.current = null;
 
-      const url = new URL('/api/v2/events/memos', window.location.origin);
+      const url = new URL('/api/event-stream', window.location.origin);
       if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
       if (lastEventIdRef.current) url.searchParams.set('last_event_id', lastEventIdRef.current);
 


### PR DESCRIPTION
## 배경

E-MEMO-RETIRE 잔존. `use-chat-sse.ts`에서 `/api/v2/events/memos`를 직접 구독 → 백엔드 엔드포인트 제거 후 401 반복 노출.

## 변경 사항

**apps/web/src/hooks/use-chat-sse.ts** 단일 라인 수정

```diff
- const url = new URL('/api/v2/events/memos', window.location.origin);
+ const url = new URL('/api/event-stream', window.location.origin);
```

`/api/event-stream`은 `/api/v2/events/stream`으로 프록시하며 인증(session.access_token) 처리 포함.

## AC 체크리스트
- [x] AC2: 프론트에서 events/memos SSE 호출 없음 ✅
- [x] AC3: /api/event-stream → /api/v2/events/stream 정상 작동
- [x] AC4: pnpm build 성공 ✅
- [x] AC5: 401 에러 없음 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)