### PR TITLE
[BF-8] Fix agents/api-keys — dynamic agent fetch + null guard

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/api-keys/page.tsx
@@ -1,7 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { AgentWebhookManager } from '@/components/agents/agent-webhook-manager';
 
-export default async function ApiKeysPage() {
+interface Agent {
+  id: string;
+  name: string;
+  type: string;
+  is_active: boolean;
+  webhook_url: string | null;
+}
+
+export default function ApiKeysPage() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadAgents() {
+      try {
+        const res = await fetch('/api/team-members?type=agent');
+        if (!res.ok) return;
+        const json = await res.json() as { data?: Agent[] };
+        setAgents((json.data ?? []).filter((m) => m.type === 'agent' && m.is_active));
+      } finally {
+        setLoading(false);
+      }
+    }
+    void loadAgents();
+  }, []);
+
   return (
     <div className="container mx-auto py-8 space-y-8">
       <div>
@@ -11,10 +39,30 @@ export default async function ApiKeysPage() {
         </p>
       </div>
 
-      <div className="space-y-6">
-        <AgentApiKeyManager agentId="" agentName="Default Agent" />
-        <AgentWebhookManager agentId="" agentName="Default Agent" currentWebhookUrl={null} />
-      </div>
+      {loading ? (
+        <div className="space-y-4">
+          {[1, 2].map((i) => (
+            <div key={i} className="h-32 animate-pulse rounded-lg border border-border bg-muted/30" />
+          ))}
+        </div>
+      ) : agents.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border px-6 py-12 text-center">
+          <p className="text-sm text-muted-foreground">No active agent members in this project.</p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {agents.map((agent) => (
+            <div key={agent.id} className="space-y-4">
+              <AgentApiKeyManager agentId={agent.id} agentName={agent.name} />
+              <AgentWebhookManager
+                agentId={agent.id}
+                agentName={agent.name}
+                currentWebhookUrl={agent.webhook_url}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -51,12 +51,13 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
     `아래의 정보를 읽고 온보딩하기 바람.\nsprintable agent name : ${agentName}\nsprintable agent api key : ${apiKey}\n${LLMS_URL}`;
 
   const loadApiKeys = useCallback(async () => {
+    if (!agentId) return;
     setLoading(true);
     try {
       const response = await fetch(`/api/agents/${agentId}/api-key`);
       if (!response.ok) throw new Error('Failed to load API keys');
-      const result = await response.json();
-      setApiKeys(result.data || []);
+      const result = await response.json() as { data?: ApiKey[] };
+      setApiKeys(result.data ?? []);
     } catch (error) {
       addToast({
         type: 'error',
@@ -74,6 +75,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   }, [loadApiKeys]);
 
   const generateApiKey = async () => {
+    if (!agentId) return;
     setLoading(true);
     try {
       const response = await fetch(`/api/agents/${agentId}/api-key`, {
@@ -82,8 +84,8 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
         body: JSON.stringify({ scope: selectedScopes }),
       });
       if (!response.ok) throw new Error('Failed to generate API key');
-      const result = await response.json();
-      const rawKey = result.data.api_key as string;
+      const result = await response.json() as { data?: { api_key?: string } };
+      const rawKey = (result.data?.api_key ?? '') as string;
       setGeneratedKey(rawKey);
       onNewKey?.(rawKey);
       await loadApiKeys();

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -101,6 +101,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   };
 
   const revokeAllAndGenerate = async () => {
+    if (!agentId) return;
     setRevokeConfirmDialog(false);
     setLoading(true);
     try {
@@ -119,6 +120,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   };
 
   const revokeApiKey = async (keyId: string) => {
+    if (!agentId) return;
     if (!confirm('Are you sure you want to revoke this API key?')) return;
 
     setLoading(true);

--- a/apps/web/src/components/agents/agent-webhook-manager.tsx
+++ b/apps/web/src/components/agents/agent-webhook-manager.tsx
@@ -21,6 +21,7 @@ export function AgentWebhookManager({ agentId, agentName, currentWebhookUrl }: A
   const { addToast } = useToast();
 
   const handleSave = async () => {
+    if (!agentId) return;
     const trimmed = webhookUrl.trim();
     if (trimmed && !/^https:\/\//i.test(trimmed)) {
       addToast({ title: 'Webhook URL must start with https://', type: 'error' });


### PR DESCRIPTION
## Root Cause

`agents/api-keys/page.tsx` rendered `AgentApiKeyManager agentId=""` (hardcoded empty string), causing:
1. `fetch('/api/agents//api-key')` → URL normalized to `/api/agents/api-key` (no route) → 422/404
2. `result.data` typed as `ApiKey[]` but untyped assertion allowed downstream null access

## Fix

**`agents/api-keys/page.tsx`** — rewritten as `'use client'` component:
- Fetches `/api/team-members?type=agent` on mount
- Renders `AgentApiKeyManager` + `AgentWebhookManager` per active agent
- Shows skeleton loader while fetching; empty state if no agents

**`agent-api-key-manager.tsx`**:
- `loadApiKeys`: early return when `agentId` is empty string
- `generateApiKey`: early return when `agentId` is empty string
- `response.json()` typed as `{ data?: ApiKey[] }` — prevents null/undefined downstream access

## Verification

- `pnpm build` ✅
- `agentId=""` no longer triggers any API call
- Active agents list renders correctly with real agentIds