### PR TITLE
[DS-S3] 보드 컬럼 헤더 카운트 단일화 — 좌측 중복 제거

### DIFF
--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -132,11 +132,6 @@ export function KanbanColumn({
           <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             <span className={`h-2 w-2 rounded-full ${statusColor.dot}`} aria-hidden="true" />
             {label}
-            {totalCount !== undefined && (
-              <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                {hasMore ? `${totalCount}+` : totalCount}
-              </span>
-            )}
           </h3>
           <div className="flex items-center gap-1.5">
             {/* AC1: WIP 초과 배지 */}
@@ -156,7 +151,7 @@ export function KanbanColumn({
               variant="secondary"
               className={`rounded-full px-2.5 font-mono text-[11px] shadow-sm ${wipExceeded ? 'bg-destructive/15 text-destructive' : ''}`}
             >
-              {stories.length}
+              {totalCount !== undefined ? (hasMore ? `${totalCount}+` : totalCount) : stories.length}
             </Badge>
             {/* AC5: WIP limit 편집 버튼 */}
             <button


### PR DESCRIPTION
## 배경

보드 컬럼 헤더에 카운트가 좌(totalCount "20+")·우(stories.length "20") 두 번 표시되는 시각 노이즈. 우측에 통합, 좌측 제거.

## 변경 사항 (kanban-column.tsx, 1파일)

| 위치 | 변경 |
|---|---|
| L135-139 | 좌측 totalCount span 제거 |
| L159 | `stories.length` → `totalCount !== undefined ? (hasMore ? \`${totalCount}+\` : totalCount) : stories.length` |

- `hasMore=true` 컬럼: "20+" 표시
- `hasMore=false` 컬럼: "20" 표시
- `totalCount` 미정의 시: `stories.length` fallback

## AC 체크리스트
- [x] AC1: 컬럼 헤더 카운트 1개(우측만)
- [x] AC2: 좌측 중복 카운트 제거
- [x] AC4: pnpm build 성공
- [x] WIP 배지/버튼 기존 동작 유지
- [x] hasMore 양쪽 정상 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)