### PR TITLE
[DOC-UX-010] Breadcrumb 문서 경로 표시

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1058,6 +1058,7 @@
     "toolbarRedo": "Redo",
     "recentDocs": "Recent",
     "noRecentDocs": "No recent docs",
+    "breadcrumbAriaLabel": "Document path",
     "statusSaved": "Saved",
     "statusSaving": "Saving...",
     "statusUnsaved": "Unsaved changes",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1058,6 +1058,7 @@
     "toolbarRedo": "다시 실행",
     "recentDocs": "최근 방문",
     "noRecentDocs": "방문 기록 없음",
+    "breadcrumbAriaLabel": "문서 경로",
     "statusSaved": "저장 완료",
     "statusSaving": "저장 중...",
     "statusUnsaved": "변경사항 있음",

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -311,7 +311,6 @@ export default function DocSlugPage() {
                 currentDocId={selectedDoc.id}
                 tree={tree}
                 onExpandFolder={expandFolder}
-                onNavigateDoc={handleNavigate}
                 ariaLabel={t('breadcrumbAriaLabel')}
               />
             ) : null

--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useDocsLayout } from '../docs-context';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
+import { DocBreadcrumb } from '@/components/docs/doc-breadcrumb';
 
 interface DocDetail {
   id: string;
@@ -127,7 +128,7 @@ export default function DocSlugPage() {
   const isNewRef = useRef(typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('new') === '1');
   const isNew = isNewRef.current;
 
-  const { projectId, setTree, pendingDocUpdate, clearPendingDocUpdate } = useDocsLayout();
+  const { projectId, tree, setTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder } = useDocsLayout();
 
   const [selectedDoc, setSelectedDoc] = useState<DocDetail | null>(null);
   const [docLoading, setDocLoading] = useState(true);
@@ -304,6 +305,17 @@ export default function DocSlugPage() {
           onTitleChange={handleTitleChange}
           titlePlaceholder={t('titlePlaceholder')}
           titleAutoFocus={isNew || !title}
+          breadcrumb={
+            tree.length > 0 && selectedDoc ? (
+              <DocBreadcrumb
+                currentDocId={selectedDoc.id}
+                tree={tree}
+                onExpandFolder={expandFolder}
+                onNavigateDoc={handleNavigate}
+                ariaLabel={t('breadcrumbAriaLabel')}
+              />
+            ) : null
+          }
           actions={docActions}
           labels={{
             contentFormat: t('contentFormat'),

--- a/apps/web/src/app/(authenticated)/docs/docs-context.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-context.tsx
@@ -20,11 +20,13 @@ export interface DocUpdate {
 
 interface DocsLayoutContextType {
   projectId: string | undefined;
+  tree: Doc[];
   setTree: Dispatch<SetStateAction<Doc[]>>;
   handleNewDoc: () => void;
   fetchTree: () => Promise<void>;
   pendingDocUpdate: DocUpdate | null;
   clearPendingDocUpdate: () => void;
+  expandFolder: (id: string) => void;
 }
 
 export const DocsLayoutContext = createContext<DocsLayoutContextType | null>(null);

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
 import { RecentsSection } from '@/components/docs/recents-section';
 import { useRecentDocs } from '@/components/docs/use-recent-docs';
+import { useTreeExpanded } from '@/components/docs/use-tree-expanded';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { ToastContainer, useToast } from '@/components/ui/toast';
@@ -22,6 +23,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const tc = useTranslations('common');
   const { projectId } = useDashboardContext();
   const { recentSlugs, pushRecent } = useRecentDocs(projectId);
+  const { expandFolder } = useTreeExpanded(projectId);
   const { toasts, addToast, dismissToast } = useToast();
 
   const [tree, setTree] = useState<Doc[]>([]);
@@ -210,7 +212,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
 
 
   return (
-    <DocsLayoutContext.Provider value={{ projectId, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate }}>
+    <DocsLayoutContext.Provider value={{ projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder }}>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
         actions={<Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}><Plus className="mr-1.5 h-3.5 w-3.5" />{isCreating ? t('loading') : t('newDoc')}</Button>}

--- a/apps/web/src/components/docs/doc-breadcrumb.tsx
+++ b/apps/web/src/components/docs/doc-breadcrumb.tsx
@@ -10,28 +10,23 @@ interface DocBreadcrumbProps {
   currentDocId: string;
   tree: Doc[];
   onExpandFolder: (id: string) => void;
-  onNavigateDoc: (slug: string) => void;
   ariaLabel: string;
 }
 
-export function DocBreadcrumb({ currentDocId, tree, onExpandFolder, onNavigateDoc, ariaLabel }: DocBreadcrumbProps) {
+export function DocBreadcrumb({ currentDocId, tree, onExpandFolder, ariaLabel }: DocBreadcrumbProps) {
   const path = buildDocPath(currentDocId, tree);
 
   const handleSegmentClick = useCallback((doc: Doc, isCurrent: boolean) => {
     if (isCurrent) return;
-    if (doc.is_folder) {
-      const ancestors = buildDocPath(doc.id, tree);
-      for (const ancestor of ancestors) {
-        if (ancestor.is_folder) onExpandFolder(ancestor.id);
-      }
-      requestAnimationFrame(() => {
-        const el = document.querySelector(`[data-doc-id="${doc.id}"]`);
-        el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      });
-    } else {
-      onNavigateDoc(doc.slug);
+    const ancestors = buildDocPath(doc.id, tree);
+    for (const ancestor of ancestors) {
+      if (ancestor.is_folder) onExpandFolder(ancestor.id);
     }
-  }, [onExpandFolder, onNavigateDoc, tree]);
+    requestAnimationFrame(() => {
+      const el = document.querySelector(`[data-doc-id="${doc.id}"]`);
+      el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+  }, [onExpandFolder, tree]);
 
   if (path.length <= 1) return null;
 

--- a/apps/web/src/components/docs/doc-breadcrumb.tsx
+++ b/apps/web/src/components/docs/doc-breadcrumb.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback } from 'react';
+import { ChevronRight } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { buildDocPath } from './lib/doc-path';
+import type { Doc } from '@/app/(authenticated)/docs/docs-context';
+
+interface DocBreadcrumbProps {
+  currentDocId: string;
+  tree: Doc[];
+  onExpandFolder: (id: string) => void;
+  onNavigateDoc: (slug: string) => void;
+  ariaLabel: string;
+}
+
+export function DocBreadcrumb({ currentDocId, tree, onExpandFolder, onNavigateDoc, ariaLabel }: DocBreadcrumbProps) {
+  const path = buildDocPath(currentDocId, tree);
+
+  const handleSegmentClick = useCallback((doc: Doc, isCurrent: boolean) => {
+    if (isCurrent) return;
+    if (doc.is_folder) {
+      const ancestors = buildDocPath(doc.id, tree);
+      for (const ancestor of ancestors) {
+        if (ancestor.is_folder) onExpandFolder(ancestor.id);
+      }
+      requestAnimationFrame(() => {
+        const el = document.querySelector(`[data-doc-id="${doc.id}"]`);
+        el?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      });
+    } else {
+      onNavigateDoc(doc.slug);
+    }
+  }, [onExpandFolder, onNavigateDoc, tree]);
+
+  if (path.length <= 1) return null;
+
+  return (
+    <nav aria-label={ariaLabel} className="flex min-w-0 items-center gap-0.5 overflow-x-auto pb-0.5 text-[11px] text-muted-foreground">
+      {path.map((doc, idx) => {
+        const isCurrent = idx === path.length - 1;
+        return (
+          <span key={doc.id} className="flex shrink-0 items-center gap-0.5">
+            {idx > 0 && <ChevronRight className="size-3 shrink-0 opacity-50" />}
+            <button
+              type="button"
+              onClick={() => handleSegmentClick(doc, isCurrent)}
+              disabled={isCurrent}
+              className={cn(
+                'max-w-[160px] truncate rounded px-1 py-0.5 transition-colors',
+                isCurrent
+                  ? 'cursor-default text-foreground/70'
+                  : 'hover:bg-muted hover:text-foreground',
+              )}
+            >
+              {doc.icon ? `${doc.icon} ` : ''}{doc.title}
+            </button>
+          </span>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -284,7 +284,7 @@ export function DocEditor({
       )}
       {/* Inline title (Notion style) */}
       {title !== undefined && (
-        <div className="flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 pt-4">
+        <div className={`flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 ${breadcrumb ? 'pt-4' : 'pt-8'}`}>
           <textarea
             ref={titleRef}
             value={title}

--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -51,6 +51,7 @@ export function DocEditor({
   onTitleChange,
   titlePlaceholder,
   titleAutoFocus,
+  breadcrumb,
   actions,
   labels,
 }: {
@@ -71,6 +72,7 @@ export function DocEditor({
   onTitleChange?: (value: string) => void;
   titlePlaceholder?: string;
   titleAutoFocus?: boolean;
+  breadcrumb?: React.ReactNode;
   actions?: React.ReactNode;
   labels: {
     contentFormat: string;
@@ -274,9 +276,15 @@ export function DocEditor({
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-2xl border border-border/60 bg-background max-md:h-[100dvh]">
+      {/* Breadcrumb (위치: title 위) */}
+      {breadcrumb && (
+        <div className="flex-shrink-0 px-6 pt-4">
+          {breadcrumb}
+        </div>
+      )}
       {/* Inline title (Notion style) */}
       {title !== undefined && (
-        <div className="flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 pt-8">
+        <div className="flex flex-shrink-0 items-start justify-between gap-2 px-6 pb-2 pt-4">
           <textarea
             ref={titleRef}
             value={title}

--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -212,6 +212,7 @@ function TreeNode({
       <div className="group relative">
         {preview && <DocPreviewCard title={preview.title} snippet={preview.snippet} x={previewPos.x} y={previewPos.y} />}
         <button
+          data-doc-id={doc.id}
           onClick={handleClick}
           onContextMenu={handleContextMenu}
           onMouseEnter={handleMouseEnter}

--- a/apps/web/src/components/docs/lib/doc-path.ts
+++ b/apps/web/src/components/docs/lib/doc-path.ts
@@ -1,0 +1,13 @@
+import type { Doc } from '@/app/(authenticated)/docs/docs-context';
+
+export function buildDocPath(docId: string, docs: Doc[]): Doc[] {
+  const docMap = new Map(docs.map((d) => [d.id, d]));
+  const path: Doc[] = [];
+  let current = docMap.get(docId);
+  while (current) {
+    path.unshift(current);
+    if (!current.parent_id) break;
+    current = docMap.get(current.parent_id);
+  }
+  return path;
+}

--- a/apps/web/src/components/docs/use-tree-expanded.ts
+++ b/apps/web/src/components/docs/use-tree-expanded.ts
@@ -53,5 +53,16 @@ export function useTreeExpanded(projectId: string | undefined) {
     [key, collapsedIds],
   );
 
-  return { isExpanded, toggleExpanded };
+  const expandFolder = useCallback(
+    (id: string) => {
+      if (!key) return;
+      const current = new Set<string>(collapsedIds);
+      current.delete(id);
+      writeCollapsed(key, current);
+      listeners.forEach((l) => l());
+    },
+    [key, collapsedIds],
+  );
+
+  return { isExpanded, toggleExpanded, expandFolder };
 }


### PR DESCRIPTION
## Summary
- `DocBreadcrumb` 컴포넌트 신규: `폴더 > 하위폴더 > 문서명` 경로 표시, 세그먼트 클릭 시 사이드바 폴더 expand + scroll-into-view (URL 변경 없음)
- `buildDocPath` 유틸 신규: 문서 ID에서 부모 chain 재귀 빌드
- `expandFolder` 추가: useSyncExternalStore 패턴 (가디언 정정 반영)
- 부모 chain 전체 expand + requestAnimationFrame scrollIntoView (가디언 정정 반영)
- `doc-tree.tsx` `data-doc-id` 속성 추가 (scrollIntoView 타겟)
- `docs-context.tsx`: `tree` + `expandFolder` Context 노출
- `layout.tsx`: `useTreeExpanded` → `expandFolder` Context 전달

## Changes
- `apps/web/src/components/docs/doc-breadcrumb.tsx` (신규)
- `apps/web/src/components/docs/lib/doc-path.ts` (신규)
- `apps/web/src/components/docs/use-tree-expanded.ts`
- `apps/web/src/components/docs/doc-tree.tsx`
- `apps/web/src/components/docs/doc-editor.tsx`
- `apps/web/src/app/(authenticated)/docs/docs-context.tsx`
- `apps/web/src/app/(authenticated)/docs/layout.tsx`
- `apps/web/src/app/(authenticated)/docs/[slug]/page.tsx`
- `apps/web/messages/{ko,en}.json`

## Test plan
- [ ] 중첩 폴더 안 문서 열기 → Breadcrumb 표시 확인
- [ ] 루트 문서 → Breadcrumb 미표시 확인 (path.length <= 1)
- [ ] 폴더 세그먼트 클릭 → 사이드바 해당 폴더 expand + scroll-into-view
- [ ] 가디언 정정 3건: expandFolder (useSyncExternalStore), 부모 chain 전체 expand, requestAnimationFrame
- [ ] 모바일: 가로 스크롤 동작 확인
- [ ] `breadcrumbAriaLabel` 접근성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)