### PR TITLE
feat(team-members): org member guard on project member add (S-MBR-02)

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -119,6 +119,22 @@ async def create_team_member(
         if body.name == actor.name:
             raise HTTPException(status_code=400, detail="Agent cannot create a member with the same name as itself")
 
+    # S-MBR-02: user_id 있으면 org_members 선행 검증
+    if body.user_id is not None:
+        from app.models.project import OrgMember
+        _org_check = await session.execute(
+            select(OrgMember).where(
+                OrgMember.org_id == org_id,
+                OrgMember.user_id == body.user_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )
+        if _org_check.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=400,
+                detail={"code": "USER_NOT_IN_ORG", "message": "먼저 조직에 초대해야 합니다"},
+            )
+
     # Human member 생성은 org invite 플로우로 이전 (E-ENTITY-CLEANUP S4)
     if body.type == "human":
         raise HTTPException(


### PR DESCRIPTION
## Summary

- \`team_members\` POST에서 \`body.user_id\`가 있을 때 \`org_members\` 선행 검증
- 미존재 시 \`USER_NOT_IN_ORG\` 400 반환 — "먼저 조직에 초대해야 합니다"
- \`user_id = None\`인 agent 생성은 검증 skip

## AC

- [x] AC1: team_members POST 시 user_id 있으면 org_members 존재 검증, 미존재 시 400
- [x] AC2: 에러 코드 \`USER_NOT_IN_ORG\` + "먼저 조직에 초대해야 합니다"
- [x] AC3: user_id=None(agent) 케이스 영향 없음
- [ ] AC4: S-MBR-01 DB 시크릿 이슈 해소 후 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)