### PR TITLE
fix: S-MIG-FIX alembic env.py 커밋 누락 + 0056/0057 idempotent

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -64,6 +64,7 @@ def run_migrations_online() -> None:
         context.configure(connection=connection, target_metadata=target_metadata)
         with context.begin_transaction():
             context.run_migrations()
+        connection.commit()  # 명시적 커밋 — run_migrations 후 alembic_version 전진 보장
 
 
 if context.is_offline_mode():

--- a/backend/alembic/versions/0056_invitation_email_tracking.py
+++ b/backend/alembic/versions/0056_invitation_email_tracking.py
@@ -13,8 +13,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("invitations", sa.Column("email_sent_at", sa.DateTime(timezone=True), nullable=True))
-    op.add_column("invitations", sa.Column("email_error", sa.Text, nullable=True))
+    # idempotent: 컬럼이 이미 존재하면 무시 — dev 버전 정합용 (S-MIG-FIX AC2)
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing_cols = {c["name"] for c in insp.get_columns("invitations")}
+    if "email_sent_at" not in existing_cols:
+        op.add_column("invitations", sa.Column("email_sent_at", sa.DateTime(timezone=True), nullable=True))
+    if "email_error" not in existing_cols:
+        op.add_column("invitations", sa.Column("email_error", sa.Text, nullable=True))
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/0057_add_display_name_to_users.py
+++ b/backend/alembic/versions/0057_add_display_name_to_users.py
@@ -16,7 +16,12 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column("users", sa.Column("display_name", sa.Text, nullable=True))
+    # idempotent: 컬럼이 이미 존재하면(수동 ADD 포함) 무시 — dev 버전 정합용 (S-MIG-FIX AC2)
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing_cols = {c["name"] for c in insp.get_columns("users")}
+    if "display_name" not in existing_cols:
+        op.add_column("users", sa.Column("display_name", sa.Text, nullable=True))
     op.execute(
         "UPDATE users SET display_name = split_part(email, '@', 1) WHERE display_name IS NULL"
     )


### PR DESCRIPTION
## Summary

dev P0(로그인 500) 근본원인 systemic fix.

## AC1 — env.py 커밋 수정

**근본원인:** `run_migrations_online()`의 증분 경로에서 `context.run_migrations()` 후 `connection.commit()`이 없어 migration이 실행되지만 alembic_version이 전진하지 않음.

`context.begin_transaction()`은 migration을 실행하지만 COMMIT을 보장하지 않음 → 잡 성공 + exit(0)인데 DB 버전 0050 고정.

수정: `with context.begin_transaction(): context.run_migrations()` 후 `connection.commit()` 명시적 추가.

## AC2 — 0056/0057 idempotent

dev DB에 PO가 수동으로 일부 컬럼 추가 → `op.add_column` "column already exists" 방지.

`sa.inspect(conn).get_columns()` 기반 조건부 ADD COLUMN:
- `0057`: `users.display_name` 존재 시 skip
- `0056`: `invitations.email_sent_at` / `email_error` 존재 시 skip

## AC3 검증 항목 (PO 확인)

- migrate 잡의 `DATABASE_URL_DEV_MIGRATE`와 백엔드 `DATABASE_URL_DEV`가 같은 DB 인스턴스를 가리키는지 확인

story: fc25dbbd-7136-42ad-bbd2-0d7ed19caa80