### PR TITLE
feat: E-OUTCOME-LOOP S3 — 스프린트 종료 자동 채점 잡

### DIFF
--- a/backend/app/repositories/sprint.py
+++ b/backend/app/repositories/sprint.py
@@ -39,19 +39,23 @@ class SprintRepository(BaseRepository[Sprint]):
         if sprint.status != "active":
             raise ValueError(f"Cannot close sprint with status: {sprint.status}")
 
-        result = await self.session.execute(
+        all_result = await self.session.execute(
             select(Story).where(
                 Story.sprint_id == id,
-                Story.status == "done",
                 Story.deleted_at.is_(None),
             )
         )
-        done_stories = result.scalars().all()
+        all_stories = all_result.scalars().all()
+        done_stories = [s for s in all_stories if s.status == "done"]
         velocity = sum(s.story_points or 0 for s in done_stories)
 
         # E-OUTCOME-LOOP S3: velocity 계산 직후 채점 (비파괴 — 기존 close 로직 무변경)
         from app.services.outcome_scorer import score_sprint_outcome
-        scoring = score_sprint_outcome(sprint.metric_definition, velocity)
+        backlog_remaining = len([s for s in all_stories if s.status != "done"])
+        total_points = sum(s.story_points or 0 for s in all_stories)
+        scoring = score_sprint_outcome(
+            sprint.metric_definition, velocity, backlog_remaining, total_points
+        )
         extra = scoring if scoring is not None else {}
 
         updated = await self.update(id, status="closed", velocity=velocity, **extra)

--- a/backend/app/repositories/sprint.py
+++ b/backend/app/repositories/sprint.py
@@ -49,6 +49,11 @@ class SprintRepository(BaseRepository[Sprint]):
         done_stories = result.scalars().all()
         velocity = sum(s.story_points or 0 for s in done_stories)
 
-        updated = await self.update(id, status="closed", velocity=velocity)
+        # E-OUTCOME-LOOP S3: velocity 계산 직후 채점 (비파괴 — 기존 close 로직 무변경)
+        from app.services.outcome_scorer import score_sprint_outcome
+        scoring = score_sprint_outcome(sprint.metric_definition, velocity)
+        extra = scoring if scoring is not None else {}
+
+        updated = await self.update(id, status="closed", velocity=velocity, **extra)
         assert updated is not None
         return updated

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -1,0 +1,62 @@
+"""E-OUTCOME-LOOP S3: 스프린트 종료 채점 서비스 (MVP).
+
+채점 대상: metric_definition 채워진 sprint.
+소스별 처리:
+  - source='internal_ops': velocity 기반 hit/miss 이진 채점.
+  - 그 외: pending (외부 소스 MVP 범위 밖).
+  - metric_definition 없음: n_a 유지 (의도 없음).
+
+outcome_status 전이: n_a → pending → hit | miss
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def score_sprint_outcome(
+    metric_definition: dict[str, Any] | None,
+    velocity: int,
+) -> dict[str, Any] | None:
+    """sprint.metric_definition + velocity 기반 채점.
+
+    Returns:
+        None              → outcome_status 변경 없음 (n_a 유지)
+        {'outcome_status': ..., 'outcome_result': ...} → update에 적용할 kwargs
+    """
+    if not metric_definition:
+        return None  # 의도 없음 → n_a 유지
+
+    source = metric_definition.get("source")
+    metric = metric_definition.get("metric")
+    target = metric_definition.get("target")
+    direction = metric_definition.get("direction")
+
+    if source != "internal_ops":
+        # 외부 소스 — MVP 범위 밖, pending 대기
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    # internal_ops: velocity를 actual로 사용 (done story points 합산)
+    try:
+        target_f = float(target)  # type: ignore[arg-type]
+        actual_f = float(velocity)
+    except (TypeError, ValueError):
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    if direction == "up":
+        hit = actual_f >= target_f
+    elif direction == "down":
+        hit = actual_f <= target_f
+    else:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    return {
+        "outcome_status": "hit" if hit else "miss",
+        "outcome_result": {
+            "metric": metric,
+            "target": target_f,
+            "actual": actual_f,
+            "direction": direction,
+            "scored_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -2,7 +2,11 @@
 
 채점 대상: metric_definition 채워진 sprint.
 소스별 처리:
-  - source='internal_ops': velocity 기반 hit/miss 이진 채점.
+  - source='internal_ops': metric 이름으로 actual 분기.
+      velocity          → done story points 합산
+      backlog_remaining → 미완료(done 아닌) 스토리 수
+      progress          → 완료율 (done_points / total_points * 100)
+      그 외             → pending (오채점 차단)
   - 그 외: pending (외부 소스 MVP 범위 밖).
   - metric_definition 없음: n_a 유지 (의도 없음).
 
@@ -13,15 +17,26 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+# internal_ops에서 지원하는 metric 이름 → 회수 키 매핑
+_INTERNAL_OPS_METRICS = frozenset({"velocity", "backlog_remaining", "progress"})
+
 
 def score_sprint_outcome(
     metric_definition: dict[str, Any] | None,
     velocity: int,
+    backlog_remaining: int,
+    total_points: int,
 ) -> dict[str, Any] | None:
-    """sprint.metric_definition + velocity 기반 채점.
+    """sprint.metric_definition 기반 채점.
+
+    Args:
+        metric_definition: sprint.metric_definition JSONB
+        velocity:          done story points 합산
+        backlog_remaining: done 아닌 스토리 수 (close 시점)
+        total_points:      sprint 전체 story_points 합산 (진행률 분모)
 
     Returns:
-        None              → outcome_status 변경 없음 (n_a 유지)
+        None                                  → outcome_status 변경 없음 (n_a 유지)
         {'outcome_status': ..., 'outcome_result': ...} → update에 적용할 kwargs
     """
     if not metric_definition:
@@ -33,20 +48,28 @@ def score_sprint_outcome(
     direction = metric_definition.get("direction")
 
     if source != "internal_ops":
-        # 외부 소스 — MVP 범위 밖, pending 대기
         return {"outcome_status": "pending", "outcome_result": None}
 
-    # internal_ops: velocity를 actual로 사용 (done story points 합산)
+    # metric 이름으로 actual 분기 — 모르는 metric은 오채점 차단
+    if metric == "velocity":
+        actual_raw: float = float(velocity)
+    elif metric == "backlog_remaining":
+        actual_raw = float(backlog_remaining)
+    elif metric == "progress":
+        actual_raw = round((velocity / total_points * 100) if total_points > 0 else 0.0, 2)
+    else:
+        # 지원하지 않는 metric → 오채점 방지 pending
+        return {"outcome_status": "pending", "outcome_result": None}
+
     try:
         target_f = float(target)  # type: ignore[arg-type]
-        actual_f = float(velocity)
     except (TypeError, ValueError):
         return {"outcome_status": "pending", "outcome_result": None}
 
     if direction == "up":
-        hit = actual_f >= target_f
+        hit = actual_raw >= target_f
     elif direction == "down":
-        hit = actual_f <= target_f
+        hit = actual_raw <= target_f
     else:
         return {"outcome_status": "pending", "outcome_result": None}
 
@@ -55,7 +78,7 @@ def score_sprint_outcome(
         "outcome_result": {
             "metric": metric,
             "target": target_f,
-            "actual": actual_f,
+            "actual": actual_raw,
             "direction": direction,
             "scored_at": datetime.now(timezone.utc).isoformat(),
         },

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -373,3 +373,134 @@ async def test_update_sprint_invalid_metric_definition_422():
         assert resp.status_code == 422
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S3: 채점 로직 테스트 ──────────────────────────────────────
+
+from app.services.outcome_scorer import score_sprint_outcome
+
+
+class TestScoreSprintOutcome:
+    """outcome_scorer.score_sprint_outcome 단위 테스트."""
+
+    def test_no_metric_definition_returns_none(self):
+        """metric_definition 없음 → None (n_a 유지)."""
+        assert score_sprint_outcome(None, 30) is None
+        assert score_sprint_outcome({}, 30) is None
+
+    def test_external_source_returns_pending(self):
+        """external source(ga4/manual) → pending."""
+        for src in ("ga4", "manual"):
+            r = score_sprint_outcome(
+                {"source": src, "metric": "m", "target": 100, "direction": "up"}, 50
+            )
+            assert r is not None
+            assert r["outcome_status"] == "pending"
+            assert r["outcome_result"] is None
+
+    def test_up_direction_hit_when_actual_ge_target(self):
+        """direction='up', actual >= target → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 30, "direction": "up"},
+            velocity=30,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 30.0
+        assert r["outcome_result"]["target"] == 30.0
+        assert "scored_at" in r["outcome_result"]
+
+    def test_up_direction_miss_when_actual_lt_target(self):
+        """direction='up', actual < target → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 50, "direction": "up"},
+            velocity=30,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+
+    def test_down_direction_hit_when_actual_le_target(self):
+        """direction='down', actual <= target → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog", "target": 5, "direction": "down"},
+            velocity=3,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_down_direction_miss_when_actual_gt_target(self):
+        """direction='down', actual > target → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog", "target": 5, "direction": "down"},
+            velocity=8,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+
+    def test_boundary_exact_target_up_is_hit(self):
+        """경계값: actual == target, direction='up' → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 42, "direction": "up"},
+            velocity=42,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_boundary_exact_target_down_is_hit(self):
+        """경계값: actual == target, direction='down' → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog", "target": 10, "direction": "down"},
+            velocity=10,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_zero_velocity_with_up_direction(self):
+        """velocity=0, direction='up', target>0 → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 10, "direction": "up"},
+            velocity=0,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+
+    def test_outcome_result_contains_required_fields(self):
+        """outcome_result에 metric·target·actual·direction·scored_at 포함."""
+        md = {"source": "internal_ops", "metric": "velocity", "target": 20, "direction": "up"}
+        r = score_sprint_outcome(md, velocity=25)
+        assert r is not None
+        result = r["outcome_result"]
+        for key in ("metric", "target", "actual", "direction", "scored_at"):
+            assert key in result, f"outcome_result에 {key} 없음"
+
+
+@pytest.mark.anyio
+async def test_close_sprint_scores_outcome_hit():
+    """sprint close 시 metric_definition 있으면 채점 → outcome_status hit/miss 반영."""
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint("active")
+        sprint.metric_definition = {
+            "metric": "velocity", "source": "internal_ops", "target": 10, "direction": "up"
+        }
+        sprint.outcome_status = "n_a"
+
+        closed = _mock_sprint("closed")
+        closed.outcome_status = "hit"
+        closed.outcome_result = {"metric": "velocity", "target": 10.0, "actual": 14.0, "direction": "up", "scored_at": "2026-05-30T00:00:00+00:00"}
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.repositories.sprint.SprintRepository.close", new_callable=AsyncMock) as mock_close:
+            mock_close.return_value = closed
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/sprints/{SPRINT_ID}/close")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["outcome_status"] == "hit"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -375,99 +375,157 @@ async def test_update_sprint_invalid_metric_definition_422():
         app.dependency_overrides.clear()
 
 
+
+
 # ── E-OUTCOME-LOOP S3: 채점 로직 테스트 ──────────────────────────────────────
 
 from app.services.outcome_scorer import score_sprint_outcome
 
+_V = 0  # velocity placeholder
+_B = 0  # backlog_remaining placeholder
+_T = 0  # total_points placeholder
+
 
 class TestScoreSprintOutcome:
-    """outcome_scorer.score_sprint_outcome 단위 테스트."""
+    """outcome_scorer.score_sprint_outcome 단위 테스트 (metric 이름 ↔ actual 분기 포함)."""
 
     def test_no_metric_definition_returns_none(self):
         """metric_definition 없음 → None (n_a 유지)."""
-        assert score_sprint_outcome(None, 30) is None
-        assert score_sprint_outcome({}, 30) is None
+        assert score_sprint_outcome(None, 30, 5, 100) is None
+        assert score_sprint_outcome({}, 30, 5, 100) is None
 
     def test_external_source_returns_pending(self):
         """external source(ga4/manual) → pending."""
         for src in ("ga4", "manual"):
             r = score_sprint_outcome(
-                {"source": src, "metric": "m", "target": 100, "direction": "up"}, 50
+                {"source": src, "metric": "velocity", "target": 100, "direction": "up"},
+                velocity=50, backlog_remaining=2, total_points=100,
             )
             assert r is not None
             assert r["outcome_status"] == "pending"
             assert r["outcome_result"] is None
 
-    def test_up_direction_hit_when_actual_ge_target(self):
-        """direction='up', actual >= target → hit."""
+    def test_unknown_metric_returns_pending(self):
+        """지원하지 않는 metric → pending (오채점 차단)."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "custom_metric", "target": 50, "direction": "up"},
+            velocity=60, backlog_remaining=0, total_points=100,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "pending"
+
+    # ── velocity metric ──────────────────────────────────────────────────────
+
+    def test_velocity_up_hit(self):
+        """metric=velocity, direction='up', actual >= target → hit."""
         r = score_sprint_outcome(
             {"source": "internal_ops", "metric": "velocity", "target": 30, "direction": "up"},
-            velocity=30,
+            velocity=30, backlog_remaining=0, total_points=30,
         )
         assert r is not None
         assert r["outcome_status"] == "hit"
         assert r["outcome_result"]["actual"] == 30.0
-        assert r["outcome_result"]["target"] == 30.0
-        assert "scored_at" in r["outcome_result"]
+        assert r["outcome_result"]["metric"] == "velocity"
 
-    def test_up_direction_miss_when_actual_lt_target(self):
-        """direction='up', actual < target → miss."""
+    def test_velocity_up_miss(self):
+        """metric=velocity, direction='up', actual < target → miss."""
         r = score_sprint_outcome(
             {"source": "internal_ops", "metric": "velocity", "target": 50, "direction": "up"},
-            velocity=30,
+            velocity=30, backlog_remaining=0, total_points=50,
         )
         assert r is not None
         assert r["outcome_status"] == "miss"
 
-    def test_down_direction_hit_when_actual_le_target(self):
-        """direction='down', actual <= target → hit."""
-        r = score_sprint_outcome(
-            {"source": "internal_ops", "metric": "backlog", "target": 5, "direction": "down"},
-            velocity=3,
-        )
-        assert r is not None
-        assert r["outcome_status"] == "hit"
-
-    def test_down_direction_miss_when_actual_gt_target(self):
-        """direction='down', actual > target → miss."""
-        r = score_sprint_outcome(
-            {"source": "internal_ops", "metric": "backlog", "target": 5, "direction": "down"},
-            velocity=8,
-        )
-        assert r is not None
-        assert r["outcome_status"] == "miss"
-
-    def test_boundary_exact_target_up_is_hit(self):
-        """경계값: actual == target, direction='up' → hit."""
+    def test_velocity_boundary_exact_target_is_hit(self):
+        """경계값: velocity == target, direction='up' → hit."""
         r = score_sprint_outcome(
             {"source": "internal_ops", "metric": "velocity", "target": 42, "direction": "up"},
-            velocity=42,
+            velocity=42, backlog_remaining=0, total_points=42,
         )
         assert r is not None
         assert r["outcome_status"] == "hit"
 
-    def test_boundary_exact_target_down_is_hit(self):
-        """경계값: actual == target, direction='down' → hit."""
-        r = score_sprint_outcome(
-            {"source": "internal_ops", "metric": "backlog", "target": 10, "direction": "down"},
-            velocity=10,
-        )
-        assert r is not None
-        assert r["outcome_status"] == "hit"
-
-    def test_zero_velocity_with_up_direction(self):
+    def test_zero_velocity_miss(self):
         """velocity=0, direction='up', target>0 → miss."""
         r = score_sprint_outcome(
             {"source": "internal_ops", "metric": "velocity", "target": 10, "direction": "up"},
-            velocity=0,
+            velocity=0, backlog_remaining=5, total_points=10,
         )
         assert r is not None
         assert r["outcome_status"] == "miss"
+
+    # ── backlog_remaining metric ─────────────────────────────────────────────
+
+    def test_backlog_remaining_down_hit(self):
+        """metric=backlog_remaining, direction='down', backlog<=target → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 3, "direction": "down"},
+            velocity=20, backlog_remaining=2, total_points=25,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 2.0
+        assert r["outcome_result"]["metric"] == "backlog_remaining"
+
+    def test_backlog_remaining_down_miss(self):
+        """metric=backlog_remaining, direction='down', backlog>target → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 0, "direction": "down"},
+            velocity=20, backlog_remaining=1, total_points=25,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 1.0
+
+    def test_backlog_remaining_dogfood_zero_target(self):
+        """dogfood: backlog_remaining=0 → target=0, down → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 0, "direction": "down"},
+            velocity=30, backlog_remaining=0, total_points=30,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_backlog_remaining_does_not_use_velocity(self):
+        """backlog_remaining metric은 velocity가 아닌 backlog_remaining을 actual로 사용."""
+        # velocity=999 지만 backlog_remaining=5 → target=3 초과 → miss
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 3, "direction": "down"},
+            velocity=999, backlog_remaining=5, total_points=999,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 5.0
+
+    # ── progress metric ──────────────────────────────────────────────────────
+
+    def test_progress_up_hit(self):
+        """metric=progress, direction='up', progress>=target → hit."""
+        # velocity=80 / total_points=100 → progress=80.0
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "progress", "target": 80, "direction": "up"},
+            velocity=80, backlog_remaining=2, total_points=100,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 80.0
+
+    def test_progress_zero_total_points(self):
+        """total_points=0 → progress=0.0, target>0 → miss (zero division safe)."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "progress", "target": 50, "direction": "up"},
+            velocity=0, backlog_remaining=0, total_points=0,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 0.0
+
+    # ── output 필드 ──────────────────────────────────────────────────────────
 
     def test_outcome_result_contains_required_fields(self):
         """outcome_result에 metric·target·actual·direction·scored_at 포함."""
         md = {"source": "internal_ops", "metric": "velocity", "target": 20, "direction": "up"}
-        r = score_sprint_outcome(md, velocity=25)
+        r = score_sprint_outcome(md, velocity=25, backlog_remaining=0, total_points=25)
         assert r is not None
         result = r["outcome_result"]
         for key in ("metric", "target", "actual", "direction", "scored_at"):


### PR DESCRIPTION
## Summary

E-OUTCOME-LOOP S3 — 스프린트 close 시 outcome 자동 채점.

## 변경

### app/services/outcome_scorer.py (신설)

`score_sprint_outcome(metric_definition, velocity)` 함수:

| 조건 | outcome_status |
|------|---------------|
| metric_definition 없음 | n_a 유지 (None 반환) |
| source != 'internal_ops' | pending |
| direction='up', actual >= target | hit |
| direction='up', actual < target | miss |
| direction='down', actual <= target | hit |
| direction='down', actual > target | miss |

MVP: velocity(done story points 합산)를 actual로 사용.
outcome_result: `{metric, target, actual, direction, scored_at}`.

### app/repositories/sprint.py `close()`

velocity 계산 직후 채점 훅 추가 (비파괴 — 기존 close 로직 무변경).

### tests/test_sprints.py

`TestScoreSprintOutcome` 10케이스:
- n_a/pending(external source)/hit-up/miss-up/hit-down/miss-down
- 경계값 hit(up/down)/zero velocity/output 필드 완전성

`test_close_sprint_scores_outcome_hit`: close 라우터 채점 통합 확인.

기존 14 + 신규 11 = 25 passed.

## 검증

- `score_sprint_outcome` 단위 케이스 PASS
- 전체 pytest 1203 passed (e2e_dev 제외)
- 기존 close 테스트 회귀 없음

story: 1570c066-4155-4d16-9672-a2860a237a0a