### PR TITLE
feat: S-INV-03 초대 이메일 발송 기반 구축

### DIFF
--- a/backend/alembic/versions/0056_invitation_email_tracking.py
+++ b/backend/alembic/versions/0056_invitation_email_tracking.py
@@ -1,0 +1,22 @@
+"""S-INV-03: invitations 테이블에 email_sent_at, email_error 컬럼 추가
+
+Revision ID: 0056
+Revises: 0055
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0056"
+down_revision = "0055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("invitations", sa.Column("email_sent_at", sa.DateTime(timezone=True), nullable=True))
+    op.add_column("invitations", sa.Column("email_error", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("invitations", "email_error")
+    op.drop_column("invitations", "email_sent_at")

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -29,3 +29,5 @@ class Invitation(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    email_sent_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    email_error: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/repositories/invitation.py
+++ b/backend/app/repositories/invitation.py
@@ -78,6 +78,16 @@ class InvitationRepository:
         await self.session.refresh(inv)
         return inv
 
+    async def update_email_result(
+        self, id: uuid.UUID, *, sent_at: datetime | None, error: str | None
+    ) -> None:
+        inv = await self.get(id)
+        if inv is None:
+            return
+        inv.email_sent_at = sent_at
+        inv.email_error = error
+        await self.session.flush()
+
     async def accept(self, token: str) -> Invitation | None:
         inv = await self.get_by_token(token)
         if inv is None:

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -2,16 +2,17 @@ import uuid
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id, require_admin
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.project import OrgMember
-from app.models.team import TeamMember
 from app.repositories.invitation import InvitationRepository
 from app.schemas.invitation import AcceptInvitation, CreateInvitation, InvitationResponse
+from app.services.org_invite_email import send_invite_email
 
 router = APIRouter(prefix="/api/v2/invitations", tags=["invitations"])
 
@@ -23,6 +24,23 @@ def _get_repo(
     return InvitationRepository(session, org_id)
 
 
+def _to_response(inv: Invitation) -> InvitationResponse:
+    base = InvitationResponse.model_validate(inv)
+    invite_url = None
+    if inv.status == "pending" and inv.expires_at > datetime.now(timezone.utc):
+        invite_url = f"{settings.app_url}/invite/accept?token={inv.token}"
+    return base.model_copy(update={"invite_url": invite_url})
+
+
+async def _get_org_name(session: AsyncSession, org_id: uuid.UUID) -> str:
+    row = await session.execute(
+        text("SELECT name FROM organizations WHERE id = :id"),
+        {"id": str(org_id)},
+    )
+    r = row.first()
+    return r[0] if r else str(org_id)
+
+
 @router.get("", response_model=list[InvitationResponse])
 async def list_invitations(
     project_id: uuid.UUID | None = Query(default=None),
@@ -30,14 +48,16 @@ async def list_invitations(
     _: None = Depends(require_admin),
 ) -> list[InvitationResponse]:
     items = await repo.list(project_id=project_id)
-    return [InvitationResponse.model_validate(i) for i in items]
+    return [_to_response(i) for i in items]
 
 
 @router.post("", response_model=InvitationResponse, status_code=201)
 async def create_invitation(
     body: CreateInvitation,
     repo: InvitationRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
     _: None = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
 ) -> InvitationResponse:
     inv = await repo.create(
         email=body.email,
@@ -45,7 +65,24 @@ async def create_invitation(
         invited_by=body.invited_by,
         project_id=body.project_id,
     )
-    return InvitationResponse.model_validate(inv)
+    await session.commit()
+
+    # AC1: 초대 생성 시 자동 이메일 발송 (실패해도 레코드 유지)
+    org_name = await _get_org_name(session, repo.org_id)
+    inviter_name = auth.email or auth.claims.get("email", "")
+    error = send_invite_email(
+        to=inv.email,
+        org_name=org_name,
+        token=inv.token,
+        role=inv.role,
+        inviter_name=inviter_name,
+    )
+    sent_at = None if error else datetime.now(timezone.utc)
+    await repo.update_email_result(inv.id, sent_at=sent_at, error=error)
+    await session.commit()
+
+    await session.refresh(inv)
+    return _to_response(inv)
 
 
 @router.delete("/{id}", response_model=InvitationResponse)
@@ -57,19 +94,38 @@ async def revoke_invitation(
     inv = await repo.revoke(id)
     if inv is None:
         raise HTTPException(status_code=404, detail="Invitation not found")
-    return InvitationResponse.model_validate(inv)
+    return _to_response(inv)
 
 
 @router.post("/{id}/resend", response_model=InvitationResponse)
 async def resend_invitation(
     id: uuid.UUID,
     repo: InvitationRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
     _: None = Depends(require_admin),
+    session: AsyncSession = Depends(get_db),
 ) -> InvitationResponse:
     inv = await repo.resend(id)
     if inv is None:
         raise HTTPException(status_code=404, detail="Invitation not found or revoked")
-    return InvitationResponse.model_validate(inv)
+    await session.commit()
+
+    # AC3: 재발송 — 새 토큰으로 이메일 재전송
+    org_name = await _get_org_name(session, repo.org_id)
+    inviter_name = auth.email or auth.claims.get("email", "")
+    error = send_invite_email(
+        to=inv.email,
+        org_name=org_name,
+        token=inv.token,
+        role=inv.role,
+        inviter_name=inviter_name,
+    )
+    sent_at = None if error else datetime.now(timezone.utc)
+    await repo.update_email_result(inv.id, sent_at=sent_at, error=error)
+    await session.commit()
+
+    await session.refresh(inv)
+    return _to_response(inv)
 
 
 @router.post("/accept", status_code=200)
@@ -100,9 +156,6 @@ async def accept_invitation(
         .values(org_id=inv.org_id, user_id=user_id, role=inv.role)
         .on_conflict_do_nothing(constraint="uq_org_members_org_user")
     )
-
-    # human team_member 생성 제거 — org_members 기반 opt-out 모델로 이전 (E-ENTITY-CLEANUP S5).
-    # project_id가 있더라도 org_member로 이미 프로젝트 접근 허용됨.
 
     await session.flush()
     return {"ok": True, "org_id": str(inv.org_id), "project_id": str(inv.project_id) if inv.project_id else None}

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -37,6 +37,9 @@ class InvitationResponse(BaseModel):
     expires_at: datetime
     accepted_at: datetime | None = None
     created_at: datetime
+    email_sent_at: datetime | None = None
+    email_error: str | None = None
+    invite_url: str | None = None
 
 
 class AcceptInvitation(BaseModel):

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,4 +1,4 @@
-"""이메일 발송 서비스 — SMTP 또는 콘솔 fallback."""
+"""이메일 발송 서비스 — Resend API 우선, SMTP fallback, 콘솔 최종 fallback."""
 import logging
 import os
 import smtplib
@@ -9,12 +9,37 @@ logger = logging.getLogger(__name__)
 
 
 def send_email(to: str, subject: str, html_body: str) -> None:
-    """이메일 발송. EMAIL_SMTP_HOST 미설정 시 콘솔 출력으로 fallback."""
-    smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-    if not smtp_host:
-        logger.info("[EMAIL FALLBACK] To: %s | Subject: %s\n%s", to, subject, html_body)
+    """이메일 발송.
+
+    우선순위: RESEND_API_KEY → EMAIL_SMTP_HOST → 콘솔 출력 fallback.
+    실패 시 예외를 re-raise — 호출자가 오류 처리 책임.
+    """
+    resend_key = os.getenv("RESEND_API_KEY", "")
+    if resend_key:
+        _send_via_resend(to=to, subject=subject, html_body=html_body, api_key=resend_key)
         return
 
+    smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
+    if smtp_host:
+        _send_via_smtp(to=to, subject=subject, html_body=html_body, smtp_host=smtp_host)
+        return
+
+    logger.info("[EMAIL FALLBACK] To: %s | Subject: %s\n%s", to, subject, html_body)
+
+
+def _send_via_resend(*, to: str, subject: str, html_body: str, api_key: str) -> None:
+    import resend  # type: ignore[import]
+    resend.api_key = api_key
+    from_addr = os.getenv("EMAIL_FROM", "Sprintable <noreply@sprintable.ai>")
+    resend.Emails.send({
+        "from": from_addr,
+        "to": [to],
+        "subject": subject,
+        "html": html_body,
+    })
+
+
+def _send_via_smtp(*, to: str, subject: str, html_body: str, smtp_host: str) -> None:
     from_addr = os.getenv("EMAIL_FROM", "noreply@sprintable.ai")
     smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
     smtp_user = os.getenv("EMAIL_SMTP_USER", "")
@@ -26,11 +51,8 @@ def send_email(to: str, subject: str, html_body: str) -> None:
     msg["To"] = to
     msg.attach(MIMEText(html_body, "html"))
 
-    try:
-        with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as s:
-            s.starttls()
-            if smtp_user:
-                s.login(smtp_user, smtp_pass)
-            s.send_message(msg)
-    except Exception:
-        logger.exception("Failed to send email to %s", to)
+    with smtplib.SMTP(smtp_host, smtp_port, timeout=10) as s:
+        s.starttls()
+        if smtp_user:
+            s.login(smtp_user, smtp_pass)
+        s.send_message(msg)

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -1,29 +1,85 @@
-"""org_invites 이메일 발송 서비스."""
+"""org_invites / invitations 이메일 발송 서비스."""
 from __future__ import annotations
 
 import logging
 import os
 
+from app.services.email import send_email
+
 logger = logging.getLogger(__name__)
 
+_BUTTON_STYLE = (
+    "display:inline-block;padding:12px 28px;background:#6366f1;color:#ffffff;"
+    "text-decoration:none;border-radius:8px;font-weight:600;font-size:15px;"
+)
 
-def send_invite_email(*, to: str, org_name: str, token: str, role: str) -> str | None:
+
+def _build_invite_html(*, org_name: str, inviter_name: str, accept_link: str, role: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="ko">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head>
+<body style="margin:0;padding:0;background:#f4f4f5;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,.1);">
+        <!-- Header -->
+        <tr><td style="background:#6366f1;padding:28px 40px;">
+          <span style="color:#ffffff;font-size:20px;font-weight:700;">Sprintable</span>
+        </td></tr>
+        <!-- Body -->
+        <tr><td style="padding:40px 40px 32px;">
+          <h2 style="margin:0 0 16px;font-size:22px;color:#111827;">팀에 초대됐어요!</h2>
+          <p style="margin:0 0 12px;color:#374151;line-height:1.6;">
+            <strong>{inviter_name}</strong>님이 <strong>{org_name}</strong> 조직에
+            <strong>{role}</strong>로 초대했습니다.
+          </p>
+          <p style="margin:0 0 32px;color:#6b7280;font-size:14px;line-height:1.6;">
+            아래 버튼을 클릭하면 초대를 수락할 수 있습니다. 링크는 7일간 유효합니다.
+          </p>
+          <a href="{accept_link}" style="{_BUTTON_STYLE}">초대 수락하기</a>
+          <hr style="margin:32px 0;border:none;border-top:1px solid #e5e7eb;">
+          <p style="margin:0;color:#9ca3af;font-size:13px;line-height:1.6;">
+            버튼이 보이지 않으면 아래 주소를 브라우저에 붙여 넣으세요:<br>
+            <a href="{accept_link}" style="color:#6366f1;word-break:break-all;">{accept_link}</a>
+          </p>
+        </td></tr>
+        <!-- Footer -->
+        <tr><td style="background:#f9fafb;padding:20px 40px;border-top:1px solid #e5e7eb;">
+          <p style="margin:0;color:#9ca3af;font-size:12px;">
+            © 2025 Sprintable. 이 이메일은 초대 발송으로 자동 생성되었습니다.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>"""
+
+
+def send_invite_email(
+    *,
+    to: str,
+    org_name: str,
+    token: str,
+    role: str,
+    inviter_name: str = "",
+) -> str | None:
     """초대 이메일 발송. 성공 시 None, 실패 시 오류 메시지 반환."""
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     accept_link = f"{app_url}/invite/accept?token={token}"
+    display_inviter = inviter_name or "팀 관리자"
 
-    html_body = (
-        f"<p><strong>{org_name}</strong> 조직에 <strong>{role}</strong>로 초대됐는.</p>"
-        f"<p>아래 링크를 클릭하여 초대를 수락하면 됩니다. 7일 이내 유효한 링크입니다.</p>"
-        f"<p><a href='{accept_link}'>초대 수락하기</a></p>"
-        f"<p>링크가 보이지 않으면 아래 주소를 브라우저에 붙여넣어 사용하세요:<br>{accept_link}</p>"
+    html_body = _build_invite_html(
+        org_name=org_name,
+        inviter_name=display_inviter,
+        accept_link=accept_link,
+        role=role,
     )
 
     try:
-        from app.services.email import send_email
         send_email(
             to=to,
-            subject=f"[Sprintable] {org_name} 조직 초대",
+            subject=f"[Sprintable] {org_name} 조직에 초대됐습니다",
             html_body=html_body,
         )
         return None

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "psycopg2-binary>=2.9.0",
     "slowapi>=0.1.9",
     "mcp>=1.0.0",
+    "resend>=2.0.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_e_org_multi_s3_2_invite_email.py
+++ b/backend/tests/test_e_org_multi_s3_2_invite_email.py
@@ -90,7 +90,7 @@ def test_send_invite_email_includes_token():
     def _mock_send(to, subject, html_body):
         sent_bodies.append(html_body)
 
-    with patch("app.services.email.send_email", side_effect=_mock_send):
+    with patch("app.services.org_invite_email.send_email", side_effect=_mock_send):
         result = send_invite_email(to="x@y.com", org_name="Test", token="tok123", role="member")
 
     assert result is None
@@ -169,7 +169,7 @@ def test_send_invite_email_returns_error_on_failure():
     """send_invite_email 실패 시 오류 문자열 반환."""
     from app.services.org_invite_email import send_invite_email
 
-    with patch("app.services.email.send_email", side_effect=Exception("SMTP fail")):
+    with patch("app.services.org_invite_email.send_email", side_effect=Exception("SMTP fail")):
         result = send_invite_email(to="x@y.com", org_name="Test", token="tok", role="member")
 
     assert result is not None

--- a/backend/tests/test_invitations.py
+++ b/backend/tests/test_invitations.py
@@ -25,6 +25,9 @@ def _mock_invitation(status: str = "pending") -> MagicMock:
     inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
     inv.accepted_at = None
     inv.created_at = datetime(2026, 4, 30, tzinfo=timezone.utc)
+    inv.email_sent_at = None
+    inv.email_error = None
+    inv.invite_url = None
     return inv
 
 
@@ -97,7 +100,12 @@ async def test_list_invitations_with_project_filter_200():
 async def test_create_invitation_201():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.invitation.InvitationRepository.create", new_callable=AsyncMock) as mock_create:
+        with (
+            patch("app.repositories.invitation.InvitationRepository.create", new_callable=AsyncMock) as mock_create,
+            patch("app.routers.invitations.send_invite_email", return_value=None),
+            patch("app.routers.invitations._get_org_name", new=AsyncMock(return_value="TestOrg")),
+            patch("app.repositories.invitation.InvitationRepository.update_email_result", new_callable=AsyncMock),
+        ):
             mock_create.return_value = _mock_invitation()
 
             async with client as c:
@@ -151,7 +159,12 @@ async def test_resend_invitation_200():
     try:
         refreshed = _mock_invitation("pending")
         refreshed.token = "newtokenhex"
-        with patch("app.repositories.invitation.InvitationRepository.resend", new_callable=AsyncMock) as mock_resend:
+        with (
+            patch("app.repositories.invitation.InvitationRepository.resend", new_callable=AsyncMock) as mock_resend,
+            patch("app.routers.invitations.send_invite_email", return_value=None),
+            patch("app.routers.invitations._get_org_name", new=AsyncMock(return_value="TestOrg")),
+            patch("app.repositories.invitation.InvitationRepository.update_email_result", new_callable=AsyncMock),
+        ):
             mock_resend.return_value = refreshed
 
             async with client as c:

--- a/backend/tests/test_s_inv_03.py
+++ b/backend/tests/test_s_inv_03.py
@@ -1,0 +1,341 @@
+"""S-INV-03: 초대 이메일 발송 기반 구축.
+
+AC1: 초대 생성 시 자동 발송 — 조직명, 초대자명, 수락 링크 포함
+AC2: HTML 이메일 템플릿 — 수락 버튼 CTA
+AC3: 발송 실패 시 email_error 기록, 재발송 API 동작
+AC4: invite_url(링크 복사용) InvitationResponse에 포함
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── AC2: 이메일 템플릿 검증 ─────────────────────────────────────────────────
+
+def test_invite_html_contains_button():
+    """HTML 템플릿에 CTA 버튼 포함."""
+    from app.services.org_invite_email import _build_invite_html
+    html = _build_invite_html(
+        org_name="Sprintable",
+        inviter_name="오르테가",
+        accept_link="https://app.sprintable.ai/invite/accept?token=abc",
+        role="member",
+    )
+    assert "초대 수락하기" in html
+    assert "https://app.sprintable.ai/invite/accept?token=abc" in html
+    assert "오르테가" in html
+    assert "Sprintable" in html
+
+
+def test_invite_html_contains_role():
+    """HTML 템플릿에 role 표시."""
+    from app.services.org_invite_email import _build_invite_html
+    html = _build_invite_html(
+        org_name="Moonklabs",
+        inviter_name="테스터",
+        accept_link="https://example.com/invite",
+        role="admin",
+    )
+    assert "admin" in html
+
+
+def test_invite_html_inviter_fallback():
+    """inviter_name 미전달 시 '팀 관리자' 표시."""
+    from app.services.org_invite_email import send_invite_email
+    captured = {}
+
+    def mock_send(*, to, subject, html_body):
+        captured["html"] = html_body
+
+    with patch("app.services.org_invite_email.send_email", side_effect=lambda **kw: mock_send(**kw)):
+        # inviter_name 미전달
+        send_invite_email(to="test@example.com", org_name="Org", token="tok", role="member")
+
+    assert "팀 관리자" in captured.get("html", "")
+
+
+# ─── AC1: 이메일 자동 발송 라우터 검증 ────────────────────────────────────────
+
+def test_create_invitation_calls_send_invite_email():
+    """create_invitation 소스에 send_invite_email 호출 존재."""
+    from app.routers import invitations as inv_module
+    source = inspect.getsource(inv_module.create_invitation)
+    assert "send_invite_email" in source
+    assert "inviter_name" in source
+
+
+def test_resend_invitation_calls_send_invite_email():
+    """resend_invitation 소스에 send_invite_email 호출 존재."""
+    from app.routers import invitations as inv_module
+    source = inspect.getsource(inv_module.resend_invitation)
+    assert "send_invite_email" in source
+
+
+# ─── AC3: 발송 실패 시 email_error 기록 ──────────────────────────────────────
+
+def test_invitation_model_has_email_fields():
+    """Invitation 모델에 email_sent_at, email_error 컬럼 존재."""
+    from app.models.invitation import Invitation
+    cols = {c.name for c in Invitation.__table__.columns}
+    assert "email_sent_at" in cols
+    assert "email_error" in cols
+
+
+def test_invitation_response_has_email_fields():
+    """InvitationResponse에 email_sent_at, email_error, invite_url 필드 존재."""
+    from app.schemas.invitation import InvitationResponse
+    fields = set(InvitationResponse.model_fields.keys())
+    assert {"email_sent_at", "email_error", "invite_url"}.issubset(fields)
+
+
+@pytest.mark.anyio
+async def test_create_invitation_records_email_error_on_failure():
+    """이메일 발송 실패 시 email_error 기록, 초대 레코드 유지 (AC3)."""
+    from app.routers.invitations import create_invitation
+    from app.schemas.invitation import CreateInvitation
+    from app.dependencies.auth import AuthContext
+
+    inv_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+    invited_by = uuid.uuid4()
+
+    mock_inv = MagicMock()
+    mock_inv.id = inv_id
+    mock_inv.org_id = org_id
+    mock_inv.project_id = project_id
+    mock_inv.email = "test@example.com"
+    mock_inv.role = "member"
+    mock_inv.token = "testtoken123"
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    mock_inv.accepted_at = None
+    mock_inv.created_at = datetime.now(timezone.utc)
+    mock_inv.email_sent_at = None
+    mock_inv.email_error = None
+    mock_inv.invite_url = None
+    mock_inv.invited_by = invited_by
+
+    mock_repo = AsyncMock()
+    mock_repo.org_id = org_id
+    mock_repo.create = AsyncMock(return_value=mock_inv)
+    mock_repo.update_email_result = AsyncMock()
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=MagicMock(first=lambda: ("TestOrg",)))
+
+    auth = AuthContext(
+        user_id=str(uuid.uuid4()),
+        email="inviter@example.com",
+        claims={"email": "inviter@example.com"},
+        org_id=str(org_id),
+    )
+
+    body = CreateInvitation(
+        email="test@example.com",
+        role="member",
+        invited_by=invited_by,
+    )
+
+    error_msg = "Connection refused"
+    with patch("app.routers.invitations.send_invite_email", return_value=error_msg):
+        await create_invitation(
+            body=body,
+            repo=mock_repo,
+            auth=auth,
+            _=None,
+            session=mock_session,
+        )
+
+    # email_error가 기록됐는지
+    mock_repo.update_email_result.assert_called_once()
+    call_kwargs = mock_repo.update_email_result.call_args
+    assert call_kwargs.kwargs.get("error") == error_msg
+    assert call_kwargs.kwargs.get("sent_at") is None
+
+
+@pytest.mark.anyio
+async def test_create_invitation_records_sent_at_on_success():
+    """이메일 발송 성공 시 email_sent_at 기록 (AC1)."""
+    from app.routers.invitations import create_invitation
+    from app.schemas.invitation import CreateInvitation
+    from app.dependencies.auth import AuthContext
+
+    inv_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    invited_by = uuid.uuid4()
+
+    mock_inv = MagicMock()
+    mock_inv.id = inv_id
+    mock_inv.org_id = org_id
+    mock_inv.project_id = None
+    mock_inv.email = "test@example.com"
+    mock_inv.role = "member"
+    mock_inv.token = "testtoken456"
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    mock_inv.accepted_at = None
+    mock_inv.created_at = datetime.now(timezone.utc)
+    mock_inv.email_sent_at = None
+    mock_inv.email_error = None
+    mock_inv.invite_url = None
+    mock_inv.invited_by = invited_by
+
+    mock_repo = AsyncMock()
+    mock_repo.org_id = org_id
+    mock_repo.create = AsyncMock(return_value=mock_inv)
+    mock_repo.update_email_result = AsyncMock()
+
+    mock_session = AsyncMock()
+    mock_session.execute = AsyncMock(return_value=MagicMock(first=lambda: ("TestOrg",)))
+
+    auth = AuthContext(
+        user_id=str(uuid.uuid4()),
+        email="inviter@example.com",
+        claims={"email": "inviter@example.com"},
+        org_id=str(org_id),
+    )
+
+    body = CreateInvitation(
+        email="test@example.com",
+        role="member",
+        invited_by=invited_by,
+    )
+
+    with patch("app.routers.invitations.send_invite_email", return_value=None):
+        await create_invitation(
+            body=body,
+            repo=mock_repo,
+            auth=auth,
+            _=None,
+            session=mock_session,
+        )
+
+    mock_repo.update_email_result.assert_called_once()
+    call_kwargs = mock_repo.update_email_result.call_args
+    assert call_kwargs.kwargs.get("error") is None
+    assert call_kwargs.kwargs.get("sent_at") is not None
+
+
+# ─── AC4: invite_url 응답 포함 ────────────────────────────────────────────────
+
+def test_to_response_includes_invite_url():
+    """pending + 미만료 초대는 invite_url 포함."""
+    from app.routers.invitations import _to_response
+
+    mock_inv = MagicMock()
+    mock_inv.id = uuid.uuid4()
+    mock_inv.org_id = uuid.uuid4()
+    mock_inv.project_id = None
+    mock_inv.invited_by = uuid.uuid4()
+    mock_inv.email = "test@example.com"
+    mock_inv.role = "member"
+    mock_inv.token = "testtoken789"
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    mock_inv.accepted_at = None
+    mock_inv.created_at = datetime.now(timezone.utc)
+    mock_inv.email_sent_at = None
+    mock_inv.email_error = None
+    mock_inv.invite_url = None
+
+    resp = _to_response(mock_inv)
+    assert resp.invite_url is not None
+    assert "testtoken789" in resp.invite_url
+
+
+def test_to_response_no_url_for_accepted():
+    """accepted 상태는 invite_url = None."""
+    from app.routers.invitations import _to_response
+
+    mock_inv = MagicMock()
+    mock_inv.id = uuid.uuid4()
+    mock_inv.org_id = uuid.uuid4()
+    mock_inv.project_id = None
+    mock_inv.invited_by = uuid.uuid4()
+    mock_inv.email = "test@example.com"
+    mock_inv.role = "member"
+    mock_inv.token = "tok"
+    mock_inv.status = "accepted"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+    mock_inv.accepted_at = datetime.now(timezone.utc)
+    mock_inv.created_at = datetime.now(timezone.utc)
+    mock_inv.email_sent_at = None
+    mock_inv.email_error = None
+    mock_inv.invite_url = None
+
+    resp = _to_response(mock_inv)
+    assert resp.invite_url is None
+
+
+# ─── 이메일 서비스 ────────────────────────────────────────────────────────────
+
+def test_email_service_resend_priority():
+    """email.py가 RESEND_API_KEY 있으면 Resend 사용 로직 포함."""
+    from app.services import email as email_module
+    source = inspect.getsource(email_module)
+    assert "RESEND_API_KEY" in source
+    assert "resend" in source.lower()
+
+
+def test_email_service_smtp_fallback():
+    """email.py가 SMTP fallback 로직 포함."""
+    from app.services import email as email_module
+    source = inspect.getsource(email_module)
+    assert "EMAIL_SMTP_HOST" in source
+
+
+def test_send_invite_email_success():
+    """send_invite_email — 이메일 발송 성공 시 None 반환."""
+    from app.services.org_invite_email import send_invite_email
+    with patch("app.services.org_invite_email.send_email") as mock_send:
+        mock_send.return_value = None
+        result = send_invite_email(
+            to="test@example.com",
+            org_name="TestOrg",
+            token="tok",
+            role="member",
+            inviter_name="홍길동",
+        )
+    assert result is None
+
+
+def test_send_invite_email_failure():
+    """send_invite_email — 이메일 발송 실패 시 오류 메시지 반환."""
+    from app.services.org_invite_email import send_invite_email
+    with patch("app.services.org_invite_email.send_email", side_effect=Exception("SMTP error")):
+        result = send_invite_email(
+            to="test@example.com",
+            org_name="TestOrg",
+            token="tok",
+            role="member",
+            inviter_name="홍길동",
+        )
+    assert result is not None
+    assert "SMTP error" in result
+
+
+# ─── migration 0056 ──────────────────────────────────────────────────────────
+
+def test_migration_0056_exists():
+    """Alembic migration 0056 파일 존재."""
+    import os
+    base = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions")
+    files = os.listdir(base)
+    assert any("0056" in f for f in files)
+
+
+def test_migration_0056_adds_email_columns():
+    """0056 upgrade에 email_sent_at, email_error 컬럼 추가 로직 포함."""
+    import os
+    base = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions")
+    path = next(os.path.join(base, f) for f in os.listdir(base) if "0056" in f)
+    source = open(path).read()
+    assert "email_sent_at" in source
+    assert "email_error" in source
+    assert "add_column" in source


### PR DESCRIPTION
## Summary

- **AC1**: `create_invitation`/`resend_invitation`에 자동 이메일 발송 추가 — 조직명, 초대자명(JWT email), 수락 링크 포함
- **AC2**: HTML 이메일 템플릿 전면 개선 — 인디고 CTA 버튼, 반응형 레이아웃, footer
- **AC3**: `email_sent_at`/`email_error` 기록 — 발송 실패해도 초대 레코드 유지, `resend` API로 재발송 가능
- **AC4**: `InvitationResponse`에 `invite_url` 추가 (pending+미만료 시 링크 복사용 URL 포함)

## 이메일 서비스 구성

```
RESEND_API_KEY 설정 → Resend API
EMAIL_SMTP_HOST 설정  → SMTP
미설정              → 콘솔 로그 fallback
```

## 변경 파일

- `email.py`: Resend API 지원 추가 (`_send_via_resend`, `_send_via_smtp` 분리)
- `org_invite_email.py`: `inviter_name` 파라미터 추가, HTML 템플릿 전면 개선
- `invitation.py` 모델: `email_sent_at`, `email_error` 컬럼 추가
- `InvitationRepository`: `update_email_result()` 메서드 추가
- `invitations.py` 라우터: auth 파라미터 추가, 이메일 발송/결과 기록, `invite_url` 응답
- `migration 0056`: invitations 테이블 email 컬럼 추가
- `test_s_inv_03.py`: AC1~AC4 17건 신규

## Test plan

- [ ] 초대 생성 시 대상 이메일로 초대 이메일 수신 확인 (RESEND_API_KEY 설정 필요)
- [ ] 이메일에 초대자명, 조직명, 수락 버튼 포함 확인
- [ ] 수락 버튼 클릭 → 초대 수락 플로우 정상 동작 확인
- [ ] 재발송 버튼으로 이메일 재전송 확인
- [ ] `invite_url` 복사 기능 유지 확인

> ⚠️ **환경 변수 필요**: `RESEND_API_KEY` 설정 (미설정 시 콘솔 fallback)
> ⚠️ **마이그레이션 필요**: 머지 후 `sprintable-migrate-dev` job 수동 실행

🤖 Generated with [Claude Code](https://claude.com/claude-code)