### PR TITLE
[INV-AC3] Org 초대 대기 row에 링크 복사 버튼 추가

### DIFF
--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Check, Copy } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
@@ -47,6 +48,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
   const [actionMessage, setActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [resendingId, setResendingId] = useState<string | null>(null);
   const [revokingId, setRevokingId] = useState<string | null>(null);
+  const [copiedInviteId, setCopiedInviteId] = useState<string | null>(null);
 
   const canManage = currentRole === 'owner' || currentRole === 'admin';
   const isOwner = currentRole === 'owner';
@@ -152,6 +154,17 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
       </div>
     );
   }
+
+  const handleCopyInviteLink = async (inviteId: string, url: string | undefined) => {
+    if (!url) return;
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopiedInviteId(inviteId);
+      setTimeout(() => setCopiedInviteId(null), 1500);
+    } catch {
+      setActionMessage({ type: 'error', text: '클립보드 복사에 실패했습니다.' });
+    }
+  };
 
   return (
     <div className="space-y-6">
@@ -275,6 +288,20 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                 </div>
                 {canManage && (
                   <div className="flex shrink-0 gap-1">
+                    <Button
+                      size="sm"
+                      variant="glass"
+                      disabled={!invite.invite_url}
+                      onClick={() => void handleCopyInviteLink(invite.id, invite.invite_url)}
+                      title={invite.invite_url ? '초대 링크 복사' : '링크 사용 불가'}
+                      className={copiedInviteId === invite.id ? 'text-success bg-success/12 border-success/30' : ''}
+                    >
+                      {copiedInviteId === invite.id ? (
+                        <><Check className="h-3 w-3 mr-1" />복사됨</>
+                      ) : (
+                        <><Copy className="h-3 w-3 mr-1" />링크 복사</>
+                      )}
+                    </Button>
                     <Button size="sm" variant="glass" disabled={resendingId === invite.id} onClick={() => void handleResendInvite(invite.id)}>
                       {resendingId === invite.id ? '...' : '재발송'}
                     </Button>


### PR DESCRIPTION
## 변경 사항

- **단일 파일**: `apps/web/src/components/settings/org-members-section.tsx`
- 초대 대기 row 액션 그룹 첫 번째 위치에 "링크 복사" 버튼 추가
- 클릭 시 `navigator.clipboard.writeText(invite.invite_url)` 호출
- 복사 후 1.5s 동안 Check 아이콘 + "복사됨" + success 토큰 색 피드백
- `invite_url` null/undefined 시 disabled + tooltip "링크 사용 불가"

## AC 체크

| AC | 결과 |
|---|---|
| 1. 액션 그룹 첫 번째 위치 "링크 복사" | ✅ |
| 2. clipboard.writeText 호출 | ✅ |
| 3. 1.5s Check + "복사됨" + success 토큰 | ✅ |
| 4. invite_url null → disabled + tooltip | ✅ |
| 5. tsc + build | ✅ |

## 검증

- `pnpm tsc --noEmit` ✅ 오류 0
- Copy/Check import 정합 ✅
- copiedInviteId state 사용 정합 ✅
- 단일 파일 수정 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)