### PR TITLE
chore: promote develop → main (S-MBR-FIX + S-AUDIT-FIX hotfixes)

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -134,7 +134,7 @@ async def get_my_memberships(
             SELECT DISTINCT p.id::text AS project_id, p.name AS project_name
             FROM projects p
             WHERE p.deleted_at IS NULL
-              AND (:org_id IS NULL OR p.org_id = :org_id)
+              AND (CAST(:org_id AS uuid) IS NULL OR p.org_id = :org_id)
               AND (
                 -- 1. TeamMember 직접 등록 (기존)
                 EXISTS (
@@ -152,7 +152,7 @@ async def get_my_memberships(
                       AND om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND pa.permission = 'granted'
-                      AND (:org_id IS NULL OR om.org_id = :org_id)
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
                 )
                 -- 3. owner/admin은 grant 없이도 org 전체 (AC2, S-MBR-03 정합)
                 OR EXISTS (
@@ -160,7 +160,7 @@ async def get_my_memberships(
                     WHERE om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND om.role IN ('owner', 'admin')
-                      AND (:org_id IS NULL OR om.org_id = :org_id)
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
                       AND p.org_id = om.org_id
                 )
               )

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -123,8 +123,10 @@ async def get_my_memberships(
     members.py list_members grant 패턴(S-MBR-10) 정합.
     """
     current_org_id: str | None = auth.claims.get("app_metadata", {}).get("org_id")
-    user_id = auth.user_id
-    org_id_param = current_org_id  # None 허용 — org 미확정 시 전체 org 기준
+    # uuid.UUID 객체로 바인딩 — asyncpg text() + ::uuid 캐스트가 syntax error를 유발하므로
+    # CAST() 또는 파라미터 타입 지정 대신 Python uuid.UUID 객체로 직접 바인딩함 (S-MBR-FIX)
+    user_id_param = uuid.UUID(auth.user_id)
+    org_id_param: uuid.UUID | None = uuid.UUID(current_org_id) if current_org_id else None
 
     rows = await session.execute(
         text(
@@ -132,13 +134,13 @@ async def get_my_memberships(
             SELECT DISTINCT p.id::text AS project_id, p.name AS project_name
             FROM projects p
             WHERE p.deleted_at IS NULL
-              AND (:org_id IS NULL OR p.org_id = :org_id::uuid)
+              AND (:org_id IS NULL OR p.org_id = :org_id)
               AND (
                 -- 1. TeamMember 직접 등록 (기존)
                 EXISTS (
                     SELECT 1 FROM team_members tm
                     WHERE tm.project_id = p.id
-                      AND (tm.id = :user_id::uuid OR tm.user_id = :user_id::uuid)
+                      AND (tm.id = :user_id OR tm.user_id = :user_id)
                       AND tm.is_active = true
                       AND tm.type = 'human'
                 )
@@ -147,25 +149,25 @@ async def get_my_memberships(
                     SELECT 1 FROM project_access pa
                     JOIN org_members om ON pa.org_member_id = om.id
                     WHERE pa.project_id = p.id
-                      AND om.user_id = :user_id::uuid
+                      AND om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND pa.permission = 'granted'
-                      AND (:org_id IS NULL OR om.org_id = :org_id::uuid)
+                      AND (:org_id IS NULL OR om.org_id = :org_id)
                 )
                 -- 3. owner/admin은 grant 없이도 org 전체 (AC2, S-MBR-03 정합)
                 OR EXISTS (
                     SELECT 1 FROM org_members om
-                    WHERE om.user_id = :user_id::uuid
+                    WHERE om.user_id = :user_id
                       AND om.deleted_at IS NULL
                       AND om.role IN ('owner', 'admin')
-                      AND (:org_id IS NULL OR om.org_id = :org_id::uuid)
+                      AND (:org_id IS NULL OR om.org_id = :org_id)
                       AND p.org_id = om.org_id
                 )
               )
             ORDER BY project_name
             """
         ),
-        {"user_id": user_id, "org_id": org_id_param},
+        {"user_id": user_id_param, "org_id": org_id_param},
     )
     return [
         {"projectId": row.project_id, "projectName": row.project_name}

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -186,7 +186,7 @@ async def create_team_member(
         audit = AuditLog(
             org_id=org_id,
             actor_id=actor.id,
-            action="team_member.create",
+            action="member_added",  # CHECK (action IN ('member_added','member_removed','role_changed'))
             target_user_id=member.id,
             audit_metadata={
                 "creator_id": str(actor.id),


### PR DESCRIPTION
## Sprint 12 hotfix 프로모션 (2회차)

이전 프로모션(#1079) 이후 dev 라이브에서 적발·수정한 핫픽스 반영. 전건 배포 엔드포인트 실토큰 검증 완료.

- **S-AUDIT-FIX (#1080)**: agent 추가 시 permission_audit_logs CHECK 위반(action) → `member_added`로 수정. dev 라이브 agent 추가 201 확인.
- **S-MBR-FIX (#1081 + #1083)**: `/me/memberships` asyncpg 런타임 500 — `:param::uuid` syntax error(#1081 uuid.UUID 바인딩) + `:org_id IS NULL` AmbiguousParameterError(#1083 `CAST(:org_id AS uuid) IS NULL`) 수정. dev 배포 엔드포인트 실토큰 200 + grant 프로젝트 반환 확인.

prod·dev 공유 DB(sprintable, alembic 0057).

🤖 Generated with [Claude Code](https://claude.com/claude-code)