### PR TITLE
fix(S-COMM-03): send_log_message → notifications/claude/channel 직접 전송

### DIFF
--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -10,10 +10,13 @@ import sys
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from random import uniform
 from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
+from mcp.shared.session import ServerMessageMetadata, SessionMessage
+from mcp.types import JSONRPCMessage, JSONRPCNotification
 
 from .config import settings
 
@@ -93,18 +96,47 @@ def register_session(session: ServerSession) -> None:
 
 
 async def _send_mcp_notification(event_type: str, data_str: str) -> None:
-    """SSE 이벤트를 MCP log notification으로 클라이언트에 전송.
+    """SSE 이벤트를 notifications/claude/channel 로 Claude Code 세션에 전송.
 
+    send_log_message는 MCP logging spec이라 Claude Code가 대화 입력으로 인식 안 함 (오스카군 실검증).
+    JSONRPCNotification을 _write_stream에 직접 write하여 fakechat TS SDK와 동일 경로로 전송.
     세션 미등록 또는 에러 시 조용히 skip — MCP 도구 호출에 영향 없음.
     """
     if _active_session is None:
         return
     try:
-        await _active_session.send_log_message(
-            level="info",
-            data={"event_type": event_type, "data": data_str},
-            logger="sprintable.sse",
+        # data_str 파싱으로 meta 필드 구성
+        try:
+            payload = json.loads(data_str) if data_str else {}
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+
+        event_id = payload.get("event_id") or payload.get("id") or ""
+        conversation_id = payload.get("conversation_id") or payload.get("source_entity_id") or ""
+        ts = datetime.now(timezone.utc).isoformat()
+
+        meta: dict[str, Any] = {
+            "chat_id": "web",
+            "message_id": str(event_id) if event_id else "",
+            "user": "web",
+            "ts": ts,
+        }
+        if conversation_id:
+            meta["thread_id"] = str(conversation_id)
+
+        # content: 이벤트 타입 + 주요 필드 요약 (Claude Code 채널 입력으로 인식되는 텍스트)
+        content = data_str or f"(event_type={event_type})"
+
+        notification = JSONRPCNotification(
+            jsonrpc="2.0",
+            method="notifications/claude/channel",
+            params={"content": content, "meta": meta},
         )
+        session_message = SessionMessage(
+            message=JSONRPCMessage(notification),
+            metadata=None,
+        )
+        await _active_session._write_stream.send(session_message)
     except Exception as exc:
         _log(f"notification error: {exc}")
 

--- a/backend/tests/test_s_comm_03.py
+++ b/backend/tests/test_s_comm_03.py
@@ -1,9 +1,10 @@
 """S-COMM-03: fakechat relay 제거 검증 테스트.
 
 AC1: relay_to_fakechat 함수 제거 — sse_bridge에 존재하지 않음.
-AC2: _send_mcp_notification 유지 — 모든 이벤트에 MCP notification 발송.
+AC2: _send_mcp_notification 유지 — 모든 이벤트에 notifications/claude/channel 발송.
 AC3: MCP notification은 backfill·webhook 여부 무관하게 항상 발송.
 AC4: has_webhook / fakechat_port 설정 제거됨.
+FIX: send_log_message → _write_stream.send(JSONRPCNotification) 교체 (오스카군 실검증).
 """
 from __future__ import annotations
 
@@ -97,21 +98,47 @@ def test_send_mcp_notification_skips_when_no_session():
     # 에러 없이 완료되면 AC2 pass
 
 
-def test_send_mcp_notification_calls_session():
-    """세션 등록 시 _send_mcp_notification이 send_log_message 호출."""
+def test_send_mcp_notification_uses_write_stream():
+    """세션 등록 시 _send_mcp_notification이 _write_stream.send로 channel notification 전송 (FIX)."""
     import sprintable_mcp.sse_bridge as bridge
+    from mcp.types import JSONRPCNotification
 
+    mock_write_stream = AsyncMock()
     mock_session = MagicMock()
-    mock_session.send_log_message = AsyncMock()
+    mock_session._write_stream = mock_write_stream
     bridge._active_session = mock_session
 
     try:
         asyncio.get_event_loop().run_until_complete(
-            bridge._send_mcp_notification("story_assigned", '{"event_id":"abc"}')
+            bridge._send_mcp_notification("story_assigned", '{"event_id":"abc","conversation_id":"def"}')
         )
-        mock_session.send_log_message.assert_called_once()
-        call_kwargs = mock_session.send_log_message.call_args.kwargs
-        assert call_kwargs["level"] == "info"
-        assert call_kwargs["data"]["event_type"] == "story_assigned"
+        mock_write_stream.send.assert_called_once()
+        sent_arg = mock_write_stream.send.call_args.args[0]
+        # JSONRPCMessage 래핑 확인
+        notification = sent_arg.message.root
+        assert isinstance(notification, JSONRPCNotification)
+        assert notification.method == "notifications/claude/channel"
+        assert notification.params["meta"]["message_id"] == "abc"
+        assert notification.params["meta"]["thread_id"] == "def"
+        assert notification.params["content"] == '{"event_id":"abc","conversation_id":"def"}'
     finally:
         bridge._active_session = None
+
+
+def test_send_mcp_notification_no_send_log_message():
+    """_send_mcp_notification이 send_log_message()를 호출하지 않아야 함 (FIX)."""
+    import inspect
+    import sprintable_mcp.sse_bridge as bridge
+    source = inspect.getsource(bridge._send_mcp_notification)
+    # 호출 패턴(괄호 포함)으로 체크 — docstring 언급과 구분
+    assert "send_log_message(" not in source, (
+        "_send_mcp_notification must not call send_log_message() (replaced by _write_stream.send)"
+    )
+
+
+def test_send_mcp_notification_uses_channel_method():
+    """_send_mcp_notification 소스에 notifications/claude/channel method가 있어야 함 (FIX)."""
+    import inspect
+    import sprintable_mcp.sse_bridge as bridge
+    source = inspect.getsource(bridge._send_mcp_notification)
+    assert "notifications/claude/channel" in source


### PR DESCRIPTION
## 문제

`send_log_message()`는 MCP spec상 `notifications/message` (logging)이라 Claude Code가 대화 입력으로 인식하지 않음. 오스카군 실검증에서 확인됨.

## 수정 내용

`_send_mcp_notification()` 구현을 교체:

**Before**
```python
await _active_session.send_log_message(
    level="info",
    data={"event_type": event_type, "data": data_str},
    logger="sprintable.sse",
)
```

**After**
```python
notification = JSONRPCNotification(
    jsonrpc="2.0",
    method="notifications/claude/channel",
    params={"content": content, "meta": meta},
)
await _active_session._write_stream.send(SessionMessage(message=JSONRPCMessage(notification)))
```

fakechat TS SDK의 `mcp.notification({ method: 'notifications/claude/channel', ... })`과 동일 경로. Claude Code가 채널 메시지로 인식함.

## meta 구성

- `message_id`: SSE 이벤트 payload의 `event_id`
- `thread_id`: `conversation_id` (있을 때)
- `chat_id`: `"web"`, `user`: `"web"`, `ts`: 현재 시각 ISO

## Test plan

- [x] `uv run pytest tests/test_s_comm_03.py -v` → 13/13 PASS
- [ ] dev 배포 후 Claude Code 세션에서 채널 메시지 수신 실검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)