### PR TITLE
feat(ws-chat): conversations API → ws_chat WebSocket 브로드캐스트 브리지

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -1,6 +1,7 @@
 """E-EVENTBUS P7-A S37: conversations 테이블 + Chat API."""
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from collections import defaultdict
@@ -735,6 +736,24 @@ async def send_message(
         _push_to_agent(pid_str, sse_payload)
     # 브라우저 SSE 구독자에게 1회 발행 — pending 유무와 무관하게 commit 후 항상 발행
     publish_event(str(org_id), "conversation:message", _msg_payload(msg, sender))
+
+    # ws_chat WebSocket 브로드캐스트 — ws-chat 전용 conversation이면 WS 허브로 실시간 전달
+    if conv.title and conv.title.startswith("ws-chat:") and conv.created_by:
+        try:
+            from app.routers.ws_chat import _broadcast
+            await _broadcast(
+                str(conv.created_by),
+                json.dumps({
+                    "id": str(msg.id),
+                    "conversation_id": str(conversation_id),
+                    "sender_id": str(sender.id),
+                    "sender_name": sender.name,
+                    "content": msg.content,
+                    "ts": msg.created_at.isoformat(),
+                }),
+            )
+        except Exception:
+            logger.warning("ws_chat broadcast failed message_id=%s", msg.id, exc_info=True)
 
     # webhook delivery BackgroundTask (AC1~8)
     from app.services.conversation_webhook import deliver_conversation_message_webhook


### PR DESCRIPTION
## Summary
- `POST /api/v2/conversations/{id}/messages` 호출 시 ws_chat WS 허브로 브로드캐스트 누락 버그 수정
- DB commit 완료 후 `conv.title`이 `ws-chat:` prefix이면 `_broadcast(str(conv.created_by), payload)` 호출
- 페이로드 형식은 ws_chat 자체 브로드캐스트와 동일(`id`, `conversation_id`, `sender_id`, `sender_name`, `content`, `ts`)
- WS 연결 없는 room은 no-op; 예외 발생 시 warning 로그만 남기고 응답 영향 없음

## Test plan
- [ ] WS 클라이언트 `/ws/chat/{agent_id}` 연결 후 conversations API로 메시지 전송 → 새로고침 없이 실시간 수신 확인
- [ ] ws-chat 아닌 일반 conversation 메시지 전송 → 기존 동작(SSE/웹훅/Discord) 유지 확인
- [ ] WS 연결 없는 상태에서 conversations API 메시지 전송 → 500 에러 없이 정상 응답 확인

## Story
story_id: 7973eceb-dda3-47ff-851e-50525c9291a0

🤖 Generated with [Claude Code](https://claude.com/claude-code)