### PR TITLE
feat: S-INV-04 초대 preview API + register invite_token + OAuth + display_name

### DIFF
--- a/backend/alembic/versions/0057_add_display_name_to_users.py
+++ b/backend/alembic/versions/0057_add_display_name_to_users.py
@@ -1,0 +1,26 @@
+"""Add display_name column to users table.
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-05-29
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0057"
+down_revision = "0056"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("display_name", sa.Text, nullable=True))
+    op.execute(
+        "UPDATE users SET display_name = split_part(email, '@', 1) WHERE display_name IS NULL"
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "display_name")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -24,6 +24,7 @@ class User(Base):
     totp_last_timestep: Mapped[int | None] = mapped_column(nullable=True)
     totp_fail_count: Mapped[int] = mapped_column(nullable=False, default=0)
     totp_locked_until: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     google_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     github_id: Mapped[str | None] = mapped_column(Text, nullable=True, unique=True, index=True)
     last_project_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -107,7 +107,9 @@ class LoginRequest(BaseModel):
 class RegisterRequest(BaseModel):
     email: str
     password: str
+    display_name: str  # AC3: 필수
     tos_accepted: bool = False
+    invite_token: str | None = None  # AC2: 초대 토큰 (가입 후 자동 수락)
 
     @field_validator("email")
     @classmethod
@@ -219,6 +221,28 @@ class SetPasswordRequest(BaseModel):
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async def _auto_accept_invitation(session: AsyncSession, user: User, invite_token: str) -> None:
+    """가입 시 invite_token이 있으면 해당 초대 자동 수락 + org_member 생성."""
+    from app.models.invitation import Invitation
+    result = await session.execute(
+        select(Invitation).where(Invitation.token == invite_token)
+    )
+    inv = result.scalar_one_or_none()
+    if inv is None or inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
+        return
+    if inv.email.lower() != user.email.lower():
+        return
+    inv.status = "accepted"
+    inv.accepted_at = datetime.now(timezone.utc)
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+    await session.execute(
+        pg_insert(OrgMember)
+        .values(org_id=inv.org_id, user_id=user.id, role=inv.role)
+        .on_conflict_do_nothing(constraint="uq_org_members_org_user")
+    )
+    await session.flush()
+
 
 async def _get_user_by_email(session: AsyncSession, email: str) -> User | None:
     result = await session.execute(select(User).where(User.email == email, User.is_active.is_(True)))
@@ -444,6 +468,7 @@ async def register(
     user = User(
         email=body.email,
         hashed_password=hash_password(body.password),
+        display_name=body.display_name.strip() or body.email.split("@")[0],
         is_active=True,
         email_verified=False,
         tos_accepted_at=datetime.now(timezone.utc),
@@ -454,6 +479,10 @@ async def register(
     except IntegrityError:
         await session.rollback()
         return _err("EMAIL_TAKEN", "Email already registered", 409)
+
+    # AC2: invite_token 있으면 가입 후 자동 수락
+    if body.invite_token:
+        await _auto_accept_invitation(session, user, body.invite_token)
 
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=await _build_app_metadata(user, session))
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
@@ -749,6 +778,7 @@ class OAuthCallbackRequest(BaseModel):
     code: str
     state: str
     tos_accepted: bool = False
+    invite_token: str | None = None  # AC4: OAuth 가입 시 초대 자동 수락
 
 
 @router.get("/oauth/{provider}/authorize")
@@ -863,11 +893,17 @@ async def oauth_callback(
             )
             session.add(user)
             try:
-                await session.commit()
-                await session.refresh(user)
+                await session.flush()
             except IntegrityError:
                 await session.rollback()
                 return _err("EMAIL_CONFLICT", "Email already registered", 409)
+
+            # AC4: invite_token 있으면 신규 OAuth 유저도 자동 수락
+            if body.invite_token:
+                await _auto_accept_invitation(session, user, body.invite_token)
+
+            await session.commit()
+            await session.refresh(user)
 
     # 4. JWT 발급
     from datetime import timedelta

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -11,7 +11,7 @@ from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.project import OrgMember
 from app.repositories.invitation import InvitationRepository
-from app.schemas.invitation import AcceptInvitation, CreateInvitation, InvitationResponse
+from app.schemas.invitation import AcceptInvitation, CreateInvitation, InvitationPreviewResponse, InvitationResponse
 from app.services.org_invite_email import send_invite_email
 
 router = APIRouter(prefix="/api/v2/invitations", tags=["invitations"])
@@ -126,6 +126,36 @@ async def resend_invitation(
 
     await session.refresh(inv)
     return _to_response(inv)
+
+
+@router.get("/preview", response_model=InvitationPreviewResponse)
+async def preview_invitation(
+    token: str = Query(...),
+    session: AsyncSession = Depends(get_db),
+) -> InvitationPreviewResponse:
+    """인증 없이 초대 미리보기 — 가입 전 org 정보 표시용 (AC1)."""
+    result = await session.execute(
+        select(Invitation).where(Invitation.token == token)
+    )
+    inv = result.scalar_one_or_none()
+    if inv is None or inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
+        raise HTTPException(status_code=400, detail="Invalid, expired, or already used token")
+
+    row = await session.execute(
+        text("SELECT name FROM organizations WHERE id = :id"),
+        {"id": str(inv.org_id)},
+    )
+    org_row = row.first()
+    org_name = org_row[0] if org_row else str(inv.org_id)
+
+    return InvitationPreviewResponse(
+        org_name=org_name,
+        org_id=inv.org_id,
+        email=inv.email,
+        role=inv.role,
+        status=inv.status,
+        expires_at=inv.expires_at,
+    )
 
 
 @router.post("/accept", status_code=200)

--- a/backend/app/schemas/invitation.py
+++ b/backend/app/schemas/invitation.py
@@ -42,5 +42,14 @@ class InvitationResponse(BaseModel):
     invite_url: str | None = None
 
 
+class InvitationPreviewResponse(BaseModel):
+    org_name: str
+    org_id: uuid.UUID
+    email: str
+    role: str
+    status: str
+    expires_at: datetime
+
+
 class AcceptInvitation(BaseModel):
     token: str

--- a/backend/tests/test_auth_email_validation.py
+++ b/backend/tests/test_auth_email_validation.py
@@ -10,7 +10,7 @@ import uuid
 # ─── RegisterRequest ──────────────────────────────────────────────────────────
 
 def test_register_valid_email():
-    r = RegisterRequest(email="User@Example.COM", password="TestPass1!")
+    r = RegisterRequest(email="User@Example.COM", password="TestPass1!", display_name="Test")
     assert r.email == "user@example.com"
 
 
@@ -26,7 +26,7 @@ def test_register_invalid_email_no_domain():
 
 
 def test_register_email_strips_whitespace():
-    r = RegisterRequest(email="  user@example.com  ", password="TestPass1!")
+    r = RegisterRequest(email="  user@example.com  ", password="TestPass1!", display_name="Test")
     assert r.email == "user@example.com"
 
 
@@ -61,6 +61,6 @@ def test_invitation_invalid_email():
 
 def test_same_email_different_case_normalizes_to_same():
     """대소문자 다른 동일 이메일이 동일 값으로 정규화되는 것 확인."""
-    r1 = RegisterRequest(email="Test@Email.com", password="TestPass1!")
-    r2 = RegisterRequest(email="test@email.com", password="TestPass1!")
+    r1 = RegisterRequest(email="Test@Email.com", password="TestPass1!", display_name="Test")
+    r2 = RegisterRequest(email="test@email.com", password="TestPass1!", display_name="Test")
     assert r1.email == r2.email

--- a/backend/tests/test_auth_password_validation.py
+++ b/backend/tests/test_auth_password_validation.py
@@ -6,7 +6,7 @@ from app.routers.auth import RegisterRequest
 
 
 def _make(password: str) -> RegisterRequest:
-    return RegisterRequest(email="test@example.com", password=password)
+    return RegisterRequest(email="test@example.com", password=password, display_name="Test")
 
 
 def test_valid_password_upper_lower_digit():

--- a/backend/tests/test_auth_tos.py
+++ b/backend/tests/test_auth_tos.py
@@ -45,6 +45,7 @@ async def test_register_without_tos_400():
             resp = await c.post("/api/v2/auth/register", json={
                 "email": "new@example.com",
                 "password": "TestPass1!",
+                "display_name": "Test User",
                 "tos_accepted": False,
             })
         assert resp.status_code == 400
@@ -62,6 +63,7 @@ async def test_register_without_tos_field_400():
             resp = await c.post("/api/v2/auth/register", json={
                 "email": "new@example.com",
                 "password": "TestPass1!",
+                "display_name": "Test User",
             })
         assert resp.status_code == 400
         assert resp.json()["error"]["code"] == "TOS_NOT_ACCEPTED"

--- a/backend/tests/test_c_s1.py
+++ b/backend/tests/test_c_s1.py
@@ -232,7 +232,7 @@ async def test_register_new_user_201():
         session.execute = AsyncMock(return_value=result_none)
         with patch.dict("os.environ", {"JWT_SECRET": "test-secret"}):
             async with client as c:
-                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "TestPass1!", "tos_accepted": True})
+                resp = await c.post("/api/v2/auth/register", json={"email": "new@test.com", "password": "TestPass1!", "display_name": "Test User", "tos_accepted": True})
         assert resp.status_code == 201
         body = resp.json()
         assert body["error"] is None
@@ -251,7 +251,7 @@ async def test_register_duplicate_email_409():
         result_existing.scalar_one_or_none.return_value = _make_user()
         session.execute = AsyncMock(return_value=result_existing)
         async with client as c:
-            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "TestPass1!", "tos_accepted": True})
+            resp = await c.post("/api/v2/auth/register", json={"email": "exists@test.com", "password": "TestPass1!", "display_name": "Test User", "tos_accepted": True})
         assert resp.status_code == 409
         assert resp.json()["error"]["code"] == "EMAIL_TAKEN"
     finally:

--- a/backend/tests/test_s_inv_04.py
+++ b/backend/tests/test_s_inv_04.py
@@ -1,0 +1,286 @@
+"""S-INV-04: BE 초대 preview API + register invite_token + OAuth callback + display_name.
+
+AC1: GET /api/v2/invitations/preview?token=XXX — 인증 없음, org_name/email/role/expires_at/status
+AC2: POST /api/auth/register — invite_token 옵션, 가입 후 자동 수락
+AC3: display_name 필수 필드 (register)
+AC4: GET /auth/callback — invite_token → 신규 OAuth 유저 자동 수락
+AC5: migration 0057 — users.display_name TEXT 컬럼 + backfill
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ─── AC3: display_name 필드 검증 ─────────────────────────────────────────────
+
+def test_register_request_has_display_name():
+    """RegisterRequest에 display_name 필드 존재."""
+    from app.routers.auth import RegisterRequest
+    fields = set(RegisterRequest.model_fields.keys())
+    assert "display_name" in fields
+
+
+def test_register_request_has_invite_token():
+    """RegisterRequest에 invite_token 필드 존재."""
+    from app.routers.auth import RegisterRequest
+    fields = set(RegisterRequest.model_fields.keys())
+    assert "invite_token" in fields
+
+
+def test_user_model_has_display_name():
+    """User 모델에 display_name 컬럼 존재."""
+    from app.models.user import User
+    cols = {c.name for c in User.__table__.columns}
+    assert "display_name" in cols
+
+
+def test_register_request_invite_token_optional():
+    """invite_token은 optional (None 기본값)."""
+    from app.routers.auth import RegisterRequest
+    field = RegisterRequest.model_fields["invite_token"]
+    assert field.is_required() is False
+
+
+def test_register_request_display_name_required():
+    """display_name은 필수 필드."""
+    from app.routers.auth import RegisterRequest
+    field = RegisterRequest.model_fields["display_name"]
+    assert field.is_required() is True
+
+
+# ─── AC1: preview 엔드포인트 ────────────────────────────────────────────────
+
+def test_preview_endpoint_exists():
+    """GET /api/v2/invitations/preview 라우트 존재."""
+    from app.routers import invitations as inv_module
+    routes = [r.path for r in inv_module.router.routes]  # type: ignore[attr-defined]
+    assert any("preview" in r for r in routes)
+
+
+def test_invitation_preview_response_schema():
+    """InvitationPreviewResponse에 필수 필드 존재."""
+    from app.schemas.invitation import InvitationPreviewResponse
+    fields = set(InvitationPreviewResponse.model_fields.keys())
+    assert {"org_name", "org_id", "email", "role", "status", "expires_at"}.issubset(fields)
+
+
+@pytest.mark.anyio
+async def test_preview_returns_org_info():
+    """유효한 token으로 preview → 200 + org_name/email/role 반환."""
+    from app.routers.invitations import preview_invitation
+
+    org_id = uuid.uuid4()
+    mock_inv = MagicMock()
+    mock_inv.org_id = org_id
+    mock_inv.email = "invited@example.com"
+    mock_inv.role = "member"
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+
+    mock_inv_result = MagicMock()
+    mock_inv_result.scalar_one_or_none.return_value = mock_inv
+
+    org_row_mock = ("TestOrg",)
+    mock_org_result = MagicMock()
+    mock_org_result.first.return_value = org_row_mock
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[mock_inv_result, mock_org_result])
+
+    resp = await preview_invitation(token="validtoken", session=session)
+
+    assert resp.email == "invited@example.com"
+    assert resp.org_name == "TestOrg"
+    assert resp.role == "member"
+    assert resp.org_id == org_id
+
+
+@pytest.mark.anyio
+async def test_preview_400_invalid_token():
+    """존재하지 않는 token → 400."""
+    from fastapi import HTTPException
+    from app.routers.invitations import preview_invitation
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=mock_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await preview_invitation(token="badtoken", session=session)
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.anyio
+async def test_preview_400_expired_token():
+    """만료된 초대 token → 400."""
+    from fastapi import HTTPException
+    from app.routers.invitations import preview_invitation
+
+    mock_inv = MagicMock()
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = mock_inv
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=mock_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await preview_invitation(token="expiredtoken", session=session)
+
+    assert exc_info.value.status_code == 400
+
+
+# ─── AC2: register invite_token 자동 수락 ────────────────────────────────────
+
+def test_auto_accept_invitation_defined():
+    """_auto_accept_invitation 헬퍼가 auth 모듈에 정의됨."""
+    from app.routers import auth as auth_module
+    assert hasattr(auth_module, "_auto_accept_invitation")
+    assert inspect.iscoroutinefunction(auth_module._auto_accept_invitation)
+
+
+def test_register_calls_auto_accept_when_invite_token():
+    """register 소스에 invite_token 있을 때 _auto_accept_invitation 호출 존재."""
+    from app.routers import auth as auth_module
+    source = inspect.getsource(auth_module.register)
+    assert "_auto_accept_invitation" in source
+    assert "invite_token" in source
+
+
+@pytest.mark.anyio
+async def test_auto_accept_accepts_valid_invitation():
+    """_auto_accept_invitation — 유효한 토큰이면 status=accepted + OrgMember INSERT."""
+    from app.routers.auth import _auto_accept_invitation
+
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    mock_user = MagicMock()
+    mock_user.id = user_id
+    mock_user.email = "test@example.com"
+
+    mock_inv = MagicMock()
+    mock_inv.org_id = org_id
+    mock_inv.email = "test@example.com"
+    mock_inv.role = "member"
+    mock_inv.status = "pending"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+
+    inv_result = MagicMock()
+    inv_result.scalar_one_or_none.return_value = mock_inv
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[inv_result, AsyncMock()])
+    session.flush = AsyncMock()
+
+    await _auto_accept_invitation(session, mock_user, "validtoken")
+
+    assert mock_inv.status == "accepted"
+    assert mock_inv.accepted_at is not None
+    session.flush.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_auto_accept_skips_expired_invitation():
+    """_auto_accept_invitation — 만료 토큰은 수락 안 함."""
+    from app.routers.auth import _auto_accept_invitation
+
+    mock_user = MagicMock()
+    mock_user.email = "test@example.com"
+
+    mock_inv = MagicMock()
+    mock_inv.status = "pending"
+    mock_inv.email = "test@example.com"
+    mock_inv.expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    inv_result = MagicMock()
+    inv_result.scalar_one_or_none.return_value = mock_inv
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=inv_result)
+    session.flush = AsyncMock()
+
+    await _auto_accept_invitation(session, mock_user, "expiredtoken")
+
+    assert mock_inv.status == "pending"
+    session.flush.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_auto_accept_skips_email_mismatch():
+    """_auto_accept_invitation — 이메일 불일치 시 수락 안 함 (권한 상승 방지)."""
+    from app.routers.auth import _auto_accept_invitation
+
+    mock_user = MagicMock()
+    mock_user.email = "other@example.com"
+
+    mock_inv = MagicMock()
+    mock_inv.status = "pending"
+    mock_inv.email = "test@example.com"
+    mock_inv.expires_at = datetime.now(timezone.utc) + timedelta(days=7)
+
+    inv_result = MagicMock()
+    inv_result.scalar_one_or_none.return_value = mock_inv
+
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=inv_result)
+    session.flush = AsyncMock()
+
+    await _auto_accept_invitation(session, mock_user, "sometoken")
+
+    assert mock_inv.status == "pending"
+    session.flush.assert_not_called()
+
+
+# ─── AC4: OAuth callback invite_token ────────────────────────────────────────
+
+def test_oauth_callback_request_has_invite_token():
+    """OAuthCallbackRequest에 invite_token 필드 존재."""
+    from app.routers.auth import OAuthCallbackRequest
+    fields = set(OAuthCallbackRequest.model_fields.keys())
+    assert "invite_token" in fields
+
+
+def test_oauth_callback_invite_token_optional():
+    """invite_token은 optional (None 기본값)."""
+    from app.routers.auth import OAuthCallbackRequest
+    field = OAuthCallbackRequest.model_fields["invite_token"]
+    assert field.is_required() is False
+
+
+def test_oauth_callback_source_calls_auto_accept():
+    """oauth_callback 소스에 _auto_accept_invitation 호출 포함."""
+    from app.routers import auth as auth_module
+    source = inspect.getsource(auth_module.oauth_callback)
+    assert "_auto_accept_invitation" in source
+
+
+# ─── AC5: migration 0057 ─────────────────────────────────────────────────────
+
+def test_migration_0057_exists():
+    """Alembic migration 0057 파일 존재."""
+    import os
+    base = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions")
+    files = os.listdir(base)
+    assert any("0057" in f for f in files)
+
+
+def test_migration_0057_adds_display_name():
+    """0057 upgrade에 display_name 컬럼 추가 + backfill 로직 포함."""
+    import os
+    base = os.path.join(os.path.dirname(__file__), "..", "alembic", "versions")
+    path = next(os.path.join(base, f) for f in os.listdir(base) if "0057" in f)
+    source = open(path).read()
+    assert "display_name" in source
+    assert "add_column" in source
+    assert "split_part" in source or "UPDATE" in source


### PR DESCRIPTION
## Summary

- **AC1** `GET /api/v2/invitations/preview?token=XXX` — 인증 불필요, `InvitationPreviewResponse(org_name, org_id, email, role, status, expires_at)` 반환. 만료/미존재 토큰 400
- **AC2** `POST /api/auth/register` — `invite_token` 옵션 추가. `_auto_accept_invitation` 헬퍼: 토큰 유효+이메일 일치 시 `invitations.status=accepted` + `OrgMember` INSERT
- **AC3** `RegisterRequest.display_name` 필수 필드. `User.display_name TEXT` 컬럼에 저장 (빈 값이면 email prefix 사용)
- **AC4** `OAuthCallbackRequest.invite_token` 추가. 신규 OAuth 유저 생성 직후 `_auto_accept_invitation` 호출
- **AC5** Migration 0056 — `users.display_name TEXT` 컬럼 추가 + `split_part(email,'@',1)` backfill

> **주의**: S-INV-03 PR이 먼저 머지될 경우 이 PR의 `0056` migration을 `0057`로 rename 후 `down_revision="0056"` 업데이트 필요.

## Test plan

- [ ] `tests/test_s_inv_04.py` 20건 AC1~AC5 전량 커버 — `uv run pytest tests/test_s_inv_04.py` 통과 확인
- [ ] 기존 `test_auth_email_validation / test_auth_password_validation / test_auth_tos / test_c_s1` `display_name` 추가로 422→정상 복원
- [ ] 전체 테스트 스위트 12 failed → S-INV-04 관련 신규 실패 없음 (mcp e2e 2건은 서버 미기동 expected)
- [ ] 머지 후 `sprintable-migrate-dev` Cloud Build job 수동 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)