### PR TITLE
fix: S-AUDIT-FIX permission_audit_logs CHECK 위반 (agent 추가 500)

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -186,7 +186,7 @@ async def create_team_member(
         audit = AuditLog(
             org_id=org_id,
             actor_id=actor.id,
-            action="team_member.create",
+            action="member_added",  # CHECK (action IN ('member_added','member_removed','role_changed'))
             target_user_id=member.id,
             audit_metadata={
                 "creator_id": str(actor.id),


### PR DESCRIPTION
## Summary

봉희신 agent 추가 500 블로커. 단일 1줄 수정.

## 근본원인

`team_members.py L189`: `action="team_member.create"` → `permission_audit_logs` CHECK 제약 위반.

라이브 제약: `CHECK (action IN ('member_added','member_removed','role_changed'))`

`asyncpg CheckViolationError` → API key flush 시 IntegrityError → 500.

## 수정

`"team_member.create"` → `"member_added"` (제약 부합 + 의미 정확)

AC2: AuditLog를 사용하는 다른 action은 `team_members.py` 단 1곳 — 전수 점검 완료.

story: 0353d089-7ffc-45b9-9288-3b79dcebe934