### PR TITLE
fix(S-COMM-03): relay_to_fakechat 복구 — notifications/claude/channel 공인 게이트 우회 불가

### DIFF
--- a/backend/sprintable_mcp/config.py
+++ b/backend/sprintable_mcp/config.py
@@ -10,8 +10,10 @@ class McpSettings(BaseSettings):
 
     sprintable_api_url: str = ""
     agent_api_key: str = ""
+    fakechat_port: int = 8787
     sse_seen_ids_max_size: int = 10000
     sse_seen_ids_ttl_seconds: int = 3600
+    has_webhook: bool = False  # True: fakechat relay 전체 스킵, Discord 웹훅으로만 수신
 
 
 settings = McpSettings()

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -10,13 +10,10 @@ import sys
 import time
 from collections import OrderedDict
 from dataclasses import dataclass
-from datetime import datetime, timezone
-from random import uniform
+from random import randint, uniform
 from typing import TYPE_CHECKING, Any, Callable
 
 import httpx
-from mcp.shared.session import ServerMessageMetadata, SessionMessage
-from mcp.types import JSONRPCMessage, JSONRPCNotification
 
 from .config import settings
 
@@ -29,6 +26,10 @@ _SseInternalHandler = Callable[["SseEvent"], None]
 _BASE_DELAY = 1.0
 _MAX_DELAY = 10.0
 _JITTER_FACTOR = 0.5    # wait * uniform(0, 0.5) jitter
+
+# relay 대상 이벤트 타입
+_RELAY_EVENT_TYPES = frozenset(["conversation:message", "conversation:mention"])
+
 
 # ── SeenIdsCache: LRU + TTL dedup 캐시 (S6-2) ────────────────────────────────
 
@@ -96,47 +97,18 @@ def register_session(session: ServerSession) -> None:
 
 
 async def _send_mcp_notification(event_type: str, data_str: str) -> None:
-    """SSE 이벤트를 notifications/claude/channel 로 Claude Code 세션에 전송.
+    """SSE 이벤트를 MCP log notification으로 클라이언트에 전송.
 
-    send_log_message는 MCP logging spec이라 Claude Code가 대화 입력으로 인식 안 함 (오스카군 실검증).
-    JSONRPCNotification을 _write_stream에 직접 write하여 fakechat TS SDK와 동일 경로로 전송.
     세션 미등록 또는 에러 시 조용히 skip — MCP 도구 호출에 영향 없음.
     """
     if _active_session is None:
         return
     try:
-        # data_str 파싱으로 meta 필드 구성
-        try:
-            payload = json.loads(data_str) if data_str else {}
-        except (json.JSONDecodeError, TypeError):
-            payload = {}
-
-        event_id = payload.get("event_id") or payload.get("id") or ""
-        conversation_id = payload.get("conversation_id") or payload.get("source_entity_id") or ""
-        ts = datetime.now(timezone.utc).isoformat()
-
-        meta: dict[str, Any] = {
-            "chat_id": "web",
-            "message_id": str(event_id) if event_id else "",
-            "user": "web",
-            "ts": ts,
-        }
-        if conversation_id:
-            meta["thread_id"] = str(conversation_id)
-
-        # content: 이벤트 타입 + 주요 필드 요약 (Claude Code 채널 입력으로 인식되는 텍스트)
-        content = data_str or f"(event_type={event_type})"
-
-        notification = JSONRPCNotification(
-            jsonrpc="2.0",
-            method="notifications/claude/channel",
-            params={"content": content, "meta": meta},
+        await _active_session.send_log_message(
+            level="info",
+            data={"event_type": event_type, "data": data_str},
+            logger="sprintable.sse",
         )
-        session_message = SessionMessage(
-            message=JSONRPCMessage(notification),
-            metadata=None,
-        )
-        await _active_session._write_stream.send(session_message)
     except Exception as exc:
         _log(f"notification error: {exc}")
 
@@ -204,6 +176,90 @@ class SseParser:
         # unknown field — ignore per spec
 
         return None
+
+
+# ── fakechat relay ────────────────────────────────────────────────────────────
+
+def _build_relay_payload(event_type: str, data: object) -> tuple[str, str, bool]:
+    """SSE data에서 (text, thread_id, is_conversation_event) 추출."""
+    if not isinstance(data, dict):
+        return f"[{event_type}] {data}", "", False
+
+    d: dict = data
+    payload: dict = d.get("payload") if isinstance(d.get("payload"), dict) else d  # type: ignore[assignment]
+
+    sender_raw = payload.get("sender") or d.get("sender_name") or d.get("member_name") or ""
+    if isinstance(sender_raw, dict):
+        sender_name = str(sender_raw.get("name", ""))
+    else:
+        sender_name = str(sender_raw)
+
+    content = (
+        payload.get("content")
+        or d.get("content")
+        or d.get("message")
+        or d.get("text")
+        or json.dumps(data, ensure_ascii=False)
+    )
+
+    text = f"[{event_type}] {sender_name}: {content}" if sender_name else f"[{event_type}] {content}"
+
+    conversation_id = str(payload.get("conversation_id") or d.get("conversation_id") or "")
+    thread_id = str(payload.get("thread_id") or d.get("thread_id") or conversation_id)
+    is_conversation_event = bool(conversation_id) and not (
+        payload.get("thread_id") or d.get("thread_id")
+    )
+
+    return text, thread_id, is_conversation_event
+
+
+async def relay_to_fakechat(
+    event_type: str,
+    data_str: str,
+    api_url: str,
+    api_key: str,
+    fakechat_port: int,
+) -> None:
+    """SSE 이벤트 → fakechat /upload POST.
+
+    relay 대상: conversation:message, conversation:mention.
+    비대상 이벤트 및 모든 에러는 조용히 skip — MCP 동작에 영향 없음.
+    """
+    if event_type not in _RELAY_EVENT_TYPES:
+        return
+
+    uid = f"sse-{int(time.time() * 1000)}-{randint(0, 999999):06d}"
+
+    try:
+        parsed: Any = json.loads(data_str)
+    except json.JSONDecodeError:
+        parsed = data_str
+
+    text, thread_id, is_conversation_event = _build_relay_payload(event_type, parsed)
+
+    form: dict[str, str] = {"id": uid, "text": text}
+
+    if thread_id:
+        base_url = api_url.rstrip("/")
+        form["thread_id"] = thread_id
+        if base_url and api_key:
+            callback_path = (
+                f"/api/v2/conversations/{thread_id}/messages"
+                if is_conversation_event
+                else f"/api/v2/chats/{thread_id}/messages"
+            )
+            form["reply_callback_url"] = f"{base_url}{callback_path}"
+            form["reply_callback_api_key"] = api_key
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(
+                f"http://127.0.0.1:{fakechat_port}/upload",
+                data=form,
+            )
+            resp.raise_for_status()
+    except Exception as exc:
+        _log(f"relay error: {exc}")
 
 
 # ── httpx SSE client ───────────────────────────────────────────────────────────
@@ -278,6 +334,7 @@ async def start_sse_bridge(
     """
     _log(f"starting bridge for member_id={member_id}")
     client = make_sse_client(api_url, api_key)
+    port = settings.fakechat_port
 
     # S6-2: LRU + TTL dedup 캐시 (환경변수 기반 설정)
     seen_ids = SeenIdsCache(
@@ -312,6 +369,17 @@ async def start_sse_bridge(
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
+
+        # relay 조건: (1) backfill 아님, (2) webhook 미설정
+        _relay = True
+        try:
+            _relay = not json.loads(event.data).get("is_backfill", False)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+        if _relay and not settings.has_webhook:
+            asyncio.create_task(
+                relay_to_fakechat(event.event_type, event.data, api_url, api_key, port)
+            )
 
         if on_event is not None:
             on_event(event.event_type, event.data)

--- a/backend/tests/test_s_comm_03.py
+++ b/backend/tests/test_s_comm_03.py
@@ -1,10 +1,9 @@
-"""S-COMM-03: fakechat relay 제거 검증 테스트.
+"""S-COMM-03: fakechat relay 복구 + MCP notification 병행 검증 테스트.
 
-AC1: relay_to_fakechat 함수 제거 — sse_bridge에 존재하지 않음.
-AC2: _send_mcp_notification 유지 — 모든 이벤트에 notifications/claude/channel 발송.
+AC1: relay_to_fakechat 함수 유지 — notifications/claude/channel은 공인 플러그인 전용.
+AC2: _send_mcp_notification 유지 — send_log_message 경로로 MCP 알림 발송.
 AC3: MCP notification은 backfill·webhook 여부 무관하게 항상 발송.
-AC4: has_webhook / fakechat_port 설정 제거됨.
-FIX: send_log_message → _write_stream.send(JSONRPCNotification) 교체 (오스카군 실검증).
+AC4: has_webhook / fakechat_port 설정 유지 — relay 조건 판단에 사용.
 """
 from __future__ import annotations
 
@@ -13,26 +12,28 @@ import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
-# ── AC1: relay_to_fakechat 제거 ───────────────────────────────────────────────
+# ── AC1: relay_to_fakechat 복구 ───────────────────────────────────────────────
 
-def test_relay_to_fakechat_removed():
-    """relay_to_fakechat 함수가 sse_bridge 모듈에 존재하지 않아야 함."""
+def test_relay_to_fakechat_exists():
+    """relay_to_fakechat 함수가 sse_bridge 모듈에 존재해야 함 (AC1 복구)."""
     import sprintable_mcp.sse_bridge as bridge
-    assert not hasattr(bridge, "relay_to_fakechat"), (
-        "relay_to_fakechat must be removed from sse_bridge (S-COMM-03 AC1)"
+    assert hasattr(bridge, "relay_to_fakechat"), (
+        "relay_to_fakechat must exist in sse_bridge (S-COMM-03 restore)"
     )
+    assert asyncio.iscoroutinefunction(bridge.relay_to_fakechat)
 
 
-def test_relay_event_types_removed():
-    """_RELAY_EVENT_TYPES 상수가 sse_bridge 모듈에 존재하지 않아야 함."""
+def test_relay_event_types_exists():
+    """_RELAY_EVENT_TYPES 상수가 sse_bridge 모듈에 존재해야 함 (AC1 복구)."""
     import sprintable_mcp.sse_bridge as bridge
-    assert not hasattr(bridge, "_RELAY_EVENT_TYPES")
+    assert hasattr(bridge, "_RELAY_EVENT_TYPES")
+    assert "conversation:message" in bridge._RELAY_EVENT_TYPES
 
 
-def test_build_relay_payload_removed():
-    """_build_relay_payload 함수가 sse_bridge 모듈에 존재하지 않아야 함."""
+def test_build_relay_payload_exists():
+    """_build_relay_payload 함수가 sse_bridge 모듈에 존재해야 함 (AC1 복구)."""
     import sprintable_mcp.sse_bridge as bridge
-    assert not hasattr(bridge, "_build_relay_payload")
+    assert hasattr(bridge, "_build_relay_payload")
 
 
 # ── AC2: _send_mcp_notification 유지 ─────────────────────────────────────────
@@ -52,13 +53,16 @@ def test_register_session_exists():
 
 # ── AC3: MCP notification은 항상 발송 ────────────────────────────────────────
 
-def test_handle_does_not_call_relay():
-    """start_sse_bridge의 _handle 내부에 relay_to_fakechat 호출이 없어야 함."""
+def test_handle_calls_relay():
+    """start_sse_bridge의 _handle 내부에 relay_to_fakechat 호출이 있어야 함 (AC1 복구)."""
     import sprintable_mcp.sse_bridge as bridge
     source = inspect.getsource(bridge.start_sse_bridge)
-    assert "relay_to_fakechat" not in source, (
-        "_handle must not call relay_to_fakechat (S-COMM-03 AC1)"
+    assert "relay_to_fakechat" in source, (
+        "_handle must call relay_to_fakechat (S-COMM-03 restore)"
     )
+    # relay 조건: has_webhook False + backfill 아닐 때
+    assert "has_webhook" in source
+    assert "is_backfill" in source
 
 
 def test_handle_always_sends_mcp_notification():
@@ -68,21 +72,22 @@ def test_handle_always_sends_mcp_notification():
     assert "_send_mcp_notification" in source
 
 
-# ── AC4: config에서 fakechat 전용 필드 제거 ──────────────────────────────────
+# ── AC4: config fakechat 전용 필드 유지 ─────────────────────────────────────
 
-def test_fakechat_port_removed_from_config():
-    """McpSettings에 fakechat_port 필드가 없어야 함."""
+def test_fakechat_port_in_config():
+    """McpSettings에 fakechat_port 필드가 있어야 함 (AC4 복구)."""
     from sprintable_mcp.config import McpSettings
-    assert not hasattr(McpSettings(), "fakechat_port"), (
-        "fakechat_port must be removed from McpSettings (S-COMM-03 AC4)"
+    assert hasattr(McpSettings(), "fakechat_port"), (
+        "fakechat_port must exist in McpSettings (S-COMM-03 restore)"
     )
+    assert McpSettings().fakechat_port == 8787
 
 
-def test_has_webhook_removed_from_config():
-    """McpSettings에 has_webhook 필드가 없어야 함."""
+def test_has_webhook_in_config():
+    """McpSettings에 has_webhook 필드가 있어야 함 (AC4 복구)."""
     from sprintable_mcp.config import McpSettings
-    assert not hasattr(McpSettings(), "has_webhook"), (
-        "has_webhook must be removed from McpSettings (S-COMM-03 AC4)"
+    assert hasattr(McpSettings(), "has_webhook"), (
+        "has_webhook must exist in McpSettings (S-COMM-03 restore)"
     )
 
 
@@ -98,47 +103,21 @@ def test_send_mcp_notification_skips_when_no_session():
     # 에러 없이 완료되면 AC2 pass
 
 
-def test_send_mcp_notification_uses_write_stream():
-    """세션 등록 시 _send_mcp_notification이 _write_stream.send로 channel notification 전송 (FIX)."""
+def test_send_mcp_notification_calls_session():
+    """세션 등록 시 _send_mcp_notification이 send_log_message 호출 (원복)."""
     import sprintable_mcp.sse_bridge as bridge
-    from mcp.types import JSONRPCNotification
 
-    mock_write_stream = AsyncMock()
     mock_session = MagicMock()
-    mock_session._write_stream = mock_write_stream
+    mock_session.send_log_message = AsyncMock()
     bridge._active_session = mock_session
 
     try:
         asyncio.get_event_loop().run_until_complete(
-            bridge._send_mcp_notification("story_assigned", '{"event_id":"abc","conversation_id":"def"}')
+            bridge._send_mcp_notification("story_assigned", '{"event_id":"abc"}')
         )
-        mock_write_stream.send.assert_called_once()
-        sent_arg = mock_write_stream.send.call_args.args[0]
-        # JSONRPCMessage 래핑 확인
-        notification = sent_arg.message.root
-        assert isinstance(notification, JSONRPCNotification)
-        assert notification.method == "notifications/claude/channel"
-        assert notification.params["meta"]["message_id"] == "abc"
-        assert notification.params["meta"]["thread_id"] == "def"
-        assert notification.params["content"] == '{"event_id":"abc","conversation_id":"def"}'
+        mock_session.send_log_message.assert_called_once()
+        call_kwargs = mock_session.send_log_message.call_args.kwargs
+        assert call_kwargs["level"] == "info"
+        assert call_kwargs["data"]["event_type"] == "story_assigned"
     finally:
         bridge._active_session = None
-
-
-def test_send_mcp_notification_no_send_log_message():
-    """_send_mcp_notification이 send_log_message()를 호출하지 않아야 함 (FIX)."""
-    import inspect
-    import sprintable_mcp.sse_bridge as bridge
-    source = inspect.getsource(bridge._send_mcp_notification)
-    # 호출 패턴(괄호 포함)으로 체크 — docstring 언급과 구분
-    assert "send_log_message(" not in source, (
-        "_send_mcp_notification must not call send_log_message() (replaced by _write_stream.send)"
-    )
-
-
-def test_send_mcp_notification_uses_channel_method():
-    """_send_mcp_notification 소스에 notifications/claude/channel method가 있어야 함 (FIX)."""
-    import inspect
-    import sprintable_mcp.sse_bridge as bridge
-    source = inspect.getsource(bridge._send_mcp_notification)
-    assert "notifications/claude/channel" in source


### PR DESCRIPTION
## Summary

- `relay_to_fakechat()`, `_build_relay_payload()`, `_RELAY_EVENT_TYPES` 복구 — PR #1044에서 제거된 코드 원복
- `_send_mcp_notification` → `send_log_message` 경로 유지 (PR #1048 revert 포함)
- `McpSettings`에 `fakechat_port: int = 8787`, `has_webhook: bool = False` 필드 복구
- `test_s_comm_03.py` relay 존재 검증으로 갱신 (11/11 PASS)

## 배경

`notifications/claude/channel`은 Anthropic 공인 플러그인(fakechat TS SDK)만 게이트 통과.
커스텀 MCP 서버(`sprintable_mcp`)에서 보내면 Claude Code가 무시 — 오스카군 실검증 결과.
fakechat relay 경로를 복구해 SSE 이벤트 → fakechat → Claude Code 입력 흐름 재수립.

## Test plan

- [ ] `pytest backend/tests/test_s_comm_03.py` 11/11 PASS 확인
- [ ] MCP 서버 기동 후 fakechat relay → Claude Code 수신 실검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)