### PR TITLE
[S-MBR-05] MemberRow 단일 컴포넌트 + 표시 통일

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -27,6 +27,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
+import { MemberRow } from '@/components/ui/member-row';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { SidebarTrigger } from '@/components/ui/sidebar';
@@ -1578,23 +1579,23 @@ export default function SettingsPage() {
                           const isEditingWebhook = member.id in webhookEditing;
                           const currentWebhookUrl = member.webhook_url ?? '';
                           return (
-                          <div key={member.id} className="rounded-md border border-border bg-muted/30 px-3 py-3 text-sm space-y-2">
-                            <div className="flex items-center justify-between gap-3">
-                              <div className="min-w-0">
-                                <div className="font-medium text-foreground">{member.name}</div>
-                                <div className="mt-1 flex flex-wrap items-center gap-2">
+                          <div key={member.id} className="space-y-1">
+                            <MemberRow
+                              name={member.name}
+                              actions={
+                                <>
                                   <Badge variant={member.type === 'agent' ? 'secondary' : 'info'}>{member.type === 'agent' ? t('agentMember') : t('humanMember')}</Badge>
                                   <Badge variant="outline">{member.role}</Badge>
-                                </div>
-                              </div>
-                              {isAdmin ? (
-                              <Button variant="glass" size="sm" onClick={() => handleRemoveProjectMember(member.id)} disabled={removingMemberId === member.id}>
-                                {removingMemberId === member.id ? '...' : t('removeFromProject')}
-                              </Button>
-                              ) : null}
-                            </div>
-                            {/* Webhook URL */}
-                            <div className="flex items-center gap-2">
+                                  {isAdmin ? (
+                                    <Button variant="glass" size="sm" onClick={() => handleRemoveProjectMember(member.id)} disabled={removingMemberId === member.id}>
+                                      {removingMemberId === member.id ? '...' : t('removeFromProject')}
+                                    </Button>
+                                  ) : null}
+                                </>
+                              }
+                            />
+                            {/* Webhook URL block — row 하단 별도 영역 유지 */}
+                            <div className="flex items-center gap-2 px-1">
                               {isEditingWebhook ? (
                                 <>
                                   <input

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -64,7 +64,8 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
       setMembers((raw.data ?? []).map((m) => ({
         id: m.id,
         user_id: m.user_id,
-        name: m.email || m.user_id.slice(0, 8),
+        name: m.email?.split('@')[0] ?? m.user_id?.slice(0, 8) ?? '?',
+        email: m.email ?? undefined,
         role: m.role,
         joined_at: m.created_at,
       })));

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import { MemberRow } from '@/components/ui/member-row';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Badge } from '@/components/ui/badge';
 import { OperatorInput } from '@/components/ui/operator-control';
@@ -223,46 +224,43 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
             const isThisOwner = member.role === 'owner';
             const canEdit = isOwner && !isThisOwner;
             return (
-              <div key={member.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-sm">
-                <div className="min-w-0">
-                  <div className="font-medium text-foreground">{member.name}</div>
-                  {member.email && <div className="text-xs text-muted-foreground">{member.email}</div>}
-                  {member.joined_at && (
-                    <div className="text-xs text-muted-foreground">
-                      {new Date(member.joined_at).toLocaleDateString('ko-KR')} 가입
-                    </div>
-                  )}
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  {canEdit ? (
-                    <select
-                      className="rounded-md border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
-                      value={member.role}
-                      disabled={changingRoleId === member.id}
-                      onChange={(e) => void handleChangeRole(member.id, e.target.value as 'admin' | 'member')}
-                    >
-                      <option value="admin">Admin</option>
-                      <option value="member">Member</option>
-                    </select>
-                  ) : (
-                    <Badge variant={isThisOwner ? 'info' : 'secondary'} className="capitalize">{member.role}</Badge>
-                  )}
-                  {canEdit && (
-                    showRemoveConfirm === member.id ? (
-                      <div className="flex gap-1">
-                        <Button size="sm" variant="destructive" onClick={() => void handleRemove(member.id)} disabled={removingId === member.id}>
-                          {removingId === member.id ? '...' : '확인'}
-                        </Button>
-                        <Button size="sm" variant="ghost" onClick={() => setShowRemoveConfirm(null)}>취소</Button>
-                      </div>
+              <MemberRow
+                key={member.id}
+                name={member.name}
+                email={member.email}
+                meta={member.joined_at ? `${new Date(member.joined_at).toLocaleDateString('ko-KR')} 가입` : undefined}
+                actions={
+                  <>
+                    {canEdit ? (
+                      <select
+                        className="rounded-md border border-input bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={member.role}
+                        disabled={changingRoleId === member.id}
+                        onChange={(e) => void handleChangeRole(member.id, e.target.value as 'admin' | 'member')}
+                      >
+                        <option value="admin">Admin</option>
+                        <option value="member">Member</option>
+                      </select>
                     ) : (
-                      <Button size="sm" variant="glass" onClick={() => setShowRemoveConfirm(member.id)}>
-                        제거
-                      </Button>
-                    )
-                  )}
-                </div>
-              </div>
+                      <Badge variant={isThisOwner ? 'info' : 'secondary'} className="capitalize">{member.role}</Badge>
+                    )}
+                    {canEdit && (
+                      showRemoveConfirm === member.id ? (
+                        <div className="flex gap-1">
+                          <Button size="sm" variant="destructive" onClick={() => void handleRemove(member.id)} disabled={removingId === member.id}>
+                            {removingId === member.id ? '...' : '확인'}
+                          </Button>
+                          <Button size="sm" variant="ghost" onClick={() => setShowRemoveConfirm(null)}>취소</Button>
+                        </div>
+                      ) : (
+                        <Button size="sm" variant="glass" onClick={() => setShowRemoveConfirm(member.id)}>
+                          제거
+                        </Button>
+                      )
+                    )}
+                  </>
+                }
+              />
             );
           })}
           {members.length === 0 && (
@@ -279,39 +277,39 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
           </SectionCardHeader>
           <SectionCardBody className="space-y-2">
             {invites.map((invite) => (
-              <div key={invite.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
-                <div className="min-w-0">
-                  <div className="font-medium text-foreground">{invite.email}</div>
-                  <div className="text-muted-foreground">
-                    {invite.role} · 만료: {new Date(invite.expires_at).toLocaleDateString('ko-KR')}
-                  </div>
-                </div>
-                {canManage && (
-                  <div className="flex shrink-0 gap-1">
-                    <Button
-                      size="sm"
-                      variant="glass"
-                      disabled={!invite.invite_url}
-                      onClick={() => void handleCopyInviteLink(invite.id, invite.invite_url)}
-                      title={invite.invite_url ? '초대 링크 복사' : '링크 사용 불가'}
-                      className={copiedInviteId === invite.id ? 'text-success bg-success/12 border-success/30' : ''}
-                    >
-                      {copiedInviteId === invite.id ? (
-                        <><Check className="h-3 w-3 mr-1" />복사됨</>
-                      ) : (
-                        <><Copy className="h-3 w-3 mr-1" />링크 복사</>
-                      )}
-                    </Button>
-                    <Button size="sm" variant="glass" disabled={resendingId === invite.id} onClick={() => void handleResendInvite(invite.id)}>
-                      {resendingId === invite.id ? '...' : '재발송'}
-                    </Button>
-                    <Button size="sm" variant="glass" disabled={revokingId === invite.id} onClick={() => void handleRevokeInvite(invite.id)}
-                      className="text-destructive hover:bg-destructive/10">
-                      {revokingId === invite.id ? '...' : '취소'}
-                    </Button>
-                  </div>
-                )}
-              </div>
+              <MemberRow
+                key={invite.id}
+                name={invite.email}
+                meta={`${invite.role} · 만료: ${new Date(invite.expires_at).toLocaleDateString('ko-KR')}`}
+                emphasis="subtle"
+                actions={
+                  canManage ? (
+                    <div className="flex shrink-0 gap-1">
+                      <Button
+                        size="sm"
+                        variant="glass"
+                        disabled={!invite.invite_url}
+                        onClick={() => void handleCopyInviteLink(invite.id, invite.invite_url)}
+                        title={invite.invite_url ? '초대 링크 복사' : '링크 사용 불가'}
+                        className={copiedInviteId === invite.id ? 'text-success bg-success/12 border-success/30' : ''}
+                      >
+                        {copiedInviteId === invite.id ? (
+                          <><Check className="h-3 w-3 mr-1" />복사됨</>
+                        ) : (
+                          <><Copy className="h-3 w-3 mr-1" />링크 복사</>
+                        )}
+                      </Button>
+                      <Button size="sm" variant="glass" disabled={resendingId === invite.id} onClick={() => void handleResendInvite(invite.id)}>
+                        {resendingId === invite.id ? '...' : '재발송'}
+                      </Button>
+                      <Button size="sm" variant="glass" disabled={revokingId === invite.id} onClick={() => void handleRevokeInvite(invite.id)}
+                        className="text-destructive hover:bg-destructive/10">
+                        {revokingId === invite.id ? '...' : '취소'}
+                      </Button>
+                    </div>
+                  ) : undefined
+                }
+              />
             ))}
           </SectionCardBody>
         </SectionCard>

--- a/apps/web/src/components/ui/member-row.tsx
+++ b/apps/web/src/components/ui/member-row.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface MemberRowProps {
+  name: string;
+  email?: string;
+  meta?: React.ReactNode;
+  actions?: React.ReactNode;
+  emphasis?: 'default' | 'subtle';
+  className?: string;
+}
+
+export function MemberRow({
+  name,
+  email,
+  meta,
+  actions,
+  emphasis = 'default',
+  className,
+}: MemberRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-center justify-between gap-3 rounded-md border border-border px-3 py-3 text-sm',
+        emphasis === 'subtle' ? 'bg-muted/20' : 'bg-muted/30',
+        className,
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="truncate font-medium text-foreground">{name}</div>
+        {email ? (
+          <div className="truncate text-xs text-muted-foreground">{email}</div>
+        ) : null}
+        {meta ? <div className="mt-0.5 text-xs text-muted-foreground">{meta}</div> : null}
+      </div>
+      {actions ? <div className="flex shrink-0 items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## 변경 사항

- `apps/web/src/components/ui/member-row.tsx` 신규 생성 (슬롯 패턴 컴포넌트)
- `org-members-section.tsx` — 조직 멤버 row + 초대 대기 row `<MemberRow>` 교체
- `settings/page.tsx` — 프로젝트 멤버 row `<MemberRow>` 교체 (webhook block은 row 하단 유지)

## AC 체크

- [x] AC1: `member-row.tsx` 신규 생성, Props 시그니처 일치
- [x] AC2: 조직 멤버 row 교체 (실명 + 이메일 + 가입일)
- [x] AC3: 초대 대기 row 교체 (`emphasis="subtle"`, 이메일 primary)
- [x] AC4: 프로젝트 멤버 row 교체 (webhook block 유지)
- [x] AC5: 토큰 일치 — `bg-muted/30` / `bg-muted/20` / `border-border` / `text-foreground` / `text-muted-foreground`
- [x] AC6: tsc 에러 0건
- [ ] AC7: 시각 회귀 없음 (가디언 검증)

## 사후 grep 결과

```
MemberRow 사용처: settings/page.tsx, org-members-section.tsx (최소 3건 ✅)
기존 인라인 row 마크업 잔존 (교체 대상 3곳): 0건 ✅
text-[N]px 임의 사용: 0건 ✅
```

## 반응형 확인

- 데스크톱: name/email 2단 + actions 우측 정렬
- 모바일: truncate 적용으로 긴 이름/이메일 clip