### PR TITLE
fix: S-COMM-FIX deliveries 500 + inbox 서명 미검증

### DIFF
--- a/backend/app/routers/agent_inbox.py
+++ b/backend/app/routers/agent_inbox.py
@@ -26,7 +26,7 @@ router = APIRouter(prefix="/api/v2/agent-inbox", tags=["agent-inbox"])
 def _verify_signature(raw_body: bytes, signature_header: str | None) -> bool:
     secret = settings.agent_inbox_webhook_secret
     if not secret:
-        return True
+        return False  # secret 미설정 시 open ingestion 차단 — 반드시 설정 필요
     if not signature_header:
         return False
     expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -86,8 +86,8 @@ async def list_webhook_deliveries(
     if not message_id and not conversation_id:
         raise HTTPException(status_code=400, detail="message_id 또는 conversation_id 중 하나 필수")
 
-    from app.models.conversation import Conversation
-    from app.models.conversation_message import ConversationMessage
+    # ConversationMessage와 Conversation은 동일 파일(app/models/conversation.py)에 정의됨
+    from app.models.conversation import Conversation, ConversationMessage
 
     if message_id:
         # org 스코핑: message → conversation → org_id 검증

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -216,7 +216,7 @@ async def _update_delivery_status(
 async def mark_agent_replied(conversation_id: uuid.UUID) -> None:
     """에이전트 답신 시 해당 conversation의 최근 gateway_accepted delivery → agent_replied."""
     from app.core.database import async_session_factory
-    from app.models.conversation_message import ConversationMessage
+    from app.models.conversation import ConversationMessage  # ConversationMessage는 conversation.py에 정의됨
     from sqlalchemy import select
 
     async with async_session_factory() as db:

--- a/backend/tests/test_s_comm_07.py
+++ b/backend/tests/test_s_comm_07.py
@@ -33,13 +33,13 @@ def test_agent_inbox_router_prefix():
 
 # ─── AC3: HMAC 서명 검증 로직 ─────────────────────────────────────────────────
 
-def test_verify_signature_passes_when_no_secret():
-    """secret 미설정 시 서명 없어도 통과 (dev 환경)."""
+def test_verify_signature_rejects_when_no_secret():
+    """secret 미설정 시 서명 없어도 거부 (secure-by-default, S-COMM-FIX AC2)."""
     from app.routers.agent_inbox import _verify_signature
     with patch("app.routers.agent_inbox.settings") as mock_settings:
         mock_settings.agent_inbox_webhook_secret = ""
-        assert _verify_signature(b"body", None) is True
-        assert _verify_signature(b"body", "sha256=anything") is True
+        assert _verify_signature(b"body", None) is False
+        assert _verify_signature(b"body", "sha256=anything") is False
 
 
 def test_verify_signature_rejects_missing_header():
@@ -73,12 +73,16 @@ def test_verify_signature_rejects_wrong_hmac():
 
 @pytest.mark.anyio
 async def test_receive_inbox_webhook_404_when_agent_not_found():
-    """없는 agent_id → 404."""
+    """없는 agent_id + 유효 서명 → 404 (서명 통과 후 agent 조회 실패)."""
     from fastapi import HTTPException
     from app.routers.agent_inbox import receive_inbox_webhook
 
+    secret = "testsecret"
+    body = b'{"event_type":"test"}'
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
     mock_request = MagicMock()
-    mock_request.body = AsyncMock(return_value=b'{"event_type":"test"}')
+    mock_request.body = AsyncMock(return_value=body)
 
     mock_db = AsyncMock()
     mock_result = MagicMock()
@@ -86,13 +90,13 @@ async def test_receive_inbox_webhook_404_when_agent_not_found():
     mock_db.execute = AsyncMock(return_value=mock_result)
 
     with patch("app.routers.agent_inbox.settings") as mock_settings:
-        mock_settings.agent_inbox_webhook_secret = ""
+        mock_settings.agent_inbox_webhook_secret = secret
         with pytest.raises(HTTPException) as exc_info:
             await receive_inbox_webhook(
                 agent_id=uuid.uuid4(),
                 request=mock_request,
                 db=mock_db,
-                x_sprintable_signature=None,
+                x_sprintable_signature=sig,
             )
     assert exc_info.value.status_code == 404
 
@@ -154,20 +158,52 @@ async def test_receive_inbox_webhook_creates_event():
     mock_db.commit = AsyncMock()
     mock_db.refresh = AsyncMock()
 
+    secret = "testsecret"
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
     with patch("app.routers.agent_inbox.settings") as mock_settings:
-        mock_settings.agent_inbox_webhook_secret = ""
+        mock_settings.agent_inbox_webhook_secret = secret
         with patch("app.routers.agent_inbox.Event") as MockEvent:
             MockEvent.return_value = mock_event
             result = await receive_inbox_webhook(
                 agent_id=agent_id,
                 request=mock_request,
                 db=mock_db,
-                x_sprintable_signature=None,
+                x_sprintable_signature=sig,
             )
 
     assert result["ok"] is True
     assert "event_id" in result
     mock_db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_receive_inbox_webhook_401_when_no_secret_or_no_sig():
+    """무서명 또는 secret 미설정 → 401 (secure-by-default 회귀 방지, S-COMM-FIX AC2)."""
+    from fastapi import HTTPException
+    from app.routers.agent_inbox import receive_inbox_webhook
+
+    mock_request = MagicMock()
+    mock_request.body = AsyncMock(return_value=b'{"event_type":"test"}')
+    mock_db = AsyncMock()
+
+    # case A: secret 없음 + 서명 없음
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = ""
+        with pytest.raises(HTTPException) as exc_info:
+            await receive_inbox_webhook(
+                agent_id=uuid.uuid4(), request=mock_request, db=mock_db, x_sprintable_signature=None
+            )
+    assert exc_info.value.status_code == 401
+
+    # case B: secret 있음 + 서명 없음
+    with patch("app.routers.agent_inbox.settings") as mock_settings:
+        mock_settings.agent_inbox_webhook_secret = "testsecret"
+        with pytest.raises(HTTPException) as exc_info:
+            await receive_inbox_webhook(
+                agent_id=uuid.uuid4(), request=mock_request, db=mock_db, x_sprintable_signature=None
+            )
+    assert exc_info.value.status_code == 401
 
 
 # ─── config 필드 존재 확인 ────────────────────────────────────────────────────
@@ -196,8 +232,11 @@ async def test_receive_inbox_webhook_calls_push_to_agent():
     mock_db.commit = AsyncMock()
     mock_db.refresh = AsyncMock()
 
+    secret = "testsecret"
+    sig = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
     with patch("app.routers.agent_inbox.settings") as mock_settings:
-        mock_settings.agent_inbox_webhook_secret = ""
+        mock_settings.agent_inbox_webhook_secret = secret
         with patch("app.routers.agent_inbox.Event") as MockEvent:
             MockEvent.return_value = mock_event
             with patch("app.routers.events._push_to_agent") as mock_push:
@@ -205,7 +244,7 @@ async def test_receive_inbox_webhook_calls_push_to_agent():
                     agent_id=agent_id,
                     request=mock_request,
                     db=mock_db,
-                    x_sprintable_signature=None,
+                    x_sprintable_signature=sig,
                 )
                 mock_push.assert_called_once_with(str(agent_id), {"event_type": "inbox_webhook"})
 


### PR DESCRIPTION
## Summary

E2E 라이브 적발 2건 수정.

## AC1 — GET /api/v2/webhooks/deliveries 500 수정

**원인:** `ConversationMessage`를 `app.models.conversation_message`에서 import 시도 → 해당 파일 없음 → `ImportError` → 500.

실제 위치: `app.models.conversation` (`conversation.py:60` `class ConversationMessage`).

수정 파일:
- `app/routers/webhooks.py` — `from app.models.conversation_message import ConversationMessage` → `from app.models.conversation import Conversation, ConversationMessage`
- `app/services/conversation_webhook.py` — `mark_agent_replied` 내 동일 import 수정

검증: 유효 conversation_id → 200 배열, 미존재/타org → 404.

## AC2 — inbox 서명 미검증 보안 수정

**원인:** `_verify_signature`에서 `if not secret: return True` → secret 미설정 시 무조건 수락.

수정: `return True` → `return False` — secret 미설정 = open ingestion 차단.

검증: 무서명 → 401, 유효 `X-Sprintable-Signature(HMAC-SHA256)` → 수락.

story: b67cc1f6-072e-4e79-a736-f2fc1461592f