### PR TITLE
[DOC-UX-006] 최근 방문 문서 목록 사이드바 추가

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1056,6 +1056,8 @@
     "toolbarLink": "Link",
     "toolbarUndo": "Undo",
     "toolbarRedo": "Redo",
+    "recentDocs": "Recent",
+    "noRecentDocs": "No recent docs",
     "statusSaved": "Saved",
     "statusSaving": "Saving...",
     "statusUnsaved": "Unsaved changes",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1056,6 +1056,8 @@
     "toolbarLink": "링크",
     "toolbarUndo": "실행 취소",
     "toolbarRedo": "다시 실행",
+    "recentDocs": "최근 방문",
+    "noRecentDocs": "방문 기록 없음",
     "statusSaved": "저장 완료",
     "statusSaving": "저장 중...",
     "statusUnsaved": "변경사항 있음",

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
 import { DocEditor } from '@/components/docs/doc-editor';
+import { useRecentDocs } from '@/components/docs/use-recent-docs';
+import { RecentsSection } from '@/components/docs/recents-section';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -76,6 +78,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   const [docsNextCursor, setDocsNextCursor] = useState<string | null>(null);
   const [docsLoadingMore, setDocsLoadingMore] = useState(false);
   const [tagsCollapsed, setTagsCollapsed] = useState(true);
+  const { recentSlugs, pushRecent } = useRecentDocs(projectId);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<Array<{ id: string; title: string; slug: string; snippet?: string }>>([]);
   const sanitizeSnippet = (html: string) =>
@@ -184,7 +187,8 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
     params.set('slug', slug);
     router.push(`?${params.toString()}`);
     setTreeDrawerOpen(false);
-  }, [fetchDoc, router, searchParams]);
+    pushRecent(slug);
+  }, [fetchDoc, router, searchParams, pushRecent]);
 
   const handleReorder = useCallback(async (docId: string, newSortOrder: number) => {
     setTree((prev) =>
@@ -511,6 +515,14 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
           />
         ) : (
           <>
+            <RecentsSection
+              recentSlugs={recentSlugs}
+              docs={tree}
+              selectedSlug={selectedDoc?.slug || null}
+              onSelect={handleSelectDoc}
+              label={t('recentDocs')}
+              emptyLabel={t('noRecentDocs')}
+            />
             <DocTree
               docs={tree}
               selectedSlug={selectedDoc?.slug || null}

--- a/apps/web/src/components/docs/recents-section.tsx
+++ b/apps/web/src/components/docs/recents-section.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Clock, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Doc {
+  id: string;
+  title: string;
+  slug: string;
+  icon?: string | null;
+}
+
+interface RecentsSectionProps {
+  recentSlugs: string[];
+  docs: Doc[];
+  selectedSlug: string | null;
+  onSelect: (slug: string) => void;
+  label: string;
+  emptyLabel: string;
+}
+
+export function RecentsSection({ recentSlugs, docs, selectedSlug, onSelect, label, emptyLabel }: RecentsSectionProps) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const recentDocs = recentSlugs
+    .map((slug) => docs.find((d) => d.slug === slug))
+    .filter((d): d is Doc => d !== undefined);
+
+  return (
+    <div className="border-b border-border/60">
+      <button
+        type="button"
+        onClick={() => setCollapsed((v) => !v)}
+        className="flex w-full items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground"
+      >
+        {collapsed ? <ChevronRight className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />}
+        <Clock className="size-3 shrink-0" />
+        <span className="flex-1 text-left">{label}</span>
+        {recentDocs.length > 0 && (
+          <span className="text-[10px] tabular-nums">{recentDocs.length}</span>
+        )}
+      </button>
+      {!collapsed && (
+        <div className="px-2 pb-1">
+          {recentDocs.length === 0 ? (
+            <p className="px-2 py-1 text-[11px] italic text-muted-foreground">{emptyLabel}</p>
+          ) : (
+            <ul className="space-y-0.5">
+              {recentDocs.map((doc) => (
+                <li key={doc.id}>
+                  <button
+                    type="button"
+                    onClick={() => onSelect(doc.slug)}
+                    className={cn(
+                      'flex w-full items-center gap-2 rounded-xl px-2.5 py-1.5 text-left text-[12px] transition-colors',
+                      selectedSlug === doc.slug
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-foreground/80 hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    {doc.icon ? (
+                      <span className="shrink-0 text-sm leading-none">{doc.icon}</span>
+                    ) : (
+                      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+                    )}
+                    <span className="truncate">{doc.title}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/docs/recents-section.tsx
+++ b/apps/web/src/components/docs/recents-section.tsx
@@ -32,6 +32,7 @@ export function RecentsSection({ recentSlugs, docs, selectedSlug, onSelect, labe
       <button
         type="button"
         onClick={() => setCollapsed((v) => !v)}
+        aria-expanded={!collapsed}
         className="flex w-full items-center gap-1.5 px-3 py-1.5 text-[11px] text-muted-foreground hover:text-foreground"
       >
         {collapsed ? <ChevronRight className="size-3 shrink-0" /> : <ChevronDown className="size-3 shrink-0" />}

--- a/apps/web/src/components/docs/use-recent-docs.ts
+++ b/apps/web/src/components/docs/use-recent-docs.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+const PREFIX = 'docs:recents:';
+const MAX = 5;
+
+function readSlugs(key: string): string[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? (parsed as string[]) : [];
+  } catch { return []; }
+}
+
+function writeSlugs(key: string, slugs: string[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(key, JSON.stringify(slugs));
+  } catch { /* silent fallback */ }
+}
+
+export function useRecentDocs(projectId: string | undefined) {
+  const key = projectId ? `${PREFIX}${projectId}` : null;
+
+  const [recentSlugs, setRecentSlugs] = useState<string[]>(() =>
+    key ? readSlugs(key) : []
+  );
+
+  useEffect(() => {
+    setRecentSlugs(key ? readSlugs(key) : []);
+  }, [key]);
+
+  const pushRecent = useCallback((slug: string) => {
+    setRecentSlugs((prev) => {
+      const next = [slug, ...prev.filter((s) => s !== slug)].slice(0, MAX);
+      if (key) writeSlugs(key, next);
+      return next;
+    });
+  }, [key]);
+
+  return { recentSlugs, pushRecent };
+}


### PR DESCRIPTION
## Summary
- 사이드바 상단에 Collapsible "최근 방문" 섹션 신설 (DocTree 위)
- `useRecentDocs` hook: LRU 최대 5개, localStorage `docs:recents:<project_id>`, SSR-safe, silent fallback
- `RecentsSection` 컴포넌트: 접기/펼치기, 아이콘+제목, 활성 강조, 방문기록 없음 빈 상태
- stale slug 자동 필터 (tree에 없는 slug 제외)

## Changes
- `apps/web/src/components/docs/use-recent-docs.ts` (신규)
- `apps/web/src/components/docs/recents-section.tsx` (신규)
- `apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx`
- `apps/web/messages/ko.json` — `recentDocs`, `noRecentDocs`
- `apps/web/messages/en.json` — `recentDocs`, `noRecentDocs`

## AC 체크리스트
- [x] 사이드바에 최근 열람 문서 목록 표시
- [x] 최근 5건 표시 (LRU 정렬)
- [x] 클릭 시 해당 문서로 이동
- [x] localStorage 기반 (백엔드 불필요)
- [x] 프로젝트별 독립 저장
- [x] SSR-safe + silent fallback
- [x] 활성 문서 강조 (`bg-primary/10 text-primary`)
- [x] 빈 상태 "방문 기록 없음" 텍스트
- [x] stale slug 자동 필터
- [x] Collapsible (Clock 아이콘 + 카운트 + chevron)
- [x] `pnpm build` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)