### PR TITLE
[OSS P0] fix: org owner 자기 프로젝트 접근 불가

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -245,11 +245,24 @@ async def get_project_scoped_org_id(
     if not project_org_id:
         return base_org_id
 
+    # Org owner/admin은 모든 project에 접근 가능 — team_members 체크 우선 bypass.
+    # project 생성 직후 team_members 미생성 상태(OSS fresh install)에서도 접근 허용.
+    from app.models.project import OrgMember
+    uid = uuid.UUID(auth.user_id)
+    org_role_row = await db.execute(
+        select(OrgMember.role).where(
+            OrgMember.org_id == project_org_id,
+            OrgMember.user_id == uid,
+            OrgMember.deleted_at.is_(None),
+        )
+    )
+    if org_role_row.scalar_one_or_none() in ("owner", "admin"):
+        return project_org_id
+
     # project_id가 지정된 경우 org 동일 여부 무관하게 TeamMember 검증
     # (동일 org 내 다른 project 미멤버 우회 방지)
     from app.models.team import TeamMember
     from sqlalchemy import or_
-    uid = uuid.UUID(auth.user_id)
     member = await db.execute(
         select(TeamMember.id).where(
             or_(TeamMember.user_id == uid, TeamMember.id == uid),

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -50,8 +50,8 @@ async def create_project(
         await session.execute(
             text(
                 "INSERT INTO org_members (id, org_id, user_id, role)"
-                " VALUES (gen_random_uuid(), :org_id, :user_id, 'owner')"
-                " ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'owner'"
+                " VALUES (gen_random_uuid(), :org_id, :user_id, 'member')"
+                " ON CONFLICT (org_id, user_id) DO NOTHING"
             ),
             {"org_id": str(org_id), "user_id": auth.user_id},
         )

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -45,15 +45,31 @@ async def create_project(
     project = await repo.create(name=body.name, description=body.description)
 
     # project_memberships 테이블 미존재 — agent 자동 첨부는 agent 생성 시 project_id로 직접 연결.
-    # Ensure the creating user is in org_members (opt-out model: org membership = project access).
+    # Ensure the creating user is in org_members and team_members.
     if auth.user_id:
         await session.execute(
             text(
                 "INSERT INTO org_members (id, org_id, user_id, role)"
-                " VALUES (gen_random_uuid(), :org_id, :user_id, 'member')"
-                " ON CONFLICT (org_id, user_id) DO NOTHING"
+                " VALUES (gen_random_uuid(), :org_id, :user_id, 'owner')"
+                " ON CONFLICT (org_id, user_id) DO UPDATE SET role = 'owner'"
             ),
             {"org_id": str(org_id), "user_id": auth.user_id},
+        )
+        # Auto-create team_members row so SSE and project-scoped auth work immediately.
+        member_name = (auth.email or auth.user_id).split("@")[0]
+        await session.execute(
+            text(
+                "INSERT INTO team_members"
+                " (id, org_id, project_id, user_id, type, name, role, is_active, color)"
+                " VALUES (gen_random_uuid(), :org_id, :project_id, :user_id,"
+                "         'human', :name, 'owner', true, '#3385f8')"
+            ),
+            {
+                "org_id": str(org_id),
+                "project_id": str(project.id),
+                "user_id": auth.user_id,
+                "name": member_name,
+            },
         )
 
     await session.commit()

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -60,9 +60,9 @@ async def create_project(
         await session.execute(
             text(
                 "INSERT INTO team_members"
-                " (id, org_id, project_id, user_id, type, name, role, is_active, color)"
+                " (id, org_id, project_id, user_id, type, name, role, is_active, color, can_manage_members)"
                 " VALUES (gen_random_uuid(), :org_id, :project_id, :user_id,"
-                "         'human', :name, 'owner', true, '#3385f8')"
+                "         'human', :name, 'owner', true, '#3385f8', true)"
             ),
             {
                 "org_id": str(org_id),


### PR DESCRIPTION
## Summary
- OSS fresh install에서 org owner가 project 생성 후 docs, SSE 등 모든 project API가 403/404로 실패
- 두 파일 수정으로 즉시 해결

## Root Cause & Fix

| | 파일 | 문제 | 수정 |
|-|------|------|------|
| A | `auth.py:248` | `get_project_scoped_org_id()`가 `team_members`만 검사 → org owner도 403 | org_members owner/admin이면 team_members 우선 bypass |
| B | `projects.py:45` | project 생성 시 `team_members` row 미생성 → SSE member_id 404 | project 생성 시 `team_members(human, owner)` 자동 INSERT |

## Test Plan
- [ ] OSS fresh install → organization 생성 → project 생성 → docs 목록 조회 → 200
- [ ] project 생성 후 SSE `/api/v2/events/stream?member_id=<team_member_id>` → 연결 성공
- [ ] 일반 member (non-owner)가 자신이 속하지 않은 project 접근 → 여전히 403 (bypass 과다적용 안됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)