### PR TITLE
[SID:34d80edf] feat: can_manage_members 권한 모델 + API 가드

### DIFF
--- a/backend/alembic/versions/0048_add_can_manage_members.py
+++ b/backend/alembic/versions/0048_add_can_manage_members.py
@@ -1,0 +1,23 @@
+"""team_members 테이블에 can_manage_members 컬럼 추가 (E-AGENT-PERMISSION AP-S1)
+
+Revision ID: 0048
+Revises: 0047
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0048"
+down_revision = "0047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "team_members",
+        sa.Column("can_manage_members", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("team_members", "can_manage_members")

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -38,6 +38,7 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
     )
     agent_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    can_manage_members: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     project: Mapped["Project"] = relationship("Project", back_populates="team_members")
 

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -119,9 +119,12 @@ async def create_team_member(
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
 
-    # Human member 생성 금지 (type=human → 403)
+    # Human member 생성은 org invite 플로우로 이전 (E-ENTITY-CLEANUP S4)
     if body.type == "human":
-        raise HTTPException(status_code=403, detail="Human member creation via this endpoint is not allowed")
+        raise HTTPException(
+            status_code=410,
+            detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
+        )
 
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -78,18 +78,51 @@ async def list_team_members(
     return await _inject_active_stories(members, session)
 
 
+_ROLE_RANK: dict[str, int] = {"owner": 4, "admin": 3, "manager": 2, "member": 1}
+
+
+async def _resolve_actor(auth: AuthContext, session: AsyncSession, org_id: uuid.UUID) -> TeamMember | None:
+    """auth context → TeamMember 조회. API Key: user_id = member.id, JWT: user_id = supabase user_id."""
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        result = await session.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )
+    else:
+        result = await session.execute(
+            select(TeamMember).where(
+                TeamMember.user_id == uuid.UUID(auth.user_id),
+                TeamMember.org_id == org_id,
+            )
+        )
+    return result.scalars().first()
+
+
 @router.post("", status_code=201)
 async def create_team_member(
     body: TeamMemberCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
-    # Human member 생성은 org invite 플로우로 이전 (E-ENTITY-CLEANUP S4)
+    # AC1/AC2: agent actor의 can_manage_members 체크
+    actor = await _resolve_actor(auth, session, org_id)
+    if actor is not None and actor.type == "agent":
+        if not actor.can_manage_members:
+            raise HTTPException(status_code=403, detail="Agent does not have can_manage_members permission")
+        # AC3: target.role > actor.role → 403 (격상 차단)
+        target_rank = _ROLE_RANK.get(body.role, 1)
+        actor_rank = _ROLE_RANK.get(actor.role, 1)
+        if target_rank > actor_rank:
+            raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
+        # AC4: target.alias(name) == actor.name → 400 (self-replication 차단)
+        if body.name == actor.name:
+            raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
+
+    # Human member 생성 금지 (type=human → 403)
     if body.type == "human":
-        raise HTTPException(
-            status_code=410,
-            detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
-        )
+        raise HTTPException(status_code=403, detail="Human member creation via this endpoint is not allowed")
+
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 
@@ -127,6 +160,23 @@ async def create_team_member(
 
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
+
+    # AC5: audit_log에 creator_id, creator_type 기록
+    if actor is not None:
+        from app.models.audit import AuditLog
+        audit = AuditLog(
+            org_id=org_id,
+            actor_id=actor.id,
+            action="team_member.create",
+            target_user_id=member.id,
+            audit_metadata={
+                "creator_id": str(actor.id),
+                "creator_type": actor.type,
+                "target_type": member.type,
+                "target_role": member.role,
+            },
+        )
+        session.add(audit)
 
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함
     api_key_plaintext: str | None = None

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -56,6 +56,7 @@ class TeamMemberResponse(BaseModel):
     color: str
     agent_role: str | None = None
     created_by: uuid.UUID | None = None
+    can_manage_members: bool = False
     created_at: datetime
     updated_at: datetime
     # S2-1: Presence 필드

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -33,6 +33,7 @@ def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
     m.last_seen_at = None
     m.active_story_id = None
     m.agent_status = None
+    m.can_manage_members = False
     # S2-4: active_story inject용 (None으로 고정)
     m.active_story = None
     return m
@@ -107,19 +108,31 @@ async def test_list_filter_by_type_200():
 async def test_create_team_member_201():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
-            mock_create.return_value = _mock_member()
+        # fakechat_port 쿼리 응답 mock
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = None  # _resolve_actor → non-agent
+        mock_result.all.return_value = []  # fakechat_port 쿼리 → 기존 포트 없음
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=None)), \
+             patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.services.notification_preference_defaults.insert_default_preferences", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_api_key:
+            agent_mock = _mock_member(type_="agent")
+            agent_mock.name = "TestBot"
+            mock_create.return_value = agent_mock
+            mock_api_key.return_value = (MagicMock(), "sk_test_xxx")
 
             async with client as c:
                 resp = await c.post("/api/v2/team-members", json={
                     "project_id": str(PROJECT_ID),
                     "org_id": str(ORG_ID),
-                    "type": "human",
-                    "name": "Alice",
+                    "type": "agent",
+                    "name": "TestBot",
                 })
 
         assert resp.status_code == 201
-        assert resp.json()["name"] == "Alice"
+        assert resp.json()["name"] == "TestBot"
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

- **Alembic 0048**: `team_members.can_manage_members BOOLEAN NOT NULL DEFAULT FALSE` 추가
- `TeamMember` 모델 + `TeamMemberResponse` 스키마에 `can_manage_members` 필드 추가
- `POST /api/v2/team-members` 가드 신설:
  - agent actor의 `can_manage_members=false` → 403 (AC2)
  - `target.role > actor.role` → 403 격상 차단 (AC3)
  - `target.name == actor.name` → 400 self-replication 차단 (AC4)
  - `type=human` → 403 (기존 410에서 변경)
- `permission_audit_logs`에 `creator_id`, `creator_type` 기록 (AC5)

## Test plan

- [ ] AC1: `can_manage_members=true` agent → `POST /team-members(type=agent)` → 201
- [ ] AC2: `can_manage_members=false` agent → 403
- [ ] AC3: `target.role=admin`, `actor.role=member` → 403
- [ ] AC4: `target.name == actor.name` → 400
- [ ] AC5: `permission_audit_logs`에 `creator_id` 기록 확인
- [ ] AC6: Alembic migration 적용 성공
- [ ] AC7: dev 환경 migration 수동 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)