### PR TITLE
fix: S-MBR-FIX :org_id IS NULL → CAST(:org_id AS uuid) IS NULL

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -134,7 +134,7 @@ async def get_my_memberships(
             SELECT DISTINCT p.id::text AS project_id, p.name AS project_name
             FROM projects p
             WHERE p.deleted_at IS NULL
-              AND (:org_id IS NULL OR p.org_id = :org_id)
+              AND (CAST(:org_id AS uuid) IS NULL OR p.org_id = :org_id)
               AND (
                 -- 1. TeamMember 직접 등록 (기존)
                 EXISTS (
@@ -152,7 +152,7 @@ async def get_my_memberships(
                       AND om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND pa.permission = 'granted'
-                      AND (:org_id IS NULL OR om.org_id = :org_id)
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
                 )
                 -- 3. owner/admin은 grant 없이도 org 전체 (AC2, S-MBR-03 정합)
                 OR EXISTS (
@@ -160,7 +160,7 @@ async def get_my_memberships(
                     WHERE om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND om.role IN ('owner', 'admin')
-                      AND (:org_id IS NULL OR om.org_id = :org_id)
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
                       AND p.org_id = om.org_id
                 )
               )


### PR DESCRIPTION
## Summary

develop post-#1081 기준 `:org_id IS NULL` 3곳 → `CAST(:org_id AS uuid) IS NULL`.

## 근본원인

asyncpg `text()` 바인딩에서 `:param IS NULL` — 타입 추론 불가 → `AmbiguousParameterError` 500.

`CAST()` 함수형은 `::` 캐스트와 달리 asyncpg 파싱 안 깸.

## 변경

3개소 치환 (L137, L155, L163). 나머지 코드 무변경.

PO asyncpg 직접 검증:
- `org_id=UUID` → count=3 ✅
- `org_id=None` → count=3, AmbiguousParameterError 없음 ✅

story: 38c03fdb-206b-4ff1-af6d-1a6c66b07196