### PR TITLE
[DH] 앱 전체 이중 헤더 제거 (TopBar 통합 정책 적용)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 
+import { useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChatListView } from '@/components/chat/chat-list-view';
 import { useDashboardContext } from '../../dashboard/dashboard-shell';
@@ -9,6 +12,7 @@ import { EmptyState } from '@/components/ui/empty-state';
 export default function ChatsPage() {
   const t = useTranslations('chats');
   const { currentTeamMemberId, projectId } = useDashboardContext();
+  const [showModal, setShowModal] = useState(false);
 
   if (!currentTeamMemberId || !projectId) {
     return (
@@ -20,9 +24,22 @@ export default function ChatsPage() {
 
   return (
     <>
-      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <TopBarSlot
+        title={<h1 className="text-sm font-medium">{t('title')}</h1>}
+        actions={
+          <Button size="sm" variant="outline" onClick={() => setShowModal(true)}>
+            <Plus className="mr-1.5 h-3.5 w-3.5" />
+            {t('newConversation')}
+          </Button>
+        }
+      />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <ChatListView projectId={projectId} currentTeamMemberId={currentTeamMemberId} />
+        <ChatListView
+          projectId={projectId}
+          currentTeamMemberId={currentTeamMemberId}
+          open={showModal}
+          onOpenChange={setShowModal}
+        />
       </div>
     </>
   );

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -676,8 +676,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
   ) : (
     <div className="flex h-full items-center justify-center p-4 lg:p-6">
       <EmptyState
-        title={t('title')}
-        description={t('selectDoc')}
+        title={t('selectDoc')}
         className="w-full max-w-lg bg-background/70"
         action={
           <Button size="sm" onClick={handleNewDoc}>
@@ -717,7 +716,6 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
             aria-label="문서 트리 열기"
           >
             <Menu className="size-4" />
-            <span>{t('title')}</span>
           </button>
         </div>
         {/* Content area — always visible on mobile */}
@@ -733,8 +731,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
               aria-hidden="true"
             />
             <div className="fixed inset-y-0 left-0 z-50 flex w-[280px] flex-col overflow-hidden bg-background shadow-xl">
-              <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-3">
-                <span className="text-sm font-medium text-foreground">{t('title')}</span>
+              <div className="flex flex-shrink-0 items-center justify-end border-b border-border/80 px-4 py-3">
                 <button
                   type="button"
                   onClick={() => setTreeDrawerOpen(false)}

--- a/apps/web/src/app/(authenticated)/retro/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { Plus } from 'lucide-react';
+import { Plus, X } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -29,12 +29,14 @@ const PHASE_VARIANTS: Record<string, 'success' | 'info' | 'outline' | 'secondary
 
 export default function RetroPage() {
   const t = useTranslations('retro');
+  const tc = useTranslations('common');
   const shellT = useTranslations('shell');
   const { projectId, orgId } = useDashboardContext();
   const [sessions, setSessions] = useState<RetroSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [title, setTitle] = useState('');
   const [creating, setCreating] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
 
@@ -79,6 +81,7 @@ export default function RetroPage() {
       const json = await res.json();
       setSessions((prev) => [json.data, ...prev]);
       setTitle('');
+      setShowCreateForm(false);
     } catch (err) {
       setCreateError(err instanceof Error ? err.message : 'Failed to create session');
     } finally {
@@ -111,36 +114,39 @@ export default function RetroPage() {
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
         actions={
-          <Button size="sm" variant="outline" onClick={() => document.getElementById('retro-title-input')?.focus()}>
-            <Plus className="mr-1.5 h-3.5 w-3.5" />
-            {t('newSession')}
+          <Button size="sm" variant="outline" onClick={() => setShowCreateForm((v) => !v)}>
+            {showCreateForm ? (
+              <><X className="mr-1.5 h-3.5 w-3.5" />{tc('cancel')}</>
+            ) : (
+              <><Plus className="mr-1.5 h-3.5 w-3.5" />{t('newSession')}</>
+            )}
           </Button>
         }
       />
 
       <div className="flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto">
-        {/* Create new session */}
-        <div className="flex-shrink-0 border-b border-border/80 px-6 py-4">
-          <p className="mb-3 text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            {t('newSession')}
-          </p>
-          <div className="flex gap-2">
-            <Input
-              id="retro-title-input"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
-              placeholder={t('newSessionPlaceholder')}
-              className="flex-1"
-            />
-            <Button variant="default" onClick={handleCreate} disabled={!title.trim() || !orgId || creating}>
-              {creating ? t('creating') : t('create')}
-            </Button>
+        {/* Create new session — toggle via TopBar button */}
+        {showCreateForm && (
+          <div className="flex-shrink-0 border-b border-border/80 px-6 py-4">
+            <div className="flex gap-2">
+              <Input
+                id="retro-title-input"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
+                placeholder={t('newSessionPlaceholder')}
+                className="flex-1"
+                autoFocus
+              />
+              <Button variant="default" onClick={handleCreate} disabled={!title.trim() || !orgId || creating}>
+                {creating ? t('creating') : t('create')}
+              </Button>
+            </div>
+            {createError ? (
+              <p className="mt-2 text-xs text-destructive">{createError}</p>
+            ) : null}
           </div>
-          {createError ? (
-            <p className="mt-2 text-xs text-destructive">{createError}</p>
-          ) : null}
-        </div>
+        )}
 
         {/* Session list */}
         <div className="flex-1 px-6 py-4">

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -2,9 +2,8 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Bot, MessageSquare, Plus, Users } from 'lucide-react';
+import { Bot, MessageSquare, Users } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { NewConversationModal } from './new-conversation-modal';
@@ -29,6 +28,8 @@ interface ConversationItem {
 interface ChatListViewProps {
   projectId: string;
   currentTeamMemberId: string;
+  open?: boolean;
+  onOpenChange?: (v: boolean) => void;
 }
 
 function formatTime(iso: string): string {
@@ -149,7 +150,7 @@ function applyConversationMessageUpdate(
 
 const PAGE_LIMIT = 30;
 
-export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewProps) {
+export function ChatListView({ projectId, currentTeamMemberId, open, onOpenChange }: ChatListViewProps) {
   const t = useTranslations('chats');
   const router = useRouter();
   const [conversations, setConversations] = useState<ConversationItem[]>([]);
@@ -161,7 +162,9 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
   const [myTotal, setMyTotal] = useState(0);
   const [agentOffset, setAgentOffset] = useState(0);
   const [agentTotal, setAgentTotal] = useState(0);
-  const [showModal, setShowModal] = useState(false);
+  const [internalShowModal, setInternalShowModal] = useState(false);
+  const showModal = open !== undefined ? open : internalShowModal;
+  const setShowModal = onOpenChange ?? setInternalShowModal;
 
   const convsRef = useRef(conversations);
   useEffect(() => { convsRef.current = conversations; }, [conversations]);
@@ -302,15 +305,6 @@ export function ChatListView({ projectId, currentTeamMemberId }: ChatListViewPro
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex flex-shrink-0 items-center justify-between border-b border-border/80 px-4 py-3">
-        <h2 className="text-sm font-semibold text-foreground">{t('title')}</h2>
-        <Button size="sm" variant="outline" onClick={() => setShowModal(true)}>
-          <Plus className="mr-1.5 h-3.5 w-3.5" />
-          {t('newConversation')}
-        </Button>
-      </div>
-
       {isAdminOrOwner ? (
         <Tabs defaultValue="my" className="flex min-h-0 flex-1 flex-col">
           <TabsList className="mx-4 mt-2 w-auto self-start">


### PR DESCRIPTION
## Story

**Story ID**: `3661522f-9f68-4d05-980d-fdb93d5ba0ea`
**Epic**: DH — Dual Header Removal
**SP**: 3 (M) | **Priority**: High — 선생님 직접 지적

## Summary

TopBar 통합 정책(D-DH-1) 적용 — 3개 페이지 이중 헤더 제거.

- `/chats`: 콘텐츠 h2 헤더 + "+ 새 대화" 버튼 제거 → TopBar actions 통합, `open/onOpenChange` controlled prop 추가
- `/docs`: 모바일 드로어 헤더 타이틀 + 드로어 toggle 버튼 텍스트 제거 (X 아이콘 only), 콘텐츠 EmptyState title 수정
- `/retro`: 항상 노출 인라인 폼 → `showCreateForm` 토글 패턴 적용, 생성 성공 시 자동 닫힘

잠재 추가 영향 페이지 grep 완료 — 추가 수정 대상 없음 확인 (settings LNB 헤더/inbox TopBar 안 — 모두 정상 패턴).

## AC 체크리스트

- [x] AC1 TopBar 통합 정책 (title + actions)
- [x] AC2 `/chats` 콘텐츠 h2 헤더 + 새 대화 버튼 제거
- [x] AC3 `/docs` 드로어 헤더 + 콘텐츠 EmptyState 수정
- [x] AC4 `/retro` 인라인 폼 토글 적용
- [x] AC5 잠재 영향 페이지 grep 확장 검증 — 추가 수정 대상 없음
- [ ] AC6 핵심 5화면 회귀 무 (가디언 검증)
- [x] AC7 i18n 신규 키 없음 (기존 common.cancel 재사용)
- [x] AC8 pnpm tsc --noEmit — 변경 파일 에러 0

## Commits

```
refactor(chats): hoist title + new conversation action to TopBar slot
refactor(docs): remove drawer title and content-area dup header
refactor(retro): toggle new-session inline form via TopBar action
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)