### PR TITLE
[DOC-01] ⌘K 커맨드 팔레트에 문서 제목 검색 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -62,8 +62,10 @@
     "goInbox": "Go to Inbox",
     "goDashboard": "Go to Dashboard",
     "goBoard": "Go to Board",
+    "goMemos": "Go to Memos",
     "goAgents": "Go to Agents",
-    "goDocs": "Go to Docs"
+    "goDocs": "Go to Docs",
+    "documents": "Documents"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -62,8 +62,10 @@
     "goInbox": "인박스로 이동",
     "goDashboard": "대시보드로 이동",
     "goBoard": "보드로 이동",
+    "goMemos": "메모로 이동",
     "goAgents": "에이전트로 이동",
-    "goDocs": "문서로 이동"
+    "goDocs": "문서로 이동",
+    "documents": "문서"
   },
   "dashboard": {
     "title": "대시보드",

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
@@ -25,6 +25,13 @@ interface CommandItem {
   shortcut?: string[];
 }
 
+interface DocResult {
+  id: string;
+  title: string;
+  slug: string;
+  icon: string | null;
+}
+
 const ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
   { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
@@ -37,14 +44,17 @@ const ITEMS: CommandItem[] = [
 export interface CommandPaletteProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  projectId?: string;
 }
 
-export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
+export function CommandPalette({ open, onOpenChange, projectId }: CommandPaletteProps) {
   const router = useRouter();
   const t = useTranslations('commandPalette');
   const [query, setQuery] = useState('');
   const [activeIndex, setActiveIndex] = useState(0);
+  const [docResults, setDocResults] = useState<DocResult[]>([]);
   const listRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -52,38 +62,84 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
     return ITEMS.filter((item) => t(item.labelKey).toLowerCase().includes(q));
   }, [query, t]);
 
-  // Clamp active index to filtered range during render (avoid cascading effects).
+  // Docs search with debounce
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+
+    const q = query.trim();
+    if (!q || !projectId) {
+      setDocResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/docs?project_id=${encodeURIComponent(projectId)}&q=${encodeURIComponent(q)}&limit=5`);
+        if (!res.ok) return;
+        const json = await res.json() as { data?: DocResult[] };
+        setDocResults(json.data ?? []);
+      } catch {
+        // ignore network errors
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [query, projectId]);
+
+  // Reset doc results when palette closes
+  useEffect(() => {
+    if (!open) setDocResults([]);
+  }, [open]);
+
+  // Total items for keyboard navigation: navigate items first, then doc results
+  const totalCount = filtered.length + docResults.length;
+
+  // Clamp active index to total range during render (avoid cascading effects).
   const clampedActiveIndex =
-    filtered.length === 0 ? 0 : Math.min(Math.max(activeIndex, 0), filtered.length - 1);
+    totalCount === 0 ? 0 : Math.min(Math.max(activeIndex, 0), totalCount - 1);
 
   function handleOpenChange(next: boolean) {
     if (!next) {
       setQuery('');
       setActiveIndex(0);
+      setDocResults([]);
     }
     onOpenChange(next);
   }
 
-  function handleSelect(item: CommandItem) {
+  function handleSelectNav(item: CommandItem) {
     router.push(item.href);
+    handleOpenChange(false);
+  }
+
+  function handleSelectDoc(doc: DocResult) {
+    router.push(`/docs/${doc.slug}`);
     handleOpenChange(false);
   }
 
   function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      setActiveIndex(Math.min(filtered.length - 1, clampedActiveIndex + 1));
+      setActiveIndex(Math.min(totalCount - 1, clampedActiveIndex + 1));
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
       setActiveIndex(Math.max(0, clampedActiveIndex - 1));
     } else if (event.key === 'Enter') {
       event.preventDefault();
-      const item = filtered[clampedActiveIndex];
-      if (item) handleSelect(item);
+      if (clampedActiveIndex < filtered.length) {
+        const item = filtered[clampedActiveIndex];
+        if (item) handleSelectNav(item);
+      } else {
+        const doc = docResults[clampedActiveIndex - filtered.length];
+        if (doc) handleSelectDoc(doc);
+      }
     }
   }
 
   const navigateItems = filtered.filter((item) => item.group === 'navigate');
+  const hasResults = navigateItems.length > 0 || docResults.length > 0;
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
@@ -122,21 +178,32 @@ export function CommandPalette({ open, onOpenChange }: CommandPaletteProps) {
           </div>
 
           <div ref={listRef} className="max-h-80 overflow-y-auto p-2">
-            {filtered.length === 0 ? (
+            {!hasResults ? (
               <div className="px-3 py-6 text-center text-sm text-muted-foreground">
                 {t('noResults')}
               </div>
             ) : (
-              navigateItems.length > 0 && (
-                <CommandGroup
-                  label={t('navigate')}
-                  items={navigateItems}
-                  activeIndex={clampedActiveIndex}
-                  filteredItems={filtered}
-                  onSelect={handleSelect}
-                  t={t}
-                />
-              )
+              <>
+                {navigateItems.length > 0 && (
+                  <CommandGroup
+                    label={t('navigate')}
+                    items={navigateItems}
+                    activeIndex={clampedActiveIndex}
+                    filteredItems={filtered}
+                    onSelect={handleSelectNav}
+                    t={t}
+                  />
+                )}
+                {docResults.length > 0 && (
+                  <DocGroup
+                    label={t('documents')}
+                    docs={docResults}
+                    activeIndexOffset={filtered.length}
+                    activeIndex={clampedActiveIndex}
+                    onSelect={handleSelectDoc}
+                  />
+                )}
+              </>
             )}
           </div>
         </DialogPrimitive.Popup>
@@ -193,6 +260,45 @@ function CommandGroup({ label, items, filteredItems, activeIndex, onSelect, t }:
                     ))}
                   </span>
                 ) : null}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+interface DocGroupProps {
+  label: string;
+  docs: DocResult[];
+  activeIndexOffset: number;
+  activeIndex: number;
+  onSelect: (doc: DocResult) => void;
+}
+
+function DocGroup({ label, docs, activeIndexOffset, activeIndex, onSelect }: DocGroupProps) {
+  return (
+    <div className="flex flex-col">
+      <div className="px-2 pt-1.5 pb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <ul className="flex flex-col">
+        {docs.map((doc, i) => {
+          const active = activeIndexOffset + i === activeIndex;
+          return (
+            <li key={doc.id}>
+              <button
+                type="button"
+                onClick={() => onSelect(doc)}
+                className={cn(
+                  'flex w-full items-center gap-2 rounded-md px-2 py-2 text-left text-sm transition-colors',
+                  active ? 'bg-accent text-accent-foreground' : 'text-foreground hover:bg-accent/60',
+                )}
+                data-active={active || undefined}
+              >
+                <BookOpen className="size-4 shrink-0 text-muted-foreground" />
+                <span className="flex-1 truncate">{doc.icon ? `${doc.icon} ` : ''}{doc.title}</span>
               </button>
             </li>
           );

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -68,7 +68,6 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
 
     const q = query.trim();
     if (!q || !projectId) {
-      setDocResults([]);
       return;
     }
 
@@ -88,13 +87,11 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
     };
   }, [query, projectId]);
 
-  // Reset doc results when palette closes
-  useEffect(() => {
-    if (!open) setDocResults([]);
-  }, [open]);
+  // Gate doc results on active query to avoid showing stale results
+  const displayedDocResults = useMemo(() => query.trim() ? docResults : [], [query, docResults]);
 
   // Total items for keyboard navigation: navigate items first, then doc results
-  const totalCount = filtered.length + docResults.length;
+  const totalCount = filtered.length + displayedDocResults.length;
 
   // Clamp active index to total range during render (avoid cascading effects).
   const clampedActiveIndex =
@@ -132,14 +129,14 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
         const item = filtered[clampedActiveIndex];
         if (item) handleSelectNav(item);
       } else {
-        const doc = docResults[clampedActiveIndex - filtered.length];
+        const doc = displayedDocResults[clampedActiveIndex - filtered.length];
         if (doc) handleSelectDoc(doc);
       }
     }
   }
 
   const navigateItems = filtered.filter((item) => item.group === 'navigate');
-  const hasResults = navigateItems.length > 0 || docResults.length > 0;
+  const hasResults = navigateItems.length > 0 || displayedDocResults.length > 0;
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={handleOpenChange}>
@@ -194,10 +191,10 @@ export function CommandPalette({ open, onOpenChange, projectId }: CommandPalette
                     t={t}
                   />
                 )}
-                {docResults.length > 0 && (
+                {displayedDocResults.length > 0 && (
                   <DocGroup
                     label={t('documents')}
-                    docs={docResults}
+                    docs={displayedDocResults}
                     activeIndexOffset={filtered.length}
                     activeIndex={clampedActiveIndex}
                     onSelect={handleSelectDoc}

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -322,7 +322,7 @@ export function AppSidebar({
       </SidebarFooter>
 
       <SidebarRail />
-      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+      <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} projectId={projectId} />
     </Sidebar>
   );
 }


### PR DESCRIPTION
## Summary

- ⌘K 팔레트에서 프로젝트 문서 제목 검색 기능 추가
- 쿼리 입력 시 300ms debounce 후 `/api/docs?project_id=X&q=query&limit=5` 호출
- Navigate 항목 아래 DocGroup 렌더링 (BookOpen 아이콘)
- 키보드 방향키/Enter 통합 내비게이션 (navigate items + doc results)
- AppSidebar → CommandPalette `projectId` prop 전달
- `goMemos`, `documents` i18n 키 추가 (en/ko)

## Changes

| File | Change |
|------|--------|
| `command-palette/command-palette.tsx` | `DocResult` 인터페이스, debounced fetch, `DocGroup` 컴포넌트, 통합 키보드 내비 |
| `nav/app-sidebar.tsx` | `projectId` prop 전달 |
| `messages/en.json` | `commandPalette.goMemos`, `commandPalette.documents` 추가 |
| `messages/ko.json` | `commandPalette.goMemos`, `commandPalette.documents` 추가 |

## Test plan

- [ ] `projectId` 있는 상태에서 쿼리 입력 → 300ms 후 `/api/docs` 호출 확인
- [ ] 문서 결과 클릭 시 `/docs/{slug}` 이동 확인
- [ ] Enter 키로 문서 결과 선택 확인
- [ ] `projectId` 없을 때 docs 검색 안 뜨는 것 확인
- [ ] 팔레트 닫을 때 docResults 초기화 확인
- [ ] 모바일/데스크톱 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)