### PR TITLE
[AP-S2] feat: agent→agent 생성 시 owner/admin 사후 알림

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -181,6 +181,30 @@ async def create_team_member(
         )
         session.add(audit)
 
+    # AP-S2: agent가 agent를 생성한 경우 owner/admin human에게 알림 발송
+    if actor is not None and actor.type == "agent" and member.type == "agent":
+        from app.services.notification_dispatch import dispatch_notification
+        admin_result = await session.execute(
+            select(TeamMember.id).where(
+                TeamMember.org_id == org_id,
+                TeamMember.type == "human",
+                TeamMember.role.in_(["owner", "admin"]),
+                TeamMember.is_active.is_(True),
+            )
+        )
+        admin_ids = [row[0] for row in admin_result.all()]
+        if admin_ids:
+            await dispatch_notification(
+                session,
+                org_id=org_id,
+                event_type="agent_joined",
+                target_member_ids=admin_ids,
+                title=f"새 에이전트 합류: {member.name}",
+                body=f"{actor.name}(에이전트)이 {member.name}을 생성했습니다.",
+                reference_type="team_member",
+                reference_id=member.id,
+            )
+
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함
     api_key_plaintext: str | None = None
     if body.type == "agent":


### PR DESCRIPTION
## Summary

- agent actor가 agent type member 생성 시 org 내 owner/admin human에게 `agent_joined` 알림 발송
- human 생성자는 알림 미발송 (AC3 — 기존 동작 유지)
- `dispatch_notification`으로 `in_app` 채널 전달

## 구현 위치

`POST /api/v2/team-members` create_team_member 함수 — audit_log 기록 직후

```python
if actor is not None and actor.type == "agent" and member.type == "agent":
    # org owner/admin human 조회 → dispatch_notification(event_type="agent_joined")
```

## Test plan

- [ ] AC1: agent → POST agent → owner/admin human에게 알림 수신 확인
- [ ] AC2: 알림 title에 신규 에이전트 이름, body에 생성자 정보 포함 확인
- [ ] AC3: human → POST agent → 알림 미발송 확인
- [ ] AC4: 알림 type="agent_joined" 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)