### PR TITLE
[SID:a0646d0a] E-FAKECHAT-INTEG:S4 — 채팅 웹 UI Sprintable 프론트엔드 통합

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -67,6 +67,19 @@
     "goDocs": "Go to Docs",
     "documents": "Documents"
   },
+  "channel": {
+    "title": "Channel Chat",
+    "missingAgentId": "agent_id parameter is required.",
+    "connecting": "Connecting…",
+    "empty": "No messages.",
+    "attachment": "Attachment",
+    "reply": "Reply",
+    "cancelReply": "Cancel reply",
+    "removeFile": "Remove file",
+    "attachFile": "Attach file",
+    "inputPlaceholder": "Type a message… (Enter to send, Shift+Enter for new line)",
+    "send": "Send"
+  },
   "dashboard": {
     "title": "Dashboard",
     "projects": "Projects",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -67,6 +67,19 @@
     "goDocs": "문서로 이동",
     "documents": "문서"
   },
+  "channel": {
+    "title": "채널 채팅",
+    "missingAgentId": "agent_id 파라미터가 필요합니다.",
+    "connecting": "연결 중…",
+    "empty": "메시지가 없습니다.",
+    "attachment": "첨부 파일",
+    "reply": "답장",
+    "cancelReply": "답장 취소",
+    "removeFile": "파일 제거",
+    "attachFile": "파일 첨부",
+    "inputPlaceholder": "메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)",
+    "send": "전송"
+  },
   "dashboard": {
     "title": "대시보드",
     "projects": "프로젝트",

--- a/apps/web/src/app/(authenticated)/channel/page.tsx
+++ b/apps/web/src/app/(authenticated)/channel/page.tsx
@@ -1,0 +1,303 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { Paperclip, Send, X } from 'lucide-react';
+import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
+import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { Button } from '@/components/ui/button';
+
+interface ChannelMsg {
+  id: string;
+  senderId: string;
+  senderName: string;
+  content: string;
+  ts: string;
+  fileUrl?: string;
+}
+
+type WsStatus = 'idle' | 'connecting' | 'connected' | 'disconnected';
+
+function fastapiWsBase(): string {
+  return (process.env.NEXT_PUBLIC_FASTAPI_URL ?? 'http://localhost:8000')
+    .replace(/^https:\/\//, 'wss://')
+    .replace(/^http:\/\//, 'ws://');
+}
+
+function fmtTime(ts: string): string {
+  try {
+    return new Date(ts).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' });
+  } catch {
+    return '';
+  }
+}
+
+export default function ChannelPage() {
+  const searchParams = useSearchParams();
+  const agentId = searchParams.get('agent_id');
+  const { currentTeamMemberId } = useDashboardContext();
+
+  const [messages, setMessages] = useState<ChannelMsg[]>([]);
+  const [input, setInput] = useState('');
+  const [pendingFile, setPendingFile] = useState<File | null>(null);
+  const [replyTo, setReplyTo] = useState<string | null>(null);
+  const [wsStatus, setWsStatus] = useState<WsStatus>('idle');
+  const [token, setToken] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const msgMapRef = useRef<Map<string, ChannelMsg>>(new Map());
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  // JWT 가져오기
+  useEffect(() => {
+    fetch('/api/channel/token')
+      .then((r) => r.json())
+      .then((d: { token: string }) => setToken(d.token))
+      .catch(() => {});
+  }, []);
+
+  // WebSocket 연결
+  useEffect(() => {
+    if (!token || !agentId) return;
+    setWsStatus('connecting');
+
+    const ws = new WebSocket(
+      `${fastapiWsBase()}/ws/chat/${agentId}?token=${encodeURIComponent(token)}`,
+    );
+    wsRef.current = ws;
+
+    ws.onopen = () => setWsStatus('connected');
+    ws.onclose = () => { setWsStatus('disconnected'); wsRef.current = null; };
+    ws.onerror = () => { setWsStatus('disconnected'); };
+
+    ws.onmessage = (e) => {
+      try {
+        const d = JSON.parse(e.data as string) as {
+          id?: string;
+          sender_id?: string;
+          sender_name?: string;
+          content?: string;
+          ts?: string;
+          file_url?: string;
+          error?: string;
+        };
+        if (d.error || !d.id) return;
+        if (seenIdsRef.current.has(d.id)) return;
+        seenIdsRef.current.add(d.id);
+
+        const msg: ChannelMsg = {
+          id: d.id,
+          senderId: d.sender_id ?? '',
+          senderName: d.sender_name ?? '',
+          content: d.content ?? '',
+          ts: d.ts ?? new Date().toISOString(),
+          fileUrl: d.file_url,
+        };
+        msgMapRef.current.set(msg.id, msg);
+        setMessages((prev) => [...prev, msg]);
+      } catch { /* ignore */ }
+    };
+
+    return () => { ws.close(); wsRef.current = null; };
+  }, [token, agentId]);
+
+  // 자동 스크롤
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text && !pendingFile) return;
+
+    setInput('');
+    setPendingFile(null);
+    setReplyTo(null);
+
+    if (pendingFile) {
+      const fd = new FormData();
+      fd.set('agent_id', agentId ?? '');
+      fd.set('content', text);
+      fd.set('file', pendingFile);
+      await fetch('/api/channel/upload', { method: 'POST', body: fd });
+    } else if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ content: text }));
+    } else {
+      await fetch('/api/channel/deliver', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent_id: agentId, content: text }),
+      });
+    }
+  }, [input, pendingFile, agentId]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        void sendMessage();
+      }
+    },
+    [sendMessage],
+  );
+
+  if (!agentId) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <p className="text-sm text-muted-foreground">agent_id 파라미터가 필요합니다.</p>
+      </div>
+    );
+  }
+
+  const statusDot =
+    wsStatus === 'connected'
+      ? 'bg-green-500'
+      : wsStatus === 'connecting'
+        ? 'bg-yellow-500 animate-pulse'
+        : 'bg-muted-foreground';
+
+  return (
+    <>
+      <TopBarSlot
+        title={
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-medium text-foreground">채널 채팅</span>
+            <span className={`h-2 w-2 rounded-full ${statusDot}`} title={wsStatus} />
+          </div>
+        }
+      />
+
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background">
+        {/* 메시지 목록 */}
+        <section className="flex-1 overflow-y-auto px-4 py-4">
+          {messages.length === 0 && (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              {wsStatus === 'connecting' ? '연결 중…' : '메시지가 없습니다.'}
+            </p>
+          )}
+          {messages.map((msg) => {
+            const isOwn = msg.senderId === currentTeamMemberId;
+            const replyTarget = replyTo === msg.id ? msg : null;
+            void replyTarget;
+
+            return (
+              <div
+                key={msg.id}
+                className={`group mb-3 flex ${isOwn ? 'justify-end' : 'justify-start'}`}
+              >
+                <div className="max-w-[70%]">
+                  {!isOwn && (
+                    <p className="mb-0.5 text-xs text-muted-foreground">{msg.senderName}</p>
+                  )}
+                  <div
+                    className={`relative rounded-2xl px-3 py-2 ${isOwn ? 'bg-brand text-brand-foreground' : 'bg-muted text-foreground'}`}
+                  >
+                    {msg.content && (
+                      <p className="whitespace-pre-wrap break-words text-sm">{msg.content}</p>
+                    )}
+                    {msg.fileUrl && (
+                      <a
+                        href={msg.fileUrl.replace(
+                          '/api/v2/channel/files/',
+                          '/api/channel/files/',
+                        )}
+                        download
+                        className="mt-1 block text-xs underline opacity-80"
+                      >
+                        [첨부 파일]
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setReplyTo(msg.id)}
+                      className={`absolute ${isOwn ? '-left-6' : '-right-6'} top-1 hidden text-muted-foreground group-hover:block`}
+                      title="답장"
+                    >
+                      ↩
+                    </button>
+                  </div>
+                  <p
+                    className={`mt-0.5 text-xs text-muted-foreground ${isOwn ? 'text-right' : 'text-left'}`}
+                  >
+                    {fmtTime(msg.ts)}
+                  </p>
+                </div>
+              </div>
+            );
+          })}
+          <div ref={bottomRef} />
+        </section>
+
+        {/* 입력 영역 */}
+        <div className="border-t border-border bg-background px-4 pb-safe-4 pb-4 pt-3">
+          {replyTo && (
+            <div className="mb-2 flex items-center gap-2 rounded-md bg-muted px-3 py-1.5 text-xs text-muted-foreground">
+              <span>
+                ↩{' '}
+                {(msgMapRef.current.get(replyTo)?.content ?? '').slice(0, 40) || '첨부 파일'}
+              </span>
+              <button
+                type="button"
+                onClick={() => setReplyTo(null)}
+                className="ml-auto"
+                aria-label="답장 취소"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+          {pendingFile && (
+            <div className="mb-2 flex items-center gap-2 rounded-md bg-muted px-3 py-1.5 text-xs text-muted-foreground">
+              <Paperclip className="h-3 w-3 flex-shrink-0" />
+              <span className="truncate">{pendingFile.name}</span>
+              <button
+                type="button"
+                onClick={() => setPendingFile(null)}
+                className="ml-auto flex-shrink-0"
+                aria-label="파일 제거"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          )}
+          <div className="flex items-end gap-2">
+            <textarea
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              rows={2}
+              placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+              className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(e) => setPendingFile(e.target.files?.[0] ?? null)}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => fileInputRef.current?.click()}
+              title="파일 첨부"
+            >
+              <Paperclip className="h-4 w-4" />
+            </Button>
+            <Button
+              type="button"
+              size="icon"
+              onClick={() => void sendMessage()}
+              disabled={!input.trim() && !pendingFile}
+              title="전송"
+            >
+              <Send className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/channel/page.tsx
+++ b/apps/web/src/app/(authenticated)/channel/page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { Paperclip, Send, X } from 'lucide-react';
 import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
@@ -33,6 +34,7 @@ function fmtTime(ts: string): string {
 }
 
 export default function ChannelPage() {
+  const t = useTranslations('channel');
   const searchParams = useSearchParams();
   const agentId = searchParams.get('agent_id');
   const { currentTeamMemberId } = useDashboardContext();
@@ -146,16 +148,16 @@ export default function ChannelPage() {
   if (!agentId) {
     return (
       <div className="flex h-64 items-center justify-center">
-        <p className="text-sm text-muted-foreground">agent_id 파라미터가 필요합니다.</p>
+        <p className="text-sm text-muted-foreground">{t('missingAgentId')}</p>
       </div>
     );
   }
 
   const statusDot =
     wsStatus === 'connected'
-      ? 'bg-green-500'
+      ? 'bg-success'
       : wsStatus === 'connecting'
-        ? 'bg-yellow-500 animate-pulse'
+        ? 'bg-warning animate-pulse'
         : 'bg-muted-foreground';
 
   return (
@@ -163,7 +165,7 @@ export default function ChannelPage() {
       <TopBarSlot
         title={
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-foreground">채널 채팅</span>
+            <span className="text-sm font-medium text-foreground">{t('title')}</span>
             <span className={`h-2 w-2 rounded-full ${statusDot}`} title={wsStatus} />
           </div>
         }
@@ -174,13 +176,11 @@ export default function ChannelPage() {
         <section className="flex-1 overflow-y-auto px-4 py-4">
           {messages.length === 0 && (
             <p className="py-8 text-center text-sm text-muted-foreground">
-              {wsStatus === 'connecting' ? '연결 중…' : '메시지가 없습니다.'}
+              {wsStatus === 'connecting' ? t('connecting') : t('empty')}
             </p>
           )}
           {messages.map((msg) => {
             const isOwn = msg.senderId === currentTeamMemberId;
-            const replyTarget = replyTo === msg.id ? msg : null;
-            void replyTarget;
 
             return (
               <div
@@ -206,14 +206,14 @@ export default function ChannelPage() {
                         download
                         className="mt-1 block text-xs underline opacity-80"
                       >
-                        [첨부 파일]
+                        [{t('attachment')}]
                       </a>
                     )}
                     <button
                       type="button"
                       onClick={() => setReplyTo(msg.id)}
                       className={`absolute ${isOwn ? '-left-6' : '-right-6'} top-1 hidden text-muted-foreground group-hover:block`}
-                      title="답장"
+                      title={t('reply')}
                     >
                       ↩
                     </button>
@@ -236,13 +236,13 @@ export default function ChannelPage() {
             <div className="mb-2 flex items-center gap-2 rounded-md bg-muted px-3 py-1.5 text-xs text-muted-foreground">
               <span>
                 ↩{' '}
-                {(msgMapRef.current.get(replyTo)?.content ?? '').slice(0, 40) || '첨부 파일'}
+                {(msgMapRef.current.get(replyTo)?.content ?? '').slice(0, 40) || t('attachment')}
               </span>
               <button
                 type="button"
                 onClick={() => setReplyTo(null)}
                 className="ml-auto"
-                aria-label="답장 취소"
+                aria-label={t('cancelReply')}
               >
                 <X className="h-3 w-3" />
               </button>
@@ -256,7 +256,7 @@ export default function ChannelPage() {
                 type="button"
                 onClick={() => setPendingFile(null)}
                 className="ml-auto flex-shrink-0"
-                aria-label="파일 제거"
+                aria-label={t('removeFile')}
               >
                 <X className="h-3 w-3" />
               </button>
@@ -268,7 +268,7 @@ export default function ChannelPage() {
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={handleKeyDown}
               rows={2}
-              placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈)"
+              placeholder={t('inputPlaceholder')}
               className="min-h-[44px] flex-1 resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
             />
             <input
@@ -282,7 +282,7 @@ export default function ChannelPage() {
               variant="ghost"
               size="icon"
               onClick={() => fileInputRef.current?.click()}
-              title="파일 첨부"
+              title={t('attachFile')}
             >
               <Paperclip className="h-4 w-4" />
             </Button>
@@ -291,7 +291,7 @@ export default function ChannelPage() {
               size="icon"
               onClick={() => void sendMessage()}
               disabled={!input.trim() && !pendingFile}
-              title="전송"
+              title={t('send')}
             >
               <Send className="h-4 w-4" />
             </Button>

--- a/apps/web/src/app/api/channel/deliver/route.ts
+++ b/apps/web/src/app/api/channel/deliver/route.ts
@@ -1,0 +1,21 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  const body = await request.text();
+  const res = await fetch(
+    `${FASTAPI_URL()}/api/v2/channel/deliver?token=${encodeURIComponent(session.access_token)}`,
+    { method: 'POST', headers: { 'Content-Type': 'application/json' }, body },
+  );
+  const resBody = await res.text();
+  return new NextResponse(resBody, {
+    status: res.status,
+    headers: { 'Content-Type': res.headers.get('Content-Type') ?? 'application/json' },
+  });
+}

--- a/apps/web/src/app/api/channel/files/[name]/route.ts
+++ b/apps/web/src/app/api/channel/files/[name]/route.ts
@@ -1,0 +1,25 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  const { name } = await params;
+  const res = await fetch(
+    `${FASTAPI_URL()}/api/v2/channel/files/${encodeURIComponent(name)}`,
+    { headers: { Authorization: `Bearer ${session.access_token}` } },
+  );
+  if (!res.ok) return new NextResponse(null, { status: res.status });
+
+  const blob = await res.blob();
+  return new NextResponse(blob, {
+    headers: { 'Content-Type': res.headers.get('Content-Type') ?? 'application/octet-stream' },
+  });
+}

--- a/apps/web/src/app/api/channel/token/route.ts
+++ b/apps/web/src/app/api/channel/token/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+
+export async function GET(): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+  return NextResponse.json({ token: session.access_token });
+}

--- a/apps/web/src/app/api/channel/upload/route.ts
+++ b/apps/web/src/app/api/channel/upload/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+
+export async function POST(request: NextRequest): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  const formData = await request.formData();
+  const res = await fetch(
+    `${FASTAPI_URL()}/api/v2/channel/upload?token=${encodeURIComponent(session.access_token)}`,
+    { method: 'POST', body: formData },
+  );
+  const resBody = await res.text();
+  return new NextResponse(resBody, { status: res.status });
+}


### PR DESCRIPTION
## 변경 사항

E-FAKECHAT-INTEG 에픽 S4 — fakechat Bun HTTP 서버에 있던 채팅 UI를 Sprintable Next.js 앱으로 이전.

### Next.js API Routes (4개)

| Route | Method | 역할 |
|---|---|---|
| `/api/channel/token` | GET | sp_at 쿠키 → JWT 반환 (WS 클라이언트 인증용) |
| `/api/channel/deliver` | POST | JSON 메시지 → FastAPI `/api/v2/channel/deliver` proxy |
| `/api/channel/upload` | POST | multipart 파일 → FastAPI `/api/v2/channel/upload` proxy |
| `/api/channel/files/[name]` | GET | 첨부 파일 → FastAPI `/api/v2/channel/files/{name}` proxy |

### 채팅 페이지 (`/channel?agent_id=<uuid>`)

- **WebSocket 실시간** — `ws://{FASTAPI_URL}/ws/chat/{agent_id}?token=<jwt>` 직접 연결
- **메시지 송신** — 텍스트만: WS 전송 / 파일 포함: `/api/channel/upload` POST
- **파일 첨부** — 파일 선택 chip 표시 + 전송 후 `/api/channel/files/` 링크
- **quote-reply** — hover 시 ↩ 버튼, 입력창 위 quote chip + 취소
- **타임스탬프** — HH:MM 형식 (ko-KR locale)
- **자동 스크롤** — 새 메시지 도착 시 smooth scroll
- **연결 상태 dot** — 녹색(connected) / 황색 pulse(connecting) / 회색(disconnected)
- **메시지 정렬** — 본인 메시지 우측(bg-brand) / 에이전트 좌측(bg-muted)

## 의존 관계

- S1 (`feature/ws-chat-hub`) — FastAPI WS 허브, PR #1019 develop 머지 완료 ✅
- S2 (`feature/channel-http-api`) — FastAPI HTTP 채널 API, PR 리뷰 대기 중 (백엔드)

## 반응형 확인

- 모바일: max-w-[70%] 버블, textarea resize-none
- 데스크톱: 동일 레이아웃
- 레이아웃 변경 없음 (신규 페이지)

## 빌드 메모

- 신규 파일 5개, 수정 파일 0개
- pre-existing TS 오류와 무관, 새 파일 TS 오류 0건