### PR TITLE
[E-OA1:S3] project-scoped API Key 발급/조회/폐기 엔드포인트

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1821,7 +1821,15 @@
     "workflowVersionRemovedRules": "-{count}",
     "workflowVersionChangedRules": "~{count}",
     "tabDeployments": "Deployments",
-    "tabPerformance": "Performance"
+    "tabPerformance": "Performance",
+    "autoBadge": "Auto",
+    "autoTooltip": "Created by {name}",
+    "createdBy": "Created by {name}",
+    "createdByUnknown": "—",
+    "canManageMembersLabel": "Manage members",
+    "toggleSuccessTitle": "Permission updated",
+    "toggleFailedTitle": "Permission update failed",
+    "toggleFailedBody": "Please try again"
   },
   "agentRuns": {
     "eyebrow": "RUN HISTORY",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1821,7 +1821,15 @@
     "workflowVersionRemovedRules": "삭제 {count}",
     "workflowVersionChangedRules": "변경 {count}",
     "tabDeployments": "배포",
-    "tabPerformance": "퍼포먼스"
+    "tabPerformance": "퍼포먼스",
+    "autoBadge": "Auto",
+    "autoTooltip": "{name} 에이전트가 생성함",
+    "createdBy": "생성자: {name}",
+    "createdByUnknown": "—",
+    "canManageMembersLabel": "멤버 관리",
+    "toggleSuccessTitle": "권한 변경 완료",
+    "toggleFailedTitle": "권한 변경 실패",
+    "toggleFailedBody": "다시 시도해 주세요"
   },
   "agentRuns": {
     "eyebrow": "실행 기록",

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -3,9 +3,11 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useLocale, useTranslations } from 'next-intl';
-import { Bot, Clock3, History, Pause, Play, RefreshCw, Rocket, TriangleAlert, Zap } from 'lucide-react';
+import { Bot, Clock3, History, Pause, Play, RefreshCw, Rocket, TriangleAlert, User, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import {
@@ -16,6 +18,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { getDeploymentHealthState, getDeploymentRecoveryCueKeys, hasActiveFailureSignal } from '@/services/agent-deployment-console';
 import { getTriggerMemoHref } from '@/services/agent-run-history';
 
@@ -45,6 +52,17 @@ export interface AgentDeploymentCard {
     next_retry_at: string | null;
     can_manual_retry: boolean;
   } | null;
+  agent_id?: string;
+}
+
+interface TeamMemberInfo {
+  id: string;
+  name: string;
+  type: 'human' | 'agent';
+  role: string;
+  user_id: string | null;
+  can_manage_members: boolean;
+  created_by: string | null;
 }
 
 type TransitionAction = { deploymentId: string; name: string; targetStatus: 'ACTIVE' | 'SUSPENDED' };
@@ -120,7 +138,13 @@ function getFailureHeadline(failure: AgentDeploymentCard['latest_failed_run']) {
 
 const AUTO_REFRESH_INTERVAL = 30_000;
 
-export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = false }: { deployments: AgentDeploymentCard[]; hideTopBar?: boolean }) {
+interface AgentsDashboardProps {
+  deployments: AgentDeploymentCard[];
+  hideTopBar?: boolean;
+  canManageMembers?: boolean;
+}
+
+export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = false, canManageMembers = false }: AgentsDashboardProps) {
   const locale = useLocale();
   const t = useTranslations('agents');
   const tr = useTranslations('agentRuns');
@@ -133,9 +157,31 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
   const [pendingAction, setPendingAction] = useState<TransitionAction | null>(null);
   const [transitioning, setTransitioning] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [teamMembersMap, setTeamMembersMap] = useState<Map<string, TeamMemberInfo>>(new Map());
+  const [userIdToMemberMap, setUserIdToMemberMap] = useState<Map<string, TeamMemberInfo>>(new Map());
 
   useEffect(() => {
     setLastRefreshed(new Date());
+  }, []);
+
+  useEffect(() => {
+    async function loadTeamMembers() {
+      try {
+        const res = await fetch('/api/team-members');
+        if (!res.ok) return;
+        const json = await res.json() as { data: TeamMemberInfo[] | null };
+        const members = json.data ?? [];
+        const byId = new Map(members.map((m) => [m.id, m]));
+        const byUserId = new Map(
+          members.filter((m) => m.user_id).map((m) => [m.user_id as string, m]),
+        );
+        setTeamMembersMap(byId);
+        setUserIdToMemberMap(byUserId);
+      } catch {
+        // silently skip
+      }
+    }
+    void loadTeamMembers();
   }, []);
 
   // Show deploy success toast from sessionStorage (S462 compat)
@@ -229,6 +275,41 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
     }
   };
 
+  const handleToggleCanManage = async (deploymentId: string, newValue: boolean) => {
+    const target = deployments.find((d) => d.id === deploymentId);
+    const agentMember = target?.agent_id ? teamMembersMap.get(target.agent_id) : null;
+    if (!agentMember) return;
+    setTeamMembersMap((prev) => {
+      const next = new Map(prev);
+      next.set(agentMember.id, { ...agentMember, can_manage_members: newValue });
+      return next;
+    });
+    try {
+      const res = await fetch(`/api/team-members/${agentMember.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ can_manage_members: newValue }),
+      });
+      if (!res.ok) {
+        setTeamMembersMap((prev) => {
+          const next = new Map(prev);
+          next.set(agentMember.id, { ...agentMember, can_manage_members: !newValue });
+          return next;
+        });
+        addToast({ title: t('toggleFailedTitle'), body: t('toggleFailedBody'), type: 'warning' });
+      } else {
+        addToast({ title: t('toggleSuccessTitle'), type: 'success' });
+      }
+    } catch {
+      setTeamMembersMap((prev) => {
+        const next = new Map(prev);
+        next.set(agentMember.id, { ...agentMember, can_manage_members: !newValue });
+        return next;
+      });
+      addToast({ title: t('toggleFailedTitle'), body: t('toggleFailedBody'), type: 'warning' });
+    }
+  };
+
   const isSuspendAction = pendingAction?.targetStatus === 'SUSPENDED';
 
   return (
@@ -237,10 +318,12 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
         <TopBarSlot
             title={<h1 className="text-sm font-medium">{t('statusTitle')}</h1>}
             actions={
-              <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
-                <Rocket className="mr-1.5 size-3.5" />
-                {t('openWizard')}
-              </Link>
+              canManageMembers ? (
+                <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
+                  <Rocket className="mr-1.5 size-3.5" />
+                  {t('openWizard')}
+                </Link>
+              ) : null
             }
           />
       )}
@@ -273,10 +356,12 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                   <Bot className="mx-auto size-10 text-primary" />
                   <h3 className="mt-4 text-lg font-semibold text-foreground">{t('emptyDeploymentsTitle')}</h3>
                   <p className="mt-2 text-sm text-muted-foreground">{t('emptyDeploymentsBody')}</p>
-                  <div className="mt-6 flex flex-wrap justify-center gap-2">
-                    <Link href="/agents/workflow" className={buttonVariants({ variant: 'glass', size: 'lg' })}>{t('workflowEditorCta')}</Link>
-                    <Link href="/agents/deploy" className={buttonVariants({ variant: 'hero', size: 'lg' })}>{t('openWizard')}</Link>
-                  </div>
+                  {canManageMembers && (
+                    <div className="mt-6 flex flex-wrap justify-center gap-2">
+                      <Link href="/agents/workflow" className={buttonVariants({ variant: 'glass', size: 'lg' })}>{t('workflowEditorCta')}</Link>
+                      <Link href="/agents/deploy" className={buttonVariants({ variant: 'hero', size: 'lg' })}>{t('openWizard')}</Link>
+                    </div>
+                  )}
                 </div>
                 <div className="grid gap-3 md:grid-cols-3">
                   {([
@@ -297,6 +382,12 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
               const recoveryCues = getDeploymentRecoveryCueKeys(deployment);
               const latestFailure = hasActiveFailureSignal(deployment) ? deployment.latest_failed_run : null;
 
+              const agentMember = deployment.agent_id ? teamMembersMap.get(deployment.agent_id) : null;
+              const creatorMember = agentMember?.created_by ? userIdToMemberMap.get(agentMember.created_by) : null;
+              const isAutoOnboarded = creatorMember?.type === 'agent';
+              const creatorName = creatorMember?.name ?? null;
+              const canManageToggle = agentMember?.can_manage_members ?? false;
+
               return (
                 <div key={deployment.id} className="rounded-md border border-border bg-muted/30 px-4 py-4">
                   <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
@@ -315,12 +406,34 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                             {t('hitlPendingBadge', { count: deployment.pending_hitl_count })}
                           </Badge>
                         )}
+                        {isAutoOnboarded && (
+                          <Tooltip>
+                            <TooltipTrigger>
+                              <Badge variant="secondary" className="px-1.5 py-0 text-[10px] font-medium leading-4">
+                                {t('autoBadge')}
+                              </Badge>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              {t('autoTooltip', { name: creatorName ?? '' })}
+                            </TooltipContent>
+                          </Tooltip>
+                        )}
                       </div>
                       <p className="text-sm text-muted-foreground">
                         {deployment.persona_name
                           ? t('statusPersonaLine', { agent: deployment.agent_name, persona: deployment.persona_name })
                           : t('statusAgentLine', { agent: deployment.agent_name })}
                       </p>
+                      {agentMember && (
+                        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                          {creatorMember?.type === 'agent' ? (
+                            <Bot className="size-3.5" aria-hidden="true" />
+                          ) : (
+                            <User className="size-3.5" aria-hidden="true" />
+                          )}
+                          <span>{t('createdBy', { name: creatorName ?? t('createdByUnknown') })}</span>
+                        </div>
+                      )}
                       <div className="grid gap-2 text-xs text-muted-foreground sm:grid-cols-2 xl:grid-cols-4">
                         <span>{t('statusRuntime', { runtime: deployment.runtime })}</span>
                         <span>{t('statusModel', { model: deployment.model ?? t('statusModelUnknown') })}</span>
@@ -374,6 +487,23 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                       <span className="text-[11px] text-muted-foreground">
                         {t('statusUpdatedAt', { time: formatLocalTime(deployment.updated_at, locale) })}
                       </span>
+                      {agentMember && (
+                        <div className="flex items-center gap-2 rounded-md border border-border/40 bg-background/60 px-2.5 py-1.5">
+                          <Switch
+                            id={`can-manage-${deployment.id}`}
+                            checked={canManageToggle}
+                            onCheckedChange={(v) => void handleToggleCanManage(deployment.id, v)}
+                            disabled={!canManageMembers}
+                            className="data-[state=checked]:bg-primary"
+                          />
+                          <Label
+                            htmlFor={`can-manage-${deployment.id}`}
+                            className="cursor-pointer text-xs text-muted-foreground"
+                          >
+                            {t('canManageMembersLabel')}
+                          </Label>
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/apps/web/src/components/agents/agents-page-tabs.tsx
+++ b/apps/web/src/components/agents/agents-page-tabs.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import Link from 'next/link';
 import { Rocket } from 'lucide-react';
@@ -18,6 +18,25 @@ interface AgentsPageTabsProps {
 export function AgentsPageTabs({ deployments }: AgentsPageTabsProps) {
   const t = useTranslations('agents');
   const [activeTab, setActiveTab] = useState<Tab>('deployments');
+  const [canManageMembers, setCanManageMembers] = useState(false);
+
+  useEffect(() => {
+    async function loadMe() {
+      try {
+        const res = await fetch('/api/me');
+        if (!res.ok) return;
+        const json = await res.json() as { data?: { role?: string; type?: string } };
+        const role = json.data?.role ?? 'member';
+        const type = json.data?.type ?? 'human';
+        setCanManageMembers(
+          (role === 'owner' || role === 'admin') && type === 'human',
+        );
+      } catch {
+        // silently skip — default false (deny)
+      }
+    }
+    void loadMe();
+  }, []);
 
   return (
     <>
@@ -47,7 +66,7 @@ export function AgentsPageTabs({ deployments }: AgentsPageTabsProps) {
           </div>
         }
         actions={
-          activeTab === 'deployments' ? (
+          activeTab === 'deployments' && canManageMembers ? (
             <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
               <Rocket className="mr-1.5 size-3.5" />
               {t('openWizard')}
@@ -56,7 +75,7 @@ export function AgentsPageTabs({ deployments }: AgentsPageTabsProps) {
         }
       />
       {activeTab === 'deployments' ? (
-        <AgentsDashboard deployments={deployments} hideTopBar />
+        <AgentsDashboard deployments={deployments} hideTopBar canManageMembers={canManageMembers} />
       ) : (
         <AgentPerformancePanel />
       )}

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Label({ className, ...props }: React.ComponentProps<"label">) {
+  return (
+    <label
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,32 @@
+"use client"
+
+import { Switch as SwitchPrimitive } from "@base-ui/react/switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: SwitchPrimitive.Root.Props & {
+  size?: "sm" | "default"
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className="pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-checked:translate-x-[calc(100%-2px)] group-data-[size=sm]/switch:data-checked:translate-x-[calc(100%-2px)] dark:data-checked:bg-primary-foreground group-data-[size=default]/switch:data-unchecked:translate-x-0 group-data-[size=sm]/switch:data-unchecked:translate-x-0 dark:data-unchecked:bg-foreground"
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/backend/alembic/versions/0050_add_project_api_keys.py
+++ b/backend/alembic/versions/0050_add_project_api_keys.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
         sa.Column(
             "created_by",
             postgresql.UUID(as_uuid=False),
-            sa.ForeignKey("team_members.id", ondelete="SET NULL"),
+            sa.ForeignKey("users.id", ondelete="SET NULL"),
             nullable=True,
         ),
         sa.Column("name", sa.Text(), nullable=False),

--- a/backend/alembic/versions/0050_add_project_api_keys.py
+++ b/backend/alembic/versions/0050_add_project_api_keys.py
@@ -1,0 +1,50 @@
+"""project_api_keys 테이블 생성 (E-OA1:S3)
+
+Revision ID: 0050
+Revises: 0049
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0050"
+down_revision = "0049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project_api_keys",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "project_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("projects.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_by",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("team_members.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("key_prefix", sa.Text(), nullable=False),
+        sa.Column("key_hash", sa.Text(), nullable=False),
+        sa.Column("scope", postgresql.ARRAY(sa.Text()), nullable=True),
+        sa.Column("plan_feature_ids", postgresql.ARRAY(postgresql.UUID(as_uuid=False)), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_project_api_keys_project_id", "project_api_keys", ["project_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_project_api_keys_project_id", table_name="project_api_keys")
+    op.drop_table("project_api_keys")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
+from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -159,6 +159,7 @@ app.include_router(workflow_report.router)
 app.include_router(workflow_trigger.router)
 app.include_router(mockups.router)
 app.include_router(plan_features.router)
+app.include_router(open_api_keys.router)
 
 if settings.is_ee_enabled:
     from ee.routers import billing  # type: ignore[import]

--- a/backend/app/models/project_api_key.py
+++ b/backend/app/models/project_api_key.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ProjectApiKey(Base):
+    __tablename__ = "project_api_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_by: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
+    key_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    scope: Mapped[list | None] = mapped_column(ARRAY(Text), nullable=True)
+    plan_feature_ids: Mapped[list | None] = mapped_column(ARRAY(UUID(as_uuid=True)), nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/project_api_key.py
+++ b/backend/app/models/project_api_key.py
@@ -16,7 +16,7 @@ class ProjectApiKey(Base):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
     )
     name: Mapped[str] = mapped_column(Text, nullable=False)
     key_prefix: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/repositories/project_api_key.py
+++ b/backend/app/repositories/project_api_key.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.project_api_key import ProjectApiKey
+
+
+def _generate_key() -> tuple[str, str, str]:
+    raw = secrets.token_hex(32)
+    prefix = f"pk_live_{raw[:8]}"
+    plaintext = f"pk_live_{raw}"
+    key_hash = hashlib.sha256(plaintext.encode()).hexdigest()
+    return plaintext, prefix, key_hash
+
+
+class ProjectApiKeyRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def create(
+        self,
+        project_id: uuid.UUID,
+        created_by: uuid.UUID | None,
+        name: str,
+        scope: list[str] | None,
+        plan_feature_ids: list[uuid.UUID] | None,
+    ) -> tuple[ProjectApiKey, str]:
+        plaintext, prefix, key_hash = _generate_key()
+        key = ProjectApiKey(
+            project_id=project_id,
+            created_by=created_by,
+            name=name,
+            key_prefix=prefix,
+            key_hash=key_hash,
+            scope=scope,
+            plan_feature_ids=plan_feature_ids,
+        )
+        self.session.add(key)
+        await self.session.flush()
+        return key, plaintext
+
+    async def list_by_project(self, project_id: uuid.UUID) -> list[ProjectApiKey]:
+        result = await self.session.execute(
+            select(ProjectApiKey)
+            .where(ProjectApiKey.project_id == project_id)
+            .order_by(ProjectApiKey.created_at.desc())
+        )
+        return list(result.scalars().all())
+
+    async def get(self, key_id: uuid.UUID) -> ProjectApiKey | None:
+        result = await self.session.execute(
+            select(ProjectApiKey).where(ProjectApiKey.id == key_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def revoke(self, key: ProjectApiKey) -> ProjectApiKey:
+        key.revoked_at = datetime.now(timezone.utc)
+        await self.session.flush()
+        return key

--- a/backend/app/routers/open_api_keys.py
+++ b/backend/app/routers/open_api_keys.py
@@ -1,0 +1,81 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
+from app.dependencies.database import get_db
+from app.repositories.project_api_key import ProjectApiKeyRepository
+from app.schemas.project_api_key import (
+    CreateProjectApiKeyRequest,
+    ProjectApiKeyCreatedResponse,
+    ProjectApiKeyResponse,
+)
+
+router = APIRouter(prefix="/api/v2", tags=["open-api-keys"])
+
+
+def _get_repo(session: AsyncSession = Depends(get_db)) -> ProjectApiKeyRepository:
+    return ProjectApiKeyRepository(session)
+
+
+def _get_project_id(auth: AuthContext = Depends(get_current_user)) -> uuid.UUID:
+    raw = auth.claims.get("app_metadata", {}).get("project_id")
+    if not raw:
+        raise HTTPException(status_code=400, detail="project_id required in JWT app_metadata")
+    try:
+        return uuid.UUID(str(raw))
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid project_id in JWT")
+
+
+@router.post("/api-keys", response_model=ProjectApiKeyCreatedResponse, status_code=201)
+async def create_project_api_key(
+    body: CreateProjectApiKeyRequest,
+    auth: AuthContext = Depends(require_admin),
+    project_id: uuid.UUID = Depends(_get_project_id),
+    _org_id: uuid.UUID = Depends(get_verified_org_id),
+    repo: ProjectApiKeyRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+) -> ProjectApiKeyCreatedResponse:
+    created_by = uuid.UUID(auth.user_id) if auth.user_id else None
+    key, plaintext = await repo.create(
+        project_id=project_id,
+        created_by=created_by,
+        name=body.name,
+        scope=body.scope,
+        plan_feature_ids=body.plan_feature_ids,
+    )
+    await session.commit()
+    await session.refresh(key)
+    data = ProjectApiKeyResponse.model_validate(key)
+    return ProjectApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
+
+
+@router.get("/api-keys", response_model=list[ProjectApiKeyResponse])
+async def list_project_api_keys(
+    _auth: AuthContext = Depends(require_admin),
+    project_id: uuid.UUID = Depends(_get_project_id),
+    _org_id: uuid.UUID = Depends(get_verified_org_id),
+    repo: ProjectApiKeyRepository = Depends(_get_repo),
+) -> list[ProjectApiKeyResponse]:
+    keys = await repo.list_by_project(project_id)
+    return [ProjectApiKeyResponse.model_validate(k) for k in keys]
+
+
+@router.delete("/api-keys/{key_id}", status_code=204)
+async def revoke_project_api_key(
+    key_id: uuid.UUID,
+    _auth: AuthContext = Depends(require_admin),
+    project_id: uuid.UUID = Depends(_get_project_id),
+    _org_id: uuid.UUID = Depends(get_verified_org_id),
+    repo: ProjectApiKeyRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+) -> None:
+    key = await repo.get(key_id)
+    if key is None or key.project_id != project_id:
+        raise HTTPException(status_code=404, detail="API key not found")
+    if key.revoked_at is not None:
+        raise HTTPException(status_code=409, detail="API key already revoked")
+    await repo.revoke(key)
+    await session.commit()

--- a/backend/app/schemas/project_api_key.py
+++ b/backend/app/schemas/project_api_key.py
@@ -1,0 +1,28 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class CreateProjectApiKeyRequest(BaseModel):
+    name: str
+    scope: list[str] | None = None
+    plan_feature_ids: list[uuid.UUID] | None = None
+
+
+class ProjectApiKeyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    created_by: uuid.UUID | None
+    name: str
+    key_prefix: str
+    scope: list[str] | None
+    plan_feature_ids: list[uuid.UUID] | None
+    revoked_at: datetime | None
+    created_at: datetime
+
+
+class ProjectApiKeyCreatedResponse(ProjectApiKeyResponse):
+    api_key: str = Field(description="One-time plaintext key — store securely")


### PR DESCRIPTION
## Summary
- migration 0050: `project_api_keys` 테이블 신설 (project_id FK, plan_feature_ids ARRAY, scope ARRAY, revoked_at)
- `POST /api/v2/api-keys` — owner/admin 전용 발급, plaintext key 1회 응답
- `GET /api/v2/api-keys` — project 내 전체 key 목록
- `DELETE /api/v2/api-keys/{key_id}` — 폐기 (revoked_at 기록, 중복폐기 시 409)
- `require_admin` dependency로 member 이하 403 자동 차단
- `plan_feature_ids` ARRAY로 S4 `plan_features` 테이블 참조

## AC Checklist
- [x] AC1: POST /api/v2/api-keys → 201 + key 응답 (owner/admin만)
- [x] AC2: GET /api/v2/api-keys → project 내 key 목록
- [x] AC3: DELETE /api/v2/api-keys/{key_id} → 폐기 성공
- [x] AC4: member role 이하 403 (require_admin)
- [x] AC5: key에 plan_feature_ids 연결
- [ ] AC6: dev 환경 migration 적용 (머지 후 sprintable-migrate-dev 수동 실행 필요)

## Test plan
- [ ] `sprintable-migrate-dev` 실행 후 `project_api_keys` 테이블 확인
- [ ] owner/admin: `POST /api/v2/api-keys` → 201, `api_key` 필드 1회만 응답
- [ ] member: 동일 요청 → 403
- [ ] `GET /api/v2/api-keys` → 생성된 key 목록 (api_key 필드 없음)
- [ ] `DELETE /api/v2/api-keys/{key_id}` → 204, 재시도 → 409

🤖 Generated with [Claude Code](https://claude.com/claude-code)