### PR TITLE
feat(org-invites): OrgInviteResponse invite_url 필드 노출

### DIFF
--- a/backend/app/routers/org_invites.py
+++ b/backend/app/routers/org_invites.py
@@ -15,6 +15,15 @@ from app.services.org_invite_email import send_invite_email
 router = APIRouter(prefix="/api/v2/organizations", tags=["org-invites"])
 
 
+def _to_response(invite) -> OrgInviteResponse:
+    """Invitation ORM → OrgInviteResponse. pending + 미만료인 경우만 invite_url 세팅."""
+    base = OrgInviteResponse.model_validate(invite)
+    invite_url = None
+    if invite.status == "pending" and invite.expires_at > datetime.now(timezone.utc):
+        invite_url = f"{settings.app_url}/invite/accept?token={invite.token}"
+    return base.model_copy(update={"invite_url": invite_url})
+
+
 def _get_invite_repo(session: AsyncSession = Depends(get_db)) -> OrgInviteRepository:
     return OrgInviteRepository(session)
 
@@ -45,7 +54,7 @@ async def list_org_invites(
     """pending 초대 목록 — owner/admin만 조회 가능."""
     await _require_owner_or_admin(id, auth, org_repo)
     items = await invite_repo.list_pending(org_id=id)
-    return [OrgInviteResponse.model_validate(i) for i in items]
+    return [_to_response(i) for i in items]
 
 
 @router.post("/{id}/invites", response_model=OrgInviteResponse, status_code=201)
@@ -90,7 +99,7 @@ async def create_org_invite(
     await session.commit()
 
     await session.refresh(invite)
-    return OrgInviteResponse.model_validate(invite)
+    return _to_response(invite)
 
 
 @router.post("/{id}/invites/{invite_id}/resend", response_model=OrgInviteResponse)
@@ -121,7 +130,7 @@ async def resend_org_invite(
     await session.commit()
 
     await session.refresh(invite)
-    return OrgInviteResponse.model_validate(invite)
+    return _to_response(invite)
 
 
 @router.delete("/{id}/invites/{invite_id}", response_model=OrgInviteResponse)
@@ -141,4 +150,4 @@ async def revoke_org_invite(
         raise HTTPException(status_code=404, detail="Invite not found")
 
     await session.commit()
-    return OrgInviteResponse.model_validate(invite)
+    return _to_response(invite)

--- a/backend/app/schemas/org_invite.py
+++ b/backend/app/schemas/org_invite.py
@@ -25,3 +25,4 @@ class OrgInviteResponse(BaseModel):
     created_at: datetime
     email_sent_at: datetime | None = None
     email_error: str | None = None
+    invite_url: str | None = None

--- a/backend/tests/test_e_org_multi_s3_1_org_invite.py
+++ b/backend/tests/test_e_org_multi_s3_1_org_invite.py
@@ -35,6 +35,7 @@ def _mock_invite(email: str = "new@example.com", role: str = "member") -> MagicM
     i.created_at = datetime.now(timezone.utc)
     i.email_sent_at = None
     i.email_error = None
+    i.invite_url = None
     return i
 
 


### PR DESCRIPTION
## Summary
- `OrgInviteResponse`에 `invite_url: str | None = None` 필드 추가
- `_to_response()` 헬퍼 추가 — `status == 'pending'` + `expires_at > now` 조건 충족 시에만 `{settings.app_url}/invite/accept?token={token}` 세팅, 나머지는 `None`
- create / list / resend / revoke 4개 반환 지점 전체 적용

## 변경 파일
- `backend/app/schemas/org_invite.py` — `invite_url` 필드 추가
- `backend/app/routers/org_invites.py` — `_to_response` 헬퍼 + 호출 지점 교체

## Test plan
- [ ] POST /invites → 응답에 `invite_url` 포함 확인 (pending 상태)
- [ ] GET /invites → 목록 항목에 `invite_url` 포함 확인
- [ ] 만료/취소된 invite → `invite_url: null` 확인
- [ ] 이메일 발송 실패 시나리오 — invite_url로 직접 수락 가능 확인

## Story
story_id: 1cda2bf1-9844-44c9-87e7-c1305518dfff

🤖 Generated with [Claude Code](https://claude.com/claude-code)