### PR TITLE
refactor(routers): auth dependency 통일 Batch 2 — get_verified_org_id

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -33,13 +33,14 @@ async def create_project(
     body: ProjectCreate,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> ProjectResponse:
-    repo = ProjectRepository(session, body.org_id)
+    repo = ProjectRepository(session, org_id)
 
     # EE: Free 플랜 project 생성 제한 (OSS에서는 로드되지 않음)
     if settings.is_ee_enabled:
         from ee.plan_limits import check_project_create_limit  # type: ignore[import]
-        await check_project_create_limit(session, body.org_id)
+        await check_project_create_limit(session, org_id)
 
     project = await repo.create(name=body.name, description=body.description)
 
@@ -52,7 +53,7 @@ async def create_project(
                 " VALUES (gen_random_uuid(), :org_id, :user_id, 'member')"
                 " ON CONFLICT (org_id, user_id) DO NOTHING"
             ),
-            {"org_id": str(body.org_id), "user_id": auth.user_id},
+            {"org_id": str(org_id), "user_id": auth.user_id},
         )
 
     await session.commit()

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -73,10 +73,8 @@ async def update_standup(
     body: StandupUpsert,
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
-    org_id = body.org_id or (_auth.org_id and uuid.UUID(_auth.org_id)) or None
-    if not org_id:
-        raise HTTPException(status_code=400, detail="org_id required")
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,

--- a/backend/tests/test_ss4_security_regression.py
+++ b/backend/tests/test_ss4_security_regression.py
@@ -108,23 +108,6 @@ async def test_api_key_org_spoof_post_stories_403():
         app.dependency_overrides.clear()
 
 
-@pytest.mark.anyio
-async def test_api_key_org_spoof_post_memos_403():
-    """AC1: API Key — body.org_id 위조 POST memos → 403."""
-    ctx = _mk_api_key_ctx(org_id=ORG_ID)
-    client, _, app = await _client(ctx)
-    try:
-        async with client as c:
-            resp = await c.post("/api/v2/memos", json={
-                "project_id": str(PROJECT_ID),
-                "org_id": str(OTHER_ORG_ID),
-                "title": "위조 메모",
-                "content": "evil content",
-            })
-        assert resp.status_code == 403
-    finally:
-        app.dependency_overrides.clear()
-
 
 @pytest.mark.anyio
 async def test_api_key_org_spoof_post_epics_403():
@@ -222,22 +205,6 @@ async def test_org_id_omitted_stories_not_403():
         app.dependency_overrides.clear()
 
 
-@pytest.mark.anyio
-async def test_org_id_omitted_memos_not_403():
-    """AC3: org_id 누락 POST memos → auth.org_id 자동 주입 → 403 아님."""
-    ctx = _mk_api_key_ctx(org_id=ORG_ID)
-    client, _, app = await _client(ctx)
-    try:
-        async with client as c:
-            resp = await c.post("/api/v2/memos", json={
-                "project_id": str(PROJECT_ID),
-                "title": "자동 주입 메모",
-                "content": "test",
-            })
-        assert resp.status_code != 403
-    finally:
-        app.dependency_overrides.clear()
-
 
 # ─── AC4: project_id 불일치 요청 시 403 ──────────────────────────────────────
 
@@ -275,23 +242,6 @@ async def test_project_id_mismatch_post_stories_403():
     finally:
         app.dependency_overrides.clear()
 
-
-@pytest.mark.anyio
-async def test_project_id_mismatch_post_memos_403():
-    """AC4: body.project_id ≠ auth.project_id POST memos → 403."""
-    ctx = _mk_api_key_ctx(project_id=PROJECT_ID)
-    client, _, app = await _client(ctx)
-    try:
-        async with client as c:
-            resp = await c.post("/api/v2/memos", json={
-                "project_id": str(OTHER_PROJECT_ID),
-                "org_id": str(ORG_ID),
-                "title": "교차 프로젝트 메모",
-                "content": "cross project attempt",
-            })
-        assert resp.status_code == 403
-    finally:
-        app.dependency_overrides.clear()
 
 
 # ─── AC5: /api/v2/auth/me 4종 테스트 ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **projects.py**: `create_project` — `body.org_id` 직접 사용 → `get_verified_org_id` 의존성 주입으로 교체. `_get_repo`는 이미 변환 완료였으므로 CREATE 핸들러만 수정
- **standups.py**: `update_standup` PUT — `body.org_id or auth.org_id` fallback 로직 제거, `get_verified_org_id` 의존성으로 단순화
- **test_ss4_security_regression.py**: `/api/v2/memos` 삭제된 엔드포인트 참조 stale 테스트 3건 제거 (S3-2에서 엔드포인트 삭제됨)

## Test plan

- [x] `tests/test_ss4_security_regression.py` 전체 PASS (24 tests)
- [x] `tests/test_docs.py` 2건 기존 실패는 pre-existing (develop 브랜치에도 동일 실패 확인, Batch 2 변경과 무관)
- [ ] 전체 pytest suite PASS (CI 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)