### PR TITLE
fix: 초대 수락 → org_member 생성 누락 버그 수정 (isaacshin)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -51,6 +51,7 @@ from app.core.rate_limit import limiter
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
+from app.models.org_invite import OrgInvite
 from app.models.project import OrgMember, Project
 from app.models.team import TeamMember
 from app.models.login_audit_log import LoginAuditLog
@@ -263,18 +264,20 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member.user_id = user.id
 
     if not member:
-        # 2. 이메일로 pending 초대 조회 → 자동 수락 + org_member + team_member 생성
+        # 2. 이메일로 pending 초대 조회 → 자동 수락 + org_member 생성
+        # 2a. Invitation (invitations 테이블 — /api/v2/invitations 경로)
+        now = datetime.now(timezone.utc)
         inv_result = await session.execute(
             select(Invitation).where(
                 Invitation.email == user.email,
                 Invitation.status == "pending",
-                Invitation.expires_at > datetime.now(timezone.utc),
+                Invitation.expires_at > now,
             ).order_by(Invitation.created_at.asc()).limit(1)
         )
         inv = inv_result.scalar_one_or_none()
         if inv:
             inv.status = "accepted"
-            inv.accepted_at = datetime.now(timezone.utc)
+            inv.accepted_at = now
             from sqlalchemy.dialects.postgresql import insert as pg_insert
             await session.execute(
                 pg_insert(OrgMember)
@@ -287,6 +290,32 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
                 "org_id": str(inv.org_id),
                 "project_id": str(inv.project_id) if inv.project_id else "",
                 "role": inv.role,
+            }
+
+        # 2b. OrgInvite (org_invites 테이블 — /api/v2/invites 경로)
+        # invite link 가입 후 explicit accept 없이 로그인 시 자동 수락 fallback.
+        org_inv_result = await session.execute(
+            select(OrgInvite).where(
+                OrgInvite.email == user.email.lower(),
+                OrgInvite.status == "pending",
+                OrgInvite.expires_at > now,
+            ).order_by(OrgInvite.created_at.asc()).limit(1)
+        )
+        org_inv = org_inv_result.scalar_one_or_none()
+        if org_inv:
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+            await session.execute(
+                pg_insert(OrgMember)
+                .values(org_id=org_inv.organization_id, user_id=user.id, role=org_inv.role)
+                .on_conflict_do_nothing(constraint="uq_org_members_org_user")
+            )
+            org_inv.status = "accepted"
+            org_inv.accepted_at = now
+            await session.flush()
+            return {
+                "org_id": str(org_inv.organization_id),
+                "project_id": "",
+                "role": org_inv.role,
             }
 
     if not member:

--- a/backend/tests/test_bug_invite_org_invite_auto_accept.py
+++ b/backend/tests/test_bug_invite_org_invite_auto_accept.py
@@ -1,0 +1,143 @@
+"""BUG: 초대 수락 → org_member 생성 흐름 깨짐 수정 검증.
+
+_build_app_metadata가 OrgInvite(org_invites 테이블)를 누락하여
+invite link 가입 후 explicit accept 없이 로그인 시 org context가 없던 문제.
+
+AC: _build_app_metadata가 Invitation 미존재 시 OrgInvite도 조회하여 자동수락.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── 소스 레벨 검증 ───────────────────────────────────────────────────────────
+
+def test_org_invite_imported_in_auth():
+    """auth.py에 OrgInvite import 추가됨."""
+    import app.routers.auth as auth_mod
+    source = inspect.getsource(auth_mod)
+    assert "from app.models.org_invite import OrgInvite" in source
+
+
+def test_build_app_metadata_handles_org_invite():
+    """_build_app_metadata 소스에 OrgInvite 조회 로직 포함."""
+    from app.routers.auth import _build_app_metadata
+    source = inspect.getsource(_build_app_metadata)
+    assert "OrgInvite" in source
+    assert "organization_id" in source  # OrgInvite → org_member 생성
+
+
+def test_build_app_metadata_org_invite_auto_accept_returns_org_id():
+    """OrgInvite 자동수락 경로가 org_id를 반환함."""
+    from app.routers.auth import _build_app_metadata
+    source = inspect.getsource(_build_app_metadata)
+    # org_inv.organization_id → 반환 dict의 org_id
+    assert "org_inv.organization_id" in source
+    assert "org_inv.status" in source
+
+
+# ─── 동작 검증 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_build_app_metadata_auto_accepts_org_invite():
+    """OrgInvite pending → 자동수락 + org_member 생성 + org_id 반환."""
+    from app.routers.auth import _build_app_metadata
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    mock_user = MagicMock()
+    mock_user.id = user_id
+    mock_user.email = "isaacshin@moonklabs.com"
+    mock_user.last_project_id = None
+
+    # mock OrgInvite
+    mock_org_inv = MagicMock()
+    mock_org_inv.organization_id = org_id
+    mock_org_inv.role = "member"
+    mock_org_inv.status = "pending"
+    mock_org_inv.expires_at = now + timedelta(days=3)
+    mock_org_inv.accepted_at = None
+
+    session = AsyncMock()
+
+    # execute call 순서 (last_project_id=None → 첫 번째 경로 skip):
+    # 1. team_member fallback 조회 → None
+    # 2. Invitation lookup → None
+    # 3. OrgInvite lookup → mock_org_inv
+    # 4. pg_insert(OrgMember)
+    no_member = MagicMock()
+    no_member.scalar_one_or_none.return_value = None
+    no_inv = MagicMock()
+    no_inv.scalar_one_or_none.return_value = None
+    org_inv_result = MagicMock()
+    org_inv_result.scalar_one_or_none.return_value = mock_org_inv
+    insert_result = MagicMock()
+
+    session.execute = AsyncMock(side_effect=[
+        no_member,       # 1. team_member fallback
+        no_inv,          # 2. Invitation lookup
+        org_inv_result,  # 3. OrgInvite lookup
+        insert_result,   # 4. pg_insert(OrgMember)
+    ])
+    session.flush = AsyncMock()
+
+    result = await _build_app_metadata(mock_user, session)
+
+    assert result.get("org_id") == str(org_id)
+    assert result.get("role") == "member"
+    assert mock_org_inv.status == "accepted"
+    assert mock_org_inv.accepted_at is not None
+    session.flush.assert_awaited()
+
+
+@pytest.mark.anyio
+async def test_build_app_metadata_skips_org_invite_when_invitation_found():
+    """Invitation 발견 시 OrgInvite 조회 스킵 (2a 경로 우선)."""
+    from app.routers.auth import _build_app_metadata
+
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+
+    mock_user = MagicMock()
+    mock_user.id = user_id
+    mock_user.email = "user@example.com"
+    mock_user.last_project_id = None
+
+    mock_inv = MagicMock()
+    mock_inv.org_id = org_id
+    mock_inv.project_id = project_id
+    mock_inv.role = "admin"
+    mock_inv.status = "pending"
+    mock_inv.accepted_at = None
+
+    session = AsyncMock()
+
+    no_member = MagicMock()
+    no_member.scalar_one_or_none.return_value = None
+    inv_result = MagicMock()
+    inv_result.scalar_one_or_none.return_value = mock_inv
+    insert_result = MagicMock()
+
+    session.execute = AsyncMock(side_effect=[
+        no_member,   # team_member fallback
+        inv_result,  # Invitation lookup → found
+        insert_result,  # pg_insert(OrgMember)
+    ])
+    session.flush = AsyncMock()
+
+    result = await _build_app_metadata(mock_user, session)
+
+    assert result.get("org_id") == str(org_id)
+    assert result.get("role") == "admin"
+    assert mock_inv.status == "accepted"
+    # OrgInvite 조회는 호출되지 않아야 함 (execute 3회: team_member, invitation, insert)
+    assert session.execute.call_count == 3


### PR DESCRIPTION
## 원인

`_build_app_metadata`(auth.py)가 로그인 시 pending 초대를 자동수락하는 경로에서  
**`Invitation`(invitations 테이블)만 조회**하고 **`OrgInvite`(org_invites 테이블)를 누락**.

invite link(`/api/v2/invites`)로 초대된 사용자가 로그인 시:
1. team_member 없음 → fallback
2. Invitation(invitations 테이블) 없음 → 자동수락 패스
3. ❌ OrgInvite 미조회 → org context 빈 상태로 return
4. 초대 pending 유지 / org_member 미생성

## 수정

`_build_app_metadata`에 **2b 경로 추가** — Invitation 미존재 시 `OrgInvite`도 조회:
- pending + 미만료 OrgInvite 발견 시 자동수락
- `pg_insert(OrgMember).on_conflict_do_nothing` 으로 org_member 생성
- `org_invite.status = "accepted"` + `accepted_at` 기록

## 데이터 정리 (운영 적용 후 실행 필요)

```sql
-- 수동 INSERT 레코드 삭제
DELETE FROM org_members WHERE id::text LIKE 'df196f2e%' OR id::text LIKE '62d433c1%';
```

삭제 후 isaacshin@moonklabs.com 재로그인 → OrgInvite 자동수락으로 정상 처리됨.  
(isaacshin OrgInvite는 현재 pending 상태이므로 별도 초기화 불필요)

## Test plan

- [x] `pytest tests/test_bug_invite_org_invite_auto_accept.py` — 5/5 PASS
- [ ] CI 통과 확인
- [ ] isaacshin 재로그인 후 org_member 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)