### PR TITLE
[SID:DOC-UX-003] 슬래시(/) hint placeholder 적용

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1045,7 +1045,7 @@
     "previewTab": "Preview",
     "toolbar": "Toolbar",
     "toolbarHint": "Apply formatting snippets to the current selection and switch between Markdown and HTML.",
-    "editorPlaceholder": "Start writing your document",
+    "editorPlaceholder": "Type \"/\" for blocks, or just start writing",
     "toolbarH1": "H1",
     "toolbarH2": "H2",
     "toolbarBold": "Bold",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1045,7 +1045,7 @@
     "previewTab": "미리보기",
     "toolbar": "툴바",
     "toolbarHint": "선택 영역에 서식을 바로 삽입합니다. Markdown/HTML 전환도 지원해 주세요",
-    "editorPlaceholder": "문서 내용을 입력하세요",
+    "editorPlaceholder": "\"/\" 입력으로 블록 추가, 입력 시작",
     "toolbarH1": "H1",
     "toolbarH2": "H2",
     "toolbarBold": "굵게",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -289,7 +289,7 @@
 .tiptap-content .tiptap th { border: 1px solid var(--tiptap-table-border); padding: 6px 8px; }
 .tiptap-content .tiptap th { background: var(--tiptap-th-bg); font-weight: 600; }
 .tiptap-content .tiptap hr { border-color: var(--tiptap-hr-border); margin: 16px 0; }
-.tiptap-content .tiptap .is-empty::before { content: attr(data-placeholder); color: var(--tiptap-placeholder); pointer-events: none; float: left; height: 0; }
+.tiptap-content .tiptap.is-editor-empty .is-empty::before { content: attr(data-placeholder); color: var(--tiptap-placeholder); pointer-events: none; float: left; height: 0; }
 .tiptap-content .tiptap .ProseMirror-selectednode { outline: 2px solid var(--tiptap-selection); border-radius: 4px; }
 .tiptap-content .tiptap a { color: var(--tiptap-link); text-decoration: underline; }
 .tiptap-content .tiptap div[data-callout] { border-left: 3px solid var(--tiptap-callout-border); background: var(--tiptap-callout-bg); padding: 12px 16px; border-radius: 0 6px 6px 0; margin: 8px 0; }

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -123,7 +123,11 @@ export function DocEditor({
       TableRow,
       TableCell,
       TableHeader,
-      Placeholder.configure({ placeholder: labels.placeholder }),
+      Placeholder.configure({
+        placeholder: labels.placeholder,
+        showOnlyCurrent: false,
+        includeChildren: true,
+      }),
       CalloutNode,
       ToggleBlock,
       ToggleSummary,


### PR DESCRIPTION
## Summary

- 빈 문서 placeholder 텍스트를 슬래시 커맨드 발견성 높이는 문구로 교체
- Tiptap `Placeholder` 옵션 `showOnlyCurrent: false` + `includeChildren: true` 추가

## 변경 파일

| 파일 | 변경 내용 |
|------|-----------|
| `messages/ko.json` | `editorPlaceholder` → `"/" 입력으로 블록 추가, 입력 시작` |
| `messages/en.json` | `editorPlaceholder` → `Type "/" for blocks, or just start writing` |
| `src/components/docs/doc-editor.tsx` | `Placeholder.configure` 옵션 확장 |

## AC 체크리스트

- [x] AC1: 빈 문서 진입 시 "/" hint placeholder 표시
- [x] AC2: 타이핑 시작 시 placeholder 즉시 사라짐 (Tiptap 기본 동작)
- [x] AC3: 기존 콘텐츠 있는 문서에서는 미표시

## 빌드 결과

- `pnpm lint`: 0 errors
- `pnpm build`: ✅ PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)