### PR TITLE
[hotfix] DOC-UX-003 placeholder CSS 셀렉터 버그 수정

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -289,7 +289,7 @@
 .tiptap-content .tiptap th { border: 1px solid var(--tiptap-table-border); padding: 6px 8px; }
 .tiptap-content .tiptap th { background: var(--tiptap-th-bg); font-weight: 600; }
 .tiptap-content .tiptap hr { border-color: var(--tiptap-hr-border); margin: 16px 0; }
-.tiptap-content .tiptap.is-editor-empty .is-empty::before { content: attr(data-placeholder); color: var(--tiptap-placeholder); pointer-events: none; float: left; height: 0; }
+.tiptap-content .tiptap .is-editor-empty.is-empty::before { content: attr(data-placeholder); color: var(--tiptap-placeholder); pointer-events: none; float: left; height: 0; }
 .tiptap-content .tiptap .ProseMirror-selectednode { outline: 2px solid var(--tiptap-selection); border-radius: 4px; }
 .tiptap-content .tiptap a { color: var(--tiptap-link); text-decoration: underline; }
 .tiptap-content .tiptap div[data-callout] { border-left: 3px solid var(--tiptap-callout-border); background: var(--tiptap-callout-bg); padding: 12px 16px; border-radius: 0 6px 6px 0; margin: 8px 0; }


### PR DESCRIPTION
## Summary
- `globals.css` L292 CSS 셀렉터 1줄 수정
- `.tiptap.is-editor-empty .is-empty::before` → `.tiptap .is-editor-empty.is-empty::before`

## 원인
Tiptap이 `is-editor-empty` 클래스를 `.tiptap` 루트 요소가 아닌 `<p>` 요소에 부여함.
- 빈 문서 `<p>`: `class="is-empty is-editor-empty"` → 두 클래스 체이닝으로 매칭
- 콘텐츠 있는 문서 빈 줄 `<p>`: `class="is-empty"` → 미매칭 → placeholder 미노출

## AC
- [x] 빈 문서 진입 시 "/" hint placeholder 노출
- [x] 콘텐츠 있는 문서 빈 줄 placeholder 미노출
- [x] `pnpm build` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)