### PR TITLE
[DS-S7-B] brand-* rename + 잔존 4종 operator-* 통합 정리

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -405,7 +405,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="문서 검색..."
-            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-muted-foreground focus:border-[color:var(--operator-primary)]/40 focus:bg-muted/50"
+            className="w-full rounded-lg border border-border/60 bg-muted/30 py-1.5 pl-8 pr-7 text-xs outline-none placeholder:text-muted-foreground focus:border-brand/40 focus:bg-muted/50"
           />
           {searchQuery && (
             <button

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -104,7 +104,7 @@ function ProgressBar({ done, total, label }: ProgressBarProps) {
           <span>{done} / {total}</span>
         </div>
       ) : null}
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--operator-border,hsl(var(--border)))]">
+      <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
         <div
           className="h-full rounded-full bg-primary transition-all duration-300"
           style={{ width: `${pct}%` }}
@@ -178,7 +178,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
           onChange={(e) => setTitle(e.target.value)}
           placeholder={t('fieldTitlePlaceholder')}
           required
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -189,7 +189,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
           onChange={(e) => setDescription(e.target.value)}
           placeholder={t('fieldDescriptionPlaceholder')}
           rows={3}
-          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full resize-none rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -199,7 +199,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
           <select
             value={priority}
             onChange={(e) => setPriority(e.target.value as EpicPriority)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="critical">{t('priorityCritical')}</option>
             <option value="high">{t('priorityHigh')}</option>
@@ -216,7 +216,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
             value={targetSp}
             onChange={(e) => setTargetSp(e.target.value)}
             placeholder="0"
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
       </div>
@@ -227,7 +227,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
           type="date"
           value={targetDate}
           onChange={(e) => setTargetDate(e.target.value)}
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -307,7 +307,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
-          className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -317,7 +317,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
-          className="w-full resize-none rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+          className="w-full resize-none rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
       </div>
 
@@ -327,7 +327,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           <select
             value={status}
             onChange={(e) => setStatus(e.target.value as EpicStatus)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="draft">{t('statusDraft')}</option>
             <option value="active">{t('statusActive')}</option>
@@ -341,7 +341,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           <select
             value={priority}
             onChange={(e) => setPriority(e.target.value as EpicPriority)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           >
             <option value="critical">{t('priorityCritical')}</option>
             <option value="high">{t('priorityHigh')}</option>
@@ -358,7 +358,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
             type="date"
             value={targetDate}
             onChange={(e) => setTargetDate(e.target.value)}
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
 
@@ -370,7 +370,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
             value={targetSp}
             onChange={(e) => setTargetSp(e.target.value)}
             placeholder="0"
-            className="w-full rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            className="w-full rounded-xl border border-border bg-card px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
           />
         </div>
       </div>
@@ -425,7 +425,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
       className={`group relative w-full rounded-2xl border px-4 py-3.5 text-left transition-all duration-150 cursor-pointer ${
         isSelected
           ? 'border-primary/40 bg-primary/5'
-          : 'border-[color:var(--operator-border,hsl(var(--border)))] bg-card hover:border-primary/30 hover:bg-primary/5'
+          : 'border-border bg-card hover:border-primary/30 hover:bg-primary/5'
       }`}
       onClick={onClick}
       role="button"
@@ -466,7 +466,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
         </div>
 
         {total > 0 ? (
-          <div className="h-1.5 w-full overflow-hidden rounded-full bg-[color:var(--operator-border,hsl(var(--border)))]">
+          <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
             <div
               className="h-full rounded-full bg-primary transition-all duration-300"
               style={{ width: `${pct}%` }}
@@ -566,11 +566,11 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
 
             {/* Meta grid */}
             <div className="grid grid-cols-2 gap-3">
-              <div className="rounded-xl bg-[color:var(--operator-surface-soft,hsl(var(--muted)))] px-3 py-2.5">
+              <div className="rounded-xl bg-muted px-3 py-2.5">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetDate')}</p>
                 <p className="mt-1 text-sm font-medium text-foreground">{formatDate(epic.target_date)}</p>
               </div>
-              <div className="rounded-xl bg-[color:var(--operator-surface-soft,hsl(var(--muted)))] px-3 py-2.5">
+              <div className="rounded-xl bg-muted px-3 py-2.5">
                 <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('targetSp')}</p>
                 <div className="mt-1 flex items-center gap-1.5">
                   <p className="text-sm font-medium text-foreground">{epic.target_sp !== undefined ? epic.target_sp : '—'}</p>
@@ -618,7 +618,7 @@ function EpicDetailPanel({ epic, onUpdate, onClose }: EpicDetailPanelProps) {
                       key={story.id}
                       type="button"
                       onClick={() => router.push(`/board?story=${story.id}`)}
-                      className="flex w-full items-center justify-between rounded-xl border border-[color:var(--operator-border,hsl(var(--border)))] px-3 py-2 text-left transition-colors hover:border-primary/30 hover:bg-primary/5"
+                      className="flex w-full items-center justify-between rounded-xl border border-border px-3 py-2 text-left transition-colors hover:border-primary/30 hover:bg-primary/5"
                     >
                       <p className="text-sm text-foreground">{story.title}</p>
                       <div className="flex shrink-0 items-center gap-2">
@@ -663,7 +663,7 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
         onClick={onClose}
         aria-label={t('cancel')}
       />
-      <div className="relative z-10 w-full max-w-md rounded-2xl border border-[color:var(--operator-border,hsl(var(--border)))] bg-card p-6 shadow-xl">
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-xl">
         <div className="mb-4 flex items-center justify-between">
           <h2 className="text-base font-bold text-foreground">{t('createEpic')}</h2>
           <button
@@ -814,7 +814,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
             className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
               statusFilter === s
                 ? 'border-primary/40 bg-primary/10 text-primary'
-                : 'border-[color:var(--operator-border,hsl(var(--border)))] text-muted-foreground hover:bg-muted/50'
+                : 'border-border text-muted-foreground hover:bg-muted/50'
             }`}
           >
             {s === 'all' ? t('filterAll') : s}

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -240,10 +240,10 @@ export default function InboxPage() {
                       onClick={() => void selectNotification(notification)}
                       className={`w-full rounded-xl border p-3 text-left transition ${
                         isSelected
-                          ? 'border-[color:var(--operator-primary)]/35 bg-brand/15'
+                          ? 'border-brand/35 bg-brand/15'
                           : notification.is_read
-                            ? 'border-white/8 bg-muted/55 hover:border-[color:var(--operator-primary)]/20 hover:bg-white/5'
-                            : 'border-[color:var(--operator-primary)]/18 bg-brand/8 hover:bg-brand/12'
+                            ? 'border-white/8 bg-muted/55 hover:border-brand/20 hover:bg-white/5'
+                            : 'border-brand/18 bg-brand/8 hover:bg-brand/12'
                       }`}
                     >
                       <div className="flex items-start gap-3">

--- a/apps/web/src/app/(authenticated)/mockups/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/mockups/[id]/page.tsx
@@ -72,7 +72,7 @@ export default function MockupViewerPage() {
     const props = getComponentProps(comp);
     const style: React.CSSProperties = {
       ...(props as React.CSSProperties),
-      outline: isSelected ? '2px solid var(--operator-primary)' : undefined,
+      outline: isSelected ? '2px solid var(--brand)' : undefined,
       outlineOffset: isSelected ? '2px' : undefined,
       cursor: 'pointer',
       transition: 'all 150ms ease',

--- a/apps/web/src/app/(authenticated)/mockups/page.tsx
+++ b/apps/web/src/app/(authenticated)/mockups/page.tsx
@@ -127,7 +127,7 @@ export default function MockupsPage() {
               <button
                 key={mockup.id}
                 type="button"
-                className="group rounded-3xl border border-white/8 bg-muted/55 p-4 text-left transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
+                className="group rounded-3xl border border-white/8 bg-muted/55 p-4 text-left transition hover:border-brand/18 hover:bg-white/8"
                 onClick={() => router.push(`/mockups/${mockup.id}`)}
               >
                 <div className="flex items-start justify-between gap-3">

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -448,7 +448,7 @@ export default function StandupPage() {
                                 </div>
                                 <div className="mt-2 h-2 overflow-hidden rounded-full bg-white/10">
                                   <div
-                                    className="h-full rounded-full bg-[linear-gradient(135deg,var(--operator-primary),var(--operator-primary-strong))]"
+                                    className="h-full rounded-full bg-[linear-gradient(135deg,var(--brand),var(--brand-strong))]"
                                     style={{ width: `${story.task_count > 0 ? Math.round((story.done_task_count / story.task_count) * 100) : 0}%` }}
                                   />
                                 </div>
@@ -529,7 +529,7 @@ export default function StandupPage() {
 
                       if (isCurrentUser && editingSelf) {
                         return (
-                          <div key={member.id} className="col-span-full rounded-xl border border-[color:var(--operator-primary)]/40 bg-card p-4 shadow-sm space-y-4">
+                          <div key={member.id} className="col-span-full rounded-xl border border-brand/40 bg-card p-4 shadow-sm space-y-4">
                             <div className="flex flex-wrap items-center justify-between gap-2">
                               <h3 className="text-sm font-semibold text-foreground">{t('selfEditTitle')}</h3>
                               <Button variant="ghost" size="sm" onClick={() => setEditingSelf(false)}>{t('cancel')}</Button>
@@ -546,7 +546,7 @@ export default function StandupPage() {
                                 />
                               </div>
                               <div>
-                                <label className="mb-2 block text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-primary-soft)]">{t('plan')}</label>
+                                <label className="mb-2 block text-xs font-semibold uppercase tracking-wider text-[color:var(--brand-soft)]">{t('plan')}</label>
                                 <OperatorTextarea
                                   value={plan}
                                   onChange={(event) => setPlan(event.target.value)}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -146,9 +146,9 @@
   --operator-foreground: var(--foreground);
   --operator-muted: var(--muted-foreground);
   --operator-primary: var(--brand);
-  --operator-primary-soft: oklch(0.90 0.06 258);
-  --operator-primary-strong: oklch(0.45 0.20 258);
-  --operator-primary-contrast: oklch(0.96 0.03 258);
+  --brand-soft: oklch(0.90 0.06 258);
+  --brand-strong: oklch(0.45 0.20 258);
+  --brand-contrast: oklch(0.96 0.03 258);
   --operator-tertiary: var(--info);
   --operator-outline: var(--border);
   --operator-danger: var(--destructive);
@@ -225,9 +225,9 @@
   --operator-foreground: var(--foreground);
   --operator-muted: var(--muted-foreground);
   --operator-primary: var(--brand);
-  --operator-primary-soft: oklch(0.80 0.10 258);
-  --operator-primary-strong: oklch(0.55 0.22 258);
-  --operator-primary-contrast: oklch(0.22 0.05 258);
+  --brand-soft: oklch(0.80 0.10 258);
+  --brand-strong: oklch(0.55 0.22 258);
+  --brand-contrast: oklch(0.22 0.05 258);
   --operator-tertiary: var(--info);
   --operator-outline: var(--border);
   --operator-danger: var(--destructive);

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -141,7 +141,6 @@
   /* Operator aliases — for feature components (mockups, theme-settings) */
   --operator-bg: var(--background);
   --operator-surface: var(--card);
-  --operator-surface-soft: var(--muted);
   --operator-panel: var(--muted);
   --operator-foreground: var(--foreground);
   --operator-muted: var(--muted-foreground);
@@ -220,7 +219,6 @@
   /* Operator aliases — dark mode */
   --operator-bg: var(--background);
   --operator-surface: var(--card);
-  --operator-surface-soft: var(--muted);
   --operator-panel: var(--muted);
   --operator-foreground: var(--foreground);
   --operator-muted: var(--muted-foreground);

--- a/apps/web/src/app/internal-dogfood/page.tsx
+++ b/apps/web/src/app/internal-dogfood/page.tsx
@@ -187,7 +187,7 @@ export default async function InternalDogfoodPage({ searchParams }: PageProps) {
           <SectionCardBody className="text-sm text-muted-foreground">
             이 경로는 임시 Moonlabs 내부 dogfooding 전용인. auth plane 복구 후 env flag를 내리면 바로 비활성화되는 구조인.
             {' '}
-            <Link href="/login" className="text-[color:var(--operator-primary-soft)] underline">일반 로그인 페이지로 이동</Link>
+            <Link href="/login" className="text-[color:var(--brand-soft)] underline">일반 로그인 페이지로 이동</Link>
           </SectionCardBody>
         </SectionCard>
       </div>

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -721,7 +721,7 @@ export function AgentDeploymentWizard({
                         type="checkbox"
                         checked={overwriteRoutingRules}
                         onChange={(event) => setOverwriteRoutingRules(event.target.checked)}
-                        className="mt-1 h-4 w-4 accent-[color:var(--operator-primary)]"
+                        className="mt-1 h-4 w-4 accent-brand"
                       />
                       <span>{t('autoRoutingOverwriteConfirm')}</span>
                     </label>

--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -159,7 +159,7 @@ export function AgentHitlPolicyEditor() {
         <SectionCard>
           <SectionCardHeader>
             <div className="flex items-center gap-2">
-              <ShieldAlert className="size-4 text-[color:var(--operator-primary-soft)]" />
+              <ShieldAlert className="size-4 text-[color:var(--brand-soft)]" />
               <div>
                 <h3 className="text-base font-semibold text-foreground">{t('catalogTitle')}</h3>
                 <p className="text-sm text-muted-foreground">{t('catalogBody')}</p>
@@ -184,7 +184,7 @@ export function AgentHitlPolicyEditor() {
         <SectionCard>
           <SectionCardHeader>
             <div className="flex items-center gap-2">
-              <CheckCircle2 className="size-4 text-[color:var(--operator-primary-soft)]" />
+              <CheckCircle2 className="size-4 text-[color:var(--brand-soft)]" />
               <div>
                 <h3 className="text-base font-semibold text-foreground">{t('approvalTitle')}</h3>
                 <p className="text-sm text-muted-foreground">{t('approvalBody')}</p>
@@ -226,7 +226,7 @@ export function AgentHitlPolicyEditor() {
         <SectionCard>
           <SectionCardHeader>
             <div className="flex items-center gap-2">
-              <Clock3 className="size-4 text-[color:var(--operator-primary-soft)]" />
+              <Clock3 className="size-4 text-[color:var(--brand-soft)]" />
               <div>
                 <h3 className="text-base font-semibold text-foreground">{t('timeoutTitle')}</h3>
                 <p className="text-sm text-muted-foreground">{t('timeoutBody')}</p>
@@ -288,7 +288,7 @@ export function AgentHitlPolicyEditor() {
       <SectionCard>
         <SectionCardHeader>
           <div className="flex items-center gap-2">
-            <AlertTriangle className="size-4 text-[color:var(--operator-primary-soft)]" />
+            <AlertTriangle className="size-4 text-[color:var(--brand-soft)]" />
             <div>
               <h3 className="text-base font-semibold text-foreground">{t('policySummaryTitle')}</h3>
               <p className="text-sm text-muted-foreground">{t('policySummaryBody')}</p>

--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -292,7 +292,7 @@ export function AgentPersonaComposer({
                         const checked = selectedToolNames.includes(option.name);
                         return (
                           <label key={option.name} className={`flex items-start gap-3 rounded-md border px-3 py-3 text-sm ${checked ? 'border-primary/40 bg-primary/10' : 'border-border bg-muted/30'}`}>
-                            <input type="checkbox" checked={checked} onChange={() => handleToggleTool(option.name)} className="mt-1 h-4 w-4 accent-[color:var(--operator-primary)]" />
+                            <input type="checkbox" checked={checked} onChange={() => handleToggleTool(option.name)} className="mt-1 h-4 w-4 accent-brand" />
                             <span className="space-y-1">
                               <span className="block font-medium text-foreground">{option.name}</span>
                               <span className="block text-xs text-muted-foreground">{option.source === 'mcp' ? t('personaComposerMcpToolHint') : t('personaComposerBuiltInToolHint')}</span>

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -438,7 +438,7 @@ export function AgentRunDetail({
                           hasError
                             ? 'border-red-400 bg-red-400/20'
                             : isLlm
-                              ? 'border-[color:var(--operator-primary)] bg-brand/20'
+                              ? 'border-brand bg-brand/20'
                               : 'border-emerald-400 bg-emerald-400/20'
                         }`} />
                         <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-white/4 px-3 py-2">

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -109,7 +109,7 @@ export function DocContentRenderer({
     const wikiCleanup = wikiLinks.map((span) => {
       const slug = span.getAttribute('data-slug') ?? '';
       const title = span.getAttribute('data-title') ?? span.textContent ?? '';
-      span.className = 'inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] bg-brand/10 text-[color:var(--operator-primary-soft)] hover:bg-brand/20 transition-colors';
+      span.className = 'inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] bg-brand/10 text-[color:var(--brand-soft)] hover:bg-brand/20 transition-colors';
       span.title = title;
       const handleClick = () => { if (slug) window.location.href = `/docs/${slug}`; };
       span.addEventListener('click', handleClick);
@@ -249,8 +249,8 @@ export function DocContentRenderer({
     '[&_h2]:scroll-mt-24 [&_h2]:mt-10 [&_h2]:text-2xl [&_h2]:font-semibold',
     '[&_h3]:scroll-mt-24 [&_h3]:mt-8 [&_h3]:text-xl [&_h3]:font-semibold',
     '[&_p]:leading-7 [&_p]:text-foreground/92',
-    '[&_a]:text-[color:var(--operator-primary-soft)] [&_a]:underline [&_a]:underline-offset-4',
-    '[&_blockquote]:rounded-2xl [&_blockquote]:border-l-4 [&_blockquote]:border-[color:var(--operator-primary)]/45 [&_blockquote]:bg-brand/8 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-foreground/88',
+    '[&_a]:text-[color:var(--brand-soft)] [&_a]:underline [&_a]:underline-offset-4',
+    '[&_blockquote]:rounded-2xl [&_blockquote]:border-l-4 [&_blockquote]:border-brand/45 [&_blockquote]:bg-brand/8 [&_blockquote]:px-4 [&_blockquote]:py-3 [&_blockquote]:text-foreground/88',
     '[&_img]:max-h-[32rem] [&_img]:w-full [&_img]:rounded-2xl [&_img]:border [&_img]:border-border [&_img]:object-contain',
     '[&_table]:w-full [&_table]:border-collapse [&_table]:overflow-hidden [&_table]:rounded-2xl [&_table]:border [&_table]:border-border [&_table]:bg-muted/20',
     '[&_thead]:bg-muted/50 [&_th]:border [&_th]:border-border [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-semibold',
@@ -449,7 +449,7 @@ function decorateHtmlContent(content: string, headings: ReturnType<typeof extrac
     return [
       '<div data-doc-code-shell="true">',
       '<div data-doc-code-actions="true">',
-      `<button type="button" data-doc-copy-button="true" class="transition hover:border-[color:var(--operator-primary)]/35 hover:text-foreground">${escapeHtmlText(codeCopyLabel)}</button>`,
+      `<button type="button" data-doc-copy-button="true" class="transition hover:border-brand/35 hover:text-foreground">${escapeHtmlText(codeCopyLabel)}</button>`,
       '</div>',
       `<pre>${inner}</pre>`,
       '</div>',

--- a/apps/web/src/components/docs/doc-toc.tsx
+++ b/apps/web/src/components/docs/doc-toc.tsx
@@ -42,8 +42,8 @@ export function DocToc({ headings, onHeadingClick, className }: DocTocProps) {
         onClick={() => setOpen((v) => !v)}
         className={`flex items-center gap-1.5 rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
           open
-            ? 'border-[color:var(--operator-primary)]/50 bg-brand/10 text-[color:var(--operator-primary-soft)]'
-            : 'border-border/60 bg-card text-foreground hover:border-[color:var(--operator-primary)]/50 hover:text-[color:var(--operator-primary-soft)]'
+            ? 'border-brand/50 bg-brand/10 text-[color:var(--brand-soft)]'
+            : 'border-border/60 bg-card text-foreground hover:border-brand/50 hover:text-[color:var(--brand-soft)]'
         }`}
         title="목차"
       >

--- a/apps/web/src/components/docs/extensions/column-layout.tsx
+++ b/apps/web/src/components/docs/extensions/column-layout.tsx
@@ -59,8 +59,8 @@ function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeV
           onClick={() => switchTo(2)}
           className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
             cols === 2
-              ? 'border-[color:var(--operator-primary)]/40 bg-brand/10 text-[color:var(--operator-primary-soft)]'
-              : 'border-border text-muted-foreground hover:border-[color:var(--operator-primary)]/30 hover:text-foreground'
+              ? 'border-brand/40 bg-brand/10 text-[color:var(--brand-soft)]'
+              : 'border-border text-muted-foreground hover:border-brand/30 hover:text-foreground'
           }`}
         >
           <Columns2 className="size-3" />2단
@@ -70,8 +70,8 @@ function ColumnsBlockView({ node, editor, getPos, updateAttributes }: ReactNodeV
           onClick={() => switchTo(3)}
           className={`flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] transition-colors ${
             cols === 3
-              ? 'border-[color:var(--operator-primary)]/40 bg-brand/10 text-[color:var(--operator-primary-soft)]'
-              : 'border-border text-muted-foreground hover:border-[color:var(--operator-primary)]/30 hover:text-foreground'
+              ? 'border-brand/40 bg-brand/10 text-[color:var(--brand-soft)]'
+              : 'border-border text-muted-foreground hover:border-brand/30 hover:text-foreground'
           }`}
         >
           <Columns3 className="size-3" />3단

--- a/apps/web/src/components/docs/extensions/embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/embed-node.tsx
@@ -73,7 +73,7 @@ function EmbedView({ node, updateAttributes, selected }: ReactNodeViewProps) {
     <NodeViewWrapper as="div" className="my-4 not-prose" contentEditable={false}>
       {/* URL editor — visible when block is selected */}
       {selected && (
-        <div className="mb-2 flex items-center gap-2 rounded-xl border border-[color:var(--operator-primary)]/30 bg-brand/6 px-3 py-2">
+        <div className="mb-2 flex items-center gap-2 rounded-xl border border-brand/30 bg-brand/6 px-3 py-2">
           <Link2 className="size-3.5 flex-shrink-0 text-muted-foreground" />
           <input
             ref={inputRef}

--- a/apps/web/src/components/docs/extensions/file-node.tsx
+++ b/apps/web/src/components/docs/extensions/file-node.tsx
@@ -44,7 +44,7 @@ function FileAttachmentView({ node }: ReactNodeViewProps) {
   return (
     <NodeViewWrapper as="div" className="my-3 not-prose">
       <div className="flex items-center gap-3 rounded-xl border border-border bg-muted/20 px-4 py-3">
-        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-brand/10 text-[color:var(--operator-primary-soft)]">
+        <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg bg-brand/10 text-[color:var(--brand-soft)]">
           <FileIcon className="size-4" />
         </div>
         <div className="min-w-0 flex-1">
@@ -55,7 +55,7 @@ function FileAttachmentView({ node }: ReactNodeViewProps) {
           type="button"
           contentEditable={false}
           onClick={handleDownload}
-          className="flex-shrink-0 rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:border-[color:var(--operator-primary)]/40 hover:text-[color:var(--operator-primary-soft)]"
+          className="flex-shrink-0 rounded-lg border border-border p-2 text-muted-foreground transition-colors hover:border-brand/40 hover:text-[color:var(--brand-soft)]"
           aria-label="파일 다운로드"
         >
           <DownloadIcon className="size-4" />

--- a/apps/web/src/components/docs/extensions/image-node.tsx
+++ b/apps/web/src/components/docs/extensions/image-node.tsx
@@ -49,7 +49,7 @@ function ImageView({ node, updateAttributes, selected }: ReactNodeViewProps) {
         draggable={false}
         style={{ width: width ? `${width}px` : undefined, maxWidth: '100%', height: 'auto', display: 'block' }}
         className={`rounded-xl border border-border object-contain transition-shadow ${
-          selected ? 'ring-2 ring-[color:var(--operator-primary)] ring-offset-1' : ''
+          selected ? 'ring-2 ring-brand ring-offset-1' : ''
         } ${isResizing ? 'select-none' : ''}`}
       />
       {selected && (

--- a/apps/web/src/components/docs/extensions/page-embed-node.tsx
+++ b/apps/web/src/components/docs/extensions/page-embed-node.tsx
@@ -164,7 +164,7 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
           />
           <button
             type="submit"
-            className="rounded-lg bg-brand/14 px-3 py-1 text-xs font-medium text-[color:var(--operator-primary-soft)] hover:bg-brand/24"
+            className="rounded-lg bg-brand/14 px-3 py-1 text-xs font-medium text-[color:var(--brand-soft)] hover:bg-brand/24"
           >
             Embed
           </button>
@@ -195,7 +195,7 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
           <button
             type="button"
             onClick={handleReset}
-            className="text-xs text-[color:var(--operator-primary-soft)] hover:underline"
+            className="text-xs text-[color:var(--brand-soft)] hover:underline"
           >
             Change
           </button>
@@ -215,12 +215,12 @@ function PageEmbedView({ node, updateAttributes, extension }: ReactNodeViewProps
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') onNavigate?.(doc.slug);
           }}
-          className="group flex cursor-pointer items-center gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-3 transition-colors hover:border-[color:var(--operator-primary)]/30 hover:bg-brand/6"
+          className="group flex cursor-pointer items-center gap-3 rounded-xl border border-white/8 bg-white/4 px-4 py-3 transition-colors hover:border-brand/30 hover:bg-brand/6"
         >
           {doc.icon ? (
             <span className="shrink-0 text-lg">{doc.icon}</span>
           ) : (
-            <FileText className="size-5 shrink-0 text-[color:var(--operator-primary-soft)]" />
+            <FileText className="size-5 shrink-0 text-[color:var(--brand-soft)]" />
           )}
           <div className="min-w-0 flex-1">
             <p className="truncate text-sm font-medium text-foreground">

--- a/apps/web/src/components/docs/extensions/slash-command.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.tsx
@@ -349,13 +349,13 @@ const SlashMenu = forwardRef<
         data-active={isActive}
         className={`flex w-full items-center gap-2.5 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
           isActive
-            ? 'bg-brand/14 text-[color:var(--operator-primary-soft)]'
+            ? 'bg-brand/14 text-[color:var(--brand-soft)]'
             : 'text-foreground hover:bg-white/6'
         }`}
         onClick={() => command(item)}
       >
-        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-[color:var(--operator-primary)]/30 bg-brand/10' : 'bg-muted/40'}`}>
-          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--operator-primary-soft)]' : 'text-muted-foreground'}`} />
+        <span className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border/60 ${isActive ? 'border-brand/30 bg-brand/10' : 'bg-muted/40'}`}>
+          <Icon className={`size-3.5 ${isActive ? 'text-[color:var(--brand-soft)]' : 'text-muted-foreground'}`} />
         </span>
         <span className="flex min-w-0 flex-col">
           <span className="text-xs font-medium leading-tight">{item.title}</span>

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -56,7 +56,7 @@ function WikiLinkView({ node, editor }: ReactNodeViewProps) {
         className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] transition-colors ${
           isNotFound
             ? 'bg-red-500/10 text-red-500 hover:bg-red-500/20'
-            : 'bg-brand/10 text-[color:var(--operator-primary-soft)] hover:bg-brand/20'
+            : 'bg-brand/10 text-[color:var(--brand-soft)] hover:bg-brand/20'
         }`}
       >
         {isNotFound
@@ -168,7 +168,7 @@ function WikiLinkMenu({
           onClick={() => command(item)}
           className={`flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors ${
             i === selectedIndex
-              ? 'bg-brand/14 text-[color:var(--operator-primary-soft)]'
+              ? 'bg-brand/14 text-[color:var(--brand-soft)]'
               : 'text-foreground hover:bg-white/6'
           }`}
         >

--- a/apps/web/src/components/docs/policy-doc-browser.tsx
+++ b/apps/web/src/components/docs/policy-doc-browser.tsx
@@ -143,7 +143,7 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
                   className={cn(
                     'w-full rounded-2xl border px-3 py-3 text-left text-sm transition-all',
                     isSelected
-                      ? 'border-[color:var(--operator-primary)]/20 bg-brand/14 text-[color:var(--operator-primary-soft)]'
+                      ? 'border-brand/20 bg-brand/14 text-[color:var(--brand-soft)]'
                       : 'border-white/8 bg-white/5 text-foreground/88 hover:bg-white/8',
                   )}
                 >
@@ -194,7 +194,7 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
                   value={query}
                   onChange={(event) => setQuery(event.target.value)}
                   placeholder={t('policySearchPlaceholder')}
-                  className="w-full rounded-2xl border border-white/8 bg-muted/90 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-[color:var(--operator-primary)]/20 focus:outline-none"
+                  className="w-full rounded-2xl border border-white/8 bg-muted/90 px-4 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:border-brand/20 focus:outline-none"
                 />
               </div>
             </div>
@@ -217,7 +217,7 @@ export function PolicyDocBrowser({ projectId, t }: PolicyDocBrowserProps) {
                         className={cn(
                           'w-full rounded-2xl border px-3 py-3 text-left text-sm transition-all',
                           isSelected
-                            ? 'border-[color:var(--operator-primary)]/20 bg-brand/14 text-[color:var(--operator-primary-soft)]'
+                            ? 'border-brand/20 bg-brand/14 text-[color:var(--brand-soft)]'
                             : 'border-white/8 bg-white/5 text-foreground/88 hover:bg-white/8',
                         )}
                       >

--- a/apps/web/src/components/mockups/mockup-editor-shell.tsx
+++ b/apps/web/src/components/mockups/mockup-editor-shell.tsx
@@ -58,7 +58,7 @@ interface MockupEditorShellProps {
 
 const GRID_SIZE = 16;
 const SNAP_THRESHOLD = 6;
-const TINY_BUTTON_CLASS = 'rounded-xl border border-white/10 bg-muted/55 px-2.5 py-1.5 text-[11px] text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
+const TINY_BUTTON_CLASS = 'rounded-xl border border-white/10 bg-muted/55 px-2.5 py-1.5 text-[11px] text-foreground transition hover:border-brand/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
 
 function cloneState(components: MockupComponent[]) {
   return cloneMockupComponents(components);
@@ -829,7 +829,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
         className="select-none"
       >
         <div
-          className={`relative h-full w-full overflow-hidden rounded-2xl border bg-white shadow-sm transition ${isSelected ? 'border-[color:var(--operator-primary)] ring-2 ring-[color:var(--operator-primary)]/25' : 'border-white/10 hover:border-[color:var(--operator-primary)]/18'} ${canContainChildren ? 'bg-muted/70' : ''}`}
+          className={`relative h-full w-full overflow-hidden rounded-2xl border bg-white shadow-sm transition ${isSelected ? 'border-brand ring-2 ring-brand/25' : 'border-white/10 hover:border-brand/18'} ${canContainChildren ? 'bg-muted/70' : ''}`}
           onMouseDown={(event) => {
             if (event.button !== 0) return;
             event.stopPropagation();
@@ -868,7 +868,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
     );
   }
 
-  const panelButtonClass = 'rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-xs text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
+  const panelButtonClass = 'rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-xs text-foreground transition hover:border-brand/18 hover:bg-white/8 disabled:cursor-not-allowed disabled:opacity-50';
 
   return (
     <div className="space-y-4">
@@ -921,7 +921,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
               <button
                 key={item.type}
                 type="button"
-                className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-left text-xs text-foreground transition hover:border-[color:var(--operator-primary)]/18 hover:bg-white/8"
+                className="flex w-full items-center justify-between rounded-2xl border border-white/10 bg-muted/55 px-3 py-2 text-left text-xs text-foreground transition hover:border-brand/18 hover:bg-white/8"
                 onClick={() => createComponent(item.type)}
               >
                 <span className="flex items-center gap-2"><span>{item.icon}</span> {item.type}</span>
@@ -964,7 +964,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                   ) : null}
                 </div>
               ))}
-              <button type="button" className="w-full rounded-2xl border border-dashed border-white/12 px-3 py-2 text-xs text-muted-foreground transition hover:border-[color:var(--operator-primary)]/24 hover:text-[color:var(--operator-primary-soft)]" onClick={() => void addScenario()}>
+              <button type="button" className="w-full rounded-2xl border border-dashed border-white/12 px-3 py-2 text-xs text-muted-foreground transition hover:border-brand/24 hover:text-[color:var(--brand-soft)]" onClick={() => void addScenario()}>
                 + {t('addScenario')}
               </button>
             </div>
@@ -978,7 +978,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                   key={node.component.id}
                   type="button"
                   onClick={(event) => handleTreeSelect(node.component.id, event)}
-                  className={`flex w-full items-center gap-2 rounded-2xl px-2 py-1.5 text-left text-[11px] transition ${selectedIds.includes(node.component.id) ? 'bg-brand/12 text-[color:var(--operator-primary-soft)]' : 'text-muted-foreground hover:bg-white/8'}`}
+                  className={`flex w-full items-center gap-2 rounded-2xl px-2 py-1.5 text-left text-[11px] transition ${selectedIds.includes(node.component.id) ? 'bg-brand/12 text-[color:var(--brand-soft)]' : 'text-muted-foreground hover:bg-white/8'}`}
                   style={{ paddingLeft: `${8 + depth * 14}px` }}
                 >
                   <span className="text-[10px]">{componentPaletteEntry(node.component.component_type)?.icon ?? '⬚'}</span>
@@ -1118,14 +1118,14 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                   if (!scenario) return null;
                   const overrides = scenario.override_props[selectedComponent.id] ?? {};
                   return (
-                    <div className="mt-4 rounded-2xl border border-[color:var(--operator-primary)]/20 bg-brand/10 p-3">
-                      <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--operator-primary-soft)]">
+                    <div className="mt-4 rounded-2xl border border-brand/20 bg-brand/10 p-3">
+                      <div className="mb-2 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--brand-soft)]">
                         {scenario.is_default ? t('defaultScenario') : scenario.name} {t('overrides')}
                       </div>
                       <div className="space-y-2">
                         {Object.keys(selectedComponent.props).map((key) => (
                           <div key={key}>
-                            <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--operator-primary-soft)]">{key}</label>
+                            <label className="mb-1 block text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--brand-soft)]">{key}</label>
                             <input
                               value={String(overrides[key] ?? '')}
                               placeholder={String(selectedComponent.props[key] ?? '')}

--- a/apps/web/src/components/settings/slack-integration-settings.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings.tsx
@@ -230,7 +230,7 @@ export function SlackIntegrationSettingsSection() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
             <div className="space-y-1">
               <div className="flex items-center gap-2">
-                <MessageSquareShare className="size-4 text-[color:var(--operator-primary-soft)]" />
+                <MessageSquareShare className="size-4 text-[color:var(--brand-soft)]" />
                 <h2 className="text-base font-semibold text-foreground">{t('title')}</h2>
               </div>
               <p className="text-sm text-muted-foreground">{t('description')}</p>
@@ -336,7 +336,7 @@ export function SlackIntegrationSettingsSection() {
             </div>
           ) : data.status === 'disconnected' ? (
             <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
-              <MessageSquareShare className="mx-auto size-9 text-[color:var(--operator-primary-soft)]" />
+              <MessageSquareShare className="mx-auto size-9 text-[color:var(--brand-soft)]" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">{t('disconnectedTitle')}</h3>
               <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('disconnectedBody')}</p>
               <div className="mt-5 flex flex-wrap items-center justify-center gap-3">
@@ -352,7 +352,7 @@ export function SlackIntegrationSettingsSection() {
             </GlassPanel>
           ) : filteredChannels.length === 0 ? (
             <GlassPanel className="border-dashed border-white/14 bg-muted/28 p-6 text-center">
-              <MessageSquareShare className="mx-auto size-9 text-[color:var(--operator-primary-soft)]" />
+              <MessageSquareShare className="mx-auto size-9 text-[color:var(--brand-soft)]" />
               <h3 className="mt-4 text-lg font-semibold text-foreground">{t('emptyTitle')}</h3>
               <p className="mx-auto mt-2 max-w-2xl text-sm text-muted-foreground">{t('emptyBody')}</p>
             </GlassPanel>
@@ -427,7 +427,7 @@ export function SlackIntegrationSettingsSection() {
                           </Button>
                         </div>
                         {mappedElsewhere ? (
-                          <div className="xl:col-span-2 rounded-2xl border border-[color:var(--operator-primary)]/18 bg-brand/10 px-3 py-3 text-sm text-[color:var(--operator-primary-soft)]">
+                          <div className="xl:col-span-2 rounded-2xl border border-brand/18 bg-brand/10 px-3 py-3 text-sm text-[color:var(--brand-soft)]">
                             {t('mappedElsewhereHint', { project: currentMapping?.project_name ?? t('unknownProject') })}
                           </div>
                         ) : null}
@@ -448,7 +448,7 @@ export function SlackIntegrationSettingsSection() {
 
       {allDirtyChannels.length > 0 ? (
         <div className="fixed inset-x-3 bottom-24 z-40 sm:bottom-6 lg:static lg:inset-auto lg:z-auto">
-          <GlassPanel className="border-[color:var(--operator-primary)]/20 bg-muted/92 p-3 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
+          <GlassPanel className="border-brand/20 bg-muted/92 p-3 shadow-[0_24px_60px_rgba(0,0,0,0.45)]">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-sm font-medium text-foreground">{t('stickyBarTitle', { count: allDirtyChannels.length })}</p>

--- a/apps/web/src/components/standup/standup-board-card.tsx
+++ b/apps/web/src/components/standup/standup-board-card.tsx
@@ -32,7 +32,7 @@ export function StandupBoardCard({
   const commentCount = feedback.filter((f) => f.review_type === 'comment').length;
 
   return (
-    <div className={cn('flex flex-col rounded-xl border border-border bg-card shadow-sm', isCurrentUser && 'ring-1 ring-[color:var(--operator-primary)]/40')}>
+    <div className={cn('flex flex-col rounded-xl border border-border bg-card shadow-sm', isCurrentUser && 'ring-1 ring-brand/40')}>
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-2 px-4 pt-4">
         <div className="min-w-0 flex-1 space-y-1">
@@ -65,7 +65,7 @@ export function StandupBoardCard({
               </p>
             </div>
             <div className="space-y-1">
-              <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
+              <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--brand-soft)]">{t('planLabel')}</div>
               <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.plan ? 'text-foreground/90' : 'text-muted-foreground')}>
                 {entry.plan || t('emptySection')}
               </p>

--- a/apps/web/src/components/standup/standup-feedback-dialog.tsx
+++ b/apps/web/src/components/standup/standup-feedback-dialog.tsx
@@ -190,7 +190,7 @@ export function StandupFeedbackDialog({
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
+                <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--brand-soft)]">{t('planLabel')}</div>
                 <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.plan && 'text-muted-foreground')}>
                   {entry.plan || t('emptySection')}
                 </p>

--- a/apps/web/src/components/standup/standup-review-card.tsx
+++ b/apps/web/src/components/standup/standup-review-card.tsx
@@ -229,7 +229,7 @@ export function StandupReviewCard({
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--operator-primary-soft)]">{t('planLabel')}</div>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--brand-soft)]">{t('planLabel')}</div>
                 <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.plan && 'text-muted-foreground')}>
                   {entry.plan || t('emptySection')}
                 </p>


### PR DESCRIPTION
## 변경 사항

### 1. operator-primary-{soft,strong,contrast} → brand-{soft,strong,contrast} rename
- tsx/ts 26파일 사용처 치환
- `globals.css` :root + .dark 양쪽 CSS 변수 정의 rename

### 2. operator-primary opacity modifier / ring / accent 정리
- `[color:var(--operator-primary)]` → `brand` (border-/ring-/accent- 모든 prefix + 슬래시 opacity 변형 포함)
- `var(--operator-primary)` → `var(--brand)` (linear-gradient, inline style 2건)

### 3. operator-border dead alias 제거 (15건)
- `--operator-border`는 globals.css에 정의 없음 — 전부 fallback `hsl(var(--border))`로 작동 중
- `[color:var(--operator-border,...)]` → `border` (epics-client.tsx 집중)

### 4. operator-surface-soft fallback 제거 (2건)
- `[color:var(--operator-surface-soft,...)]` → `muted` (epics-client.tsx)

## 검증

| 항목 | 결과 |
|---|---|
| `grep -rn "operator-" apps/web/src/*.{tsx,ts}` 사용처 잔존 | **0건** ✅ |
| globals.css operator-primary-* 정의 잔존 | **0건** ✅ |
| `pnpm type-check` | ✅ |
| `pnpm build` | ✅ |

## Out of Scope (PR-C 예정)
- globals.css의 나머지 `--operator-*` 정의 자체 제거 → PR-C에서 처리

🤖 Generated with [Claude Code](https://claude.com/claude-code)