### PR TITLE
[SID:5244c974] 모바일 Docs 에디터 콘텐츠 영역 확대 — 스크롤 UX 개선

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -217,6 +217,7 @@ export default function DocSlugPage() {
             projectId={projectId}
             currentAssigneeId={selectedDoc.assignee_id}
             onAssigneePatched={(aid) => setSelectedDoc((prev) => prev ? { ...prev, assignee_id: aid } : prev)}
+            mobileMode="assignee-only"
           />
         </div>
       )}

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -38,13 +38,17 @@ export function EntityDispatchPanel({
 
   useEffect(() => {
     if (!moreOpen) return;
-    const handler = (e: MouseEvent) => {
+    const handler = (e: MouseEvent | TouchEvent) => {
       if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
         setMoreOpen(false);
       }
     };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
+    document.addEventListener('mousedown', handler as EventListener);
+    document.addEventListener('touchstart', handler as EventListener);
+    return () => {
+      document.removeEventListener('mousedown', handler as EventListener);
+      document.removeEventListener('touchstart', handler as EventListener);
+    };
   }, [moreOpen]);
 
   useEffect(() => {

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { Zap } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { MoreHorizontal, Zap } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 
@@ -18,6 +18,7 @@ interface EntityDispatchPanelProps {
   projectId: string;
   currentAssigneeId?: string | null;
   onAssigneePatched?: (assigneeId: string) => void;
+  mobileMode?: 'full' | 'assignee-only';
 }
 
 export function EntityDispatchPanel({
@@ -26,11 +27,25 @@ export function EntityDispatchPanel({
   projectId,
   currentAssigneeId,
   onAssigneePatched,
+  mobileMode,
 }: EntityDispatchPanelProps) {
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [assigneeId, setAssigneeId] = useState<string>(currentAssigneeId ?? '');
   const [dispatching, setDispatching] = useState(false);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement>(null);
   const { toasts, addToast, dismissToast } = useToast();
+
+  useEffect(() => {
+    if (!moreOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
+        setMoreOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [moreOpen]);
 
   useEffect(() => {
     fetch(`/api/team-members?project_id=${projectId}`)
@@ -92,7 +107,8 @@ export function EntityDispatchPanel({
         disabled={!assigneeId || dispatching}
         onClick={() => void handleDispatch()}
         className={cn(
-          'flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition',
+          'shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition',
+          mobileMode === 'assignee-only' ? 'hidden md:flex' : 'flex',
           assigneeId && !dispatching
             ? 'bg-primary text-primary-foreground hover:bg-primary/90'
             : 'cursor-not-allowed bg-muted text-muted-foreground',
@@ -101,6 +117,36 @@ export function EntityDispatchPanel({
         <Zap className="size-3.5" />
         {dispatching ? 'Dispatching…' : 'Dispatch'}
       </button>
+      {mobileMode === 'assignee-only' && (
+        <div ref={moreRef} className="relative md:hidden">
+          <button
+            type="button"
+            onClick={() => setMoreOpen((o) => !o)}
+            className="flex items-center justify-center rounded-md border border-border px-2 py-1.5 text-muted-foreground transition hover:bg-muted"
+            aria-label="더보기"
+          >
+            <MoreHorizontal className="size-4" />
+          </button>
+          {moreOpen && (
+            <div className="absolute right-0 top-full z-10 mt-1 min-w-[140px] rounded-md border border-border bg-background py-1 shadow-md">
+              <button
+                type="button"
+                disabled={!assigneeId || dispatching}
+                onClick={() => { void handleDispatch(); setMoreOpen(false); }}
+                className={cn(
+                  'flex w-full items-center gap-1.5 px-3 py-2 text-sm transition',
+                  assigneeId && !dispatching
+                    ? 'text-foreground hover:bg-muted'
+                    : 'cursor-not-allowed text-muted-foreground',
+                )}
+              >
+                <Zap className="size-3.5" />
+                {dispatching ? 'Dispatching…' : 'Dispatch'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />
     </div>
   );

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -93,6 +93,7 @@ export function DocEditor({
   const suppressUpdateRef = useRef(false);
   const [viewMode, setViewMode] = useState<ViewMode>('preview');
   const [tocHeadings, setTocHeadings] = useState<DocHeading[]>([]);
+  const [isFocused, setIsFocused] = useState(false);
   const editorContentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -150,6 +151,8 @@ export function DocEditor({
         onChange(html);
       }
     },
+    onFocus: () => setIsFocused(true),
+    onBlur: () => setIsFocused(false),
   });
 
   useEffect(() => {
@@ -264,7 +267,7 @@ export function DocEditor({
   }, [title, autoResizeTitle]);
 
   return (
-    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-background">
+    <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-background max-md:h-[100dvh]">
       {/* Inline title (Notion style) */}
       {title !== undefined && (
         <div className="flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 pt-8">
@@ -278,7 +281,7 @@ export function DocEditor({
             placeholder={titlePlaceholder ?? 'Untitled'}
             autoFocus={titleAutoFocus}
             rows={1}
-            className="w-full resize-none overflow-hidden bg-transparent text-4xl font-bold leading-tight outline-none placeholder:text-muted-foreground/40"
+            className="w-full resize-none overflow-hidden bg-transparent text-4xl max-md:text-2xl font-bold leading-tight outline-none placeholder:text-muted-foreground/40"
           />
           {actions && (
             <div className="flex flex-shrink-0 items-center gap-1 pt-1">
@@ -308,9 +311,9 @@ export function DocEditor({
           ))}
         </div>
 
-        {/* Toolbar — only in preview mode */}
+        {/* Toolbar — only in preview mode, desktop only (mobile uses sticky bottom toolbar) */}
         {viewMode === 'preview' && editor ? (
-          <div className="flex flex-wrap items-center gap-1.5">
+          <div className="hidden md:flex flex-wrap items-center gap-1.5">
             <ToolbarButton
               active={editor.isActive('heading', { level: 1 })}
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
@@ -440,7 +443,7 @@ export function DocEditor({
           placeholder={labels.placeholder}
         />
       ) : (
-        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3">
+        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3 max-md:pb-20">
           <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
         </div>
       )}
@@ -481,6 +484,66 @@ export function DocEditor({
           </button>
         </div>
       ) : null}
+
+      {/* Mobile sticky bottom toolbar — appears on editor focus in preview mode */}
+      {editor && editable && viewMode === 'preview' && (
+        <div
+          className={`fixed bottom-0 left-0 right-0 z-30 border-t border-border/60 bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur-sm transition-transform duration-200 md:hidden ${
+            isFocused ? 'translate-y-0' : 'translate-y-full'
+          }`}
+        >
+          <div className="flex flex-wrap items-center gap-1 px-2 py-2">
+            <ToolbarButton
+              active={editor.isActive('heading', { level: 1 })}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+            >
+              {labels.h1}
+            </ToolbarButton>
+            <ToolbarButton
+              active={editor.isActive('heading', { level: 2 })}
+              onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+            >
+              {labels.h2}
+            </ToolbarButton>
+            <Sep />
+            <ToolbarButton
+              active={editor.isActive('bold')}
+              onClick={() => editor.chain().focus().toggleBold().run()}
+            >
+              {labels.bold}
+            </ToolbarButton>
+            <ToolbarButton
+              active={editor.isActive('italic')}
+              onClick={() => editor.chain().focus().toggleItalic().run()}
+            >
+              {labels.italic}
+            </ToolbarButton>
+            <Sep />
+            <ToolbarButton
+              active={editor.isActive('bulletList')}
+              onClick={() => editor.chain().focus().toggleBulletList().run()}
+            >
+              {labels.bullet}
+            </ToolbarButton>
+            <ToolbarButton
+              active={editor.isActive('blockquote')}
+              onClick={() => editor.chain().focus().toggleBlockquote().run()}
+            >
+              {labels.quote}
+            </ToolbarButton>
+            <ToolbarButton
+              active={editor.isActive('codeBlock')}
+              onClick={() => editor.chain().focus().toggleCodeBlock().run()}
+            >
+              {labels.code}
+            </ToolbarButton>
+            <Sep />
+            <ToolbarButton active={false} onClick={addLink}>
+              {labels.link}
+            </ToolbarButton>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -443,7 +443,7 @@ export function DocEditor({
           placeholder={labels.placeholder}
         />
       ) : (
-        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3 max-md:pb-20">
+        <div ref={editorContentRef as RefObject<HTMLDivElement>} className="tiptap-editor-wrapper flex-1 overflow-y-auto p-3 max-md:pb-20 max-md:min-h-[50vh]">
           <EditorContent editor={editor} className="tiptap-content h-full outline-none" />
         </div>
       )}
@@ -494,7 +494,7 @@ export function DocEditor({
             isFocused ? 'translate-y-0' : 'translate-y-full pointer-events-none'
           }`}
         >
-          <div className="flex overflow-x-auto items-center gap-1 px-2 py-2">
+          <div className="flex overflow-x-auto items-center gap-1 px-2 py-2" onMouseDown={(e) => e.preventDefault()}>
             <ToolbarButton
               active={editor.isActive('heading', { level: 1 })}
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -488,11 +488,13 @@ export function DocEditor({
       {/* Mobile sticky bottom toolbar — appears on editor focus in preview mode */}
       {editor && editable && viewMode === 'preview' && (
         <div
+          role="toolbar"
+          aria-label={labels.toolbar}
           className={`fixed bottom-0 left-0 right-0 z-30 border-t border-border/60 bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur-sm transition-transform duration-200 md:hidden ${
-            isFocused ? 'translate-y-0' : 'translate-y-full'
+            isFocused ? 'translate-y-0' : 'translate-y-full pointer-events-none'
           }`}
         >
-          <div className="flex flex-wrap items-center gap-1 px-2 py-2">
+          <div className="flex overflow-x-auto items-center gap-1 px-2 py-2">
             <ToolbarButton
               active={editor.isActive('heading', { level: 1 })}
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}


### PR DESCRIPTION
## Summary

- **D-DOCS-MOB-1** `doc-editor.tsx`: 포맷팅 툴바를 모바일에서 숨기고, 에디터 포커스 시 뷰포트 하단에 sticky 툴바 노출 (`translate-y` 전환, `safe-area-inset-bottom` 대응)
- **D-DOCS-MOB-2** `entity-dispatch-panel.tsx`: `mobileMode="assignee-only"` prop 추가 — Dispatch 버튼 `hidden md:flex`, ⋯ 더보기 드롭다운으로 Dispatch 액션 제공
- `docs/[slug]/page.tsx`: `EntityDispatchPanel`에 `mobileMode="assignee-only"` 전달
- 에디터 루트 `max-md:h-[100dvh]`, 제목 `max-md:text-2xl`, 콘텐츠 영역 `max-md:pb-20` (sticky 툴바 overlap 방지)

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `src/components/docs/doc-editor.tsx` | isFocused 상태, sticky bottom toolbar, h-[100dvh], text-2xl, pb-20 |
| `src/components/dispatch/entity-dispatch-panel.tsx` | mobileMode prop, ⋯ 드롭다운, 클릭 외부 닫기 |
| `src/app/(authenticated)/docs/[slug]/page.tsx` | mobileMode="assignee-only" 전달 |

## AC 체크리스트

- [x] D-DOCS-MOB-1: 포맷팅 툴바 모바일 포커스 시 sticky bottom 노출, blur 시 translate-y-full로 숨김
- [x] D-DOCS-MOB-1: safe-area-inset-bottom 적용 (pb-[env(safe-area-inset-bottom)])
- [x] D-DOCS-MOB-2: Dispatch 버튼 hidden md:flex, ⋯ 더보기 드롭다운
- [x] 제목 max-md:text-2xl
- [x] 에디터 루트 max-md:h-[100dvh] (이중 스크롤 방지)
- [x] 콘텐츠 영역 max-md:pb-20 (sticky 툴바 overlap 방지)
- [x] 데스크탑 동작 동일 (변경 없음)
- [x] D-DOCS-MOB-3: GNB hide-on-scroll 미적용 (본 PR 범위 외)

## 빌드 결과

- `pnpm lint`: 0 errors (기존 warnings만)
- `pnpm build`: ✅ PASS

## 스크린샷

> 실기기 확인 필요 — 까심군 QA 시 모바일 Chrome/Safari 양쪽 확인 부탁드리겠는.

🤖 Generated with [Claude Code](https://claude.com/claude-code)