### PR TITLE
[DS-S7-C] globals.css --operator-* alias 정의 전면 제거

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -138,19 +138,9 @@
   --scrollbar-thumb-hover: oklch(0 0 0 / 18%);
   --scrollbar-track: transparent;
 
-  /* Operator aliases — for feature components (mockups, theme-settings) */
-  --operator-bg: var(--background);
-  --operator-surface: var(--card);
-  --operator-panel: var(--muted);
-  --operator-foreground: var(--foreground);
-  --operator-muted: var(--muted-foreground);
-  --operator-primary: var(--brand);
   --brand-soft: oklch(0.90 0.06 258);
   --brand-strong: oklch(0.45 0.20 258);
   --brand-contrast: oklch(0.96 0.03 258);
-  --operator-tertiary: var(--info);
-  --operator-outline: var(--border);
-  --operator-danger: var(--destructive);
 
   /* Tiptap editor */
   --tiptap-code-bg: oklch(0.22 0 0);
@@ -216,19 +206,9 @@
   --scrollbar-thumb-hover: oklch(1 0 0 / 18%);
   --scrollbar-track: transparent;
 
-  /* Operator aliases — dark mode */
-  --operator-bg: var(--background);
-  --operator-surface: var(--card);
-  --operator-panel: var(--muted);
-  --operator-foreground: var(--foreground);
-  --operator-muted: var(--muted-foreground);
-  --operator-primary: var(--brand);
   --brand-soft: oklch(0.80 0.10 258);
   --brand-strong: oklch(0.55 0.22 258);
   --brand-contrast: oklch(0.22 0.05 258);
-  --operator-tertiary: var(--info);
-  --operator-outline: var(--border);
-  --operator-danger: var(--destructive);
 
   /* Tiptap editor (dark) */
   --tiptap-code-bg: oklch(0.22 0 0);


### PR DESCRIPTION
## 변경 사항

PR-A(단순 alias 10종 사용처 치환) + PR-B(brand-* rename + 잔존 4종 통합)로 사용처 정리 완료 후, globals.css에 남은 `--operator-*` alias 정의 전면 제거.

### 제거 내역
- `:root` 블록: `--operator-*` alias 10종 + 주석 1줄
- `.dark` 블록: 동일 10종 + 주석 1줄
- 총 **20 라인 삭제** (1 파일)

### 유지 항목
- `--brand-soft/strong/contrast` 정의는 그대로 유지 (PR-B에서 rename된 토큰)

## 검증

| 항목 | 결과 |
|---|---|
| `grep -rn "operator-" apps/web/src/` | **0건** ✅ |
| `pnpm type-check` | ✅ |
| `pnpm build` | ✅ |

## DS-S7 전체 완주
- PR-A #950: 단순 alias 10종 사용처 치환 ✅
- PR-B #951: brand-* rename + 잔존 4종 통합 ✅
- PR-C #952: globals.css alias 정의 전면 제거 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)