### PR TITLE
hotfix: NEXT_PUBLIC_OAUTH_ENABLED 빌드 인자 누락 수정

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -29,6 +29,8 @@ ENV NEXT_TELEMETRY_DISABLED=1
 # rewrites()가 빌드 시점에 routes-manifest.json으로 베이크인되므로 ARG로 주입 필요
 ARG NEXT_PUBLIC_FASTAPI_URL
 ENV NEXT_PUBLIC_FASTAPI_URL=${NEXT_PUBLIC_FASTAPI_URL}
+ARG NEXT_PUBLIC_OAUTH_ENABLED
+ENV NEXT_PUBLIC_OAUTH_ENABLED=${NEXT_PUBLIC_OAUTH_ENABLED}
 RUN pnpm build
 
 # ─── 런타임 ──────────────────────────────────────────────────────────────────

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,6 +28,8 @@ steps:
       - ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/frontend:latest-${_DEPLOY_ENV}
       - --build-arg
       - NEXT_PUBLIC_FASTAPI_URL=${_FASTAPI_URL}
+      - --build-arg
+      - NEXT_PUBLIC_OAUTH_ENABLED=true
       - .
     env:
       - DOCKER_BUILDKIT=1


### PR DESCRIPTION
## Summary
- PR #1014에서 OAuth 버튼이 `NEXT_PUBLIC_OAUTH_ENABLED=true` 조건부로 변경됐으나 빌드 파이프라인에 미전달 → prod/dev 양쪽 OAuth 로그인 불가
- `apps/web/Dockerfile`: `ARG NEXT_PUBLIC_OAUTH_ENABLED` + `ENV` 추가
- `cloudbuild.yaml`: build-frontend step에 `--build-arg NEXT_PUBLIC_OAUTH_ENABLED=true` 추가

## Test Plan
- [ ] Cloud Build 재빌드 후 OAuth 버튼 노출 확인
- [ ] Google/GitHub OAuth 로그인 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)