### PR TITLE
feat(migration): backfill project-only members into org_members (S-MBR-01)

### DIFF
--- a/backend/alembic/versions/0052_backfill_project_members_to_org_members.py
+++ b/backend/alembic/versions/0052_backfill_project_members_to_org_members.py
@@ -1,0 +1,46 @@
+"""team_members(human)에 있지만 org_members에 없는 사용자 backfill (S-MBR-01)
+
+Revision ID: 0052
+Revises: 0051
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0052"
+down_revision = "0051"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            """
+            INSERT INTO org_members (id, org_id, user_id, role, created_at)
+            SELECT DISTINCT ON (tm.org_id, tm.user_id)
+                gen_random_uuid(),
+                tm.org_id,
+                tm.user_id,
+                'member',
+                NOW()
+            FROM team_members tm
+            WHERE
+                tm.type = 'human'
+                AND tm.user_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM org_members om
+                    WHERE om.org_id = tm.org_id
+                      AND om.user_id = tm.user_id
+                      AND om.deleted_at IS NULL
+                )
+            ON CONFLICT (org_id, user_id) DO NOTHING
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    # 데이터 이관 마이그레이션 — 어떤 레코드가 이 migration으로 삽입됐는지
+    # 추적 불가하므로 rollback 미지원
+    pass


### PR DESCRIPTION
## Summary

- Alembic migration `0052` 추가
- `team_members(type='human', user_id IS NOT NULL)`에 존재하지만 `org_members`에 없는 사용자를 `role='member'`로 INSERT
- `DISTINCT ON (org_id, user_id)` + `ON CONFLICT DO NOTHING` — idempotent 보장
- `downgrade()` = no-op (데이터 이관 불가역)

## AC 체크

- [x] AC1: Alembic migration 작성 완료 (`0052_backfill_project_members_to_org_members.py`)
- [ ] AC2: dev 환경 migration 실행 후 신이삭, 차봉희 포함 확인 (PO 수동 실행)
- [x] AC3: INSERT only — UPDATE/DELETE 없음
- [ ] AC4: prod 환경 적용 전 PO 승인 필수

## 참고

- `sprintable-migrate-dev` job 수동 실행 필요 (`alembic upgrade 0052`)
- prod 적용은 PO 승인 후

🤖 Generated with [Claude Code](https://claude.com/claude-code)