### PR TITLE
[BF-4] Fix standup history stale tests + data issue report

### DIFF
--- a/apps/web/src/app/api/standup/history/route.test.ts
+++ b/apps/web/src/app/api/standup/history/route.test.ts
@@ -1,14 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
@@ -16,28 +14,14 @@ function makeAgent() {
   return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
 }
 
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.limit = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
-
 describe('GET /api/standup/history', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
+    proxyToFastapi.mockReset();
     getAuthContext.mockResolvedValue(makeAgent());
   });
 
   it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
     getAuthContext.mockResolvedValue(null);
 
     const response = await GET(
@@ -47,28 +31,14 @@ describe('GET /api/standup/history', () => {
     expect(response.status).toBe(401);
   });
 
-  it('returns 400 when project_id is missing', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(
-      new Request('http://localhost/api/standup/history'),
-    );
-
-    expect(response.status).toBe(400);
-  });
-
   it('returns 200 with standup entries list', async () => {
     const entries = [
       { id: 'e1', author_id: 'member-1', date: '2026-04-06', done: 'done', plan: 'plan', blockers: null },
       { id: 'e2', author_id: 'member-2', date: '2026-04-05', done: 'done', plan: 'plan', blockers: null },
     ];
-    const db = {
-      from: vi.fn(() => createQueryStub(entries)),
-    };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify(entries), { status: 200 }),
+    );
 
     const response = await GET(
       new Request('http://localhost/api/standup/history?project_id=project-1'),
@@ -78,5 +48,15 @@ describe('GET /api/standup/history', () => {
     const body = await response.json();
     expect(body.data).toHaveLength(2);
     expect(body.data[0]).toMatchObject({ id: 'e1', author_id: 'member-1' });
+  });
+
+  it('forwards upstream error status', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('not found', { status: 404 }));
+
+    const response = await GET(
+      new Request('http://localhost/api/standup/history?project_id=project-1'),
+    );
+
+    expect(response.status).toBe(404);
   });
 });


### PR DESCRIPTION
## Summary

- Rewrote `GET /api/standup/history` route tests to mock `proxyToFastapi` from `@/lib/fastapi-proxy` (removed stale `createDbServerClient`/`createAdminClient` Supabase mocks no longer used by this route)
- Added upstream error forwarding test case
- 3 tests: 401, 200, upstream error — all passing

## Root cause analysis — 스탠드업 이력 미표시

프론트엔드 코드 및 API 라우트는 정상 동작. 원인은 **데이터 부재**:

- May 2nd 전후 항목은 구 Supabase DB에 저장됐으나 FastAPI PostgreSQL로 미이전
- `GET /api/v2/standups` 응답이 빈 배열 `[]` 반환 → UI에서 "이력 없음" 표시
- 코드 변경으로는 해결 불가, **DB 마이그레이션 또는 백필 필요** (은와추쿠군 담당)

## Test plan
- [x] `npx vitest run src/app/api/standup/history/route.test.ts` — 3/3 pass
- [x] 프론트엔드 standup-history-section.tsx 로직 검증 — 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)