### PR TITLE
feat(S-COMM-03): remove fakechat relay from SSE bridge

### DIFF
--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -10,10 +10,8 @@ class McpSettings(BaseSettings):
 
     sprintable_api_url: str = ""
     agent_api_key: str = ""
-    fakechat_port: int = 8787
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
-    has_webhook: bool = False  # True: fakechat relay 전체 스킵, Discord 웹훅으로만 수신
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -10,7 +10,7 @@ import sys
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from random import randint, uniform
+from random import uniform
 from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
@@ -26,10 +26,6 @@ _SseInternalHandler = Callable[["SseEvent"], None]
 _BASE_DELAY = 1.0
 _MAX_DELAY = 10.0
 _JITTER_FACTOR = 0.5    # wait * uniform(0, 0.5) jitter
-
-# relay 대상 이벤트 타입
-_RELAY_EVENT_TYPES = frozenset(["conversation:message", "conversation:mention"])
-
 
 # ── SeenIdsCache: LRU + TTL dedup 캐시 (S6-2) ────────────────────────────────
 
@@ -178,90 +174,6 @@ class SseParser:
         return None
 
 
-# ── fakechat relay ─────────────────────────────────────────────────────────────
-
-def _build_relay_payload(event_type: str, data: object) -> tuple[str, str, bool]:
-    """SSE data에서 (text, thread_id, is_conversation_event) 추출."""
-    if not isinstance(data, dict):
-        return f"[{event_type}] {data}", "", False
-
-    d: dict = data
-    payload: dict = d.get("payload") if isinstance(d.get("payload"), dict) else d  # type: ignore[assignment]
-
-    sender_raw = payload.get("sender") or d.get("sender_name") or d.get("member_name") or ""
-    if isinstance(sender_raw, dict):
-        sender_name = str(sender_raw.get("name", ""))
-    else:
-        sender_name = str(sender_raw)
-
-    content = (
-        payload.get("content")
-        or d.get("content")
-        or d.get("message")
-        or d.get("text")
-        or json.dumps(data, ensure_ascii=False)
-    )
-
-    text = f"[{event_type}] {sender_name}: {content}" if sender_name else f"[{event_type}] {content}"
-
-    conversation_id = str(payload.get("conversation_id") or d.get("conversation_id") or "")
-    thread_id = str(payload.get("thread_id") or d.get("thread_id") or conversation_id)
-    is_conversation_event = bool(conversation_id) and not (
-        payload.get("thread_id") or d.get("thread_id")
-    )
-
-    return text, thread_id, is_conversation_event
-
-
-async def relay_to_fakechat(
-    event_type: str,
-    data_str: str,
-    api_url: str,
-    api_key: str,
-    fakechat_port: int,
-) -> None:
-    """SSE 이벤트 → fakechat /upload POST.
-
-    relay 대상: conversation:message, conversation:mention.
-    비대상 이벤트 및 모든 에러는 조용히 skip — MCP 동작에 영향 없음.
-    """
-    if event_type not in _RELAY_EVENT_TYPES:
-        return
-
-    uid = f"sse-{int(time.time() * 1000)}-{randint(0, 999999):06d}"
-
-    try:
-        parsed: Any = json.loads(data_str)
-    except json.JSONDecodeError:
-        parsed = data_str
-
-    text, thread_id, is_conversation_event = _build_relay_payload(event_type, parsed)
-
-    form: dict[str, str] = {"id": uid, "text": text}
-
-    if thread_id:
-        base_url = api_url.rstrip("/")
-        form["thread_id"] = thread_id
-        if base_url and api_key:
-            callback_path = (
-                f"/api/v2/conversations/{thread_id}/messages"
-                if is_conversation_event
-                else f"/api/v2/chats/{thread_id}/messages"
-            )
-            form["reply_callback_url"] = f"{base_url}{callback_path}"
-            form["reply_callback_api_key"] = api_key
-
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            resp = await client.post(
-                f"http://127.0.0.1:{fakechat_port}/upload",
-                data=form,
-            )
-            resp.raise_for_status()
-    except Exception as exc:
-        _log(f"relay error: {exc}")
-
-
 # ── httpx SSE client ───────────────────────────────────────────────────────────
 
 def make_sse_client(api_url: str, api_key: str) -> httpx.AsyncClient:
@@ -334,7 +246,6 @@ async def start_sse_bridge(
     """
     _log(f"starting bridge for member_id={member_id}")
     client = make_sse_client(api_url, api_key)
-    port = settings.fakechat_port
 
     # S6-2: LRU + TTL dedup 캐시 (환경변수 기반 설정)
     seen_ids = SeenIdsCache(
@@ -369,17 +280,6 @@ async def start_sse_bridge(
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
-
-        # relay 조건: (1) backfill 아님, (2) webhook 미설정
-        _relay = True
-        try:
-            _relay = not json.loads(event.data).get("is_backfill", False)
-        except (json.JSONDecodeError, AttributeError):
-            pass
-        if _relay and not settings.has_webhook:
-            asyncio.create_task(
-                relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
-            )
 
         if on_event is not None:
             on_event(event.event_type, event.data)

--- a/backend/tests/test_s_comm_03.py
+++ b/backend/tests/test_s_comm_03.py
@@ -1,0 +1,117 @@
+"""S-COMM-03: fakechat relay 제거 검증 테스트.
+
+AC1: relay_to_fakechat 함수 제거 — sse_bridge에 존재하지 않음.
+AC2: _send_mcp_notification 유지 — 모든 이벤트에 MCP notification 발송.
+AC3: MCP notification은 backfill·webhook 여부 무관하게 항상 발송.
+AC4: has_webhook / fakechat_port 설정 제거됨.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ── AC1: relay_to_fakechat 제거 ───────────────────────────────────────────────
+
+def test_relay_to_fakechat_removed():
+    """relay_to_fakechat 함수가 sse_bridge 모듈에 존재하지 않아야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert not hasattr(bridge, "relay_to_fakechat"), (
+        "relay_to_fakechat must be removed from sse_bridge (S-COMM-03 AC1)"
+    )
+
+
+def test_relay_event_types_removed():
+    """_RELAY_EVENT_TYPES 상수가 sse_bridge 모듈에 존재하지 않아야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert not hasattr(bridge, "_RELAY_EVENT_TYPES")
+
+
+def test_build_relay_payload_removed():
+    """_build_relay_payload 함수가 sse_bridge 모듈에 존재하지 않아야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert not hasattr(bridge, "_build_relay_payload")
+
+
+# ── AC2: _send_mcp_notification 유지 ─────────────────────────────────────────
+
+def test_send_mcp_notification_exists():
+    """_send_mcp_notification 함수가 sse_bridge 모듈에 존재해야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert hasattr(bridge, "_send_mcp_notification")
+    assert asyncio.iscoroutinefunction(bridge._send_mcp_notification)
+
+
+def test_register_session_exists():
+    """register_session 함수가 유지되어야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    assert hasattr(bridge, "register_session")
+
+
+# ── AC3: MCP notification은 항상 발송 ────────────────────────────────────────
+
+def test_handle_does_not_call_relay():
+    """start_sse_bridge의 _handle 내부에 relay_to_fakechat 호출이 없어야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    source = inspect.getsource(bridge.start_sse_bridge)
+    assert "relay_to_fakechat" not in source, (
+        "_handle must not call relay_to_fakechat (S-COMM-03 AC1)"
+    )
+
+
+def test_handle_always_sends_mcp_notification():
+    """start_sse_bridge 소스에 _send_mcp_notification 호출이 있어야 함."""
+    import sprintable_mcp.sse_bridge as bridge
+    source = inspect.getsource(bridge.start_sse_bridge)
+    assert "_send_mcp_notification" in source
+
+
+# ── AC4: config에서 fakechat 전용 필드 제거 ──────────────────────────────────
+
+def test_fakechat_port_removed_from_config():
+    """McpSettings에 fakechat_port 필드가 없어야 함."""
+    from sprintable_mcp.config import McpSettings
+    assert not hasattr(McpSettings(), "fakechat_port"), (
+        "fakechat_port must be removed from McpSettings (S-COMM-03 AC4)"
+    )
+
+
+def test_has_webhook_removed_from_config():
+    """McpSettings에 has_webhook 필드가 없어야 함."""
+    from sprintable_mcp.config import McpSettings
+    assert not hasattr(McpSettings(), "has_webhook"), (
+        "has_webhook must be removed from McpSettings (S-COMM-03 AC4)"
+    )
+
+
+# ── MCP notification 기능 동작 검증 ─────────────────────────────────────────
+
+def test_send_mcp_notification_skips_when_no_session():
+    """세션 미등록 시 _send_mcp_notification이 조용히 skip."""
+    import sprintable_mcp.sse_bridge as bridge
+    bridge._active_session = None
+    asyncio.get_event_loop().run_until_complete(
+        bridge._send_mcp_notification("memo_created", '{"event_id":"test"}')
+    )
+    # 에러 없이 완료되면 AC2 pass
+
+
+def test_send_mcp_notification_calls_session():
+    """세션 등록 시 _send_mcp_notification이 send_log_message 호출."""
+    import sprintable_mcp.sse_bridge as bridge
+
+    mock_session = MagicMock()
+    mock_session.send_log_message = AsyncMock()
+    bridge._active_session = mock_session
+
+    try:
+        asyncio.get_event_loop().run_until_complete(
+            bridge._send_mcp_notification("story_assigned", '{"event_id":"abc"}')
+        )
+        mock_session.send_log_message.assert_called_once()
+        call_kwargs = mock_session.send_log_message.call_args.kwargs
+        assert call_kwargs["level"] == "info"
+        assert call_kwargs["data"]["event_type"] == "story_assigned"
+    finally:
+        bridge._active_session = None


### PR DESCRIPTION
## Summary
- `relay_to_fakechat()`, `_build_relay_payload()`, `_RELAY_EVENT_TYPES` 전량 제거 (AC1)
- MCP `session.send_log_message()` 직접 전달 경로만 유지 (AC2)
- `McpSettings`에서 `fakechat_port` / `has_webhook` 필드 제거 (AC4)
- 11개 테스트 전량 PASS (`tests/test_s_comm_03.py`)

## AC 체크리스트
- [x] AC1: `relay_to_fakechat` 함수 제거
- [x] AC2: `_send_mcp_notification` 유지 — 모든 이벤트 MCP notification 발송
- [x] AC3: MCP notification은 backfill·webhook 여부 무관하게 항상 발송
- [x] AC4: `has_webhook` / `fakechat_port` config 필드 제거

## Test plan
- [ ] `uv run pytest tests/test_s_comm_03.py -v` — 11/11 PASS 확인
- [ ] SSE 이벤트 수신 시 MCP notification 도달 확인 (Claude Code 터미널)
- [ ] relay 코드 경로 미실행 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)