### PR TITLE
Prod promotion: 핫픽스 3건 + DS-S3/S4 + AP-S1/S2

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -127,7 +127,7 @@ export default async function DashboardPage() {
                   <div className="text-xs text-muted-foreground">{t('inReview')}</div>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 px-4 py-3">
-                  <div className="text-2xl font-bold text-destructive">{storyCounts.blocked}</div>
+                  <div className={`text-2xl font-bold ${storyCounts.blocked > 0 ? 'text-destructive' : 'text-foreground'}`}>{storyCounts.blocked}</div>
                   <div className="text-xs text-muted-foreground">{t('blocked')}</div>
                 </div>
                 <div className="rounded-md border border-border bg-muted/30 px-4 py-3">

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -132,11 +132,6 @@ export function KanbanColumn({
           <h3 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
             <span className={`h-2 w-2 rounded-full ${statusColor.dot}`} aria-hidden="true" />
             {label}
-            {totalCount !== undefined && (
-              <span className="ml-1 rounded-full bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                {hasMore ? `${totalCount}+` : totalCount}
-              </span>
-            )}
           </h3>
           <div className="flex items-center gap-1.5">
             {/* AC1: WIP 초과 배지 */}
@@ -156,7 +151,7 @@ export function KanbanColumn({
               variant="secondary"
               className={`rounded-full px-2.5 font-mono text-[11px] shadow-sm ${wipExceeded ? 'bg-destructive/15 text-destructive' : ''}`}
             >
-              {stories.length}
+              {totalCount !== undefined ? (hasMore ? `${totalCount}+` : totalCount) : stories.length}
             </Badge>
             {/* AC5: WIP limit 편집 버튼 */}
             <button

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -86,7 +86,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       sourceRef.current?.close();
       sourceRef.current = null;
 
-      const url = new URL('/api/v2/events/memos', window.location.origin);
+      const url = new URL('/api/event-stream', window.location.origin);
       if (memberIdRef.current) url.searchParams.set('member_id', memberIdRef.current);
       if (lastEventIdRef.current) url.searchParams.set('last_event_id', lastEventIdRef.current);
 

--- a/backend/alembic/versions/0048_add_can_manage_members.py
+++ b/backend/alembic/versions/0048_add_can_manage_members.py
@@ -1,0 +1,23 @@
+"""team_members 테이블에 can_manage_members 컬럼 추가 (E-AGENT-PERMISSION AP-S1)
+
+Revision ID: 0048
+Revises: 0047
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0048"
+down_revision = "0047"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "team_members",
+        sa.Column("can_manage_members", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("team_members", "can_manage_members")

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -38,6 +38,7 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
     )
     agent_status: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    can_manage_members: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     project: Mapped["Project"] = relationship("Project", back_populates="team_members")
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -445,10 +445,12 @@ async def list_messages(
     if conv_project_id is None:
         raise HTTPException(status_code=404, detail="Conversation not found")
 
-    sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
+    # owner/admin: org-level 조회 (project 소속 무관 접근), member: project-level 유지
+    sender = await _resolve_member(auth, org_id, db, project_id=None)
 
-    # 참여자 검증 — owner/admin은 에이전트 대화 열람 허용
     if sender.role not in ("owner", "admin"):
+        # project isolation 보존 — project 소속 member 재확인
+        sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
         participant = (await db.execute(
             select(ConversationParticipant.id).where(
                 ConversationParticipant.conversation_id == conversation_id,

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -133,63 +133,6 @@ def _event_to_payload(event: "Event") -> dict:
 
 # ─── SSE endpoint ─────────────────────────────────────────────────────────────
 
-@router.get("/memos")
-async def memo_event_stream(
-    request: Request,
-    auth: AuthContext = Depends(get_current_user),
-    member_id: str | None = Query(default=None),
-    last_event_id: str | None = Query(default=None),  # AC2: reconnect 판별
-):
-    """GET /api/v2/events/memos — SSE 스트림.
-
-    이벤트:
-    - heartbeat: 30초마다 연결 유지
-    - memo_created: 새 메모 INSERT
-    - memo_updated: 메모 UPDATE
-    - reply_created: 새 메모 답글 INSERT
-
-    AC1: 모든 이벤트에 id: 필드 발행 → 브라우저 Last-Event-ID 자동 추적
-    AC2: last_event_id 파라미터 또는 Last-Event-ID 헤더로 재연결 판별
-    """
-    org_id = auth.claims.get("app_metadata", {}).get("org_id", auth.user_id)
-
-    # Last-Event-ID 헤더도 지원 (브라우저 EventSource 자동 전달)
-    _last_eid = last_event_id or request.headers.get("last-event-id")
-    _is_reconnect = _last_eid is not None
-
-    queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
-    _subscribers[org_id].add(queue)
-
-    async def generate():
-        try:
-            # 초기 heartbeat — HTTP 응답 헤더 즉시 플러시, 재연결 여부 client에 알림
-            reconnect_flag = "true" if _is_reconnect else "false"
-            yield f"event: heartbeat\ndata: {{\"reconnect\":{reconnect_flag}}}\n\n"
-
-            while not await request.is_disconnected():
-                try:
-                    event = await asyncio.wait_for(queue.get(), timeout=30.0)
-                    event_type = event.get("type", "message")
-                    data = {k: v for k, v in event.items() if k != "type"}
-                    # AC1: event_id 우선, 없으면 uuid 생성
-                    eid = data.get("event_id") or str(uuid.uuid4())
-                    yield f"event: {event_type}\nid: {eid}\ndata: {json.dumps(data)}\n\n"
-                except asyncio.TimeoutError:
-                    yield "event: heartbeat\ndata: {}\n\n"
-        except (asyncio.CancelledError, GeneratorExit):
-            pass
-        finally:
-            _subscribers[org_id].discard(queue)
-
-    return StreamingResponse(
-        generate(),
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-            "Connection": "keep-alive",
-        },
-    )
 
 
 # ─── Pydantic schemas ─────────────────────────────────────────────────────────

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -78,18 +78,54 @@ async def list_team_members(
     return await _inject_active_stories(members, session)
 
 
+_ROLE_RANK: dict[str, int] = {"owner": 4, "admin": 3, "manager": 2, "member": 1}
+
+
+async def _resolve_actor(auth: AuthContext, session: AsyncSession, org_id: uuid.UUID) -> TeamMember | None:
+    """auth context → TeamMember 조회. API Key: user_id = member.id, JWT: user_id = supabase user_id."""
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        result = await session.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )
+    else:
+        result = await session.execute(
+            select(TeamMember).where(
+                TeamMember.user_id == uuid.UUID(auth.user_id),
+                TeamMember.org_id == org_id,
+            )
+        )
+    return result.scalars().first()
+
+
 @router.post("", status_code=201)
 async def create_team_member(
     body: TeamMemberCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    # AC1/AC2: agent actor의 can_manage_members 체크
+    actor = await _resolve_actor(auth, session, org_id)
+    if actor is not None and actor.type == "agent":
+        if not actor.can_manage_members:
+            raise HTTPException(status_code=403, detail="Agent does not have can_manage_members permission")
+        # AC3: target.role > actor.role → 403 (격상 차단)
+        target_rank = _ROLE_RANK.get(body.role, 1)
+        actor_rank = _ROLE_RANK.get(actor.role, 1)
+        if target_rank > actor_rank:
+            raise HTTPException(status_code=403, detail="Cannot assign role higher than your own")
+        # AC4: target.alias(name) == actor.name → 400 (self-replication 차단)
+        if body.name == actor.name:
+            raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
+
     # Human member 생성은 org invite 플로우로 이전 (E-ENTITY-CLEANUP S4)
     if body.type == "human":
         raise HTTPException(
             status_code=410,
             detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
         )
+
     repo = TeamMemberRepository(session, body.org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 
@@ -127,6 +163,23 @@ async def create_team_member(
 
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
+
+    # AC5: audit_log에 creator_id, creator_type 기록
+    if actor is not None:
+        from app.models.audit import AuditLog
+        audit = AuditLog(
+            org_id=org_id,
+            actor_id=actor.id,
+            action="team_member.create",
+            target_user_id=member.id,
+            audit_metadata={
+                "creator_id": str(actor.id),
+                "creator_type": actor.type,
+                "target_type": member.type,
+                "target_role": member.role,
+            },
+        )
+        session.add(audit)
 
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함
     api_key_plaintext: str | None = None

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -181,6 +181,30 @@ async def create_team_member(
         )
         session.add(audit)
 
+    # AP-S2: agent가 agent를 생성한 경우 owner/admin human에게 알림 발송
+    if actor is not None and actor.type == "agent" and member.type == "agent":
+        from app.services.notification_dispatch import dispatch_notification
+        admin_result = await session.execute(
+            select(TeamMember.id).where(
+                TeamMember.org_id == org_id,
+                TeamMember.type == "human",
+                TeamMember.role.in_(["owner", "admin"]),
+                TeamMember.is_active.is_(True),
+            )
+        )
+        admin_ids = [row[0] for row in admin_result.all()]
+        if admin_ids:
+            await dispatch_notification(
+                session,
+                org_id=org_id,
+                event_type="agent_joined",
+                target_member_ids=admin_ids,
+                title=f"새 에이전트 합류: {member.name}",
+                body=f"{actor.name}(에이전트)이 {member.name}을 생성했습니다.",
+                reference_type="team_member",
+                reference_id=member.id,
+            )
+
     # AC3: agent 생성 시 API key 자동 생성 + response에 포함
     api_key_plaintext: str | None = None
     if body.type == "agent":

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -56,6 +56,7 @@ class TeamMemberResponse(BaseModel):
     color: str
     agent_role: str | None = None
     created_by: uuid.UUID | None = None
+    can_manage_members: bool = False
     created_at: datetime
     updated_at: datetime
     # S2-1: Presence 필드

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -33,6 +33,7 @@ def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
     m.last_seen_at = None
     m.active_story_id = None
     m.agent_status = None
+    m.can_manage_members = False
     # S2-4: active_story inject용 (None으로 고정)
     m.active_story = None
     return m
@@ -107,19 +108,31 @@ async def test_list_filter_by_type_200():
 async def test_create_team_member_201():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
-            mock_create.return_value = _mock_member()
+        # fakechat_port 쿼리 응답 mock
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.first.return_value = None  # _resolve_actor → non-agent
+        mock_result.all.return_value = []  # fakechat_port 쿼리 → 기존 포트 없음
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.routers.team_members._resolve_actor", new=AsyncMock(return_value=None)), \
+             patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.services.notification_preference_defaults.insert_default_preferences", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_api_key:
+            agent_mock = _mock_member(type_="agent")
+            agent_mock.name = "TestBot"
+            mock_create.return_value = agent_mock
+            mock_api_key.return_value = (MagicMock(), "sk_test_xxx")
 
             async with client as c:
                 resp = await c.post("/api/v2/team-members", json={
                     "project_id": str(PROJECT_ID),
                     "org_id": str(ORG_ID),
-                    "type": "human",
-                    "name": "Alice",
+                    "type": "agent",
+                    "name": "TestBot",
                 })
 
         assert resp.status_code == 201
-        assert resp.json()["name"] == "Alice"
+        assert resp.json()["name"] == "TestBot"
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary
- **핫픽스 3건**: events/memos SSE 제거 (#934), FE SSE 전환 (#935), conversation 403 fix (#936)
- **DS-S3**: 보드 컬럼 헤더 카운트 단일화 (#937)
- **DS-S4**: 대시보드 blocked 카운트 0-state 색상 중립화 (#939)
- **AP-S1**: can_manage_members 권한 모델 + API 가드 (#938) — **migration 0048 포함**
- **AP-S2**: agent→agent 생성 시 사후 알림 (#940)

## Migration
- `0048_add_can_manage_members`: team_members 테이블에 can_manage_members BOOLEAN 컬럼 추가
- prod CB SUCCESS 후 `gcloud run jobs execute sprintable-migrate --region asia-northeast3` 필요

## Test plan
- [x] dev smoke PASS
- [x] 까심군 QA 전량 APPROVE
- [x] 유나양 DS-S4 시각 회귀 검증 PASS
- [ ] prod CB SUCCESS
- [ ] prod migration 0048 적용
- [ ] prod smoke