### PR TITLE
fix: S-STANDUP-FIX standup/sprint MCP 조회 4종 404 복구

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -151,6 +151,46 @@ async def kickoff_sprint(
     return {"notified": 0, "sprint_id": str(id), "message": body.message}
 
 
+@router.get("/{id}/summary")
+async def sprint_summary(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    repo: SprintRepository = Depends(_get_repo),
+) -> dict:
+    """GET /api/v2/sprints/{id}/summary — 스프린트 스토리 상태별 집계 (AC3 S-STANDUP-FIX)."""
+    sprint = await repo.get(id)
+    if sprint is None:
+        raise HTTPException(status_code=404, detail="Sprint not found")
+
+    stories_result = await db.execute(
+        select(Story.status, Story.story_points).where(Story.sprint_id == id)
+    )
+    stories = stories_result.all()
+
+    status_counts: dict[str, int] = {}
+    status_points: dict[str, int] = {}
+    for s in stories:
+        status_counts[s.status] = status_counts.get(s.status, 0) + 1
+        status_points[s.status] = status_points.get(s.status, 0) + (s.story_points or 0)
+
+    total_stories = len(stories)
+    total_points = sum(s.story_points or 0 for s in stories)
+    done_points = status_points.get("done", 0)
+    completion_pct = round((done_points / total_points) * 100) if total_points > 0 else 0
+
+    return {
+        "sprint_id": str(id),
+        "total_stories": total_stories,
+        "total_points": total_points,
+        "done_points": done_points,
+        "completion_pct": completion_pct,
+        "by_status": {
+            status: {"count": status_counts.get(status, 0), "points": status_points.get(status, 0)}
+            for status in ["todo", "in_progress", "review", "done", "blocked"]
+        },
+    }
+
+
 @router.get("/{id}/checkin")
 async def checkin_sprint(
     id: uuid.UUID,

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -184,9 +184,10 @@ async def sprint_summary(
         "total_points": total_points,
         "done_points": done_points,
         "completion_pct": completion_pct,
+        # 실제 DB에 존재하는 상태값 기준 동적 생성 — 하드코딩 시 enum 불일치 위험 방지
         "by_status": {
-            status: {"count": status_counts.get(status, 0), "points": status_points.get(status, 0)}
-            for status in ["todo", "in_progress", "review", "done", "blocked"]
+            status: {"count": count, "points": status_points.get(status, 0)}
+            for status, count in status_counts.items()
         },
     }
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -89,6 +89,17 @@ async def update_standup(
     return StandupEntryResponse.model_validate(entry)
 
 
+@router.get("/history", response_model=list[StandupEntryResponse])
+async def list_standup_history(
+    project_id: uuid.UUID = Query(...),
+    limit: int = Query(default=30, ge=1, le=200),
+    repo: StandupEntryRepository = Depends(_get_repo),
+) -> list[StandupEntryResponse]:
+    """GET /api/v2/standups/history — 최근 N개 스탠드업 히스토리 조회 (AC2 S-STANDUP-FIX)."""
+    entries = await repo.list(project_id=project_id, limit=limit)
+    return [StandupEntryResponse.model_validate(e) for e in entries]
+
+
 @router.get("/missing", response_model=list[uuid.UUID])
 async def get_missing_standups(
     project_id: uuid.UUID = Query(...),

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -52,7 +52,7 @@ class CheckinSprintInput(SprintableInput):
 async def standup_missing(args: StandupDateInput) -> list[TextContent]:
     """스탠드업 미제출 멤버 조회."""
     try:
-        return ok(await client.get("/api/v2/standup/missing", params={"project_id": client.project_id, "date": args.date}))
+        return ok(await client.get("/api/v2/standups/missing", params={"project_id": client.project_id, "date": args.date}))
     except Exception as exc:
         return err(str(exc))
 
@@ -63,16 +63,17 @@ async def standup_history(args: StandupHistoryInput) -> list[TextContent]:
     if args.limit is not None:
         params["limit"] = str(args.limit)
     try:
-        return ok(await client.get("/api/v2/standup/history", params=params))
+        return ok(await client.get("/api/v2/standups/history", params=params))
     except Exception as exc:
         return err(str(exc))
 
 
 async def get_standup(args: GetStandupInput) -> list[TextContent]:
     """멤버+날짜 기준 스탠드업 조회."""
-    params: dict = {"member_id": args.member_id, "date": args.date, "project_id": client.project_id}
+    # standups.py:34 author_id 파라미터 (MCP 입력은 member_id → author_id 매핑)
+    params: dict = {"author_id": args.member_id, "date": args.date, "project_id": client.project_id}
     try:
-        return ok(await client.get("/api/v2/standup", params=params))
+        return ok(await client.get("/api/v2/standups", params=params))
     except Exception as exc:
         return err(str(exc))
 
@@ -85,7 +86,7 @@ async def save_standup(args: SaveStandupInput) -> list[TextContent]:
         if val is not None:
             body[field] = val
     try:
-        return ok(await client.post("/api/v2/standup", json=body))
+        return ok(await client.post("/api/v2/standups", json=body))
     except Exception as exc:
         return err(str(exc))
 
@@ -93,7 +94,7 @@ async def save_standup(args: SaveStandupInput) -> list[TextContent]:
 async def list_standup_entries(args: ListStandupEntriesInput) -> list[TextContent]:
     """날짜 기준 스탠드업 목록 조회."""
     try:
-        return ok(await client.get("/api/v2/standup", params={"project_id": client.project_id, "date": args.date}))
+        return ok(await client.get("/api/v2/standups", params={"project_id": client.project_id, "date": args.date}))
     except Exception as exc:
         return err(str(exc))
 


### PR DESCRIPTION
## Summary

MCP standup/sprint 툴 4종 404 원인 수정 (경로 단수→복수) + 누락 백엔드 라우트 2종 신설.

## AC 체크

- [x] AC1 — MCP standup 경로 단수→복수 (`standups.py:19 prefix=/api/v2/standups` 기준)
- [x] AC2 — `GET /api/v2/standups/history` 신설 (limit 파라미터, BaseRepository.list 활용)
- [x] AC3 — `GET /api/v2/sprints/{id}/summary` 신설 (상태별 count+points+completion_pct)

## 코드 대조 근거

| 툴 | 수정 전 | 수정 후 | 근거 |
|---|---|---|---|
| `standup_missing` | `/standup/missing` | `/standups/missing` | `standups.py:92` |
| `standup_history` | `/standup/history` | `/standups/history` | 신설 (`standups.py`) |
| `get_standup` | `/standup` (GET) | `/standups` (author_id 파라미터) | `standups.py:34` |
| `save_standup` | `/standup` (POST) | `/standups` (POST) | `standups.py:50` |
| `list_standup_entries` | `/standup` (GET) | `/standups` (GET) | `standups.py:29` |
| `sprint_summary` | `/sprints/{id}/summary` (404) | 신설 | `sprints.py` |

story: 1a2dc215-0de0-4654-b479-937f45fe6255