### PR TITLE
[BF-DOCS-1] memoize TopBarSlot props to break infinite render loop

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-client-layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useTopBar } from '@/components/nav/top-bar-context';
 import { useMediaQuery } from '@/lib/use-media-query';
@@ -174,6 +174,20 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
   const closeDrawer = useCallback(() => setTreeDrawerOpen(false), []);
   const { progress: drawerProgress, dragging: drawerDragging } = useSwipeDrawer(treeDrawerOpen, openDrawer, closeDrawer);
 
+  const topBarTitle = useMemo(
+    () => <h1 className="text-sm font-medium">{t('title')}</h1>,
+    [t]
+  );
+  const topBarActions = useMemo(
+    () => (
+      <Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}>
+        <Plus className="mr-1.5 h-3.5 w-3.5" />
+        {isCreating ? t('loading') : t('newDoc')}
+      </Button>
+    ),
+    [handleNewDoc, isCreating, t]
+  );
+
   const sidebarContent = (
     <>
       <TreeSearchInput
@@ -249,8 +263,8 @@ export function DocsClientLayout({ children }: { children: React.ReactNode }) {
   return (
     <DocsLayoutContext.Provider value={{ projectId, tree, setTree, handleNewDoc, fetchTree, pendingDocUpdate, clearPendingDocUpdate, expandFolder }}>
       <TopBarSlot
-        title={<h1 className="text-sm font-medium">{t('title')}</h1>}
-        actions={<Button size="sm" variant="outline" onClick={handleNewDoc} disabled={isCreating}><Plus className="mr-1.5 h-3.5 w-3.5" />{isCreating ? t('loading') : t('newDoc')}</Button>}
+        title={topBarTitle}
+        actions={topBarActions}
       />
 
       {/* Unified: children rendered exactly once — sidebar responsive via breakpoint classes */}


### PR DESCRIPTION
## Root cause (confirmed by 까심 codex analysis)

`docs-client-layout.tsx` both subscribes to `useTopBar()` context AND passes inline JSX to `<TopBarSlot>`. Every render creates new JSX object references → `TopBarSlot.useEffect([title, actions])` fires → `setSlot()` → `TopBarProvider` re-renders → `useTopBar()` consumers re-render → infinite loop → `expiredLanes` accumulation → `router.push` blocked.

Bug introduced in PR #992 (D-DOCS-MOB-3, commit `b1a1a4d3`) when `useTopBar()` call was added to docs layout.

## Fix

Stabilize `TopBarSlot` props with `useMemo` in `docs-client-layout.tsx`:

```tsx
const topBarTitle = useMemo(
  () => <h1 className="text-sm font-medium">{t('title')}</h1>,
  [t]
);
const topBarActions = useMemo(
  () => <Button ... onClick={handleNewDoc} disabled={isCreating}>...</Button>,
  [handleNewDoc, isCreating, t]
);
// TopBarSlot receives stable refs → useEffect only fires on actual dependency changes
<TopBarSlot title={topBarTitle} actions={topBarActions} />
```

## Changes

1 file changed: `docs/docs-client-layout.tsx` — `useMemo` added to import + 2 memoized variables + `TopBarSlot` props updated

## Test plan

- [ ] pnpm build 성공
- [ ] /docs 진입 후 expiredLanes === 0
- [ ] 트리 항목 클릭 → URL 변경 + 콘텐츠 로딩
- [ ] GNB 사이드바 링크 클릭 → 정상 네비게이션
- [ ] /docs 이외 페이지 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)