### PR TITLE
[DS-S5] 대시보드 레이아웃 빈 공간 정리

### DIFF
--- a/apps/web/src/components/activity/dashboard-activity-timeline.tsx
+++ b/apps/web/src/components/activity/dashboard-activity-timeline.tsx
@@ -119,7 +119,7 @@ export function DashboardActivityTimeline({ projectId }: DashboardActivityTimeli
   }, [fetchItems]);
 
   return (
-    <SectionCard className="col-span-full">
+    <SectionCard className="xl:col-span-2">
       <SectionCardHeader>
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- `DashboardActivityTimeline` SectionCard: `col-span-full` → `xl:col-span-2`
- Row 2 레이아웃: 최근 문서(1col) + ActivityTimeline(2col) = 3col 균형 배치
- PR #932 메모 위젯 제거 후 생긴 우측 빈 슬롯 제거

## Changes
- `apps/web/src/components/activity/dashboard-activity-timeline.tsx` L122: 1줄 수정

## Before / After
| | Before | After |
|---|---|---|
| Row 2 | 최근 문서(1col) + 빈 슬롯(2col) | 최근 문서(1col) + ActivityTimeline(2col) |
| Row 3 | ActivityTimeline(풀-width) | — (Row 2로 병합) |

## Test Plan
- [ ] AC1: 대시보드 하단 시각적 끊김 없음
- [ ] AC2: 최근 문서 + ActivityTimeline 1:2 균형
- [ ] AC3: xl 미만 브레이크포인트 회귀 없음
- [ ] AC4: 라이트/다크 모드 정상
- [ ] AC5: pnpm build ✅ 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)