### PR TITLE
feat: E-OUTCOME-LOOP S2 — create 라우터 의도필드 + metric_definition 검증

### DIFF
--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -53,6 +53,9 @@ async def create_sprint(
         start_date=body.start_date,
         end_date=body.end_date,
         team_size=body.team_size,
+        success_hypothesis=body.success_hypothesis,
+        metric_definition=body.metric_definition,
+        measure_after=body.measure_after,
     )
     return SprintResponse.model_validate(sprint)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -130,6 +130,9 @@ async def create_story(
         description=body.description,
         acceptance_criteria=body.acceptance_criteria,
         position=body.position,
+        success_hypothesis=body.success_hypothesis,
+        metric_definition=body.metric_definition,
+        measure_after=body.measure_after,
     )
     return StoryResponse.model_validate(story)
 

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -2,7 +2,8 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+from app.schemas.story import _validate_metric_definition
 
 
 class SprintBase(BaseModel):
@@ -14,6 +15,11 @@ class SprintBase(BaseModel):
     success_hypothesis: str | None = None
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class SprintCreate(SprintBase):
@@ -35,6 +41,11 @@ class SprintUpdate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
     # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class SprintResponse(SprintBase):

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -2,7 +2,24 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_METRIC_SOURCES = frozenset({"internal_ops", "ga4", "manual"})
+_METRIC_DIRECTIONS = frozenset({"up", "down"})
+
+
+def _validate_metric_definition(v: dict | None) -> dict | None:
+    """metric_definition 구조 검증: {metric, source, target, direction} 필수."""
+    if v is None:
+        return v
+    missing = {"metric", "source", "target", "direction"} - v.keys()
+    if missing:
+        raise ValueError(f"metric_definition에 필수 키 누락: {missing}")
+    if v["source"] not in _METRIC_SOURCES:
+        raise ValueError(f"metric_definition.source must be one of {_METRIC_SOURCES}")
+    if v["direction"] not in _METRIC_DIRECTIONS:
+        raise ValueError(f"metric_definition.direction must be one of {_METRIC_DIRECTIONS}")
+    return v
 
 STORY_STATUSES = ("backlog", "ready-for-dev", "in-progress", "in-review", "done")
 STATUS_TRANSITIONS: dict[str, str] = {
@@ -32,6 +49,11 @@ class StoryCreate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
 
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
+
 
 class StoryUpdate(BaseModel):
     title: str | None = None
@@ -49,6 +71,11 @@ class StoryUpdate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
     # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class StoryStatusUpdate(BaseModel):

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -302,3 +302,74 @@ async def test_kickoff_sprint_200():
         assert body["sprint_id"] == str(SPRINT_ID)
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S2: 의도필드 + metric_definition 검증 ──────────────────────
+
+_VALID_METRIC = {"metric": "retention", "source": "internal_ops", "target": 0.8, "direction": "up"}
+
+
+@pytest.mark.anyio
+async def test_create_sprint_with_intent_fields_201():
+    """create에 의도필드 전달 → 201 + repo.create에 의도필드 전달 확인 (AC1/AC2)."""
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        sprint.success_hypothesis = "Retention 80% 달성"
+        sprint.metric_definition = _VALID_METRIC
+        sprint.measure_after = None
+
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = sprint
+
+            async with client as c:
+                resp = await c.post("/api/v2/sprints", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Outcome Sprint",
+                    "success_hypothesis": "Retention 80% 달성",
+                    "metric_definition": _VALID_METRIC,
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("success_hypothesis") == "Retention 80% 달성"
+        assert kwargs.get("metric_definition") == _VALID_METRIC
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_metric,desc", [
+    ({"source": "manual", "target": 0.8, "direction": "up"}, "metric 키 누락"),
+    ({"metric": "retention", "source": "unknown", "target": 0.8, "direction": "up"}, "source 비정상값"),
+    ({"metric": "retention", "source": "manual", "target": 0.8, "direction": "flat"}, "direction 비정상값"),
+])
+async def test_create_sprint_invalid_metric_definition_422(bad_metric: dict, desc: str):
+    """metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/sprints", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "title": "Test Sprint",
+                "metric_definition": bad_metric,
+            })
+        assert resp.status_code == 422, f"expected 422 for {desc}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_sprint_invalid_metric_definition_422():
+    """update metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={
+                "metric_definition": {"bad": "structure"},
+            })
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -339,3 +339,102 @@ async def test_status_backward_transition_400(from_status: str, to_status: str):
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S2: 의도필드 + metric_definition 검증 ──────────────────────
+
+_VALID_METRIC = {"metric": "MAU", "source": "ga4", "target": 1000, "direction": "up"}
+
+
+@pytest.mark.anyio
+async def test_create_story_with_intent_fields_201():
+    """create에 의도필드(success_hypothesis·metric_definition·measure_after) 전달 → 201 (AC1/AC2)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        story.success_hypothesis = "MAU 10% 증가"
+        story.metric_definition = _VALID_METRIC
+        story.measure_after = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Outcome Story",
+                    "success_hypothesis": "MAU 10% 증가",
+                    "metric_definition": _VALID_METRIC,
+                    "measure_after": "2026-07-01T00:00:00Z",
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("success_hypothesis") == "MAU 10% 증가"
+        assert kwargs.get("metric_definition") == _VALID_METRIC
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_metric,desc", [
+    ({"source": "ga4", "target": 100, "direction": "up"}, "metric 키 누락"),
+    ({"metric": "MAU", "source": "bad_src", "target": 100, "direction": "up"}, "source 비정상값"),
+    ({"metric": "MAU", "source": "ga4", "target": 100, "direction": "sideways"}, "direction 비정상값"),
+    ({"metric": "MAU", "source": "ga4", "target": 100}, "direction 키 누락"),
+])
+async def test_create_story_invalid_metric_definition_422(bad_metric: dict, desc: str):
+    """metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/stories", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "title": "Test",
+                "metric_definition": bad_metric,
+            })
+        assert resp.status_code == 422, f"expected 422 for {desc}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_story_invalid_metric_definition_422():
+    """update metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={
+                "metric_definition": {"bad": "structure"},
+            })
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_story_outcome_fields_ignored():
+    """create 시 outcome_status/outcome_result는 무시 — 채점잡 전용 (AC4)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Test",
+                    "outcome_status": "achieved",
+                    "outcome_result": {"score": 90},
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert "outcome_status" not in kwargs, "outcome_status가 create에 전달되면 안됨"
+        assert "outcome_result" not in kwargs, "outcome_result가 create에 전달되면 안됨"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

E-OUTCOME-LOOP S2 — create 라우터에 의도필드 전달 누락 수정 + metric_definition 구조 검증.

## 변경

### routers/stories.py + routers/sprints.py

`create()` 호출부에 의도필드 3종 추가:
- `success_hypothesis`
- `metric_definition`
- `measure_after`

update(`exclude_unset`) / get / list는 자동 매핑 → 변경 없음.

### schemas/story.py

`_validate_metric_definition()` 유틸 함수 신설.

`StoryCreate` + `StoryUpdate`에 `field_validator("metric_definition")` 추가:
- 필수 키: `metric`, `source`, `target`, `direction`
- `source`: `internal_ops | ga4 | manual`
- `direction`: `up | down`
- 잘못된 구조 → 422

### schemas/sprint.py

`SprintBase` + `SprintUpdate`에 동일 validator 추가 (`_validate_metric_definition` 재사용).

### 권한 분리

`outcome_status` / `outcome_result` create·update 모두 제외 — 채점잡(S3) 전용.

## 검증

- metric_definition 422 테스트 로컬 PASS
- 전체 pytest 1180 passed (e2e_dev 2건은 라이브 서버 연결 필요 — 기존 실패, 내 변경 무관)

story: 313eaff4-7299-4fb4-b0d9-cb490221f8a4