### PR TITLE
fix(migration): restore soft-deleted org_members backfill (S-MBR-01 fix)

### DIFF
--- a/backend/alembic/versions/0053_fix_backfill_soft_deleted_org_members.py
+++ b/backend/alembic/versions/0053_fix_backfill_soft_deleted_org_members.py
@@ -1,0 +1,70 @@
+"""0052 backfill 보정 — soft-deleted org_members 복구 포함 (S-MBR-01 fix)
+
+Revision ID: 0053
+Revises: 0052
+
+0052는 ON CONFLICT DO NOTHING 때문에 soft-deleted 레코드가 unique constraint와
+충돌하면 INSERT를 건너뜀. 이 migration에서 soft-deleted 레코드를 복구하고
+신규 레코드도 INSERT.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0053"
+down_revision = "0052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # soft-deleted 레코드 복구: deleted_at → NULL
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE org_members om
+            SET deleted_at = NULL
+            FROM team_members tm
+            WHERE om.org_id = tm.org_id
+              AND om.user_id = tm.user_id
+              AND om.deleted_at IS NOT NULL
+              AND tm.type = 'human'
+              AND tm.user_id IS NOT NULL
+            """
+        )
+    )
+    if result.rowcount:
+        print(f"[0053] restored {result.rowcount} soft-deleted org_member(s)")
+
+    # 0052가 놓쳤을 수 있는 신규 레코드 INSERT (멱등)
+    result2 = conn.execute(
+        sa.text(
+            """
+            INSERT INTO org_members (id, org_id, user_id, role, created_at)
+            SELECT DISTINCT ON (tm.org_id, tm.user_id)
+                gen_random_uuid(),
+                tm.org_id,
+                tm.user_id,
+                'member',
+                NOW()
+            FROM team_members tm
+            WHERE
+                tm.type = 'human'
+                AND tm.user_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1 FROM org_members om
+                    WHERE om.org_id = tm.org_id
+                      AND om.user_id = tm.user_id
+                      AND om.deleted_at IS NULL
+                )
+            ON CONFLICT (org_id, user_id) DO NOTHING
+            """
+        )
+    )
+    if result2.rowcount:
+        print(f"[0053] inserted {result2.rowcount} missing org_member(s)")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 원인

PR #1034 (0052) migration에서 `ON CONFLICT DO NOTHING`이 org_members에 이미 존재하는 soft-deleted `(org_id, user_id)` 레코드와 unique constraint 충돌을 일으켜 INSERT가 건너뛰어진 것으로 추정.

**팩트 확인:**
- 신이삭 `user_id=df196f2e`, 차봉희 `user_id=62d433c1` — 모두 non-NULL
- `org_id=54bac162` 동일
- migration job 성공이지만 org_members API에 여전히 4명만 반환

## 수정 내용 (0053)

1. `UPDATE org_members SET deleted_at = NULL` — soft-deleted 레코드 복구
2. `INSERT ... ON CONFLICT DO NOTHING` — 신규 레코드 재시도 (멱등)
3. `rowcount` 로그 출력 — 실제 영향 건수 migration job 로그에서 확인 가능

## AC 체크

- [x] AC1: migration 작성 완료
- [ ] AC2: dev migration 실행 후 신이삭/차봉희 포함 확인 (migration job 로그 + org-members API)
- [x] AC3: INSERT + UPDATE(deleted_at=NULL)만 — 기존 active 레코드 변경 없음
- [ ] AC4: prod 적용 전 PO 승인

🤖 Generated with [Claude Code](https://claude.com/claude-code)