### PR TITLE
feat(org-members): affected-projects API + cascade delete + owner guard (S-MBR-07)

### DIFF
--- a/apps/web/src/app/api/org-members/[id]/affected-projects/route.ts
+++ b/apps/web/src/app/api/org-members/[id]/affected-projects/route.ts
@@ -1,0 +1,11 @@
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ id: string }> };
+
+export async function GET(request: Request, { params }: RouteParams) {
+  const { id } = await params;
+  const _r = await proxyToFastapiWithParams(request, '/api/v2/org-members/[id]/affected-projects', { id });
+  if (!_r.ok) return _r;
+  return apiSuccess(await _r.json());
+}

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -124,15 +124,65 @@ async def update_org_member(
     return OrgMemberResponse.model_validate(member)
 
 
+@router.get("/{id}/affected-projects")
+async def get_affected_projects(
+    id: uuid.UUID,
+    repo: OrgMemberRepository = Depends(_require_admin),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[dict]:
+    """해당 org member가 참여 중인 프로젝트 목록 반환 (AC1/AC2/AC3)."""
+    from app.models.team import TeamMember
+    from app.models.project import Project
+    member = await repo.get(id)
+    if member is None:
+        raise HTTPException(status_code=404, detail="Org member not found")
+    result = await session.execute(
+        text(
+            """
+            SELECT DISTINCT p.id AS project_id, p.name AS project_name, tm.role
+            FROM team_members tm
+            JOIN projects p ON p.id = tm.project_id
+            WHERE tm.org_id = :org_id
+              AND tm.user_id = :user_id
+              AND tm.is_active = true
+              AND p.deleted_at IS NULL
+            ORDER BY p.name
+            """
+        ),
+        {"org_id": str(org_id), "user_id": str(member.user_id)},
+    )
+    return [
+        {"project_id": str(row.project_id), "project_name": row.project_name, "role": row.role}
+        for row in result
+    ]
+
+
 @router.delete("/{id}", status_code=200)
 async def delete_org_member(
     id: uuid.UUID,
     repo: OrgMemberRepository = Depends(_require_admin),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
     existing = await repo.get(id)
     if existing is None:
         raise HTTPException(status_code=404, detail="Org member not found")
+    # AC5: owner guard — owner는 삭제 불가
+    if existing.role == "owner":
+        raise HTTPException(status_code=403, detail="조직 owner는 삭제할 수 없습니다")
     await _revoke_user_refresh_tokens(repo.session, existing.user_id)
+    # AC4: cascade — team_members is_active = False
+    await session.execute(
+        text(
+            """
+            UPDATE team_members
+            SET is_active = false
+            WHERE org_id = :org_id AND user_id = :user_id AND is_active = true
+            """
+        ),
+        {"org_id": str(org_id), "user_id": str(existing.user_id)},
+    )
     ok = await repo.soft_delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Org member not found")


### PR DESCRIPTION
## Summary

- \`GET /api/v2/org-members/{id}/affected-projects\` 신규 엔드포인트 — owner/admin 전용
- \`DELETE /api/v2/org-members/{id}\` owner guard 추가 — owner 삭제 시 403
- \`DELETE\` cascade — team_members \`is_active=false\` 처리
- Next.js proxy route 추가 (\`apps/web/src/app/api/org-members/[id]/affected-projects/route.ts\`)

## AC

- [x] AC1: GET /{id}/affected-projects — team_members JOIN projects, 참여 프로젝트 목록 반환
- [x] AC2: 프로젝트 없으면 빈 배열
- [x] AC3: 권한 owner/admin only
- [x] AC4: DELETE cascade — team_members is_active=false
- [x] AC5: DELETE owner guard — 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)