### PR TITLE
[BF-DOCS-1] add 'use client' to docs pages — fix RSC flight transition stuck

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/page.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { DocsEmptyView } from './docs-empty-view';
 
 export default function DocsPage() {


### PR DESCRIPTION
## Summary

- Add `'use client'` to `docs/page.tsx`
- Add `'use client'` to `docs/design-tokens/page.tsx`

## Root cause

Server Component page + `'use client'` layout combination causes RSC flight `expiredLanes` immediately → all `/docs` client-side navigation blocked. This is the confirmed root cause after PR #997 (children double-render) and PR #998 (Suspense boundary removal) as partial fixes.

Converting both page components to Client Components eliminates the RSC flight transition stuck condition. `/docs` is the only route in the project with this SC page + CC layout combination.

## Test plan

- [ ] /docs 진입 후 트리 항목 클릭 → URL 변경 + 콘텐츠 로딩
- [ ] /docs/[slug]에서 다른 문서 클릭 → 전환 정상 (freeze 없음)
- [ ] GNB 사이드바 링크 클릭 → 정상 네비게이션
- [ ] /docs/design-tokens 진입 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)