### PR TITLE
[DS-S12] Error State 패턴 통일 + DS-S13 missed 통합 정리

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -1264,9 +1264,9 @@ export default function SettingsPage() {
                       ) : null}
 
                       {newAgentResult ? (
-                        <div className="rounded-md border border-emerald-500/30 bg-emerald-500/5 p-4 space-y-3">
+                        <div className="rounded-md border border-success-border bg-success-tint p-4 space-y-3">
                           <div className="flex items-center justify-between">
-                            <p className="text-sm font-semibold text-emerald-500">
+                            <p className="text-sm font-semibold text-success">
                               {newAgentResult.name} 생성 완료
                             </p>
                             <button type="button" onClick={() => setNewAgentResult(null)} className="text-muted-foreground hover:text-foreground">
@@ -1460,7 +1460,7 @@ export default function SettingsPage() {
                                   </button>
                                   <button
                                     type="button"
-                                    className="rounded border border-rose-400/30 px-2 py-0.5 text-xs text-rose-400 transition-colors hover:border-rose-300/50 hover:text-rose-300 disabled:opacity-50"
+                                    className="rounded border border-destructive-border px-2 py-0.5 text-xs text-destructive transition-colors hover:bg-destructive-tint disabled:opacity-50"
                                     disabled={revokingInviteId === invitation.id}
                                     onClick={() => handleRevokeInvite(invitation.id)}
                                   >
@@ -1470,7 +1470,7 @@ export default function SettingsPage() {
                               ) : null}
                             </div>
                             {resendResult?.id === invitation.id ? (
-                              <p className="mt-1 break-all px-1 text-xs text-amber-200">{t('inviteLinkCopied')}: {resendResult.url}</p>
+                              <p className="mt-1 break-all px-1 text-xs text-warning">{t('inviteLinkCopied')}: {resendResult.url}</p>
                             ) : null}
                           </div>
                         ))}
@@ -1801,7 +1801,7 @@ export default function SettingsPage() {
                   <li>• Project <span className="font-semibold">{orgImpact.project_count}개</span> 영구 삭제</li>
                   <li>• Member <span className="font-semibold">{orgImpact.member_count}명</span> 접근 불가</li>
                   {orgImpact.has_active_subscription && (
-                    <li className="text-amber-400">• 활성 구독이 있습니다 — 삭제 전 구독을 취소해주세요.</li>
+                    <li className="text-warning">• 활성 구독이 있습니다 — 삭제 전 구독을 취소해주세요.</li>
                   )}
                 </ul>
               </div>

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -22,6 +22,7 @@ import { RefreshSettings } from '@/components/settings/refresh-settings';
 import { StandupDeadlineSection } from '@/components/settings/standup-deadline-section';
 import { TwoFactorSection } from '@/components/settings/two-factor-section';
 import { SetPasswordSection } from '@/components/settings/set-password-section';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
@@ -1188,9 +1189,9 @@ export default function SettingsPage() {
                   </div>
 
                   {projectActionMessage ? (
-                    <div className={`rounded-md border p-3 text-xs ${projectActionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                      {projectActionMessage.text}
-                    </div>
+                    <Alert variant={projectActionMessage.type === 'success' ? 'success' : 'destructive'}>
+                      <AlertDescription>{projectActionMessage.text}</AlertDescription>
+                    </Alert>
                   ) : null}
 
                   {isAdmin ? (
@@ -1210,9 +1211,9 @@ export default function SettingsPage() {
                       </Button>
                     </div>
                   ) : adminChecked ? (
-                    <div className="rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400">
-                      {t('projectAdminRequired')}
-                    </div>
+                    <Alert variant="warning">
+                      <AlertDescription>{t('projectAdminRequired')}</AlertDescription>
+                    </Alert>
                   ) : null}
                 </SectionCardBody>
               </SectionCard>
@@ -1257,9 +1258,9 @@ export default function SettingsPage() {
                     </SectionCardHeader>
                     <SectionCardBody className="space-y-4">
                       {agentActionMessage ? (
-                        <div className={`rounded-md border p-3 text-xs ${agentActionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                          {agentActionMessage.text}
-                        </div>
+                        <Alert variant={agentActionMessage.type === 'success' ? 'success' : 'destructive'}>
+                          <AlertDescription>{agentActionMessage.text}</AlertDescription>
+                        </Alert>
                       ) : null}
 
                       {newAgentResult ? (
@@ -1430,9 +1431,9 @@ export default function SettingsPage() {
                     </div>
 
                     {inviteResult ? (
-                      <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 p-3 text-xs text-emerald-600 dark:text-emerald-400 break-all">
-                        {t('inviteLinkCopied')}: {inviteResult}
-                      </div>
+                      <Alert variant="success">
+                        <AlertDescription className="break-all">{t('inviteLinkCopied')}: {inviteResult}</AlertDescription>
+                      </Alert>
                     ) : null}
 
                     {invitations.length > 0 ? (
@@ -1444,7 +1445,7 @@ export default function SettingsPage() {
                               <span className="shrink-0 text-muted-foreground">
                                 {invitation.projects?.name ?? t('orgWide')}
                               </span>
-                              <span className={`shrink-0 ${invitation.status === 'accepted' ? 'text-emerald-300' : invitation.status === 'revoked' ? 'text-muted-foreground line-through' : new Date(invitation.expires_at) < new Date() ? 'text-rose-300' : 'text-amber-200'}`}>
+                              <span className={`shrink-0 ${invitation.status === 'accepted' ? 'text-success' : invitation.status === 'revoked' ? 'text-muted-foreground line-through' : new Date(invitation.expires_at) < new Date() ? 'text-destructive' : 'text-warning'}`}>
                                 {invitation.status === 'accepted' ? t('accepted') : invitation.status === 'revoked' ? t('revoked') : new Date(invitation.expires_at) < new Date() ? t('expired') : t('pending')}
                               </span>
                               {invitation.status === 'pending' ? (
@@ -1513,9 +1514,9 @@ export default function SettingsPage() {
                       </Button>
                     </div>
                     {projectInviteResult ? (
-                      <div className={`rounded-md border p-3 text-xs break-all ${projectInviteResult.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                        {projectInviteResult.text}
-                      </div>
+                      <Alert variant={projectInviteResult.type === 'success' ? 'success' : 'destructive'}>
+                        <AlertDescription className="break-all">{projectInviteResult.text}</AlertDescription>
+                      </Alert>
                     ) : null}
                   </SectionCardBody>
                 </SectionCard>
@@ -1555,9 +1556,9 @@ export default function SettingsPage() {
                     ) : null}
 
                     {memberActionMessage ? (
-                      <div className={`rounded-md border p-3 text-xs ${memberActionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                        {memberActionMessage.text}
-                      </div>
+                      <Alert variant={memberActionMessage.type === 'success' ? 'success' : 'destructive'}>
+                        <AlertDescription>{memberActionMessage.text}</AlertDescription>
+                      </Alert>
                     ) : null}
 
                     <div className="space-y-2">
@@ -1719,9 +1720,9 @@ export default function SettingsPage() {
                 </SectionCardHeader>
                 <SectionCardBody className="space-y-3">
                   {graceUntil && new Date(graceUntil) > new Date() ? (
-                    <p className="rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-300">
-                      {t('gracePeriodNotice', { date: new Date(graceUntil).toLocaleDateString('ko-KR') })}
-                    </p>
+                    <Alert variant="warning">
+                      <AlertDescription>{t('gracePeriodNotice', { date: new Date(graceUntil).toLocaleDateString('ko-KR') })}</AlertDescription>
+                    </Alert>
                   ) : null}
                   <Button
                     variant="glass"

--- a/apps/web/src/app/mfa/page.tsx
+++ b/apps/web/src/app/mfa/page.tsx
@@ -53,7 +53,7 @@ export default function MfaPage() {
             onKeyDown={(e) => e.key === 'Enter' && handleVerify()}
             autoFocus
           />
-          {error && <p className="text-sm text-red-600">{error}</p>}
+          {error && <p className="text-sm text-destructive">{error}</p>}
           <button
             onClick={handleVerify}
             disabled={loading || code.length !== 6}

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -211,7 +211,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
               onClick={() => void copyOnboardingMessage(generatedKey ?? (activeKeys[0] ? `${activeKeys[0].key_prefix}...` : ''))}
               className="gap-1.5"
             >
-              {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+              {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
               온보딩 메시지 복사
             </Button>
             <Button
@@ -344,7 +344,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
                     className="font-mono text-sm"
                   />
                   <Button onClick={() => void copyToClipboard(generatedKey)} className="gap-1.5 shrink-0">
-                    {copiedKey ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+                    {copiedKey ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
                     {copiedKey ? 'Copied!' : 'Copy'}
                   </Button>
                 </div>
@@ -364,7 +364,7 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
                   className="mt-2 gap-1.5"
                   onClick={() => void copyOnboardingMessage(generatedKey)}
                 >
-                  {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-emerald-500" /> : <Copy className="h-3.5 w-3.5" />}
+                  {copiedOnboarding ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
                   온보딩 메시지 복사
                 </Button>
               </div>

--- a/apps/web/src/components/agents/agent-deployment-verification-step.tsx
+++ b/apps/web/src/components/agents/agent-deployment-verification-step.tsx
@@ -49,15 +49,11 @@ export function AgentDeploymentVerificationStep({
         <p className="text-sm text-muted-foreground">{t('verifyStepBody')}</p>
       </div>
 
-      <div className={`rounded-2xl px-4 py-4 text-sm ${verificationCompleted ? 'border border-emerald-400/18 bg-emerald-400/10 text-emerald-100' : 'border border-amber-400/16 bg-amber-400/10 text-amber-100'}`}>
-        <div className="flex items-start gap-3">
-          {verificationCompleted ? <CheckCircle2 className="mt-0.5 size-4 shrink-0" /> : <AlertTriangle className="mt-0.5 size-4 shrink-0" />}
-          <div className="space-y-1">
-            <p className="font-medium">{verificationCompleted ? t('verificationCompletedTitle') : t('verificationPendingTitle')}</p>
-            <p>{verificationCompleted ? t('verificationCompletedBody', { name: deploymentName }) : t('verificationPendingBody', { name: deploymentName })}</p>
-          </div>
-        </div>
-      </div>
+      <Alert variant={verificationCompleted ? 'success' : 'warning'}>
+        {verificationCompleted ? <CheckCircle2 className="size-4" /> : <AlertTriangle className="size-4" />}
+        <AlertTitle>{verificationCompleted ? t('verificationCompletedTitle') : t('verificationPendingTitle')}</AlertTitle>
+        <AlertDescription>{verificationCompleted ? t('verificationCompletedBody', { name: deploymentName }) : t('verificationPendingBody', { name: deploymentName })}</AlertDescription>
+      </Alert>
 
       <div className="grid gap-3 md:grid-cols-4">
         <GlassPanel className="border-white/8 bg-muted/35 p-4">

--- a/apps/web/src/components/agents/agent-deployment-verification-step.tsx
+++ b/apps/web/src/components/agents/agent-deployment-verification-step.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { AlertTriangle, CheckCircle2, Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { GlassPanel } from '@/components/ui/glass-panel';

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { OperatorInput, OperatorSelect } from '@/components/ui/operator-control';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { AgentDeploymentVerificationStep } from '@/components/agents/agent-deployment-verification-step';
@@ -589,18 +590,20 @@ export function AgentDeploymentWizard({
           </div>
 
           {modelMode === 'byom' ? (
-            <div className={`rounded-md border px-4 py-3 text-sm ${defaults.hasProjectApiKey ? 'border-sky-500/20 bg-sky-500/10 text-sky-600 dark:text-sky-400' : 'border-amber-500/20 bg-amber-500/10 text-amber-600 dark:text-amber-400'}`}>
-              <p>{defaults.hasProjectApiKey ? t('byomHintWithDefaults', { provider: deploymentProviderLabel }) : t('byomHintWithoutDefaults')}</p>
-              {!defaults.hasProjectApiKey ? (
-                <div className="mt-3">
-                  <Link href="/dashboard/settings" className={buttonVariants({ variant: 'glass', size: 'sm' })}>{t('configureProjectAi')}</Link>
-                </div>
-              ) : null}
-            </div>
+            <Alert variant={defaults.hasProjectApiKey ? 'info' : 'warning'}>
+              <AlertDescription>
+                <p>{defaults.hasProjectApiKey ? t('byomHintWithDefaults', { provider: deploymentProviderLabel }) : t('byomHintWithoutDefaults')}</p>
+                {!defaults.hasProjectApiKey ? (
+                  <div className="mt-3">
+                    <Link href="/dashboard/settings" className={buttonVariants({ variant: 'glass', size: 'sm' })}>{t('configureProjectAi')}</Link>
+                  </div>
+                ) : null}
+              </AlertDescription>
+            </Alert>
           ) : (
-            <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-4 py-3 text-sm text-emerald-600 dark:text-emerald-400">
-              {t('managedHint')}
-            </div>
+            <Alert variant="success">
+              <AlertDescription>{t('managedHint')}</AlertDescription>
+            </Alert>
           )}
         </div>
       );
@@ -711,23 +714,21 @@ export function AgentDeploymentWizard({
             )}
 
             {autoRoutingPreview.requiresOverwriteConfirmation && autoRoutingPreview.rules.length > 0 ? (
-              <div className="mt-4 rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-4 text-sm text-amber-600 dark:text-amber-400">
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-                  <div className="space-y-3">
-                    <p>{t('autoRoutingOverwriteWarning', { count: autoRoutingPreview.existingRuleCount })}</p>
-                    <label className="flex items-start gap-3 text-sm text-amber-50">
-                      <input
-                        type="checkbox"
-                        checked={overwriteRoutingRules}
-                        onChange={(event) => setOverwriteRoutingRules(event.target.checked)}
-                        className="mt-1 h-4 w-4 accent-brand"
-                      />
-                      <span>{t('autoRoutingOverwriteConfirm')}</span>
-                    </label>
-                  </div>
-                </div>
-              </div>
+              <Alert variant="warning" className="mt-4">
+                <AlertTriangle className="size-4" />
+                <AlertDescription className="space-y-3">
+                  <p>{t('autoRoutingOverwriteWarning', { count: autoRoutingPreview.existingRuleCount })}</p>
+                  <label className="flex items-start gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={overwriteRoutingRules}
+                      onChange={(event) => setOverwriteRoutingRules(event.target.checked)}
+                      className="mt-1 h-4 w-4 accent-brand"
+                    />
+                    <span>{t('autoRoutingOverwriteConfirm')}</span>
+                  </label>
+                </AlertDescription>
+              </Alert>
             ) : null}
           </div>
 
@@ -759,20 +760,17 @@ export function AgentDeploymentWizard({
 
             {preflight ? (
               preflight.ok ? (
-                <div className="mt-4 rounded-md border border-emerald-500/20 bg-emerald-500/10 px-4 py-4 text-sm text-emerald-600 dark:text-emerald-400">
-                  <div className="flex items-start gap-3">
-                    <CheckCircle2 className="mt-0.5 size-4 shrink-0" />
-                    <div className="space-y-1">
-                      <p>{t('deployPreflightReadyBody')}</p>
-                      <p className="text-xs text-emerald-200">{t('deployPreflightMcpOk', { count: preflight.mcp_validation_errors.length })}</p>
-                    </div>
-                  </div>
-                </div>
+                <Alert variant="success" className="mt-4">
+                  <CheckCircle2 className="size-4" />
+                  <AlertDescription className="space-y-1">
+                    <p>{t('deployPreflightReadyBody')}</p>
+                    <p className="text-xs opacity-75">{t('deployPreflightMcpOk', { count: preflight.mcp_validation_errors.length })}</p>
+                  </AlertDescription>
+                </Alert>
               ) : (
-                <div className="mt-4 space-y-3 rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-4 text-sm text-amber-600 dark:text-amber-400">
-                  <div className="flex items-start gap-3">
-                    <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-                    <div className="space-y-3">
+                <Alert variant="warning" className="mt-4">
+                  <AlertTriangle className="size-4" />
+                  <AlertDescription className="space-y-3">
                       <p>{t('deployPreflightBlockedBody')}</p>
                       <ul className="list-disc space-y-1 pl-4">
                         {preflight.blocking_reasons.map((reason) => (
@@ -781,7 +779,7 @@ export function AgentDeploymentWizard({
                       </ul>
                       {preflight.mcp_validation_errors.length > 0 ? (
                         <div>
-                          <p className="font-medium text-amber-50">{t('deployPreflightMcpErrorsTitle')}</p>
+                          <p className="font-medium">{t('deployPreflightMcpErrorsTitle')}</p>
                           <ul className="mt-2 list-disc space-y-1 pl-4">
                             {preflight.mcp_validation_errors.map((reason) => (
                               <li key={reason}>{reason}</li>
@@ -790,8 +788,8 @@ export function AgentDeploymentWizard({
                         </div>
                       ) : null}
                     </div>
-                  </div>
-                </div>
+                  </AlertDescription>
+                </Alert>
               )
             ) : (
               <div className="mt-4 rounded-md border border-dashed border-border bg-muted/30 px-4 py-4 text-sm text-muted-foreground">
@@ -856,9 +854,9 @@ export function AgentDeploymentWizard({
                 const active = index === step;
                 const complete = index < step;
                 return (
-                  <div key={key} className={`rounded-md border px-4 py-3 transition ${active ? 'border-primary/40 bg-primary/10' : complete ? 'border-emerald-500/20 bg-emerald-500/10' : 'border-border bg-muted/30'}`}>
+                  <div key={key} className={`rounded-md border px-4 py-3 transition ${active ? 'border-primary/40 bg-primary/10' : complete ? 'border-success-border bg-success-tint' : 'border-border bg-muted/30'}`}>
                     <div className="flex items-center gap-3">
-                      <div className={`flex size-9 items-center justify-center rounded-md ${active ? 'bg-primary/20 text-primary' : complete ? 'bg-emerald-500/20 text-emerald-600 dark:text-emerald-400' : 'bg-muted text-muted-foreground'}`}>
+                      <div className={`flex size-9 items-center justify-center rounded-md ${active ? 'bg-primary/20 text-primary' : complete ? 'bg-success-tint text-success' : 'bg-muted text-muted-foreground'}`}>
                         {complete ? <CheckCircle2 className="size-4" /> : <Icon className="size-4" />}
                       </div>
                       <div>
@@ -923,12 +921,10 @@ export function AgentDeploymentWizard({
             <DialogTitle>{t('deployFailedTitle')}</DialogTitle>
             <DialogDescription className="text-muted-foreground">{failureMessage ?? t('deployFailedBody')}</DialogDescription>
           </DialogHeader>
-          <div className="rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-              <p>{t('deployFailedHint')}</p>
-            </div>
-          </div>
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>{t('deployFailedHint')}</AlertDescription>
+          </Alert>
           <DialogFooter className="border-t border-border bg-transparent">
             <Button variant="glass" onClick={() => setFailureMessage(null)}>{tc('close')}</Button>
           </DialogFooter>

--- a/apps/web/src/components/agents/agent-deployment-wizard.tsx
+++ b/apps/web/src/components/agents/agent-deployment-wizard.tsx
@@ -787,7 +787,6 @@ export function AgentDeploymentWizard({
                           </ul>
                         </div>
                       ) : null}
-                    </div>
                   </AlertDescription>
                 </Alert>
               )

--- a/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
+++ b/apps/web/src/components/agents/agent-hitl-policy-editor.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertTriangle, CheckCircle2, Clock3, ShieldAlert } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
@@ -150,9 +151,9 @@ export function AgentHitlPolicyEditor() {
       </div>
 
       {error ? (
-        <div className="rounded-2xl border border-amber-400/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-100">
-          {error}
-        </div>
+        <Alert variant="warning">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
       ) : null}
 
       <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,1.1fr)_minmax(0,1fr)]">

--- a/apps/web/src/components/agents/agent-persona-composer.tsx
+++ b/apps/web/src/components/agents/agent-persona-composer.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import type { PersonaChangeHistoryEntry, PersonaPermissionBoundary, PersonaVersionMetadata } from '@/lib/persona-governance-contract';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -326,14 +327,16 @@ export function AgentPersonaComposer({
         ) : null}
 
         {createdPersona ? (
-          <div className="rounded-md border border-emerald-500/20 bg-emerald-500/10 px-4 py-4 text-sm text-emerald-600 dark:text-emerald-400">
-            <p className="font-semibold">{t('personaComposerSuccessTitle', { name: createdPersona.name })}</p>
-            <p className="mt-1 text-emerald-200/90">{t('personaComposerSuccessBody', { slug: createdPersona.slug })}</p>
-            <div className="mt-3 flex flex-wrap gap-3">
-              <Link href="/agents/deploy" className="text-sm font-medium underline-offset-4 hover:underline">{t('backToWizard')}</Link>
-              <button type="button" onClick={() => setCreatedPersona(null)} className="text-sm font-medium underline-offset-4 hover:underline">{t('personaComposerCreateAnother')}</button>
-            </div>
-          </div>
+          <Alert variant="success">
+            <AlertTitle>{t('personaComposerSuccessTitle', { name: createdPersona.name })}</AlertTitle>
+            <AlertDescription>
+              <p>{t('personaComposerSuccessBody', { slug: createdPersona.slug })}</p>
+              <div className="mt-3 flex flex-wrap gap-3">
+                <Link href="/agents/deploy" className="text-sm font-medium underline-offset-4 hover:underline">{t('backToWizard')}</Link>
+                <button type="button" onClick={() => setCreatedPersona(null)} className="text-sm font-medium underline-offset-4 hover:underline">{t('personaComposerCreateAnother')}</button>
+              </div>
+            </AlertDescription>
+          </Alert>
         ) : null}
       </div>
 

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { AlertTriangle, ArrowLeft, CheckCircle2, Clock3, Cpu, Hash, RefreshCw, Zap } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -436,10 +437,10 @@ export function AgentRunDetail({
                       <div key={idx} className="relative flex gap-4 pb-4 pl-9">
                         <div className={`absolute left-2.5 top-1.5 size-3 rounded-full border-2 ${
                           hasError
-                            ? 'border-red-400 bg-red-400/20'
+                            ? 'border-destructive bg-destructive/20'
                             : isLlm
                               ? 'border-brand bg-brand/20'
-                              : 'border-emerald-400 bg-emerald-400/20'
+                              : 'border-success bg-success-tint'
                         }`} />
                         <div className="min-w-0 flex-1 rounded-xl border border-white/8 bg-white/4 px-3 py-2">
                           <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -462,13 +462,13 @@ export function AgentRunDetail({
                               </span>
                             )}
                             {hasError ? (
-                              <AlertTriangle className="size-3.5 text-red-400" />
+                              <AlertTriangle className="size-3.5 text-destructive" />
                             ) : (
                               <CheckCircle2 className="size-3.5 text-emerald-400/60" />
                             )}
                           </div>
                           {hasError && (
-                            <div className="mt-1 space-y-1 text-xs text-red-300/80">
+                            <div className="mt-1 space-y-1 text-xs text-destructive/80">
                               <p>{display.error}</p>
                               {display.userReason ? <p>{display.userReason}</p> : null}
                               {display.nextAction ? <p>{display.nextAction}</p> : null}
@@ -561,7 +561,7 @@ export function AgentRunDetail({
                           </div>
                         ) : null}
                         {error ? (
-                          <p className="mt-3 text-sm text-red-300/80">{error}</p>
+                          <p className="mt-3 text-sm text-destructive/80">{error}</p>
                         ) : null}
                         {!operatorReason && !userReason && !nextAction && detailSummary ? (
                           <p className="mt-3 text-sm text-muted-foreground">{detailSummary}</p>

--- a/apps/web/src/components/agents/agent-run-detail.tsx
+++ b/apps/web/src/components/agents/agent-run-detail.tsx
@@ -329,21 +329,19 @@ export function AgentRunDetail({
 
             {/* Error message for failed runs */}
             {run.status === 'failed' && errorDisplay.message && (
-              <div className="mb-4 rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3">
-                <div className="flex items-start gap-3">
-                  <AlertTriangle className="mt-0.5 size-5 shrink-0 text-red-400" />
-                  <div>
-                    <p className="text-sm font-semibold text-red-300">{t('errorLabel')}</p>
-                    <p className="mt-1 text-sm text-red-200/80">{errorDisplay.message}</p>
-                    {errorDisplay.code && (
-                      <p className="mt-1 text-xs text-red-200/60">{t('errorCodeLabel')}: {errorDisplay.code}</p>
-                    )}
-                    {failureDisposition === 'retry_scheduled' && run.next_retry_at && (
-                      <p className="mt-1 text-xs text-red-200/60">{t('nextRetryAt')}: {toLocaleStr(run.next_retry_at, locale)}</p>
-                    )}
-                  </div>
-                </div>
-              </div>
+              <Alert variant="destructive" className="mb-4">
+                <AlertTriangle className="size-4" />
+                <AlertDescription>
+                  <p className="font-semibold">{t('errorLabel')}</p>
+                  <p className="mt-1">{errorDisplay.message}</p>
+                  {errorDisplay.code && (
+                    <p className="mt-1 text-xs opacity-75">{t('errorCodeLabel')}: {errorDisplay.code}</p>
+                  )}
+                  {failureDisposition === 'retry_scheduled' && run.next_retry_at && (
+                    <p className="mt-1 text-xs opacity-75">{t('nextRetryAt')}: {toLocaleStr(run.next_retry_at, locale)}</p>
+                  )}
+                </AlertDescription>
+              </Alert>
             )}
 
             {/* Result summary */}

--- a/apps/web/src/components/agents/agent-workflow-editor.tsx
+++ b/apps/web/src/components/agents/agent-workflow-editor.tsx
@@ -25,6 +25,7 @@ import {
   ArrowDown, ArrowUp, Ban, Bot, ClipboardCheck,
   Route, Save, ShieldCheck, Smartphone, Trash2, TriangleAlert, User, RotateCcw,
 } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { PageHeader } from '@/components/ui/page-header';
@@ -775,9 +776,9 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
                 </select>
               </div>
               {dryRunSurface === 'draft' && draftWorkflow.error ? (
-                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400">
-                  {t('workflowDraftInvalidBody', { error: draftWorkflow.error })}
-                </div>
+                <Alert variant="warning">
+                  <AlertDescription>{t('workflowDraftInvalidBody', { error: draftWorkflow.error })}</AlertDescription>
+                </Alert>
               ) : (
                 <div className="space-y-3 rounded-md border border-border bg-muted/30 p-4">
                   <div className="flex flex-wrap items-center justify-between gap-2">
@@ -859,9 +860,9 @@ function AgentWorkflowEditorInner({ initialMembers, initialRules, projectName }:
                 <Badge variant="outline">{t('workflowRolloutRemovedRules', { count: workflowDiff.removedRules })}</Badge>
               </div>
               {draftWorkflow.error ? (
-                <div className="rounded-md border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-sm text-amber-600 dark:text-amber-400">
-                  {t('workflowDraftInvalidBody', { error: draftWorkflow.error })}
-                </div>
+                <Alert variant="warning">
+                  <AlertDescription>{t('workflowDraftInvalidBody', { error: draftWorkflow.error })}</AlertDescription>
+                </Alert>
               ) : !hasDraftChanges ? (
                 <div className="rounded-md border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
                   {t('workflowRolloutNoChanges')}

--- a/apps/web/src/components/agents/agents-dashboard.tsx
+++ b/apps/web/src/components/agents/agents-dashboard.tsx
@@ -446,7 +446,7 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                           {t('tokenUsageToday', { count: deployment.tokens_today })}
                         </span>
                         {deployment.pending_hitl_count > 0 && (
-                          <span className="inline-flex items-center gap-1 text-amber-200 sm:col-span-2 xl:col-span-4">
+                          <span className="inline-flex items-center gap-1 text-warning sm:col-span-2 xl:col-span-4">
                             <TriangleAlert className="size-3.5" />
                             {t('hitlDeadlineLabel', {
                               countdown: formatHitlCountdown(deployment.next_hitl_deadline_at, t) ?? t('hitlDeadlineUnknown'),
@@ -477,7 +477,7 @@ export function AgentsDashboard({ deployments: initialDeployments, hideTopBar = 
                         </Button>
                       )}
                       <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                        {deployment.status === 'DEPLOY_FAILED' ? <TriangleAlert className="size-4 text-amber-300" /> : <Clock3 className="size-4" />}
+                        {deployment.status === 'DEPLOY_FAILED' ? <TriangleAlert className="size-4 text-warning" /> : <Clock3 className="size-4" />}
                         <span>
                           {deployment.last_run_at
                             ? t('lastRunAt', { time: formatLocalTime(deployment.last_run_at, locale) })

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -119,7 +119,7 @@ export function AddParticipantModal({
             </ul>
           )}
 
-          {error && <p className="mt-2 text-xs text-red-600">{error}</p>}
+          {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
         </div>
 
         {/* Footer */}

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -91,7 +91,7 @@ function ConversationRow({
       {/* Avatar */}
       <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full text-sm font-medium ${
         isAgentConv
-          ? 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+          ? 'bg-warning-tint text-warning'
           : conv.type === 'dm'
             ? 'bg-primary/15 text-primary'
             : 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'

--- a/apps/web/src/components/docs/doc-content-renderer.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.tsx
@@ -123,7 +123,7 @@ export function DocContentRenderer({
       if (!latex.trim()) return;
       void renderKatex(latex, true).then(({ html: katexHtml, error }) => {
         if (error) {
-          block.innerHTML = `<div class="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">${escapeHtmlText(error)}</div>`;
+          block.innerHTML = `<div class="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive font-mono">${escapeHtmlText(error)}</div>`;
         } else {
           block.innerHTML = `<div class="flex justify-center overflow-x-auto py-3 [&_.katex]:text-foreground">${katexHtml}</div>`;
         }
@@ -136,7 +136,7 @@ export function DocContentRenderer({
       if (!latex.trim()) return;
       void renderKatex(latex, false).then(({ html: katexHtml, error }) => {
         if (error) {
-          span.className = 'rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono';
+          span.className = 'rounded bg-destructive/10 px-1 text-xs text-destructive font-mono';
         } else {
           span.innerHTML = katexHtml;
         }
@@ -348,7 +348,7 @@ function MermaidReadonlyBlock({ code }: { code: string }) {
   }, [code]);
 
   if (error) {
-    return <div className="not-prose my-4 rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400">{error}</div>;
+    return <div className="not-prose my-4 rounded-xl border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive">{error}</div>;
   }
   if (!svg) {
     return <div className="not-prose my-4 rounded-xl border border-slate-700 bg-[#0b1120] p-4 text-xs text-slate-500">렌더링 중...</div>;

--- a/apps/web/src/components/docs/extensions/code-block-copy.tsx
+++ b/apps/web/src/components/docs/extensions/code-block-copy.tsx
@@ -68,7 +68,7 @@ function MermaidBlockView({ node, editor, selected }: ReactNodeViewProps) {
             style={{ cursor: isEditable ? 'pointer' : 'default' }}
           >
             {error ? (
-              <div className="rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400">
+              <div className="rounded-xl border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive">
                 {error}
               </div>
             ) : svg ? (

--- a/apps/web/src/components/docs/extensions/math-node.tsx
+++ b/apps/web/src/components/docs/extensions/math-node.tsx
@@ -63,7 +63,7 @@ function MathBlockView({ node, selected }: ReactNodeViewProps) {
         {!showEdit && (
           <div className="px-4 pb-4" contentEditable={false}>
             {error ? (
-              <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-400 font-mono">{error}</div>
+              <div className="rounded-lg border border-destructive-border bg-destructive-tint p-3 text-xs text-destructive font-mono">{error}</div>
             ) : html ? (
               <div
                 dangerouslySetInnerHTML={{ __html: html }}
@@ -98,7 +98,7 @@ function MathInlineView({ node }: ReactNodeViewProps) {
 
   if (error) {
     return (
-      <NodeViewWrapper as="span" className="rounded bg-red-500/10 px-1 text-xs text-red-400 font-mono">
+      <NodeViewWrapper as="span" className="rounded bg-destructive-tint px-1 text-xs text-destructive font-mono">
         {latex}
       </NodeViewWrapper>
     );

--- a/apps/web/src/components/docs/extensions/wiki-link.tsx
+++ b/apps/web/src/components/docs/extensions/wiki-link.tsx
@@ -55,7 +55,7 @@ function WikiLinkView({ node, editor }: ReactNodeViewProps) {
         title={isNotFound ? '문서를 찾을 수 없습니다' : title}
         className={`inline-flex cursor-pointer items-center gap-0.5 rounded px-1 py-0.5 text-[0.9em] transition-colors ${
           isNotFound
-            ? 'bg-red-500/10 text-red-500 hover:bg-red-500/20'
+            ? 'bg-destructive-tint text-destructive hover:bg-destructive/20'
             : 'bg-brand/10 text-[color:var(--brand-soft)] hover:bg-brand/20'
         }`}
       >

--- a/apps/web/src/components/inbox/decisions-waiting.tsx
+++ b/apps/web/src/components/inbox/decisions-waiting.tsx
@@ -149,7 +149,7 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
       </header>
 
       {error ? (
-        <p className="mb-2 text-xs text-red-400" role="alert">
+        <p className="mb-2 text-xs text-destructive" role="alert">
           {t('decisionsErrorRetry')}
         </p>
       ) : null}
@@ -170,7 +170,7 @@ export function DecisionsWaiting({ onChange }: DecisionsWaitingProps = {}) {
                       {item.kind}
                     </Badge>
                     {item.priority === 'high' ? (
-                      <Badge className="bg-red-500/15 text-red-300 text-[10px] uppercase">
+                      <Badge className="bg-destructive/15 text-destructive text-[10px] uppercase">
                         {t('priorityHigh')}
                       </Badge>
                     ) : null}

--- a/apps/web/src/components/meetings/ai-summarize-button.tsx
+++ b/apps/web/src/components/meetings/ai-summarize-button.tsx
@@ -57,7 +57,7 @@ export function AiSummarizeButton({ meetingId, hasTranscript, guardedFetch, onRe
 
       {/* AC6: 에러 표시 (AC9: i18n) */}
       {error && (
-        <p className="text-xs text-red-500">
+        <p className="text-xs text-destructive">
           {error.includes('NO_API_KEY') ? t('aiKeyRequired')
             : error.includes('NO_TRANSCRIPT') ? t('transcriptRequired')
             : error.includes('Monthly') || error.includes('monthly') ? t('aiMonthlyLimit')

--- a/apps/web/src/components/mockups/mockup-editor-shell.tsx
+++ b/apps/web/src/components/mockups/mockup-editor-shell.tsx
@@ -886,7 +886,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
           <span className="rounded-full border border-white/10 bg-muted/55 px-3 py-1 text-[11px] text-muted-foreground">
             {components.length} {t('components')}
           </span>
-          <span className={`rounded-full px-3 py-1 text-[11px] ${hasChanges ? 'bg-amber-500/15 text-amber-400' : 'border border-white/10 bg-emerald-500/10 text-emerald-400'}`}>
+          <span className={`rounded-full px-3 py-1 text-[11px] ${hasChanges ? 'bg-warning-tint text-warning' : 'border border-border bg-success-tint text-success'}`}>
             {saving ? t('saving') : hasChanges ? t('unsaved') : t('saved')}
           </span>
         </div>

--- a/apps/web/src/components/mockups/mockup-editor-shell.tsx
+++ b/apps/web/src/components/mockups/mockup-editor-shell.tsx
@@ -199,7 +199,7 @@ function MockupNodeContent({ component }: { component: MockupComponent }) {
 
   if (type === 'Alert') {
     return (
-      <div className="flex h-full items-center rounded-2xl border border-amber-200 bg-amber-50 px-3 text-xs text-amber-900">
+      <div className="flex h-full items-center rounded-2xl border border-warning-border bg-warning-tint px-3 text-xs text-foreground">
         {text}
       </div>
     );
@@ -960,7 +960,7 @@ export function MockupEditorShell({ mockupId }: MockupEditorShellProps) {
                     </button>
                   )}
                   {!scenario.is_default ? (
-                    <button type="button" className="text-xs text-rose-300 hover:text-rose-200" onClick={() => void deleteScenario(scenario.id)}>✕</button>
+                    <button type="button" className="text-xs text-destructive hover:text-destructive/80" onClick={() => void deleteScenario(scenario.id)}>✕</button>
                   ) : null}
                 </div>
               ))}

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -352,7 +352,7 @@ export function AgentApiKeysSection({ projectId }: { projectId: string }) {
                     </Button>
                   </div>
                   {webhookErrors[agent.id] ? (
-                    <p className="text-xs text-red-600">{webhookErrors[agent.id]}</p>
+                    <p className="text-xs text-destructive">{webhookErrors[agent.id]}</p>
                   ) : null}
                 </div>
               </div>

--- a/apps/web/src/components/settings/byom-key-management.tsx
+++ b/apps/web/src/components/settings/byom-key-management.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
@@ -299,31 +300,21 @@ export function ByomKeyManagement({ projectId }: { projectId: string }) {
 
             {/* Validation result */}
             {validationResult === 'success' ? (
-              <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200">
-                {t('validationSuccess')}
-              </div>
+              <Alert variant="success"><AlertDescription>{t('validationSuccess')}</AlertDescription></Alert>
             ) : null}
             {validationResult === 'error' ? (
-              <div className="rounded-2xl border border-rose-400/20 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-                {t('validationError')}
-              </div>
+              <Alert variant="destructive"><AlertDescription>{t('validationError')}</AlertDescription></Alert>
             ) : null}
 
             {/* Save result */}
             {saveResult === 'success' ? (
-              <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200">
-                {t('saveSuccess')}
-              </div>
+              <Alert variant="success"><AlertDescription>{t('saveSuccess')}</AlertDescription></Alert>
             ) : null}
             {deleteMessage ? (
-              <div className="rounded-2xl border border-emerald-400/20 bg-emerald-400/10 px-3 py-2 text-xs text-emerald-200">
-                {deleteMessage}
-              </div>
+              <Alert variant="success"><AlertDescription>{deleteMessage}</AlertDescription></Alert>
             ) : null}
             {saveResult === 'error' && saveError ? (
-              <div className="rounded-2xl border border-rose-400/20 bg-rose-500/10 px-3 py-2 text-xs text-rose-200">
-                {saveError}
-              </div>
+              <Alert variant="destructive"><AlertDescription>{saveError}</AlertDescription></Alert>
             ) : null}
 
             {/* Action buttons */}

--- a/apps/web/src/components/settings/mcp-connection-settings.tsx
+++ b/apps/web/src/components/settings/mcp-connection-settings.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput, OperatorTextarea } from '@/components/ui/operator-control';
@@ -186,9 +187,9 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message ? (
-          <div className={`rounded-2xl border px-3 py-2 text-xs ${message.type === 'success' ? 'border-emerald-400/20 bg-emerald-400/10 text-emerald-200' : 'border-rose-400/20 bg-rose-500/10 text-rose-200'}`}>
-            {message.text}
-          </div>
+          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
         ) : null}
 
         {loading ? (
@@ -212,7 +213,7 @@ export function McpConnectionSettings({ projectId }: { projectId: string }) {
                         {connection.maskedSecret ? <div>{t('maskedSecretValue', { secret: connection.maskedSecret })}</div> : null}
                         <div>{t('toolCountValue', { count: connection.toolNames.length })}</div>
                         {connection.validatedAt ? <div>{t('validatedAtValue', { date: new Date(connection.validatedAt).toLocaleString() })}</div> : null}
-                        {connection.lastError ? <div className="text-rose-200">{connection.lastError}</div> : null}
+                        {connection.lastError ? <div className="text-destructive">{connection.lastError}</div> : null}
                       </div>
                     </div>
 

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Badge } from '@/components/ui/badge';
@@ -184,9 +185,9 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
               </Button>
             </div>
             {inviteResult && (
-              <div className={`rounded-md border p-3 text-xs break-all ${inviteResult.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-                {inviteResult.text}
-              </div>
+              <Alert variant={inviteResult.type === 'success' ? 'success' : 'destructive'}>
+                <AlertDescription className="break-all">{inviteResult.text}</AlertDescription>
+              </Alert>
             )}
           </SectionCardBody>
         </SectionCard>
@@ -194,9 +195,9 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
 
       {/* 액션 메시지 */}
       {actionMessage && (
-        <div className={`rounded-md border p-3 text-xs ${actionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-          {actionMessage.text}
-        </div>
+        <Alert variant={actionMessage.type === 'success' ? 'success' : 'destructive'}>
+          <AlertDescription>{actionMessage.text}</AlertDescription>
+        </Alert>
       )}
 
       {/* 멤버 목록 */}

--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Badge } from '@/components/ui/badge';
 
@@ -112,9 +113,9 @@ export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSe
       </SectionCardHeader>
       <SectionCardBody className="space-y-3">
         {message && (
-          <div className={`rounded-md border p-2 text-xs ${message.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-            {message.text}
-          </div>
+          <Alert variant={message.type === 'success' ? 'success' : 'destructive'}>
+            <AlertDescription>{message.text}</AlertDescription>
+          </Alert>
         )}
         {orgMembers.length === 0 ? (
           <p className="text-sm text-muted-foreground">조직 멤버가 없습니다.</p>

--- a/apps/web/src/components/settings/project-access-section.tsx
+++ b/apps/web/src/components/settings/project-access-section.tsx
@@ -140,7 +140,7 @@ export function ProjectAccessSection({ projectId, currentRole }: ProjectAccessSe
                       type="button"
                       disabled={toggling === member.id}
                       onClick={() => void handleToggle(member)}
-                      className={`rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${blocked ? 'bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400' : 'bg-destructive/10 text-destructive hover:bg-destructive/20'} disabled:opacity-50`}
+                      className={`rounded-md px-2 py-0.5 text-xs font-medium transition-colors ${blocked ? 'bg-success-tint text-success hover:bg-success/20' : 'bg-destructive/10 text-destructive hover:bg-destructive/20'} disabled:opacity-50`}
                     >
                       {toggling === member.id ? '...' : blocked ? '허용' : '차단'}
                     </button>

--- a/apps/web/src/components/settings/set-password-section.tsx
+++ b/apps/web/src/components/settings/set-password-section.tsx
@@ -79,7 +79,7 @@ export function SetPasswordSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {message && (
-          <p className={`text-sm ${message.type === 'success' ? 'text-emerald-400' : 'text-rose-400'}`}>
+          <p className={`text-sm ${message.type === 'success' ? 'text-success' : 'text-destructive'}`}>
             {message.text}
           </p>
         )}
@@ -111,7 +111,7 @@ export function SetPasswordSection() {
           {showRules && (
             <ul className="space-y-1 text-xs">
               <PasswordRuleItem met={rules.length} label="At least 8 characters" />
-              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-emerald-500' : 'text-muted-foreground'}`}>
+              <li className={`flex items-center gap-1.5 ${categoriesMet >= 3 ? 'text-success' : 'text-muted-foreground'}`}>
                 <span>{categoriesMet >= 3 ? '✓' : '○'}</span>
                 <span>At least 3 of: uppercase, lowercase, digit, special character ({categoriesMet}/3)</span>
               </li>
@@ -119,7 +119,7 @@ export function SetPasswordSection() {
           )}
 
           {touched && confirm && !isConfirmValid && (
-            <p className="text-xs text-rose-400">Passwords do not match.</p>
+            <p className="text-xs text-destructive">Passwords do not match.</p>
           )}
 
           <button
@@ -137,7 +137,7 @@ export function SetPasswordSection() {
 
 function PasswordRuleItem({ met, label }: { met: boolean; label: string }) {
   return (
-    <li className={`flex items-center gap-1.5 ${met ? 'text-emerald-500' : 'text-muted-foreground'}`}>
+    <li className={`flex items-center gap-1.5 ${met ? 'text-success' : 'text-muted-foreground'}`}>
       <span>{met ? '✓' : '○'}</span>
       <span>{label}</span>
     </li>

--- a/apps/web/src/components/settings/slack-integration-settings.tsx
+++ b/apps/web/src/components/settings/slack-integration-settings.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { AlertTriangle, CheckCircle2, Loader2, MessageSquareShare, RefreshCcw, Search } from 'lucide-react';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -309,15 +310,11 @@ export function SlackIntegrationSettingsSection() {
           </div>
 
           {data.status === 'channel_fetch_error' ? (
-            <div className="rounded-2xl border border-amber-400/20 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
-              <div className="flex items-start gap-3">
-                <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-                <div className="space-y-1">
-                  <p className="font-medium">{t('fetchErrorTitle')}</p>
-                  <p className="text-amber-100/80">{data.error?.message ?? t('fetchErrorBody')}</p>
-                </div>
-              </div>
-            </div>
+            <Alert variant="warning">
+              <AlertTriangle className="size-4" />
+              <AlertTitle>{t('fetchErrorTitle')}</AlertTitle>
+              <AlertDescription>{data.error?.message ?? t('fetchErrorBody')}</AlertDescription>
+            </Alert>
           ) : null}
 
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
@@ -432,9 +429,9 @@ export function SlackIntegrationSettingsSection() {
                           </div>
                         ) : null}
                         {isDirty ? (
-                          <div className="xl:col-span-2 rounded-2xl border border-amber-400/16 bg-amber-400/10 px-3 py-3 text-sm text-amber-100">
-                            {t('pendingHint', { project: selectedProjectName ?? t('unknownProject') })}
-                          </div>
+                          <Alert variant="warning" className="xl:col-span-2">
+                            <AlertDescription>{t('pendingHint', { project: selectedProjectName ?? t('unknownProject') })}</AlertDescription>
+                          </Alert>
                         ) : null}
                       </div>
                     </div>
@@ -471,12 +468,10 @@ export function SlackIntegrationSettingsSection() {
               {remapConflict ? t('remapDialogBody', { channel: `#${remapConflict.channelName}`, project: remapConflict.existingProjectName }) : ''}
             </DialogDescription>
           </DialogHeader>
-          <div className="rounded-2xl border border-amber-400/16 bg-amber-400/10 px-4 py-3 text-sm text-amber-100">
-            <div className="flex items-start gap-3">
-              <AlertTriangle className="mt-0.5 size-4 shrink-0" />
-              <p>{t('remapDialogWarning')}</p>
-            </div>
-          </div>
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>{t('remapDialogWarning')}</AlertDescription>
+          </Alert>
           <DialogFooter className="border-t border-white/8 bg-transparent">
             <Button variant="glass" onClick={() => setRemapConflict(null)}>{tc('cancel')}</Button>
             <Button variant="hero" onClick={() => void handleConfirmRemap()} disabled={saving}>

--- a/apps/web/src/components/settings/workflow-trigger-types-section.tsx
+++ b/apps/web/src/components/settings/workflow-trigger-types-section.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
@@ -149,9 +150,9 @@ export function WorkflowTriggerTypesSection() {
       </SectionCardHeader>
       <SectionCardBody className="space-y-4">
         {actionMessage ? (
-          <div className={`rounded-md border p-3 text-xs ${actionMessage.type === 'success' ? 'border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' : 'border-destructive/20 bg-destructive/10 text-destructive'}`}>
-            {actionMessage.text}
-          </div>
+          <Alert variant={actionMessage.type === 'success' ? 'success' : 'destructive'}>
+            <AlertDescription>{actionMessage.text}</AlertDescription>
+          </Alert>
         ) : null}
 
         {loading ? (

--- a/apps/web/src/components/standup/standup-review-card.tsx
+++ b/apps/web/src/components/standup/standup-review-card.tsx
@@ -217,13 +217,13 @@ export function StandupReviewCard({
       </div>
 
       <div className="mt-4 space-y-4">
-        {actionError ? <p className="text-sm text-rose-300">{actionError}</p> : null}
+        {actionError ? <p className="text-sm text-destructive">{actionError}</p> : null}
 
         {entry ? (
           <>
             <div className="grid gap-3 md:grid-cols-3">
               <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-emerald-300">{t('doneLabel')}</div>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-success">{t('doneLabel')}</div>
                 <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.done && 'text-muted-foreground')}>
                   {entry.done || t('emptySection')}
                 </p>
@@ -235,7 +235,7 @@ export function StandupReviewCard({
                 </p>
               </div>
               <div className="rounded-md border border-border bg-muted/30 p-3">
-                <div className="text-xs font-medium uppercase tracking-[0.18em] text-rose-300">{t('blockersLabel')}</div>
+                <div className="text-xs font-medium uppercase tracking-[0.18em] text-destructive">{t('blockersLabel')}</div>
                 <p className={cn('mt-2 whitespace-pre-wrap text-sm text-foreground/90', !entry.blockers && 'text-muted-foreground')}>
                   {entry.blockers || t('emptySection')}
                 </p>

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative grid w-full grid-cols-[auto_1fr] items-start gap-x-3 gap-y-0.5 rounded-lg border p-3 text-sm [&>svg]:mt-0.5 [&>svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'border-border bg-muted/40 text-foreground',
+        success:
+          'border-success-border bg-success-tint text-success',
+        warning:
+          'border-warning-border bg-warning-tint text-foreground',
+        destructive:
+          'border-destructive-border bg-destructive-tint text-destructive',
+        info:
+          'border-info-border bg-info-tint text-info',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('col-start-2 font-medium leading-5', className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn('col-start-2 text-xs leading-relaxed opacity-90', className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -19,7 +19,7 @@ const badgeVariants = cva(
         ghost:
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
-        success: "border-emerald-500/20 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
+        success: "border-success-border bg-success-tint text-success",
         info: "border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400",
         chip: "border-border/80 bg-muted/70 text-muted-foreground",
         counter: "border-transparent bg-destructive text-destructive-foreground",

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -20,7 +20,7 @@ const badgeVariants = cva(
           "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
         link: "text-primary underline-offset-4 hover:underline",
         success: "border-success-border bg-success-tint text-success",
-        info: "border-blue-500/20 bg-blue-500/10 text-blue-600 dark:text-blue-400",
+        info: "border-info-border bg-info-tint text-info",
         chip: "border-border/80 bg-muted/70 text-muted-foreground",
         counter: "border-transparent bg-destructive text-destructive-foreground",
       },

--- a/apps/web/src/components/ui/route-error-state.tsx
+++ b/apps/web/src/components/ui/route-error-state.tsx
@@ -25,7 +25,7 @@ export function RouteErrorState({
 
   return (
     <div className={`flex items-center justify-center ${compact ? 'min-h-[50vh]' : 'min-h-screen bg-background'}`}>
-      <div className={`space-y-4 rounded-2xl bg-white text-center shadow-lg ${compact ? 'w-full max-w-lg border p-6' : 'w-full max-w-sm p-8'}`}>
+      <div className={`space-y-4 rounded-2xl bg-card text-center shadow-lg ${compact ? 'w-full max-w-lg border p-6' : 'w-full max-w-sm p-8'}`}>
         <div className="space-y-2">
           <p className={`${compact ? 'text-base' : 'text-lg'} font-semibold text-foreground`}>
             {title ?? t('error')}
@@ -38,7 +38,7 @@ export function RouteErrorState({
         <div className="flex justify-center gap-3">
           <button
             onClick={reset}
-            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+            className="rounded-lg bg-brand px-4 py-2 text-sm font-medium text-brand-foreground hover:bg-brand/90"
           >
             {t('retry')}
           </button>

--- a/apps/web/src/components/ui/toast.tsx
+++ b/apps/web/src/components/ui/toast.tsx
@@ -22,8 +22,16 @@ function Toast({ item, onDismiss }: ToastProps) {
   }, [item.id, onDismiss]);
 
   const borderColor = item.isHighlight
-    ? 'border-l-4 border-l-primary'
-    : 'border-l-4 border-l-border';
+    ? 'border-l-4 border-l-brand'
+    : item.type === 'success'
+      ? 'border-l-4 border-l-success'
+      : item.type === 'warning'
+        ? 'border-l-4 border-l-warning'
+        : item.type === 'error'
+          ? 'border-l-4 border-l-destructive'
+          : item.type === 'info'
+            ? 'border-l-4 border-l-info'
+            : 'border-l-4 border-l-border';
 
   return (
     <div className={`animate-slide-in rounded-lg border border-border bg-popover p-4 shadow-lg ${borderColor}`}>

--- a/apps/web/src/ee/components/billing/billing-tab.tsx
+++ b/apps/web/src/ee/components/billing/billing-tab.tsx
@@ -36,7 +36,7 @@ const TIER_BADGE: Record<string, string> = {
 const STATUS_BADGE: Record<string, string> = {
   active: 'bg-green-100 text-green-700',
   past_due: 'bg-yellow-100 text-yellow-700',
-  cancelled: 'bg-red-100 text-red-700',
+  cancelled: 'bg-destructive-tint text-destructive',
 };
 
 const PLAN_PRICES: Record<string, { monthly: number; yearly: number }> = {


### PR DESCRIPTION
## 변경 사항

### Alert 컴포넌트 신규 (Commit 1)
- `components/ui/alert.tsx` — cva 기반 5 variants (default/success/warning/destructive/info)
- 2-col grid 구조, icon slot 자동 정렬, DS-S13 색상 토큰 연결

### Toast 색상 통일 (Commit 2)
- `components/ui/toast.tsx` — type별 border-l 색상 → 시맨틱 토큰

### Badge success 변형 (Commit 3)
- `components/ui/badge.tsx` — success variant border-emerald → success-border/success-tint 토큰

### Route error state (Commit 4)
- `components/ui/route-error-state.tsx` — bg-white→bg-card, bg-blue-600→bg-brand 등

### Standup (Commit 5)
- `standup/standup-review-card.tsx` — rose-300→destructive, emerald-300→success

### MFA / Chat (Commit 6)
- `app/mfa/page.tsx`, `chat/add-participant-modal.tsx` — text-red-600→text-destructive

### Settings 10파일 (Commit 7)
- `settings/mcp-connection-settings.tsx`, `byom-key-management.tsx`, `slack-integration-settings.tsx`, `app/(authenticated)/settings/page.tsx`
- 6개 emerald/amber/rose 상태 div → Alert variants, invitation 인라인 색상 토큰 통일

### Agents 5파일 (Commit 8)
- `agents/agent-persona-composer.tsx`, `agent-deployment-wizard.tsx`, `agent-hitl-policy-editor.tsx`, `agent-deployment-verification-step.tsx`, `agent-run-detail.tsx`
- step indicator / confirmation / error banner → Alert variants

### Inbox / Docs (Commit 9)
- `docs/doc-content-renderer.tsx`, `inbox/decisions-waiting.tsx`
- red-500 패턴 → destructive-border/destructive-tint 토큰

### Missed 정리 (Commit 10)
- `agent-run-detail.tsx` error banner (Python replace 실패 재수정)
- `agent-workflow-editor.tsx` amber warning divs × 2
- `settings/org-members-section.tsx`, `project-access-section.tsx`, `workflow-trigger-types-section.tsx` section alerts

## 스크린샷

> Alert variants 렌더링 (success / warning / destructive / info / default)

| Before | After |
|--------|-------|
| 하드코딩 `border-emerald-500/20 bg-emerald-500/10` | `Alert variant="success"` — success-border/success-tint 토큰 |
| 하드코딩 `border-red-500/20 bg-red-500/10` | `Alert variant="destructive"` — destructive-border/destructive-tint 토큰 |
| 하드코딩 `border-amber-500/30 bg-amber-500/10` | `Alert variant="warning"` — warning-border/warning-tint 토큰 |

## 반응형 확인

- [ ] 데스크톱 (1440px)
- [ ] 모바일 (375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)