### PR TITLE
[hotfix] Base UI error #31 — ProfileMenu 설정 항목 render prop 수정

### DIFF
--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -8,6 +8,7 @@ import { logoutUser } from '@/lib/db/client';
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -48,12 +49,14 @@ export function ProfileMenu({ name, email }: ProfileMenuProps) {
         <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-56">
-        <DropdownMenuLabel className="flex flex-col gap-0.5">
-          <span className="text-sm font-medium">{name}</span>
-          {displayLabel !== name && (
-            <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
-          )}
-        </DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium">{name}</span>
+            {displayLabel !== name && (
+              <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
+            )}
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem render={<Link href="/settings" />}>
           <Settings className="size-4" />

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -55,11 +55,9 @@ export function ProfileMenu({ name, email }: ProfileMenuProps) {
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
-          <Link href="/settings" className="flex w-full items-center gap-2">
-            <Settings className="size-4" />
-            설정
-          </Link>
+        <DropdownMenuItem render={<Link href="/settings" />}>
+          <Settings className="size-4" />
+          설정
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => void handleLogout()} className="flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive">


### PR DESCRIPTION
## 원인 진단 (2차 정정 — 까심군 codex exec 정밀 진단 반영)

### 루트 원인 (error #31)
`Base UI: MenuGroupRootContext is missing. Menu group parts must be used within <Menu.Group>.`

`DropdownMenuLabel` (= `MenuPrimitive.GroupLabel`)을 `DropdownMenuGroup` (= `MenuPrimitive.Group`) 없이 직접 사용 → error #31 throw.

### 부수 안티 패턴 (동시 수정)
`DropdownMenuItem` 내부에 `<Link>` 직접 children 중첩 — Base UI는 Radix 방식과 달리 `render` prop 패턴 필요.

---

## 수정 내용 (커밋 2개)

### 커밋 1 — render prop 수정
```tsx
// Before
<DropdownMenuItem>
  <Link href="/settings" className="flex w-full items-center gap-2">…</Link>
</DropdownMenuItem>

// After
<DropdownMenuItem render={<Link href="/settings" />}>
  <Settings className="size-4" />
  설정
</DropdownMenuItem>
```

### 커밋 2 — GroupLabel context 수정 (루트 원인)
```tsx
// Before
<DropdownMenuContent>
  <DropdownMenuLabel>...</DropdownMenuLabel>   {/* Group 없음 → error #31 */}
  <DropdownMenuSeparator />
  ...

// After
<DropdownMenuContent>
  <DropdownMenuGroup>
    <DropdownMenuLabel>...</DropdownMenuLabel>
  </DropdownMenuGroup>
  <DropdownMenuSeparator />
  ...
```

---

## 검증

- `pnpm build` ✅ (양 커밋 후)
- `pnpm lint` ✅ (신규 에러 0)
- 로그아웃 항목(onClick 방식) 변경 없음
- 회귀 다른 곳 없음 (일괄 grep 확인)

## AC

- [ ] AC1: ProfileMenu 트리거 클릭 시 드롭다운 정상 오픈 (ErrorBoundary 폴백 없음)
- [ ] AC2: 설정 클릭 시 `/settings` 이동
- [ ] AC3: 로그아웃 클릭 시 `/login` 리다이렉트
- [ ] AC4: 콘솔 Base UI error #31 없음
- [ ] AC5: `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)