### PR TITLE
[S-INV-02] 가입 폼 displayName 필수화

### DIFF
--- a/apps/web/src/app/register/page.tsx
+++ b/apps/web/src/app/register/page.tsx
@@ -21,6 +21,7 @@ function countCategories(rules: ReturnType<typeof checkPasswordRules>) {
 
 export default function RegisterPage() {
   const router = useRouter();
+  const [displayName, setDisplayName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [passwordTouched, setPasswordTouched] = useState(false);
@@ -33,7 +34,7 @@ export default function RegisterPage() {
   const isPasswordValid = rules.length && categoriesMet >= 3;
 
   const handleRegister = async () => {
-    if (!email.trim() || !password.trim()) return;
+    if (!displayName.trim() || !email.trim() || !password.trim()) return;
     if (!tosAccepted) return;
     if (!isPasswordValid) {
       setPasswordTouched(true);
@@ -45,7 +46,7 @@ export default function RegisterPage() {
       const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: email.trim(), password, tos_accepted: true }),
+        body: JSON.stringify({ email: email.trim(), password, display_name: displayName.trim(), tos_accepted: true }),
       });
       const json = await res.json() as { data?: { ok: boolean }; error?: { message: string } };
       if (!res.ok || !json.data?.ok) {
@@ -79,6 +80,16 @@ export default function RegisterPage() {
         </div>
 
         <div className="space-y-3">
+          <input
+            type="text"
+            placeholder="Name"
+            autoComplete="name"
+            className="w-full rounded-lg border border-border px-4 py-3 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-brand"
+            value={displayName}
+            onChange={(e) => setDisplayName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleRegister()}
+            disabled={loading}
+          />
           <input
             type="email"
             placeholder="Email"
@@ -134,7 +145,7 @@ export default function RegisterPage() {
           {error && <p className="text-sm text-destructive">{error}</p>}
           <button
             onClick={handleRegister}
-            disabled={loading || !email.trim() || !password.trim() || !tosAccepted}
+            disabled={loading || !displayName.trim() || !email.trim() || !password.trim() || !tosAccepted}
             className="flex w-full min-h-[44px] items-center justify-center rounded-lg bg-brand px-4 py-3 text-sm font-medium text-brand-foreground transition hover:bg-brand/90 disabled:opacity-50"
           >
             {loading ? 'Creating account...' : 'Sign up'}


### PR DESCRIPTION
## 변경 사항

`apps/web/src/app/register/page.tsx` — Name 필드 추가 (+14/-3)

| 항목 | 내용 |
|---|---|
| `displayName` state 추가 | `useState('')` |
| Name input 추가 | Email 위, `autoComplete="name"`, placeholder="Name" |
| POST body | `display_name: displayName.trim()` 추가 |
| 제출 가드 | `!displayName.trim()` disabled 조건 추가 |
| handleRegister 가드 | `!displayName.trim()` early return 추가 |

## 검증

- [x] `displayName` / `display_name` register/page.tsx 5곳 적용 ✅
- [x] login/page.tsx 영향 없음 (0건) ✅
- [x] tsc 에러 0건 ✅

## BE 의존성

BE S-INV-04 (register API `display_name` 처리) 미머지 시: FE body에 포함되지만 BE가 무시 → 가입 정상 진행. BE 머지 후 자연스럽게 displayName 저장 작동.

🤖 Generated with [Claude Code](https://claude.com/claude-code)