### PR TITLE
[S-MBR-06] 조직 멤버 제거 시 영향 프로젝트 목록 + 확인 다이얼로그

### DIFF
--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -5,6 +5,7 @@ import { Check, Copy } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { MemberRow } from '@/components/ui/member-row';
+import { RemoveOrgMemberDialog } from '@/components/settings/remove-org-member-dialog';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { Badge } from '@/components/ui/badge';
 import { OperatorInput } from '@/components/ui/operator-control';
@@ -44,7 +45,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
   const [inviteResult, setInviteResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
   const [removingId, setRemovingId] = useState<string | null>(null);
-  const [showRemoveConfirm, setShowRemoveConfirm] = useState<string | null>(null);
+  const [removeDialogMemberId, setRemoveDialogMemberId] = useState<string | null>(null);
   const [changingRoleId, setChangingRoleId] = useState<string | null>(null);
   const [actionMessage, setActionMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [resendingId, setResendingId] = useState<string | null>(null);
@@ -126,7 +127,6 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
     const res = await fetch(`/api/org-members/${memberId}`, { method: 'DELETE' });
     if (res.ok) {
       setActionMessage({ type: 'success', text: '멤버가 제거됐습니다.' });
-      setShowRemoveConfirm(null);
       await refreshData();
     } else {
       const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
@@ -248,18 +248,9 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
                       <Badge variant={isThisOwner ? 'info' : 'secondary'} className="capitalize">{member.role}</Badge>
                     )}
                     {canEdit && (
-                      showRemoveConfirm === member.id ? (
-                        <div className="flex gap-1">
-                          <Button size="sm" variant="destructive" onClick={() => void handleRemove(member.id)} disabled={removingId === member.id}>
-                            {removingId === member.id ? '...' : '확인'}
-                          </Button>
-                          <Button size="sm" variant="ghost" onClick={() => setShowRemoveConfirm(null)}>취소</Button>
-                        </div>
-                      ) : (
-                        <Button size="sm" variant="glass" onClick={() => setShowRemoveConfirm(member.id)}>
-                          제거
-                        </Button>
-                      )
+                      <Button size="sm" variant="glass" onClick={() => setRemoveDialogMemberId(member.id)}>
+                        제거
+                      </Button>
                     )}
                   </>
                 }
@@ -271,6 +262,22 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
           )}
         </SectionCardBody>
       </SectionCard>
+
+      {removeDialogMemberId ? (() => {
+        const target = members.find((m) => m.id === removeDialogMemberId);
+        if (!target) return null;
+        return (
+          <RemoveOrgMemberDialog
+            open
+            member={{ id: target.id, name: target.name, email: target.email }}
+            onCancel={() => setRemoveDialogMemberId(null)}
+            onConfirm={async () => {
+              await handleRemove(target.id);
+              setRemoveDialogMemberId(null);
+            }}
+          />
+        );
+      })() : null}
 
       {/* 초대 대기 목록 */}
       {invites.length > 0 && (

--- a/apps/web/src/components/settings/remove-org-member-dialog.tsx
+++ b/apps/web/src/components/settings/remove-org-member-dialog.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { AlertTriangle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+interface AffectedProject {
+  project_id: string;
+  project_name: string;
+  role: string;
+}
+
+export interface RemoveOrgMemberDialogProps {
+  open: boolean;
+  member: { id: string; name: string; email?: string };
+  onConfirm: () => Promise<void> | void;
+  onCancel: () => void;
+}
+
+export function RemoveOrgMemberDialog({
+  open,
+  member,
+  onConfirm,
+  onCancel,
+}: RemoveOrgMemberDialogProps) {
+  const [loading, setLoading] = useState(true);
+  const [affected, setAffected] = useState<AffectedProject[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/org-members/${member.id}/affected-projects`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error('failed');
+        const json = await res.json() as { data?: AffectedProject[] };
+        setAffected(json.data ?? []);
+      })
+      .catch(() => setError('영향 프로젝트 목록을 불러오지 못했습니다. 다시 시도하세요.'))
+      .finally(() => setLoading(false));
+  }, [open, member.id]);
+
+  const handleConfirm = async () => {
+    setConfirming(true);
+    try {
+      await onConfirm();
+    } finally {
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>멤버 제거</DialogTitle>
+          <DialogDescription>
+            <span className="font-medium text-foreground">{member.name}</span>
+            {member.email ? <span className="text-muted-foreground"> ({member.email})</span> : null}
+            <span> 을(를) 조직에서 제거합니다.</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        {loading ? (
+          <div className="space-y-2">
+            <div className="h-4 animate-pulse rounded bg-muted" />
+            <div className="h-12 animate-pulse rounded bg-muted" />
+            <div className="h-12 animate-pulse rounded bg-muted" />
+          </div>
+        ) : error ? (
+          <Alert variant="destructive">
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : affected && affected.length > 0 ? (
+          <div className="space-y-3">
+            <Alert variant="warning">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertDescription>
+                이 사용자는 아래 프로젝트에서도 함께 제거됩니다:
+              </AlertDescription>
+            </Alert>
+            <div className="space-y-1 rounded-md border border-border bg-muted/30 px-3 py-2">
+              {affected.map((p) => (
+                <div key={p.project_id} className="flex items-center justify-between gap-3 py-1 text-sm">
+                  <span className="truncate text-foreground">{p.project_name}</span>
+                  <Badge variant="outline" className="capitalize">{p.role}</Badge>
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-muted-foreground">이 작업은 되돌릴 수 없습니다.</p>
+          </div>
+        ) : (
+          <div className="space-y-2 text-sm">
+            <p className="text-muted-foreground">이 사용자는 어느 프로젝트에도 참여하지 않습니다.</p>
+            <p className="text-xs text-muted-foreground">이 작업은 되돌릴 수 없습니다.</p>
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel} disabled={confirming}>
+            취소
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() => void handleConfirm()}
+            disabled={loading || !!error || confirming}
+          >
+            {confirming ? '...' : '제거'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## 변경 사항

- `remove-org-member-dialog.tsx` 신규 생성 — 4 케이스 분기 (A: 프로젝트 있음 / B: 없음 / C: 로딩 / D: API 실패)
- `org-members-section.tsx` — 인라인 confirm UI 제거 + RemoveOrgMemberDialog 마운트

## AC 체크

- [x] AC1: `remove-org-member-dialog.tsx` 신규 생성, Props 시그니처 일치
- [x] AC2: 인라인 confirm UI 제거, `RemoveOrgMemberDialog` 마운트
- [x] AC3: open 시 `GET /api/org-members/{id}/affected-projects` 호출
- [x] AC4: Case A — warning Alert + 프로젝트 목록 + role badge
- [x] AC5: Case B — "어느 프로젝트에도 참여하지 않습니다" 인포
- [x] AC6: Case D — destructive Alert + 제거 버튼 disabled
- [x] AC7: 토큰 일치 (임의 hex 색 0건)
- [x] AC8: tsc 에러 0건
- [ ] AC9: 가디언 시각 회귀 (4 케이스 × light/dark × 모바일)

## 사후 grep 결과

```
RemoveOrgMemberDialog import: org-members-section.tsx ✅
showRemoveConfirm 잔존: 0건 ✅
/affected-projects 호출처: remove-org-member-dialog.tsx 1건 ✅
hex 색 (#xxx): 0건 ✅
```

## BE 의존성

S-MBR-07 (`GET /api/org-members/{id}/affected-projects`) 미착수 — mock spec 기반 FE 선행. BE 머지 전 dev에서 404 → Case D (API 실패) 분기 작동. 안전.