### PR TITLE
feat: S-COMM-07 에이전트별 inbox webhook endpoint

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,9 @@ class Settings(BaseSettings):
     polar_sandbox: bool = True  # dev=True(sandbox), prod=False
     polar_webhook_secret: str = ""  # HMAC signature 검증용
 
+    # S-COMM-07: 에이전트 inbox webhook HMAC 검증 시크릿
+    agent_inbox_webhook_secret: str = ""
+
     # Rate limiting (E-OA1:S5)
     rate_limit_backend: str = "memory"  # "memory" | "redis"
     redis_url: str = "redis://localhost:6379/0"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -139,6 +139,7 @@ app.include_router(project_settings.router)
 app.include_router(webhooks.router)
 app.include_router(api_keys.router)
 app.include_router(agent_runs.router)
+app.include_router(agent_inbox.router)
 app.include_router(policy_documents.router)
 app.include_router(subscription.router)
 app.include_router(account.router)

--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -1,0 +1,91 @@
+"""S-COMM-07: 에이전트별 전용 inbox webhook endpoint.
+
+AC1: POST /api/v2/agent-inbox/{agent_id}/webhook — 외부 JSON POST → events 테이블 적재
+AC2: agent_id 유효성 검증 — team_members에 없으면 404
+AC3: HMAC 서명 검증 — X-Sprintable-Signature (sha256=HEX)
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.dependencies.database import get_db
+from app.models.event import Event
+from app.models.team import TeamMember
+
+router = APIRouter(prefix="/api/v2/agent-inbox", tags=["agent-inbox"])
+
+
+def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    secret = settings.agent_inbox_webhook_secret
+    if not secret:
+        return True
+    if not signature_header:
+        return False
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header.removeprefix("sha256="))
+
+
+@router.post("/{agent_id}/webhook", status_code=201)
+async def receive_inbox_webhook(
+    agent_id: uuid.UUID,
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    x_sprintable_signature: str | None = Header(default=None),
+) -> dict:
+    """POST /api/v2/agent-inbox/{agent_id}/webhook — 외부 서비스 → 에이전트 inbox."""
+    raw_body = await request.body()
+
+    if not _verify_signature(raw_body, x_sprintable_signature):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    result = await db.execute(
+        select(TeamMember.org_id, TeamMember.project_id).where(
+            TeamMember.id == agent_id,
+            TeamMember.type == "agent",
+            TeamMember.is_active.is_(True),
+        )
+    )
+    row = result.one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    org_id, project_id = row
+
+    try:
+        payload: dict = json.loads(raw_body) if raw_body else {}
+    except (ValueError, UnicodeDecodeError):
+        payload = {"raw": raw_body.decode("utf-8", errors="replace")}
+
+    event_type = str(payload.get("event_type", "inbox_webhook"))
+    source_entity_type: str | None = payload.get("source_entity_type")
+    raw_source_id = payload.get("source_entity_id")
+    try:
+        source_entity_id: uuid.UUID | None = uuid.UUID(str(raw_source_id)) if raw_source_id else None
+    except ValueError:
+        source_entity_id = None
+
+    event = Event(
+        project_id=project_id,
+        org_id=org_id,
+        event_type=event_type,
+        source_entity_type=source_entity_type,
+        source_entity_id=source_entity_id,
+        sender_id=None,
+        recipient_id=agent_id,
+        recipient_type="agent",
+        payload=payload,
+        status="pending",
+    )
+    db.add(event)
+    await db.commit()
+    await db.refresh(event)
+
+    return {"ok": True, "event_id": str(event.id)}

--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -88,4 +88,8 @@ async def receive_inbox_webhook(
     await db.commit()
     await db.refresh(event)
 
+    # AC4: SSE 즉시 push (연결 중인 에이전트에게 바로 전달)
+    from app.routers.events import _push_to_agent
+    _push_to_agent(str(agent_id), payload)
+
     return {"ok": True, "event_id": str(event.id)}

--- a/backend/tests/test_s_comm_07.py
+++ b/backend/tests/test_s_comm_07.py
@@ -172,6 +172,44 @@ async def test_receive_inbox_webhook_creates_event():
 
 # ─── config 필드 존재 확인 ────────────────────────────────────────────────────
 
+@pytest.mark.anyio
+async def test_receive_inbox_webhook_calls_push_to_agent():
+    """commit 후 _push_to_agent 호출로 SSE 즉시 push (AC4)."""
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+
+    body = json.dumps({"event_type": "inbox_webhook"}).encode()
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=body)
+
+    mock_db = AsyncMock()
+    lookup_result = MagicMock()
+    lookup_result.one_or_none.return_value = (org_id, project_id)
+    mock_db.execute = AsyncMock(return_value=lookup_result)
+
+    mock_event = MagicMock()
+    mock_event.id = uuid.uuid4()
+    mock_db.add = MagicMock(side_effect=lambda obj: setattr(obj, "id", mock_event.id))
+    mock_db.commit = AsyncMock()
+    mock_db.refresh = AsyncMock()
+
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = ""
+        with patch("app.routers.agent_inbox.Event") as MockEvent:
+            MockEvent.return_value = mock_event
+            with patch("app.routers.events._push_to_agent") as mock_push:
+                await receive_inbox_webhook(
+                    agent_id=agent_id,
+                    request=mock_request,
+                    db=mock_db,
+                    x_sprintable_signature=None,
+                )
+                mock_push.assert_called_once_with(str(agent_id), {"event_type": "inbox_webhook"})
+
+
 def test_agent_inbox_webhook_secret_in_config():
     """Settings에 agent_inbox_webhook_secret 필드 존재."""
     from app.core.config import Settings

--- a/backend/tests/test_s_comm_07.py
+++ b/backend/tests/test_s_comm_07.py
@@ -1,0 +1,180 @@
+"""S-COMM-07: 에이전트별 inbox webhook endpoint 검증.
+
+AC1: POST /api/v2/agent-inbox/{agent_id}/webhook → events 테이블 적재
+AC2: agent_id 유효성 검증 — 없으면 404
+AC3: HMAC 서명 검증 — X-Sprintable-Signature
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import inspect
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── AC1: 라우터 등록 확인 ────────────────────────────────────────────────────
+
+def test_agent_inbox_router_registered():
+    """agent_inbox 라우터가 main.py에 등록됨."""
+    import app.main as main_module
+    source = inspect.getsource(main_module)
+    assert "agent_inbox" in source
+
+
+def test_agent_inbox_router_prefix():
+    """router prefix가 /api/v2/agent-inbox."""
+    from app.routers.agent_inbox import router
+    assert router.prefix == "/api/v2/agent-inbox"
+
+
+# ─── AC3: HMAC 서명 검증 로직 ─────────────────────────────────────────────────
+
+def test_verify_signature_passes_when_no_secret():
+    """secret 미설정 시 서명 없어도 통과 (dev 환경)."""
+    from app.routers.agent_inbox import _verify_signature
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = ""
+        assert _verify_signature(b"body", None) is True
+        assert _verify_signature(b"body", "sha256=anything") is True
+
+
+def test_verify_signature_rejects_missing_header():
+    """secret 설정 시 헤더 없으면 False."""
+    from app.routers.agent_inbox import _verify_signature
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = "testsecret"
+        assert _verify_signature(b"body", None) is False
+
+
+def test_verify_signature_passes_valid_hmac():
+    """올바른 HMAC sha256= 헤더는 True."""
+    from app.routers.agent_inbox import _verify_signature
+    secret = "testsecret"
+    body = b'{"event_type":"test"}'
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = secret
+        assert _verify_signature(body, f"sha256={expected}") is True
+
+
+def test_verify_signature_rejects_wrong_hmac():
+    """틀린 HMAC은 False."""
+    from app.routers.agent_inbox import _verify_signature
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = "testsecret"
+        assert _verify_signature(b"body", "sha256=deadbeef") is False
+
+
+# ─── AC2 + AC1: 엔드포인트 동작 검증 ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_receive_inbox_webhook_404_when_agent_not_found():
+    """없는 agent_id → 404."""
+    from fastapi import HTTPException
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=b'{"event_type":"test"}')
+
+    mock_db = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=mock_result)
+
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = ""
+        with pytest.raises(HTTPException) as exc_info:
+            await receive_inbox_webhook(
+                agent_id=uuid.uuid4(),
+                request=mock_request,
+                db=mock_db,
+                x_sprintable_signature=None,
+            )
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_receive_inbox_webhook_401_on_bad_signature():
+    """잘못된 서명 → 401."""
+    from fastapi import HTTPException
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=b'{"event_type":"test"}')
+
+    mock_db = AsyncMock()
+
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = "secret"
+        with pytest.raises(HTTPException) as exc_info:
+            await receive_inbox_webhook(
+                agent_id=uuid.uuid4(),
+                request=mock_request,
+                db=mock_db,
+                x_sprintable_signature="sha256=wrong",
+            )
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_receive_inbox_webhook_creates_event():
+    """유효한 agent_id + 올바른 서명 → Event 생성 후 event_id 반환 (AC1)."""
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    agent_id = uuid.uuid4()
+    event_id = uuid.uuid4()
+
+    body = json.dumps({"event_type": "story_assigned", "data": "hello"}).encode()
+
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=body)
+
+    mock_db = AsyncMock()
+
+    # execute: agent lookup 반환
+    agent_row = MagicMock()
+    agent_row.__iter__ = MagicMock(return_value=iter([org_id, project_id]))
+    lookup_result = MagicMock()
+    lookup_result.one_or_none.return_value = (org_id, project_id)
+    mock_db.execute = AsyncMock(return_value=lookup_result)
+
+    mock_event = MagicMock()
+    mock_event.id = event_id
+
+    def fake_add(obj):
+        obj.id = event_id
+
+    mock_db.add = MagicMock(side_effect=fake_add)
+    mock_db.commit = AsyncMock()
+    mock_db.refresh = AsyncMock()
+
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = ""
+        with patch("app.routers.agent_inbox.Event") as MockEvent:
+            MockEvent.return_value = mock_event
+            result = await receive_inbox_webhook(
+                agent_id=agent_id,
+                request=mock_request,
+                db=mock_db,
+                x_sprintable_signature=None,
+            )
+
+    assert result["ok"] is True
+    assert "event_id" in result
+    mock_db.commit.assert_awaited_once()
+
+
+# ─── config 필드 존재 확인 ────────────────────────────────────────────────────
+
+def test_agent_inbox_webhook_secret_in_config():
+    """Settings에 agent_inbox_webhook_secret 필드 존재."""
+    from app.core.config import Settings
+    s = Settings()
+    assert hasattr(s, "agent_inbox_webhook_secret")
+    assert s.agent_inbox_webhook_secret == ""


### PR DESCRIPTION
## Summary

- `POST /api/v2/agent-inbox/{agent_id}/webhook` 신규 엔드포인트
- AC1: 외부 JSON POST → `events` 테이블에 해당 에이전트 recipient로 적재
- AC2: `agent_id` 유효성 검증 — `team_members` type=agent 없으면 404
- AC3: HMAC-SHA256 서명 검증 (`X-Sprintable-Signature: sha256=HEX`) — `AGENT_INBOX_WEBHOOK_SECRET` 환경변수 미설정 시 dev skip

## Changes

- `app/routers/agent_inbox.py` — 신규 라우터
- `app/core/config.py` — `agent_inbox_webhook_secret` 필드 추가
- `app/main.py` — `agent_inbox.router` 등록
- `tests/test_s_comm_07.py` — 10개 테스트 PASS

## Test plan

- [x] `pytest tests/test_s_comm_07.py` — 10/10 PASS
- [ ] CI 전체 pytest 통과 확인

story_id: 69818f70-8b3e-424b-b701-755fadf1419d

🤖 Generated with [Claude Code](https://claude.com/claude-code)