### PR TITLE
feat(compose): E-FAKECHAT-INTEG:S5 — docker-compose 통합 + OSS 온보딩

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,25 @@ NEXT_PUBLIC_FASTAPI_URL=http://localhost:8000
 
 # Secret token shared with GitHub webhook. Generate: openssl rand -hex 32
 # GITHUB_WEBHOOK_SECRET=
+
+# -----------------------------------------------------------------------------
+# Agent Chat / fakechat MCP (optional — required for real-time agent chat)
+# -----------------------------------------------------------------------------
+# fakechat is the MCP plugin that connects Claude Code (or any MCP agent) to
+# the Sprintable real-time chat channel via WebSocket.
+#
+# Setup:
+#   1. In Sprintable UI: Settings → Agents → New Agent → copy Agent ID + API Key
+#   2. Add to your Claude Code .mcp.json (see README → Agent Chat)
+#   3. Set the two variables below in your .env (or in the MCP env block)
+#
+# SPRINTABLE_AGENT_ID — UUID of the agent team member (from Settings → Agents)
+# SPRINTABLE_AGENT_ID=00000000-0000-0000-0000-000000000000
+#
+# SPRINTABLE_API_KEY — API key for WS authentication (sk_live_...)
+# SPRINTABLE_API_KEY=sk_live_...
+#
+# SPRINTABLE_WS_URL — WebSocket base URL of the backend
+#   docker-compose (host → container): ws://localhost:8000  (default)
+#   docker-compose (container → container): ws://backend:8000
+# SPRINTABLE_WS_URL=ws://localhost:8000

--- a/README.md
+++ b/README.md
@@ -236,6 +236,77 @@ send_memo({
 
 ---
 
+## Agent Chat (fakechat)
+
+fakechat is the MCP plugin that connects your agent to the Sprintable real-time WebSocket chat channel. Once configured, messages sent to your agent appear as `<channel source="fakechat" ...>` tags in your agent's session, and replies go back through the same channel.
+
+### Prerequisites
+
+- Sprintable running (`docker compose up -d`)
+- An agent registered in Sprintable (Settings → Agents → New Agent)
+
+### Step 1 — Get your Agent ID and API Key
+
+In Sprintable: **Settings → Agents → [Your Agent]**
+
+Copy:
+- **Agent ID** — UUID shown in the agent detail page
+- **API Key** — `sk_live_...` token (generated once, store safely)
+
+### Step 2 — Add fakechat to your MCP config
+
+**Claude Code** (`.claude/mcp.json` or `.mcp.json` in your project):
+
+```json
+{
+  "mcpServers": {
+    "fakechat": {
+      "type": "stdio",
+      "command": "bun",
+      "args": ["packages/fakechat/server.ts"],
+      "env": {
+        "SPRINTABLE_AGENT_ID": "YOUR_AGENT_UUID",
+        "SPRINTABLE_API_KEY": "sk_live_...",
+        "SPRINTABLE_WS_URL": "ws://localhost:8000"
+      }
+    }
+  }
+}
+```
+
+> If your agent runs **inside** a Docker network, set `SPRINTABLE_WS_URL=ws://backend:8000` instead.
+
+### Step 3 — Start chatting
+
+With both Sprintable and fakechat running, open the **Channel** page in the Sprintable UI (or use `send_chat_message` via MCP). Messages flow:
+
+```
+Sprintable UI / API
+      │  POST /api/v2/channel/deliver
+      ▼
+Backend WebSocket Hub (/ws/chat/{agent_id})
+      │  broadcast
+      ▼
+fakechat (WS client) → mcp.notification → Claude Code <channel> tag
+```
+
+Reply path (agent → UI):
+
+```
+Claude Code reply tool
+      │  ws.send({ content })
+      ▼
+Backend WebSocket Hub → broadcast to all room members
+      ▼
+Sprintable UI / other WS clients
+```
+
+### Reconnection
+
+fakechat reconnects automatically with exponential backoff (1 s → 30 s) if the backend restarts.
+
+---
+
 ## Connect GitHub (auto-close stories)
 
 When a PR merges, the linked story moves to **Done** automatically.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@ services:
       JWT_SECRET: ${JWT_SECRET:-change-me-in-production-min-32-chars}
       SECRET_KEY: ${SECRET_KEY:-change-me-in-production-min-32-chars}
       DEBUG: "True"
+      # Agent chat file uploads (POST /api/v2/channel/upload)
+      CHANNEL_FILES_DIR: /app/data/channel_files
+    volumes:
+      - ./data/channel_files:/app/data/channel_files
     command: >
       sh -c "python bootstrap.py && uvicorn app.main:app --host 0.0.0.0 --port 8000"
     ports:


### PR DESCRIPTION
## Summary

- `docker-compose.yml`: backend에 `CHANNEL_FILES_DIR=/app/data/channel_files` + 볼륨 마운트 추가 (파일 업로드 지속성)
- `.env.example`: `# Agent Chat / fakechat MCP` 섹션 신설 — `SPRINTABLE_AGENT_ID`, `SPRINTABLE_API_KEY`, `SPRINTABLE_WS_URL` 안내
- `README.md`: **Agent Chat (fakechat)** 온보딩 섹션 신설 — Step-by-step 설정 + 메시지 플로우 다이어그램

## AC Checklist

- [x] AC1: `docker compose up` → 백엔드 WS 허브(`/ws/chat/{agent_id}`) 8000 포트에서 서빙, 채팅 즉시 동작 가능
- [x] AC2: `SPRINTABLE_WS_URL` 기본값 `ws://localhost:8000`으로 추가 설정 최소화 (Agent ID + API Key만 필수)
- [x] AC3: README Agent Chat 섹션 — Step 1~3 + 메시지 플로우 + 재연결 안내 완비

## Test plan

- [ ] `docker compose up -d` 후 `ws://localhost:8000/ws/chat/{agent_id}?api_key=sk_live_...` WS 연결 확인
- [ ] `POST /api/v2/channel/upload` → `./data/channel_files/` 에 파일 저장 확인
- [ ] `.env.example` 변수 설명 정확성 검토
- [ ] README fakechat 섹션 링크/커맨드 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)