### PR TITLE
[DS-S11] Loading Skeleton shimmer 패턴 통일 + 페이지별 전용 컴포넌트

### DIFF
--- a/apps/web/src/app/(authenticated)/board/loading.tsx
+++ b/apps/web/src/app/(authenticated)/board/loading.tsx
@@ -1,5 +1,5 @@
-import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { KanbanSkeleton } from '@/components/kanban/kanban-skeleton';
 
 export default function Loading() {
-  return <PageSkeleton />;
+  return <KanbanSkeleton />;
 }

--- a/apps/web/src/app/(authenticated)/docs/loading.tsx
+++ b/apps/web/src/app/(authenticated)/docs/loading.tsx
@@ -1,5 +1,5 @@
-import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { DocsListSkeleton } from '@/components/docs/docs-list-skeleton';
 
 export default function Loading() {
-  return <PageSkeleton />;
+  return <DocsListSkeleton />;
 }

--- a/apps/web/src/app/(authenticated)/epics/loading.tsx
+++ b/apps/web/src/app/(authenticated)/epics/loading.tsx
@@ -1,0 +1,5 @@
+import { EpicsSkeleton } from '@/components/epics/epics-skeleton';
+
+export default function Loading() {
+  return <EpicsSkeleton />;
+}

--- a/apps/web/src/app/dashboard/loading.tsx
+++ b/apps/web/src/app/dashboard/loading.tsx
@@ -1,5 +1,5 @@
-import { PageSkeleton } from '@/components/ui/page-skeleton';
+import { DashboardSkeleton } from '@/components/dashboard/dashboard-skeleton';
 
 export default function Loading() {
-  return <PageSkeleton />;
+  return <DashboardSkeleton />;
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -37,6 +37,12 @@
   animation: onboarding-enter 0.4s ease both;
 }
 
+/* DS-S11: Skeleton shimmer */
+@keyframes skeleton-shimmer {
+  0%   { background-position: -200% 0; }
+  100% { background-position:  200% 0; }
+}
+
 @theme inline {
   --font-heading: var(--font-sans);
   --font-sans: var(--font-sans);
@@ -91,6 +97,12 @@
   --gnb-mobile-height: 48px;
   --gnb-hide-duration: 250ms;
   --gnb-hide-easing: cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* DS-S11: Loading Skeleton */
+  --skeleton-base: var(--muted);
+  --skeleton-highlight: color-mix(in oklch, var(--muted) 60%, var(--background) 40%);
+  --skeleton-duration: 1.5s;
+  --animate-skeleton-shimmer: skeleton-shimmer 1.5s linear infinite;
 }
 
 /* ─── Light Mode (OKLCH zinc) ─── */

--- a/apps/web/src/components/dashboard/dashboard-skeleton.tsx
+++ b/apps/web/src/components/dashboard/dashboard-skeleton.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DashboardSkeleton() {
+  return (
+    <div className="space-y-6 p-4 md:p-6">
+      <Skeleton className="h-7 w-48" />
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2 rounded-xl border border-border/80 p-4">
+            <Skeleton variant="text" className="w-20" />
+            <Skeleton className="h-8 w-16" />
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="space-y-3 rounded-xl border border-border/80 p-4 lg:col-span-2">
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="h-40 w-full" />
+        </div>
+        <div className="space-y-3 rounded-xl border border-border/80 p-4">
+          <Skeleton className="h-5 w-24" />
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <Skeleton variant="circle" className="size-8" />
+              <Skeleton variant="text" className="flex-1" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/docs/docs-list-skeleton.tsx
+++ b/apps/web/src/components/docs/docs-list-skeleton.tsx
@@ -1,0 +1,24 @@
+'use client';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function DocsListSkeleton() {
+  return (
+    <div className="flex h-full">
+      <aside className="hidden w-[300px] flex-shrink-0 space-y-2 border-r border-border/80 p-3 lg:block">
+        <Skeleton className="h-8 w-full" />
+        {Array.from({ length: 10 }).map((_, i) => (
+          <Skeleton key={i} variant="text" className={i % 3 === 0 ? 'w-full' : 'w-3/4'} />
+        ))}
+      </aside>
+      <div className="flex-1 space-y-4 p-6">
+        <Skeleton className="h-8 w-1/2" />
+        <Skeleton variant="text" className="w-full" />
+        <Skeleton variant="text" className="w-5/6" />
+        <Skeleton variant="text" className="w-4/5" />
+        <div className="pt-4">
+          <Skeleton className="h-32 w-full" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/epics/epics-skeleton.tsx
+++ b/apps/web/src/components/epics/epics-skeleton.tsx
@@ -1,0 +1,27 @@
+'use client';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export function EpicsSkeleton() {
+  return (
+    <div className="space-y-4 p-4 md:p-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-40" />
+        <Skeleton className="h-9 w-28" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="space-y-3 rounded-xl border border-border/80 p-4">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton variant="text" className="w-full" />
+            <Skeleton className="h-2 w-full" />
+            <div className="flex gap-2">
+              <Skeleton variant="circle" className="size-6" />
+              <Skeleton variant="circle" className="size-6" />
+              <Skeleton className="ml-auto h-6 w-12" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/kanban/kanban-skeleton.tsx
+++ b/apps/web/src/components/kanban/kanban-skeleton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { COLUMNS } from './types';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export function KanbanSkeleton() {
   return (
@@ -9,13 +10,13 @@ export function KanbanSkeleton() {
       <div className="flex h-11 flex-shrink-0 items-center justify-between border-b border-border/80 px-4">
         <div className="flex items-center gap-1">
           {[1, 2, 3].map((i) => (
-            <div key={i} className="h-6 w-16 animate-pulse rounded-md bg-muted" />
+            <Skeleton key={i} className="h-6 w-16" />
           ))}
         </div>
         <div className="flex items-center gap-1">
-          <div className="h-7 w-7 animate-pulse rounded-md bg-muted" />
-          <div className="h-7 w-7 animate-pulse rounded-md bg-muted" />
-          <div className="h-7 w-14 animate-pulse rounded-md bg-muted" />
+          <Skeleton className="h-7 w-7" />
+          <Skeleton className="h-7 w-7" />
+          <Skeleton className="h-7 w-14" />
         </div>
       </div>
 
@@ -23,10 +24,10 @@ export function KanbanSkeleton() {
       <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto px-3 py-3">
         {COLUMNS.map((col) => (
           <div key={col.id} className="flex h-full w-[280px] min-w-[240px] flex-col rounded-xl bg-muted/40 p-3">
-            <div className="mb-3 h-4 w-20 animate-pulse rounded bg-muted" />
+            <Skeleton className="mb-3 h-4 w-20 rounded" />
             <div className="flex flex-col gap-2">
               {[1, 2, 3].map((i) => (
-                <div key={i} className="h-20 animate-pulse rounded-lg bg-background shadow-sm" />
+                <div key={i} className="h-20 rounded-lg bg-background shadow-sm" />
               ))}
             </div>
           </div>

--- a/apps/web/src/components/ui/page-skeleton.tsx
+++ b/apps/web/src/components/ui/page-skeleton.tsx
@@ -1,32 +1,28 @@
 'use client';
 
+import { Skeleton } from '@/components/ui/skeleton';
+
 interface PageSkeletonProps {
-  /** 타이틀 바 표시 */
   showTitle?: boolean;
-  /** 카드 수 */
   cards?: number;
-  /** 리스트 행 수 */
   rows?: number;
 }
 
-/** 범용 페이지 로딩 스켈레톤 */
 export function PageSkeleton({ showTitle = true, cards = 3, rows = 5 }: PageSkeletonProps) {
   return (
-    <div className="animate-pulse space-y-6 p-6">
-      {showTitle && (
-        <div className="h-8 w-48 rounded-lg bg-muted" />
-      )}
+    <div className="space-y-6 p-6">
+      {showTitle && <Skeleton className="h-8 w-48" />}
       {cards > 0 && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
           {Array.from({ length: cards }).map((_, i) => (
-            <div key={i} className="h-24 rounded-xl bg-muted" />
+            <Skeleton key={i} className="h-24 rounded-xl" />
           ))}
         </div>
       )}
       {rows > 0 && (
         <div className="space-y-3">
           {Array.from({ length: rows }).map((_, i) => (
-            <div key={i} className="h-12 rounded-lg bg-muted" />
+            <Skeleton key={i} className="h-12 rounded-lg" />
           ))}
         </div>
       )}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,13 +1,26 @@
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+interface SkeletonProps extends React.ComponentProps<"div"> {
+  variant?: "rect" | "text" | "circle";
+}
+
+function Skeleton({ className, variant = "rect", ...props }: SkeletonProps) {
   return (
     <div
       data-slot="skeleton"
-      className={cn("animate-pulse rounded-md bg-muted", className)}
+      className={cn(
+        "bg-gradient-to-r from-[var(--skeleton-base)] via-[var(--skeleton-highlight)] to-[var(--skeleton-base)]",
+        "bg-[length:200%_100%]",
+        "animate-skeleton-shimmer",
+        "motion-reduce:animate-none motion-reduce:bg-none motion-reduce:bg-muted",
+        variant === "rect" && "rounded-md",
+        variant === "text" && "rounded h-4",
+        variant === "circle" && "rounded-full aspect-square",
+        className,
+      )}
       {...props}
     />
-  )
+  );
 }
 
-export { Skeleton }
+export { Skeleton };


### PR DESCRIPTION
## Summary

- `animate-pulse` → `shimmer(linear-gradient slide)` 전환으로 PO 요구 충족
- `Skeleton` 원자에 shimmer + `rect/text/circle` variant 추가 (기존 사용처 자동 호환)
- 대시보드/보드/문서목록/에픽 4페이지 전용 skeleton 신설 + `loading.tsx` 매핑
- `prefers-reduced-motion` 대응 (`motion-reduce:animate-none` + `bg-muted` fallback)

## 변경 파일 (시안 §6 일치 11개)

| 파일 | 변경 |
|---|---|
| `globals.css` | `@keyframes skeleton-shimmer` + `--skeleton-*` 토큰 4종 |
| `ui/skeleton.tsx` | shimmer gradient + variant prop (rect/text/circle) |
| `ui/page-skeleton.tsx` | 내부 `bg-muted` div → `<Skeleton>` 원자 교체 |
| `kanban/kanban-skeleton.tsx` | `animate-pulse div` → `<Skeleton>` 원자 교체 |
| `dashboard/dashboard-skeleton.tsx` | **신규** — stats 4 + main + activity feed |
| `docs/docs-list-skeleton.tsx` | **신규** — sidebar tree + main content |
| `epics/epics-skeleton.tsx` | **신규** — grid 3-col, 6 epic cards |
| `dashboard/loading.tsx` | `PageSkeleton` → `DashboardSkeleton` |
| `(authenticated)/board/loading.tsx` | `PageSkeleton` → `KanbanSkeleton` |
| `(authenticated)/docs/loading.tsx` | `PageSkeleton` → `DocsListSkeleton` |
| `(authenticated)/epics/loading.tsx` | **신규** → `EpicsSkeleton` |

## 가디언 룰 준수

- [x] 하드코딩 색상 없음 — `var(--skeleton-base)` / `bg-muted` 토큰만
- [x] `animate-pulse` 신규 도입 없음 — 모두 `<Skeleton>` 원자 사용
- [x] `motion-reduce:` variant 자동 처리 (Skeleton 원자에 포함)
- [x] 6개 fallback 페이지(`inbox` 등) 변경 없음

## QA 중점 확인

- [ ] 4개 적용 페이지 loading → 콘텐츠 전환 시 CLS 없음
- [ ] shimmer 시각 확인 (라이트/다크 양쪽)
- [ ] `prefers-reduced-motion: reduce` → animation 정지, `bg-muted` 단색 표시

## 빌드 검증

- [x] `pnpm build` 성공
- [x] `pnpm lint` error 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)