### PR TITLE
fix: invite accept 404 — token body 전달 누락

### DIFF
--- a/apps/web/src/app/api/invites/[token]/accept/route.ts
+++ b/apps/web/src/app/api/invites/[token]/accept/route.ts
@@ -1,11 +1,19 @@
 import { apiSuccess } from '@/lib/api-response';
-import { proxyToFastapiWithParams } from '@/lib/fastapi-proxy';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 type RouteParams = { params: Promise<{ token: string }> };
 
 export async function POST(request: Request, { params }: RouteParams) {
   const { token } = await params;
-  const _r = await proxyToFastapiWithParams(request, '/api/v2/invites/[token]/accept', { token });
+  // Backend: POST /api/v2/invites/accept with body {token} (not path param)
+  const headers = new Headers(request.headers);
+  headers.set('Content-Type', 'application/json');
+  const syntheticRequest = new Request(request.url, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ token }),
+  });
+  const _r = await proxyToFastapi(syntheticRequest, '/api/v2/invites/accept');
   if (!_r.ok) return _r;
   if (_r.status === 204) return apiSuccess({ ok: true });
   return apiSuccess(await _r.json());


### PR DESCRIPTION
## 원인

`POST /api/v2/invites/{token}/accept` (path param) 방식으로 백엔드에 요청 → FastAPI 404

백엔드 실제 엔드포인트: `POST /api/v2/invites/accept` with body `{"token": "..."}`

## 수정

`apps/web/src/app/api/invites/[token]/accept/route.ts` route handler에서
- 기존: `proxyToFastapiWithParams(..., '/api/v2/invites/[token]/accept', { token })`
- 수정: token을 request body에 담아 `POST /api/v2/invites/accept`로 proxy

## 재현

1. 초대 링크 `/invite/accept?token=63fbcc5a...` 접속
2. "초대 수락" 버튼 클릭
3. 기존: 404 → "초대 수락에 실패했습니다."
4. 수정 후: 200 → 정상 수락

🤖 Generated with [Claude Code](https://claude.com/claude-code)