### PR TITLE
🚨 hotfix promotion: stories actor_id UnboundLocalError 정공법 (#958)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -163,16 +163,18 @@ async def update_story(
     # 변경사항 먼저 commit — side effects 에러가 rollback시키지 않도록
     await db.commit()
 
+    # S-C2: 모든 스토리 업데이트에서 actor resolve — assignee 변경 여부와 무관하게 공통 적용
+    actor_id: uuid.UUID | None = None
+    actor_name: str | None = None
+    actor_role: str | None = None
+    try:
+        actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+        actor_name, actor_role = await _resolve_actor_info(db, actor_id)
+    except Exception:
+        pass
+
     if "assignee_id" in data and old_assignee_id != story.assignee_id:
         org_id = repo.org_id
-        actor_id: uuid.UUID | None = None
-        actor_name: str | None = None
-        actor_role: str | None = None
-        try:
-            actor_id = await _resolve_team_member_id(auth, org_id, db)
-            actor_name, actor_role = await _resolve_actor_info(db, actor_id)
-        except Exception:
-            pass
         epic_title: str | None = None
         try:
             epic_title = await _resolve_epic_title(db, story.epic_id)
@@ -296,6 +298,16 @@ async def update_story_status(
     # 내부 DB 에러가 트랜잭션을 aborted 상태로 만들어 status 변경까지 rollback하는 버그 방지
     await db.commit()
 
+    # S-C2: 모든 스토리 업데이트에서 actor resolve — status 변경 여부와 무관하게 공통 적용
+    actor_id: uuid.UUID | None = None
+    actor_name: str | None = None
+    actor_role: str | None = None
+    try:
+        actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
+        actor_name, actor_role = await _resolve_actor_info(db, actor_id)
+    except Exception:
+        pass
+
     if old_status != story.status:
         org_id = repo.org_id
         # AC2/3/4/6: warn 모드 위반 — 전이는 정상 진행, 이벤트+웹훅만 발행
@@ -318,14 +330,6 @@ async def update_story_status(
                 await fire_webhooks(db, org_id, "workflow_violation", _v_event)
             except Exception:
                 pass
-        actor_id: uuid.UUID | None = None
-        actor_name: str | None = None
-        actor_role: str | None = None
-        try:
-            actor_id = await _resolve_team_member_id(auth, org_id, db)
-            actor_name, actor_role = await _resolve_actor_info(db, actor_id)
-        except Exception:
-            pass
         epic_title: str | None = None
         try:
             epic_title = await _resolve_epic_title(db, story.epic_id)


### PR DESCRIPTION
## Summary

P0 hotfix: `PATCH /api/v2/stories/{id}` + 상태 변경 5개 엔드포인트에서 `actor_id` UnboundLocalError 해소.

## 원인 (까심군 codex exec 진단)

S-C2 커밋 `af5baf9b` (2026-05-15, "actor가 agent인 경우 기록" hook 추가)에서 `update_story` 함수 스코프 `actor_id` 초기화 누락. assignee 변경 없는 일반 update(예: `story_points=5` patch) 시 line 238 `if actor_id:` 평가에서 UnboundLocalError → 500.

- auth dep batch 1/2 (#945, #946)와 무관 — git log 확인 완료
- 잠복 회귀 다른 라우터 없음 — stories.py 2건만

## 정공법 fix (반창고 아님)

`update_story` + `update_story_status` 둘 다 `db.commit()` 직후 actor resolve를 **함수 스코프**로 이동. if 블록 내 중복 resolve 제거. S-C2 원래 의도("모든 스토리 업데이트에서 actor 기록") 충족.

- 단일 파일 단일 commit
- 외부 인터페이스/시그니처 변경 없음 (backward compatible)
- 로컬 `tests/test_stories.py` 20/20 PASS

## Test plan

- [x] 까심군 codex exec 정공법 진단 + AC1~5 APPROVE
- [x] tests/test_stories.py 20/20 PASS
- [ ] main 머지 후 Cloud Build SUCCESS
- [ ] prod runtime — PATCH /api/v2/stories/{id} (story_points/title/priority 단일 필드 patch) → 500 미발생

🤖 Generated with [Claude Code](https://claude.com/claude-code)