### PR TITLE
fix(oss): fresh DB init failure — remove memos FK + register Conversation models + pool_pre_ping

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -16,6 +16,7 @@ engine = create_async_engine(
     settings.database_url,
     pool_size=10,
     max_overflow=20,
+    pool_pre_ping=True,
     echo=settings.debug,
 )
 

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -15,6 +15,7 @@ from app.models.webhook_config import WebhookConfig
 from app.models.doc import Doc
 from app.models.invitation import Invitation
 from app.models.meeting import Meeting
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.models.notification import InboxItem, Notification, NotificationSetting
 from app.models.notification_preference import NotificationPreference
@@ -58,6 +59,9 @@ __all__ = [
     "Invitation",
     "Meeting",
     "Notification",
+    "Conversation",
+    "ConversationMessage",
+    "ConversationParticipant",
     "ConversationWebhookDelivery",
     "NotificationPreference",
     "NotificationSetting",

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -28,7 +28,7 @@ class AgentRun(Base):
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
     )
     memo_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("memos.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     trigger: Mapped[str] = mapped_column(Text, nullable=False, default="manual")
     model: Mapped[str | None] = mapped_column(Text, nullable=True)


### PR DESCRIPTION
## Summary

- **agent_run.py**: `ForeignKey("memos.id")` 제거 — memos 테이블은 E-MEMO-RETIRE에서 삭제됨. `Base.metadata.create_all()` 시 참조 불가로 fresh OSS 초기화 실패 유발
- **models/__init__.py**: `Conversation`, `ConversationMessage`, `ConversationParticipant` import 추가 — bootstrap.py `create_all` 시 테이블 미등록 문제 해결
- **database.py**: `pool_pre_ping=True` 추가 — DB 재시작 후 stale connection 자동 복구

## Test plan

- [ ] `docker compose up` fresh DB 초기화 정상 완료 확인
- [ ] 973개 기존 통과 테스트 회귀 없음 (내 수정 관련 신규 실패 없음)
- [ ] `Base.metadata.create_all()` → agent_runs, conversations 테이블 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)