### PR TITLE
[DS-S1] 사이드바 footer 프로필 메뉴 신설

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -7,6 +7,7 @@ interface MemberContext {
   org_id: string;
   project_id: string;
   project_name: string;
+  name: string;
 }
 
 interface OrgMembership {
@@ -57,6 +58,7 @@ export default async function AuthenticatedLayout({
       orgId={me?.org_id}
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
+      userName={me?.name}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -20,6 +20,7 @@ interface DashboardContext {
   orgId?: string;
   projectId?: string;
   projectName?: string;
+  userName?: string;
   projectMemberships: DashboardProjectOption[];
   orgMemberships: OrgSwitcherItem[];
 }
@@ -39,6 +40,7 @@ export function DashboardShell({
   orgId,
   projectId,
   projectName,
+  userName,
   projectMemberships,
   orgMemberships,
   children,
@@ -47,7 +49,7 @@ export function DashboardShell({
   const showTopBar = !pathname.startsWith('/settings');
 
   return (
-    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId, projectName, projectMemberships, orgMemberships }}>
+    <DashboardCtx.Provider value={{ currentTeamMemberId, orgId, projectId, projectName, userName, projectMemberships, orgMemberships }}>
       <RefreshProvider>
       <RealtimeProvider currentTeamMemberId={currentTeamMemberId}>
         <TopBarProvider>
@@ -58,6 +60,7 @@ export function DashboardShell({
               projectMemberships={projectMemberships}
               orgId={orgId}
               orgMemberships={orgMemberships}
+              userName={userName}
             />
             <SidebarInset className="relative flex flex-col overflow-hidden">
               {showTopBar && <TopBar />}

--- a/apps/web/src/app/dashboard/layout.tsx
+++ b/apps/web/src/app/dashboard/layout.tsx
@@ -7,6 +7,7 @@ interface MemberContext {
   org_id: string;
   project_id: string;
   project_name: string;
+  name: string;
 }
 
 interface OrgMembership {
@@ -56,6 +57,7 @@ export default async function DashboardLayout({
       orgId={me?.org_id}
       projectId={me?.project_id}
       projectName={me?.project_name ?? undefined}
+      userName={me?.name}
       projectMemberships={projectMemberships}
       orgMemberships={orgMemberships}
     >

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -24,6 +24,7 @@ import { LogoutButton } from '@/app/dashboard/logout-button';
 import { LocaleSwitcher } from '@/components/locale-switcher';
 import { ThemeToggle } from '@/components/nav/theme-toggle';
 import { CommandPalette } from '@/components/command-palette/command-palette';
+import { ProfileMenu } from '@/components/nav/profile-menu';
 import { UnifiedSwitcher, type OrgSwitcherItem } from '@/components/nav/unified-switcher';
 import {
   Sidebar,
@@ -46,6 +47,7 @@ interface AppSidebarProps {
   orgMemberships?: OrgSwitcherItem[];
   projectId?: string;
   projectMemberships: Array<{ projectId: string; projectName: string }>;
+  userName?: string;
 }
 
 function KbdHint({ children }: { children: React.ReactNode }) {
@@ -61,6 +63,7 @@ export function AppSidebar({
   orgMemberships = [],
   projectId,
   projectMemberships,
+  userName,
 }: AppSidebarProps) {
   const pathname = usePathname();
   const t = useTranslations('nav');
@@ -301,7 +304,8 @@ export function AppSidebar({
         </SidebarGroup>
       </SidebarContent>
 
-      <SidebarFooter className="p-2">
+      <SidebarFooter className="space-y-2 p-2">
+        {userName && <ProfileMenu name={userName} />}
         <div className="flex items-center justify-between gap-1">
           <div className="flex items-center gap-1">
             <LocaleSwitcher />

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+import { ChevronsUpDown, Settings, LogOut } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface ProfileMenuProps {
+  name: string;
+  email?: string | null;
+  avatarUrl?: string | null;
+}
+
+function getInitial(name: string): string {
+  if (!name) return '?';
+  return name[0]?.toUpperCase() ?? '?';
+}
+
+export function ProfileMenu({ name, email }: ProfileMenuProps) {
+  const displayLabel = email ?? name;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-sidebar-accent">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-sidebar-accent text-xs font-semibold text-sidebar-accent-foreground">
+          {getInitial(name)}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium text-sidebar-foreground">
+          {name}
+        </span>
+        <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent side="top" align="start" className="w-56">
+        <DropdownMenuLabel className="flex flex-col gap-0.5">
+          <span className="text-sm font-medium">{name}</span>
+          {displayLabel !== name && (
+            <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
+          )}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem>
+          <Link href="/settings" className="flex w-full items-center gap-2">
+            <Settings className="size-4" />
+            설정
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* DS-S2에서 LogoutButton 통합 예정 */}
+        <DropdownMenuItem disabled className="flex items-center gap-2 text-muted-foreground">
+          <LogOut className="size-4" />
+          로그아웃
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
## Summary
- `apps/web/src/components/nav/profile-menu.tsx` 신규 컴포넌트 생성
- 사이드바 footer 최상단에 현재 사용자 avatar(초성) + 이름 + 드롭다운 메뉴 추가
- me API `name` 필드 → layout → DashboardShell → AppSidebar props 체인으로 전달
- DS-S2 전까지 기존 `<LogoutButton />` 위치 유지

## Changes
- `profile-menu.tsx` (신규): avatar 초성, 이름, ChevronsUpDown 트리거 + 설정/로그아웃(disabled) 드롭다운
- `app-sidebar.tsx`: `ProfileMenu` import + `userName` prop + SidebarFooter 상단 배치
- `dashboard-shell.tsx`: `userName` prop 추가
- `(authenticated)/layout.tsx` + `dashboard/layout.tsx`: `MemberContext.name` 추가, `userName={me?.name}` 전달

## Design Tokens Used
- Avatar: `bg-sidebar-accent`, `text-sidebar-accent-foreground`, `size-7`
- 이름: `text-sm font-medium text-sidebar-foreground`
- chevron: `size-3.5 text-sidebar-foreground/60`
- 트리거 호버: `hover:bg-sidebar-accent`, `rounded-md`, `px-2 py-1.5`

## Test Plan
- [ ] AC1: 사이드바 footer 상단 avatar + 이름 표시
- [ ] AC2: 클릭 시 드롭다운 — 설정(활성), 로그아웃(disabled, DS-S2 예정)
- [ ] AC3: 라이트/다크 모드 양쪽 정상
- [ ] AC4: 모바일 반응형 확인
- [ ] AC5: pnpm build ✅ 통과
- [ ] 기존 LogoutButton, 헤더 로그아웃 그대로 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)