### PR TITLE
[DS-S7-A] --operator-* 단순 alias 10종 표준 토큰 일괄 치환 (~496건)

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -33,7 +33,7 @@ interface DocDetail {
 }
 
 const SAVE_STATUS_CLASS: Partial<Record<SaveStatus, string>> = {
-  saving: 'text-[color:var(--operator-muted)]',
+  saving: 'text-muted-foreground',
   saved: 'text-emerald-500/70',
   unsaved: 'text-amber-500/70',
   error: 'text-rose-500',
@@ -158,7 +158,7 @@ export default function DocSlugPage() {
   if (docLoading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/view/page.tsx
@@ -48,7 +48,7 @@ export default function DocViewPage() {
   if (doc === null) {
     return (
       <div className="flex h-full items-center justify-center">
-        <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+        <p className="text-sm text-muted-foreground">{t('loading')}</p>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -388,7 +388,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       <>
         <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
         <div className="flex h-64 items-center justify-center">
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
       </>
     );
@@ -399,19 +399,19 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
       {/* Full-text search input */}
       <div className="border-b border-border/60 px-3 py-2">
         <div className="relative">
-          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-[color:var(--operator-muted)]" />
+          <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
           <input
             type="text"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="문서 검색..."
-            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-[color:var(--operator-muted)] focus:border-[color:var(--operator-primary)]/40 focus:bg-muted/50"
+            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-muted-foreground focus:border-[color:var(--operator-primary)]/40 focus:bg-muted/50"
           />
           {searchQuery && (
             <button
               type="button"
               onClick={() => setSearchQuery('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-[color:var(--operator-muted)] hover:text-foreground"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
             >
               <X className="size-3" />
             </button>
@@ -470,9 +470,9 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         {/* Search results */}
         {searchQuery.trim() ? (
           searchLoading ? (
-            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 중...</p>
+            <p className="py-4 text-center text-xs text-muted-foreground">검색 중...</p>
           ) : searchResults.length === 0 ? (
-            <p className="py-4 text-center text-xs text-[color:var(--operator-muted)]">검색 결과 없음</p>
+            <p className="py-4 text-center text-xs text-muted-foreground">검색 결과 없음</p>
           ) : (
             <ul className="space-y-1">
               {searchResults.map((result) => (
@@ -482,13 +482,13 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                     onClick={() => handleSelectDoc(result.slug)}
                     className="flex w-full flex-col items-start gap-1 rounded-xl px-3 py-2 text-left transition-colors hover:bg-muted/60"
                   >
-                    <span className="flex items-center gap-1.5 text-xs font-medium text-[color:var(--operator-foreground)]">
-                      <FileText className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+                    <span className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+                      <FileText className="size-3.5 flex-shrink-0 text-muted-foreground" />
                       {result.title}
                     </span>
                     {result.snippet && (
                       <span
-                        className="line-clamp-2 text-[11px] leading-relaxed text-[color:var(--operator-muted)] [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-[color:var(--operator-foreground)] [&_mark]:px-0.5 [&_b]:rounded [&_b]:bg-yellow-400/40 [&_b]:font-normal [&_b]:text-[color:var(--operator-foreground)] [&_b]:px-0.5"
+                        className="line-clamp-2 text-[11px] leading-relaxed text-muted-foreground [&_mark]:rounded [&_mark]:bg-yellow-400/40 [&_mark]:text-foreground [&_mark]:px-0.5 [&_b]:rounded [&_b]:bg-yellow-400/40 [&_b]:font-normal [&_b]:text-foreground [&_b]:px-0.5"
                         dangerouslySetInnerHTML={{ __html: sanitizeSnippet(result.snippet) }}
                       />
                     )}
@@ -699,7 +699,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
           <button
             type="button"
             onClick={() => setTreeDrawerOpen(true)}
-            className="flex min-h-[44px] items-center gap-2 text-sm text-[color:var(--operator-muted)] hover:text-[color:var(--operator-foreground)]"
+            className="flex min-h-[44px] items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
             aria-label="문서 트리 열기"
           >
             <Menu className="size-4" />

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -237,7 +237,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
       {/* Mobile: content + tree drawer (< lg) */}
       <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
         <div className="flex-shrink-0 flex items-center gap-2 border-b border-border/80 bg-background px-4 py-2">
-          <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] items-center gap-2 text-sm text-[color:var(--operator-muted)] hover:text-[color:var(--operator-foreground)]" aria-label="문서 트리 열기">
+          <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] items-center gap-2 text-sm text-muted-foreground hover:text-foreground" aria-label="문서 트리 열기">
             <Menu className="size-4" />
             <span>{t('title')}</span>
           </button>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -99,7 +99,7 @@ function ProgressBar({ done, total, label }: ProgressBarProps) {
   return (
     <div className="space-y-1">
       {label ? (
-        <div className="flex items-center justify-between text-xs text-[color:var(--operator-muted)]">
+        <div className="flex items-center justify-between text-xs text-muted-foreground">
           <span>{label}</span>
           <span>{done} / {total}</span>
         </div>
@@ -171,35 +171,35 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTitle')}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldTitle')}</label>
         <input
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder={t('fieldTitlePlaceholder')}
           required
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldDescription')}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldDescription')}</label>
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           placeholder={t('fieldDescriptionPlaceholder')}
           rows={3}
-          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldPriority')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldPriority')}</label>
           <select
             value={priority}
             onChange={(e) => setPriority(e.target.value as EpicPriority)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="critical">{t('priorityCritical')}</option>
             <option value="high">{t('priorityHigh')}</option>
@@ -209,25 +209,25 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTargetSp')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldTargetSp')}</label>
           <input
             type="number"
             min="0"
             value={targetSp}
             onChange={(e) => setTargetSp(e.target.value)}
             placeholder="0"
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
       </div>
 
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTargetDate')}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldTargetDate')}</label>
         <input
           type="date"
           value={targetDate}
           onChange={(e) => setTargetDate(e.target.value)}
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -301,33 +301,33 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTitle')}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldTitle')}</label>
         <input
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
       <div className="space-y-1.5">
-        <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldDescription')}</label>
+        <label className="text-xs font-medium text-muted-foreground">{t('fieldDescription')}</label>
         <textarea
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
-          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldStatus')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldStatus')}</label>
           <select
             value={status}
             onChange={(e) => setStatus(e.target.value as EpicStatus)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="draft">{t('statusDraft')}</option>
             <option value="active">{t('statusActive')}</option>
@@ -337,11 +337,11 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldPriority')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldPriority')}</label>
           <select
             value={priority}
             onChange={(e) => setPriority(e.target.value as EpicPriority)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="critical">{t('priorityCritical')}</option>
             <option value="high">{t('priorityHigh')}</option>
@@ -353,24 +353,24 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
 
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTargetDate')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldTargetDate')}</label>
           <input
             type="date"
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
 
         <div className="space-y-1.5">
-          <label className="text-xs font-medium text-[color:var(--operator-muted)]">{t('fieldTargetSp')}</label>
+          <label className="text-xs font-medium text-muted-foreground">{t('fieldTargetSp')}</label>
           <input
             type="number"
             min="0"
             value={targetSp}
             onChange={(e) => setTargetSp(e.target.value)}
             placeholder="0"
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] px-3 py-2 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
       </div>
@@ -425,7 +425,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
       className={`group relative w-full rounded-2xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
         isSelected
           ? 'border-primary/40 bg-primary/5'
-          : 'border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] hover:border-primary/30 hover:bg-primary/5'
+          : 'border-[color:var(--operator-border,hsl(var(--border)))] bg-card hover:border-primary/30 hover:bg-primary/5'
       }`}
       onClick={onClick}
       role="button"
@@ -434,7 +434,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
     >
       <div className="space-y-2.5">
         <div className="flex items-start justify-between gap-2">
-          <p className="text-sm font-semibold leading-snug text-[color:var(--operator-foreground)]">{epic.title}</p>
+          <p className="text-sm font-semibold leading-snug text-foreground">{epic.title}</p>
           <div className="flex shrink-0 items-center gap-1.5">
             <Badge variant={statusBadgeVariant(epic.status)}>{statusLabel[epic.status]}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{priorityLabel[epic.priority]}</Badge>
@@ -450,10 +450,10 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
         </div>
 
         {epic.description?.trim() ? (
-          <p className="text-xs text-[color:var(--operator-muted)] line-clamp-1">{epic.description.split('\n')[0]?.replace(/^#+\s*/, '')}</p>
+          <p className="text-xs text-muted-foreground line-clamp-1">{epic.description.split('\n')[0]?.replace(/^#+\s*/, '')}</p>
         ) : null}
 
-        <div className="flex items-center gap-3 text-xs text-[color:var(--operator-muted)]">
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
           {epic.target_date ? (
             <span>{t('targetDate')}: {formatDate(epic.target_date)}</span>
           ) : null}
@@ -518,7 +518,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
           <button
             type="button"
             onClick={onClose}
-            className="flex items-center gap-1 text-xs text-[color:var(--operator-muted)] transition-colors hover:text-[color:var(--operator-foreground)] lg:hidden"
+            className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground lg:hidden"
           >
             <ChevronLeft className="size-3.5" />
             {t('backToList')}
@@ -542,7 +542,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
           <button
             type="button"
             onClick={onClose}
-            className="hidden rounded-xl p-1.5 text-[color:var(--operator-muted)] transition-colors hover:bg-[color:var(--operator-surface-soft)] hover:text-[color:var(--operator-foreground)] lg:block"
+            className="hidden rounded-xl p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:block"
           >
             <X className="size-4" />
           </button>
@@ -562,18 +562,18 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
         ) : (
           <div className="space-y-6">
             {/* Title */}
-            <h2 className="text-base font-bold text-[color:var(--operator-foreground)]">{epic.title}</h2>
+            <h2 className="text-base font-bold text-foreground">{epic.title}</h2>
 
             {/* Meta grid */}
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-xl bg-[color:var(--operator-surface-soft,hsl(var(--muted)))] px-3 py-2.5">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('targetDate')}</p>
-                <p className="mt-1 text-sm font-medium text-[color:var(--operator-foreground)]">{formatDate(epic.target_date)}</p>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetDate')}</p>
+                <p className="mt-1 text-sm font-medium text-foreground">{formatDate(epic.target_date)}</p>
               </div>
               <div className="rounded-xl bg-[color:var(--operator-surface-soft,hsl(var(--muted)))] px-3 py-2.5">
-                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('targetSp')}</p>
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetSp')}</p>
                 <div className="mt-1 flex items-center gap-1.5">
-                  <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
+                  <p className="text-sm font-medium text-foreground">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
                   {spExceeded ? (
                     <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">{t('spExceeded')}</span>
                   ) : null}
@@ -583,20 +583,20 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Description */}
             <div className="space-y-1.5">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('description')}</p>
-              <p className="text-sm leading-relaxed text-[color:var(--operator-foreground)]">
-                {epic.description?.trim() ? epic.description : <span className="italic text-[color:var(--operator-muted)]">{t('noDescription')}</span>}
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('description')}</p>
+              <p className="text-sm leading-relaxed text-foreground">
+                {epic.description?.trim() ? epic.description : <span className="italic text-muted-foreground">{t('noDescription')}</span>}
               </p>
             </div>
 
             {/* Progress */}
             <div className="space-y-3">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('storiesProgress')}</p>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('storiesProgress')}</p>
               <ProgressBar done={storyProgress.done} total={storyProgress.total} label={`${t('doneStories')} / ${t('totalStories')}`} />
               {spProgress.total > 0 ? (
                 <>
                   <div className="flex items-center gap-2">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('spProgress')}</p>
+                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('spProgress')}</p>
                     {spExceeded ? (
                       <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
                         {t('spExceededDetail', { total: spProgress.total, target: epic.target_sp ?? 0 })}
@@ -610,7 +610,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Story list */}
             <div className="space-y-2">
-              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('stories')}</p>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('stories')}</p>
               {stories.length > 0 ? (
                 <div className="space-y-1.5">
                   {stories.map((story) => (
@@ -620,10 +620,10 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                       onClick={() => router.push(`/board?story=${story.id}`)}
                       className="flex w-full items-center justify-between rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] px-3 py-2 text-left transition-colors hover:border-primary/30 hover:bg-primary/5"
                     >
-                      <p className="text-sm text-[color:var(--operator-foreground)]">{story.title}</p>
+                      <p className="text-sm text-foreground">{story.title}</p>
                       <div className="flex shrink-0 items-center gap-2">
                         {story.story_points !== undefined ? (
-                          <span className="text-xs text-[color:var(--operator-muted)]">{story.story_points} SP</span>
+                          <span className="text-xs text-muted-foreground">{story.story_points} SP</span>
                         ) : null}
                         <Badge variant={story.status === 'done' ? 'success' : 'secondary'} className="text-[10px]">
                           {story.status}
@@ -633,7 +633,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                   ))}
                 </div>
               ) : (
-                <p className="text-sm italic text-[color:var(--operator-muted)]">{t('noStories')}</p>
+                <p className="text-sm italic text-muted-foreground">{t('noStories')}</p>
               )}
             </div>
           </div>
@@ -663,13 +663,13 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
         onClick={onClose}
         aria-label={t('cancel')}
       />
-      <div className="relative z-10 w-full max-w-md rounded-2xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-[color:var(--operator-surface)] p-6 shadow-xl">
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-bold text-[color:var(--operator-foreground)]">{t('createEpic')}</h2>
+          <h2 className="text-base font-bold text-foreground">{t('createEpic')}</h2>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-xl p-1.5 text-[color:var(--operator-muted)] transition-colors hover:bg-[color:var(--operator-surface-soft)] hover:text-[color:var(--operator-foreground)]"
+            className="rounded-xl p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <X className="size-4" />
           </button>
@@ -793,7 +793,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
       <>
         <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
         <div className="flex h-64 items-center justify-center">
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
         </div>
       </>
     );
@@ -802,7 +802,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const filteredEpics = statusFilter === 'all' ? epics : epics.filter((e) => e.status === statusFilter);
 
   const listPanel = (
-    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-[color:var(--operator-surface-soft)]/35">
+    <div className="flex h-full min-h-0 flex-col overflow-hidden bg-muted/35">
 
       {/* Status filter */}
       <div className="flex shrink-0 gap-1 px-4 pt-3 pb-1 flex-wrap">
@@ -814,7 +814,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
             className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
               statusFilter === s
                 ? 'border-primary/40 bg-primary/10 text-primary'
-                : 'border-[color:var(--operator-border,hsl(var(--border)))] text-[color:var(--operator-muted)] hover:bg-muted/50'
+                : 'border-[color:var(--operator-border,hsl(var(--border)))] text-muted-foreground hover:bg-muted/50'
             }`}
           >
             {s === 'all' ? t('filterAll') : s}

--- a/apps/web/src/app/(authenticated)/epics/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/page.tsx
@@ -11,7 +11,7 @@ export default function EpicsPage() {
   if (!projectId) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <p className="text-sm text-[color:var(--operator-muted)]">{t('noProject')}</p>
+        <p className="text-sm text-muted-foreground">{t('noProject')}</p>
       </div>
     );
   }

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -178,7 +178,7 @@ export default function InboxPage() {
           <div className="flex items-center gap-2">
             <h1 className="text-sm font-medium">{t('title')}</h1>
             {unreadCount > 0 ? (
-              <span className="text-sm tabular-nums text-[color:var(--operator-muted)]">{unreadCount}</span>
+              <span className="text-sm tabular-nums text-muted-foreground">{unreadCount}</span>
             ) : null}
           </div>
         }
@@ -194,19 +194,19 @@ export default function InboxPage() {
 
         {workflowExecs.length > 0 && (
           <div className="shrink-0 border-b border-border/80 px-4 py-3">
-            <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-[color:var(--operator-muted)]">워크플로우 실행</p>
+            <p className="mb-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">워크플로우 실행</p>
             <div className="flex flex-col gap-1.5">
               {workflowExecs.slice(0, 5).map((exec) => (
-                <div key={exec.id} className="flex items-center gap-2 rounded-lg bg-[color:var(--operator-surface-soft)]/55 px-3 py-2 text-xs">
+                <div key={exec.id} className="flex items-center gap-2 rounded-lg bg-muted/55 px-3 py-2 text-xs">
                   {exec.status === 'matched' ? (
                     <Zap className="h-3.5 w-3.5 shrink-0 text-amber-500" />
                   ) : (
-                    <ZapOff className="h-3.5 w-3.5 shrink-0 text-[color:var(--operator-muted)]" />
+                    <ZapOff className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                   )}
-                  <span className="min-w-0 flex-1 truncate text-[color:var(--operator-foreground)]">
+                  <span className="min-w-0 flex-1 truncate text-foreground">
                     {exec.rule_name ?? exec.event_type}
                   </span>
-                  <span className="shrink-0 text-[10px] text-[color:var(--operator-muted)]">
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
                     {exec.completed_at ? new Date(exec.completed_at).toLocaleString() : new Date(exec.created_at).toLocaleString()}
                   </span>
                 </div>
@@ -222,12 +222,12 @@ export default function InboxPage() {
             {loading ? (
               <div className="space-y-2">
                 {[1, 2, 3, 4, 5].map((i) => (
-                  <div key={i} className="h-16 animate-pulse rounded-xl bg-[color:var(--operator-surface-soft)]" />
+                  <div key={i} className="h-16 animate-pulse rounded-xl bg-muted" />
                 ))}
               </div>
             ) : notifications.length === 0 ? (
               <div className="flex flex-col items-center justify-center px-6 py-12 text-center">
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('noNotifications')}</p>
+                <p className="text-sm text-muted-foreground">{t('noNotifications')}</p>
               </div>
             ) : (
               <div className="space-y-1.5">
@@ -240,10 +240,10 @@ export default function InboxPage() {
                       onClick={() => void selectNotification(notification)}
                       className={`w-full rounded-xl border p-3 text-left transition ${
                         isSelected
-                          ? 'border-[color:var(--operator-primary)]/35 bg-[color:var(--operator-primary)]/15'
+                          ? 'border-[color:var(--operator-primary)]/35 bg-brand/15'
                           : notification.is_read
-                            ? 'border-white/8 bg-[color:var(--operator-surface-soft)]/55 hover:border-[color:var(--operator-primary)]/20 hover:bg-white/5'
-                            : 'border-[color:var(--operator-primary)]/18 bg-[color:var(--operator-primary)]/8 hover:bg-[color:var(--operator-primary)]/12'
+                            ? 'border-white/8 bg-muted/55 hover:border-[color:var(--operator-primary)]/20 hover:bg-white/5'
+                            : 'border-[color:var(--operator-primary)]/18 bg-brand/8 hover:bg-brand/12'
                       }`}
                     >
                       <div className="flex items-start gap-3">
@@ -252,16 +252,16 @@ export default function InboxPage() {
                         </div>
                         <div className="min-w-0 flex-1 space-y-1">
                           <div className="flex items-start justify-between gap-2">
-                            <p className={`truncate text-sm ${notification.is_read ? 'text-[color:var(--operator-muted)]' : 'font-semibold text-[color:var(--operator-foreground)]'}`}>
+                            <p className={`truncate text-sm ${notification.is_read ? 'text-muted-foreground' : 'font-semibold text-foreground'}`}>
                               {notification.title}
                             </p>
-                            <span className="shrink-0 text-[11px] text-[color:var(--operator-muted)]">{formatTime(notification.created_at)}</span>
+                            <span className="shrink-0 text-[11px] text-muted-foreground">{formatTime(notification.created_at)}</span>
                           </div>
                           {notification.body ? (
-                            <p className="line-clamp-1 text-xs text-[color:var(--operator-muted)]">{notification.body}</p>
+                            <p className="line-clamp-1 text-xs text-muted-foreground">{notification.body}</p>
                           ) : null}
                           {!notification.is_read ? (
-                            <span className="inline-block h-1.5 w-1.5 rounded-full bg-[color:var(--operator-primary)]" />
+                            <span className="inline-block h-1.5 w-1.5 rounded-full bg-brand" />
                           ) : null}
                         </div>
                       </div>
@@ -284,16 +284,16 @@ export default function InboxPage() {
                 <div className="min-w-0 flex-1 space-y-2">
                   <div className="flex flex-wrap items-center gap-2">
                     <Badge variant="outline">{getInboxNotificationLabel(t, selectedNotification.type)}</Badge>
-                    <span className="text-xs text-[color:var(--operator-muted)]">
+                    <span className="text-xs text-muted-foreground">
                       {t('receivedAt')} · {new Date(selectedNotification.created_at).toLocaleString()}
                     </span>
                   </div>
-                  <h2 className="text-lg font-semibold text-[color:var(--operator-foreground)]">{selectedNotification.title}</h2>
+                  <h2 className="text-lg font-semibold text-foreground">{selectedNotification.title}</h2>
                 </div>
               </div>
 
               {selectedNotification.body ? (
-                <div className="rounded-xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-4 text-sm leading-6 text-[color:var(--operator-foreground)] whitespace-pre-wrap">
+                <div className="rounded-xl border border-white/8 bg-muted/55 p-4 text-sm leading-6 text-foreground whitespace-pre-wrap">
                   {selectedNotification.body}
                 </div>
               ) : null}
@@ -319,10 +319,10 @@ export default function InboxPage() {
             </div>
           ) : (
             <div className="flex flex-1 flex-col items-center justify-center gap-3 px-6 py-12 text-center">
-              <div className="flex size-14 items-center justify-center rounded-2xl bg-[color:var(--operator-surface-soft)]/55">
-                <InboxIcon className="size-6 text-[color:var(--operator-muted)]" />
+              <div className="flex size-14 items-center justify-center rounded-2xl bg-muted/55">
+                <InboxIcon className="size-6 text-muted-foreground" />
               </div>
-              <p className="text-sm font-medium text-[color:var(--operator-muted)]">{t('selectToView')}</p>
+              <p className="text-sm font-medium text-muted-foreground">{t('selectToView')}</p>
             </div>
           )}
         </div>

--- a/apps/web/src/app/(authenticated)/mockups/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/mockups/[id]/page.tsx
@@ -121,7 +121,7 @@ export default function MockupViewerPage() {
         <div>
           <div className="border-b border-border/80 px-4 py-3">
             <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('title')}</div>
+              <div className="text-sm font-semibold text-foreground">{t('title')}</div>
               {scenarios.length > 0 ? (
                 <OperatorSelect
                   value={activeScenario}
@@ -135,7 +135,7 @@ export default function MockupViewerPage() {
             </div>
           </div>
           <div className="px-4 py-4">
-            <div className="rounded-3xl border border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-4" onClick={() => setSelectedId(null)}>
+            <div className="rounded-3xl border border-white/8 bg-muted/35 p-4" onClick={() => setSelectedId(null)}>
               <div className={`mx-auto bg-white text-black shadow-lg ${isMobile ? 'w-[375px] rounded-[2rem] border-4 border-gray-800 p-4' : 'w-full max-w-4xl rounded-2xl p-6'}`}>
                 {rootComponents.length === 0 ? (
                   <div className="py-16 text-center text-sm text-gray-400">{t('noMockups')}</div>
@@ -150,7 +150,7 @@ export default function MockupViewerPage() {
         <div>
           <div className="border-b border-border/80 px-4 py-3">
             <div className="flex items-center justify-between gap-3">
-              <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{selectedComponent?.component_type ?? t('selectComponent')}</div>
+              <div className="text-sm font-semibold text-foreground">{selectedComponent?.component_type ?? t('selectComponent')}</div>
               <Button variant="glass" size="sm" onClick={() => setSelectedId(null)} disabled={!selectedComponent}>✕</Button>
             </div>
           </div>
@@ -158,15 +158,15 @@ export default function MockupViewerPage() {
             {selectedComponent ? (
               <div className="space-y-4">
                 {selectedComponent.spec_description ? (
-                  <div className="prose prose-sm max-w-none text-[color:var(--operator-muted)] prose-headings:text-[color:var(--operator-foreground)] prose-strong:text-[color:var(--operator-foreground)] prose-p:text-[color:var(--operator-muted)] prose-li:text-[color:var(--operator-muted)]">
+                  <div className="prose prose-sm max-w-none text-muted-foreground prose-headings:text-foreground prose-strong:text-foreground prose-p:text-muted-foreground prose-li:text-muted-foreground">
                     <ReactMarkdown>{selectedComponent.spec_description}</ReactMarkdown>
                   </div>
                 ) : (
-                  <p className="text-sm text-[color:var(--operator-muted)]">{t('noSpec')}</p>
+                  <p className="text-sm text-muted-foreground">{t('noSpec')}</p>
                 )}
                 <div>
-                  <h4 className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('props')}</h4>
-                  <pre className="mt-2 overflow-x-auto rounded-2xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-3 text-xs text-[color:var(--operator-foreground)]">{JSON.stringify(getComponentProps(selectedComponent), null, 2)}</pre>
+                  <h4 className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('props')}</h4>
+                  <pre className="mt-2 overflow-x-auto rounded-2xl border border-white/8 bg-muted/55 p-3 text-xs text-foreground">{JSON.stringify(getComponentProps(selectedComponent), null, 2)}</pre>
                 </div>
               </div>
             ) : (

--- a/apps/web/src/app/(authenticated)/mockups/page.tsx
+++ b/apps/web/src/app/(authenticated)/mockups/page.tsx
@@ -74,11 +74,11 @@ export default function MockupsPage() {
 
       {showCreate ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="w-full max-w-md rounded-3xl border border-white/10 bg-[color:var(--operator-panel)] p-6 shadow-xl backdrop-blur-xl">
-            <h3 className="mb-4 text-lg font-semibold text-[color:var(--operator-foreground)]">{t('createMockup')}</h3>
+          <div className="w-full max-w-md rounded-3xl border border-white/10 bg-muted p-6 shadow-xl backdrop-blur-xl">
+            <h3 className="mb-4 text-lg font-semibold text-foreground">{t('createMockup')}</h3>
             <div className="space-y-3">
               <div>
-                <label className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('titlePlaceholder')}</label>
+                <label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('titlePlaceholder')}</label>
                 <OperatorInput
                   type="text"
                   value={newTitle}
@@ -91,7 +91,7 @@ export default function MockupsPage() {
                 />
               </div>
               <div>
-                <label className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('slug')}</label>
+                <label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('slug')}</label>
                 <OperatorInput
                   type="text"
                   value={newSlug}
@@ -101,7 +101,7 @@ export default function MockupsPage() {
                 />
               </div>
               <div>
-                <label className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('viewport')}</label>
+                <label className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('viewport')}</label>
                 <div className="mt-1 flex gap-2">
                   <Button variant={newViewport === 'desktop' ? 'hero' : 'glass'} size="sm" onClick={() => setNewViewport('desktop')}>🖥 {t('desktop')}</Button>
                   <Button variant={newViewport === 'mobile' ? 'hero' : 'glass'} size="sm" onClick={() => setNewViewport('mobile')}>📱 {t('mobile')}</Button>
@@ -127,12 +127,12 @@ export default function MockupsPage() {
               <button
                 key={mockup.id}
                 type="button"
-                className="group rounded-3xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-4 text-left transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
+                className="group rounded-3xl border border-white/8 bg-muted/55 p-4 text-left transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
                 onClick={() => router.push(`/mockups/${mockup.id}`)}
               >
                 <div className="flex items-start justify-between gap-3">
                   <div>
-                    <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{mockup.title}</h3>
+                    <h3 className="text-sm font-semibold text-foreground">{mockup.title}</h3>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <Badge variant="outline">{mockup.category}</Badge>
                       <Badge variant="info">v{mockup.version}</Badge>
@@ -140,7 +140,7 @@ export default function MockupsPage() {
                   </div>
                   <span className="text-lg">{mockup.viewport === 'mobile' ? '📱' : '🖥'}</span>
                 </div>
-                <div className="mt-3 text-xs text-[color:var(--operator-muted)]">{new Date(mockup.created_at).toLocaleDateString()}</div>
+                <div className="mt-3 text-xs text-muted-foreground">{new Date(mockup.created_at).toLocaleDateString()}</div>
                 <div className="mt-3 opacity-0 transition group-hover:opacity-100">
                   <Button
                     variant="glass"

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -411,16 +411,16 @@ export default function StandupPage() {
                   onClick={() => setSprintExpanded((prev) => !prev)}
                 >
                   <div className="space-y-0.5">
-                    <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('currentSprint')}</h2>
+                    <h2 className="text-sm font-semibold text-foreground">{t('currentSprint')}</h2>
                     {activeSprint ? (
-                      <p className="text-xs text-[color:var(--operator-muted)]">{activeSprint.title} · {t('sprintStoryCount', { count: stories.length })}</p>
+                      <p className="text-xs text-muted-foreground">{activeSprint.title} · {t('sprintStoryCount', { count: stories.length })}</p>
                     ) : (
-                      <p className="text-xs text-[color:var(--operator-muted)]">{t('noActiveSprint')}</p>
+                      <p className="text-xs text-muted-foreground">{t('noActiveSprint')}</p>
                     )}
                   </div>
                   <div className="flex items-center gap-2">
                     <Badge variant="outline">{t('taskProgress', { done: doneTasks, total: totalTasks })}</Badge>
-                    <span className="text-xs text-[color:var(--operator-muted)]">{sprintExpanded ? t('collapseSprintStories') : t('expandSprintStories')}</span>
+                    <span className="text-xs text-muted-foreground">{sprintExpanded ? t('collapseSprintStories') : t('expandSprintStories')}</span>
                   </div>
                 </button>
 
@@ -429,7 +429,7 @@ export default function StandupPage() {
                     {loading ? (
                       <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
                         {[1, 2, 3].map((item) => (
-                          <div key={item} className="h-28 animate-pulse rounded-2xl bg-[color:var(--operator-surface-soft)]" />
+                          <div key={item} className="h-28 animate-pulse rounded-2xl bg-muted" />
                         ))}
                       </div>
                     ) : activeSprint ? (
@@ -439,10 +439,10 @@ export default function StandupPage() {
                             {stories.map((story) => (
                               <div key={story.id} className="rounded-2xl border border-border/70 bg-background p-4 shadow-sm">
                                 <div className="flex flex-wrap items-center justify-between gap-2">
-                                  <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{story.title}</p>
+                                  <p className="text-sm font-medium text-foreground">{story.title}</p>
                                   <Badge variant="outline">{story.status}</Badge>
                                 </div>
-                                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-[color:var(--operator-muted)]">
+                                <div className="mt-2 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
                                   <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
                                   <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
                                 </div>
@@ -507,18 +507,18 @@ export default function StandupPage() {
               {loading ? (
                 <section className="space-y-3">
                   <div className="flex items-center gap-2">
-                    <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">👤 {t('people')}</h2>
+                    <h2 className="text-sm font-semibold text-foreground">👤 {t('people')}</h2>
                   </div>
                   <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
                     {[1, 2, 3].map((item) => (
-                      <div key={item} className="h-48 animate-pulse rounded-xl bg-[color:var(--operator-surface-soft)]" />
+                      <div key={item} className="h-48 animate-pulse rounded-xl bg-muted" />
                     ))}
                   </div>
                 </section>
               ) : humanMembers.length > 0 ? (
                 <section className="space-y-3">
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">👤 {t('people')}</h2>
+                    <h2 className="text-sm font-semibold text-foreground">👤 {t('people')}</h2>
                     <Badge variant="chip">{t('memberCount', { count: humanMembers.length })}</Badge>
                   </div>
                   <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -531,7 +531,7 @@ export default function StandupPage() {
                         return (
                           <div key={member.id} className="col-span-full rounded-xl border border-[color:var(--operator-primary)]/40 bg-card p-4 shadow-sm space-y-4">
                             <div className="flex flex-wrap items-center justify-between gap-2">
-                              <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('selfEditTitle')}</h3>
+                              <h3 className="text-sm font-semibold text-foreground">{t('selfEditTitle')}</h3>
                               <Button variant="ghost" size="sm" onClick={() => setEditingSelf(false)}>{t('cancel')}</Button>
                             </div>
 
@@ -567,7 +567,7 @@ export default function StandupPage() {
 
                             <div className="space-y-3 rounded-xl border border-border/70 bg-muted/10 p-3">
                               <div className="flex flex-wrap items-center justify-between gap-2">
-                                <p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-muted)]">{t('linkedStories')}</p>
+                                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t('linkedStories')}</p>
                                 <Badge variant="outline">{t('linkedStoryCount', { count: planStoryIds.length })}</Badge>
                               </div>
                               {storyPickerStories.length > 0 ? (
@@ -603,7 +603,7 @@ export default function StandupPage() {
                                   })}
                                 </div>
                               ) : (
-                                <p className="text-sm text-[color:var(--operator-muted)]">{t('noSprintStories')}</p>
+                                <p className="text-sm text-muted-foreground">{t('noSprintStories')}</p>
                               )}
                             </div>
 
@@ -639,7 +639,7 @@ export default function StandupPage() {
               {!loading && agentMembers.length > 0 ? (
                 <section className="space-y-3">
                   <div className="flex flex-wrap items-center justify-between gap-2">
-                    <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">🤖 {t('agents')}</h2>
+                    <h2 className="text-sm font-semibold text-foreground">🤖 {t('agents')}</h2>
                     <Badge variant="chip">{t('memberCount', { count: agentMembers.length })}</Badge>
                   </div>
                   <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -139,7 +139,7 @@ export default async function DashboardPage() {
               {/* Assigned Stories */}
               {assignedStories && assignedStories.length > 0 ? (
                 <div>
-                  <div className="mb-2 text-sm font-medium text-[color:var(--operator-foreground)]">{t('assignedToMe')}</div>
+                  <div className="mb-2 text-sm font-medium text-foreground">{t('assignedToMe')}</div>
                   <div className="space-y-2">
                     {assignedStories.map((story) => (
                       <div key={story.id} className="flex items-center justify-between rounded-md border border-border bg-muted/30 px-4 py-2">

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -60,11 +60,11 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         {createdMemoId || createdStoryId ? (
           <SectionCard>
             <SectionCardHeader>
-              <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">생성 결과</div>
+              <div className="text-sm font-semibold text-foreground">생성 결과</div>
             </SectionCardHeader>
-            <SectionCardBody className="space-y-2 text-sm text-[color:var(--operator-muted)]">
-              {createdMemoId ? <div>memo created: <span className="font-mono text-[color:var(--operator-foreground)]">{createdMemoId}</span></div> : null}
-              {createdStoryId ? <div>story created: <span className="font-mono text-[color:var(--operator-foreground)]">{createdStoryId}</span></div> : null}
+            <SectionCardBody className="space-y-2 text-sm text-muted-foreground">
+              {createdMemoId ? <div>memo created: <span className="font-mono text-foreground">{createdMemoId}</span></div> : null}
+              {createdStoryId ? <div>story created: <span className="font-mono text-foreground">{createdStoryId}</span></div> : null}
             </SectionCardBody>
           </SectionCard>
         ) : null}
@@ -72,7 +72,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         {!actor ? (
           <SectionCard>
             <SectionCardHeader>
-              <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">내부 세션 열기</div>
+              <div className="text-sm font-semibold text-foreground">내부 세션 열기</div>
             </SectionCardHeader>
             <SectionCardBody className="space-y-4">
               {actors.length ? (
@@ -100,20 +100,20 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
           <>
             <SectionCard>
               <SectionCardHeader>
-                <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">현재 세션</div>
+                <div className="text-sm font-semibold text-foreground">현재 세션</div>
               </SectionCardHeader>
-              <SectionCardBody className="grid gap-2 text-sm text-[color:var(--operator-muted)] md:grid-cols-2">
-                <div>actor: <span className="font-medium text-[color:var(--operator-foreground)]">{actor.name}</span></div>
-                <div>project: <span className="font-medium text-[color:var(--operator-foreground)]">{actor.project_name}</span></div>
-                <div>team member id: <span className="font-mono text-[color:var(--operator-foreground)]">{actor.id}</span></div>
-                <div>project id: <span className="font-mono text-[color:var(--operator-foreground)]">{actor.project_id}</span></div>
+              <SectionCardBody className="grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
+                <div>actor: <span className="font-medium text-foreground">{actor.name}</span></div>
+                <div>project: <span className="font-medium text-foreground">{actor.project_name}</span></div>
+                <div>team member id: <span className="font-mono text-foreground">{actor.id}</span></div>
+                <div>project id: <span className="font-mono text-foreground">{actor.project_id}</span></div>
               </SectionCardBody>
             </SectionCard>
 
             <div className="grid gap-6 lg:grid-cols-2">
               <SectionCard>
                 <SectionCardHeader>
-                  <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">메모 생성</div>
+                  <div className="text-sm font-semibold text-foreground">메모 생성</div>
                 </SectionCardHeader>
                 <SectionCardBody>
                   <form action="/api/internal-dogfood/memos" method="post" className="space-y-4">
@@ -140,7 +140,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
 
               <SectionCard>
                 <SectionCardHeader>
-                  <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">스토리 생성</div>
+                  <div className="text-sm font-semibold text-foreground">스토리 생성</div>
                 </SectionCardHeader>
                 <SectionCardBody>
                   <form action="/api/internal-dogfood/stories" method="post" className="space-y-4">
@@ -184,7 +184,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
         )}
 
         <SectionCard>
-          <SectionCardBody className="text-sm text-[color:var(--operator-muted)]">
+          <SectionCardBody className="text-sm text-muted-foreground">
             이 경로는 임시 Moonlabs 내부 dogfooding 전용인. auth plane 복구 후 env flag를 내리면 바로 비활성화되는 구조인.
             {' '}
             <Link href="/login" className="text-[color:var(--operator-primary-soft)] underline">일반 로그인 페이지로 이동</Link>

--- a/apps/web/src/components/agents/agent-deployment-verification-step.tsx
+++ b/apps/web/src/components/agents/agent-deployment-verification-step.tsx
@@ -45,8 +45,8 @@ export function AgentDeploymentVerificationStep({
   return (
     <div className="space-y-5">
       <div>
-        <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('verifyStepTitle')}</p>
-        <p className="text-sm text-[color:var(--operator-muted)]">{t('verifyStepBody')}</p>
+        <p className="text-sm font-medium text-foreground">{t('verifyStepTitle')}</p>
+        <p className="text-sm text-muted-foreground">{t('verifyStepBody')}</p>
       </div>
 
       <div className={`rounded-2xl px-4 py-4 text-sm ${verificationCompleted ? 'border border-emerald-400/18 bg-emerald-400/10 text-emerald-100' : 'border border-amber-400/16 bg-amber-400/10 text-amber-100'}`}>
@@ -60,39 +60,39 @@ export function AgentDeploymentVerificationStep({
       </div>
 
       <div className="grid gap-3 md:grid-cols-4">
-        <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('verificationStatusLabel')}</div>
-          <div className="mt-2 text-sm font-medium text-[color:var(--operator-foreground)]">{deploymentStatus}</div>
-          <div className="mt-2 text-xs text-[color:var(--operator-muted)]">{lastDeployedAt ? new Date(lastDeployedAt).toLocaleString() : t('verificationStatusPending')}</div>
+        <GlassPanel className="border-white/8 bg-muted/35 p-4">
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationStatusLabel')}</div>
+          <div className="mt-2 text-sm font-medium text-foreground">{deploymentStatus}</div>
+          <div className="mt-2 text-xs text-muted-foreground">{lastDeployedAt ? new Date(lastDeployedAt).toLocaleString() : t('verificationStatusPending')}</div>
         </GlassPanel>
-        <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('verificationResultLabel')}</div>
+        <GlassPanel className="border-white/8 bg-muted/35 p-4">
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationResultLabel')}</div>
           <div className="mt-2 flex items-center gap-2">
-            <div className="text-sm font-medium text-[color:var(--operator-foreground)]">{verificationCompleted ? t('verificationStatusValueCompleted') : t('verificationStatusValuePending')}</div>
+            <div className="text-sm font-medium text-foreground">{verificationCompleted ? t('verificationStatusValueCompleted') : t('verificationStatusValuePending')}</div>
             <Badge variant={verificationCompleted ? 'success' : 'outline'}>
               {verificationCompleted ? t('verificationStatusValueCompleted') : t('verificationStatusValuePending')}
             </Badge>
           </div>
-          <div className="mt-2 text-xs text-[color:var(--operator-muted)]">{verificationCompletedAt ? t('verificationCompletedAtValue', { date: new Date(verificationCompletedAt).toLocaleString() }) : t('verificationPendingHint')}</div>
+          <div className="mt-2 text-xs text-muted-foreground">{verificationCompletedAt ? t('verificationCompletedAtValue', { date: new Date(verificationCompletedAt).toLocaleString() }) : t('verificationPendingHint')}</div>
         </GlassPanel>
-        <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('verificationScopeLabel')}</div>
-          <div className="mt-2 text-sm font-medium text-[color:var(--operator-foreground)]">{verificationScopeSummary}</div>
-          <div className="mt-2 text-xs text-[color:var(--operator-muted)]">{t('verificationModelValue', { provider: deploymentProviderLabel, model })}</div>
+        <GlassPanel className="border-white/8 bg-muted/35 p-4">
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationScopeLabel')}</div>
+          <div className="mt-2 text-sm font-medium text-foreground">{verificationScopeSummary}</div>
+          <div className="mt-2 text-xs text-muted-foreground">{t('verificationModelValue', { provider: deploymentProviderLabel, model })}</div>
         </GlassPanel>
-        <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-4">
-          <div className="text-xs uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('verificationRoutingLabel')}</div>
-          <div className="mt-2 text-sm font-medium text-[color:var(--operator-foreground)]">{autoRoutingPreviewLabel}</div>
-          <div className="mt-2 text-xs text-[color:var(--operator-muted)]">{t('deployPreflightRoutingValue', { template: autoRoutingPreviewLabel, count: autoRoutingRuleCount })}</div>
+        <GlassPanel className="border-white/8 bg-muted/35 p-4">
+          <div className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('verificationRoutingLabel')}</div>
+          <div className="mt-2 text-sm font-medium text-foreground">{autoRoutingPreviewLabel}</div>
+          <div className="mt-2 text-xs text-muted-foreground">{t('deployPreflightRoutingValue', { template: autoRoutingPreviewLabel, count: autoRoutingRuleCount })}</div>
         </GlassPanel>
       </div>
 
-      <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/35 p-5">
+      <GlassPanel className="border-white/8 bg-muted/35 p-5">
         <div>
-          <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('verificationChecklistTitle')}</p>
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('verificationChecklistBody')}</p>
+          <p className="text-sm font-medium text-foreground">{t('verificationChecklistTitle')}</p>
+          <p className="text-sm text-muted-foreground">{t('verificationChecklistBody')}</p>
         </div>
-        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-[color:var(--operator-muted)]">
+        <ul className="mt-4 list-disc space-y-2 pl-5 text-sm text-muted-foreground">
           <li>{t('verificationCheckpointDashboard')}</li>
           <li>{t('verificationCheckpointRouting', { count: autoRoutingRuleCount })}</li>
           <li>{mcpValidationErrorCount !== null && mcpValidationErrorCount !== undefined ? t('verificationCheckpointMcp', { count: mcpValidationErrorCount }) : t('verificationCheckpointMcpFallback')}</li>

--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -107,12 +107,12 @@ export function AgentHitlPolicyEditor() {
     return (
       <SectionCard>
         <SectionCardHeader>
-          <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('policyLoadingTitle')}</h2>
+          <h2 className="text-base font-semibold text-foreground">{t('policyLoadingTitle')}</h2>
         </SectionCardHeader>
         <SectionCardBody>
           <div className="space-y-3">
             {[1, 2, 3].map((item) => (
-              <div key={item} className="h-28 animate-pulse rounded-3xl bg-[color:var(--operator-surface-soft)]" />
+              <div key={item} className="h-28 animate-pulse rounded-3xl bg-muted" />
             ))}
           </div>
         </SectionCardBody>
@@ -124,7 +124,7 @@ export function AgentHitlPolicyEditor() {
     return (
       <SectionCard>
         <SectionCardHeader>
-          <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('policyTitle')}</h2>
+          <h2 className="text-base font-semibold text-foreground">{t('policyTitle')}</h2>
         </SectionCardHeader>
         <SectionCardBody className="space-y-3">
           <p className="text-sm text-amber-100">{error ?? t('policyLoadFailed')}</p>
@@ -138,9 +138,9 @@ export function AgentHitlPolicyEditor() {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-3 rounded-3xl border border-white/8 bg-white/4 px-4 py-4">
         <div>
-          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{t('policyEyebrow')}</p>
-          <h2 className="mt-1 text-lg font-semibold text-[color:var(--operator-foreground)]">{t('policyTitle')}</h2>
-          <p className="mt-1 text-sm text-[color:var(--operator-muted)]">{t('policyBody')}</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.24em] text-muted-foreground">{t('policyEyebrow')}</p>
+          <h2 className="mt-1 text-lg font-semibold text-foreground">{t('policyTitle')}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{t('policyBody')}</p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {savedAt ? <Badge variant="success">{t('policySaved')}</Badge> : null}
@@ -161,8 +161,8 @@ export function AgentHitlPolicyEditor() {
             <div className="flex items-center gap-2">
               <ShieldAlert className="size-4 text-[color:var(--operator-primary-soft)]" />
               <div>
-                <h3 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('catalogTitle')}</h3>
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('catalogBody')}</p>
+                <h3 className="text-base font-semibold text-foreground">{t('catalogTitle')}</h3>
+                <p className="text-sm text-muted-foreground">{t('catalogBody')}</p>
               </div>
             </div>
           </SectionCardHeader>
@@ -174,8 +174,8 @@ export function AgentHitlPolicyEditor() {
                   <Badge variant="outline">{t(`requestType_${item.default_request_type}`)}</Badge>
                   <Badge variant="chip">{t(`timeoutClass_${item.default_timeout_class}`)}</Badge>
                 </div>
-                <p className="mt-3 text-sm font-semibold text-[color:var(--operator-foreground)]">{t(`catalog_${item.key}_title`)}</p>
-                <p className="mt-2 text-sm text-[color:var(--operator-muted)]">{t(`catalog_${item.key}_body`)}</p>
+                <p className="mt-3 text-sm font-semibold text-foreground">{t(`catalog_${item.key}_title`)}</p>
+                <p className="mt-2 text-sm text-muted-foreground">{t(`catalog_${item.key}_body`)}</p>
               </div>
             ))}
           </SectionCardBody>
@@ -186,8 +186,8 @@ export function AgentHitlPolicyEditor() {
             <div className="flex items-center gap-2">
               <CheckCircle2 className="size-4 text-[color:var(--operator-primary-soft)]" />
               <div>
-                <h3 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('approvalTitle')}</h3>
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('approvalBody')}</p>
+                <h3 className="text-base font-semibold text-foreground">{t('approvalTitle')}</h3>
+                <p className="text-sm text-muted-foreground">{t('approvalBody')}</p>
               </div>
             </div>
           </SectionCardHeader>
@@ -199,17 +199,17 @@ export function AgentHitlPolicyEditor() {
                   <Badge variant="outline">{t(`timeoutClass_${rule.timeout_class}`)}</Badge>
                 </div>
                 <div>
-                  <p className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t(`approval_${rule.key}_title`)}</p>
-                  <p className="mt-1 text-sm text-[color:var(--operator-muted)]">{t(`approval_${rule.key}_body`)}</p>
+                  <p className="text-sm font-semibold text-foreground">{t(`approval_${rule.key}_title`)}</p>
+                  <p className="mt-1 text-sm text-muted-foreground">{t(`approval_${rule.key}_body`)}</p>
                 </div>
                 <div className="grid gap-3 md:grid-cols-2">
-                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">
+                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                     <span>{t('approvalRequestTypeLabel')}</span>
-                    <div className="flex h-10 items-center rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)] px-3 text-sm font-medium normal-case tracking-normal text-[color:var(--operator-foreground)]">
+                    <div className="flex h-10 items-center rounded-2xl border border-white/10 bg-muted px-3 text-sm font-medium normal-case tracking-normal text-foreground">
                       {t('requestType_approval')}
                     </div>
                   </label>
-                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">
+                  <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                     <span>{t('approvalTimeoutClassLabel')}</span>
                     <OperatorSelect value={rule.timeout_class} onChange={(event) => updateApprovalRule(rule.key, event.target.value)}>
                       {policy.timeout_classes.map((timeoutClass) => (
@@ -228,8 +228,8 @@ export function AgentHitlPolicyEditor() {
             <div className="flex items-center gap-2">
               <Clock3 className="size-4 text-[color:var(--operator-primary-soft)]" />
               <div>
-                <h3 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('timeoutTitle')}</h3>
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('timeoutBody')}</p>
+                <h3 className="text-base font-semibold text-foreground">{t('timeoutTitle')}</h3>
+                <p className="text-sm text-muted-foreground">{t('timeoutBody')}</p>
               </div>
             </div>
           </SectionCardHeader>
@@ -245,11 +245,11 @@ export function AgentHitlPolicyEditor() {
                     ))}
                   </div>
                   <div>
-                    <p className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t(`timeout_${timeoutClass.key}_title`)}</p>
-                    <p className="mt-1 text-sm text-[color:var(--operator-muted)]">{t(`timeout_${timeoutClass.key}_body`)}</p>
+                    <p className="text-sm font-semibold text-foreground">{t(`timeout_${timeoutClass.key}_title`)}</p>
+                    <p className="mt-1 text-sm text-muted-foreground">{t(`timeout_${timeoutClass.key}_body`)}</p>
                   </div>
                   <div className="grid gap-3">
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">
+                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                       <span>{t('timeoutDurationLabel')}</span>
                       <OperatorInput
                         type="number"
@@ -259,7 +259,7 @@ export function AgentHitlPolicyEditor() {
                         onChange={(event) => updateTimeoutClass(timeoutClass.key, 'duration_minutes', event.target.value)}
                       />
                     </label>
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">
+                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                       <span>{t('timeoutReminderLabel')}</span>
                       <OperatorInput
                         type="number"
@@ -269,7 +269,7 @@ export function AgentHitlPolicyEditor() {
                         onChange={(event) => updateTimeoutClass(timeoutClass.key, 'reminder_minutes_before', event.target.value)}
                       />
                     </label>
-                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">
+                    <label className="space-y-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground">
                       <span>{t('timeoutEscalationLabel')}</span>
                       <OperatorSelect value={timeoutClass.escalation_mode} onChange={(event) => updateTimeoutClass(timeoutClass.key, 'escalation_mode', event.target.value)}>
                         {ESCALATION_MODE_OPTIONS.map((mode) => (
@@ -290,13 +290,13 @@ export function AgentHitlPolicyEditor() {
           <div className="flex items-center gap-2">
             <AlertTriangle className="size-4 text-[color:var(--operator-primary-soft)]" />
             <div>
-              <h3 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('policySummaryTitle')}</h3>
-              <p className="text-sm text-[color:var(--operator-muted)]">{t('policySummaryBody')}</p>
+              <h3 className="text-base font-semibold text-foreground">{t('policySummaryTitle')}</h3>
+              <p className="text-sm text-muted-foreground">{t('policySummaryBody')}</p>
             </div>
           </div>
         </SectionCardHeader>
         <SectionCardBody>
-          <pre className="whitespace-pre-wrap rounded-3xl border border-white/10 bg-slate-950/40 px-4 py-4 text-sm text-[color:var(--operator-muted)]">{policy.prompt_summary}</pre>
+          <pre className="whitespace-pre-wrap rounded-3xl border border-white/10 bg-slate-950/40 px-4 py-4 text-sm text-muted-foreground">{policy.prompt_summary}</pre>
         </SectionCardBody>
       </SectionCard>
     </div>

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -224,15 +224,15 @@ export function AgentRunDetail({
   if (loading) {
     return (
       <div className="space-y-4">
-        <div className="h-24 animate-pulse rounded-2xl bg-[color:var(--operator-surface-soft)]" />
-        <div className="h-64 animate-pulse rounded-2xl bg-[color:var(--operator-surface-soft)]" />
+        <div className="h-24 animate-pulse rounded-2xl bg-muted" />
+        <div className="h-64 animate-pulse rounded-2xl bg-muted" />
       </div>
     );
   }
 
   if (!run) {
     return (
-      <div className="py-20 text-center text-[color:var(--operator-muted)]">
+      <div className="py-20 text-center text-muted-foreground">
         {tc('noData')}
       </div>
     );
@@ -284,7 +284,7 @@ export function AgentRunDetail({
               <Badge variant={STATUS_BADGE_VARIANT[run.status] ?? 'outline'}>
                 {t(`status_${run.status}`)}
               </Badge>
-              <span className="text-xs text-[color:var(--operator-muted)]">
+              <span className="text-xs text-muted-foreground">
                 {t('startedAt')}: {toLocaleStr(run.started_at, locale)}
               </span>
               {run.status === 'failed' && failureDisposition && (
@@ -293,7 +293,7 @@ export function AgentRunDetail({
                 </Badge>
               )}
               {run.finished_at && (
-                <span className="text-xs text-[color:var(--operator-muted)]">
+                <span className="text-xs text-muted-foreground">
                   {t('finishedAt')}: {toLocaleStr(run.finished_at, locale)}
                 </span>
               )}
@@ -317,7 +317,7 @@ export function AgentRunDetail({
 
             {Array.isArray(run.billing_notes) && run.billing_notes.length > 0 && (
               <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('billingNotesLabel')}</p>
+                <p className="text-sm font-medium text-foreground">{t('billingNotesLabel')}</p>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {run.billing_notes.map((note) => (
                     <Badge key={note} variant="chip">{note}</Badge>
@@ -348,14 +348,14 @@ export function AgentRunDetail({
             {/* Result summary */}
             {run.result_summary && (
               <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('resultSummary')}</p>
-                <p className="mt-1 text-sm text-[color:var(--operator-muted)]">{run.result_summary}</p>
+                <p className="text-sm font-medium text-foreground">{t('resultSummary')}</p>
+                <p className="mt-1 text-sm text-muted-foreground">{run.result_summary}</p>
               </div>
             )}
 
             {retrievalDiagnostics && (
               <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('memoryRetrievalTitle')}</p>
+                <p className="text-sm font-medium text-foreground">{t('memoryRetrievalTitle')}</p>
                 <div className="mt-3 grid gap-3 md:grid-cols-2">
                   <MemoryBucketCard
                     label={t('memoryRetrievalSession')}
@@ -374,7 +374,7 @@ export function AgentRunDetail({
                     injectedIdsLabel={t('memoryRetrievalInjectedIds')}
                   />
                 </div>
-                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[color:var(--operator-muted)]">
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
                   <Badge variant="chip">{t('memoryRetrievalTotalInjected')}: {retrievalDiagnostics.totalInjected}</Badge>
                   <Badge variant="chip">{t('memoryRetrievalDropped')}: {retrievalDiagnostics.droppedByTokenBudget}</Badge>
                 </div>
@@ -383,8 +383,8 @@ export function AgentRunDetail({
 
             {compactionPolicy && (
               <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('memoryCompactionTitle')}</p>
-                <p className="mt-1 text-sm text-[color:var(--operator-muted)]">
+                <p className="text-sm font-medium text-foreground">{t('memoryCompactionTitle')}</p>
+                <p className="mt-1 text-sm text-muted-foreground">
                   {t('memoryCompactionThresholds', {
                     minImportance: compactionPolicy.thresholds.minImportance,
                     maxAgeDays: compactionPolicy.thresholds.maxAgeDays,
@@ -395,7 +395,7 @@ export function AgentRunDetail({
                   <CriteriaList title={t('memoryCompactionKeep')} items={compactionPolicy.keepCriteria} />
                   <CriteriaList title={t('memoryCompactionDelete')} items={compactionPolicy.deleteCriteria} />
                 </div>
-                <div className="mt-3 flex flex-wrap gap-2 text-xs text-[color:var(--operator-muted)]">
+                <div className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
                   {Object.entries(compactionPolicy.typeQuota).map(([type, quota]) => (
                     <Badge key={type} variant="chip">{type}: {quota}</Badge>
                   ))}
@@ -405,7 +405,7 @@ export function AgentRunDetail({
 
             {run.continuity_debug && (
               <div className="mb-4 rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('continuityDebugTitle')}</p>
+                <p className="text-sm font-medium text-foreground">{t('continuityDebugTitle')}</p>
                 <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                   <MetaCard label={t('sessionId')} value={run.continuity_debug.sessionId ?? '-'} />
                   <MetaCard label={t('continuitySnapshotPresent')} value={run.continuity_debug.snapshotPresent ? t('booleanYes') : t('booleanNo')} />
@@ -417,11 +417,11 @@ export function AgentRunDetail({
 
             {/* Timeline */}
             <div>
-              <h3 className="mb-3 text-sm font-semibold text-[color:var(--operator-foreground)]">
+              <h3 className="mb-3 text-sm font-semibold text-foreground">
                 {t('timeline')} ({timeline.length})
               </h3>
               {timeline.length === 0 ? (
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('noTimelineEntries')}</p>
+                <p className="text-sm text-muted-foreground">{t('noTimelineEntries')}</p>
               ) : (
                 <div className="relative space-y-0">
                   {/* Vertical line */}
@@ -438,7 +438,7 @@ export function AgentRunDetail({
                           hasError
                             ? 'border-red-400 bg-red-400/20'
                             : isLlm
-                              ? 'border-[color:var(--operator-primary)] bg-[color:var(--operator-primary)]/20'
+                              ? 'border-[color:var(--operator-primary)] bg-brand/20'
                               : 'border-emerald-400 bg-emerald-400/20'
                         }`} />
                         <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-white/4 px-3 py-2">
@@ -446,19 +446,19 @@ export function AgentRunDetail({
                             <Badge variant={isLlm ? 'info' : isTool ? (hasError ? 'destructive' : 'success') : 'outline'} className="text-[10px]">
                               {isLlm ? 'LLM' : isTool ? 'TOOL' : (entry.type ?? 'step')}
                             </Badge>
-                            <span className="text-xs font-medium text-[color:var(--operator-foreground)]">
+                            <span className="text-xs font-medium text-foreground">
                               {isLlm ? (entry.model ?? 'LLM call') : display.name}
                             </span>
                             {display.source && (
                               <Badge variant="chip" className="text-[10px]">{display.source}</Badge>
                             )}
                             {display.durationMs != null && (
-                              <span className="text-[10px] text-[color:var(--operator-muted)]">
+                              <span className="text-[10px] text-muted-foreground">
                                 {formatDuration(display.durationMs)}
                               </span>
                             )}
                             {display.tokens && (
-                              <span className="text-[10px] text-[color:var(--operator-muted)]">
+                              <span className="text-[10px] text-muted-foreground">
                                 {display.tokens.input ?? 0}/{display.tokens.output ?? 0} tok
                               </span>
                             )}
@@ -484,11 +484,11 @@ export function AgentRunDetail({
             </div>
 
             <div className="mt-6">
-              <h3 className="mb-3 text-sm font-semibold text-[color:var(--operator-foreground)]">
+              <h3 className="mb-3 text-sm font-semibold text-foreground">
                 {t('toolAuditTrail')} ({toolAuditTrail.length})
               </h3>
               {toolAuditTrail.length === 0 ? (
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('noToolAuditEntries')}</p>
+                <p className="text-sm text-muted-foreground">{t('noToolAuditEntries')}</p>
               ) : (
                 <div className="space-y-3">
                   {toolAuditTrail.map((entry) => {
@@ -511,61 +511,61 @@ export function AgentRunDetail({
                           <Badge variant={outcome === 'denied' ? 'destructive' : outcome === 'failed' ? 'secondary' : 'success'}>
                             {outcome === 'denied' ? t('toolAuditOutcomeDenied') : outcome === 'failed' ? t('toolAuditOutcomeFailed') : t('toolAuditOutcomeAllowed')}
                           </Badge>
-                          <span className="text-sm font-medium text-[color:var(--operator-foreground)]">{toolName}</span>
+                          <span className="text-sm font-medium text-foreground">{toolName}</span>
                           {toolSource ? <Badge variant="chip">{t(`toolAuditSource_${toolSource}`)}</Badge> : null}
-                          <span className="text-xs text-[color:var(--operator-muted)]">{toLocaleStr(entry.created_at, locale)}</span>
+                          <span className="text-xs text-muted-foreground">{toLocaleStr(entry.created_at, locale)}</span>
                         </div>
-                        <div className="mt-2 grid gap-2 text-sm text-[color:var(--operator-muted)] md:grid-cols-2">
+                        <div className="mt-2 grid gap-2 text-sm text-muted-foreground md:grid-cols-2">
                           <div>
                             <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditActorLabel')}</span>
-                            <p className="mt-1 text-[color:var(--operator-foreground)]">{entry.actor_name ?? run.agent_name ?? t('unknownAgent')}</p>
+                            <p className="mt-1 text-foreground">{entry.actor_name ?? run.agent_name ?? t('unknownAgent')}</p>
                           </div>
                           <div>
                             <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditEventLabel')}</span>
-                            <p className="mt-1 break-all text-[color:var(--operator-foreground)]">{entry.event_type}</p>
+                            <p className="mt-1 break-all text-foreground">{entry.event_type}</p>
                           </div>
                           {reasonCode ? (
                             <div>
                               <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditReasonCodeLabel')}</span>
-                              <p className="mt-1 break-all text-[color:var(--operator-foreground)]">{reasonCode}</p>
+                              <p className="mt-1 break-all text-foreground">{reasonCode}</p>
                             </div>
                           ) : null}
                           {durationMs != null ? (
                             <div>
                               <span className="text-xs uppercase tracking-[0.16em]">{t('duration')}</span>
-                              <p className="mt-1 text-[color:var(--operator-foreground)]">{formatDuration(durationMs)}</p>
+                              <p className="mt-1 text-foreground">{formatDuration(durationMs)}</p>
                             </div>
                           ) : null}
                           {serverName ? (
                             <div>
                               <span className="text-xs uppercase tracking-[0.16em]">{t('toolAuditServerLabel')}</span>
-                              <p className="mt-1 text-[color:var(--operator-foreground)]">{serverName}</p>
+                              <p className="mt-1 text-foreground">{serverName}</p>
                             </div>
                           ) : null}
                         </div>
                         {operatorReason ? (
                           <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--operator-muted)]">{t('toolAuditOperatorReasonLabel')}</p>
-                            <p className="mt-1 text-sm text-[color:var(--operator-foreground)]">{operatorReason}</p>
+                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditOperatorReasonLabel')}</p>
+                            <p className="mt-1 text-sm text-foreground">{operatorReason}</p>
                           </div>
                         ) : null}
                         {userReason ? (
                           <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--operator-muted)]">{t('toolAuditUserReasonLabel')}</p>
-                            <p className="mt-1 text-sm text-[color:var(--operator-foreground)]">{userReason}</p>
+                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditUserReasonLabel')}</p>
+                            <p className="mt-1 text-sm text-foreground">{userReason}</p>
                           </div>
                         ) : null}
                         {nextAction ? (
                           <div className="mt-3 rounded-2xl border border-white/8 bg-white/3 px-3 py-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-[color:var(--operator-muted)]">{t('toolAuditNextActionLabel')}</p>
-                            <p className="mt-1 text-sm text-[color:var(--operator-foreground)]">{nextAction}</p>
+                            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-muted-foreground">{t('toolAuditNextActionLabel')}</p>
+                            <p className="mt-1 text-sm text-foreground">{nextAction}</p>
                           </div>
                         ) : null}
                         {error ? (
                           <p className="mt-3 text-sm text-red-300/80">{error}</p>
                         ) : null}
                         {!operatorReason && !userReason && !nextAction && detailSummary ? (
-                          <p className="mt-3 text-sm text-[color:var(--operator-muted)]">{detailSummary}</p>
+                          <p className="mt-3 text-sm text-muted-foreground">{detailSummary}</p>
                         ) : null}
                       </div>
                     );
@@ -584,11 +584,11 @@ export function AgentRunDetail({
 function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
   return (
     <div className="rounded-2xl border border-white/8 bg-white/4 px-4 py-3">
-      <div className="flex items-center gap-2 text-[color:var(--operator-muted)]">
+      <div className="flex items-center gap-2 text-muted-foreground">
         {icon}
         <span className="text-xs">{label}</span>
       </div>
-      <p className="mt-1 text-lg font-semibold text-[color:var(--operator-foreground)]">{value}</p>
+      <p className="mt-1 text-lg font-semibold text-foreground">{value}</p>
     </div>
   );
 }
@@ -596,8 +596,8 @@ function StatCard({ icon, label, value }: { icon: React.ReactNode; label: string
 function MetaCard({ label, value }: { label: string; value: string }) {
   return (
     <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3">
-      <p className="text-xs text-[color:var(--operator-muted)]">{label}</p>
-      <p className="mt-1 break-all text-sm font-medium text-[color:var(--operator-foreground)]">{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-1 break-all text-sm font-medium text-foreground">{value}</p>
     </div>
   );
 }
@@ -618,8 +618,8 @@ function MemoryBucketCard({
   injectedIdsLabel: string;
 }) {
   return (
-    <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3 text-sm text-[color:var(--operator-muted)]">
-      <p className="font-medium text-[color:var(--operator-foreground)]">{label}</p>
+    <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3 text-sm text-muted-foreground">
+      <p className="font-medium text-foreground">{label}</p>
       <div className="mt-2 space-y-1">
         <p>{queriedLabel}: {bucket.queriedCount}</p>
         <p>{inScopeLabel}: {bucket.inScopeCount}</p>
@@ -633,8 +633,8 @@ function MemoryBucketCard({
 function CriteriaList({ title, items }: { title: string; items: string[] }) {
   return (
     <div className="rounded-2xl border border-white/8 bg-white/3 px-4 py-3">
-      <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{title}</p>
-      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-[color:var(--operator-muted)]">
+      <p className="text-sm font-medium text-foreground">{title}</p>
+      <ul className="mt-2 list-disc space-y-1 pl-5 text-sm text-muted-foreground">
         {items.map((item) => <li key={item}>{item}</li>)}
       </ul>
     </div>

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -109,7 +109,7 @@ export function DocContentRenderer({
     const wikiCleanup = wikiLinks.map((span) => {
       const slug = span.getAttribute('data-slug') ?? '';
       const title = span.getAttribute('data-title') ?? span.textContent ?? '';
-      span.className = 'inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)] hover:bg-[color:var(--operator-primary)]/20 transition-colors';
+      span.className = 'inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] bg-brand/10 text-[color:var(--operator-primary-soft)] hover:bg-brand/20 transition-colors';
       span.title = title;
       const handleClick = () => { if (slug) window.location.href = `/docs/${slug}`; };
       span.addEventListener('click', handleClick);
@@ -125,7 +125,7 @@ export function DocContentRenderer({
         if (error) {
           block.innerHTML = `<div class="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">${escapeHtmlText(error)}</div>`;
         } else {
-          block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-[color:var(--operator-foreground)]">${katexHtml}</div>`;
+          block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-foreground">${katexHtml}</div>`;
         }
       });
     });
@@ -195,7 +195,7 @@ export function DocContentRenderer({
 
       block.innerHTML = `
         <div class="flex items-center gap-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--muted))]/20 px-4 py-3 cursor-pointer hover:bg-[hsl(var(--muted))]/40 transition-colors">
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-[color:var(--operator-muted)]"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="flex-shrink-0 text-muted-foreground"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/></svg>
           <div class="min-w-0 flex-1">
             <p class="truncate text-sm font-medium">${escapeHtmlText(filename)}</p>
             <p class="text-xs opacity-60">${escapeHtmlText(sizeLabel)}</p>
@@ -244,13 +244,13 @@ export function DocContentRenderer({
   }, [codeCopyLabel, content, contentFormat, headings]);
 
   const rootClassName = cn(
-    'doc-renderer prose dark:prose-invert prose-sm max-w-none text-[color:var(--operator-foreground)]',
+    'doc-renderer prose dark:prose-invert prose-sm max-w-none text-foreground',
     '[&_h1]:scroll-mt-24 [&_h1]:text-3xl [&_h1]:font-bold [&_h1]:tracking-tight',
     '[&_h2]:scroll-mt-24 [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-semibold',
     '[&_h3]:scroll-mt-24 [&_h3]:mt-8 [&_h3]:text-xl [&_h3]:font-semibold',
-    '[&_p]:leading-7 [&_p]:text-[color:var(--operator-foreground)]/92',
+    '[&_p]:leading-7 [&_p]:text-foreground/92',
     '[&_a]:text-[color:var(--operator-primary-soft)] [&_a]:underline [&_a]:underline-offset-4',
-    '[&_blockquote]:rounded-2xl [&_blockquote]:border-l-4 [&_blockquote]:border-[color:var(--operator-primary)]/45 [&_blockquote]:bg-[color:var(--operator-primary)]/8 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-[color:var(--operator-foreground)]/88',
+    '[&_blockquote]:rounded-2xl [&_blockquote]:border-l-4 [&_blockquote]:border-[color:var(--operator-primary)]/45 [&_blockquote]:bg-brand/8 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-foreground/88',
     '[&_img]:max-h-[32rem] [&_img]:w-full [&_img]:rounded-2xl [&_img]:border [&_img]:border-border [&_img]:object-contain',
     '[&_table]:w-full [&_table]:border-collapse [&_table]:overflow-hidden [&_table]:rounded-2xl [&_table]:border [&_table]:border-border [&_table]:bg-muted/20',
     '[&_thead]:bg-muted/50 [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-semibold',
@@ -262,7 +262,7 @@ export function DocContentRenderer({
     '[&_pre_code]:bg-transparent [&_pre_code]:p-0',
     '[&_[data-doc-code-shell="true"]]:not-prose [&_[data-doc-code-shell="true"]]:my-6',
     '[&_[data-doc-code-actions="true"]]:mb-2 [&_[data-doc-code-actions="true"]]:flex [&_[data-doc-code-actions="true"]]:justify-end',
-    '[&_[data-doc-copy-button="true"]]:rounded-full [&_[data-doc-copy-button="true"]]:border [&_[data-doc-copy-button="true"]]:border-border [&_[data-doc-copy-button="true"]]:bg-muted/50 [&_[data-doc-copy-button="true"]]:px-3 [&_[data-doc-copy-button="true"]]:py-1.5 [&_[data-doc-copy-button="true"]]:text-[11px] [&_[data-doc-copy-button="true"]]:font-medium [&_[data-doc-copy-button="true"]]:uppercase [&_[data-doc-copy-button="true"]]:tracking-[0.18em] [&_[data-doc-copy-button="true"]]:text-[color:var(--operator-muted)]',
+    '[&_[data-doc-copy-button="true"]]:rounded-full [&_[data-doc-copy-button="true"]]:border [&_[data-doc-copy-button="true"]]:border-border [&_[data-doc-copy-button="true"]]:bg-muted/50 [&_[data-doc-copy-button="true"]]:px-3 [&_[data-doc-copy-button="true"]]:py-1.5 [&_[data-doc-copy-button="true"]]:text-[11px] [&_[data-doc-copy-button="true"]]:font-medium [&_[data-doc-copy-button="true"]]:uppercase [&_[data-doc-copy-button="true"]]:tracking-[0.18em] [&_[data-doc-copy-button="true"]]:text-muted-foreground',
     className,
   );
 
@@ -449,7 +449,7 @@ function decorateHtmlContent(content: string, headings: ReturnType<typeof extrac
     return [
       '<div data-doc-code-shell="true">',
       '<div data-doc-code-actions="true">',
-      `<button type="button" data-doc-copy-button="true" class="transition hover:border-[color:var(--operator-primary)]/35 hover:text-[color:var(--operator-foreground)]">${escapeHtmlText(codeCopyLabel)}</button>`,
+      `<button type="button" data-doc-copy-button="true" class="transition hover:border-[color:var(--operator-primary)]/35 hover:text-foreground">${escapeHtmlText(codeCopyLabel)}</button>`,
       '</div>',
       `<pre>${inner}</pre>`,
       '</div>',

--- a/apps/web/src/components/docs/doc-toc.tsx
+++ b/apps/web/src/components/docs/doc-toc.tsx
@@ -42,7 +42,7 @@ export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
         onClick={() => setOpen((v) => !v)}
         className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
           open
-            ? 'border-[color:var(--operator-primary)]/50 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
+            ? 'border-[color:var(--operator-primary)]/50 bg-brand/10 text-[color:var(--operator-primary-soft)]'
             : 'border-border/60 bg-card text-foreground hover:border-[color:var(--operator-primary)]/50 hover:text-[color:var(--operator-primary-soft)]'
         }`}
         title="목차"
@@ -54,11 +54,11 @@ export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
       {open && (
         <div className="absolute right-0 top-full z-50 mt-1.5 w-64 overflow-hidden rounded-xl border border-border bg-background shadow-lg">
           <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
-            <span className="text-xs font-semibold text-[color:var(--operator-foreground)]">목차</span>
+            <span className="text-xs font-semibold text-foreground">목차</span>
             <button
               type="button"
               onClick={() => setOpen(false)}
-              className="rounded p-0.5 text-[color:var(--operator-muted)] hover:bg-muted hover:text-foreground"
+              className="rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
             >
               <X className="size-3.5" />
             </button>
@@ -71,13 +71,13 @@ export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
                 onClick={() => handleClick(heading.id)}
                 className={`flex w-full items-start px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted/60 ${
                   heading.level === 1
-                    ? 'font-semibold text-[color:var(--operator-foreground)]'
+                    ? 'font-semibold text-foreground'
                     : heading.level === 2
-                      ? 'pl-5 text-[color:var(--operator-foreground)]/80'
-                      : 'pl-7 text-[color:var(--operator-muted)]'
+                      ? 'pl-5 text-foreground/80'
+                      : 'pl-7 text-muted-foreground'
                 }`}
               >
-                <span className="mr-1.5 mt-px flex-shrink-0 text-[color:var(--operator-muted)]">
+                <span className="mr-1.5 mt-px flex-shrink-0 text-muted-foreground">
                   {heading.level === 1 ? '◆' : heading.level === 2 ? '◇' : '·'}
                 </span>
                 <span className="truncate">{heading.text}</span>

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -34,11 +34,11 @@ function DocPreviewCard({ title, snippet, x, y }: { title: string; snippet: stri
       style={{ position: 'fixed', left, top, width: CARD_WIDTH, zIndex: 9999, pointerEvents: 'none' }}
       className="rounded-xl border border-border bg-background p-3 shadow-lg"
     >
-      <p className="mb-1 text-xs font-semibold text-[color:var(--operator-foreground)] truncate">{title}</p>
+      <p className="mb-1 text-xs font-semibold text-foreground truncate">{title}</p>
       {snippet ? (
-        <p className="text-[11px] leading-relaxed text-[color:var(--operator-muted)] line-clamp-4">{snippet}</p>
+        <p className="text-[11px] leading-relaxed text-muted-foreground line-clamp-4">{snippet}</p>
       ) : (
-        <p className="text-[11px] text-[color:var(--operator-muted)] opacity-60">내용 없음</p>
+        <p className="text-[11px] text-muted-foreground opacity-60">내용 없음</p>
       )}
     </div>,
     document.body,
@@ -283,7 +283,7 @@ function TreeNode({
             </SortableContext>
           ) : (
             <p
-              className="py-1 text-[11px] italic text-[color:var(--operator-muted)]"
+              className="py-1 text-[11px] italic text-muted-foreground"
               style={{ paddingLeft: `${Math.min((depth + 1) * 14 + 24, 88)}px` }}
             >
               {emptyFolderLabel}

--- a/apps/web/src/components/docs/extensions/column-layout.tsx
+++ b/apps/web/src/components/docs/extensions/column-layout.tsx
@@ -53,14 +53,14 @@ function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeV
         contentEditable={false}
         className="mb-1.5 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity"
       >
-        <span className="text-[10px] uppercase tracking-widest text-[color:var(--operator-muted)] mr-1">컬럼</span>
+        <span className="text-[10px] uppercase tracking-widest text-muted-foreground mr-1">컬럼</span>
         <button
           type="button"
           onClick={() => switchTo(2)}
           className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
             cols === 2
-              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
-              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+              ? 'border-[color:var(--operator-primary)]/40 bg-brand/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-muted-foreground hover:border-[color:var(--operator-primary)]/30 hover:text-foreground'
           }`}
         >
           <Columns2 className="size-3" />2단
@@ -70,8 +70,8 @@ function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeV
           onClick={() => switchTo(3)}
           className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
             cols === 3
-              ? 'border-[color:var(--operator-primary)]/40 bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]'
-              : 'border-border text-[color:var(--operator-muted)] hover:border-[color:var(--operator-primary)]/30 hover:text-[color:var(--operator-foreground)]'
+              ? 'border-[color:var(--operator-primary)]/40 bg-brand/10 text-[color:var(--operator-primary-soft)]'
+              : 'border-border text-muted-foreground hover:border-[color:var(--operator-primary)]/30 hover:text-foreground'
           }`}
         >
           <Columns3 className="size-3" />3단

--- a/apps/web/src/components/docs/extensions/embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/embed-node.tsx
@@ -73,8 +73,8 @@ function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
     <NodeViewWrapper as="div" className="my-4 not-prose" contentEditable={false}>
       {/* URL editor — visible when block is selected */}
       {selected && (
-        <div className="mb-2 flex items-center gap-2 rounded-xl border border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/6 px-3 py-2">
-          <Link2 className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+        <div className="mb-2 flex items-center gap-2 rounded-xl border border-[color:var(--operator-primary)]/30 bg-brand/6 px-3 py-2">
+          <Link2 className="size-3.5 flex-shrink-0 text-muted-foreground" />
           <input
             ref={inputRef}
             value={editUrl}
@@ -82,7 +82,7 @@ function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
             onKeyDown={handleKeyDown}
             onBlur={applyUrl}
             placeholder="URL 입력 후 Enter"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-[color:var(--operator-muted)]/60"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
           />
         </div>
       )}
@@ -119,13 +119,13 @@ function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
               rel="noopener noreferrer"
               className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3 text-sm transition-colors hover:bg-muted/40"
             >
-              <ExternalLink className="size-4 flex-shrink-0 text-[color:var(--operator-muted)]" />
-              <span className="min-w-0 flex-1 truncate text-[color:var(--operator-foreground)]/80">{url}</span>
+              <ExternalLink className="size-4 flex-shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate text-foreground/80">{url}</span>
             </a>
           )}
         </>
       ) : (
-        <div className="flex items-center gap-2 rounded-xl border border-dashed border-border px-4 py-4 text-sm text-[color:var(--operator-muted)]">
+        <div className="flex items-center gap-2 rounded-xl border border-dashed border-border px-4 py-4 text-sm text-muted-foreground">
           <Link2 className="size-4" />
           <span>블록을 선택해 URL을 입력하세요</span>
         </div>

--- a/apps/web/src/components/docs/extensions/file-node.tsx
+++ b/apps/web/src/components/docs/extensions/file-node.tsx
@@ -44,18 +44,18 @@ function FileAttachmentView({ node }: ReactNodeViewProps) {
   return (
     <NodeViewWrapper as="div" className="my-3 not-prose">
       <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3">
-        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)]">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-brand/10 text-[color:var(--operator-primary-soft)]">
           <FileIcon className="size-4" />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate text-sm font-medium text-[color:var(--operator-foreground)]">{filename}</p>
-          <p className="text-xs text-[color:var(--operator-muted)]">{formatFileSize(size)}</p>
+          <p className="truncate text-sm font-medium text-foreground">{filename}</p>
+          <p className="text-xs text-muted-foreground">{formatFileSize(size)}</p>
         </div>
         <button
           type="button"
           contentEditable={false}
           onClick={handleDownload}
-          className="flex-shrink-0 rounded-lg border border-border p-2 text-[color:var(--operator-muted)] transition-colors hover:border-[color:var(--operator-primary)]/40 hover:text-[color:var(--operator-primary-soft)]"
+          className="flex-shrink-0 rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:border-[color:var(--operator-primary)]/40 hover:text-[color:var(--operator-primary-soft)]"
           aria-label="파일 다운로드"
         >
           <DownloadIcon className="size-4" />

--- a/apps/web/src/components/docs/extensions/math-node.tsx
+++ b/apps/web/src/components/docs/extensions/math-node.tsx
@@ -48,14 +48,14 @@ function MathBlockView({ node, selected }: ReactNodeViewProps) {
       <div className="rounded-xl border border-border bg-muted/10">
         {/* Header */}
         <div className="flex items-center justify-between px-3 py-2" contentEditable={false}>
-          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-[color:var(--operator-muted)]">math</span>
+          <span className="text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">math</span>
           {selected && (
-            <span className="text-[11px] text-[color:var(--operator-muted)]">LaTeX 편집 중</span>
+            <span className="text-[11px] text-muted-foreground">LaTeX 편집 중</span>
           )}
         </div>
 
         {/* LaTeX editor — visible when selected */}
-        <pre className={`border-t border-border/50 p-4 text-[13px] leading-6 text-[color:var(--operator-foreground)] font-mono ${showEdit ? '' : 'hidden'}`}>
+        <pre className={`border-t border-border/50 p-4 text-[13px] leading-6 text-foreground font-mono ${showEdit ? '' : 'hidden'}`}>
           <NodeViewContent />
         </pre>
 
@@ -67,10 +67,10 @@ function MathBlockView({ node, selected }: ReactNodeViewProps) {
             ) : html ? (
               <div
                 dangerouslySetInnerHTML={{ __html: html }}
-                className="flex justify-center overflow-x-auto [&_.katex]:text-[color:var(--operator-foreground)]"
+                className="flex justify-center overflow-x-auto [&_.katex]:text-foreground"
               />
             ) : (
-              <p className="text-xs text-[color:var(--operator-muted)] text-center">수식을 입력하세요 (LaTeX)</p>
+              <p className="text-xs text-muted-foreground text-center">수식을 입력하세요 (LaTeX)</p>
             )}
           </div>
         )}
@@ -109,7 +109,7 @@ function MathInlineView({ node }: ReactNodeViewProps) {
       <NodeViewWrapper as="span" contentEditable={false}>
         <span
           dangerouslySetInnerHTML={{ __html: html }}
-          className="[&_.katex]:text-[color:var(--operator-foreground)]"
+          className="[&_.katex]:text-foreground"
         />
       </NodeViewWrapper>
     );

--- a/apps/web/src/components/docs/extensions/page-embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/page-embed-node.tsx
@@ -153,18 +153,18 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
           onSubmit={handleSubmit}
           className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/4 px-4 py-3"
         >
-          <FileText className="size-4 shrink-0 text-[color:var(--operator-muted)]" />
+          <FileText className="size-4 shrink-0 text-muted-foreground" />
           <input
             type="text"
             value={inputSlug}
             onChange={(e) => setInputSlug(e.target.value)}
             placeholder="Enter document slug or ID…"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-[color:var(--operator-muted)]"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
             autoFocus
           />
           <button
             type="submit"
-            className="rounded-lg bg-[color:var(--operator-primary)]/14 px-3 py-1 text-xs font-medium text-[color:var(--operator-primary-soft)] hover:bg-[color:var(--operator-primary)]/24"
+            className="rounded-lg bg-brand/14 px-3 py-1 text-xs font-medium text-[color:var(--operator-primary-soft)] hover:bg-brand/24"
           >
             Embed
           </button>
@@ -177,7 +177,7 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
   if (loading) {
     return (
       <NodeViewWrapper data-testid="page-embed-loading">
-        <div className="flex items-center gap-2 rounded-xl border border-white/8 bg-white/4 px-4 py-3 text-sm text-[color:var(--operator-muted)]">
+        <div className="flex items-center gap-2 rounded-xl border border-white/8 bg-white/4 px-4 py-3 text-sm text-muted-foreground">
           <RefreshCw className="size-4 shrink-0 animate-spin" />
           <span>Loading document…</span>
         </div>
@@ -190,8 +190,8 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
     return (
       <NodeViewWrapper data-testid="page-embed-error">
         <div className="flex items-center gap-2 rounded-xl border border-white/8 bg-white/4 px-4 py-3">
-          <AlertCircle className="size-4 shrink-0 text-[color:var(--operator-muted)]" />
-          <span className="flex-1 text-sm text-[color:var(--operator-muted)]">{error}</span>
+          <AlertCircle className="size-4 shrink-0 text-muted-foreground" />
+          <span className="flex-1 text-sm text-muted-foreground">{error}</span>
           <button
             type="button"
             onClick={handleReset}
@@ -215,7 +215,7 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') onNavigate?.(doc.slug);
           }}
-          className="group flex cursor-pointer items-center gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-3 transition-colors hover:border-[color:var(--operator-primary)]/30 hover:bg-[color:var(--operator-primary)]/6"
+          className="group flex cursor-pointer items-center gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-3 transition-colors hover:border-[color:var(--operator-primary)]/30 hover:bg-brand/6"
         >
           {doc.icon ? (
             <span className="shrink-0 text-lg">{doc.icon}</span>
@@ -223,10 +223,10 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
             <FileText className="size-5 shrink-0 text-[color:var(--operator-primary-soft)]" />
           )}
           <div className="min-w-0 flex-1">
-            <p className="truncate text-sm font-medium text-[color:var(--operator-foreground)]">
+            <p className="truncate text-sm font-medium text-foreground">
               {doc.title}
             </p>
-            <p className="text-xs text-[color:var(--operator-muted)]">/{doc.slug}</p>
+            <p className="text-xs text-muted-foreground">/{doc.slug}</p>
           </div>
           <button
             type="button"
@@ -234,7 +234,7 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
               e.stopPropagation();
               handleReset();
             }}
-            className="text-xs text-[color:var(--operator-muted)] opacity-0 transition group-hover:opacity-100 hover:text-[color:var(--operator-foreground)]"
+            className="text-xs text-muted-foreground opacity-0 transition group-hover:opacity-100 hover:text-foreground"
           >
             Change
           </button>

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -349,17 +349,17 @@ const SlashMenu = forwardRef<
         data-active={isActive}
         className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
           isActive
-            ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-            : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
+            ? 'bg-brand/14 text-[color:var(--operator-primary-soft)]'
+            : 'text-foreground hover:bg-white/6'
         }`}
         onClick={() => command(item)}
       >
-        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-[color:var(--operator-primary)]/30 bg-[color:var(--operator-primary)]/10' : 'bg-muted/40'}`}>
-          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--operator-primary-soft)]' : 'text-[color:var(--operator-muted)]'}`} />
+        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-[color:var(--operator-primary)]/30 bg-brand/10' : 'bg-muted/40'}`}>
+          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--operator-primary-soft)]' : 'text-muted-foreground'}`} />
         </span>
         <span className="flex min-w-0 flex-col">
           <span className="text-xs font-medium leading-tight">{item.title}</span>
-          <span className="truncate text-[11px] text-[color:var(--operator-muted)]">{item.description}</span>
+          <span className="truncate text-[11px] text-muted-foreground">{item.description}</span>
         </span>
       </button>
     );
@@ -368,12 +368,12 @@ const SlashMenu = forwardRef<
   return (
     <div
       ref={containerRef}
-      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg"
+      className="max-h-72 w-64 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-lg"
     >
       {grouped ? (
         grouped.map((group) => (
           <div key={group.label}>
-            <p className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-[color:var(--operator-muted)]">
+            <p className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
               {group.label}
             </p>
             {group.items.map((item) => {

--- a/apps/web/src/components/docs/extensions/toggle-block.tsx
+++ b/apps/web/src/components/docs/extensions/toggle-block.tsx
@@ -53,7 +53,7 @@ function ToggleSummaryView({ getPos, editor }: ReactNodeViewProps) {
         type="button"
         contentEditable={false}
         onClick={handleToggle}
-        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-[color:var(--operator-muted)] transition-colors hover:bg-muted hover:text-[color:var(--operator-foreground)]"
+        className="flex h-5 w-5 flex-shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         aria-label={isOpen ? '접기' : '펼치기'}
       >
         {isOpen

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -56,7 +56,7 @@ function WikiLinkView({ node, editor }: ReactNodeViewProps) {
         className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] transition-colors ${
           isNotFound
             ? 'bg-red-500/10 text-red-500 hover:bg-red-500/20'
-            : 'bg-[color:var(--operator-primary)]/10 text-[color:var(--operator-primary-soft)] hover:bg-[color:var(--operator-primary)]/20'
+            : 'bg-brand/10 text-[color:var(--operator-primary-soft)] hover:bg-brand/20'
         }`}
       >
         {isNotFound
@@ -153,14 +153,14 @@ function WikiLinkMenu({
 
   if (items.length === 0) {
     return (
-      <div className="w-56 rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-3 text-xs text-[color:var(--operator-muted)] shadow-lg">
+      <div className="w-56 rounded-xl border border-white/10 bg-card p-3 text-xs text-muted-foreground shadow-lg">
         문서를 찾을 수 없습니다
       </div>
     );
   }
 
   return (
-    <div ref={menuRef} className="max-h-64 w-56 overflow-y-auto rounded-xl border border-white/10 bg-[color:var(--operator-surface)] p-1 shadow-lg">
+    <div ref={menuRef} className="max-h-64 w-56 overflow-y-auto rounded-xl border border-white/10 bg-card p-1 shadow-lg">
       {items.map((item, i) => (
         <button
           key={item.id}
@@ -168,11 +168,11 @@ function WikiLinkMenu({
           onClick={() => command(item)}
           className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
             i === selectedIndex
-              ? 'bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-              : 'text-[color:var(--operator-foreground)] hover:bg-white/6'
+              ? 'bg-brand/14 text-[color:var(--operator-primary-soft)]'
+              : 'text-foreground hover:bg-white/6'
           }`}
         >
-          <FileText className="size-3.5 flex-shrink-0 text-[color:var(--operator-muted)]" />
+          <FileText className="size-3.5 flex-shrink-0 text-muted-foreground" />
           <span className="truncate text-xs">{item.title}</span>
         </button>
       ))}

--- a/apps/web/src/components/docs/policy-doc-browser.tsx
+++ b/apps/web/src/components/docs/policy-doc-browser.tsx
@@ -111,12 +111,12 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
   const policyPanelToggleLabel = policyPanelInlineOpen || policyPanelDrawerOpen ? t('hidePolicySprints') : t('openPolicySprints');
 
   const renderSprintSidebar = ({ mode, closePanel }: { mode: 'inline' | 'drawer'; closePanel: () => void }) => (
-    <GlassPanel className="flex h-full min-h-0 flex-col overflow-hidden border-white/8 bg-[color:var(--operator-surface-soft)]/75">
+    <GlassPanel className="flex h-full min-h-0 flex-col overflow-hidden border-white/8 bg-muted/75">
       <div className="space-y-4 overflow-y-auto p-4">
         <div className="flex items-start justify-between gap-3">
           <div>
-            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-[color:var(--operator-muted)]">{t('policySprints')}</div>
-            <p className="mt-2 text-sm text-[color:var(--operator-muted)]">{t('policySprintsDescription')}</p>
+            <div className="text-[11px] font-semibold uppercase tracking-[0.22em] text-muted-foreground">{t('policySprints')}</div>
+            <p className="mt-2 text-sm text-muted-foreground">{t('policySprintsDescription')}</p>
           </div>
           {mode === 'drawer' ? (
             <Button variant="glass" size="icon-sm" aria-label={t('hidePolicySprints')} onClick={closePanel}>
@@ -125,9 +125,9 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
           ) : null}
         </div>
         {loading && sprints.length === 0 ? (
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+          <p className="text-sm text-muted-foreground">{t('loading')}</p>
         ) : sprints.length === 0 ? (
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('noSprints')}</p>
+          <p className="text-sm text-muted-foreground">{t('noSprints')}</p>
         ) : (
           <div className="space-y-2">
             {sprints.map((sprint) => {
@@ -143,12 +143,12 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
                   className={cn(
                     'w-full rounded-2xl border px-3 py-3 text-left text-sm transition-all',
                     isSelected
-                      ? 'border-[color:var(--operator-primary)]/20 bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-                      : 'border-white/8 bg-white/5 text-[color:var(--operator-foreground)]/88 hover:bg-white/8',
+                      ? 'border-[color:var(--operator-primary)]/20 bg-brand/14 text-[color:var(--operator-primary-soft)]'
+                      : 'border-white/8 bg-white/5 text-foreground/88 hover:bg-white/8',
                   )}
                 >
                   <div className="font-medium">{sprint.title}</div>
-                  {isActive ? <div className="mt-1 text-[11px] text-[color:var(--operator-tertiary)]">{t('activeSprint')}</div> : null}
+                  {isActive ? <div className="mt-1 text-[11px] text-info">{t('activeSprint')}</div> : null}
                 </button>
               );
             })}
@@ -166,7 +166,7 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
           {policyPanelToggleLabel}
         </Button>
         {selectedSprintId ? (
-          <div className="rounded-full border border-white/8 bg-white/5 px-3 py-1.5 text-xs text-[color:var(--operator-muted)]">
+          <div className="rounded-full border border-white/8 bg-white/5 px-3 py-1.5 text-xs text-muted-foreground">
             {sprints.find((sprint) => sprint.id === selectedSprintId)?.title ?? t('policySprints')}
           </div>
         ) : null}
@@ -186,23 +186,23 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
             <div className="border-b border-white/8 px-4 py-4">
               <div className="space-y-3">
                 <div>
-                  <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('policyEpics')}</div>
-                  <div className="mt-1 text-sm text-[color:var(--operator-muted)]">{t('policyEpicsDescription')}</div>
+                  <div className="text-sm font-semibold text-foreground">{t('policyEpics')}</div>
+                  <div className="mt-1 text-sm text-muted-foreground">{t('policyEpicsDescription')}</div>
                 </div>
                 <input
                   type="text"
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder={t('policySearchPlaceholder')}
-                  className="w-full rounded-2xl border border-white/8 bg-[color:var(--operator-surface-soft)]/90 px-4 py-2.5 text-sm text-[color:var(--operator-foreground)] placeholder:text-[color:var(--operator-muted)] focus:border-[color:var(--operator-primary)]/20 focus:outline-none"
+                  className="w-full rounded-2xl border border-white/8 bg-muted/90 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-[color:var(--operator-primary)]/20 focus:outline-none"
                 />
               </div>
             </div>
             <div className="px-4 py-4">
               {loading ? (
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+                <p className="text-sm text-muted-foreground">{t('loading')}</p>
               ) : docs.length === 0 ? (
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('noPolicyEpics')}</p>
+                <p className="text-sm text-muted-foreground">{t('noPolicyEpics')}</p>
               ) : (
                 <div className="space-y-2">
                   {docs.map((doc) => {
@@ -217,8 +217,8 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
                         className={cn(
                           'w-full rounded-2xl border px-3 py-3 text-left text-sm transition-all',
                           isSelected
-                            ? 'border-[color:var(--operator-primary)]/20 bg-[color:var(--operator-primary)]/14 text-[color:var(--operator-primary-soft)]'
-                            : 'border-white/8 bg-white/5 text-[color:var(--operator-foreground)]/88 hover:bg-white/8',
+                            ? 'border-[color:var(--operator-primary)]/20 bg-brand/14 text-[color:var(--operator-primary-soft)]'
+                            : 'border-white/8 bg-white/5 text-foreground/88 hover:bg-white/8',
                         )}
                       >
                         <div className="font-medium">{doc.title || doc.epic?.title || t('untitledPolicyDoc')}</div>
@@ -234,18 +234,18 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
             <div className="border-b border-white/8 px-4 py-4">
               <div className="flex items-center justify-between gap-3">
                 <div>
-                  <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{selectedDoc?.title || selectedDoc?.epic?.title || t('selectPolicyEpic')}</div>
-                  {selectedDoc ? <div className="mt-1 text-xs text-[color:var(--operator-muted)]">{t('lastUpdated')}: {new Date(selectedDoc.updated_at).toLocaleString()}</div> : null}
+                  <div className="text-sm font-semibold text-foreground">{selectedDoc?.title || selectedDoc?.epic?.title || t('selectPolicyEpic')}</div>
+                  {selectedDoc ? <div className="mt-1 text-xs text-muted-foreground">{t('lastUpdated')}: {new Date(selectedDoc.updated_at).toLocaleString()}</div> : null}
                 </div>
               </div>
             </div>
             <div className="px-4 py-4">
               {selectedDoc ? (
-                <div className="prose prose-invert prose-sm max-w-none text-[color:var(--operator-foreground)]">
+                <div className="prose prose-invert prose-sm max-w-none text-foreground">
                   <ReactMarkdown>{selectedDoc.content?.trim() || t('emptyPolicyEpic')}</ReactMarkdown>
                 </div>
               ) : (
-                <div className="flex min-h-[280px] items-center justify-center text-sm text-[color:var(--operator-muted)]">
+                <div className="flex min-h-[280px] items-center justify-center text-sm text-muted-foreground">
                   {t('selectPolicyEpic')}
                 </div>
               )}

--- a/apps/web/src/components/inbox/decisions-waiting.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.tsx
@@ -136,11 +136,11 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
   return (
     <section
       data-testid="decisions-waiting"
-      className="border-b border-white/8 bg-[color:var(--operator-surface-soft)]/40 px-4 py-3"
+      className="border-b border-white/8 bg-muted/40 px-4 py-3"
     >
       <header className="mb-2 flex items-center gap-2">
-        <Sparkles className="size-4 text-[color:var(--operator-primary)]" />
-        <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">
+        <Sparkles className="size-4 text-brand" />
+        <h2 className="text-sm font-semibold text-foreground">
           {t('decisionsWaiting')}
         </h2>
         <Badge variant="outline" className="tabular-nums">
@@ -161,7 +161,7 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
             <li
               key={item.id}
               data-testid={`decision-item-${item.id}`}
-              className="rounded-xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-3"
+              className="rounded-xl border border-white/8 bg-muted/55 p-3"
             >
               <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0 flex-1 space-y-1">
@@ -175,18 +175,18 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
                       </Badge>
                     ) : null}
                     {item.origin_chain.length > 0 ? (
-                      <span className="text-[11px] text-[color:var(--operator-muted)]">
+                      <span className="text-[11px] text-muted-foreground">
                         {item.origin_chain
                           .map((n) => `${ORIGIN_LABEL[n.type]} · ${n.id.slice(0, 8)}`)
                           .join(' → ')}
                       </span>
                     ) : null}
                   </div>
-                  <p className="text-sm font-medium text-[color:var(--operator-foreground)]">
+                  <p className="text-sm font-medium text-foreground">
                     {item.title}
                   </p>
                   {item.agent_summary ? (
-                    <p className="line-clamp-2 text-xs text-[color:var(--operator-muted)]">
+                    <p className="line-clamp-2 text-xs text-muted-foreground">
                       {item.agent_summary}
                     </p>
                   ) : null}

--- a/apps/web/src/components/kanban/kanban-list-view.tsx
+++ b/apps/web/src/components/kanban/kanban-list-view.tsx
@@ -66,7 +66,7 @@ function ListStoryRow({ story, epicMap, memberMap, onStoryClick, onChangeStatus 
             <Badge variant={PRIORITY_BADGE[story.priority] ?? 'default'} className="text-[10px] capitalize">{story.priority as string}</Badge>
           )}
           {story.story_points != null && (
-            <span className="text-[10px] text-[color:var(--operator-muted)]">{t('storyPointsBadge', { count: story.story_points })}</span>
+            <span className="text-[10px] text-muted-foreground">{t('storyPointsBadge', { count: story.story_points })}</span>
           )}
         </div>
         <p className="mt-1 text-sm font-medium text-foreground line-clamp-2 relative z-10">{story.title}</p>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -53,7 +53,7 @@ interface StoryDetailPanelProps {
 
 function taskTone(status: string) {
   if (status === 'done') return 'bg-emerald-300';
-  if (status === 'in-progress') return 'bg-[color:var(--operator-primary)]';
+  if (status === 'in-progress') return 'bg-brand';
   return 'bg-white/20';
 }
 
@@ -505,7 +505,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
               <TabsContent value="tasks" className="mt-4 space-y-2">
                 {tasks.length === 0 ? (
-                  <p className="text-sm text-[color:var(--operator-muted)]">{t('noTasks')}</p>
+                  <p className="text-sm text-muted-foreground">{t('noTasks')}</p>
                 ) : (
                   <>
                     <ul className="space-y-2">
@@ -554,9 +554,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
                 {/* Comments list */}
                 {loadingComments ? (
-                  <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+                  <p className="text-sm text-muted-foreground">{t('loading')}</p>
                 ) : comments.length === 0 ? (
-                  <p className="text-sm text-[color:var(--operator-muted)]">No comments yet</p>
+                  <p className="text-sm text-muted-foreground">No comments yet</p>
                 ) : (
                   <>
                     <ul className="space-y-3">
@@ -582,9 +582,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
 
               <TabsContent value="activity" className="mt-4 space-y-2">
                 {loadingActivities ? (
-                  <p className="text-sm text-[color:var(--operator-muted)]">{t('loading')}</p>
+                  <p className="text-sm text-muted-foreground">{t('loading')}</p>
                 ) : activities.length === 0 ? (
-                  <p className="text-sm text-[color:var(--operator-muted)]">No activity yet</p>
+                  <p className="text-sm text-muted-foreground">No activity yet</p>
                 ) : (
                   <>
                     <ul className="space-y-2">

--- a/apps/web/src/components/locale-switcher.tsx
+++ b/apps/web/src/components/locale-switcher.tsx
@@ -23,7 +23,7 @@ export function LocaleSwitcher({ className = '' }: { className?: string }) {
       type="button"
       onClick={handleToggle}
       title={locale === 'en' ? '한국어로 변경' : 'Switch to English'}
-      className={`flex items-center gap-1 rounded-xl px-2 py-1.5 text-xs font-medium text-[color:var(--operator-muted)] transition hover:bg-[color:var(--operator-surface-soft)] hover:text-[color:var(--operator-foreground)] ${className}`.trim()}
+      className={`flex items-center gap-1 rounded-xl px-2 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground ${className}`.trim()}
     >
       <Globe className="h-3.5 w-3.5" />
       <span>{locale.toUpperCase()}</span>

--- a/apps/web/src/components/mockups/mockup-editor-shell.tsx
+++ b/apps/web/src/components/mockups/mockup-editor-shell.tsx
@@ -58,7 +58,7 @@ interface MockupEditorShellProps {
 
 const GRID_SIZE = 16;
 const SNAP_THRESHOLD = 6;
-const TINY_BUTTON_CLASS = 'rounded-xl border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-2.5 py-1.5 text-[11px] text-[color:var(--operator-foreground)] transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
+const TINY_BUTTON_CLASS = 'rounded-xl border border-white/10 bg-muted/55 px-2.5 py-1.5 text-[11px] text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
 
 function cloneState(components: MockupComponent[]) {
   return cloneMockupComponents(components);
@@ -799,7 +799,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
 
   if (loading) return <PageSkeleton />;
   if (isMobileView) {
-    return <div className="flex min-h-screen items-center justify-center p-6 text-sm text-[color:var(--operator-muted)]">{t('desktopOnly')}</div>;
+    return <div className="flex min-h-screen items-center justify-center p-6 text-sm text-muted-foreground">{t('desktopOnly')}</div>;
   }
 
   const stageScale = zoom / 100;
@@ -829,7 +829,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
         className="select-none"
       >
         <div
-          className={`relative h-full w-full overflow-hidden rounded-2xl border bg-white shadow-sm transition ${isSelected ? 'border-[color:var(--operator-primary)] ring-2 ring-[color:var(--operator-primary)]/25' : 'border-white/10 hover:border-[color:var(--operator-primary)]/18'} ${canContainChildren ? 'bg-[color:var(--operator-panel)]/70' : ''}`}
+          className={`relative h-full w-full overflow-hidden rounded-2xl border bg-white shadow-sm transition ${isSelected ? 'border-[color:var(--operator-primary)] ring-2 ring-[color:var(--operator-primary)]/25' : 'border-white/10 hover:border-[color:var(--operator-primary)]/18'} ${canContainChildren ? 'bg-muted/70' : ''}`}
           onMouseDown={(event) => {
             if (event.button !== 0) return;
             event.stopPropagation();
@@ -854,7 +854,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
             </div>
           ) : null}
           {selectedIds.length > 1 && isSelected ? (
-            <div className="pointer-events-none absolute right-2 top-2 rounded-full bg-[color:var(--operator-primary)] px-2 py-0.5 text-[10px] font-medium text-white shadow-sm">
+            <div className="pointer-events-none absolute right-2 top-2 rounded-full bg-brand px-2 py-0.5 text-[10px] font-medium text-white shadow-sm">
               ✓
             </div>
           ) : null}
@@ -868,7 +868,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
     );
   }
 
-  const panelButtonClass = 'rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-2 text-xs text-[color:var(--operator-foreground)] transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
+  const panelButtonClass = 'rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-xs text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
 
   return (
     <div className="space-y-4">
@@ -880,10 +880,10 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
               setTitle(event.target.value);
               setHasChanges(true);
             }}
-            className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-[color:var(--operator-panel)] px-4 py-3 text-sm font-semibold text-[color:var(--operator-foreground)] outline-none ring-0 placeholder:text-[color:var(--operator-muted)]"
+            className="min-w-0 flex-1 rounded-2xl border border-white/10 bg-muted px-4 py-3 text-sm font-semibold text-foreground outline-none ring-0 placeholder:text-muted-foreground"
             placeholder={t('titlePlaceholder')}
           />
-          <span className="rounded-full border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-1 text-[11px] text-[color:var(--operator-muted)]">
+          <span className="rounded-full border border-white/10 bg-muted/55 px-3 py-1 text-[11px] text-muted-foreground">
             {components.length} {t('components')}
           </span>
           <span className={`rounded-full px-3 py-1 text-[11px] ${hasChanges ? 'bg-amber-500/15 text-amber-400' : 'border border-white/10 bg-emerald-500/10 text-emerald-400'}`}>
@@ -892,7 +892,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <button type="button" className={panelButtonClass} onClick={() => setZoom((current) => Math.max(25, current - 25))}>-</button>
-          <span className="rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-2 text-xs text-[color:var(--operator-muted)]">{zoom}%</span>
+          <span className="rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-xs text-muted-foreground">{zoom}%</span>
           <button type="button" className={panelButtonClass} onClick={() => setZoom((current) => Math.min(400, current + 25))}>+</button>
           <button type="button" className={panelButtonClass} onClick={() => setZoom(100)}>{t('resetZoom')}</button>
           <button type="button" className={panelButtonClass} onClick={() => setShowGrid((current) => !current)}>{showGrid ? t('gridOn') : t('gridOff')}</button>
@@ -909,11 +909,11 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
       </div>
 
       <div className="grid gap-4 xl:grid-cols-[300px_minmax(0,1fr)_340px]">
-        <aside className="rounded-3xl border border-white/10 bg-[color:var(--operator-panel)]/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl">
+        <aside className="rounded-3xl border border-white/10 bg-muted/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl">
           <div className="mb-4 flex items-center justify-between gap-2">
             <div>
-              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('components')}</div>
-              <div className="text-[11px] text-[color:var(--operator-muted)]">{t('treeCanvasSync')}</div>
+              <div className="text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('components')}</div>
+              <div className="text-[11px] text-muted-foreground">{t('treeCanvasSync')}</div>
             </div>
           </div>
           <div className="space-y-2">
@@ -921,20 +921,20 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
               <button
                 key={item.type}
                 type="button"
-                className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-2 text-left text-xs text-[color:var(--operator-foreground)] transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
+                className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-left text-xs text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
                 onClick={() => createComponent(item.type)}
               >
                 <span className="flex items-center gap-2"><span>{item.icon}</span> {item.type}</span>
-                <span className="text-[10px] text-[color:var(--operator-muted)]">{getDefaultComponentSize(item.type).w}×{getDefaultComponentSize(item.type).h}</span>
+                <span className="text-[10px] text-muted-foreground">{getDefaultComponentSize(item.type).w}×{getDefaultComponentSize(item.type).h}</span>
               </button>
             ))}
           </div>
 
           <div className="mt-6">
-            <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('scenarios')}</div>
+            <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('scenarios')}</div>
             <div className="space-y-1">
               {scenarios.map((scenario) => (
-                <div key={scenario.id} className={`flex items-center gap-2 rounded-2xl px-2 py-1.5 ${activeScenarioId === scenario.id ? 'bg-[color:var(--operator-primary)]/12' : ''}`}>
+                <div key={scenario.id} className={`flex items-center gap-2 rounded-2xl px-2 py-1.5 ${activeScenarioId === scenario.id ? 'bg-brand/12' : ''}`}>
                   {editingScenarioId === scenario.id ? (
                     <input
                       value={editingName}
@@ -944,7 +944,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                         if (event.key === 'Enter') void renameScenario(scenario.id);
                       }}
                       autoFocus
-                      className="w-full rounded-xl border border-white/10 bg-[color:var(--operator-surface-soft)] px-2 py-1 text-xs text-[color:var(--operator-foreground)] outline-none"
+                      className="w-full rounded-xl border border-white/10 bg-muted px-2 py-1 text-xs text-foreground outline-none"
                     />
                   ) : (
                     <button
@@ -954,7 +954,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                         setEditingScenarioId(scenario.id);
                         setEditingName(scenario.name);
                       }}
-                      className="flex-1 truncate text-left text-xs text-[color:var(--operator-foreground)]"
+                      className="flex-1 truncate text-left text-xs text-foreground"
                     >
                       {scenario.is_default ? `⭐ ${t('defaultScenario')}` : scenario.name}
                     </button>
@@ -964,40 +964,40 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                   ) : null}
                 </div>
               ))}
-              <button type="button" className="w-full rounded-2xl border border-dashed border-white/12 px-3 py-2 text-xs text-[color:var(--operator-muted)] transition hover:border-[color:var(--operator-primary)]/24 hover:text-[color:var(--operator-primary-soft)]" onClick={() => void addScenario()}>
+              <button type="button" className="w-full rounded-2xl border border-dashed border-white/12 px-3 py-2 text-xs text-muted-foreground transition hover:border-[color:var(--operator-primary)]/24 hover:text-[color:var(--operator-primary-soft)]" onClick={() => void addScenario()}>
                 + {t('addScenario')}
               </button>
             </div>
           </div>
 
           <div className="mt-6">
-            <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('componentTree')}</div>
+            <div className="mb-3 text-xs font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('componentTree')}</div>
             <div className="space-y-0.5">
               {buildTreeNodeRows(renderedNodes).map(({ node, depth }) => (
                 <button
                   key={node.component.id}
                   type="button"
                   onClick={(event) => handleTreeSelect(node.component.id, event)}
-                  className={`flex w-full items-center gap-2 rounded-2xl px-2 py-1.5 text-left text-[11px] transition ${selectedIds.includes(node.component.id) ? 'bg-[color:var(--operator-primary)]/12 text-[color:var(--operator-primary-soft)]' : 'text-[color:var(--operator-muted)] hover:bg-white/8'}`}
+                  className={`flex w-full items-center gap-2 rounded-2xl px-2 py-1.5 text-left text-[11px] transition ${selectedIds.includes(node.component.id) ? 'bg-brand/12 text-[color:var(--operator-primary-soft)]' : 'text-muted-foreground hover:bg-white/8'}`}
                   style={{ paddingLeft: `${8 + depth * 14}px` }}
                 >
                   <span className="text-[10px]">{componentPaletteEntry(node.component.component_type)?.icon ?? '⬚'}</span>
                   <span className="truncate">{node.component.component_type}</span>
-                  <span className="ml-auto text-[10px] text-[color:var(--operator-muted)]">z:{node.box.zIndex}</span>
+                  <span className="ml-auto text-[10px] text-muted-foreground">z:{node.box.zIndex}</span>
                 </button>
               ))}
-              {!renderedNodes.length ? <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-xs text-[color:var(--operator-muted)]">{t('dragHere')}</div> : null}
+              {!renderedNodes.length ? <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-xs text-muted-foreground">{t('dragHere')}</div> : null}
             </div>
           </div>
         </aside>
 
-        <main className="rounded-3xl border border-white/10 bg-[color:var(--operator-panel)]/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl" onMouseDown={(event) => {
+        <main className="rounded-3xl border border-white/10 bg-muted/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl" onMouseDown={(event) => {
           if (event.target === event.currentTarget) clearSelection();
         }}>
           <div className="mb-3 flex items-center justify-between gap-3">
-            <div className="flex flex-wrap items-center gap-2 text-xs text-[color:var(--operator-muted)]">
-              <span className="rounded-full border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-1">{selectedIds.length ? `${selectedIds.length} ${t('selected')}` : t('selectComponent')}</span>
-              {selectedIds.length > 1 ? <span className="rounded-full border border-white/10 bg-[color:var(--operator-surface-soft)]/55 px-3 py-1">{t('multiSelect')}</span> : null}
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span className="rounded-full border border-white/10 bg-muted/55 px-3 py-1">{selectedIds.length ? `${selectedIds.length} ${t('selected')}` : t('selectComponent')}</span>
+              {selectedIds.length > 1 ? <span className="rounded-full border border-white/10 bg-muted/55 px-3 py-1">{t('multiSelect')}</span> : null}
             </div>
             <div className="flex flex-wrap gap-2">
               <button type="button" className={TINY_BUTTON_CLASS} onClick={() => applyAlignment('left')} disabled={selectedIds.length < 2}>{t('alignLeft')}</button>
@@ -1059,30 +1059,30 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
           </div>
         </main>
 
-        <aside className="rounded-3xl border border-white/10 bg-[color:var(--operator-panel)]/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl">
+        <aside className="rounded-3xl border border-white/10 bg-muted/82 p-4 shadow-[0_18px_50px_rgba(0,0,0,0.24)] backdrop-blur-xl">
           {showVersions ? (
             <div>
-              <div className="mb-3 text-sm font-semibold text-[color:var(--operator-foreground)]">{t('versionHistory')}</div>
+              <div className="mb-3 text-sm font-semibold text-foreground">{t('versionHistory')}</div>
               <div className="space-y-2">
                 {versions.length ? versions.map((version) => (
-                  <div key={version.id} className="rounded-2xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 p-3">
+                  <div key={version.id} className="rounded-2xl border border-white/8 bg-muted/55 p-3">
                     <div className="flex items-center justify-between gap-2">
                       <div>
-                        <div className="text-xs font-medium text-[color:var(--operator-foreground)]">v{version.version}</div>
-                        <div className="text-[10px] text-[color:var(--operator-muted)]">{new Date(version.created_at).toLocaleString()}</div>
+                        <div className="text-xs font-medium text-foreground">v{version.version}</div>
+                        <div className="text-[10px] text-muted-foreground">{new Date(version.created_at).toLocaleString()}</div>
                       </div>
                       <button type="button" className={TINY_BUTTON_CLASS} onClick={() => void restoreVersion(version.id)}>{t('restore')}</button>
                     </div>
                   </div>
-                )) : <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-xs text-[color:var(--operator-muted)]">{t('noVersions')}</div>}
+                )) : <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-xs text-muted-foreground">{t('noVersions')}</div>}
               </div>
             </div>
           ) : selectedComponent ? (
             <div>
               <div className="mb-3 flex items-center justify-between gap-2">
                 <div>
-                  <div className="text-sm font-semibold text-[color:var(--operator-foreground)]">{selectedComponent.component_type}</div>
-                  <div className="text-[10px] text-[color:var(--operator-muted)]">{selectedComponent.id}</div>
+                  <div className="text-sm font-semibold text-foreground">{selectedComponent.component_type}</div>
+                  <div className="text-[10px] text-muted-foreground">{selectedComponent.id}</div>
                 </div>
                 <button type="button" className={TINY_BUTTON_CLASS} onClick={deleteSelection}>{t('deleteSelected')}</button>
               </div>
@@ -1090,24 +1090,24 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
               <div className="space-y-2">
                 {Object.entries(selectedComponent.props).map(([key, value]) => (
                   <div key={key}>
-                    <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--operator-muted)]">{key}</label>
+                    <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">{key}</label>
                     <input
                       type={typeof value === 'number' ? 'number' : 'text'}
                       value={typeof value === 'object' && value !== null ? JSON.stringify(value) : String(value ?? '')}
                       onChange={(event) => updateSelectedProp(key, event.target.value)}
-                      className="w-full rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)] px-3 py-2 text-xs text-[color:var(--operator-foreground)] outline-none"
+                      className="w-full rounded-2xl border border-white/10 bg-muted px-3 py-2 text-xs text-foreground outline-none"
                     />
                   </div>
                 ))}
               </div>
 
               <div className="mt-4">
-                <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--operator-muted)]">{t('specDescription')}</label>
+                <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-muted-foreground">{t('specDescription')}</label>
                 <textarea
                   value={selectedComponent.spec_description ?? ''}
                   onChange={(event) => updateSelectedSpec(event.target.value)}
                   rows={5}
-                  className="w-full rounded-2xl border border-white/10 bg-[color:var(--operator-surface-soft)] px-3 py-2 text-xs text-[color:var(--operator-foreground)] outline-none"
+                  className="w-full rounded-2xl border border-white/10 bg-muted px-3 py-2 text-xs text-foreground outline-none"
                   placeholder={t('markdownPlaceholder')}
                 />
               </div>
@@ -1118,7 +1118,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                   if (!scenario) return null;
                   const overrides = scenario.override_props[selectedComponent.id] ?? {};
                   return (
-                    <div className="mt-4 rounded-2xl border border-[color:var(--operator-primary)]/20 bg-[color:var(--operator-primary)]/10 p-3">
+                    <div className="mt-4 rounded-2xl border border-[color:var(--operator-primary)]/20 bg-brand/10 p-3">
                       <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--operator-primary-soft)]">
                         {scenario.is_default ? t('defaultScenario') : scenario.name} {t('overrides')}
                       </div>
@@ -1139,7 +1139,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                                 }
                                 await saveScenarioOverrides(activeScenarioId, nextOverrides);
                               }}
-                              className="w-full rounded-2xl border border-white/10 bg-[color:var(--operator-panel)] px-3 py-2 text-xs text-[color:var(--operator-foreground)] outline-none"
+                              className="w-full rounded-2xl border border-white/10 bg-muted px-3 py-2 text-xs text-foreground outline-none"
                             />
                           </div>
                         ))}
@@ -1150,7 +1150,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
               ) : null}
             </div>
           ) : (
-            <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-sm text-[color:var(--operator-muted)]">
+            <div className="rounded-2xl border border-dashed border-white/12 px-3 py-6 text-center text-sm text-muted-foreground">
               {t('selectComponent')}
             </div>
           )}

--- a/apps/web/src/components/nav/theme-toggle.tsx
+++ b/apps/web/src/components/nav/theme-toggle.tsx
@@ -30,7 +30,7 @@ export function ThemeToggle({ className = '' }: { className?: string }) {
             className={`rounded-xl p-1.5 transition ${
               isActive
                 ? 'bg-primary text-primary-foreground shadow-sm'
-                : 'text-[color:var(--operator-muted)] hover:bg-[color:var(--operator-surface-soft)] hover:text-[color:var(--operator-foreground)]'
+                : 'text-muted-foreground hover:bg-muted hover:text-foreground'
             }`}
           >
             <Icon className="size-4" />

--- a/apps/web/src/components/settings/byom-key-management.tsx
+++ b/apps/web/src/components/settings/byom-key-management.tsx
@@ -180,11 +180,11 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
       <SectionCard>
         <SectionCardHeader>
           <div className="space-y-1">
-            <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('title')}</h2>
+            <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
           </div>
         </SectionCardHeader>
         <SectionCardBody>
-          <div className="h-24 animate-pulse rounded-2xl bg-[color:var(--operator-surface-soft)]" />
+          <div className="h-24 animate-pulse rounded-2xl bg-muted" />
         </SectionCardBody>
       </SectionCard>
     );
@@ -195,27 +195,27 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
       <SectionCard>
         <SectionCardHeader>
           <div className="space-y-1">
-            <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('title')}</h2>
-            <p className="text-sm text-[color:var(--operator-muted)]">{t('description')}</p>
+            <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
+            <p className="text-sm text-muted-foreground">{t('description')}</p>
           </div>
         </SectionCardHeader>
         <SectionCardBody className="space-y-4">
           {/* Saved key summary */}
           {savedKey ? (
-            <div className="flex items-center justify-between rounded-2xl border border-white/8 bg-[color:var(--operator-surface-soft)]/55 px-4 py-3">
+            <div className="flex items-center justify-between rounded-2xl border border-white/8 bg-muted/55 px-4 py-3">
               <div className="space-y-1">
                 <div className="flex items-center gap-2">
                   <Badge variant="info">{PROVIDER_LABELS[savedKey.provider]}</Badge>
                   {savedKey.model ? <Badge variant="outline">{savedKey.model}</Badge> : null}
                 </div>
-                <div className="flex items-center gap-2 text-xs text-[color:var(--operator-muted)]">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <span>{t('savedKeyLabel')}</span>
-                  <code className="rounded bg-white/5 px-1.5 py-0.5 font-mono text-[color:var(--operator-foreground)]">
+                  <code className="rounded bg-white/5 px-1.5 py-0.5 font-mono text-foreground">
                     {savedKey.maskedKey}
                   </code>
                 </div>
                 {savedKey.baseUrl ? (
-                  <div className="text-xs text-[color:var(--operator-muted)]">
+                  <div className="text-xs text-muted-foreground">
                     {t('baseUrlSavedLabel')} <code className="rounded bg-white/5 px-1.5 py-0.5">{savedKey.baseUrl}</code>
                   </div>
                 ) : null}
@@ -233,7 +233,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
           {/* Key input form */}
           <div className="space-y-3">
             <div>
-              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">
+              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 {t('providerLabel')}
               </label>
               <OperatorDropdownSelect
@@ -249,7 +249,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
             </div>
 
             <div>
-              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">
+              <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                 {t('apiKeyLabel')}
               </label>
               <div className="flex gap-2">
@@ -268,7 +268,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
                   <button
                     type="button"
                     onClick={() => setShowKey((prev) => !prev)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-[color:var(--operator-muted)] hover:text-[color:var(--operator-foreground)] transition"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-xs text-muted-foreground hover:text-foreground transition"
                     aria-label={showKey ? t('hideKey') : t('showKey')}
                   >
                     {showKey ? t('hideKey') : t('showKey')}
@@ -279,7 +279,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
 
             {requiresBaseUrl ? (
               <div>
-                <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">
+                <label className="mb-1.5 block text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
                   {t('baseUrlLabel')}
                 </label>
                 <OperatorInput
@@ -293,7 +293,7 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
                   }}
                   placeholder={t('baseUrlPlaceholder')}
                 />
-                <p className="mt-1 text-xs text-[color:var(--operator-muted)]">{t('baseUrlHint')}</p>
+                <p className="mt-1 text-xs text-muted-foreground">{t('baseUrlHint')}</p>
               </div>
             ) : null}
 
@@ -352,9 +352,9 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
       {/* Delete confirmation dialog */}
       {showDeleteConfirm ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-          <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-[color:var(--operator-panel)] p-6 shadow-xl backdrop-blur-xl">
+          <div className="w-full max-w-sm rounded-3xl border border-white/10 bg-muted p-6 shadow-xl backdrop-blur-xl">
             <h3 className="text-lg font-semibold text-rose-100">{t('deleteConfirmTitle')}</h3>
-            <p className="mt-2 text-sm text-[color:var(--operator-muted)]">{t('deleteConfirmDesc')}</p>
+            <p className="mt-2 text-sm text-muted-foreground">{t('deleteConfirmDesc')}</p>
             <div className="mt-6 flex gap-3">
               <Button variant="glass" className="flex-1" onClick={() => setShowDeleteConfirm(false)}>
                 {tc('cancel')}

--- a/apps/web/src/components/settings/mcp-connection-settings.tsx
+++ b/apps/web/src/components/settings/mcp-connection-settings.tsx
@@ -180,8 +180,8 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
     <SectionCard>
       <SectionCardHeader>
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('title')}</h2>
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('description')}</p>
+          <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
+          <p className="text-sm text-muted-foreground">{t('description')}</p>
         </div>
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
@@ -192,22 +192,22 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
         ) : null}
 
         {loading ? (
-          <div className="h-32 animate-pulse rounded-2xl bg-[color:var(--operator-surface-soft)]" />
+          <div className="h-32 animate-pulse rounded-2xl bg-muted" />
         ) : (
           <div className="space-y-4">
             {connections.map((connection) => {
               const isOAuth = connection.authStrategy === 'oauth';
               const canSave = !isOAuth && Boolean(secretDrafts[connection.serverKey]?.trim());
               return (
-                <div key={connection.serverKey} className="rounded-3xl border border-white/10 bg-[color:var(--operator-surface-soft)]/45 p-4">
+                <div key={connection.serverKey} className="rounded-3xl border border-white/10 bg-muted/45 p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="space-y-2">
                       <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{connection.displayName}</h3>
+                        <h3 className="text-sm font-semibold text-foreground">{connection.displayName}</h3>
                         <Badge variant={STATUS_VARIANTS[connection.status]}>{t(`status.${connection.status}`)}</Badge>
                         <Badge variant="outline">{t(`auth.${connection.authStrategy}`)}</Badge>
                       </div>
-                      <div className="space-y-1 text-xs text-[color:var(--operator-muted)]">
+                      <div className="space-y-1 text-xs text-muted-foreground">
                         {connection.label ? <div>{t('labelValue', { label: connection.label })}</div> : null}
                         {connection.maskedSecret ? <div>{t('maskedSecretValue', { secret: connection.maskedSecret })}</div> : null}
                         <div>{t('toolCountValue', { count: connection.toolNames.length })}</div>
@@ -275,8 +275,8 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
 
         <div className="rounded-3xl border border-dashed border-white/10 p-4">
           <div className="space-y-1">
-            <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">{t('customRequestTitle')}</h3>
-            <p className="text-sm text-[color:var(--operator-muted)]">{t('customRequestDescription')}</p>
+            <h3 className="text-sm font-semibold text-foreground">{t('customRequestTitle')}</h3>
+            <p className="text-sm text-muted-foreground">{t('customRequestDescription')}</p>
           </div>
           <div className="mt-4 space-y-3">
             <OperatorInput value={requestName} onChange={(event) => setRequestName(event.target.value)} placeholder={t('requestNamePlaceholder')} />

--- a/apps/web/src/components/settings/slack-integration-settings.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings.tsx
@@ -231,9 +231,9 @@ export function SlackIntegrationSettingsSection() {
             <div className="space-y-1">
               <div className="flex items-center gap-2">
                 <MessageSquareShare className="size-4 text-[color:var(--operator-primary-soft)]" />
-                <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">{t('title')}</h2>
+                <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
               </div>
-              <p className="text-sm text-[color:var(--operator-muted)]">{t('description')}</p>
+              <p className="text-sm text-muted-foreground">{t('description')}</p>
             </div>
             <div className="flex flex-wrap items-center gap-2">
               <Badge variant={data.status === 'connected' ? 'success' : data.status === 'channel_fetch_error' ? 'destructive' : 'outline'}>
@@ -245,15 +245,15 @@ export function SlackIntegrationSettingsSection() {
         </SectionCardHeader>
         <SectionCardBody className="space-y-4">
           <div className="grid gap-4 xl:grid-cols-[minmax(0,1.35fr)_360px]">
-            <GlassPanel className="overflow-hidden border-white/8 bg-[color:var(--operator-surface-soft)]/40">
+            <GlassPanel className="overflow-hidden border-white/8 bg-muted/40">
               <div className="border-b border-white/8 px-5 py-4">
                 <div className="flex flex-wrap items-start justify-between gap-3">
                   <div className="space-y-1">
-                    <p className="text-xs uppercase tracking-[0.24em] text-[color:var(--operator-muted)]">{t('workspaceLabel')}</p>
-                    <h3 className="text-lg font-semibold text-[color:var(--operator-foreground)]">
+                    <p className="text-xs uppercase tracking-[0.24em] text-muted-foreground">{t('workspaceLabel')}</p>
+                    <h3 className="text-lg font-semibold text-foreground">
                       {data.workspace?.team_name ?? t('workspaceDisconnected')}
                     </h3>
-                    <p className="text-sm text-[color:var(--operator-muted)]">
+                    <p className="text-sm text-muted-foreground">
                       {data.workspace?.team_id ? t('workspaceConnectedSummary', { teamId: data.workspace.team_id }) : t('workspaceDisconnectedSummary')}
                     </p>
                   </div>
@@ -272,27 +272,27 @@ export function SlackIntegrationSettingsSection() {
               </div>
               <div className="grid gap-3 px-5 py-4 sm:grid-cols-3">
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">{t('metricChannels')}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[color:var(--operator-foreground)]">{data.channels.length}</p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricChannels')}</p>
+                  <p className="mt-2 text-2xl font-semibold text-foreground">{data.channels.length}</p>
                 </div>
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">{t('metricMapped')}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[color:var(--operator-foreground)]">{data.mappings.length}</p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricMapped')}</p>
+                  <p className="mt-2 text-2xl font-semibold text-foreground">{data.mappings.length}</p>
                 </div>
                 <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3">
-                  <p className="text-xs uppercase tracking-[0.2em] text-[color:var(--operator-muted)]">{t('metricDirty')}</p>
-                  <p className="mt-2 text-2xl font-semibold text-[color:var(--operator-foreground)]">{allDirtyChannels.length}</p>
+                  <p className="text-xs uppercase tracking-[0.2em] text-muted-foreground">{t('metricDirty')}</p>
+                  <p className="mt-2 text-2xl font-semibold text-foreground">{allDirtyChannels.length}</p>
                 </div>
               </div>
             </GlassPanel>
 
-            <GlassPanel className="border-white/8 bg-[color:var(--operator-surface-soft)]/40 p-5">
+            <GlassPanel className="border-white/8 bg-muted/40 p-5">
               <div className="space-y-3">
-                <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--operator-foreground)]">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground">
                   <CheckCircle2 className="size-4 text-emerald-300" />
                   {t('actionPanelTitle')}
                 </div>
-                <p className="text-sm text-[color:var(--operator-muted)]">{t('actionPanelDescription')}</p>
+                <p className="text-sm text-muted-foreground">{t('actionPanelDescription')}</p>
                 <Button variant="hero" size="lg" className="w-full" disabled={allDirtyChannels.length === 0 || saving} onClick={() => void handleSaveAll()}>
                   {saving ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
                   {allDirtyChannels.length > 0 ? t('savePending', { count: allDirtyChannels.length }) : t('saveIdle')}
@@ -301,7 +301,7 @@ export function SlackIntegrationSettingsSection() {
                   {loading ? <Loader2 className="mr-2 size-4 animate-spin" /> : <RefreshCcw className="mr-2 size-4" />}
                   {t('refresh')}
                 </Button>
-                <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3 text-xs text-[color:var(--operator-muted)]">
+                <div className="rounded-2xl border border-white/8 bg-black/10 px-4 py-3 text-xs text-muted-foreground">
                   {t('helperText')}
                 </div>
               </div>
@@ -322,23 +322,23 @@ export function SlackIntegrationSettingsSection() {
 
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <label className="relative block w-full md:max-w-sm">
-              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[color:var(--operator-muted)]" />
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <OperatorInput value={search} onChange={(event) => setSearch(event.target.value)} placeholder={t('searchPlaceholder')} className="pl-9" />
             </label>
-            <p className="text-xs text-[color:var(--operator-muted)]">{t('resultCount', { count: filteredChannels.length })}</p>
+            <p className="text-xs text-muted-foreground">{t('resultCount', { count: filteredChannels.length })}</p>
           </div>
 
           {loading ? (
             <div className="grid gap-3">
               {[1, 2, 3].map((item) => (
-                <div key={item} className="h-28 animate-pulse rounded-3xl border border-white/8 bg-[color:var(--operator-surface-soft)]/45" />
+                <div key={item} className="h-28 animate-pulse rounded-3xl border border-white/8 bg-muted/45" />
               ))}
             </div>
           ) : data.status === 'disconnected' ? (
-            <GlassPanel className="border-dashed border-white/14 bg-[color:var(--operator-surface-soft)]/28 p-6 text-center">
+            <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
               <MessageSquareShare className="mx-auto size-9 text-[color:var(--operator-primary-soft)]" />
-              <h3 className="mt-4 text-lg font-semibold text-[color:var(--operator-foreground)]">{t('disconnectedTitle')}</h3>
-              <p className="mx-auto mt-2 max-w-2xl text-sm text-[color:var(--operator-muted)]">{t('disconnectedBody')}</p>
+              <h3 className="mt-4 text-lg font-semibold text-foreground">{t('disconnectedTitle')}</h3>
+              <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('disconnectedBody')}</p>
               <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
                 <Button variant="hero" size="lg" disabled={!data.connect_url} onClick={() => data.connect_url && (window.location.href = data.connect_url)}>
                   <MessageSquareShare className="mr-2 size-4" />
@@ -351,10 +351,10 @@ export function SlackIntegrationSettingsSection() {
               </div>
             </GlassPanel>
           ) : filteredChannels.length === 0 ? (
-            <GlassPanel className="border-dashed border-white/14 bg-[color:var(--operator-surface-soft)]/28 p-6 text-center">
+            <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
               <MessageSquareShare className="mx-auto size-9 text-[color:var(--operator-primary-soft)]" />
-              <h3 className="mt-4 text-lg font-semibold text-[color:var(--operator-foreground)]">{t('emptyTitle')}</h3>
-              <p className="mx-auto mt-2 max-w-2xl text-sm text-[color:var(--operator-muted)]">{t('emptyBody')}</p>
+              <h3 className="mt-4 text-lg font-semibold text-foreground">{t('emptyTitle')}</h3>
+              <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('emptyBody')}</p>
             </GlassPanel>
           ) : (
             <div className="grid gap-3">
@@ -366,28 +366,28 @@ export function SlackIntegrationSettingsSection() {
                 const mappedElsewhere = Boolean(currentProjectId && currentMapping?.project_id && currentMapping.project_id !== currentProjectId);
 
                 return (
-                  <GlassPanel key={channel.id} className="border-white/8 bg-[color:var(--operator-surface-soft)]/42 p-4">
+                  <GlassPanel key={channel.id} className="border-white/8 bg-muted/42 p-4">
                     <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                       <div className="space-y-3">
                         <div className="flex flex-wrap items-center gap-2">
-                          <h3 className="text-sm font-semibold text-[color:var(--operator-foreground)]">#{channel.name}</h3>
+                          <h3 className="text-sm font-semibold text-foreground">#{channel.name}</h3>
                           {channel.is_private ? <Badge variant="outline">{t('privateBadge')}</Badge> : <Badge variant="outline">{t('publicBadge')}</Badge>}
                           {channel.is_member ? <Badge variant="success">{t('joinedBadge')}</Badge> : <Badge variant="outline">{t('notJoinedBadge')}</Badge>}
                           {mappedElsewhere ? <Badge variant="info">{t('mappedElsewhereBadge')}</Badge> : null}
                         </div>
-                        <div className="flex flex-wrap items-center gap-3 text-xs text-[color:var(--operator-muted)]">
+                        <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
                           <span>{t('channelId', { id: channel.id })}</span>
                           {channel.member_count ? <span>{t('memberCount', { count: channel.member_count })}</span> : null}
                         </div>
                         <div className="rounded-2xl border border-white/8 bg-black/10 px-3 py-3 text-sm">
-                          <p className="text-[color:var(--operator-muted)]">{t('mappedProjectLabel')}</p>
-                          <p className="mt-1 font-medium text-[color:var(--operator-foreground)]">{currentMapping?.project_name ?? t('unmapped')}</p>
+                          <p className="text-muted-foreground">{t('mappedProjectLabel')}</p>
+                          <p className="mt-1 font-medium text-foreground">{currentMapping?.project_name ?? t('unmapped')}</p>
                         </div>
                       </div>
 
                       <div className="grid flex-1 gap-3 xl:max-w-xl xl:grid-cols-[minmax(0,1fr)_auto]">
                         <div className="space-y-2">
-                          <label className="text-xs uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('selectProjectLabel')}</label>
+                          <label className="text-xs uppercase tracking-[0.18em] text-muted-foreground">{t('selectProjectLabel')}</label>
                           <OperatorDropdownSelect
                             value={selectedProjectId}
                             onValueChange={(v) => setSelectedProjects((prev) => ({ ...prev, [channel.id]: v }))}
@@ -427,7 +427,7 @@ export function SlackIntegrationSettingsSection() {
                           </Button>
                         </div>
                         {mappedElsewhere ? (
-                          <div className="xl:col-span-2 rounded-2xl border border-[color:var(--operator-primary)]/18 bg-[color:var(--operator-primary)]/10 px-3 py-3 text-sm text-[color:var(--operator-primary-soft)]">
+                          <div className="xl:col-span-2 rounded-2xl border border-[color:var(--operator-primary)]/18 bg-brand/10 px-3 py-3 text-sm text-[color:var(--operator-primary-soft)]">
                             {t('mappedElsewhereHint', { project: currentMapping?.project_name ?? t('unknownProject') })}
                           </div>
                         ) : null}
@@ -448,11 +448,11 @@ export function SlackIntegrationSettingsSection() {
 
       {allDirtyChannels.length > 0 ? (
         <div className="fixed inset-x-3 bottom-24 z-40 sm:bottom-6 lg:static lg:inset-auto lg:z-auto">
-          <GlassPanel className="border-[color:var(--operator-primary)]/20 bg-[color:var(--operator-panel)]/92 p-3 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+          <GlassPanel className="border-[color:var(--operator-primary)]/20 bg-muted/92 p-3 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
-                <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{t('stickyBarTitle', { count: allDirtyChannels.length })}</p>
-                <p className="text-xs text-[color:var(--operator-muted)]">{t('stickyBarBody')}</p>
+                <p className="text-sm font-medium text-foreground">{t('stickyBarTitle', { count: allDirtyChannels.length })}</p>
+                <p className="text-xs text-muted-foreground">{t('stickyBarBody')}</p>
               </div>
               <Button variant="hero" size="lg" disabled={saving} onClick={() => void handleSaveAll()}>
                 {saving ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
@@ -464,10 +464,10 @@ export function SlackIntegrationSettingsSection() {
       ) : null}
 
       <Dialog open={Boolean(remapConflict)} onOpenChange={(open) => { if (!open) setRemapConflict(null); }}>
-        <DialogContent className="max-w-lg rounded-3xl border border-white/10 bg-[color:var(--operator-panel)] text-[color:var(--operator-foreground)] shadow-[0_30px_80px_rgba(0,0,0,0.42)]">
+        <DialogContent className="max-w-lg rounded-3xl border border-white/10 bg-muted text-foreground shadow-[0_30px_80px_rgba(0,0,0,0.42)]">
           <DialogHeader>
             <DialogTitle>{t('remapDialogTitle')}</DialogTitle>
-            <DialogDescription className="text-[color:var(--operator-muted)]">
+            <DialogDescription className="text-muted-foreground">
               {remapConflict ? t('remapDialogBody', { channel: `#${remapConflict.channelName}`, project: remapConflict.existingProjectName }) : ''}
             </DialogDescription>
           </DialogHeader>

--- a/apps/web/src/components/settings/theme-settings.tsx
+++ b/apps/web/src/components/settings/theme-settings.tsx
@@ -24,14 +24,14 @@ export function ThemeSettings() {
     <SectionCard>
       <SectionCardHeader>
         <div className="space-y-1">
-          <h2 className="text-base font-semibold text-[color:var(--operator-foreground)]">🎨 테마 설정</h2>
-          <p className="text-sm text-[color:var(--operator-muted)]">라이트 모드, 다크 모드 또는 시스템 설정을 따를 수 있습니다.</p>
+          <h2 className="text-base font-semibold text-foreground">🎨 테마 설정</h2>
+          <p className="text-sm text-muted-foreground">라이트 모드, 다크 모드 또는 시스템 설정을 따를 수 있습니다.</p>
         </div>
       </SectionCardHeader>
       <SectionCardBody>
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium mb-2 text-[color:var(--operator-foreground)]">
+            <label className="block text-sm font-medium mb-2 text-foreground">
               테마 선택
             </label>
             <OperatorDropdownSelect
@@ -46,8 +46,8 @@ export function ThemeSettings() {
           </div>
 
           {theme === 'system' && (
-            <p className="text-sm text-[color:var(--operator-muted)]">
-              현재 시스템 설정: <span className="font-medium text-[color:var(--operator-foreground)]">{currentTheme === 'dark' ? '다크 모드' : '라이트 모드'}</span>
+            <p className="text-sm text-muted-foreground">
+              현재 시스템 설정: <span className="font-medium text-foreground">{currentTheme === 'dark' ? '다크 모드' : '라이트 모드'}</span>
             </p>
           )}
         </div>

--- a/apps/web/src/components/standup/standup-board-card.tsx
+++ b/apps/web/src/components/standup/standup-board-card.tsx
@@ -37,14 +37,14 @@ export function StandupBoardCard({
       <div className="flex flex-wrap items-start justify-between gap-2 px-4 pt-4">
         <div className="min-w-0 flex-1 space-y-1">
           <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-sm font-semibold text-[color:var(--operator-foreground)]">{member.name}</span>
+            <span className="text-sm font-semibold text-foreground">{member.name}</span>
             {isCurrentUser && <Badge variant="info">{t('you')}</Badge>}
             <Badge variant={member.type === 'agent' ? 'secondary' : 'outline'}>
               {member.type === 'agent' ? t('agent') : t('human')}
             </Badge>
           </div>
           {activeSprintTitle ? (
-            <span className="text-xs text-[color:var(--operator-muted)]">{activeSprintTitle}</span>
+            <span className="text-xs text-muted-foreground">{activeSprintTitle}</span>
           ) : null}
         </div>
         {isCurrentUser && onEdit ? (
@@ -60,27 +60,27 @@ export function StandupBoardCard({
           <>
             <div className="space-y-1">
               <div className="text-xs font-semibold uppercase tracking-wider text-emerald-400">{t('doneLabel')}</div>
-              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.done ? 'text-[color:var(--operator-foreground)]/90' : 'text-[color:var(--operator-muted)]')}>
+              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.done ? 'text-foreground/90' : 'text-muted-foreground')}>
                 {entry.done || t('emptySection')}
               </p>
             </div>
             <div className="space-y-1">
               <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
-              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.plan ? 'text-[color:var(--operator-foreground)]/90' : 'text-[color:var(--operator-muted)]')}>
+              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.plan ? 'text-foreground/90' : 'text-muted-foreground')}>
                 {entry.plan || t('emptySection')}
               </p>
             </div>
             {entry.blockers ? (
               <div className="space-y-1">
                 <div className="text-xs font-semibold uppercase tracking-wider text-rose-300">{t('blockersLabel')}</div>
-                <p className="whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90 line-clamp-3">
+                <p className="whitespace-pre-wrap text-sm text-foreground/90 line-clamp-3">
                   {entry.blockers}
                 </p>
               </div>
             ) : null}
           </>
         ) : (
-          <p className="text-sm text-[color:var(--operator-muted)]">{t('notWrittenYet')}</p>
+          <p className="text-sm text-muted-foreground">{t('notWrittenYet')}</p>
         )}
       </div>
 
@@ -91,7 +91,7 @@ export function StandupBoardCard({
           {requestCount > 0 ? <Badge variant="destructive">{t('feedbackRequestChangesCount', { count: requestCount })}</Badge> : null}
           {commentCount > 0 ? <Badge variant="info">{t('feedbackCommentCount', { count: commentCount })}</Badge> : null}
           {feedback.length === 0 ? (
-            <span className="text-xs text-[color:var(--operator-muted)]">{t('feedbackCount', { count: 0 })}</span>
+            <span className="text-xs text-muted-foreground">{t('feedbackCount', { count: 0 })}</span>
           ) : null}
         </div>
         {entry && !isCurrentUser ? (

--- a/apps/web/src/components/standup/standup-feedback-dialog.tsx
+++ b/apps/web/src/components/standup/standup-feedback-dialog.tsx
@@ -185,42 +185,42 @@ export function StandupFeedbackDialog({
             <div className="grid gap-3 md:grid-cols-3">
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-semibold uppercase tracking-wider text-emerald-400">{t('doneLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.done && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.done && 'text-muted-foreground')}>
                   {entry.done || t('emptySection')}
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.plan && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.plan && 'text-muted-foreground')}>
                   {entry.plan || t('emptySection')}
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-semibold uppercase tracking-wider text-rose-300">{t('blockersLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.blockers && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.blockers && 'text-muted-foreground')}>
                   {entry.blockers || t('emptySection')}
                 </p>
               </div>
             </div>
           ) : (
-            <p className="text-sm text-[color:var(--operator-muted)]">{t('notWrittenYet')}</p>
+            <p className="text-sm text-muted-foreground">{t('notWrittenYet')}</p>
           )}
 
           {/* 연결된 스토리 */}
           {linkedStories.length > 0 ? (
             <div className="rounded-md border border-border bg-muted/30 p-3 space-y-2">
               <div className="flex items-center justify-between gap-2">
-                <p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-muted)]">{t('linkedStories')}</p>
+                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t('linkedStories')}</p>
                 <Badge variant="outline">{t('linkedStoryCount', { count: linkedStories.length })}</Badge>
               </div>
               <div className="space-y-2">
                 {linkedStories.map((story) => (
                   <div key={story.id} className="rounded-md border border-border bg-background p-3">
                     <div className="flex flex-wrap items-center justify-between gap-2">
-                      <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{story.title}</p>
+                      <p className="text-sm font-medium text-foreground">{story.title}</p>
                       <Badge variant="outline">{story.status}</Badge>
                     </div>
-                    <div className="mt-2 flex items-center gap-2 text-xs text-[color:var(--operator-muted)]">
+                    <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
                       <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
                       <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
                     </div>
@@ -239,7 +239,7 @@ export function StandupFeedbackDialog({
           {/* 피드백 섹션 */}
           <div className="space-y-3">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <p className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-muted)]">{t('feedback')}</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t('feedback')}</p>
               {canAddFeedback ? (
                 <Button variant="glass" size="sm" onClick={() => setShowFeedbackForm((prev) => !prev)}>
                   {showFeedbackForm ? t('cancel') : t('addFeedback')}
@@ -250,7 +250,7 @@ export function StandupFeedbackDialog({
             {actionError ? <p className="text-sm text-rose-300">{actionError}</p> : null}
 
             {feedback.length === 0 ? (
-              <p className="text-sm text-[color:var(--operator-muted)]">{t('noFeedback')}</p>
+              <p className="text-sm text-muted-foreground">{t('noFeedback')}</p>
             ) : (
               <div className="space-y-2">
                 {feedback.map((item) => {
@@ -262,9 +262,9 @@ export function StandupFeedbackDialog({
                       <div className="flex flex-wrap items-center justify-between gap-2">
                         <div className="flex flex-wrap items-center gap-2">
                           <Badge variant={getReviewTypeVariant(item.review_type)}>{t(`reviewType_${item.review_type}`)}</Badge>
-                          <span className="text-sm font-medium text-[color:var(--operator-foreground)]">{authorName}</span>
+                          <span className="text-sm font-medium text-foreground">{authorName}</span>
                         </div>
-                        <span className="text-xs text-[color:var(--operator-muted)]">{formatTimestamp(item.created_at)}</span>
+                        <span className="text-xs text-muted-foreground">{formatTimestamp(item.created_at)}</span>
                       </div>
                       {isEditing ? (
                         <div className="mt-3 space-y-3">
@@ -290,7 +290,7 @@ export function StandupFeedbackDialog({
                         </div>
                       ) : (
                         <>
-                          <p className="mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90">{item.feedback_text}</p>
+                          <p className="mt-2 whitespace-pre-wrap text-sm text-foreground/90">{item.feedback_text}</p>
                           {isAuthor ? (
                             <div className="mt-3 flex flex-wrap gap-2">
                               <Button variant="outline" size="sm" onClick={() => startEditFeedback(item)}>{t('editFeedback')}</Button>

--- a/apps/web/src/components/standup/standup-history-section.tsx
+++ b/apps/web/src/components/standup/standup-history-section.tsx
@@ -47,7 +47,7 @@ export function StandupHistorySection({ projectId, memberNameById = {} }: Props)
   return (
     <section className="mt-8 space-y-3">
       <div className="flex items-center gap-2">
-        <h2 className="text-sm font-semibold text-[color:var(--operator-foreground)]">
+        <h2 className="text-sm font-semibold text-foreground">
           {t('history', { defaultValue: '📋 작성 이력' })}
         </h2>
         <Badge variant="chip">{entries.length}</Badge>

--- a/apps/web/src/components/standup/standup-review-card.tsx
+++ b/apps/web/src/components/standup/standup-review-card.tsx
@@ -199,12 +199,12 @@ export function StandupReviewCard({
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 space-y-2">
           <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-base font-semibold text-[color:var(--operator-foreground)]">{member.name}</h3>
+            <h3 className="text-base font-semibold text-foreground">{member.name}</h3>
             {isOwnEntry ? <Badge variant="info">{t('you')}</Badge> : null}
             <Badge variant={member.type === 'agent' ? 'secondary' : 'outline'}>{member.type === 'agent' ? t('agent') : t('human')}</Badge>
             {entry ? <Badge variant="chip">{entry.date}</Badge> : <Badge variant="outline">{t('noEntries')}</Badge>}
           </div>
-          <p className="text-sm text-[color:var(--operator-muted)]">
+          <p className="text-sm text-muted-foreground">
             {entry ? t('teamReviewDescription') : t('noEntryForMember')}
           </p>
         </div>
@@ -224,19 +224,19 @@ export function StandupReviewCard({
             <div className="grid gap-3 md:grid-cols-3">
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-medium uppercase tracking-[0.18em] text-emerald-300">{t('doneLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.done && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.done && 'text-muted-foreground')}>
                   {entry.done || t('emptySection')}
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.plan && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.plan && 'text-muted-foreground')}>
                   {entry.plan || t('emptySection')}
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
                 <div className="text-xs font-medium uppercase tracking-[0.18em] text-rose-300">{t('blockersLabel')}</div>
-                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90', !entry.blockers && 'text-[color:var(--operator-muted)]')}>
+                <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.blockers && 'text-muted-foreground')}>
                   {entry.blockers || t('emptySection')}
                 </p>
               </div>
@@ -245,8 +245,8 @@ export function StandupReviewCard({
             <div className="rounded-md border border-border bg-muted/30 p-3">
               <div className="flex flex-wrap items-center justify-between gap-2">
                 <div>
-                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('linkedStories')}</p>
-                  <p className="text-sm text-[color:var(--operator-muted)]">{t('linkedStoriesDescription')}</p>
+                  <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('linkedStories')}</p>
+                  <p className="text-sm text-muted-foreground">{t('linkedStoriesDescription')}</p>
                 </div>
                 <Badge variant="outline">{t('linkedStoryCount', { count: linkedStories.length })}</Badge>
               </div>
@@ -255,10 +255,10 @@ export function StandupReviewCard({
                   {linkedStories.map((story) => (
                     <div key={story.id} className="rounded-md border border-border bg-muted/30 p-3">
                       <div className="flex flex-wrap items-center justify-between gap-2">
-                        <p className="text-sm font-medium text-[color:var(--operator-foreground)]">{story.title}</p>
+                        <p className="text-sm font-medium text-foreground">{story.title}</p>
                         <Badge variant="outline">{story.status}</Badge>
                       </div>
-                      <div className="mt-2 flex items-center gap-2 text-xs text-[color:var(--operator-muted)]">
+                      <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
                         <Badge variant="chip">{story.assignee_name ?? t('unknown')}</Badge>
                         <span>{t('taskProgress', { done: story.done_task_count, total: story.task_count })}</span>
                       </div>
@@ -291,8 +291,8 @@ export function StandupReviewCard({
         <div className="rounded-md border border-border bg-muted/30 p-3">
           <div className="flex flex-wrap items-center justify-between gap-2">
             <div>
-              <p className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-muted)]">{t('feedback')}</p>
-              <p className="text-sm text-[color:var(--operator-muted)]">{t('feedbackDescription')}</p>
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">{t('feedback')}</p>
+              <p className="text-sm text-muted-foreground">{t('feedbackDescription')}</p>
             </div>
             {canAddFeedback ? (
               <Button variant="glass" size="sm" onClick={() => setShowFeedbackForm((prev) => !prev)}>
@@ -302,7 +302,7 @@ export function StandupReviewCard({
           </div>
 
           {feedback.length === 0 ? (
-            <p className="mt-3 text-sm text-[color:var(--operator-muted)]">{t('noFeedback')}</p>
+            <p className="mt-3 text-sm text-muted-foreground">{t('noFeedback')}</p>
           ) : (
             <div className="mt-3 space-y-2">
               {feedback.map((item) => {
@@ -314,9 +314,9 @@ export function StandupReviewCard({
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex flex-wrap items-center gap-2">
                         <Badge variant={getReviewTypeVariant(item.review_type)}>{t(`reviewType_${item.review_type}`)}</Badge>
-                        <span className="text-sm font-medium text-[color:var(--operator-foreground)]">{authorName}</span>
+                        <span className="text-sm font-medium text-foreground">{authorName}</span>
                       </div>
-                      <span className="text-xs text-[color:var(--operator-muted)]">{formatTimestamp(item.created_at)}</span>
+                      <span className="text-xs text-muted-foreground">{formatTimestamp(item.created_at)}</span>
                     </div>
 
                     {isEditing ? (
@@ -343,7 +343,7 @@ export function StandupReviewCard({
                       </div>
                     ) : (
                       <>
-                        <p className="mt-2 whitespace-pre-wrap text-sm text-[color:var(--operator-foreground)]/90">{item.feedback_text}</p>
+                        <p className="mt-2 whitespace-pre-wrap text-sm text-foreground/90">{item.feedback_text}</p>
                         {isAuthor ? (
                           <div className="mt-3 flex flex-wrap gap-2">
                             <Button variant="outline" size="sm" onClick={() => startEditFeedback(item)}>{t('editFeedback')}</Button>


### PR DESCRIPTION
## Summary
`--operator-*` CSS 변수 중 단순 alias 10종을 표준 Tailwind 토큰으로 일괄 치환.
시각적 차이 없음 — alias가 `var()`로 표준 토큰을 가리키므로 동일 색상.

## 치환 매핑 (10종)
| Before | After |
|---|---|
| `text-[color:var(--operator-muted)]` | `text-muted-foreground` |
| `text-[color:var(--operator-foreground)]` | `text-foreground` |
| `text/bg-[color:var(--operator-primary)]` | `text/bg-brand` |
| `bg-[color:var(--operator-surface-soft)]` | `bg-muted` |
| `bg-[color:var(--operator-surface)]` | `bg-card` |
| `bg-[color:var(--operator-panel)]` | `bg-muted` |
| `bg-[color:var(--operator-bg)]` | `bg-background` |
| `text/bg-[color:var(--operator-tertiary)]` | `text/bg-info` |
| `border-[color:var(--operator-outline)]` | `border-border` |
| `text/bg-[color:var(--operator-danger)]` | `text/bg-destructive` |

## 잔존 (PR-A 범위 외)
- opacity modifier 붙은 패턴 (`/35`, `/18`, `/20` 등)
- fallback 패턴 (`--operator-border,hsl(var(--border))`)
- `ring-`, `accent-` prefix
- inline style

## Stats
- 변경 파일: 41개
- 변경 라인: 464 삽입 / 464 삭제 (순수 치환)

## Test Plan
- [ ] `grep -rn "operator-" apps/web/src/` — 단순 alias 10종 잔존 0건 (복합 패턴 제외)
- [ ] pnpm build ✅ 통과
- [ ] 핵심 5화면 라이트/다크 회귀 없음
- [ ] inbox/standup/internal-dogfood 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)