### PR TITLE
[DOC-UX-008] Autosave 상태 인디케이터 인라인 노출

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1064,6 +1064,7 @@
     "statusConflict": "Conflict: another user edited this document",
     "statusRemoteChanged": "This document was updated remotely",
     "statusError": "Save failed",
+    "retry": "Retry",
     "conflictReload": "Reload latest",
     "conflictOverwrite": "Overwrite with my changes",
     "remoteRefresh": "Refresh",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1064,6 +1064,7 @@
     "statusConflict": "충돌: 다른 사용자가 이 문서를 수정했습니다",
     "statusRemoteChanged": "이 문서가 원격에서 업데이트되었습니다",
     "statusError": "저장 실패",
+    "retry": "재시도",
     "conflictReload": "최신 버전 불러오기",
     "conflictOverwrite": "내 변경사항으로 덮어쓰기",
     "remoteRefresh": "새로고침",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -43,15 +43,19 @@ function InlineSaveIndicator({
   t: ReturnType<typeof useTranslations>;
 }) {
   const [show, setShow] = useState(false);
+  const [fading, setFading] = useState(false);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    if (status === 'idle') { setShow(false); return; }
+    if (status === 'idle') { setShow(false); setFading(false); return; }
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setShow(true);
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setFading(false);
     if (status !== 'saved') return;
-    const timer = setTimeout(() => setShow(false), 1600);
-    return () => clearTimeout(timer);
+    const t1 = setTimeout(() => setFading(true), 200);
+    const t2 = setTimeout(() => setShow(false), 1600);
+    return () => { clearTimeout(t1); clearTimeout(t2); };
   }, [status]);
 
   if (!show) return null;
@@ -65,7 +69,7 @@ function InlineSaveIndicator({
   }
   if (status === 'saved') {
     return (
-      <span aria-label={t('statusSaved')} title={t('statusSaved')} className="flex items-center">
+      <span aria-label={t('statusSaved')} title={t('statusSaved')} className={`flex items-center transition-opacity duration-[1400ms] ${fading ? 'opacity-0' : 'opacity-100'}`}>
         <span className="size-2 rounded-full bg-emerald-500/70" />
       </span>
     );

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { DocEditor } from '@/components/docs/doc-editor';
 import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { htmlToMarkdown } from '@/components/docs/lib/content-converter';
 import Link from 'next/link';
-import { Check, Copy, Eye, MoreHorizontal, Trash2 } from 'lucide-react';
+import { AlertTriangle, Check, Copy, Eye, Loader2, MoreHorizontal, RotateCw, Trash2, XCircle } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -33,27 +33,85 @@ interface DocDetail {
   assignee_id?: string | null;
 }
 
-const SAVE_STATUS_CLASS: Partial<Record<SaveStatus, string>> = {
-  saving: 'text-muted-foreground',
-  saved: 'text-emerald-500/70',
-  unsaved: 'text-amber-500/70',
-  error: 'text-rose-500',
-  conflict: 'text-rose-500',
-  'remote-changed': 'text-amber-500',
-};
+function InlineSaveIndicator({
+  status,
+  onAction,
+  t,
+}: {
+  status: SaveStatus;
+  onAction: () => void;
+  t: ReturnType<typeof useTranslations>;
+}) {
+  const [show, setShow] = useState(false);
 
-function SaveStatusIndicator({ status, t }: { status: SaveStatus; t: ReturnType<typeof useTranslations> }) {
-  const map: Partial<Record<SaveStatus, string>> = {
-    saving: t('statusSaving'),
-    saved: t('statusSaved'),
-    unsaved: t('statusUnsaved'),
-    error: t('statusError'),
-    conflict: t('statusConflict'),
-    'remote-changed': t('statusRemoteChanged'),
-  };
-  const text = map[status] ?? null;
-  if (!text) return null;
-  return <span className={`shrink-0 text-xs ${SAVE_STATUS_CLASS[status] ?? ''}`}>{text}</span>;
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    if (status === 'idle') { setShow(false); return; }
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setShow(true);
+    if (status !== 'saved') return;
+    const timer = setTimeout(() => setShow(false), 1600);
+    return () => clearTimeout(timer);
+  }, [status]);
+
+  if (!show) return null;
+
+  if (status === 'saving') {
+    return (
+      <span aria-label={t('statusSaving')} title={t('statusSaving')} className="flex items-center">
+        <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+      </span>
+    );
+  }
+  if (status === 'saved') {
+    return (
+      <span aria-label={t('statusSaved')} title={t('statusSaved')} className="flex items-center">
+        <span className="size-2 rounded-full bg-emerald-500/70" />
+      </span>
+    );
+  }
+  if (status === 'unsaved') {
+    return (
+      <span aria-label={t('statusUnsaved')} title={t('statusUnsaved')} className="flex items-center">
+        <span className="size-2 rounded-full bg-amber-500/70" />
+      </span>
+    );
+  }
+  if (status === 'error') {
+    return (
+      <button type="button" onClick={onAction}
+        aria-label={`${t('statusError')} · ${t('retry')}`}
+        title={`${t('statusError')} · ${t('retry')}`}
+        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-rose-500 hover:text-rose-600 md:max-w-none"
+      >
+        <XCircle className="size-3.5 shrink-0" />
+        <span className="truncate">{t('statusError')} · {t('retry')}</span>
+      </button>
+    );
+  }
+  if (status === 'conflict') {
+    return (
+      <button type="button" onClick={onAction}
+        aria-label={t('statusConflict')} title={t('statusConflict')}
+        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-rose-500 hover:text-rose-600 md:max-w-none"
+      >
+        <AlertTriangle className="size-3.5 shrink-0" />
+        <span className="truncate">{t('statusConflict')}</span>
+      </button>
+    );
+  }
+  if (status === 'remote-changed') {
+    return (
+      <button type="button" onClick={onAction}
+        aria-label={t('statusRemoteChanged')} title={t('statusRemoteChanged')}
+        className="flex max-w-[120px] items-center gap-1 truncate text-xs text-amber-500 hover:text-amber-600 md:max-w-none"
+      >
+        <RotateCw className="size-3.5 shrink-0" />
+        <span className="truncate">{t('statusRemoteChanged')}</span>
+      </button>
+    );
+  }
+  return null;
 }
 
 export default function DocSlugPage() {
@@ -175,6 +233,7 @@ export default function DocSlugPage() {
 
   const docActions = (
     <>
+      <InlineSaveIndicator status={saveStatus} onAction={save} t={t} />
       <button
         type="button"
         onClick={handleCopyMarkdown}
@@ -189,14 +248,6 @@ export default function DocSlugPage() {
           <MoreHorizontal className="h-4 w-4" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-48">
-          {saveStatus !== 'idle' && (
-            <>
-              <div className="flex items-center px-2 py-1.5">
-                <SaveStatusIndicator status={saveStatus} t={t} />
-              </div>
-              <DropdownMenuSeparator />
-            </>
-          )}
           <DropdownMenuItem render={<Link href={`/docs/${slug}/view`} />}>
             <Eye className="mr-2 h-4 w-4" />
             {t('preview')}


### PR DESCRIPTION
## Summary
- `InlineSaveIndicator` 컴포넌트 추가: saving/saved/unsaved/error/conflict/remote-changed 상태별 아이콘/dot/텍스트 분기
- saved 상태는 1.6초 후 자동 숨김
- `docActions`에 Copy 버튼 좌측으로 `InlineSaveIndicator` 삽입, DropdownMenu 내 SaveStatus 섹션 완전 제거
- i18n `docs.retry` 키 추가 (ko/en)

## Changes
- `apps/web/src/app/(authenticated)/docs/[slug]/page.tsx`
- `apps/web/messages/ko.json` + `en.json`

## Test plan
- [ ] 에디터에서 타이핑 → 상태별 인디케이터 확인 (saving → saved dot 1.6s → 사라짐)
- [ ] error/conflict 상태: 텍스트 + 아이콘 노출, 클릭 시 재시도
- [ ] ⋯ 메뉴에 SaveStatus 섹션 없음 확인
- [ ] sprint_report doc 타입에서 편집 비활성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)