### PR TITLE
[E-OUTCOME-LOOP S4-A] 성과 의도 입력 + 채점 카드 (Sprint) — Ledger

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2194,5 +2194,32 @@
     "doneStories": "Done Stories",
     "assignedStories": "Assigned",
     "avgLeadTime": "Avg Lead Time"
+  },
+  "outcomeLoop": {
+    "resultLabel": "Outcome",
+    "statusHit": "On target",
+    "statusMiss": "Off target",
+    "statusPending": "Awaiting",
+    "hypothesisLabel": "Hypothesis",
+    "target": "Target",
+    "actual": "Actual",
+    "scoredSuffix": "scored",
+    "forwardNote": "A note for the next plan",
+    "pendingNote": "Awaiting measurement — auto-scored when sprint closes.",
+    "addIntent": "Add outcome intent (optional)",
+    "intentLabel": "Outcome intent",
+    "optional": "optional",
+    "hypothesisField": "Success hypothesis",
+    "hypothesisPlaceholder": "What would be different if this sprint succeeds?",
+    "metricField": "Success metric",
+    "dirUp": "Hit if above",
+    "dirDown": "Hit if below",
+    "targetPlaceholder": "Target value",
+    "externalSourceNote": "Only internal_ops metrics are auto-scored on close. Others stay pending.",
+    "measureAfterField": "Measure after",
+    "measureAfterHint": "Leave blank to measure at sprint close.",
+    "metric_velocity": "Velocity",
+    "metric_backlog_remaining": "Backlog remaining",
+    "metric_progress": "Progress"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2194,5 +2194,32 @@
     "doneStories": "완료 스토리",
     "assignedStories": "배정 스토리",
     "avgLeadTime": "평균 리드타임"
+  },
+  "outcomeLoop": {
+    "resultLabel": "결과 기록",
+    "statusHit": "적중",
+    "statusMiss": "빗나감",
+    "statusPending": "측정 대기",
+    "hypothesisLabel": "세웠던 가설",
+    "target": "목표",
+    "actual": "실제",
+    "scoredSuffix": "채점",
+    "forwardNote": "다음 계획의 참고 기록",
+    "pendingNote": "측정 대기 중 — 스프린트 종료 시 자동 채점된다.",
+    "addIntent": "성과 의도 추가 (선택)",
+    "intentLabel": "성과 의도",
+    "optional": "선택",
+    "hypothesisField": "성공 가설",
+    "hypothesisPlaceholder": "이 스프린트가 성공이라면 무엇이 달라지는가?",
+    "metricField": "성과 지표",
+    "dirUp": "이상이면 적중",
+    "dirDown": "이하면 적중",
+    "targetPlaceholder": "목표값",
+    "externalSourceNote": "internal_ops 지표만 종료 시 자동 채점된다. 그 외 소스는 '측정 대기'로 기록된다.",
+    "measureAfterField": "측정 시점",
+    "measureAfterHint": "비우면 스프린트 종료 시점에 측정된다.",
+    "metric_velocity": "벨로시티",
+    "metric_backlog_remaining": "백로그 잔여",
+    "metric_progress": "진행률"
   }
 }

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -7,6 +7,9 @@ import { Plus, X, Play, StopCircle, ChevronRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { OutcomeIntentFields, type OutcomeIntentValue, type MetricDefinition } from '@/components/outcome/outcome-intent-fields';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import type { OutcomeStatus } from '@/components/outcome/outcome-status-badge';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -19,6 +22,11 @@ interface Sprint {
   duration: number;
   velocity: number | null;
   report_doc_id: string | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: OutcomeStatus | null;
+  outcome_result: OutcomeResult | null;
 }
 
 interface Story {
@@ -66,6 +74,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
   const [title, setTitle] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [intent, setIntent] = useState<OutcomeIntentValue>({ success_hypothesis: '', metric_definition: null, measure_after: '' });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -75,10 +84,15 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
     setSubmitting(true);
     setError(null);
     try {
+      const payload = {
+        success_hypothesis: intent.success_hypothesis.trim() || null,
+        metric_definition: intent.metric_definition,
+        measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,
+      };
       const res = await fetch('/api/sprints', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), start_date: startDate, end_date: endDate, project_id: projectId }),
+        body: JSON.stringify({ title: title.trim(), start_date: startDate, end_date: endDate, project_id: projectId, ...payload }),
       });
       if (!res.ok) throw new Error(await res.text());
       const { data } = await res.json() as { data: Sprint };
@@ -134,6 +148,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
               />
             </div>
           </div>
+          <OutcomeIntentFields value={intent} onChange={setIntent} />
           {error ? <p className="text-xs text-destructive">{error}</p> : null}
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="ghost" size="sm" onClick={onClose}>{t('cancel')}</Button>
@@ -419,6 +434,18 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         </Button>
       ) : null}
       {actionError ? <p className="mb-3 text-xs text-destructive">{actionError}</p> : null}
+
+      {/* Outcome result card */}
+      {selected.outcome_status && selected.outcome_status !== 'n_a' ? (
+        <div className="mb-4">
+          <OutcomeResultCard
+            status={selected.outcome_status}
+            hypothesis={selected.success_hypothesis}
+            result={selected.outcome_result as OutcomeResult | null}
+            pendingMetricLabel={selected.metric_definition?.metric}
+          />
+        </div>
+      ) : null}
 
       {/* Burndown */}
       {loadingBurndown ? (

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+export interface MetricDefinition { metric: string; source: 'internal_ops' | 'ga4' | 'manual'; target: number; direction: 'up' | 'down'; }
+export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
+const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
+
+export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
+  { value: OutcomeIntentValue; onChange: (v: OutcomeIntentValue) => void; defaultOpen?: boolean }) {
+  const t = useTranslations('outcomeLoop');
+  const [open, setOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const md = value.metric_definition;
+  const setMd = (patch: Partial<MetricDefinition>) => {
+    const base: MetricDefinition = md ?? { metric: 'velocity', source: 'internal_ops', target: 0, direction: 'up' };
+    onChange({ ...value, metric_definition: { ...base, ...patch } });
+  };
+  if (!open) return (
+    <button type="button" onClick={() => setOpen(true)}
+      className="w-full rounded-xl border border-dashed border-border py-2.5 text-sm text-muted-foreground transition hover:border-primary hover:text-primary">
+      + {t('addIntent')}
+    </button>
+  );
+  const isInternal = !md || md.source === 'internal_ops';
+  return (
+    <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('intentLabel')}</span>
+        <span className="text-[10px] text-muted-foreground">{t('optional')}</span>
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('hypothesisField')}</label>
+        <textarea rows={2} value={value.success_hypothesis} onChange={(e) => onChange({ ...value, success_hypothesis: e.target.value })}
+          placeholder={t('hypothesisPlaceholder')}
+          className="w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('metricField')}</label>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_auto]">
+          <select value={md?.metric ?? 'velocity'} onChange={(e) => setMd({ metric: e.target.value })}
+            className="rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40">
+            {INTERNAL_METRICS.map((m) => <option key={m} value={m}>{t(`metric_${m}` as 'metric_velocity')}</option>)}
+          </select>
+          <div className="flex overflow-hidden rounded-xl border border-border">
+            {(['up', 'down'] as const).map((dir) => (
+              <button key={dir} type="button" onClick={() => setMd({ direction: dir })}
+                className={cn('whitespace-nowrap px-3 py-2 text-xs font-medium transition',
+                  (md?.direction ?? 'up') === dir ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:text-foreground')}>
+                {dir === 'up' ? t('dirUp') : t('dirDown')}
+              </button>
+            ))}
+          </div>
+          <input type="number" inputMode="decimal" value={md?.target ?? ''}
+            onChange={(e) => setMd({ target: e.target.value === '' ? 0 : Number(e.target.value) })} placeholder={t('targetPlaceholder')}
+            className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground tabular-nums placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 sm:w-24" />
+        </div>
+        {!isInternal ? <p className="text-[11px] text-muted-foreground">{t('externalSourceNote')}</p> : null}
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('measureAfterField')}</label>
+        <input type="date" value={value.measure_after} onChange={(e) => onChange({ ...value, measure_after: e.target.value })}
+          className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
+        <p className="text-[11px] text-muted-foreground">{t('measureAfterHint')}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/outcome/outcome-result-card.tsx
+++ b/apps/web/src/components/outcome/outcome-result-card.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { OutcomeStatusBadge, type OutcomeStatus } from './outcome-status-badge';
+
+export interface OutcomeResult { metric: string; target: number; actual: number; direction: 'up' | 'down'; scored_at: string; }
+interface Props { status: OutcomeStatus; hypothesis?: string | null; result?: OutcomeResult | null; pendingMetricLabel?: string; }
+const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
+
+export function OutcomeResultCard({ status, hypothesis, result, pendingMetricLabel }: Props) {
+  const t = useTranslations('outcomeLoop');
+  if (status === 'n_a') return null;
+  const isHit = status === 'hit', isMiss = status === 'miss', isPending = status === 'pending';
+  const metricLabel = result ? t(`metric_${result.metric}` as 'metric_velocity') : (pendingMetricLabel ?? '');
+  return (
+    <div className={cn('rounded-2xl border p-4 animate-in fade-in duration-500',
+      isHit && 'border-success-border bg-success-tint',
+      isMiss && 'border-border bg-muted/40',
+      isPending && 'border-dashed border-border bg-muted/20')}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('resultLabel')}</span>
+        <OutcomeStatusBadge status={status} />
+      </div>
+      {hypothesis ? (
+        <div className="mt-3">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{t('hypothesisLabel')}</span>
+          <p className="mt-0.5 text-sm leading-6 text-foreground">{hypothesis}</p>
+        </div>) : null}
+      {isPending ? (
+        <p className="mt-3 text-sm text-muted-foreground">{t('pendingNote')}</p>
+      ) : result ? (<>
+        <div className="mt-4 flex items-baseline justify-between gap-3 text-sm">
+          <span className="font-medium text-foreground">{metricLabel}</span>
+          <span className="tabular-nums text-muted-foreground">
+            {t('target')} {result.direction === 'up' ? '≥' : '≤'} {fmt(result.target)}
+            <span className="mx-1.5 text-border">·</span>
+            {t('actual')} <span className={cn('font-semibold', isHit ? 'text-success' : 'text-foreground')}>{fmt(result.actual)}</span>
+          </span>
+        </div>
+        <DeltaTrack target={result.target} actual={result.actual} isHit={isHit} targetLabel={t('target')} />
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          {result.scored_at.slice(0, 10)} {t('scoredSuffix')}<span className="mx-1.5 text-border">·</span>{t('forwardNote')}
+        </p>
+      </>) : null}
+    </div>
+  );
+}
+
+function DeltaTrack({ target, actual, isHit, targetLabel }: { target: number; actual: number; isHit: boolean; targetLabel: string }) {
+  const scale = Math.max(Math.abs(target), Math.abs(actual), 1);
+  const offset = Math.max(-42, Math.min(42, ((actual - target) / scale) * 42));
+  return (
+    <div className="mt-3" aria-hidden>
+      <div className="relative h-px w-full bg-border">
+        <span className="absolute top-1/2 h-2.5 w-px -translate-y-1/2 bg-muted-foreground/60" style={{ left: '50%' }} />
+        <span className={cn('absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-background animate-in fade-in slide-in-from-left-1 duration-700', isHit ? 'bg-success' : 'bg-foreground')}
+          style={{ left: `${50 + offset}%` }} />
+      </div>
+      <div className="mt-1 text-center text-[10px] text-muted-foreground">{targetLabel}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/outcome/outcome-status-badge.tsx
+++ b/apps/web/src/components/outcome/outcome-status-badge.tsx
@@ -1,0 +1,12 @@
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+
+export type OutcomeStatus = 'n_a' | 'pending' | 'hit' | 'miss';
+
+export function OutcomeStatusBadge({ status }: { status: OutcomeStatus }) {
+  const t = useTranslations('outcomeLoop');
+  if (status === 'n_a') return null;
+  if (status === 'hit') return <Badge variant="success">{t('statusHit')}</Badge>;
+  if (status === 'miss') return <Badge variant="chip">{t('statusMiss')}</Badge>;
+  return <Badge variant="outline" className="border-dashed text-muted-foreground">{t('statusPending')}</Badge>;
+}

--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -66,7 +66,7 @@ export class SprintService {
   }
 
   async update(id: string, input: UpdateSprintInput) {
-    const ALLOWED_FIELDS: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size'];
+    const ALLOWED_FIELDS: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'success_hypothesis', 'metric_definition', 'measure_after'];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) { if (key in input) sanitized[key] = input[key]; }
     if (Object.keys(sanitized).length === 0) throw new Error('No valid fields to update');

--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -1,6 +1,21 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
 
+export interface MetricDefinition {
+  metric: string;
+  source: 'internal_ops' | 'ga4' | 'manual';
+  target: number;
+  direction: 'up' | 'down';
+}
+
+export interface OutcomeResult {
+  metric: string;
+  target: number;
+  actual: number;
+  direction: 'up' | 'down';
+  scored_at: string;
+}
+
 export interface Sprint {
   id: string;
   org_id: string;
@@ -13,6 +28,11 @@ export interface Sprint {
   velocity: number | null;
   duration: number;
   report_doc_id: string | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
   created_at: string;
   updated_at: string;
 }
@@ -24,6 +44,9 @@ export interface CreateSprintInput {
   start_date: string;
   end_date: string;
   team_size?: number;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface UpdateSprintInput {
@@ -35,6 +58,9 @@ export interface UpdateSprintInput {
   velocity?: number | null;
   duration?: number;
   report_doc_id?: string | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface SprintListFilters extends PaginationOptions {

--- a/packages/shared/src/schemas/sprints.ts
+++ b/packages/shared/src/schemas/sprints.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod/v4';
 
+const metricDefinitionSchema = z.object({
+  metric: z.string().min(1),
+  source: z.enum(['internal_ops', 'ga4', 'manual']),
+  target: z.number(),
+  direction: z.enum(['up', 'down']),
+});
+
 export const createSprintSchema = z.object({
   project_id: z.string().min(1),
   org_id: z.string().min(1),
@@ -7,6 +14,9 @@ export const createSprintSchema = z.object({
   start_date: z.string().min(1),
   end_date: z.string().min(1),
   team_size: z.number().optional(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 export const updateSprintSchema = z.object({
@@ -14,4 +24,7 @@ export const updateSprintSchema = z.object({
   start_date: z.string().min(1).optional(),
   end_date: z.string().min(1).optional(),
   team_size: z.number().optional(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });


### PR DESCRIPTION
## 변경 요약

**PR-A (Sprint측)** — E-OUTCOME-LOOP S4 3분할 중 첫 번째. sequential — 본 PR 머지 후 PR-B(Story측) 진행.

### 게이팅 맵 (sprint측 3지점 완결)

| # | 파일 | 변경 |
|---|---|---|
| 1 | `packages/shared/src/schemas/sprints.ts` | `createSprintSchema` + `updateSprintSchema`에 3필드 추가 |
| 2 | `packages/core-storage/src/interfaces/ISprintRepository.ts` | `Sprint` (outcome 읽기) + `CreateSprintInput` + `UpdateSprintInput`에 3필드 추가 |
| 3 | `apps/web/src/services/sprint.ts` | `ALLOWED_FIELDS`에 3필드 추가 |

`outcome_status` / `outcome_result`는 읽기 타입(`Sprint`)에만 — 쓰기 스키마 미포함 (BE 채점 job 전용).

### 신규 컴포넌트 3종

- `apps/web/src/components/outcome/outcome-status-badge.tsx` — hit(success) / miss(chip 중립) / pending(outline dashed). miss에 destructive 0건.
- `apps/web/src/components/outcome/outcome-result-card.tsx` — Ledger 채점 카드 + DeltaTrack 시각화. n_a → 완전 숨김.
- `apps/web/src/components/outcome/outcome-intent-fields.tsx` — 접힘 default, 펼치면 hypothesis + metric + measure_after.

### Sprint 통합

- `CreateDialog`: 날짜 필드 아래 `<OutcomeIntentFields>` + intent → POST body 직렬화 (measure_after ISO 변환).
- detail 패널: `outcome_status !== 'n_a'`일 때 burndown 위 `<OutcomeResultCard>` 표시.

### i18n

`outcomeLoop` 네임스페이스 — en + ko 완비 (23키).

## AC 체크리스트

- [x] ① 게이팅 sprint측 3지점 + `pnpm build` 성공
- [x] ② CreateDialog intent 접힘 default, 미입력 시 3필드 null
- [x] ③ OutcomeResultCard hit/miss/pending 분기, n_a 숨김
- [x] ④ `grep -rn "destructive" apps/web/src/components/outcome/` → 0건
- [x] ⑤ hit/miss 동일 위계 (chip 중립)
- [x] ⑥ DeltaTrack 델타 트랙 렌더
- [x] ⑦ measure_after ISO 직렬화 (`T00:00:00Z`)
- [x] ⑧ i18n en + ko
- [x] ⑨ 다크모드 토큰 (bg-success-tint / bg-muted/40 — 하드코딩 hex 0건)
- [x] ⑩ 모바일 375px intent 1열 (grid-cols-1 sm:grid-cols-[1fr_auto_auto])
- [x] ⑪ `pnpm type-check` 에러 0, `pnpm build` 성공 (30s)

## 빌드 결과

```
✅ pnpm type-check (web) — 에러 0
✅ pnpm build (web) — 30s, 0 errors
✅ pnpm type-check (core-storage) — 에러 0
✅ @sprintable/shared build — 1.5s
✅ grep destructive outcome/ — 0건
✅ grep hex colors outcome/ — 0건
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)