### PR TITLE
fix: S-MBR-FIX asyncpg :param::uuid syntax error

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -123,8 +123,10 @@ async def get_my_memberships(
     members.py list_members grant 패턴(S-MBR-10) 정합.
     """
     current_org_id: str | None = auth.claims.get("app_metadata", {}).get("org_id")
-    user_id = auth.user_id
-    org_id_param = current_org_id  # None 허용 — org 미확정 시 전체 org 기준
+    # uuid.UUID 객체로 바인딩 — asyncpg text() + ::uuid 캐스트가 syntax error를 유발하므로
+    # CAST() 또는 파라미터 타입 지정 대신 Python uuid.UUID 객체로 직접 바인딩함 (S-MBR-FIX)
+    user_id_param = uuid.UUID(auth.user_id)
+    org_id_param: uuid.UUID | None = uuid.UUID(current_org_id) if current_org_id else None
 
     rows = await session.execute(
         text(
@@ -132,13 +134,13 @@ async def get_my_memberships(
             SELECT DISTINCT p.id::text AS project_id, p.name AS project_name
             FROM projects p
             WHERE p.deleted_at IS NULL
-              AND (:org_id IS NULL OR p.org_id = :org_id::uuid)
+              AND (:org_id IS NULL OR p.org_id = :org_id)
               AND (
                 -- 1. TeamMember 직접 등록 (기존)
                 EXISTS (
                     SELECT 1 FROM team_members tm
                     WHERE tm.project_id = p.id
-                      AND (tm.id = :user_id::uuid OR tm.user_id = :user_id::uuid)
+                      AND (tm.id = :user_id OR tm.user_id = :user_id)
                       AND tm.is_active = true
                       AND tm.type = 'human'
                 )
@@ -147,25 +149,25 @@ async def get_my_memberships(
                     SELECT 1 FROM project_access pa
                     JOIN org_members om ON pa.org_member_id = om.id
                     WHERE pa.project_id = p.id
-                      AND om.user_id = :user_id::uuid
+                      AND om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND pa.permission = 'granted'
-                      AND (:org_id IS NULL OR om.org_id = :org_id::uuid)
+                      AND (:org_id IS NULL OR om.org_id = :org_id)
                 )
                 -- 3. owner/admin은 grant 없이도 org 전체 (AC2, S-MBR-03 정합)
                 OR EXISTS (
                     SELECT 1 FROM org_members om
-                    WHERE om.user_id = :user_id::uuid
+                    WHERE om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND om.role IN ('owner', 'admin')
-                      AND (:org_id IS NULL OR om.org_id = :org_id::uuid)
+                      AND (:org_id IS NULL OR om.org_id = :org_id)
                       AND p.org_id = om.org_id
                 )
               )
             ORDER BY project_name
             """
         ),
-        {"user_id": user_id, "org_id": org_id_param},
+        {"user_id": user_id_param, "org_id": org_id_param},
     )
     return [
         {"projectId": row.project_id, "projectName": row.project_name}


### PR DESCRIPTION
## Summary

배포 `/me/memberships` → 500 `asyncpg.exceptions.PostgresSyntaxError: syntax error at or near ":"` 수정.

## 근본원인

`text()` + asyncpg에서 `:param::uuid` — `::` 뒤 `:` 이 파라미터 바인딩 토큰으로 파싱됨 → prepare 단계 syntax error.

## 수정

`user_id`/`org_id`를 `uuid.UUID` 객체로 Python 레벨에서 변환 후 바인딩:
- `user_id_param = uuid.UUID(auth.user_id)`
- `org_id_param = uuid.UUID(current_org_id) if current_org_id else None`

SQL에서 `::uuid` 캐스트 6개소 전량 제거. asyncpg가 `uuid.UUID` 객체를 UUID 타입으로 자동 인식.

story: 38c03fdb-206b-4ff1-af6d-1a6c66b07196