### PR TITLE
hotfix: middleware.ts shim 삭제 — proxy.ts 충돌 해소

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as default, config } from './proxy';


### PR DESCRIPTION
## 원인

Next.js 16이 `proxy.ts`를 이미 미들웨어로 인식하는 상태에서 `middleware.ts` re-export shim 추가 → 충돌 에러:
```
Both middleware file "./src/src/middleware.ts" and proxy file "./src/src/proxy.ts" are detected.
```

## 변경 내역

- `apps/web/src/middleware.ts` 삭제

Related: PR #1005