### PR TITLE
fix(s-mbr-03): /me 엔드포인트 org role 상속 — isAdmin 프론트 연동

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -95,6 +95,20 @@ async def get_me(
         if user:
             data.has_password = bool(user.hashed_password)
 
+    # S-MBR-03: org owner/admin → effective role 상속. /me role이 JWT role과 일치하도록.
+    if not is_api_key and member.user_id:
+        _ROLE_RANK: dict[str, int] = {"owner": 4, "admin": 3, "manager": 2, "member": 1}
+        org_role_result = await session.execute(
+            select(OrgMember.role).where(
+                OrgMember.org_id == member.org_id,
+                OrgMember.user_id == member.user_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )
+        org_role = org_role_result.scalar_one_or_none()
+        if org_role and _ROLE_RANK.get(org_role, 0) > _ROLE_RANK.get(data.role, 0):
+            data = data.model_copy(update={"role": org_role})
+
     return data
 
 

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -109,6 +109,115 @@ def test_unknown_org_preserves_project_role():
 import pytest
 
 
+# ─── AC1/AC2: /me 엔드포인트 role 상속 ─────────────────────────────────────────
+
+def test_me_router_has_org_role_override():
+    """me.py get_me 소스에 org role override 로직이 포함됨."""
+    import app.routers.me as me_module
+    source = inspect.getsource(me_module.get_me)
+    assert "_ROLE_RANK" in source
+    assert "org_role" in source
+    assert "model_copy" in source
+
+
+@pytest.mark.anyio
+async def test_get_me_org_admin_role_override():
+    """GET /me: team_member.role=member + org_member.role=admin → role=admin 반환 (AC2)."""
+    from app.routers.me import get_me
+    from app.dependencies.auth import AuthContext
+
+    member_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    mock_member = MagicMock()
+    mock_member.id = member_id
+    mock_member.org_id = org_id
+    mock_member.project_id = project_id
+    mock_member.user_id = user_id
+    mock_member.type = "human"
+    mock_member.name = "test"
+    mock_member.role = "member"  # project level: member
+    mock_member.is_active = True
+    mock_member.project_name = None  # MeResponse 직렬화 필수
+    mock_member.has_password = None
+    mock_member.project = MagicMock()
+    mock_member.project.name = "Test Project"
+
+    mock_session = AsyncMock()
+    member_result = MagicMock()
+    member_result.scalars.return_value.first.return_value = mock_member
+
+    user_result = MagicMock()
+    mock_user = MagicMock()
+    mock_user.hashed_password = None
+    user_result.scalar_one_or_none.return_value = mock_user
+
+    org_role_result = MagicMock()
+    org_role_result.scalar_one_or_none.return_value = "admin"  # org level: admin
+
+    mock_session.execute = AsyncMock(side_effect=[member_result, user_result, org_role_result])
+
+    auth = AuthContext(
+        user_id=str(user_id),
+        email="test@example.com",
+        claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        org_id=str(org_id),
+    )
+
+    result = await get_me(member_id=None, session=mock_session, auth=auth)
+    assert result.role == "admin"
+
+
+@pytest.mark.anyio
+async def test_get_me_project_role_higher_preserved():
+    """GET /me: team_member.role=admin + org_member.role=member → role=admin 유지."""
+    from app.routers.me import get_me
+    from app.dependencies.auth import AuthContext
+
+    member_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    mock_member = MagicMock()
+    mock_member.id = member_id
+    mock_member.org_id = org_id
+    mock_member.project_id = project_id
+    mock_member.user_id = user_id
+    mock_member.type = "human"
+    mock_member.name = "test"
+    mock_member.role = "admin"  # project level: admin (높음)
+    mock_member.is_active = True
+    mock_member.project_name = None
+    mock_member.has_password = None
+    mock_member.project = MagicMock()
+    mock_member.project.name = "Test Project"
+
+    mock_session = AsyncMock()
+    member_result = MagicMock()
+    member_result.scalars.return_value.first.return_value = mock_member
+
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = MagicMock(hashed_password=None)
+
+    org_role_result = MagicMock()
+    org_role_result.scalar_one_or_none.return_value = "member"  # org level: member (낮음)
+
+    mock_session.execute = AsyncMock(side_effect=[member_result, user_result, org_role_result])
+
+    auth = AuthContext(
+        user_id=str(user_id),
+        email="test@example.com",
+        claims={"app_metadata": {"org_id": str(org_id), "project_id": str(project_id)}},
+        org_id=str(org_id),
+    )
+
+    result = await get_me(member_id=None, session=mock_session, auth=auth)
+    assert result.role == "admin"  # 기존 높은 role 유지
+
+
 @pytest.mark.anyio
 async def test_list_members_owner_always_included():
     """AC4: org owner는 denied project_access 레코드가 있어도 목록에 포함됨.


### PR DESCRIPTION
## 원인

PR #1057(S-MBR-03)에서 `_build_app_metadata`의 JWT role은 org role로 override됐지만, `GET /me`는 `team_members` 테이블을 직접 조회하여 project-level role을 반환. 프론트의 `isAdmin = (meJson.data.role === 'admin')` 판단이 여전히 project-level member role로 읽히는 구조.

## 수정

`backend/app/routers/me.py` `get_me` 함수에 동일한 org role override 로직 추가:
- `org_members.role`을 조회하여 `team_member.role`보다 높으면 effective role 반환
- API key 인증 경로는 적용 제외 (API key는 agent 전용)

## Test plan
- [ ] `test_s_mbr_03.py` — 13건 PASS (`get_me` override 2건 신규)
- [ ] 전체 테스트 1054건 PASS
- [ ] Org admin 계정 재로그인 없이 settings 페이지 새로고침 → isAdmin=true 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)