### PR TITLE
[CHP] Agent Chats 리스트 참여자 시각 표시

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2129,7 +2129,11 @@
     "addParticipantsTitle": "Add Participants",
     "participantsOthers": "{count} more",
     "forkInfo": "Adding someone to a DM creates a new group chat. The existing DM is preserved.",
-    "adding": "Adding…"
+    "adding": "Adding…",
+    "you": "You",
+    "agent": "Agent",
+    "personCount": "{count} people",
+    "agentCount": "You + {count} agents"
   },
   "activityLog": {
     "title": "Activity Log",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2129,7 +2129,11 @@
     "addParticipantsTitle": "참여자 추가",
     "participantsOthers": "외 {count}명",
     "forkInfo": "DM에 참여자를 추가하면 새 그룹 채팅이 생성됩니다. 기존 DM은 유지됩니다.",
-    "adding": "추가 중…"
+    "adding": "추가 중…",
+    "you": "나",
+    "agent": "에이전트",
+    "personCount": "{count}명",
+    "agentCount": "나 + {count}명의 에이전트"
   },
   "activityLog": {
     "title": "활동 로그",

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -13,6 +13,7 @@ interface Participant {
   member_id: string;
   name: string;
   avatar_url?: string | null;
+  type?: 'agent' | 'human';
 }
 
 interface ConversationItem {
@@ -47,14 +48,23 @@ function formatParticipantNames(
   participants: Participant[],
   currentMemberId: string,
   type: 'dm' | 'group',
+  t: (key: string, values?: Record<string, string | number>) => string,
 ): string {
   const others = participants.filter((p) => p.member_id !== currentMemberId);
-  if (others.length === 0) return type === 'dm' ? 'DM' : '그룹 채팅';
+  if (others.length === 0) return type === 'dm' ? 'DM' : t('groupSection');
   if (type === 'dm') return others[0]!.name;
   const MAX = 3;
   if (others.length <= MAX) return others.map((p) => p.name).join(', ');
   const visible = others.slice(0, MAX).map((p) => p.name).join(', ');
-  return `${visible} 외 ${others.length - MAX}명`;
+  return `${visible} ${t('participantsOthers', { count: others.length - MAX })}`;
+}
+
+function getOtherParticipants(participants: Participant[], currentMemberId: string): Participant[] {
+  return participants.filter((p) => p.member_id !== currentMemberId);
+}
+
+function hasAgentParticipant(participants: Participant[]): boolean {
+  return participants.some((p) => p.type === 'agent');
 }
 
 function ConversationRow({
@@ -72,8 +82,8 @@ function ConversationRow({
 
   const displayName = conv.title ??
     (conv.participants && conv.participants.length > 0
-      ? formatParticipantNames(conv.participants, currentMemberId, conv.type)
-      : conv.type === 'dm' ? t('dmWith') : '그룹 채팅');
+      ? formatParticipantNames(conv.participants, currentMemberId, conv.type, t)
+      : conv.type === 'dm' ? t('dmWith') : t('groupSection'));
 
   const preview = conv.latest_message?.content ?? t('noMessages');
   const time = conv.latest_message?.created_at ?? conv.updated_at;
@@ -82,6 +92,54 @@ function ConversationRow({
   const avatarInitial = !isAgentConv && conv.type === 'dm' && conv.participants
     ? (conv.participants.find((p) => p.member_id !== currentMemberId)?.name.slice(0, 2) ?? 'DM')
     : null;
+
+  const others = conv.participants ? getOtherParticipants(conv.participants, currentMemberId) : [];
+  const isAgentInConv = conv.participants ? hasAgentParticipant(conv.participants) : false;
+  const agentCount = others.filter((p) => p.type === 'agent').length;
+
+  const participantLayer = conv.participants && conv.participants.length > 0 ? (
+    conv.type === 'dm' ? (
+      <div className="mt-0.5 flex items-center gap-1 text-[11px] text-muted-foreground">
+        <span className="rounded bg-muted px-1 py-0.5 font-medium text-muted-foreground">{t('you')}</span>
+        <span>↔</span>
+        <span className="max-w-[80px] truncate rounded bg-muted px-1 py-0.5 font-medium text-muted-foreground">
+          {others[0]?.name ?? '...'}
+        </span>
+        {isAgentInConv && (
+          <span className="flex-shrink-0 rounded border border-brand/30 bg-brand/12 px-1.5 py-0.5 text-[10px] font-medium text-brand-strong">
+            {t('agent')}
+          </span>
+        )}
+      </div>
+    ) : (
+      <div className="mt-0.5 flex items-center gap-1.5 text-[11px] text-muted-foreground">
+        <div className="flex -space-x-1.5">
+          {others.slice(0, 3).map((p) => (
+            <div
+              key={p.member_id}
+              className="relative flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground ring-1 ring-background"
+            >
+              {p.name.slice(0, 1)}
+              {p.type === 'agent' && (
+                <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-brand-strong ring-1 ring-background" />
+              )}
+            </div>
+          ))}
+          {others.length > 3 && (
+            <div className="flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground ring-1 ring-background">
+              +{others.length - 3}
+            </div>
+          )}
+        </div>
+        <span className="truncate">
+          {isAgentInConv && agentCount > 0
+            ? t('agentCount', { count: agentCount })
+            : `${t('personCount', { count: others.length + 1 })} · ${others.slice(0, 2).map((p) => p.name).join(', ')}${others.length > 2 ? ` ${t('participantsOthers', { count: others.length - 2 })}` : ''}`
+          }
+        </span>
+      </div>
+    )
+  ) : null;
 
   return (
     <button
@@ -112,6 +170,7 @@ function ConversationRow({
           <span className="truncate text-sm font-medium text-foreground">{displayName}</span>
           <span className="flex-shrink-0 text-[10px] text-muted-foreground">{formatTime(time)}</span>
         </div>
+        {participantLayer}
         <div className="flex items-center justify-between gap-1">
           <p className="truncate text-xs text-muted-foreground">{preview}</p>
           {unread > 0 && (

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -383,10 +383,10 @@ async def list_conversations(
 
     all_member_ids = {r.member_id for r in p_rows}
     member_rows = (await db.execute(
-        select(TeamMember.id, TeamMember.name, TeamMember.avatar_url)
+        select(TeamMember.id, TeamMember.name, TeamMember.avatar_url, TeamMember.type)
         .where(TeamMember.id.in_(all_member_ids))
     )).all() if all_member_ids else []
-    member_map = {r.id: {"name": r.name, "avatar_url": r.avatar_url} for r in member_rows}
+    member_map = {r.id: {"name": r.name, "avatar_url": r.avatar_url, "type": r.type} for r in member_rows}
 
     conv_participants: dict[uuid.UUID, list[dict]] = defaultdict(list)
     for r in p_rows:
@@ -395,6 +395,7 @@ async def list_conversations(
             "member_id": str(r.member_id),
             "name": info.get("name"),
             "avatar_url": info.get("avatar_url"),
+            "type": info.get("type", "human"),
         })
 
     result = []


### PR DESCRIPTION
## Story

**Story ID**: `c5c053cc-f539-4e77-844d-9c50dc613914`
**Epic**: CHP — Chats Participants
**SP**: 2 (S) | **Priority**: High — 선생님 직접 지적

## Summary

`/chats` 리스트에서 참여자 시각 layer 추가.

- **Backend**: `conversations.py` participants 배치 조회에 `TeamMember.type` 추가 → payload에 `"type": "agent" | "human"` 포함
- **Frontend**: `chat-list-view.tsx` `ConversationRow` 내부 강화
  - DM: `You ↔ 상대` chip + `Agent` badge (agent 참여자 있을 때)
  - 그룹: 18px avatar stack (최대 3 + `+N` overflow) + agent dot indicator (6px brand-strong) + 참여자 수/이름 join
  - `Participant` interface `type?` 추가 (graceful degradation — type 없어도 기존 동작 유지)
  - 한국어 하드코딩 정리 (`formatParticipantNames` → `t('groupSection')`, `t('participantsOthers')`)
- **i18n**: `chats` namespace 4키 추가 (`you` / `agent` / `personCount` / `agentCount`) ko ↔ en 1:1

## AC 체크리스트

- [x] AC1 DM 참여자 시각 표시 (You ↔ 상대 chip)
- [x] AC2 그룹 with title — avatar stack + 참여자 수 + 이름 join
- [x] AC3 그룹 with agent — agent dot indicator + agent count
- [x] AC4 기존 `participants` 데이터 활용 (신규 backend API 0)
- [x] AC5 한국어 하드코딩 정리 + i18n 키 추가 (ko ↔ en 1:1)
- [x] AC6 DS-S13 토큰 활용 (`bg-brand-strong`, `bg-brand/12`, `text-brand-strong`, `bg-muted`)
- [x] AC7 신규 component 0건 (`ConversationRow` 내부 강화만)
- [x] AC8 `pnpm exec tsc --noEmit` 통과 (변경 파일 에러 0)

## Commits

```
feat(backend): add member type to conversation participants payload
refactor(chats): visualize participants with avatar stack and agent indicator
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)