### PR TITLE
feat(ws-chat): ws-chat 전용 conv 폐기 — 에이전트↔사용자 DM 재사용

### DIFF
--- a/backend/alembic/versions/0051_migrate_ws_chat_convs_to_dm.py
+++ b/backend/alembic/versions/0051_migrate_ws_chat_convs_to_dm.py
@@ -15,6 +15,44 @@ branch_labels = None
 depends_on = None
 
 
+def _find_or_create_dm(conn, agent_id: str, caller_id: str, org_id: str, project_id: str, now) -> str:
+    """에이전트↔사용자 DM conversation 조회 또는 생성. dm_id(str) 반환."""
+    existing = conn.execute(
+        sa.text(
+            "SELECT c.id FROM conversations c "
+            "JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.member_id = :agent_id "
+            "JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.member_id = :caller_id "
+            "WHERE c.type = 'dm' AND c.org_id = :org_id AND c.project_id = :project_id "
+            "AND c.status != 'deleted' LIMIT 1"
+        ),
+        {"agent_id": agent_id, "caller_id": caller_id, "org_id": org_id, "project_id": project_id},
+    ).fetchone()
+
+    if existing:
+        return str(existing.id)
+
+    dm_id = str(uuid.uuid4())
+    conn.execute(
+        sa.text(
+            "INSERT INTO conversations "
+            "(id, org_id, project_id, type, title, status, created_by, created_at, updated_at) "
+            "VALUES (:id, :org_id, :project_id, 'dm', NULL, 'open', :agent_id, :now, :now)"
+        ),
+        {"id": dm_id, "org_id": org_id, "project_id": project_id, "agent_id": agent_id, "now": now},
+    )
+    for mid in [agent_id, caller_id]:
+        conn.execute(
+            sa.text(
+                "INSERT INTO conversation_participants "
+                "(id, conversation_id, member_id, joined_at) "
+                "VALUES (gen_random_uuid(), :conv_id, :member_id, :now) "
+                "ON CONFLICT ON CONSTRAINT uq_conversation_participant DO NOTHING"
+            ),
+            {"conv_id": dm_id, "member_id": mid, "now": now},
+        )
+    return dm_id
+
+
 def upgrade() -> None:
     conn = op.get_bind()
     now = datetime.now(timezone.utc)
@@ -34,7 +72,7 @@ def upgrade() -> None:
         project_id = str(wsc.project_id)
         agent_id = title[len("ws-chat:"):]
 
-        # 2. 대화에 참여한 non-agent 발신자 조회
+        # 2. non-agent 발신자 목록 조회
         senders = conn.execute(
             sa.text(
                 "SELECT DISTINCT cm.sender_id FROM conversation_messages cm "
@@ -43,66 +81,42 @@ def upgrade() -> None:
             ),
             {"cid": conv_id},
         ).fetchall()
+        caller_ids = [str(s.sender_id) for s in senders]
 
-        if len(senders) == 0:
-            # 메시지 없는 ws-chat conv — 그냥 soft delete
-            pass
-        elif len(senders) == 1:
-            caller_id = str(senders[0].sender_id)
-
-            # 3. 기존 DM 조회 (에이전트 + 사용자 모두 participant)
-            existing = conn.execute(
+        if caller_ids:
+            # 3. agent 메시지 이관 대상 — 메시지 이관 전에 가장 활발한 caller 확인
+            most_active_row = conn.execute(
                 sa.text(
-                    "SELECT c.id FROM conversations c "
-                    "JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.member_id = :agent_id "
-                    "JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.member_id = :caller_id "
-                    "WHERE c.type = 'dm' AND c.org_id = :org_id AND c.status != 'deleted' "
-                    "LIMIT 1"
+                    "SELECT sender_id FROM conversation_messages "
+                    "WHERE conversation_id = :cid AND sender_id != :agent_id "
+                    "GROUP BY sender_id ORDER BY COUNT(*) DESC LIMIT 1"
                 ),
-                {"agent_id": agent_id, "caller_id": caller_id, "org_id": org_id},
+                {"cid": conv_id, "agent_id": agent_id},
             ).fetchone()
+            most_active_caller = str(most_active_row.sender_id) if most_active_row else caller_ids[0]
 
-            if existing:
-                dm_id = str(existing.id)
-            else:
-                # 4. DM conversation 신규 생성
-                dm_id = str(uuid.uuid4())
+            # 4. caller별 DM 생성/조회 + caller 발신 메시지 이관
+            caller_dm_map: dict[str, str] = {}
+            for caller_id in caller_ids:
+                dm_id = _find_or_create_dm(conn, agent_id, caller_id, org_id, project_id, now)
+                caller_dm_map[caller_id] = dm_id
                 conn.execute(
                     sa.text(
-                        "INSERT INTO conversations "
-                        "(id, org_id, project_id, type, title, status, created_by, created_at, updated_at) "
-                        "VALUES (:id, :org_id, :project_id, 'dm', NULL, 'open', :agent_id, :now, :now)"
+                        "UPDATE conversation_messages SET conversation_id = :dm_id "
+                        "WHERE conversation_id = :old_id AND sender_id = :caller_id"
                     ),
-                    {
-                        "id": dm_id,
-                        "org_id": org_id,
-                        "project_id": project_id,
-                        "agent_id": agent_id,
-                        "now": now,
-                    },
+                    {"dm_id": dm_id, "old_id": conv_id, "caller_id": caller_id},
                 )
-                for mid in [agent_id, caller_id]:
-                    conn.execute(
-                        sa.text(
-                            "INSERT INTO conversation_participants "
-                            "(id, conversation_id, member_id, joined_at) "
-                            "VALUES (gen_random_uuid(), :conv_id, :member_id, :now) "
-                            "ON CONFLICT ON CONSTRAINT uq_conversation_participant DO NOTHING"
-                        ),
-                        {"conv_id": dm_id, "member_id": mid, "now": now},
-                    )
 
-            # 5. 메시지 이관 (전체 — agent 발신 포함)
+            # 5. agent 발신 메시지 → 가장 활발한 caller의 DM으로 이관
+            primary_dm = caller_dm_map.get(most_active_caller, next(iter(caller_dm_map.values())))
             conn.execute(
                 sa.text(
                     "UPDATE conversation_messages SET conversation_id = :dm_id "
                     "WHERE conversation_id = :old_id"
                 ),
-                {"dm_id": dm_id, "old_id": conv_id},
+                {"dm_id": primary_dm, "old_id": conv_id},
             )
-        else:
-            # 복수 사용자 참가 — 메시지 이관 생략, soft delete만 수행
-            pass
 
         # 6. ws-chat conv soft delete
         conn.execute(

--- a/backend/alembic/versions/0051_migrate_ws_chat_convs_to_dm.py
+++ b/backend/alembic/versions/0051_migrate_ws_chat_convs_to_dm.py
@@ -1,0 +1,116 @@
+"""ws-chat 전용 conversation → DM conversation 이관 (E-FAKECHAT-INTEG)
+
+Revision ID: 0051
+Revises: 0050
+"""
+import uuid
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0051"
+down_revision = "0050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+
+    # 1. ws-chat:{agent_id} 전용 conversation 전체 조회
+    ws_chats = conn.execute(
+        sa.text(
+            "SELECT id, title, org_id, project_id FROM conversations "
+            "WHERE title LIKE 'ws-chat:%' AND status != 'deleted'"
+        )
+    ).fetchall()
+
+    for wsc in ws_chats:
+        conv_id = str(wsc.id)
+        title: str = wsc.title
+        org_id = str(wsc.org_id)
+        project_id = str(wsc.project_id)
+        agent_id = title[len("ws-chat:"):]
+
+        # 2. 대화에 참여한 non-agent 발신자 조회
+        senders = conn.execute(
+            sa.text(
+                "SELECT DISTINCT cm.sender_id FROM conversation_messages cm "
+                "JOIN team_members tm ON tm.id = cm.sender_id "
+                "WHERE cm.conversation_id = :cid AND tm.type != 'agent'"
+            ),
+            {"cid": conv_id},
+        ).fetchall()
+
+        if len(senders) == 0:
+            # 메시지 없는 ws-chat conv — 그냥 soft delete
+            pass
+        elif len(senders) == 1:
+            caller_id = str(senders[0].sender_id)
+
+            # 3. 기존 DM 조회 (에이전트 + 사용자 모두 participant)
+            existing = conn.execute(
+                sa.text(
+                    "SELECT c.id FROM conversations c "
+                    "JOIN conversation_participants cp1 ON cp1.conversation_id = c.id AND cp1.member_id = :agent_id "
+                    "JOIN conversation_participants cp2 ON cp2.conversation_id = c.id AND cp2.member_id = :caller_id "
+                    "WHERE c.type = 'dm' AND c.org_id = :org_id AND c.status != 'deleted' "
+                    "LIMIT 1"
+                ),
+                {"agent_id": agent_id, "caller_id": caller_id, "org_id": org_id},
+            ).fetchone()
+
+            if existing:
+                dm_id = str(existing.id)
+            else:
+                # 4. DM conversation 신규 생성
+                dm_id = str(uuid.uuid4())
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO conversations "
+                        "(id, org_id, project_id, type, title, status, created_by, created_at, updated_at) "
+                        "VALUES (:id, :org_id, :project_id, 'dm', NULL, 'open', :agent_id, :now, :now)"
+                    ),
+                    {
+                        "id": dm_id,
+                        "org_id": org_id,
+                        "project_id": project_id,
+                        "agent_id": agent_id,
+                        "now": now,
+                    },
+                )
+                for mid in [agent_id, caller_id]:
+                    conn.execute(
+                        sa.text(
+                            "INSERT INTO conversation_participants "
+                            "(id, conversation_id, member_id, joined_at) "
+                            "VALUES (gen_random_uuid(), :conv_id, :member_id, :now) "
+                            "ON CONFLICT ON CONSTRAINT uq_conversation_participant DO NOTHING"
+                        ),
+                        {"conv_id": dm_id, "member_id": mid, "now": now},
+                    )
+
+            # 5. 메시지 이관 (전체 — agent 발신 포함)
+            conn.execute(
+                sa.text(
+                    "UPDATE conversation_messages SET conversation_id = :dm_id "
+                    "WHERE conversation_id = :old_id"
+                ),
+                {"dm_id": dm_id, "old_id": conv_id},
+            )
+        else:
+            # 복수 사용자 참가 — 메시지 이관 생략, soft delete만 수행
+            pass
+
+        # 6. ws-chat conv soft delete
+        conn.execute(
+            sa.text("UPDATE conversations SET status = 'deleted' WHERE id = :cid"),
+            {"cid": conv_id},
+        )
+
+
+def downgrade() -> None:
+    # 데이터 이관은 되돌릴 수 없음 — no-op
+    pass

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -94,6 +94,7 @@ async def _get_or_create_conversation(
                 Conversation.id.in_(agent_conv_ids),
                 Conversation.type == "dm",
                 Conversation.org_id == org_id,
+                Conversation.project_id == project_id,
                 Conversation.status != "deleted",
             )
             .limit(1)

--- a/backend/app/routers/ws_chat.py
+++ b/backend/app/routers/ws_chat.py
@@ -11,14 +11,14 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect
-from sqlalchemy import select
+from sqlalchemy import and_, select
 
 from sqlalchemy.exc import IntegrityError
 
 from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.models.api_key import ApiKey
-from app.models.conversation import Conversation, ConversationMessage
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.team import TeamMember
 
 logger = logging.getLogger(__name__)
@@ -71,40 +71,49 @@ async def _authenticate(api_key: str | None, token: str | None) -> TeamMember | 
 
 async def _get_or_create_conversation(
     agent_id: uuid.UUID,
+    caller_id: uuid.UUID,
     org_id: uuid.UUID,
     project_id: uuid.UUID,
 ) -> uuid.UUID:
-    """agent_id 기반 ws-chat 전용 conversation 조회 또는 생성. conversation.id 반환."""
-    title = f"ws-chat:{agent_id}"
+    """에이전트↔사용자 쌍의 DM conversation 조회 또는 생성. conversation.id 반환."""
     async with async_session_factory() as db:
+        # 에이전트가 참가한 conversation_id 서브쿼리
+        agent_conv_ids = (
+            select(ConversationParticipant.conversation_id)
+            .where(ConversationParticipant.member_id == agent_id)
+            .scalar_subquery()
+        )
+        # 두 멤버가 모두 참가한 DM conversation 조회
         conv = (await db.execute(
-            select(Conversation).where(
+            select(Conversation)
+            .join(ConversationParticipant, and_(
+                ConversationParticipant.conversation_id == Conversation.id,
+                ConversationParticipant.member_id == caller_id,
+            ))
+            .where(
+                Conversation.id.in_(agent_conv_ids),
+                Conversation.type == "dm",
                 Conversation.org_id == org_id,
-                Conversation.project_id == project_id,
-                Conversation.title == title,
+                Conversation.status != "deleted",
             )
+            .limit(1)
         )).scalar_one_or_none()
+
         if conv is None:
-            try:
-                conv = Conversation(
-                    org_id=org_id,
-                    project_id=project_id,
-                    type="group",
-                    title=title,
-                    created_by=agent_id,
-                )
-                db.add(conv)
-                await db.commit()
-                await db.refresh(conv)
-            except IntegrityError:
-                await db.rollback()
-                conv = (await db.execute(
-                    select(Conversation).where(
-                        Conversation.org_id == org_id,
-                        Conversation.project_id == project_id,
-                        Conversation.title == title,
-                    )
-                )).scalar_one()
+            conv = Conversation(
+                org_id=org_id,
+                project_id=project_id,
+                type="dm",
+                title=None,
+                created_by=agent_id,
+            )
+            db.add(conv)
+            await db.flush()
+            db.add(ConversationParticipant(conversation_id=conv.id, member_id=agent_id))
+            db.add(ConversationParticipant(conversation_id=conv.id, member_id=caller_id))
+            await db.commit()
+            await db.refresh(conv)
+
         return conv.id
 
 
@@ -167,7 +176,7 @@ async def ws_chat_hub(
         return
 
     conv_id = await _get_or_create_conversation(
-        agent_id, agent_member.org_id, agent_member.project_id
+        agent_id, caller.id, agent_member.org_id, agent_member.project_id
     )
 
     try:


### PR DESCRIPTION
## Summary
- `_get_or_create_conversation(agent_id, caller_id, org_id, project_id)` — DM conversation 조회/생성 로직으로 완전 교체
- `ConversationParticipant` JOIN 쿼리로 agent+caller 쌍 DM 조회 → 없으면 type=dm 신규 생성 + 양쪽 participant 추가
- migration 0051: 기존 `ws-chat:{uuid}` conv → 대응 DM으로 메시지 이관 + `status='deleted'` soft delete

## 변경 내역
| 파일 | 내용 |
|------|------|
| `backend/app/routers/ws_chat.py` | `_get_or_create_conversation` 재작성, `caller.id` 파라미터 추가, `and_`/`ConversationParticipant` import 추가 |
| `backend/alembic/versions/0051_migrate_ws_chat_convs_to_dm.py` | 데이터 마이그레이션 — 1인 사용자 ws-chat conv는 DM 이관, 복수 사용자는 soft delete만 |

## Test plan
- [ ] 신규 WS 연결 → DM conversation 생성 확인 (type=dm, participants 2명)
- [ ] 동일 agent+caller 재연결 → 기존 DM 재사용 (신규 conv 미생성)
- [ ] migration 0051 dev 적용 → ws-chat conv status='deleted', 메시지 DM으로 이관 확인
- [ ] fakechat 클라이언트 기존과 동일하게 연결/수신 가능 확인

## Story
story_id: 5a7d24d1-847f-4a47-9fe1-46494d058de0

🤖 Generated with [Claude Code](https://claude.com/claude-code)