### PR TITLE
🚨 hotfix promotion: ProfileMenu Base UI error #31 (#955)

### DIFF
--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -8,6 +8,7 @@ import { logoutUser } from '@/lib/db/client';
 import {
   DropdownMenu,
   DropdownMenuContent,
+  DropdownMenuGroup,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuSeparator,
@@ -48,12 +49,14 @@ export function ProfileMenu({ name, email }: ProfileMenuProps) {
         <ChevronsUpDown className="size-3.5 shrink-0 text-sidebar-foreground/60" />
       </DropdownMenuTrigger>
       <DropdownMenuContent side="top" align="start" className="w-56">
-        <DropdownMenuLabel className="flex flex-col gap-0.5">
-          <span className="text-sm font-medium">{name}</span>
-          {displayLabel !== name && (
-            <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
-          )}
-        </DropdownMenuLabel>
+        <DropdownMenuGroup>
+          <DropdownMenuLabel className="flex flex-col gap-0.5">
+            <span className="text-sm font-medium">{name}</span>
+            {displayLabel !== name && (
+              <span className="text-xs font-normal text-muted-foreground">{displayLabel}</span>
+            )}
+          </DropdownMenuLabel>
+        </DropdownMenuGroup>
         <DropdownMenuSeparator />
         <DropdownMenuItem render={<Link href="/settings" />}>
           <Settings className="size-4" />

--- a/apps/web/src/components/nav/profile-menu.tsx
+++ b/apps/web/src/components/nav/profile-menu.tsx
@@ -55,11 +55,9 @@ export function ProfileMenu({ name, email }: ProfileMenuProps) {
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem>
-          <Link href="/settings" className="flex w-full items-center gap-2">
-            <Settings className="size-4" />
-            설정
-          </Link>
+        <DropdownMenuItem render={<Link href="/settings" />}>
+          <Settings className="size-4" />
+          설정
         </DropdownMenuItem>
         <DropdownMenuSeparator />
         <DropdownMenuItem onClick={() => void handleLogout()} className="flex items-center gap-2 text-destructive focus:bg-destructive/10 focus:text-destructive">


### PR DESCRIPTION
## Summary

P0 hotfix: ProfileMenu 클릭 시 페이지 ErrorBoundary 폴백 (Base UI error #31) 해소.

**원인**: `profile-menu.tsx`에서 (1) `DropdownMenuItem`에 `<Link>` children 직접 사용 (render prop 패턴 미사용) + (2) `DropdownMenuLabel`을 `DropdownMenuGroup` 없이 사용 → `MenuGroupRootContext missing`.

## 포함

- PR #955 (#e99587ef + 0305bcfb) — render prop 패턴 적용 + DropdownMenuLabel을 DropdownMenuGroup으로 감싸기
- 단일 파일 변경: `apps/web/src/components/nav/profile-menu.tsx`

## 영향

- prod 모든 로그인 사용자 ProfileMenu/로그아웃 사용 가능 복귀
- migration·시크릿·deps 변경 없음
- 까심군 dev fast-track QA APPROVE 완료

## Test plan

- [x] dev develop 환경 까심군 fast-track QA APPROVE
- [x] type-check / build / smoke-test PASS
- [ ] main 머지 후 Cloud Build SUCCESS
- [ ] prod URL Puppeteer 시각 검증 (ProfileMenu 정상 펼침)
- [ ] 까심군 prod runtime smoke (로그아웃 흐름 + 콘솔 error #31 미발생)

🤖 Generated with [Claude Code](https://claude.com/claude-code)