### PR TITLE
[D-DOCS-MOB-3] 모바일 Docs 스크롤 시 GNB hide-on-scroll

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -291,7 +291,7 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
             'sticky top-12 z-20 transition-transform',
             '[transition-duration:var(--gnb-hide-duration)]',
             '[transition-timing-function:var(--gnb-hide-easing)]',
-            gnbHidden && '-translate-y-[calc(100%+48px)]',
+            gnbHidden && '-translate-y-[calc(100%+var(--gnb-mobile-height))]',
           )}
         >
           <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] items-center gap-2 text-sm text-muted-foreground hover:text-foreground" aria-label="문서 트리 열기">

--- a/apps/web/src/app/(authenticated)/docs/layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/layout.tsx
@@ -1,6 +1,10 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { useTopBar } from '@/components/nav/top-bar-context';
+import { useMediaQuery } from '@/lib/use-media-query';
+import { useHideOnScroll } from '@/lib/use-hide-on-scroll';
 import { useParams, useRouter } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { DocTree } from '@/components/docs/doc-tree';
@@ -28,6 +32,15 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
   const { recentSlugs, pushRecent } = useRecentDocs(projectId);
   const { expandFolder } = useTreeExpanded(projectId);
   const { toasts, addToast, dismissToast } = useToast();
+
+  const { scrollContainer, setHidden } = useTopBar();
+  const isMobile = useMediaQuery('(max-width: 1023px)');
+  const gnbHidden = useHideOnScroll({ enabled: isMobile, scrollContainer });
+
+  useEffect(() => {
+    setHidden(gnbHidden);
+    return () => setHidden(false);
+  }, [gnbHidden, setHidden]);
 
   const [tree, setTree] = useState<Doc[]>([]);
   const [loading, setLoading] = useState(true);
@@ -272,7 +285,15 @@ export default function DocsLayout({ children }: { children: React.ReactNode }) 
 
       {/* Mobile: content + tree drawer (< lg) */}
       <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
-        <div className="flex-shrink-0 flex items-center gap-2 border-b border-border/80 bg-background px-4 py-2">
+        <div
+          className={cn(
+            'flex-shrink-0 flex items-center gap-2 border-b border-border/80 bg-background px-4 py-2',
+            'sticky top-12 z-20 transition-transform',
+            '[transition-duration:var(--gnb-hide-duration)]',
+            '[transition-timing-function:var(--gnb-hide-easing)]',
+            gnbHidden && '-translate-y-[calc(100%+48px)]',
+          )}
+        >
           <button type="button" onClick={() => setTreeDrawerOpen(true)} className="flex min-h-[44px] items-center gap-2 text-sm text-muted-foreground hover:text-foreground" aria-label="문서 트리 열기">
             <Menu className="size-4" />
             <span>{t('title')}</span>

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { AppSidebar } from '@/components/nav/app-sidebar';
 import { TopBar } from '@/components/nav/top-bar';
-import { TopBarProvider } from '@/components/nav/top-bar-context';
+import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { RefreshProvider } from '@/contexts/refresh-context';
 import type { OrgSwitcherItem } from '@/components/nav/unified-switcher';
@@ -35,6 +35,22 @@ interface DashboardShellProps extends DashboardContext {
   children: React.ReactNode;
 }
 
+function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: React.ReactNode }) {
+  const { setScrollContainer } = useTopBar();
+  const setRef = useCallback((el: HTMLDivElement | null) => {
+    setScrollContainer(el);
+  }, [setScrollContainer]);
+
+  return (
+    <SidebarInset className="relative flex flex-col overflow-hidden">
+      <div ref={setRef} className="flex flex-1 min-h-0 flex-col overflow-y-auto">
+        {showTopBar && <TopBar />}
+        {children}
+      </div>
+    </SidebarInset>
+  );
+}
+
 export function DashboardShell({
   currentTeamMemberId,
   orgId,
@@ -62,12 +78,9 @@ export function DashboardShell({
               orgMemberships={orgMemberships}
               userName={userName}
             />
-            <SidebarInset className="relative flex flex-col overflow-hidden">
-              {showTopBar && <TopBar />}
-              <div className="flex flex-1 min-h-0 flex-col overflow-y-auto">
-                {children}
-              </div>
-            </SidebarInset>
+            <ScrollShell showTopBar={showTopBar}>
+              {children}
+            </ScrollShell>
           </SidebarProvider>
         </TopBarProvider>
       </RealtimeProvider>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -86,6 +86,11 @@
   --radius-2xl: calc(var(--radius) * 1.8);
   --radius-3xl: calc(var(--radius) * 2.2);
   --radius-4xl: calc(var(--radius) * 2.6);
+
+  /* GNB hide-on-scroll (D-DOCS-MOB-3) */
+  --gnb-mobile-height: 48px;
+  --gnb-hide-duration: 250ms;
+  --gnb-hide-easing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* ─── Light Mode (OKLCH zinc) ─── */

--- a/apps/web/src/components/nav/top-bar-context.tsx
+++ b/apps/web/src/components/nav/top-bar-context.tsx
@@ -10,16 +10,26 @@ interface TopBarState {
 interface TopBarStore extends TopBarState {
   setSlot: (slot: TopBarState) => void;
   clearSlot: () => void;
+  hidden: boolean;
+  setHidden: (h: boolean) => void;
+  scrollContainer: HTMLElement | null;
+  setScrollContainer: (el: HTMLElement | null) => void;
 }
 
 const TopBarCtx = createContext<TopBarStore | null>(null);
 
 export function TopBarProvider({ children }: { children: ReactNode }) {
   const [state, setState] = useState<TopBarState>({ title: null, actions: null });
+  const [hidden, setHidden] = useState(false);
+  const [scrollContainer, setScrollContainer] = useState<HTMLElement | null>(null);
   const value: TopBarStore = {
     ...state,
     setSlot: (slot) => setState(slot),
     clearSlot: () => setState({ title: null, actions: null }),
+    hidden,
+    setHidden,
+    scrollContainer,
+    setScrollContainer,
   };
   return <TopBarCtx.Provider value={value}>{children}</TopBarCtx.Provider>;
 }

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -10,9 +10,18 @@ interface TopBarProps {
 }
 
 export function TopBar({ className }: TopBarProps) {
-  const { title, actions } = useTopBar();
+  const { title, actions, hidden } = useTopBar();
   return (
-    <div className={cn('flex h-12 shrink-0 items-center gap-2 border-b px-4', className)}>
+    <div
+      className={cn(
+        'flex h-12 shrink-0 items-center gap-2 border-b px-4',
+        'sticky top-0 z-30 bg-background transition-transform',
+        '[transition-duration:var(--gnb-hide-duration)]',
+        '[transition-timing-function:var(--gnb-hide-easing)]',
+        hidden && '-translate-y-full',
+        className,
+      )}
+    >
       <SidebarTrigger className="mr-2 md:hidden" />
       <div className="flex min-w-0 flex-1 items-center gap-2">
         {title}

--- a/apps/web/src/lib/use-hide-on-scroll.ts
+++ b/apps/web/src/lib/use-hide-on-scroll.ts
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect, useRef, useState } from 'react';
+
+interface Options {
+  enabled: boolean;
+  scrollContainer: HTMLElement | null;
+  deltaThreshold?: number;
+  nearTopThreshold?: number;
+}
+
+export function useHideOnScroll({
+  enabled,
+  scrollContainer,
+  deltaThreshold = 8,
+  nearTopThreshold = 32,
+}: Options): boolean {
+  const [hidden, setHidden] = useState(false);
+  const lastY = useRef(0);
+
+  useEffect(() => {
+    if (!enabled || !scrollContainer) return;
+
+    lastY.current = scrollContainer.scrollTop;
+
+    const handler = () => {
+      const currentY = scrollContainer.scrollTop;
+      const delta = currentY - lastY.current;
+
+      if (currentY <= nearTopThreshold) {
+        setHidden(false);
+      } else if (delta > deltaThreshold) {
+        setHidden(true);
+        lastY.current = currentY;
+      } else if (delta < -deltaThreshold) {
+        setHidden(false);
+        lastY.current = currentY;
+      }
+    };
+
+    scrollContainer.addEventListener('scroll', handler, { passive: true });
+    return () => {
+      scrollContainer.removeEventListener('scroll', handler);
+      setHidden(false);
+    };
+  }, [enabled, scrollContainer, deltaThreshold, nearTopThreshold]);
+
+  return hidden;
+}

--- a/apps/web/src/lib/use-media-query.ts
+++ b/apps/web/src/lib/use-media-query.ts
@@ -1,0 +1,16 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+    update();
+    mql.addEventListener('change', update);
+    return () => mql.removeEventListener('change', update);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary

- 모바일(lg 이하) Docs 라우트에서 스크롤 다운 시 TopBar + Docs 모바일 헤더(~92px) 자동 숨김, 스크롤 업 시 재출현
- Docs 라우트 한정 + matchMedia 게이트 → 다른 라우트/데스크탑 영향 없음

## 변경 파일 (시안 §7 일치)

| 파일 | 변경 |
|---|---|
| `apps/web/src/app/globals.css` | `--gnb-mobile-height/duration/easing` 토큰 추가 |
| `apps/web/src/lib/use-hide-on-scroll.ts` | **신규** — delta threshold scroll hide 훅 |
| `apps/web/src/lib/use-media-query.ts` | **신규** — matchMedia 헬퍼 훅 |
| `apps/web/src/components/nav/top-bar-context.tsx` | `hidden` + `scrollContainer` state 확장 |
| `apps/web/src/components/nav/top-bar.tsx` | sticky top-0 z-30 + transform hide 적용 |
| `apps/web/src/app/dashboard/dashboard-shell.tsx` | `ScrollShell` 분리, TopBar를 scroll div 내부로 이동 |
| `apps/web/src/app/(authenticated)/docs/layout.tsx` | 모바일 헤더 sticky z-20 + transform, `useHideOnScroll` 연동 |

## 가디언 룰 준수

- [x] 하드코딩 색상 없음 — `bg-background`, `border-border/80` 유지
- [x] magic number 없음 — duration/easing은 CSS 토큰 사용
- [x] z-index 순서 유지 — TopBar z-30, Docs 헤더 z-20, drawer overlay z-40/panel z-50
- [x] 44px 터치 타겟 — `min-h-[44px]` 변경 없음

## 동작 규칙

| 조건 | 동작 |
|---|---|
| scrollY ≤ 32px | 항상 show |
| down delta > 8px AND scrollY > 32px | hide |
| up delta > 8px | show |
| ≤ 8px delta | 상태 유지 (떨림 방지) |
| 라우트 이탈 | show 즉시 복귀 (cleanup) |
| 데스크탑 (lg+) | matchMedia 게이트, 비활성 |

## QA 중점 확인

- [ ] Docs 모바일: scroll down → hide, up → show, 진입 직후 show
- [ ] 다른 모바일 라우트 (`/dashboard` 등): TopBar sticky 추가됐으나 hide 비활성 → layout shift 없음
- [ ] iOS Safari: rubber-band over-scroll 시 깜빡임 없음
- [ ] iOS Safari: back gesture 충돌 없음 (swipe drawer와 별개)

## 빌드 검증

- [x] `pnpm build` 성공
- [x] `pnpm lint` error 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)