### PR TITLE
feat: E-OUTCOME-LOOP S1 — outcome 필드 스키마 추가 (migration 0058)

### DIFF
--- a/backend/alembic/versions/0058_add_outcome_fields.py
+++ b/backend/alembic/versions/0058_add_outcome_fields.py
@@ -1,0 +1,45 @@
+"""E-OUTCOME-LOOP S1: stories·sprints에 outcome 필드 추가.
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-05-30
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+_OUTCOME_COLS = [
+    ("success_hypothesis", sa.Text, {"nullable": True}),
+    ("metric_definition", JSONB, {"nullable": True}),
+    ("measure_after", sa.DateTime(timezone=True), {"nullable": True}),
+    ("outcome_status", sa.String(20), {"nullable": False, "server_default": "n_a"}),
+    ("outcome_result", JSONB, {"nullable": True}),
+]
+
+
+def _add_cols_idempotent(table: str) -> None:
+    """컬럼이 이미 존재하면 무시 — dev 환경 idempotent (0056·0057 패턴)."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = {c["name"] for c in insp.get_columns(table)}
+    for col_name, col_type, kwargs in _OUTCOME_COLS:
+        if col_name not in existing:
+            op.add_column(table, sa.Column(col_name, col_type, **kwargs))
+
+
+def upgrade() -> None:
+    _add_cols_idempotent("stories")
+    _add_cols_idempotent("sprints")
+
+
+def downgrade() -> None:
+    for col_name, _, _ in reversed(_OUTCOME_COLS):
+        op.drop_column("sprints", col_name)
+        op.drop_column("stories", col_name)

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 
 from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -26,6 +26,13 @@ class Sprint(Base, OrgScopedMixin, TimestampMixin):
     velocity: Mapped[int | None] = mapped_column(Integer, nullable=True)
     team_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
     duration: Mapped[int] = mapped_column(Integer, nullable=False, default=14)
+    # E-OUTCOME-LOOP: 의도 필드 (intent)
+    success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    measure_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # E-OUTCOME-LOOP: 채점 필드 (outcome, 채점잡 전용)
+    outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="sprints")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="sprint", lazy="select")
@@ -80,6 +87,13 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     acceptance_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
     position: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # E-OUTCOME-LOOP: 의도 필드 (intent)
+    success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    measure_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # E-OUTCOME-LOOP: 채점 필드 (outcome, 채점잡 전용)
+    outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     epic: Mapped[Epic | None] = relationship("Epic", back_populates="stories")
     sprint: Mapped[Sprint | None] = relationship("Sprint", back_populates="stories")

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import date, datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -9,6 +10,10 @@ class SprintBase(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     team_size: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class SprintCreate(SprintBase):
@@ -25,6 +30,11 @@ class SprintUpdate(BaseModel):
     velocity: int | None = None
     duration: int | None = None
     report_doc_id: uuid.UUID | None = None
+    # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
 
 
 class SprintResponse(SprintBase):
@@ -37,6 +47,9 @@ class SprintResponse(SprintBase):
     velocity: int | None = None
     duration: int
     report_doc_id: uuid.UUID | None = None
+    # E-OUTCOME-LOOP: 채점 필드
+    outcome_status: str = "n_a"
+    outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -26,6 +27,10 @@ class StoryCreate(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class StoryUpdate(BaseModel):
@@ -39,6 +44,11 @@ class StoryUpdate(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
 
 
 class StoryStatusUpdate(BaseModel):
@@ -62,5 +72,12 @@ class StoryResponse(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # E-OUTCOME-LOOP: 채점 필드
+    outcome_status: str = "n_a"
+    outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -25,6 +25,12 @@ def _mock_sprint(status: str = "planning") -> MagicMock:
     s.team_size = None
     s.duration = 14
     s.report_doc_id = None
+    # E-OUTCOME-LOOP: 신규 필드 (MagicMock 반환 객체가 Pydantic 검증 실패하므로 명시 세팅)
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
     from datetime import datetime, timezone
     s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -27,6 +27,12 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.description = None
     s.acceptance_criteria = None
     s.position = None
+    # E-OUTCOME-LOOP: 신규 필드 (MagicMock이 반환하는 MagicMock 객체가 Pydantic 검증 실패하므로 명시 세팅)
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
     s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return s


### PR DESCRIPTION
## Summary

E-OUTCOME-LOOP 에픽 S1 — stories·sprints에 outcome 필드 추가.

## 변경

### models/pm.py

Story·Sprint 양쪽에 컬럼 5종:

| 컬럼 | 타입 | 기본값 |
|------|------|--------|
| `success_hypothesis` | Text | NULL |
| `metric_definition` | JSONB | NULL |
| `measure_after` | timestamptz | NULL |
| `outcome_status` | String(20) | `'n_a'` |
| `outcome_result` | JSONB | NULL |

### schemas/story.py + schemas/sprint.py

- `StoryCreate` / `SprintBase`: 의도 필드 3종 추가 (`success_hypothesis`, `metric_definition`, `measure_after`)
- `StoryUpdate` / `SprintUpdate`: 의도 필드 3종 추가. `outcome_status` / `outcome_result` 제외 (채점잡 전용)
- `StoryResponse` / `SprintResponse`: 5종 모두 포함

### 0058_add_outcome_fields.py

- `down_revision = '0057'` (현 head)
- idempotent: `sa.inspect` 기반 컬럼 존재 확인 후 ADD (0056·0057 패턴)
- upgrade / downgrade 양방향

## 검증

- Python import + 모델 필드 존재 확인 PASS
- OSS fresh DB 경로: `create_all` 에 신규 컬럼 포함 확인 PASS
- dev migration: 머지 후 sprintable-migrate-dev 수동 실행 예정

story: bf76d726-0fc9-46c4-9a31-b05a9136a0f0