### PR TITLE
[BF-6] 회고 상세 빈 화면 수정 — retro session/items/actions 분리 fetch

### DIFF
--- a/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
@@ -61,22 +61,12 @@ export default function RetroSessionPage() {
     setLoading(true);
     setLoadError(null);
     try {
-      const [sessionRes, itemsRes, actionsRes] = await Promise.all([
-        fetch(`/api/retro-sessions/${sessionId}?project_id=${projectId}`),
-        fetch(`/api/retro-sessions/${sessionId}/items?project_id=${projectId}`),
-        fetch(`/api/retro-sessions/${sessionId}/actions?project_id=${projectId}`),
-      ]);
-      if (!sessionRes.ok) throw new Error(`HTTP ${sessionRes.status}`);
-      const sessionJson = await sessionRes.json() as { data: RetroSessionRecord };
-      setSession(sessionJson.data);
-      if (itemsRes.ok) {
-        const itemsJson = await itemsRes.json() as { data: RetroItemRecord[] };
-        setItems(itemsJson.data ?? []);
-      }
-      if (actionsRes.ok) {
-        const actionsJson = await actionsRes.json() as { data: RetroActionRecord[] };
-        setActions(actionsJson.data ?? []);
-      }
+      const res = await fetch(`/api/retro-sessions/${sessionId}?project_id=${projectId}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = await res.json() as { data: RetroSessionRecord & { items?: RetroItemRecord[]; actions?: RetroActionRecord[] } };
+      setSession(json.data);
+      setItems(json.data.items ?? []);
+      setActions(json.data.actions ?? []);
     } catch {
       setLoadError(t('loadFailed'));
     } finally {

--- a/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
@@ -61,12 +61,22 @@ export default function RetroSessionPage() {
     setLoading(true);
     setLoadError(null);
     try {
-      const res = await fetch(`/api/retro-sessions/${sessionId}?project_id=${projectId}`);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const json = await res.json() as { data: { session: RetroSessionRecord; items: RetroItemRecord[]; actions: RetroActionRecord[] } };
-      setSession(json.data.session);
-      setItems(json.data.items);
-      setActions(json.data.actions);
+      const [sessionRes, itemsRes, actionsRes] = await Promise.all([
+        fetch(`/api/retro-sessions/${sessionId}?project_id=${projectId}`),
+        fetch(`/api/retro-sessions/${sessionId}/items?project_id=${projectId}`),
+        fetch(`/api/retro-sessions/${sessionId}/actions?project_id=${projectId}`),
+      ]);
+      if (!sessionRes.ok) throw new Error(`HTTP ${sessionRes.status}`);
+      const sessionJson = await sessionRes.json() as { data: RetroSessionRecord };
+      setSession(sessionJson.data);
+      if (itemsRes.ok) {
+        const itemsJson = await itemsRes.json() as { data: RetroItemRecord[] };
+        setItems(itemsJson.data ?? []);
+      }
+      if (actionsRes.ok) {
+        const actionsJson = await actionsRes.json() as { data: RetroActionRecord[] };
+        setActions(actionsJson.data ?? []);
+      }
     } catch {
       setLoadError(t('loadFailed'));
     } finally {

--- a/apps/web/src/app/api/retro-sessions/[id]/route.test.ts
+++ b/apps/web/src/app/api/retro-sessions/[id]/route.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+const { getAuthContext, proxyToFastapiWithParams } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapiWithParams: vi.fn(),
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapiWithParams }));
 
 import { PATCH } from './route';
 
@@ -16,27 +14,14 @@ function makeAgent() {
   return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
 }
 
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.update = vi.fn(chain);
-  q.single = vi.fn(() => Promise.resolve({ data: rows[0] ?? null, error: rows[0] ? null : { message: 'not found' } }));
-  return q;
-}
-
 describe('PATCH /api/retro-sessions/[id]', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
+    proxyToFastapiWithParams.mockReset();
     getAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
     getAuthContext.mockResolvedValue(null);
 
     const response = await PATCH(
@@ -51,10 +36,6 @@ describe('PATCH /api/retro-sessions/[id]', () => {
   });
 
   it('returns 400 when project_id is missing', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
     const response = await PATCH(
       new Request('http://localhost/api/retro-sessions/session-1', {
         method: 'PATCH',
@@ -67,16 +48,10 @@ describe('PATCH /api/retro-sessions/[id]', () => {
   });
 
   it('returns 200 with updated session phase', async () => {
-    const session = { id: 'session-1', project_id: 'project-1', phase: 'collect' };
-    const updated = { ...session, phase: 'group' };
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'retro_sessions') return createQueryStub([session, updated]);
-        return createQueryStub();
-      }),
-    };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+    const updated = { id: 'session-1', project_id: 'project-1', phase: 'group', items: [], actions: [] };
+    proxyToFastapiWithParams.mockResolvedValue(
+      new Response(JSON.stringify(updated), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+    );
 
     const response = await PATCH(
       new Request('http://localhost/api/retro-sessions/session-1?project_id=project-1', {
@@ -87,5 +62,7 @@ describe('PATCH /api/retro-sessions/[id]', () => {
     );
 
     expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data.phase).toBe('group');
   });
 });


### PR DESCRIPTION
## Summary

- `load()` 함수가 단일 fetch로 `{ data: { session, items, actions } }` 중첩 구조를 기대했으나 실제 FastAPI 응답은 flat `RetroSessionRecord`
- session / items / actions 를 각 전용 엔드포인트로 병렬 fetch 하도록 수정
- `json.data.session` → `sessionJson.data`, `json.data.items` → `itemsJson.data` 등 unwrap 교정

## Root Cause

`/api/v2/retros/[id]` 는 flat session 객체만 반환. items·actions 는 별도 엔드포인트
(`/items`, `/actions`) 가 존재함에도 단일 fetch로 모두 기대 → `undefined` → 빈 화면

## Test Plan

- [ ] 회고 상세 진입 시 세션 타이틀·phase 정상 렌더
- [ ] 아이템(good/bad/improve) 목록 표시
- [ ] 액션 아이템 목록 표시 (action/closed 단계)
- [ ] collect 단계 아이템 추가 동작
- [ ] vote 단계 투표 동작
- [ ] 모바일/데스크톱 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)