### PR TITLE
[DOC-UX-007] 트리 펼침 상태 localStorage 영속화

### DIFF
--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -7,6 +7,7 @@ import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closest
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { cn } from '@/lib/utils';
+import { useTreeExpanded } from './use-tree-expanded';
 
 // ─── Preview Card ─────────────────────────────────────────────────────────────
 
@@ -99,6 +100,8 @@ function TreeNode({
   depth = 0,
   emptyFolderLabel = 'No child docs',
   projectId,
+  isExpanded,
+  onToggleExpanded,
 }: {
   doc: Doc;
   allDocs: Doc[];
@@ -111,11 +114,13 @@ function TreeNode({
   depth?: number;
   emptyFolderLabel?: string;
   projectId?: string;
+  isExpanded: (id: string, defaultValue?: boolean) => boolean;
+  onToggleExpanded: (id: string) => void;
 }) {
   const childDocs = allDocs.filter((entry) => entry.parent_id === doc.id).sort((a, b) => a.sort_order - b.sort_order);
   const hasChildren = childDocs.length > 0;
   const isFolder = Boolean(doc.is_folder || hasChildren);
-  const [expanded, setExpanded] = useState(true);
+  const expanded = isExpanded(doc.id);
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const isSelected = selectedSlug === doc.slug;
   const menuRef = useRef<HTMLDivElement>(null);
@@ -171,9 +176,9 @@ function TreeNode({
   }, [contextMenuOpen]);
 
   const handleClick = useCallback(() => {
-    if (isFolder) setExpanded((prev) => !prev);
+    if (isFolder) onToggleExpanded(doc.id);
     onSelect(doc.slug);
-  }, [isFolder, doc.slug, onSelect]);
+  }, [isFolder, doc.id, doc.slug, onSelect, onToggleExpanded]);
 
   const handleContextMenu = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -278,6 +283,8 @@ function TreeNode({
                   depth={depth + 1}
                   emptyFolderLabel={emptyFolderLabel}
                   projectId={projectId}
+                  isExpanded={isExpanded}
+                  onToggleExpanded={onToggleExpanded}
                 />
               ))}
             </SortableContext>
@@ -298,6 +305,7 @@ function TreeNode({
 export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMoveDenied, onRename, onDelete, onAddChild, emptyFolderLabel, projectId }: DocTreeProps) {
   const rootDocs = docs.filter((entry) => !entry.parent_id).sort((a, b) => a.sort_order - b.sort_order);
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const { isExpanded, toggleExpanded } = useTreeExpanded(projectId);
 
   const handleDragEnd = useCallback(async (event: DragEndEvent) => {
     const { active, over } = event;
@@ -364,7 +372,7 @@ export function DocTree({ docs, selectedSlug, onSelect, onReorder, onMove, onMov
       <SortableContext items={rootDocs.map((d) => d.id)} strategy={verticalListSortingStrategy}>
         <nav className="space-y-1">
           {rootDocs.map((doc) => (
-            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} projectId={projectId} />
+            <TreeNode key={doc.id} doc={doc} allDocs={docs} selectedSlug={selectedSlug} onSelect={onSelect} onReorder={onReorder} onRename={onRename} onDelete={onDelete} onAddChild={onAddChild} depth={0} emptyFolderLabel={emptyFolderLabel} projectId={projectId} isExpanded={isExpanded} onToggleExpanded={toggleExpanded} />
           ))}
         </nav>
       </SortableContext>

--- a/apps/web/src/components/docs/use-tree-expanded.ts
+++ b/apps/web/src/components/docs/use-tree-expanded.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 const PREFIX = 'docs:tree:expanded:';
 
@@ -29,6 +29,10 @@ export function useTreeExpanded(projectId: string | undefined) {
   const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() =>
     key ? readCollapsed(key) : new Set()
   );
+
+  useEffect(() => {
+    setCollapsedIds(key ? readCollapsed(key) : new Set());
+  }, [key]);
 
   const isExpanded = useCallback(
     (id: string, _defaultValue = true) => !collapsedIds.has(id),

--- a/apps/web/src/components/docs/use-tree-expanded.ts
+++ b/apps/web/src/components/docs/use-tree-expanded.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+const PREFIX = 'docs:tree:expanded:';
+
+function readCollapsed(key: string): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? new Set(parsed as string[]) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeCollapsed(key: string, ids: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify([...ids]));
+  } catch { /* silent fallback */ }
+}
+
+export function useTreeExpanded(projectId: string | undefined) {
+  const key = projectId ? `${PREFIX}${projectId}` : null;
+
+  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() =>
+    key ? readCollapsed(key) : new Set()
+  );
+
+  const isExpanded = useCallback(
+    (id: string, _defaultValue = true) => !collapsedIds.has(id),
+    [collapsedIds]
+  );
+
+  const toggleExpanded = useCallback(
+    (id: string) => {
+      setCollapsedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        if (key) writeCollapsed(key, next);
+        return next;
+      });
+    },
+    [key]
+  );
+
+  return { isExpanded, toggleExpanded };
+}


### PR DESCRIPTION
## Summary
- `useTreeExpanded` hook 신규 생성 (`use-tree-expanded.ts`)
  - localStorage 키: `docs:tree:expanded:<project_id>`
  - SSR-safe (`typeof window === 'undefined'` 가드)
  - localStorage 실패 시 silent fallback
  - 새 폴더 default expanded 유지 (collapsedIds 역방향 저장)
- `doc-tree.tsx`: `DocTree`에서 hook 호출, `TreeNode`에 prop 전달
  - `useState(true)` 제거 → `isExpanded(doc.id)` 교체
  - DOC-UX-010 Breadcrumb 재사용 대비 인터페이스 정리

## Changes
- `apps/web/src/components/docs/use-tree-expanded.ts` (신규)
- `apps/web/src/components/docs/doc-tree.tsx`

## AC 체크리스트
- [x] 폴더 펼침/접힘 시 localStorage에 상태 저장
- [x] 페이지 재방문 시 이전 펼침 상태 복원
- [x] 프로젝트별 독립 저장 (`docs:tree:expanded:<project_id>`)
- [x] SSR-safe guard
- [x] localStorage 실패 시 silent fallback
- [x] 새 폴더 default expanded 유지
- [x] UI 변경 없음 (동작만 변경)
- [x] `pnpm build` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)