### PR TITLE
[Phase 6-2] EventMetadata source_agent_id + assignees 컨텍스트 구조화

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -24,13 +24,17 @@ router = APIRouter(prefix="/api/v2/stories", tags=["stories"])
 
 async def _resolve_actor_info(
     db: AsyncSession, actor_id: uuid.UUID | None
-) -> tuple[str | None, str | None]:
-    """Returns (name, role) for a TeamMember ID."""
+) -> tuple[str | None, str | None, str | None]:
+    """Returns (name, role, member_type) for a TeamMember ID."""
     if not actor_id:
-        return None, None
+        return None, None, None
     result = await db.execute(select(TeamMember).where(TeamMember.id == actor_id).limit(1))
     member = result.scalar_one_or_none()
-    return (member.name if member else None, member.role if member else None)
+    return (
+        member.name if member else None,
+        member.role if member else None,
+        member.type if member else None,
+    )
 
 
 async def _resolve_epic_title(db: AsyncSession, epic_id: uuid.UUID | None) -> str | None:
@@ -167,9 +171,10 @@ async def update_story(
     actor_id: uuid.UUID | None = None
     actor_name: str | None = None
     actor_role: str | None = None
+    actor_type: str | None = None
     try:
         actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
-        actor_name, actor_role = await _resolve_actor_info(db, actor_id)
+        actor_name, actor_role, actor_type = await _resolve_actor_info(db, actor_id)
     except Exception:
         pass
 
@@ -193,6 +198,8 @@ async def update_story(
             "actor_id": str(actor_id) if actor_id else None,
             "actor_name": actor_name,
             "actor_role": actor_role,
+            "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
+            "assignees": [str(story.assignee_id)] if story.assignee_id else [],
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         publish_event(str(org_id), "story.assignee_changed", event_data)
@@ -302,9 +309,10 @@ async def update_story_status(
     actor_id: uuid.UUID | None = None
     actor_name: str | None = None
     actor_role: str | None = None
+    actor_type: str | None = None
     try:
         actor_id = await _resolve_team_member_id(auth, repo.org_id, db)
-        actor_name, actor_role = await _resolve_actor_info(db, actor_id)
+        actor_name, actor_role, actor_type = await _resolve_actor_info(db, actor_id)
     except Exception:
         pass
 
@@ -349,6 +357,8 @@ async def update_story_status(
             "actor_id": str(actor_id) if actor_id else None,
             "actor_name": actor_name,
             "actor_role": actor_role,
+            "source_agent_id": str(actor_id) if (actor_id and actor_type == "agent") else None,
+            "assignees": [str(story.assignee_id)] if story.assignee_id else [],
             "timestamp": datetime.now(timezone.utc).isoformat(),
         }
         publish_event(str(org_id), "story.status_changed", event_data)

--- a/backend/app/services/rule_evaluator.py
+++ b/backend/app/services/rule_evaluator.py
@@ -36,6 +36,8 @@ class EventMetadata(BaseModel):
     memo_type: str | None = None
     title: str | None = None
     context_message: str | None = None
+    source_agent_id: str | None = None
+    assignees: list[str] | None = None
 
 
 @dataclass

--- a/backend/tests/test_p6_context_structuring.py
+++ b/backend/tests/test_p6_context_structuring.py
@@ -65,13 +65,15 @@ class TestResolveActorInfo:
         member = MagicMock()
         member.name = "Didi"
         member.role = "agent"
+        member.type = "agent"
         result_mock = MagicMock()
         result_mock.scalar_one_or_none.return_value = member
         db.execute = AsyncMock(return_value=result_mock)
 
-        name, role = await _resolve_actor_info(db, actor_id)
+        name, role, member_type = await _resolve_actor_info(db, actor_id)
         assert name == "Didi"
         assert role == "agent"
+        assert member_type == "agent"
 
     @pytest.mark.asyncio
     async def test_returns_none_when_not_found(self):
@@ -80,16 +82,18 @@ class TestResolveActorInfo:
         result_mock.scalar_one_or_none.return_value = None
         db.execute = AsyncMock(return_value=result_mock)
 
-        name, role = await _resolve_actor_info(db, uuid.uuid4())
+        name, role, member_type = await _resolve_actor_info(db, uuid.uuid4())
         assert name is None
         assert role is None
+        assert member_type is None
 
     @pytest.mark.asyncio
     async def test_returns_none_when_actor_id_is_none(self):
         db = AsyncMock()
-        name, role = await _resolve_actor_info(db, None)
+        name, role, member_type = await _resolve_actor_info(db, None)
         assert name is None
         assert role is None
+        assert member_type is None
         db.execute.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- `rule_evaluator.py` `EventMetadata`: `source_agent_id`, `assignees` 필드 추가
- `stories.py`: 두 process_event 호출부(`assignee_changed`, `status_changed`)에 새 필드 수집·전달

## 변경 내용

### rule_evaluator.py
```python
class EventMetadata(BaseModel):
    ...
    source_agent_id: str | None = None   # 이벤트 발생시킨 에이전트 TeamMember.id
    assignees: list[str] | None = None   # 스토리 담당자 ID 목록
```

### stories.py
- `_resolve_actor_info` 반환값: `(name, role)` → `(name, role, member_type)`
- `event_data` 추가 필드:
  - `source_agent_id`: actor_type == "agent"인 경우 actor_id, 아니면 None
  - `assignees`: `[story.assignee_id]` if 담당자 존재 else `[]`

## Regression 안전성

`EventMetadata.model_config = {"extra": "allow"}` 유지 → 기존 metadata 키를 사용하는 워크플로우 룰에 영향 없음.

## Test plan

- [ ] story status change → `workflow_execution_logs.event_context.metadata.assignees` 담당자 ID 포함 확인
- [ ] agent actor로 status 변경 시 `source_agent_id` 채워짐 확인
- [ ] human actor로 status 변경 시 `source_agent_id = null` 확인
- [ ] 기존 룰 평가 결과 동일 (regression 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)