### PR TITLE
[BF-DOCS-1] Docs 트리 클릭 불가 — dnd-kit listeners click 차단 fix

### DIFF
--- a/apps/web/src/components/docs/doc-tree.tsx
+++ b/apps/web/src/components/docs/doc-tree.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, MoreVertical } from 'lucide-react';
+import { ChevronDown, ChevronRight, FileText, Folder, FolderOpen, GripVertical, MoreVertical } from 'lucide-react';
 import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, closestCenter } from '@dnd-kit/core';
 import { SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
@@ -238,6 +238,15 @@ function TreeNode({
     <div ref={setNodeRef} style={style}>
       <div className="group relative">
         {preview && <DocPreviewCard title={preview.title} snippet={preview.snippet} x={previewPos.x} y={previewPos.y} />}
+        {/* Drag handle — listeners isolated here to avoid blocking click */}
+        <div
+          {...attributes}
+          {...listeners}
+          className="absolute top-1/2 z-10 -translate-y-1/2 cursor-grab touch-none opacity-0 transition group-hover:opacity-100"
+          style={{ left: `${Math.min(depth * 14 + 4, 68)}px` }}
+        >
+          <GripVertical className="size-3 text-muted-foreground" />
+        </div>
         <button
           data-doc-id={doc.id}
           onClick={handleClick}
@@ -251,8 +260,6 @@ function TreeNode({
               : 'text-foreground/88 hover:bg-muted hover:text-foreground',
           )}
           style={{ paddingLeft: `${Math.min(depth * 14 + 8, 72)}px` }}
-          {...attributes}
-          {...listeners}
         >
           {isFolder ? (
             expanded ? <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" /> : <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />


### PR DESCRIPTION
## 원인

`doc-tree.tsx` TreeNode의 `<button>`에 `useSortable` `{...listeners}`가 직접 적용되어 있어, `onPointerDown`이 `preventDefault()` + `setPointerCapture()`를 호출하여 브라우저 native `click` composite event를 차단.

## 수정

`{...attributes}` + `{...listeners}`를 `<button>`에서 분리하여 별도 GripVertical drag handle 요소에 적용.

**Before:**
```tsx
<button onClick={handleClick} {...attributes} {...listeners}>
```

**After:**
```tsx
{/* Drag handle — listeners isolated here */}
<div {...attributes} {...listeners} className="... cursor-grab opacity-0 group-hover:opacity-100">
  <GripVertical className="size-3" />
</div>
{/* Click button — no listeners */}
<button onClick={handleClick}>
```

- drag handle은 depth에 맞는 left 위치 + `group-hover:opacity-100`으로 hover 시만 표시
- drag-to-reorder 기능 유지 (listeners는 handle에 그대로 보존)
- `button`의 click 이벤트 정상 복구

## AC 체크

- [x] listeners → drag handle 분리
- [x] 트리 항목 클릭 → 문서 선택 정상 동작
- [x] drag-to-reorder 기능 유지
- [x] pnpm build 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)