### PR TITLE
[DOC-UX-013] 모바일 사이드바 drawer 스와이프 제스처

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -13,6 +13,7 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChevronDown, ChevronLeft, ChevronRight, Menu, Plus, X } from 'lucide-react';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
 import { DocsLayoutContext, type Doc, type DocUpdate } from './docs-context';
+import { useSwipeDrawer } from '@/lib/use-swipe-drawer';
 
 export default function DocsLayout({ children }: { children: React.ReactNode }) {
   const router = useRouter();
@@ -150,6 +151,10 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const handleNewDoc = useCallback(() => { void createDoc(null); }, [createDoc]);
   const handleAddChild = useCallback((parentId: string) => createDoc(parentId), [createDoc]);
 
+  const openDrawer = useCallback(() => setTreeDrawerOpen(true), []);
+  const closeDrawer = useCallback(() => setTreeDrawerOpen(false), []);
+  const { progress: drawerProgress, dragging: drawerDragging } = useSwipeDrawer(treeDrawerOpen, openDrawer, closeDrawer);
+
   const sidebarContent = (
     <>
       {(() => {
@@ -257,18 +262,32 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
           {children}
         </div>
-        {treeDrawerOpen && (
-          <>
-            <div className="fixed inset-0 z-40 bg-black/50" onClick={() => setTreeDrawerOpen(false)} aria-hidden="true" />
-            <div className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl">
-              <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-3">
-                <span className="text-sm font-medium text-foreground">{t('title')}</span>
-                <button type="button" onClick={() => setTreeDrawerOpen(false)} className="rounded p-1 text-muted-foreground hover:text-foreground" aria-label="닫기"><X className="size-4" /></button>
-              </div>
-              <div className="flex-1 overflow-y-auto">{sidebarContent}</div>
-            </div>
-          </>
-        )}
+        {/* Swipe drawer overlay */}
+        <div
+          className="fixed inset-0 z-40 bg-foreground/40"
+          style={{
+            opacity: drawerProgress,
+            pointerEvents: drawerProgress > 0.05 ? 'auto' : 'none',
+            transition: drawerDragging ? 'none' : 'opacity 280ms cubic-bezier(0.4,0,0.2,1)',
+          }}
+          onClick={closeDrawer}
+          aria-hidden="true"
+        />
+        {/* Swipe drawer panel */}
+        <div
+          className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl"
+          style={{
+            transform: `translateX(${(drawerProgress - 1) * 100}%)`,
+            transition: drawerDragging ? 'none' : 'transform 280ms cubic-bezier(0.4,0,0.2,1)',
+          }}
+          aria-hidden={drawerProgress === 0}
+        >
+          <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-3">
+            <span className="text-sm font-medium text-foreground">{t('title')}</span>
+            <button type="button" onClick={closeDrawer} className="rounded p-1 text-muted-foreground hover:text-foreground" aria-label="닫기"><X className="size-4" /></button>
+          </div>
+          <div className="flex-1 overflow-y-auto">{sidebarContent}</div>
+        </div>
       </div>
 
       <ToastContainer toasts={toasts} onDismiss={dismissToast} />

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -264,7 +264,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
         </div>
         {/* Swipe drawer overlay */}
         <div
-          className="fixed inset-0 z-40 bg-foreground/40"
+          className="fixed inset-0 z-40 bg-foreground/40 lg:hidden"
           style={{
             opacity: drawerProgress,
             pointerEvents: drawerProgress > 0.05 ? 'auto' : 'none',
@@ -275,7 +275,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
         />
         {/* Swipe drawer panel */}
         <div
-          className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl"
+          className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl lg:hidden"
           style={{
             transform: `translateX(${(drawerProgress - 1) * 100}%)`,
             transition: drawerDragging ? 'none' : 'transform 280ms cubic-bezier(0.4,0,0.2,1)',

--- a/apps/web/src/lib/use-swipe-drawer.ts
+++ b/apps/web/src/lib/use-swipe-drawer.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+const EDGE_THRESHOLD = 24;   // px from left edge to trigger open swipe
+const OPEN_THRESHOLD = 0.3;  // 30% drag to commit open/close
+const DRAWER_WIDTH = 280;    // must match layout drawer width
+
+export function useSwipeDrawer(
+  isOpen: boolean,
+  onOpen: () => void,
+  onClose: () => void,
+) {
+  const [progress, setProgress] = useState(isOpen ? 1 : 0);
+  const [dragging, setDragging] = useState(false);
+
+  const isOpenRef = useRef(isOpen);
+  const activeRef = useRef(false);
+  const startXRef = useRef(0);
+  const startOpenRef = useRef(false);
+
+  useEffect(() => { isOpenRef.current = isOpen; }, [isOpen]);
+
+  // Snap progress when isOpen changes externally (not during drag)
+  useEffect(() => {
+    if (!activeRef.current) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setProgress(isOpen ? 1 : 0);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    const onTouchStart = (e: TouchEvent) => {
+      const touch = e.touches[0];
+      if (!touch) return;
+      const x = touch.clientX;
+      const open = isOpenRef.current;
+
+      const fromEdge = !open && x < EDGE_THRESHOLD;
+      const fromDrawer = open && x < DRAWER_WIDTH;
+
+      if (!fromEdge && !fromDrawer) return;
+
+      activeRef.current = true;
+      startXRef.current = x;
+      startOpenRef.current = open;
+      setDragging(true);
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!activeRef.current) return;
+      const touch = e.touches[0];
+      if (!touch) return;
+
+      const dx = touch.clientX - startXRef.current;
+      const p = startOpenRef.current
+        ? Math.max(0, Math.min(1, 1 + dx / DRAWER_WIDTH))
+        : Math.max(0, Math.min(1, dx / DRAWER_WIDTH));
+
+      setProgress(p);
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      if (!activeRef.current) return;
+      activeRef.current = false;
+      setDragging(false);
+
+      const touch = e.changedTouches[0];
+      if (!touch) return;
+      const dx = touch.clientX - startXRef.current;
+      const p = startOpenRef.current
+        ? Math.max(0, Math.min(1, 1 + dx / DRAWER_WIDTH))
+        : Math.max(0, Math.min(1, dx / DRAWER_WIDTH));
+
+      if (startOpenRef.current) {
+        if (p <= 1 - OPEN_THRESHOLD) onClose();
+        else onOpen();
+      } else {
+        if (p >= OPEN_THRESHOLD) onOpen();
+        else onClose();
+      }
+    };
+
+    document.addEventListener('touchstart', onTouchStart, { passive: true });
+    document.addEventListener('touchmove', onTouchMove, { passive: true });
+    document.addEventListener('touchend', onTouchEnd, { passive: true });
+
+    return () => {
+      document.removeEventListener('touchstart', onTouchStart);
+      document.removeEventListener('touchmove', onTouchMove);
+      document.removeEventListener('touchend', onTouchEnd);
+    };
+  }, [onOpen, onClose]);
+
+  return { progress, dragging };
+}

--- a/apps/web/src/lib/use-swipe-drawer.ts
+++ b/apps/web/src/lib/use-swipe-drawer.ts
@@ -31,6 +31,7 @@ export function useSwipeDrawer(
 
   useEffect(() => {
     const onTouchStart = (e: TouchEvent) => {
+      if (window.matchMedia('(min-width: 1024px)').matches) return;
       const touch = e.touches[0];
       if (!touch) return;
       const x = touch.clientX;


### PR DESCRIPTION
## 변경 사항

- **`apps/web/src/lib/use-swipe-drawer.ts`** (신규): progress 0~1 + dragging 상태 관리 hook
- **`apps/web/src/app/(authenticated)/docs/layout.tsx`**: 모바일 drawer 스와이프 애니메이션 적용

## 시안 §11 파일 경로 ↔ PR 변경 파일 일치

| 시안 명시 | PR 변경 |
|---|---|
| `apps/web/src/lib/use-swipe-drawer.ts` (신규) | ✅ |
| `apps/web/src/app/(authenticated)/docs/layout.tsx` | ✅ |

## 핵심 구현

**`use-swipe-drawer.ts`**
- `EDGE_THRESHOLD = 24px`: 좌측 가장자리 open 트리거 영역
- `OPEN_THRESHOLD = 30%`: drag 완료 시 open/close 커밋 임계
- `DRAWER_WIDTH = 280px`: progress 계산 기준 너비
- 자체 `touchstart / touchmove / touchend` 핸들러 (라이브러리 의존성 0)
- `passive: true` 이벤트 리스너 (스크롤 성능)
- `isOpenRef`: 클로저 stale 방지용 ref

**`layout.tsx`**
- Overlay: `opacity: drawerProgress`, `bg-foreground/40`, `pointer-events: none` when progress ≤ 0.05
- Drawer panel: `transform: translateX(${(progress - 1) * 100}%)`
- transition: `cubic-bezier(0.4,0,0.2,1) 280ms`, drag 중 `transition: none`
- hamburger Menu 버튼 접근성 대안 병행 유지

## AC 검증

1. ✅ 좌→우 스와이프로 사이드바 열기 (EDGE_THRESHOLD 24px)
2. ✅ 우→좌 스와이프 또는 오버레이 탭으로 닫기
3. ✅ cubic-bezier(0.4,0,0.2,1) 280ms easing
4. ✅ 데스크탑 기존 동작 유지 (lg:hidden 분기)

## ⚠ iOS Safari 실기기 테스트 결과

iOS Safari 좌측 가장자리 시스템 back gesture와 24px 트리거 영역 충돌 가능성 인지. **실기기 테스트 항목으로 QA 요청 포함** — 가상 기기로 검증 불가, 까심군 실기기 확인 요청.

## 빌드 / 린트

- `pnpm build` ✅ 오류 없음
- `pnpm lint` ✅ 0 errors (기존 20 warnings 모두 pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)