### PR TITLE
[DS-S4] 대시보드 blocked 카운트 0-state 색상 중립화

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -127,7 +127,7 @@ export default async function DashboardPage() {
                   <div className="text-xs text-muted-foreground">{t('inReview')}</div>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
-                  <div className="text-2xl font-bold text-destructive">{storyCounts.blocked}</div>
+                  <div className={`text-2xl font-bold ${storyCounts.blocked > 0 ? 'text-destructive' : 'text-foreground'}`}>{storyCounts.blocked}</div>
                   <div className="text-xs text-muted-foreground">{t('blocked')}</div>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 px-4 py-3">


### PR DESCRIPTION
## Summary
- `storyCounts.blocked`가 0일 때 `text-destructive` → `text-foreground`로 전환
- 0 초과 시에만 경고색(destructive) 유지, 정상 상태(0)는 중립색
- inProgress/inReview/open 카운트 색상 변경 없음

## Changes
- `apps/web/src/app/dashboard/page.tsx` L130: 조건부 className

## Before / After
| 상태 | Before | After |
|------|--------|-------|
| blocked = 0 | `text-destructive` (빨강) | `text-foreground` (중립) |
| blocked > 0 | `text-destructive` (빨강) | `text-destructive` (빨강) |

## Test Plan
- [ ] 대시보드 진입 → blocked 0 → 숫자 중립색 확인
- [ ] blocked > 0 시 여전히 빨간색 확인
- [ ] pnpm build 통과 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)