### PR TITLE
[DOC-UX-006/007] layout.tsx 통합 버그 수정 + useSyncExternalStore 리팩터

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
+import { RecentsSection } from '@/components/docs/recents-section';
+import { useRecentDocs } from '@/components/docs/use-recent-docs';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ToastContainer, useToast } from '@/components/ui/toast';
@@ -19,6 +21,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const t = useTranslations('docs');
   const tc = useTranslations('common');
   const { projectId } = useDashboardContext();
+  const { recentSlugs, pushRecent } = useRecentDocs(projectId);
   const { toasts, addToast, dismissToast } = useToast();
 
   const [tree, setTree] = useState<Doc[]>([]);
@@ -76,9 +79,10 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   useEffect(() => { void fetchTree(selectedTags.length ? selectedTags : undefined); }, [fetchTree, selectedTags]);
 
   const handleSelectDoc = useCallback((slug: string) => {
+    pushRecent(slug);
     router.push(`/docs/${slug}`);
     setTreeDrawerOpen(false);
-  }, [router]);
+  }, [router, pushRecent]);
 
   const handleReorder = useCallback(async (docId: string, newSortOrder: number) => {
     setTree((prev) => prev.map((doc) => (doc.id === docId ? { ...doc, sort_order: newSortOrder } : doc)));
@@ -182,7 +186,15 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
           <EmptyState title={t('title')} description={t('selectDoc')} className="mt-2 bg-background/70" action={<Button size="sm" onClick={handleNewDoc}><Plus className="mr-1 h-4 w-4" />{t('newDoc')}</Button>} />
         ) : (
           <>
-            <DocTree docs={tree} selectedSlug={currentSlug} onSelect={handleSelectDoc} onReorder={handleReorder} onMove={handleMove} onMoveDenied={handleMoveDenied} onRename={handleRename} onDelete={handleDeleteDoc} onAddChild={handleAddChild} />
+            <RecentsSection
+              recentSlugs={recentSlugs}
+              docs={tree}
+              selectedSlug={currentSlug}
+              onSelect={handleSelectDoc}
+              label={t('recentDocs')}
+              emptyLabel={t('noRecentDocs')}
+            />
+            <DocTree docs={tree} selectedSlug={currentSlug} onSelect={handleSelectDoc} onReorder={handleReorder} onMove={handleMove} onMoveDenied={handleMoveDenied} onRename={handleRename} onDelete={handleDeleteDoc} onAddChild={handleAddChild} projectId={projectId} />
             {docsHasMore && (
               <div className="px-2 py-1">
                 <Button variant="ghost" size="sm" className="w-full text-xs text-muted-foreground" disabled={docsLoadingMore} onClick={() => { if (!docsNextCursor || docsLoadingMore) return; setDocsLoadingMore(true); void fetchTree(selectedTags.length ? selectedTags : undefined, docsNextCursor); }}>

--- a/apps/web/src/components/docs/use-recent-docs.ts
+++ b/apps/web/src/components/docs/use-recent-docs.ts
@@ -1,45 +1,50 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
 const PREFIX = 'docs:recents:';
 const MAX = 5;
 
-function readSlugs(key: string): string[] {
-  if (typeof window === 'undefined') return [];
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? (parsed as string[]) : [];
-  } catch { return []; }
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+function readRaw(key: string): string {
+  if (typeof window === 'undefined') return '[]';
+  return window.localStorage.getItem(key) ?? '[]';
 }
 
 function writeSlugs(key: string, slugs: string[]): void {
   if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(key, JSON.stringify(slugs));
-  } catch { /* silent fallback */ }
+  try { window.localStorage.setItem(key, JSON.stringify(slugs)); } catch { /* silent fallback */ }
 }
 
 export function useRecentDocs(projectId: string | undefined) {
   const key = projectId ? `${PREFIX}${projectId}` : null;
 
-  const [recentSlugs, setRecentSlugs] = useState<string[]>(() =>
-    key ? readSlugs(key) : []
+  const raw = useSyncExternalStore(
+    subscribe,
+    () => (key ? readRaw(key) : '[]'),
+    () => '[]',
   );
 
-  useEffect(() => {
-    setRecentSlugs(key ? readSlugs(key) : []);
-  }, [key]);
+  const recentSlugs = useMemo<string[]>(() => {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return Array.isArray(parsed) ? (parsed as string[]) : [];
+    } catch { return []; }
+  }, [raw]);
 
   const pushRecent = useCallback((slug: string) => {
-    setRecentSlugs((prev) => {
-      const next = [slug, ...prev.filter((s) => s !== slug)].slice(0, MAX);
-      if (key) writeSlugs(key, next);
-      return next;
-    });
-  }, [key]);
+    if (!key) return;
+    const prev = recentSlugs;
+    const next = [slug, ...prev.filter((s) => s !== slug)].slice(0, MAX);
+    writeSlugs(key, next);
+    listeners.forEach((l) => l());
+  }, [key, recentSlugs]);
 
   return { recentSlugs, pushRecent };
 }

--- a/apps/web/src/components/docs/use-tree-expanded.ts
+++ b/apps/web/src/components/docs/use-tree-expanded.ts
@@ -1,55 +1,56 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
 const PREFIX = 'docs:tree:expanded:';
 
-function readCollapsed(key: string): Set<string> {
-  if (typeof window === 'undefined') return new Set();
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return new Set();
-    const parsed = JSON.parse(raw) as unknown;
-    return Array.isArray(parsed) ? new Set(parsed as string[]) : new Set();
-  } catch {
-    return new Set();
-  }
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+function readRaw(key: string): string {
+  if (typeof window === 'undefined') return '[]';
+  return window.localStorage.getItem(key) ?? '[]';
 }
 
 function writeCollapsed(key: string, ids: Set<string>): void {
   if (typeof window === 'undefined') return;
-  try {
-    localStorage.setItem(key, JSON.stringify([...ids]));
-  } catch { /* silent fallback */ }
+  try { window.localStorage.setItem(key, JSON.stringify([...ids])); } catch { /* silent fallback */ }
 }
 
 export function useTreeExpanded(projectId: string | undefined) {
   const key = projectId ? `${PREFIX}${projectId}` : null;
 
-  const [collapsedIds, setCollapsedIds] = useState<Set<string>>(() =>
-    key ? readCollapsed(key) : new Set()
+  const raw = useSyncExternalStore(
+    subscribe,
+    () => (key ? readRaw(key) : '[]'),
+    () => '[]',
   );
 
-  useEffect(() => {
-    setCollapsedIds(key ? readCollapsed(key) : new Set());
-  }, [key]);
+  const collapsedIds = useMemo<Set<string>>(() => {
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      return Array.isArray(parsed) ? new Set<string>(parsed as string[]) : new Set<string>();
+    } catch { return new Set<string>(); }
+  }, [raw]);
 
   const isExpanded = useCallback(
     (id: string, _defaultValue = true) => !collapsedIds.has(id),
-    [collapsedIds]
+    [collapsedIds],
   );
 
   const toggleExpanded = useCallback(
     (id: string) => {
-      setCollapsedIds((prev) => {
-        const next = new Set(prev);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        if (key) writeCollapsed(key, next);
-        return next;
-      });
+      if (!key) return;
+      const current = new Set<string>(collapsedIds);
+      if (current.has(id)) current.delete(id); else current.add(id);
+      writeCollapsed(key, current);
+      listeners.forEach((l) => l());
     },
-    [key]
+    [key, collapsedIds],
   );
 
   return { isExpanded, toggleExpanded };


### PR DESCRIPTION
## Summary
- `docs/layout.tsx`가 실제 사이드바 렌더링 파일임을 확인 — `docs-shell-client.tsx`에만 있던 DOC-UX-006/007 로직을 layout.tsx로 이식
- `use-recent-docs.ts` / `use-tree-expanded.ts`: `useState+useEffect` → `useSyncExternalStore+useMemo` 패턴으로 리팩터 (lint error 3개 → 0개)

## Changes
- `apps/web/src/app/(authenticated)/docs/layout.tsx`
  - `useRecentDocs(projectId)` 훅 호출 추가
  - `handleSelectDoc`에 `pushRecent(slug)` 연동
  - `sidebarContent`에 `<RecentsSection>` 추가 (DocTree 상단)
  - `<DocTree>`에 `projectId={projectId}` prop 추가 → `useTreeExpanded` localStorage 영속화 활성화
- `apps/web/src/components/docs/use-recent-docs.ts` — `useSyncExternalStore` 패턴
- `apps/web/src/components/docs/use-tree-expanded.ts` — `useSyncExternalStore` 패턴

## Test plan
- [ ] 문서 클릭 시 Recent 섹션에 slug 추가 확인
- [ ] 페이지 새로고침 후 Recent 목록 유지 확인
- [ ] 트리 폴더 토글 후 새로고침 → 펼침 상태 유지 확인
- [ ] 프로젝트 전환 시 각 프로젝트별 독립 상태 확인
- [ ] lint errors 0개 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)