### PR TITLE
[DS-S8] EmptyState icon prop 추가 — backward compatible 확장

### DIFF
--- a/apps/web/src/components/ui/empty-state.tsx
+++ b/apps/web/src/components/ui/empty-state.tsx
@@ -4,16 +4,19 @@ export function EmptyState({
   title,
   description,
   action,
+  icon,
   className,
 }: {
   title: string;
   description?: string;
   action?: React.ReactNode;
+  icon?: React.ReactNode;
   className?: string;
 }) {
   return (
     <div className={cn('rounded-2xl bg-muted/50 px-6 py-10 text-center', className)}>
       <div className="mx-auto max-w-md space-y-3">
+        {icon ? <div className="mb-3 flex justify-center text-muted-foreground/60">{icon}</div> : null}
         <h3 className="text-base font-semibold tracking-tight text-foreground">{title}</h3>
         {description ? <p className="text-sm leading-6 text-muted-foreground">{description}</p> : null}
         {action ? <div className="pt-2.5">{action}</div> : null}


### PR DESCRIPTION
## Summary
- `EmptyState` 컴포넌트에 `icon?: React.ReactNode` prop 추가
- title 상단에 icon 컨테이너 렌더 (`mb-3 flex justify-center text-muted-foreground/60`)
- 기존 23개 사용처 **동작 변화 없음** (backward compatible)

## Changes
- `apps/web/src/components/ui/empty-state.tsx`: 3줄 추가

## Before / After
```tsx
// Before
<EmptyState title="항목 없음" description="..." action={<Button>...</Button>} />

// After — icon 없이 사용 시 기존과 동일
<EmptyState title="항목 없음" description="..." action={<Button>...</Button>} />

// After — icon 추가 시
<EmptyState
  icon={<FolderOpen className="size-10" />}
  title="항목 없음"
  description="..."
  action={<Button>...</Button>}
/>
```

## Test Plan
- [ ] AC1: `icon` prop 추가 확인
- [ ] AC2: 기존 23개 사용처 동작 변화 없음
- [ ] AC3: 라이트/다크 모드 정상 (token-based)
- [ ] AC4: pnpm build ✅ 통과
- [ ] icon 미전달 시 기존 렌더와 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)