### PR TITLE
[SID:DOC-UX-001] Docs 에디터 툴바 Undo/Redo 버튼 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1054,6 +1054,8 @@
     "toolbarQuote": "Quote",
     "toolbarCode": "Code",
     "toolbarLink": "Link",
+    "toolbarUndo": "Undo",
+    "toolbarRedo": "Redo",
     "statusSaved": "Saved",
     "statusSaving": "Saving...",
     "statusUnsaved": "Unsaved changes",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1054,6 +1054,8 @@
     "toolbarQuote": "인용",
     "toolbarCode": "코드",
     "toolbarLink": "링크",
+    "toolbarUndo": "실행 취소",
+    "toolbarRedo": "다시 실행",
     "statusSaved": "저장 완료",
     "statusSaving": "저장 중...",
     "statusUnsaved": "변경사항 있음",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -257,6 +257,8 @@ export default function DocSlugPage() {
             code: t('toolbarCode'),
             link: t('toolbarLink'),
             autosave: t('autosave'),
+            undo: t('toolbarUndo'),
+            redo: t('toolbarRedo'),
           }}
         />
       </div>

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -655,6 +655,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
                   code: t('toolbarCode'),
                   link: t('toolbarLink'),
                   autosave: t('autosave'),
+                  undo: t('toolbarUndo'),
+                  redo: t('toolbarRedo'),
                 }}
               />
             </div>

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -88,6 +88,8 @@ export function DocEditor({
     code: string;
     link: string;
     autosave: string;
+    undo: string;
+    redo: string;
   };
 }) {
   const suppressUpdateRef = useRef(false);
@@ -317,6 +319,7 @@ export function DocEditor({
             <ToolbarButton
               active={false}
               disabled={!editor.can().undo()}
+              ariaLabel={labels.undo}
               onClick={() => editor.chain().focus().undo().run()}
             >
               <Undo2 className="size-3.5" />
@@ -324,6 +327,7 @@ export function DocEditor({
             <ToolbarButton
               active={false}
               disabled={!editor.can().redo()}
+              ariaLabel={labels.redo}
               onClick={() => editor.chain().focus().redo().run()}
             >
               <Redo2 className="size-3.5" />
@@ -513,6 +517,7 @@ export function DocEditor({
             <ToolbarButton
               active={false}
               disabled={!editor.can().undo()}
+              ariaLabel={labels.undo}
               onClick={() => editor.chain().focus().undo().run()}
             >
               <Undo2 className="size-3.5" />
@@ -520,6 +525,7 @@ export function DocEditor({
             <ToolbarButton
               active={false}
               disabled={!editor.can().redo()}
+              ariaLabel={labels.redo}
               onClick={() => editor.chain().focus().redo().run()}
             >
               <Redo2 className="size-3.5" />
@@ -611,11 +617,13 @@ function ToolbarButton({
   active,
   onClick,
   disabled,
+  ariaLabel,
   children,
 }: {
   active: boolean;
   onClick: () => void;
   disabled?: boolean;
+  ariaLabel?: string;
   children: React.ReactNode;
 }) {
   return (
@@ -623,6 +631,7 @@ function ToolbarButton({
       type="button"
       onClick={onClick}
       disabled={disabled}
+      aria-label={ariaLabel}
       className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
         disabled
           ? 'cursor-not-allowed border-border/40 bg-card text-muted-foreground opacity-50'

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -16,7 +16,7 @@ import TableRow from '@tiptap/extension-table-row';
 import TableCell from '@tiptap/extension-table-cell';
 import TableHeader from '@tiptap/extension-table-header';
 import Placeholder from '@tiptap/extension-placeholder';
-import { Bold, Italic, Strikethrough, Code, Link2, Highlighter } from 'lucide-react';
+import { Bold, Italic, Strikethrough, Code, Link2, Highlighter, Undo2, Redo2 } from 'lucide-react';
 import { CalloutNode } from './extensions/callout-node';
 import { SlashCommandExtension } from './extensions/slash-command';
 import { PageEmbedExtension } from './extensions/page-embed-node';
@@ -315,6 +315,21 @@ export function DocEditor({
         {viewMode === 'preview' && editor ? (
           <div className="hidden md:flex flex-wrap items-center gap-1.5">
             <ToolbarButton
+              active={false}
+              disabled={!editor.can().undo()}
+              onClick={() => editor.chain().focus().undo().run()}
+            >
+              <Undo2 className="size-3.5" />
+            </ToolbarButton>
+            <ToolbarButton
+              active={false}
+              disabled={!editor.can().redo()}
+              onClick={() => editor.chain().focus().redo().run()}
+            >
+              <Redo2 className="size-3.5" />
+            </ToolbarButton>
+            <Sep />
+            <ToolbarButton
               active={editor.isActive('heading', { level: 1 })}
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
             >
@@ -496,6 +511,21 @@ export function DocEditor({
         >
           <div className="flex overflow-x-auto items-center gap-1 px-2 py-2" onMouseDown={(e) => e.preventDefault()}>
             <ToolbarButton
+              active={false}
+              disabled={!editor.can().undo()}
+              onClick={() => editor.chain().focus().undo().run()}
+            >
+              <Undo2 className="size-3.5" />
+            </ToolbarButton>
+            <ToolbarButton
+              active={false}
+              disabled={!editor.can().redo()}
+              onClick={() => editor.chain().focus().redo().run()}
+            >
+              <Redo2 className="size-3.5" />
+            </ToolbarButton>
+            <Sep />
+            <ToolbarButton
               active={editor.isActive('heading', { level: 1 })}
               onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
             >
@@ -580,20 +610,25 @@ function BubbleButton({
 function ToolbarButton({
   active,
   onClick,
+  disabled,
   children,
 }: {
   active: boolean;
   onClick: () => void;
+  disabled?: boolean;
   children: React.ReactNode;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition ${
-        active
-          ? 'border-primary/50 bg-primary/14 text-primary'
-          : 'border-border/60 bg-card text-foreground hover:border-primary/50 hover:text-primary'
+        disabled
+          ? 'cursor-not-allowed border-border/40 bg-card text-muted-foreground opacity-50'
+          : active
+            ? 'border-primary/50 bg-primary/14 text-primary'
+            : 'border-border/60 bg-card text-foreground hover:border-primary/50 hover:text-primary'
       }`}
     >
       {children}


### PR DESCRIPTION
## Summary

- 데스크톱 인라인 툴바 + 모바일 sticky bottom 툴바 양쪽 맨 왼쪽에 Undo/Redo 버튼 배치
- lucide-react `Undo2` / `Redo2` 아이콘 사용
- `editor.can().undo()` / `editor.can().redo()` false 시 `opacity-50 cursor-not-allowed` disabled 상태
- `ToolbarButton` 컴포넌트에 `disabled?: boolean` prop 추가

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `src/components/docs/doc-editor.tsx` | Undo2/Redo2 임포트, ToolbarButton disabled prop, 양 툴바에 버튼 추가 |

## AC 체크리스트

- [x] AC1: 데스크톱 툴바 맨 왼쪽에 Undo/Redo 버튼 표시
- [x] AC2: 모바일 sticky bottom 툴바에도 동일 위치 표시
- [x] AC3: undo/redo 불가 시 opacity-50 + cursor-not-allowed disabled 상태
- [x] AC4: 클릭 시 editor.chain().focus().undo()/redo().run() 정상 동작
- [x] AC5: 기존 Ctrl+Z / Ctrl+Shift+Z — StarterKit History 확장 그대로 유지

## 빌드 결과

- `pnpm lint`: 0 errors
- `pnpm build`: ✅ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)