### PR TITLE
fix(migration): S-MBR-01 0054 — ON CONFLICT DO UPDATE로 soft-delete 차단 우회

### DIFF
--- a/backend/alembic/versions/0053_fix_backfill_soft_deleted_org_members.py
+++ b/backend/alembic/versions/0053_fix_backfill_soft_deleted_org_members.py
@@ -1,0 +1,70 @@
+"""0052 backfill 보정 — soft-deleted org_members 복구 포함 (S-MBR-01 fix)
+
+Revision ID: 0053
+Revises: 0052
+
+0052는 ON CONFLICT DO NOTHING 때문에 soft-deleted 레코드가 unique constraint와
+충돌하면 INSERT를 건너뜀. 이 migration에서 soft-deleted 레코드를 복구하고
+신규 레코드도 INSERT.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0053"
+down_revision = "0052"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # soft-deleted 레코드 복구: deleted_at → NULL
+    result = conn.execute(
+        sa.text(
+            """
+            UPDATE org_members om
+            SET deleted_at = NULL
+            FROM team_members tm
+            WHERE om.org_id = tm.org_id
+              AND om.user_id = tm.user_id
+              AND om.deleted_at IS NOT NULL
+              AND tm.type = 'human'
+              AND tm.user_id IS NOT NULL
+            """
+        )
+    )
+    if result.rowcount:
+        print(f"[0053] restored {result.rowcount} soft-deleted org_member(s)")
+
+    # 0052가 놓쳤을 수 있는 신규 레코드 INSERT (멱등)
+    result2 = conn.execute(
+        sa.text(
+            """
+            INSERT INTO org_members (id, org_id, user_id, role, created_at)
+            SELECT DISTINCT ON (tm.org_id, tm.user_id)
+                gen_random_uuid(),
+                tm.org_id,
+                tm.user_id,
+                'member',
+                NOW()
+            FROM team_members tm
+            WHERE
+                tm.type = 'human'
+                AND tm.user_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1 FROM org_members om
+                    WHERE om.org_id = tm.org_id
+                      AND om.user_id = tm.user_id
+                      AND om.deleted_at IS NULL
+                )
+            ON CONFLICT (org_id, user_id) DO NOTHING
+            """
+        )
+    )
+    if result2.rowcount:
+        print(f"[0053] inserted {result2.rowcount} missing org_member(s)")
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/0054_force_backfill_org_members_upsert.py
+++ b/backend/alembic/versions/0054_force_backfill_org_members_upsert.py
@@ -1,0 +1,54 @@
+"""0053 backfill 재시도 — ON CONFLICT DO UPDATE로 soft-delete 차단 우회 (S-MBR-01 fix2)
+
+Revision ID: 0054
+Revises: 0053
+
+0053은 두 단계(UPDATE 복구 → INSERT DO NOTHING)로 처리했는데 여전히 0건.
+원인: soft-deleted 레코드가 unique constraint를 점유하면 ON CONFLICT DO NOTHING이
+INSERT를 조용히 건너뜀.
+이 migration은 DO UPDATE SET deleted_at = NULL 단일 쿼리로
+신규 삽입과 soft-delete 복구를 동시에 처리한다.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0054"
+down_revision = "0053"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # UPSERT: 신규 레코드 INSERT + soft-deleted 레코드 복구를 단일 문으로 처리
+    result = conn.execute(
+        sa.text(
+            """
+            INSERT INTO org_members (id, org_id, user_id, role, created_at)
+            SELECT DISTINCT ON (tm.org_id, tm.user_id)
+                gen_random_uuid(),
+                tm.org_id,
+                tm.user_id,
+                'member',
+                NOW()
+            FROM team_members tm
+            WHERE
+                tm.type = 'human'
+                AND tm.user_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1 FROM org_members om
+                    WHERE om.org_id = tm.org_id
+                      AND om.user_id = tm.user_id
+                      AND om.deleted_at IS NULL
+                )
+            ON CONFLICT (org_id, user_id) DO UPDATE
+                SET deleted_at = NULL
+            """
+        )
+    )
+    print(f"[0054] upserted {result.rowcount} org_member(s) (insert or soft-delete restore)")
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## 변경 사항

**migration 0054** 추가 (`0054_force_backfill_org_members_upsert.py`)

### 근본 원인 분석

| migration | 결과 | 원인 |
|-----------|------|------|
| 0052 | 0건 | soft-deleted org_member 레코드가 unique constraint 점유 → ON CONFLICT DO NOTHING 침묵 스킵 |
| 0053 | 0건 | Step1 UPDATE 0행 → Step2 INSERT도 ON CONFLICT DO NOTHING에 동일하게 막힘 |
| **0054** | **예상: 2건+** | DO UPDATE SET deleted_at = NULL — 신규 삽입 + soft-delete 복구 단일 쿼리 처리 |

### 구조

```sql
INSERT INTO org_members ...
SELECT DISTINCT ON (tm.org_id, tm.user_id) ... FROM team_members tm
WHERE tm.type = 'human' AND tm.user_id IS NOT NULL
  AND NOT EXISTS (... deleted_at IS NULL)
ON CONFLICT (org_id, user_id) DO UPDATE
    SET deleted_at = NULL
```

- `NOT EXISTS (deleted_at IS NULL)`: 이미 활성화된 레코드는 건드리지 않음 (멱등)
- `ON CONFLICT DO UPDATE SET deleted_at = NULL`: soft-deleted 레코드 복구 처리

## 확인 사항

- [x] team_members에 신이삭(df196f2e), 차봉희(62d433c1) user_id 실재 확인 (API 조회)
- [x] org_members 4건 중 해당 user_id 없음 확인
- [ ] migration 0054 적용 후 org_members 6건 이상 확인

## AC 대응

- S-MBR-01 AC1: `team_members` human → `org_members` 전량 백필
- S-MBR-01 AC2: 멱등 (NOT EXISTS 필터로 중복 방지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)