### PR TITLE
feat(webhook): secret 필드 API 노출 + HMAC 서명 완결

### DIFF
--- a/backend/app/repositories/webhook_config.py
+++ b/backend/app/repositories/webhook_config.py
@@ -43,6 +43,7 @@ class WebhookConfigRepository:
         project_id: uuid.UUID | None = None,
         events: list[str] | None = None,
         is_active: bool = True,
+        secret: str | None = None,
     ) -> WebhookConfig:
         existing = await self.session.execute(
             select(WebhookConfig).where(
@@ -60,6 +61,7 @@ class WebhookConfigRepository:
                 project_id=project_id,
                 events=events or [],
                 is_active=is_active,
+                secret=secret or None,
             )
             self.session.add(config)
         else:
@@ -68,6 +70,8 @@ class WebhookConfigRepository:
             if events is not None:
                 config.events = events
             config.is_active = is_active
+            if secret is not None:
+                config.secret = secret or None
 
         await self.session.flush()
         await self.session.refresh(config)

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -38,6 +38,7 @@ async def upsert_webhook_config(
         project_id=body.project_id,
         events=body.events,
         is_active=body.is_active,
+        secret=body.secret,
     )
     return WebhookConfigResponse.model_validate(config)
 

--- a/backend/app/schemas/webhook_config.py
+++ b/backend/app/schemas/webhook_config.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from app.core.ssrf import validate_webhook_url
 
@@ -20,6 +20,12 @@ class WebhookConfigResponse(BaseModel):
     channel: str
     is_active: bool
     created_at: datetime
+    secret: str | None = Field(default=None, exclude=True)
+
+    @computed_field
+    @property
+    def has_secret(self) -> bool:
+        return bool(self.secret)
 
 
 class UpsertWebhookConfig(BaseModel):
@@ -28,6 +34,7 @@ class UpsertWebhookConfig(BaseModel):
     project_id: uuid.UUID | None = None
     events: list[str] | None = None
     is_active: bool = True
+    secret: str | None = None
 
     @field_validator("url")
     @classmethod
@@ -36,3 +43,8 @@ class UpsertWebhookConfig(BaseModel):
             raise ValueError("url must start with https://")
         validate_webhook_url(v)  # DNS resolve → private IP 차단 (SSRF 방어)
         return v
+
+    @field_validator("secret", mode="before")
+    @classmethod
+    def empty_secret_to_none(cls, v: str | None) -> str | None:
+        return v if v else None


### PR DESCRIPTION
## 변경 내역

**`schemas/webhook_config.py`**
- `WebhookConfigResponse`에 `secret: str | None = Field(exclude=True)` 추가 — ORM에서 읽되 직렬화 제외
- `@computed_field has_secret: bool` 추가 — `bool(self.secret)` 반환
- `UpsertWebhookConfig`에 `secret: str | None = None` 추가
- `empty_secret_to_none` validator: 빈 문자열 → `None` 정규화

**`repositories/webhook_config.py`**
- `upsert()`에 `secret: str | None = None` 파라미터 추가
- 신규: `secret or None` 저장, 업데이트: `secret is not None`인 경우만 덮어쓰기 (기존 유지 패턴)

**`routers/webhooks.py`**
- `upsert_webhook_config`에서 `secret=body.secret` 전달

## AC

- ✅ `PUT /api/v2/webhooks/config` + `secret` → DB 저장
- ✅ `GET /api/v2/webhooks/config` 응답에 `has_secret: true/false` 포함, `secret` 값 미노출
- ✅ `webhook_dispatch.py`의 HMAC (`_build_signature_headers`) — 기존 코드 그대로 동작
- ✅ secret 미전달 시 기존 값 유지

Story: ce2b824b-e753-41da-acbc-9e2961bc0adb