### PR TITLE
[DS-TOKEN-001] Design Tokens 페이지 컴포넌트화 + globals.css 자동 수집

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,6 +36,9 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: process.env['NEXT_DEV_ALLOWED_ORIGINS']?.split(',').map((s) => s.trim()).filter(Boolean) ?? [],
   output: 'standalone',
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
+  outputFileTracingIncludes: {
+    '/(authenticated)/docs/design-tokens': ['./src/app/globals.css'],
+  },
   devIndicators: {
     position: 'bottom-right',
   },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -37,7 +37,7 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
   outputFileTracingIncludes: {
-    '/(authenticated)/docs/design-tokens': ['./src/app/globals.css'],
+    '/docs/design-tokens': ['./src/app/globals.css'],
   },
   devIndicators: {
     position: 'bottom-right',

--- a/apps/web/src/app/(authenticated)/docs/design-tokens/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/design-tokens/page.tsx
@@ -1,129 +1,24 @@
-'use client';
-
-interface ColorToken {
-  name: string;
-  var: string;
-  tailwind: string;
-}
-
-interface FontToken {
-  name: string;
-  var: string;
-  tailwind: string;
-}
-
-interface RadiusToken {
-  name: string;
-  var: string;
-  tailwind: string;
-}
-
-const COLOR_GROUPS: { label: string; tokens: ColorToken[] }[] = [
-  {
-    label: 'Brand',
-    tokens: [
-      { name: 'brand', var: '--brand', tailwind: 'bg-brand' },
-      { name: 'brand-foreground', var: '--brand-foreground', tailwind: 'bg-brand-foreground' },
-      { name: 'brand-soft', var: '--brand-soft', tailwind: 'bg-[--brand-soft]' },
-      { name: 'brand-strong', var: '--brand-strong', tailwind: 'bg-[--brand-strong]' },
-      { name: 'brand-contrast', var: '--brand-contrast', tailwind: 'bg-[--brand-contrast]' },
-    ],
-  },
-  {
-    label: 'Semantic',
-    tokens: [
-      { name: 'background', var: '--background', tailwind: 'bg-background' },
-      { name: 'foreground', var: '--foreground', tailwind: 'bg-foreground' },
-      { name: 'card', var: '--card', tailwind: 'bg-card' },
-      { name: 'popover', var: '--popover', tailwind: 'bg-popover' },
-      { name: 'primary', var: '--primary', tailwind: 'bg-primary' },
-      { name: 'secondary', var: '--secondary', tailwind: 'bg-secondary' },
-      { name: 'muted', var: '--muted', tailwind: 'bg-muted' },
-      { name: 'muted-foreground', var: '--muted-foreground', tailwind: 'bg-muted-foreground' },
-      { name: 'accent', var: '--accent', tailwind: 'bg-accent' },
-      { name: 'destructive', var: '--destructive', tailwind: 'bg-destructive' },
-      { name: 'border', var: '--border', tailwind: 'bg-border' },
-      { name: 'input', var: '--input', tailwind: 'bg-input' },
-      { name: 'ring', var: '--ring', tailwind: 'bg-ring' },
-      { name: 'success', var: '--success', tailwind: 'bg-success' },
-      { name: 'warning', var: '--warning', tailwind: 'bg-warning' },
-      { name: 'info', var: '--info', tailwind: 'bg-info' },
-      { name: 'priority', var: '--priority', tailwind: 'bg-priority' },
-    ],
-  },
-  {
-    label: 'Charts',
-    tokens: [
-      { name: 'chart-1', var: '--chart-1', tailwind: 'bg-chart-1' },
-      { name: 'chart-2', var: '--chart-2', tailwind: 'bg-chart-2' },
-      { name: 'chart-3', var: '--chart-3', tailwind: 'bg-chart-3' },
-      { name: 'chart-4', var: '--chart-4', tailwind: 'bg-chart-4' },
-      { name: 'chart-5', var: '--chart-5', tailwind: 'bg-chart-5' },
-    ],
-  },
-  {
-    label: 'Sidebar',
-    tokens: [
-      { name: 'sidebar', var: '--sidebar', tailwind: 'bg-sidebar' },
-      { name: 'sidebar-foreground', var: '--sidebar-foreground', tailwind: 'bg-sidebar-foreground' },
-      { name: 'sidebar-primary', var: '--sidebar-primary', tailwind: 'bg-sidebar-primary' },
-      { name: 'sidebar-accent', var: '--sidebar-accent', tailwind: 'bg-sidebar-accent' },
-      { name: 'sidebar-border', var: '--sidebar-border', tailwind: 'bg-sidebar-border' },
-      { name: 'sidebar-ring', var: '--sidebar-ring', tailwind: 'bg-sidebar-ring' },
-    ],
-  },
-];
-
-const FONT_TOKENS: FontToken[] = [
-  { name: 'Sans', var: '--font-sans', tailwind: 'font-sans' },
-  { name: 'Heading', var: '--font-heading', tailwind: 'font-heading' },
-  { name: 'Serif', var: '--font-serif', tailwind: 'font-serif' },
-  { name: 'Mono', var: '--font-mono', tailwind: 'font-mono' },
-];
-
-const RADIUS_TOKENS: RadiusToken[] = [
-  { name: 'sm', var: '--radius-sm', tailwind: 'rounded-sm' },
-  { name: 'md', var: '--radius-md', tailwind: 'rounded-md' },
-  { name: 'base (--radius)', var: '--radius', tailwind: 'rounded' },
-  { name: 'lg', var: '--radius-lg', tailwind: 'rounded-lg' },
-  { name: 'xl', var: '--radius-xl', tailwind: 'rounded-xl' },
-  { name: '2xl', var: '--radius-2xl', tailwind: 'rounded-2xl' },
-  { name: '3xl', var: '--radius-3xl', tailwind: 'rounded-3xl' },
-  { name: '4xl', var: '--radius-4xl', tailwind: 'rounded-4xl' },
-];
-
-function readVar(name: string): string {
-  if (typeof window === 'undefined') return '';
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
-}
-
-function ColorSwatch({ token }: { token: ColorToken }) {
-  const value = readVar(token.var);
-  return (
-    <div className="flex items-center gap-3">
-      <div
-        className="size-8 shrink-0 rounded border border-border/60"
-        style={{ background: `var(${token.var})` }}
-      />
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-xs font-medium text-foreground">{token.name}</p>
-        <p suppressHydrationWarning className="truncate font-mono text-[10px] text-muted-foreground">{value || token.var}</p>
-      </div>
-      <code className="shrink-0 rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-        {token.tailwind}
-      </code>
-    </div>
-  );
-}
+import { parseColorGroups, parseFontTokens, parseRadiusTokens } from '@/lib/parse-design-tokens';
+import { ColorSwatch } from '@/components/design-system/color-swatch';
+import { FontPreview } from '@/components/design-system/font-preview';
+import { RadiusSwatch } from '@/components/design-system/radius-swatch';
 
 export default function DesignTokensPage() {
+  const colorGroups = parseColorGroups();
+  const fontTokens = parseFontTokens();
+  const radiusTokens = parseRadiusTokens();
+  const brandGroup = colorGroups.find(g => g.label === 'Brand');
+
   return (
     <div className="min-h-full overflow-y-auto px-6 py-8">
       <div className="mx-auto max-w-4xl space-y-12">
         <div>
           <h1 className="text-2xl font-semibold text-foreground">Design Tokens</h1>
           <p className="mt-1 text-sm text-muted-foreground">
-            Live CSS custom properties resolved from <code className="rounded bg-muted px-1 font-mono text-xs">:root</code>.
+            Live CSS custom properties resolved from{' '}
+            <code className="rounded bg-muted px-1 font-mono text-xs">:root</code>.
+            Tokens are auto-collected from{' '}
+            <code className="rounded bg-muted px-1 font-mono text-xs">globals.css</code>.
           </p>
         </div>
 
@@ -131,14 +26,14 @@ export default function DesignTokensPage() {
         <section>
           <h2 className="mb-4 text-base font-semibold text-foreground">Colors</h2>
           <div className="space-y-8">
-            {COLOR_GROUPS.map((group) => (
+            {colorGroups.map((group) => (
               <div key={group.label}>
                 <h3 className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   {group.label}
                 </h3>
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   {group.tokens.map((token) => (
-                    <ColorSwatch key={token.var} token={token} />
+                    <ColorSwatch key={token.cssVar} token={token} />
                   ))}
                 </div>
               </div>
@@ -150,70 +45,50 @@ export default function DesignTokensPage() {
         <section>
           <h2 className="mb-4 text-base font-semibold text-foreground">Typography</h2>
           <div className="space-y-4">
-            {FONT_TOKENS.map((token) => (
-              <div key={token.var} className="flex items-center gap-4 rounded-lg border border-border/60 px-4 py-3">
-                <div className="w-24 shrink-0">
-                  <p className="text-xs font-medium text-foreground">{token.name}</p>
-                  <code className="font-mono text-[10px] text-muted-foreground">{token.tailwind}</code>
-                </div>
-                <p
-                  className="flex-1 text-base text-foreground"
-                  style={{ fontFamily: `var(${token.var})` }}
-                >
-                  The quick brown fox jumps over the lazy dog
-                </p>
-              </div>
+            {fontTokens.map((token) => (
+              <FontPreview key={token.cssVar} token={token} />
             ))}
           </div>
         </section>
 
-        {/* Radius */}
+        {/* Border Radius */}
         <section>
           <h2 className="mb-4 text-base font-semibold text-foreground">Border Radius</h2>
           <div className="flex flex-wrap gap-4">
-            {RADIUS_TOKENS.map((token) => {
-              const value = readVar(token.var);
-              return (
-                <div key={token.var} className="flex flex-col items-center gap-2">
-                  <div
-                    className="size-14 border-2 border-brand bg-brand/15"
-                    style={{ borderRadius: `var(${token.var})` }}
-                  />
-                  <div className="text-center">
-                    <p className="text-xs font-medium text-foreground">{token.name}</p>
-                    <p suppressHydrationWarning className="font-mono text-[10px] text-muted-foreground">{value || '—'}</p>
-                  </div>
-                </div>
-              );
-            })}
+            {radiusTokens.map((token) => (
+              <RadiusSwatch key={token.cssVar} token={token} />
+            ))}
           </div>
         </section>
 
         {/* Dark Mode Preview */}
-        <section>
-          <h2 className="mb-1 text-base font-semibold text-foreground">Dark Mode Preview</h2>
-          <p className="mb-4 text-sm text-muted-foreground">
-            Brand swatches resolved inside a scoped <code className="rounded bg-muted px-1 font-mono text-xs">.dark</code> container.
-          </p>
-          <div className="dark rounded-xl border border-border/60 bg-background p-6">
-            <p className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Brand — dark mode
+        {brandGroup && (
+          <section>
+            <h2 className="mb-1 text-base font-semibold text-foreground">Dark Mode Preview</h2>
+            <p className="mb-4 text-sm text-muted-foreground">
+              Brand swatches resolved inside a scoped{' '}
+              <code className="rounded bg-muted px-1 font-mono text-xs">.dark</code> container.
             </p>
-            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-              {COLOR_GROUPS[0]!.tokens.map((token) => (
-                <div key={token.var} className="flex items-center gap-3">
-                  <div
-                    className="size-8 shrink-0 rounded border border-border/60"
-                    style={{ background: `var(${token.var})` }}
-                  />
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-xs font-medium text-foreground">{token.name}</p>
+            <div className="dark rounded-xl border border-border/60 bg-background p-6">
+              <p className="mb-4 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Brand — dark mode
+              </p>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {brandGroup.tokens.map((token) => (
+                  <div key={token.cssVar} className="flex items-center gap-3">
+                    <div
+                      className="size-8 shrink-0 rounded border border-border/60"
+                      style={{ background: `var(${token.cssVar})` }}
+                    />
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-xs font-medium text-foreground">{token.name}</p>
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))}
+              </div>
             </div>
-          </div>
-        </section>
+          </section>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/design-system/color-swatch.tsx
+++ b/apps/web/src/components/design-system/color-swatch.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { ColorToken } from '@/lib/parse-design-tokens';
+
+function readVar(name: string): string {
+  if (typeof window === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+export function ColorSwatch({ token }: { token: ColorToken }) {
+  const value = readVar(token.cssVar);
+  return (
+    <div className="flex items-center gap-3">
+      <div
+        className="size-8 shrink-0 rounded border border-border/60"
+        style={{ background: `var(${token.cssVar})` }}
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-xs font-medium text-foreground">{token.name}</p>
+        <p suppressHydrationWarning className="truncate font-mono text-[10px] text-muted-foreground">
+          {value || token.cssVar}
+        </p>
+      </div>
+      <code className="shrink-0 rounded bg-muted/60 px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+        {token.tailwind}
+      </code>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/font-preview.tsx
+++ b/apps/web/src/components/design-system/font-preview.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import type { FontToken } from '@/lib/parse-design-tokens';
+
+export function FontPreview({ token }: { token: FontToken }) {
+  return (
+    <div className="flex items-center gap-4 rounded-lg border border-border/60 px-4 py-3">
+      <div className="w-24 shrink-0">
+        <p className="text-xs font-medium text-foreground">{token.name}</p>
+        <code className="font-mono text-[10px] text-muted-foreground">{token.tailwind}</code>
+      </div>
+      <p className="flex-1 text-base text-foreground" style={{ fontFamily: `var(${token.cssVar})` }}>
+        The quick brown fox jumps over the lazy dog
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/design-system/radius-swatch.tsx
+++ b/apps/web/src/components/design-system/radius-swatch.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import type { RadiusToken } from '@/lib/parse-design-tokens';
+
+function readVar(name: string): string {
+  if (typeof window === 'undefined') return '';
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+export function RadiusSwatch({ token }: { token: RadiusToken }) {
+  const value = readVar(token.cssVar);
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <div
+        className="size-14 border-2 border-brand bg-brand/15"
+        style={{ borderRadius: `var(${token.cssVar})` }}
+      />
+      <div className="text-center">
+        <p className="text-xs font-medium text-foreground">{token.name}</p>
+        <p suppressHydrationWarning className="font-mono text-[10px] text-muted-foreground">
+          {value || '—'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/parse-design-tokens.ts
+++ b/apps/web/src/lib/parse-design-tokens.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export interface ColorToken { name: string; cssVar: string; tailwind: string; }
+export interface FontToken { name: string; cssVar: string; tailwind: string; }
+export interface RadiusToken { name: string; cssVar: string; tailwind: string; }
+export interface ColorGroup { label: string; tokens: ColorToken[]; }
+
+const COLOR_EXCLUDED_PREFIXES = ['scrollbar', 'tiptap', 'radius', 'font'];
+const GROUP_ORDER = ['Brand', 'Semantic', 'Status', 'Charts', 'Sidebar'];
+const STATUS_NAMES = new Set(['success', 'warning', 'info', 'priority']);
+
+function readGlobalsCss(): string {
+  return readFileSync(join(process.cwd(), 'src/app/globals.css'), 'utf-8');
+}
+
+function extractBlock(css: string, selector: string): string {
+  const idx = css.indexOf(selector);
+  if (idx === -1) return '';
+  const start = css.indexOf('{', idx);
+  if (start === -1) return '';
+  let depth = 0;
+  let end = start;
+  for (let i = start; i < css.length; i++) {
+    if (css[i] === '{') depth++;
+    else if (css[i] === '}') {
+      depth--;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  return css.slice(start + 1, end);
+}
+
+function extractVarNames(block: string): string[] {
+  const result: string[] = [];
+  const re = /--([\w-]+)\s*:/g;
+  let m;
+  while ((m = re.exec(block)) !== null) result.push(m[1]!);
+  return result;
+}
+
+function colorGroup(name: string): string {
+  if (name.startsWith('brand')) return 'Brand';
+  if (name.startsWith('sidebar')) return 'Sidebar';
+  if (name.startsWith('chart')) return 'Charts';
+  if (STATUS_NAMES.has(name)) return 'Status';
+  return 'Semantic';
+}
+
+export function parseColorGroups(): ColorGroup[] {
+  const css = readGlobalsCss();
+  const rootBlock = extractBlock(css, ':root');
+  const themeBlock = extractBlock(css, '@theme inline');
+
+  const themeColorNames = new Set(
+    extractVarNames(themeBlock)
+      .filter(n => n.startsWith('color-'))
+      .map(n => n.slice(6)),
+  );
+
+  const colorNames = extractVarNames(rootBlock).filter(
+    n => n !== 'radius' && !COLOR_EXCLUDED_PREFIXES.some(p => n.startsWith(p)),
+  );
+
+  const grouped: Record<string, ColorToken[]> = {};
+  for (const name of colorNames) {
+    const group = colorGroup(name);
+    if (!grouped[group]) grouped[group] = [];
+    const tailwind = themeColorNames.has(name) ? `bg-${name}` : `bg-[--${name}]`;
+    grouped[group]!.push({ name, cssVar: `--${name}`, tailwind });
+  }
+
+  return GROUP_ORDER.filter(g => grouped[g]).map(label => ({ label, tokens: grouped[label]! }));
+}
+
+export function parseFontTokens(): FontToken[] {
+  const css = readGlobalsCss();
+  const themeBlock = extractBlock(css, '@theme inline');
+  const seen = new Set<string>();
+  return extractVarNames(themeBlock)
+    .filter(n => n.startsWith('font-'))
+    .filter(n => { if (seen.has(n)) return false; seen.add(n); return true; })
+    .map(n => {
+      const suffix = n.slice(5);
+      return {
+        name: suffix.charAt(0).toUpperCase() + suffix.slice(1),
+        cssVar: `--${n}`,
+        tailwind: `font-${suffix}`,
+      };
+    });
+}
+
+export function parseRadiusTokens(): RadiusToken[] {
+  const css = readGlobalsCss();
+  const rootBlock = extractBlock(css, ':root');
+  const themeBlock = extractBlock(css, '@theme inline');
+  const tokens: RadiusToken[] = [];
+
+  if (/--radius\s*:/.test(rootBlock)) {
+    tokens.push({ name: 'base', cssVar: '--radius', tailwind: 'rounded' });
+  }
+
+  const SM_LG_MAP: Record<string, string> = { sm: 'rounded-sm', md: 'rounded-md', lg: 'rounded-lg' };
+  extractVarNames(themeBlock)
+    .filter(n => n.startsWith('radius-'))
+    .forEach(n => {
+      const suffix = n.slice(7);
+      tokens.push({ name: suffix, cssVar: `--${n}`, tailwind: SM_LG_MAP[suffix] ?? `rounded-${suffix}` });
+    });
+
+  return tokens;
+}


### PR DESCRIPTION
## 변경 사항

### 신규 파일
- `apps/web/src/lib/parse-design-tokens.ts` — 서버 사이드 globals.css 파싱 유틸
- `apps/web/src/components/design-system/color-swatch.tsx` — ColorSwatch 컴포넌트
- `apps/web/src/components/design-system/font-preview.tsx` — FontPreview 컴포넌트
- `apps/web/src/components/design-system/radius-swatch.tsx` — RadiusSwatch 컴포넌트

### 수정 파일
- `apps/web/src/app/(authenticated)/docs/design-tokens/page.tsx` — 서버 컴포넌트로 전환, const 배열 하드코딩 제거

## AC 체크
- [x] AC1: ColorSwatch/FontPreview/RadiusSwatch → `components/design-system/`에 독립 파일 분리
- [x] AC2: 토큰 목록 globals.css `:root`/`@theme inline` 파싱으로 자동 추출 — const 배열 제거
- [x] AC3: `/docs/design-tokens` 페이지 동일 UI 유지 (Color/Typography/Radius/Dark Mode 4섹션)
- [x] AC4: globals.css에 CSS 변수 추가 시 재빌드만으로 자동 반영 (서버 사이드 파싱)
- [x] AC5: tsc --noEmit exit 0

## 자동 수집 방식

parse-design-tokens.ts가 빌드/서버 렌더링 시 globals.css를 fs.readFileSync로 읽어 파싱:
- 색상: :root { } 블록에서 변수 추출 → Brand/Semantic/Status/Charts/Sidebar 그룹 자동 분류
- tailwind 클래스: @theme inline의 --color-* 목록과 교차하여 자동 결정
- 폰트: @theme inline 블록에서 --font-* 추출
- 라디우스: :root의 --radius + @theme inline의 --radius-* 추출

🤖 Generated with [Claude Code](https://claude.com/claude-code)