### PR TITLE
feat(auth): _build_app_metadata org_members fallback 경로 추가

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -22,7 +22,7 @@ def _normalize_email(v: str) -> str:
         raise ValueError("Invalid email format")
     return v
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import or_, select, update
+from sqlalchemy import or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -290,6 +290,46 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
             }
 
     if not member:
+        # Path 4: org_members fallback — team_member 없지만 org에는 등록된 사용자
+        # 해당 org의 첫 project에 team_member 자동 생성 후 반환. 이후 로그인은 Path 1/2로 정상 진입.
+        org_member_result = await session.execute(
+            select(OrgMember)
+            .where(OrgMember.user_id == user.id, OrgMember.deleted_at.is_(None))
+            .order_by(OrgMember.created_at.asc())
+            .limit(1)
+        )
+        org_member = org_member_result.scalar_one_or_none()
+        if org_member:
+            project_result = await session.execute(
+                select(Project)
+                .where(Project.org_id == org_member.org_id, Project.deleted_at.is_(None))
+                .order_by(Project.created_at.asc())
+                .limit(1)
+            )
+            project = project_result.scalar_one_or_none()
+            if project:
+                member_name = (user.email or str(user.id)).split("@")[0]
+                await session.execute(
+                    text(
+                        "INSERT INTO team_members"
+                        " (id, org_id, project_id, user_id, type, name, role, is_active, color, can_manage_members)"
+                        " VALUES (gen_random_uuid(), :org_id, :project_id, :user_id,"
+                        "         'human', :name, :role, true, '#3385f8', false)"
+                    ),
+                    {
+                        "org_id": str(org_member.org_id),
+                        "project_id": str(project.id),
+                        "user_id": str(user.id),
+                        "name": member_name,
+                        "role": org_member.role,
+                    },
+                )
+                await session.flush()
+                return {
+                    "org_id": str(org_member.org_id),
+                    "project_id": str(project.id),
+                    "role": org_member.role,
+                }
         return {}
 
     # login 시 last_project_id 자동 갱신 — 다음 로그인부터 last_project_id 우선 경로 사용


### PR DESCRIPTION
## Summary
- Google OAuth 로그인 시 org_members에 등록됐지만 team_member가 없어 빈 "ORGANIZATION"으로 표시되는 버그 수정
- `_build_app_metadata` Path 1/2/3 모두 실패 후 `return {}` 직전에 Path 4 (org_members fallback) 추가
- `org_members.user_id == user.id AND deleted_at IS NULL` → 소속 org 첫 project 조회 → `team_members` INSERT → `{org_id, project_id, role}` 반환
- 이후 로그인에서는 자동 생성된 team_member로 Path 1/2 정상 진입

## 변경 파일
- `backend/app/routers/auth.py` — `text` import 추가 + Path 4 fallback 블록 (41줄)

## Test plan
- [ ] org_members에만 등록된 사용자로 Google OAuth 로그인 → org 컨텍스트 진입 + JWT에 org_id/project_id 포함 확인
- [ ] 동일 사용자 재로그인 → Path 1/2로 team_member 경로 정상 진입 확인
- [ ] 기존 team_member 있는 사용자 로그인 → Path 1/2 동작 무변경 확인
- [ ] org_members에도 없는 신규 사용자 → `return {}` 기존 동작 유지 확인

## Story
story_id: b5f182e3-d22e-42f2-b558-f611b95cc9f4

🤖 Generated with [Claude Code](https://claude.com/claude-code)