### PR TITLE
feat: S-COMM-12 delivery 4단계 + 이벤트명 canonical 통일 + delivery 조회 API

### DIFF
--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -133,17 +133,16 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
         } catch { /* ignore parse errors */ }
       });
 
-      // conversation:message — realtime update for conversation list
-      // S-COMM-12: canonical(conversation.message_created) + legacy alias(conversation:message) 둘 다 리슨
-      const onConversationMsg = (e: MessageEvent) => {
+      // conversation.message_created — realtime update for conversation list
+      // S-COMM-12: canonical 이름만 리슨. server가 legacy(conversation:message)도 병행 emit하므로
+      // 외부 consumer 하위호환은 server 레벨에서 처리됨 — 프론트가 둘 다 받으면 2회 발화됨.
+      source.addEventListener('conversation.message_created', (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const payload = JSON.parse(e.data as string) as Record<string, unknown>;
           onConversationMessageRef.current?.(payload);
         } catch { /* ignore parse errors */ }
-      };
-      source.addEventListener('conversation.message_created', onConversationMsg);  // canonical
-      source.addEventListener('conversation:message', onConversationMsg);           // legacy alias
+      });
     }
 
     connect();

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -134,13 +134,16 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
       });
 
       // conversation:message — realtime update for conversation list
-      source.addEventListener('conversation:message', (e: MessageEvent) => {
+      // S-COMM-12: canonical(conversation.message_created) + legacy alias(conversation:message) 둘 다 리슨
+      const onConversationMsg = (e: MessageEvent) => {
         if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
         try {
           const payload = JSON.parse(e.data as string) as Record<string, unknown>;
           onConversationMessageRef.current?.(payload);
         } catch { /* ignore parse errors */ }
-      });
+      };
+      source.addEventListener('conversation.message_created', onConversationMsg);  // canonical
+      source.addEventListener('conversation:message', onConversationMsg);           // legacy alias
     }
 
     connect();

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -108,7 +108,7 @@ async def _dispatch_conversation_event(
         event = Event(
             project_id=conversation.project_id,
             org_id=org_id,
-            event_type="conversation:message",
+            event_type="conversation.message_created",  # canonical (S-COMM-12)
             source_entity_type="conversation_message",
             source_entity_id=msg.id,
             sender_id=sender.id,
@@ -122,7 +122,7 @@ async def _dispatch_conversation_event(
 
     # flush로 event.id 확보 — push는 호출측에서 commit 후 수행 (race condition 방지)
     await db.flush()
-    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:message", **payload})
+    return [(pid_str, {"event_id": str(event.id), "event_type": "conversation.message_created", **payload})
             for pid_str, event in events_to_push]
 
 
@@ -735,7 +735,7 @@ async def send_message(
     for pid_str, sse_payload in pending_sse_pushes:
         _push_to_agent(pid_str, sse_payload)
     # 브라우저 SSE 구독자에게 1회 발행 — pending 유무와 무관하게 commit 후 항상 발행
-    publish_event(str(org_id), "conversation:message", _msg_payload(msg, sender))
+    publish_event(str(org_id), "conversation.message_created", _msg_payload(msg, sender))  # canonical (S-COMM-12)
 
     # ws_chat WebSocket 브로드캐스트 — agent 참가자 room에 실시간 전달 (conv.type/title 무관)
     try:
@@ -793,6 +793,11 @@ async def send_message(
         message_id=msg.id,
         org_id=org_id,
     )
+
+    # S-COMM-12 AC1: agent 답신 시 해당 conversation의 최근 gateway_accepted delivery → agent_replied
+    if sender.type == "agent":
+        from app.services.conversation_webhook import mark_agent_replied
+        background_tasks.add_task(mark_agent_replied, conversation_id)
 
     # S-C2: agent sender인 경우에만 message_sent 기록 (AC2, AC4, AC5, AC6)
     if sender.type == "agent":

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -351,7 +351,11 @@ async def agent_event_stream(
                     # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
                     # is_backfill: False 명시 + event_id 동기화 — SeenIdsCache dedup 및 relay 필터 정합성
                     _live_id = eid or str(uuid.uuid4())
-                    yield f"event: {event_type}\nid: {_live_id}\ndata: {json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})}\n\n"
+                    _sse_data = json.dumps({**event_data, 'event_id': _live_id, 'is_backfill': False})
+                    # S-COMM-12: canonical 이벤트 시 legacy alias도 병행 yield (HTTP SSE 하위호환)
+                    if event_type == "conversation.message_created":
+                        yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                    yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
                 except asyncio.TimeoutError:
                     # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
                     yield "event: heartbeat\ndata: {}\n\n"

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -86,7 +86,18 @@ async def list_webhook_deliveries(
     if not message_id and not conversation_id:
         raise HTTPException(status_code=400, detail="message_id 또는 conversation_id 중 하나 필수")
 
+    from app.models.conversation import Conversation
+    from app.models.conversation_message import ConversationMessage
+
     if message_id:
+        # org 스코핑: message → conversation → org_id 검증
+        msg = (await db.execute(
+            select(ConversationMessage)
+            .join(Conversation, ConversationMessage.conversation_id == Conversation.id)
+            .where(ConversationMessage.id == message_id, Conversation.org_id == _org_id)
+        )).scalar_one_or_none()
+        if msg is None:
+            raise HTTPException(status_code=404, detail="Message not found")
         rows = (await db.execute(
             select(ConversationWebhookDelivery)
             .where(ConversationWebhookDelivery.message_id == message_id)
@@ -94,8 +105,13 @@ async def list_webhook_deliveries(
             .limit(limit)
         )).scalars().all()
     else:
-        # conversation_id 기준: conversation_messages → webhook_deliveries JOIN
-        from app.models.conversation_message import ConversationMessage
+        # org 스코핑: conversation.org_id 검증
+        conv = (await db.execute(
+            select(Conversation)
+            .where(Conversation.id == conversation_id, Conversation.org_id == _org_id)
+        )).scalar_one_or_none()
+        if conv is None:
+            raise HTTPException(status_code=404, detail="Conversation not found")
         msg_ids = (await db.execute(
             select(ConversationMessage.id)
             .where(ConversationMessage.conversation_id == conversation_id)

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -1,14 +1,30 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.conversation_webhook_delivery import ConversationWebhookDelivery
 from app.repositories.webhook_config import WebhookConfigRepository
 from app.schemas.webhook_config import UpsertWebhookConfig, WebhookConfigResponse
 
 router = APIRouter(prefix="/api/v2/webhooks", tags=["webhooks"])
+
+
+class DeliveryStatusResponse(BaseModel):
+    id: str
+    message_id: str
+    webhook_config_id: str | None
+    status: str  # event_created | webhook_posted | gateway_accepted | agent_replied | failed
+    attempt_count: int
+    last_error: str | None
+    created_at: str
+    updated_at: str | None
+
+    model_config = {"from_attributes": True}
 
 
 def _get_repo(
@@ -52,3 +68,57 @@ async def delete_webhook_config(
     if not ok:
         raise HTTPException(status_code=404, detail="WebhookConfig not found")
     return {"ok": True}
+
+
+@router.get("/deliveries", response_model=list[DeliveryStatusResponse])
+async def list_webhook_deliveries(
+    message_id: uuid.UUID | None = Query(default=None),
+    conversation_id: uuid.UUID | None = Query(default=None),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    _org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[DeliveryStatusResponse]:
+    """GET /api/v2/webhooks/deliveries — message_id 또는 conversation_id 기준 delivery 상태 조회.
+
+    AC3 (S-COMM-12): delivery 4단계 상태 디버깅용.
+    status: event_created → webhook_posted → gateway_accepted → agent_replied | failed
+    """
+    if not message_id and not conversation_id:
+        raise HTTPException(status_code=400, detail="message_id 또는 conversation_id 중 하나 필수")
+
+    if message_id:
+        rows = (await db.execute(
+            select(ConversationWebhookDelivery)
+            .where(ConversationWebhookDelivery.message_id == message_id)
+            .order_by(ConversationWebhookDelivery.created_at.desc())
+            .limit(limit)
+        )).scalars().all()
+    else:
+        # conversation_id 기준: conversation_messages → webhook_deliveries JOIN
+        from app.models.conversation_message import ConversationMessage
+        msg_ids = (await db.execute(
+            select(ConversationMessage.id)
+            .where(ConversationMessage.conversation_id == conversation_id)
+            .order_by(ConversationMessage.created_at.desc())
+            .limit(limit)
+        )).scalars().all()
+        rows = (await db.execute(
+            select(ConversationWebhookDelivery)
+            .where(ConversationWebhookDelivery.message_id.in_(msg_ids))
+            .order_by(ConversationWebhookDelivery.created_at.desc())
+            .limit(limit)
+        )).scalars().all() if msg_ids else []
+
+    return [
+        DeliveryStatusResponse(
+            id=str(r.id),
+            message_id=str(r.message_id),
+            webhook_config_id=str(r.webhook_config_id) if r.webhook_config_id else None,
+            status=r.status,
+            attempt_count=r.attempt_count,
+            last_error=r.last_error,
+            created_at=r.created_at.isoformat(),
+            updated_at=r.updated_at.isoformat() if r.updated_at else None,
+        )
+        for r in rows
+    ]

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -172,7 +172,7 @@ async def deliver_conversation_message_webhook(
                     id=uuid.uuid4(),
                     message_id=message_id,
                     webhook_config_id=wh.id,
-                    status="pending",
+                    status="event_created",  # 4단계: event_created → webhook_posted → gateway_accepted → agent_replied
                     attempt_count=0,
                 )
                 db.add(delivery)
@@ -189,29 +189,81 @@ async def deliver_conversation_message_webhook(
             logger.exception("conversation webhook schedule failed message_id=%s", message_id)
 
 
+async def _update_delivery_status(
+    delivery_id: uuid.UUID,
+    status: str,
+    attempt_count: int | None = None,
+    last_error: str | None = None,
+) -> None:
+    """delivery 상태 업데이트 — 별도 세션."""
+    from app.core.database import async_session_factory
+    from sqlalchemy import select
+
+    async with async_session_factory() as db:
+        delivery = (await db.execute(
+            select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.id == delivery_id)
+        )).scalar_one_or_none()
+        if delivery:
+            delivery.status = status
+            delivery.updated_at = datetime.now(timezone.utc)
+            if attempt_count is not None:
+                delivery.attempt_count = attempt_count
+            if last_error is not None:
+                delivery.last_error = last_error
+            await db.commit()
+
+
+async def mark_agent_replied(conversation_id: uuid.UUID) -> None:
+    """에이전트 답신 시 해당 conversation의 최근 gateway_accepted delivery → agent_replied."""
+    from app.core.database import async_session_factory
+    from app.models.conversation_message import ConversationMessage
+    from sqlalchemy import select
+
+    async with async_session_factory() as db:
+        # conversation의 최근 메시지 id 목록 조회 후 delivery 검색
+        msg_ids = (await db.execute(
+            select(ConversationMessage.id)
+            .where(ConversationMessage.conversation_id == conversation_id)
+            .order_by(ConversationMessage.created_at.desc())
+            .limit(20)
+        )).scalars().all()
+
+        if not msg_ids:
+            return
+
+        delivery = (await db.execute(
+            select(ConversationWebhookDelivery)
+            .where(
+                ConversationWebhookDelivery.message_id.in_(msg_ids),
+                ConversationWebhookDelivery.status == "gateway_accepted",
+            )
+            .order_by(ConversationWebhookDelivery.created_at.desc())
+            .limit(1)
+        )).scalar_one_or_none()
+
+        if delivery:
+            delivery.status = "agent_replied"
+            delivery.updated_at = datetime.now(timezone.utc)
+            await db.commit()
+
+
 async def _retry_deliver(
     delivery_id: uuid.UUID,
     url: str,
     secret: str | None,
     payload: dict,
 ) -> None:
-    """최대 3회 retry + exponential backoff."""
-    from app.core.database import async_session_factory
-    from sqlalchemy import select
+    """최대 3회 retry + exponential backoff.
+
+    상태 전이: event_created → webhook_posted → gateway_accepted (성공) / failed (영구실패)
+    """
+    # 첫 attempt 전: webhook_posted
+    await _update_delivery_status(delivery_id, "webhook_posted")
 
     for attempt in range(1, _MAX_RETRIES + 1):
         try:
             await _attempt_delivery(url, secret, payload)
-
-            async with async_session_factory() as db:
-                delivery = (await db.execute(
-                    select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.id == delivery_id)
-                )).scalar_one_or_none()
-                if delivery:
-                    delivery.status = "delivered"
-                    delivery.attempt_count = attempt
-                    delivery.updated_at = datetime.now(timezone.utc)
-                    await db.commit()
+            await _update_delivery_status(delivery_id, "gateway_accepted", attempt_count=attempt)
             return
 
         except Exception as exc:
@@ -228,13 +280,6 @@ async def _retry_deliver(
                     "webhook delivery failed permanently delivery_id=%s: %s",
                     delivery_id, error_msg,
                 )
-                async with async_session_factory() as db:
-                    delivery = (await db.execute(
-                        select(ConversationWebhookDelivery).where(ConversationWebhookDelivery.id == delivery_id)
-                    )).scalar_one_or_none()
-                    if delivery:
-                        delivery.status = "failed"
-                        delivery.attempt_count = attempt
-                        delivery.last_error = error_msg
-                        delivery.updated_at = datetime.now(timezone.utc)
-                        await db.commit()
+                await _update_delivery_status(
+                    delivery_id, "failed", attempt_count=attempt, last_error=error_msg
+                )

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -28,7 +28,18 @@ _MAX_DELAY = 10.0
 _JITTER_FACTOR = 0.5    # wait * uniform(0, 0.5) jitter
 
 # relay 대상 이벤트 타입
-_RELAY_EVENT_TYPES = frozenset(["conversation:message", "conversation:mention"])
+# S-COMM-12: canonical = conversation.message_created (점 표기)
+# conversation:message (콜론) 는 전환기 하위호환용 — 신규 emit 없으나 유지
+_RELAY_EVENT_TYPES = frozenset([
+    "conversation.message_created",  # canonical (S-COMM-12)
+    "conversation:message",          # legacy alias, deprecated
+    "conversation:mention",
+])
+
+# canonical → legacy alias 매핑 (전환기 하위호환 병행 emit)
+_EVENT_TYPE_LEGACY_ALIASES: dict[str, str] = {
+    "conversation.message_created": "conversation:message",
+}
 
 
 # ── SeenIdsCache: LRU + TTL dedup 캐시 (S6-2) ────────────────────────────────
@@ -369,6 +380,9 @@ async def start_sse_bridge(
         asyncio.create_task(
             _send_mcp_notification(event.event_type, event.data)
         )
+        # S-COMM-12: canonical 이벤트 수신 시 legacy alias도 병행 emit (전환기 하위호환)
+        if _alias := _EVENT_TYPE_LEGACY_ALIASES.get(event.event_type):
+            asyncio.create_task(_send_mcp_notification(_alias, event.data))
 
         # relay 조건: (1) backfill 아님, (2) webhook 미설정
         _relay = True

--- a/docs/runtime-channel-map.md
+++ b/docs/runtime-channel-map.md
@@ -100,7 +100,8 @@ Sprintable (Server-Sent Events stream)
          poll_events MCP tool 또는 webhook으로 수신.
 ```
 
-> **이벤트명 표기 불일치**: SSE는 콜론 표기(`conversation:message`), webhook은 점 표기(`conversation.message_created`)로 현재 통일되지 않음. 통일 작업은 S-COMM-12(backlog) 예정.
+> **이벤트명 통일 완료 (S-COMM-12)**: canonical = `conversation.message_created` (점 표기). SSE와 webhook 모두 동일 이름 사용.
+> 전환기 하위호환: SSE는 canonical 수신 시 `conversation:message` (레거시 alias)도 병행 emit (`sse_bridge.py`). 기존 consumer 코드가 레거시 이름으로 동작 중이라면 canonical로 점진 전환 권장.
 
 poll_events MCP tool: SSE를 열 수 없는 환경에서 동일 이벤트를 폴링으로 수신하는 fallback.
 

--- a/packages/cli/src/commands/health-check.ts
+++ b/packages/cli/src/commands/health-check.ts
@@ -80,8 +80,9 @@ async function waitForSseEvent(
             conversation_id?: string
             id?: string  // conversations.py:55 _msg_payload: "id": str(msg.id)
           }
+          // S-COMM-12: canonical(conversation.message_created) + legacy alias(conversation:message) 모두 허용
           if (
-            payload.event_type === "conversation:message" &&
+            (payload.event_type === "conversation.message_created" || payload.event_type === "conversation:message") &&
             payload.conversation_id === conversationId
           ) {
             clearTimeout(timer)


### PR DESCRIPTION
## Summary

AC1·AC2·AC3 전량 + 09·10·11 산출물 동기화.

## AC 체크

- [x] AC1 — `ConversationWebhookDelivery.status` 4단계: `event_created → webhook_posted → gateway_accepted → agent_replied` (Text 자유필드, migration 불필요)
- [x] AC2 — canonical = `conversation.message_created`, 하위호환 legacy alias 병행 emit
- [x] AC3 — `GET /api/v2/webhooks/deliveries?message_id=...&conversation_id=...`

## 코드 대조 근거

| 항목 | 파일 | 근거 |
|------|------|------|
| 상태 Text 자유필드 | `models/conversation_webhook_delivery.py:22` | `Mapped[str] = mapped_column(Text)` |
| event_created | `services/conversation_webhook.py` | delivery 생성 시 초기값 |
| webhook_posted | `_retry_deliver()` | `_attempt_delivery` 직전 |
| gateway_accepted | `_retry_deliver()` | HTTP 200 응답 후 (기존 `delivered`) |
| agent_replied | `mark_agent_replied()` + `conversations.py` | agent sender POST 시 background task |
| canonical emit | `conversations.py:111,125,738` | `conversation.message_created` |
| legacy alias | `sse_bridge.py _EVENT_TYPE_LEGACY_ALIASES` | canonical 수신 시 `conversation:message`도 병행 emit |
| health-check sync | `health-check.ts:waitForSseEvent` | 두 이름 모두 허용 |
| delivery API | `webhooks.py` | `GET /api/v2/webhooks/deliveries` |

## 하위호환 전략

- `sse_bridge.py`: `conversation.message_created` 수신 시 `conversation:message` alias도 `create_task`로 병행 emit → 기존 MCP consumer는 변경 없이 동작
- `_RELAY_EVENT_TYPES`: `conversation.message_created` + `conversation:message` + `conversation:mention` 3종
- `runtime-channel-map.md`: 통일 결과 + 하위호환 정책 명시

story: 87accd0a-ced5-4dbe-a102-4a7d1f341fa0