### PR TITLE
feat(mcp): webhook config 관리 tools 3개 추가

### DIFF
--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -1,4 +1,4 @@
-"""Sprintable MCP 서버 — 88개 도구 등록 (flat schema)."""
+"""Sprintable MCP 서버 — 91개 도구 등록 (flat schema)."""
 from __future__ import annotations
 
 import asyncio
@@ -92,6 +92,10 @@ from .tools.tasks import (
     ListTasksInput, UpdateTaskInput, UpdateTaskStatusInput,
     add_task, delete_task, get_task, list_my_tasks, list_tasks,
     update_task, update_task_status,
+)
+from .tools.webhooks import (
+    DeleteWebhookConfigInput, ListWebhookConfigsInput, UpsertWebhookConfigInput,
+    delete_webhook_config, list_webhook_configs, upsert_webhook_config,
 )
 
 
@@ -431,6 +435,16 @@ _TOOL_DEFS: list[tuple] = [
     ("sprintable_poll_events",
      "에이전트 수신 대기 이벤트 폴링.",
      PollEventsInput, poll_events),
+    # Webhooks (3)
+    ("sprintable_list_webhook_configs",
+     "Webhook config 목록 조회.",
+     ListWebhookConfigsInput, list_webhook_configs),
+    ("sprintable_upsert_webhook_config",
+     "Webhook config 생성/수정. secret 설정 시 HMAC 서명 활성화.",
+     UpsertWebhookConfigInput, upsert_webhook_config),
+    ("sprintable_delete_webhook_config",
+     "Webhook config 삭제.",
+     DeleteWebhookConfigInput, delete_webhook_config),
 ]
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:

--- a/backend/sprintable_mcp/tools/webhooks.py
+++ b/backend/sprintable_mcp/tools/webhooks.py
@@ -1,0 +1,66 @@
+"""Webhook config 관리 MCP 도구 (3개)."""
+from __future__ import annotations
+
+import uuid
+
+from mcp.types import TextContent
+
+from ..api_client import client
+from ..response import err, ok
+from ..schemas import SprintableInput
+
+
+class ListWebhookConfigsInput(SprintableInput):
+    project_id: str | None = None
+
+
+class UpsertWebhookConfigInput(SprintableInput):
+    url: str
+    project_id: str | None = None
+    events: list[str] | None = None
+    is_active: bool = True
+    secret: str | None = None
+
+
+class DeleteWebhookConfigInput(SprintableInput):
+    id: str
+
+
+async def list_webhook_configs(args: ListWebhookConfigsInput) -> list[TextContent]:
+    """Webhook config 목록 조회."""
+    params: dict = {}
+    if args.project_id:
+        params["project_id"] = args.project_id
+    try:
+        return ok(await client.get("/api/v2/webhooks/config", params=params))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def upsert_webhook_config(args: UpsertWebhookConfigInput) -> list[TextContent]:
+    """Webhook config 생성/수정. secret 설정 시 HMAC 서명 활성화."""
+    if not client.member_id:
+        return err("member_id not resolved")
+    body: dict = {
+        "member_id": client.member_id,
+        "url": args.url,
+        "is_active": args.is_active,
+    }
+    if args.project_id is not None:
+        body["project_id"] = args.project_id
+    if args.events is not None:
+        body["events"] = args.events
+    if args.secret is not None:
+        body["secret"] = args.secret
+    try:
+        return ok(await client.put("/api/v2/webhooks/config", json=body))
+    except Exception as exc:
+        return err(str(exc))
+
+
+async def delete_webhook_config(args: DeleteWebhookConfigInput) -> list[TextContent]:
+    """Webhook config 삭제."""
+    try:
+        return ok(await client.delete("/api/v2/webhooks/config", params={"id": args.id}))
+    except Exception as exc:
+        return err(str(exc))


### PR DESCRIPTION
## 변경 내역

**`sprintable_mcp/tools/webhooks.py`** (신규)
- `sprintable_list_webhook_configs`: `GET /api/v2/webhooks/config?project_id=...`
- `sprintable_upsert_webhook_config`: `PUT /api/v2/webhooks/config` — member_id 자동 주입, secret 포함
- `sprintable_delete_webhook_config`: `DELETE /api/v2/webhooks/config?id=...`

**`sprintable_mcp/server.py`**
- `tools/webhooks.py` import 추가
- `_TOOL_DEFS`에 3개 등록 (91개로 업데이트)

## AC

- ✅ `sprintable_list_webhook_configs` — project_id 필터 지원
- ✅ `sprintable_upsert_webhook_config` — secret 설정 시 HMAC 서명 활성화 (PR #1006 API 연동)
- ✅ `sprintable_delete_webhook_config` — id 기반 삭제
- ✅ 기존 tools 패턴 일관성 유지 (flat schema + _TOOL_DEFS)

Story: 258762f1-0186-4238-8800-c78ace9972cf