### PR TITLE
[E-OUTCOME-LOOP S7] Story intent 입력 UI (PR-B)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -212,13 +212,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
   };
 
-  const handleSaveIntent = async (newIntent: OutcomeIntentValue) => {
-    setIntent(newIntent);
+  const handleSaveIntent = async () => {
     setSavingIntent(true);
     await patchStory({
-      success_hypothesis: newIntent.success_hypothesis.trim() || null,
-      metric_definition: newIntent.metric_definition,
-      measure_after: newIntent.measure_after ? `${newIntent.measure_after}T00:00:00Z` : null,
+      success_hypothesis: intent.success_hypothesis.trim() || null,
+      metric_definition: intent.metric_definition,
+      measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,
     });
     setSavingIntent(false);
   };
@@ -532,10 +531,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               ) : null}
               <OutcomeIntentFields
                 value={intent}
-                onChange={(v) => { void handleSaveIntent(v); }}
+                onChange={setIntent}
                 defaultOpen={!!story.success_hypothesis || !!story.metric_definition}
               />
-              {savingIntent ? <p className="text-[11px] text-muted-foreground">저장 중...</p> : null}
+              <div className="flex justify-end gap-2">
+                <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
+                  {savingIntent ? t('loading') : t('save')}
+                </Button>
+              </div>
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -7,6 +7,8 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { Trash2 } from 'lucide-react';
 import type { KanbanStory, KanbanMember } from './types';
+import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -109,6 +111,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [descriptionDraft, setDescriptionDraft] = useState(story.description ?? '');
   const [savingDescription, setSavingDescription] = useState(false);
 
+  const [intent, setIntent] = useState<OutcomeIntentValue>({
+    success_hypothesis: story.success_hypothesis ?? '',
+    metric_definition: story.metric_definition ?? null,
+    measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
+  });
+  const [savingIntent, setSavingIntent] = useState(false);
+
   const [editingAssignee, setEditingAssignee] = useState(false);
   const [savingAssignee, setSavingAssignee] = useState(false);
 
@@ -136,7 +145,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   useEffect(() => {
     setTitleDraft(story.title);
     setDescriptionDraft(story.description ?? '');
-  }, [story.id, story.title, story.description]);
+    setIntent({
+      success_hypothesis: story.success_hypothesis ?? '',
+      metric_definition: story.metric_definition ?? null,
+      measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
+    });
+  }, [story.id, story.title, story.description, story.success_hypothesis, story.metric_definition, story.measure_after]);
 
   useEffect(() => {
     if (editingTitle) {
@@ -196,6 +210,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setSavingDescription(false);
     setEditingDescription(false);
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
+  };
+
+  const handleSaveIntent = async (newIntent: OutcomeIntentValue) => {
+    setIntent(newIntent);
+    setSavingIntent(true);
+    await patchStory({
+      success_hypothesis: newIntent.success_hypothesis.trim() || null,
+      metric_definition: newIntent.metric_definition,
+      measure_after: newIntent.measure_after ? `${newIntent.measure_after}T00:00:00Z` : null,
+    });
+    setSavingIntent(false);
   };
 
   // Fetch comments
@@ -493,6 +518,24 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   + {t('addDescription')}
                 </button>
               )}
+            </div>
+
+            {/* Outcome intent + result */}
+            <div className="space-y-3">
+              {story.outcome_status && story.outcome_status !== 'n_a' ? (
+                <OutcomeResultCard
+                  status={story.outcome_status}
+                  hypothesis={story.success_hypothesis}
+                  result={story.outcome_result as OutcomeResult | null}
+                  pendingMetricLabel={story.metric_definition?.metric}
+                />
+              ) : null}
+              <OutcomeIntentFields
+                value={intent}
+                onChange={(v) => { void handleSaveIntent(v); }}
+                defaultOpen={!!story.success_hypothesis || !!story.metric_definition}
+              />
+              {savingIntent ? <p className="text-[11px] text-muted-foreground">저장 중...</p> : null}
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -1,3 +1,5 @@
+import type { MetricDefinition, OutcomeResult } from '@sprintable/core-storage';
+
 export interface KanbanStory {
   id: string;
   title: string;
@@ -9,6 +11,11 @@ export interface KanbanStory {
   sprint_id: string | null;
   description: string | null;
   position: number | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
 }
 
 export interface KanbanEpic {

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -2,8 +2,9 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import type { MetricDefinition } from '@sprintable/core-storage';
 
-export interface MetricDefinition { metric: string; source: 'internal_ops' | 'ga4' | 'manual'; target: number; direction: 'up' | 'down'; }
+export type { MetricDefinition };
 export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
 const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
 

--- a/apps/web/src/components/outcome/outcome-result-card.tsx
+++ b/apps/web/src/components/outcome/outcome-result-card.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import type { OutcomeResult } from '@sprintable/core-storage';
 import { OutcomeStatusBadge, type OutcomeStatus } from './outcome-status-badge';
 
-export interface OutcomeResult { metric: string; target: number; actual: number; direction: 'up' | 'down'; scored_at: string; }
+export type { OutcomeResult };
 interface Props { status: OutcomeStatus; hypothesis?: string | null; result?: OutcomeResult | null; pendingMetricLabel?: string; }
 const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
 

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -91,6 +91,7 @@ export class StoryService {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
       'epic_id', 'sprint_id', 'assignee_id', 'position',
+      'success_hypothesis', 'metric_definition', 'measure_after',
     ];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) {

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -1,5 +1,6 @@
 export * from './errors';
 export * from './types';
+export type { MetricDefinition, OutcomeResult } from './interfaces/outcome';
 
 export type {
   IEpicRepository,

--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -1,20 +1,7 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
-
-export interface MetricDefinition {
-  metric: string;
-  source: 'internal_ops' | 'ga4' | 'manual';
-  target: number;
-  direction: 'up' | 'down';
-}
-
-export interface OutcomeResult {
-  metric: string;
-  target: number;
-  actual: number;
-  direction: 'up' | 'down';
-  scored_at: string;
-}
+import type { MetricDefinition, OutcomeResult } from './outcome';
+export type { MetricDefinition, OutcomeResult } from './outcome';
 
 export interface Sprint {
   id: string;

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -1,5 +1,6 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
+import type { MetricDefinition, OutcomeResult } from './outcome';
 
 export interface Story {
   id: string;
@@ -15,6 +16,11 @@ export interface Story {
   description: string | null;
   acceptance_criteria: string | null;
   position: number | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -33,6 +39,9 @@ export interface CreateStoryInput {
   description?: string | null;
   acceptance_criteria?: string | null;
   meeting_id?: string | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface UpdateStoryInput {
@@ -46,6 +55,9 @@ export interface UpdateStoryInput {
   sprint_id?: string | null;
   assignee_id?: string | null;
   position?: number | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface BulkUpdateItem {

--- a/packages/core-storage/src/interfaces/outcome.ts
+++ b/packages/core-storage/src/interfaces/outcome.ts
@@ -1,0 +1,14 @@
+export interface MetricDefinition {
+  metric: string;
+  source: 'internal_ops' | 'ga4' | 'manual';
+  target: number;
+  direction: 'up' | 'down';
+}
+
+export interface OutcomeResult {
+  metric: string;
+  target: number;
+  actual: number;
+  direction: 'up' | 'down';
+  scored_at: string;
+}

--- a/packages/shared/src/schemas/outcome.ts
+++ b/packages/shared/src/schemas/outcome.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod/v4';
+
+export const metricDefinitionSchema = z.object({
+  metric: z.string().min(1),
+  source: z.enum(['internal_ops', 'ga4', 'manual']),
+  target: z.number(),
+  direction: z.enum(['up', 'down']),
+});

--- a/packages/shared/src/schemas/sprints.ts
+++ b/packages/shared/src/schemas/sprints.ts
@@ -1,11 +1,5 @@
 import { z } from 'zod/v4';
-
-const metricDefinitionSchema = z.object({
-  metric: z.string().min(1),
-  source: z.enum(['internal_ops', 'ga4', 'manual']),
-  target: z.number(),
-  direction: z.enum(['up', 'down']),
-});
+import { metricDefinitionSchema } from './outcome';
 
 export const createSprintSchema = z.object({
   project_id: z.string().min(1),

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { metricDefinitionSchema } from './outcome';
 
 export const STORY_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done'] as const;
 export const STORY_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
@@ -36,6 +37,9 @@ export const createStorySchema = z.object({
   description: z.string().optional().nullable(),
   acceptance_criteria: z.string().optional().nullable(),
   meeting_id: z.string().uuid().optional().nullable(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 export const updateStorySchema = z.object({
@@ -49,6 +53,9 @@ export const updateStorySchema = z.object({
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),
   position: z.number().int().optional().nullable(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 const bulkUpdateItemSchema = z.object({


### PR DESCRIPTION
## 변경 요약

**PR-B (Story측)** — E-OUTCOME-LOOP S4/S7 3분할 중 두 번째. PR-A(#1088) 머지 후 develop 기반 분기.

### 타입/스키마 dedup (PR-A 리뷰 nit 흡수)

| 파일 | 내용 |
|---|---|
| `packages/shared/src/schemas/outcome.ts` (신규) | `metricDefinitionSchema` 단일 소스 |
| `packages/core-storage/src/interfaces/outcome.ts` (신규) | `MetricDefinition` + `OutcomeResult` 단일 소스 |
| `packages/shared/src/schemas/sprints.ts` | 로컬 정의 → outcome.ts import |
| `packages/core-storage/src/interfaces/ISprintRepository.ts` | 로컬 정의 → outcome.ts import |
| `apps/web/src/components/outcome/outcome-intent-fields.tsx` | 로컬 `MetricDefinition` → core-storage import |
| `apps/web/src/components/outcome/outcome-result-card.tsx` | 로컬 `OutcomeResult` → core-storage import |

### 게이팅 맵 (story측 3지점 완결)

| # | 파일 | 변경 |
|---|---|---|
| 1 | `packages/shared/src/schemas/stories.ts` | `createStorySchema` + `updateStorySchema`에 3필드 |
| 2 | `packages/core-storage/src/interfaces/IStoryRepository.ts` | `Story`(outcome 읽기) + `CreateStoryInput` + `UpdateStoryInput`에 3필드 |
| 3 | `apps/web/src/services/story.ts` | `ALLOWED_FIELDS`에 3필드 추가 |

### 읽기 경로

- `apps/web/src/components/kanban/types.ts` `KanbanStory` +5필드 (intent 3 + outcome 읽기 2)
- 칸반 보드 fetch: `json.data` 통째 passthrough — 하드 pick 없음. 필드 자동 carry 확인.

### story-detail-panel 통합

- `OutcomeIntentFields` onChange 시 `patchStory` 자동 저장 (초기값 기존 story intent로 채움, 기존 있으면 펼침 default)
- `OutcomeResultCard` — story 채점(S5) 전까지 `outcome_status` = `n_a` → 카드 자동 숨김. forward-compat 배선만.

## AC 체크리스트

- [x] ① story측 게이팅 3지점 (Zod create+update / IStoryRepository Story+Create+Update / ALLOWED_FIELDS)
- [x] ② 타입/스키마 dedup — `MetricDefinition`, `OutcomeResult` 단일 소스 (core-storage), `metricDefinitionSchema` 단일 소스 (shared)
- [x] ③ KanbanStory +5필드 + 보드 fetch passthrough (하드 pick 없음)
- [x] ④ story-detail 의도 편집(patchStory 재사용) + 결과 카드(n_a 숨김)
- [x] ⑤ `OutcomeIntentFields` 재사용 — import 위치 2개(sprints-client + story-detail), 정의 1개만
- [x] ⑥ measure_after ISO 직렬화
- [x] ⑦ `pnpm type-check` 에러 0, `pnpm build` 성공 (24s)

## 빌드 결과

```
✅ pnpm type-check (web) — 에러 0
✅ pnpm build (web) — 24s 성공
✅ pnpm type-check (core-storage) — 에러 0
✅ @sprintable/shared build — 성공
✅ grep interface MetricDefinition — 단일 소스 (core-storage/interfaces/outcome.ts)
✅ grep interface OutcomeResult — 단일 소스 (core-storage/interfaces/outcome.ts)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)