### PR TITLE
[DOC-UX-014] 모바일 텍스트 선택 서식 메뉴

### DIFF
--- a/apps/web/src/components/docs/doc-editor.tsx
+++ b/apps/web/src/components/docs/doc-editor.tsx
@@ -30,6 +30,7 @@ import { WikiLinkNode, createWikiLinkSuggestion } from './extensions/wiki-link';
 import { DocToc } from './doc-toc';
 import { type DocHeading, slugifyHeading } from './doc-heading-utils';
 import { markdownToHtml, htmlToMarkdown } from './lib/content-converter';
+import { MobileSelectionMenu, isMobileDevice } from './mobile-selection-menu';
 
 type ContentFormat = 'markdown' | 'html';
 type ViewMode = 'preview' | 'markdown';
@@ -399,8 +400,10 @@ export function DocEditor({
 
       {/* Floating bubble toolbar — visible on text selection in preview mode */}
       {editor && editable && viewMode === 'preview' && (
+        <>
         <BubbleMenu
           editor={editor}
+          shouldShow={() => !isMobileDevice()}
           className="flex items-center gap-0.5 rounded-lg border border-border/60 bg-background p-1 shadow-lg"
         >
           <BubbleButton
@@ -454,6 +457,8 @@ export function DocEditor({
             <Highlighter className="size-3.5" />
           </BubbleButton>
         </BubbleMenu>
+        <MobileSelectionMenu editor={editor} />
+        </>
       )}
 
       {/* Editor content — fills remaining height */}

--- a/apps/web/src/components/docs/mobile-selection-menu.tsx
+++ b/apps/web/src/components/docs/mobile-selection-menu.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { Bold, Italic, Strikethrough, Code, Link2, Highlighter } from 'lucide-react';
+import type { Editor } from '@tiptap/core';
+
+export function isMobileDevice(): boolean {
+  return typeof window !== 'undefined'
+    && 'ontouchstart' in window
+    && matchMedia('(max-width: 768px)').matches;
+}
+
+interface MenuPos { top: number; left: number }
+
+const MENU_EST_WIDTH = 296; // 6 × 44px + 2×4px padding
+
+export function MobileSelectionMenu({ editor }: { editor: Editor | null }) {
+  const [visible, setVisible] = useState(false);
+  const [pos, setPos] = useState<MenuPos>({ top: 0, left: 0 });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const computePos = useCallback((): MenuPos | null => {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return null;
+    const range = sel.getRangeAt(0);
+    const rect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return null;
+
+    const selMidX = rect.left + rect.width / 2;
+    const left = Math.max(8, Math.min(selMidX - MENU_EST_WIDTH / 2, window.innerWidth - MENU_EST_WIDTH - 8));
+    const top = rect.bottom + 8;
+
+    return { top, left };
+  }, []);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    const onSelectionUpdate = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+
+      const { from, to } = editor.state.selection;
+      if (from === to) { setVisible(false); return; }
+
+      timerRef.current = setTimeout(() => {
+        if (!isMobileDevice()) return;
+        const p = computePos();
+        if (!p) { setVisible(false); return; }
+        setPos(p);
+        setVisible(true);
+      }, 200);
+    };
+
+    const onBlur = () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setVisible(false);
+    };
+
+    editor.on('selectionUpdate', onSelectionUpdate);
+    editor.on('blur', onBlur);
+
+    return () => {
+      editor.off('selectionUpdate', onSelectionUpdate);
+      editor.off('blur', onBlur);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [editor, computePos]);
+
+  if (!visible || !editor) return null;
+
+  const buttons = [
+    { icon: Bold, label: '굵게', action: () => editor.chain().focus().toggleBold().run(), active: editor.isActive('bold') },
+    { icon: Italic, label: '기울임', action: () => editor.chain().focus().toggleItalic().run(), active: editor.isActive('italic') },
+    { icon: Strikethrough, label: '취소선', action: () => editor.chain().focus().toggleStrike().run(), active: editor.isActive('strike') },
+    { icon: Code, label: '인라인 코드', action: () => editor.chain().focus().toggleCode().run(), active: editor.isActive('code') },
+    {
+      icon: Link2,
+      label: '링크',
+      action: () => {
+        if (editor.isActive('link')) { editor.chain().focus().unsetLink().run(); return; }
+        const url = window.prompt('URL:');
+        if (url) editor.chain().focus().setLink({ href: url }).run();
+      },
+      active: editor.isActive('link'),
+    },
+    { icon: Highlighter, label: '형광펜', action: () => editor.chain().focus().toggleHighlight().run(), active: editor.isActive('highlight') },
+  ] as const;
+
+  return createPortal(
+    <div
+      role="toolbar"
+      aria-label="텍스트 서식"
+      style={{ position: 'fixed', top: pos.top, left: pos.left, zIndex: 9999 }}
+      className="flex items-center gap-0.5 rounded-xl border border-border bg-background p-1 shadow-lg"
+    >
+      {buttons.map(({ icon: Icon, label, action, active }) => (
+        <button
+          key={label}
+          type="button"
+          aria-label={label}
+          aria-pressed={active}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={action}
+          className={`flex h-11 w-11 items-center justify-center rounded-lg transition-colors ${
+            active
+              ? 'bg-primary/10 text-primary'
+              : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+          }`}
+        >
+          <Icon className="size-4" />
+        </button>
+      ))}
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## 변경 사항

- **`apps/web/src/components/docs/mobile-selection-menu.tsx`** (신규): 모바일 텍스트 선택 서식 메뉴 컴포넌트
- **`apps/web/src/components/docs/doc-editor.tsx`**: BubbleMenu `shouldShow` + MobileSelectionMenu 삽입

## 시안 §11 파일 경로 ↔ PR 변경 파일 일치

| 시안 명시 | PR 변경 |
|---|---|
| `mobile-selection-menu.tsx` (신규) | ✅ |
| `doc-editor.tsx` | ✅ |

## 핵심 구현

**`mobile-selection-menu.tsx`**
- `isMobileDevice()`: `'ontouchstart' in window && matchMedia('(max-width: 768px)').matches`
- `editor.on('selectionUpdate', ...)` + 200ms 디바운스
- `window.getSelection().getRangeAt(0).getBoundingClientRect()` → selection 아래 8px
- left-clip 경계 보정: `Math.max(8, Math.min(centerX - menuWidth/2, viewportWidth - menuWidth - 8))`
- 버튼 `h-11 w-11` (44×44 tap target, WCAG 2.5.5)
- `onMouseDown={(e) => e.preventDefault()}` selection 풀림 방지
- `role="toolbar"` + `aria-label`
- `editor.on('blur', ...)` → 메뉴 숨김
- `createPortal(document.body)` — overflow:hidden 컨테이너 탈출
- 6개 버튼: Bold/Italic/Strike/Code/Link/Highlight (BubbleMenu 동일)

**`doc-editor.tsx`**
- BubbleMenu `shouldShow={() => !isMobileDevice()}` — 데스크탑 전용
- MobileSelectionMenu는 모바일에서만 표시 (내부 `isMobileDevice()` 체크)

## PO 확정 결정 반영

- D-014-PO-2 C: 모바일에서 BubbleMenu 완전 대체 (shouldShow 분기)
- D-014-PO-3: BubbleMenu와 동일 6개 서식

## 빌드 / 린트

- `pnpm build` ✅
- `pnpm lint` ✅ 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)