### PR TITLE
refactor: auth dependency 통일 Batch 1 — get_verified_org_id

### DIFF
--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -54,8 +54,9 @@ async def create_session(
     body: CreateSession,
     db: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SessionListResponse:
-    repo = RetroSessionRepository(db, body.org_id)
+    repo = RetroSessionRepository(db, org_id)
     session = await repo.create(
         project_id=body.project_id,
         title=body.title,

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.models.standup import StandupEntry
@@ -19,7 +19,7 @@ router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintRepository:
     return SprintRepository(session, org_id)
 
@@ -44,8 +44,9 @@ async def create_sprint(
     body: SprintCreate,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintResponse:
-    repo = SprintRepository(session, body.org_id)
+    repo = SprintRepository(session, org_id)
     sprint = await repo.create(
         project_id=body.project_id,
         title=body.title,

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_project_scoped_org_id, get_verified_org_id
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.standup import StandupEntry, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
@@ -21,7 +21,7 @@ router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
 def _get_repo(
     session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryRepository:
     return StandupEntryRepository(session, org_id)
 
@@ -52,10 +52,8 @@ async def upsert_standup(
     body: StandupUpsert,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
-    org_id = body.org_id or (_auth.org_id and uuid.UUID(_auth.org_id)) or None
-    if not org_id:
-        raise HTTPException(status_code=400, detail="org_id required")
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
@@ -84,7 +82,7 @@ async def list_feedback(
     project_id: uuid.UUID = Query(...),
     date_filter: date = Query(..., alias="date"),
     db: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[FeedbackResponse]:
     q = (
         select(StandupFeedback)
@@ -116,17 +114,18 @@ async def add_feedback(
     body: FeedbackCreate,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> FeedbackResponse:
     from app.schemas.standup import REVIEW_TYPES
     if body.review_type not in REVIEW_TYPES:
         raise HTTPException(status_code=400, detail=f"review_type must be one of: {', '.join(REVIEW_TYPES)}")
 
-    entry_repo = StandupEntryRepository(session, body.org_id)
+    entry_repo = StandupEntryRepository(session, org_id)
     entry = await entry_repo.get(id)
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
 
-    fb_repo = StandupFeedbackRepository(session, body.org_id)
+    fb_repo = StandupFeedbackRepository(session, org_id)
     feedback = await fb_repo.create(
         project_id=body.project_id,
         sprint_id=body.sprint_id,

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -126,7 +126,7 @@ async def create_team_member(
             detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
         )
 
-    repo = TeamMemberRepository(session, body.org_id)
+    repo = TeamMemberRepository(session, org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 
     # AC1/AC2: agent 생성 시 fakechat_port 자동 할당 (project 내 중복 방지)


### PR DESCRIPTION
## Summary

`body.org_id` 직접 접근 / `get_project_scoped_org_id` 혼용 패턴을 `get_verified_org_id` dependency로 통일.

**변경 파일 (4개):**
- `sprints.py`: `_get_repo` + `create_sprint`
- `standups.py`: `_get_repo`, `upsert_standup`, `list_feedback`, `add_feedback`
- `retros.py`: `create_session`
- `team_members.py`: `create_team_member`

**효과:** JWT/API Key에서 검증된 org_id 사용 → body에서 org_id 위조 방어

## Test plan

- [ ] `pytest tests/test_standups.py tests/test_sprints.py tests/test_team_members.py` 전량 통과
- [ ] 기존 동작 무변경 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)