### PR TITLE
fix: assignableMembers 드롭다운 org_members 기반으로 전환

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -376,7 +376,7 @@ export default function SettingsPage() {
 
     const [projectMemberRes, orgMemberRes] = await Promise.all([
       fetch(`/api/team-members?project_id=${projectId}`),
-      fetch('/api/team-members?include_inactive=true'),
+      fetch('/api/org-members'),
     ]);
 
     if (projectMemberRes.ok) {
@@ -386,7 +386,18 @@ export default function SettingsPage() {
 
     if (orgMemberRes.ok) {
       const json = await orgMemberRes.json();
-      setOrgMembers((json.data ?? []) as ProjectMember[]);
+      type OrgMemberRow = { id: string; user_id: string; role: string; email?: string; deleted_at?: string | null };
+      const mapped: ProjectMember[] = (json.data ?? []).map((row: OrgMemberRow) => ({
+        id: row.id,
+        name: row.email ?? row.user_id,
+        email: row.email,
+        type: 'human' as const,
+        role: row.role,
+        user_id: row.user_id,
+        project_id: projectId,
+        is_active: !row.deleted_at,
+      }));
+      setOrgMembers(mapped);
     }
   };
 


### PR DESCRIPTION
## Summary

- `refreshMemberData`에서 `fetch('/api/team-members?include_inactive=true')` → `fetch('/api/org-members')`로 변경
- E-ENTITY-CLEANUP 이후 human 유저는 `team_members`가 아닌 `org_members`에만 존재하므로, `assignableMembers` 드롭다운에서 해당 유저가 누락되는 버그 수정
- `/api/org-members` 응답(`id, user_id, role, email, deleted_at`)을 `ProjectMember` 인터페이스로 매핑

## Root Cause

`assignableMembers` useMemo가 `orgMembers` state를 사용하는데, 이 state를 `team_members` API로 채우고 있었음. `dev1@moonklabs.com` 같이 `org_members`에만 존재하는 유저는 결과에 포함 안 됨.

## Test plan

- [ ] 멤버 추가 드롭다운('멤버 선택')에 org_members 기반 유저 모두 표시 확인
- [ ] 이미 프로젝트에 추가된 유저는 드롭다운에서 제외 확인 (`assignableMembers` 필터 동작)
- [ ] 드롭다운 선택 후 '추가' 버튼으로 정상 추가 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)