### PR TITLE
[P0] feat(oss): JWT_SECRET auto-gen + .env 자동 생성

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+.PHONY: up dev down env logs ps
+
+## Generate .env from .env.example with random secrets (skips if .env exists)
+env:
+	python3 scripts/init-env.py
+
+## Start all services (auto-generates .env if missing)
+up: env
+	docker compose up -d
+
+## Start all services in foreground (auto-generates .env if missing)
+dev: env
+	docker compose up
+
+## Stop all services
+down:
+	docker compose down
+
+## Show service logs
+logs:
+	docker compose logs -f
+
+## Show running containers
+ps:
+	docker compose ps

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # Sprintable — self-hosted / local development
-# Usage: cp .env.example .env  &&  docker compose up -d
+# Quick start: make up          (auto-generates .env with random secrets)
+# Manual:      python3 scripts/init-env.py && docker compose up -d
 
 services:
   db:

--- a/scripts/init-env.py
+++ b/scripts/init-env.py
@@ -1,0 +1,37 @@
+"""Generate .env from .env.example with auto-generated secrets.
+
+Usage:
+    python3 scripts/init-env.py          # creates .env if not present
+    python3 scripts/init-env.py --force  # overwrite existing .env
+"""
+import os
+import secrets
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ENV_FILE = os.path.join(ROOT, ".env")
+EXAMPLE_FILE = os.path.join(ROOT, ".env.example")
+
+PLACEHOLDERS = {
+    "JWT_SECRET=change-me-in-production-min-32-chars": lambda: f"JWT_SECRET={secrets.token_hex(32)}",
+    "SECRET_KEY=change-me-in-production-min-32-chars": lambda: f"SECRET_KEY={secrets.token_hex(32)}",
+    "POSTGRES_PASSWORD=change-me-in-production": lambda: f"POSTGRES_PASSWORD={secrets.token_hex(16)}",
+}
+
+force = "--force" in sys.argv
+
+if os.path.exists(ENV_FILE) and not force:
+    print("[init-env] .env already exists — skipping (use --force to overwrite)")
+    sys.exit(0)
+
+with open(EXAMPLE_FILE) as f:
+    content = f.read()
+
+for placeholder, generator in PLACEHOLDERS.items():
+    content = content.replace(placeholder, generator(), 1)
+
+with open(ENV_FILE, "w") as f:
+    f.write(content)
+
+print("[init-env] .env created with auto-generated JWT_SECRET, SECRET_KEY, POSTGRES_PASSWORD")
+print("[init-env] Next: docker compose up -d")


### PR DESCRIPTION
## 변경 내역

- `scripts/init-env.py` 신설: `.env.example` 기반으로 `.env` 자동 생성. `JWT_SECRET`, `SECRET_KEY`, `POSTGRES_PASSWORD` → `secrets.token_hex()` 랜덤값으로 대체. `.env` 이미 존재 시 skip (`--force`로 덮어쓰기 가능)
- `Makefile` 신설: `make up` → `.env` 자동 생성 후 `docker compose up -d`. `make dev`, `make down`, `make logs`, `make ps` 제공
- `docker-compose.yml` 상단 주석 업데이트: `make up` 권장 플로우 안내

## AC 검증

- ✅ `.env` 없는 상태에서 `python3 scripts/init-env.py` → `.env` 생성 + 랜덤 시크릿 주입
- ✅ `.env` 이미 존재 시 skip 메시지 출력
- ✅ `--force` 옵션으로 덮어쓰기 가능
- ✅ `make up` → `.env` 자동 생성 후 docker compose 실행

Story: b4581aff-f093-46ba-9448-51a5074f07ee