### PR TITLE
[CLEANUP] outcome intent nit 2건 — collapsed Save 숨김 + story placeholder

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2220,6 +2220,7 @@
     "measureAfterHint": "Leave blank to measure at sprint close.",
     "metric_velocity": "Velocity",
     "metric_backlog_remaining": "Backlog remaining",
-    "metric_progress": "Progress"
+    "metric_progress": "Progress",
+    "hypothesisPlaceholder_story": "What would be different if this story succeeds?"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2220,6 +2220,7 @@
     "measureAfterHint": "비우면 스프린트 종료 시점에 측정된다.",
     "metric_velocity": "벨로시티",
     "metric_backlog_remaining": "백로그 잔여",
-    "metric_progress": "진행률"
+    "metric_progress": "진행률",
+    "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?"
   }
 }

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -116,6 +116,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     metric_definition: story.metric_definition ?? null,
     measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
   });
+  const [intentOpen, setIntentOpen] = useState(!!story.success_hypothesis || !!story.metric_definition);
   const [savingIntent, setSavingIntent] = useState(false);
 
   const [editingAssignee, setEditingAssignee] = useState(false);
@@ -150,6 +151,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       metric_definition: story.metric_definition ?? null,
       measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
     });
+    setIntentOpen(!!story.success_hypothesis || !!story.metric_definition);
   }, [story.id, story.title, story.description, story.success_hypothesis, story.metric_definition, story.measure_after]);
 
   useEffect(() => {
@@ -532,13 +534,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <OutcomeIntentFields
                 value={intent}
                 onChange={setIntent}
-                defaultOpen={!!story.success_hypothesis || !!story.metric_definition}
+                open={intentOpen}
+                onOpenChange={setIntentOpen}
+                context="story"
               />
-              <div className="flex justify-end gap-2">
-                <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
-                  {savingIntent ? t('loading') : t('save')}
-                </Button>
-              </div>
+              {intentOpen ? (
+                <div className="flex justify-end gap-2">
+                  <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
+                    {savingIntent ? t('loading') : t('save')}
+                  </Button>
+                </div>
+              ) : null}
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -8,15 +8,29 @@ export type { MetricDefinition };
 export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
 const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
 
-export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
-  { value: OutcomeIntentValue; onChange: (v: OutcomeIntentValue) => void; defaultOpen?: boolean }) {
+interface OutcomeIntentFieldsProps {
+  value: OutcomeIntentValue;
+  onChange: (v: OutcomeIntentValue) => void;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  context?: 'sprint' | 'story';
+}
+
+export function OutcomeIntentFields({ value, onChange, defaultOpen = false, open: controlledOpen, onOpenChange, context = 'sprint' }: OutcomeIntentFieldsProps) {
   const t = useTranslations('outcomeLoop');
-  const [open, setOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   const md = value.metric_definition;
   const setMd = (patch: Partial<MetricDefinition>) => {
     const base: MetricDefinition = md ?? { metric: 'velocity', source: 'internal_ops', target: 0, direction: 'up' };
     onChange({ ...value, metric_definition: { ...base, ...patch } });
   };
+  const placeholder = context === 'story' ? t('hypothesisPlaceholder_story') : t('hypothesisPlaceholder');
   if (!open) return (
     <button type="button" onClick={() => setOpen(true)}
       className="w-full rounded-xl border border-dashed border-border py-2.5 text-sm text-muted-foreground transition hover:border-primary hover:text-primary">
@@ -33,7 +47,7 @@ export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
       <div className="space-y-1">
         <label className="text-xs font-medium text-muted-foreground">{t('hypothesisField')}</label>
         <textarea rows={2} value={value.success_hypothesis} onChange={(e) => onChange({ ...value, success_hypothesis: e.target.value })}
-          placeholder={t('hypothesisPlaceholder')}
+          placeholder={placeholder}
           className="w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
       </div>
       <div className="space-y-1">


### PR DESCRIPTION
## 변경 요약

S7 dev 검수 후 오르테가군 지적 nit 2건 cleanup. 기능 변경 없음.

### nit 1 — collapsed 상태에서 Save 버튼 숨김
- `OutcomeIntentFields`에 `open`/`onOpenChange` 제어 prop 추가
- `story-detail-panel.tsx`: `intentOpen` state로 Save 버튼 조건부 렌더 (`intentOpen === false` → 숨김)
- **sprints-client.tsx 무변경** — form submit 저장이라 영향 없음

### nit 2 — story 컨텍스트 placeholder 분기
- `OutcomeIntentFields`에 `context?: 'sprint' | 'story'` prop 추가 (default `'sprint'`)
- `story-detail-panel.tsx`: `context="story"` 전달 → "이 스토리가 성공이라면 무엇이 달라지는가?"
- i18n `hypothesisPlaceholder_story` 키 추가 (en + ko)
- **sprints-client.tsx 무변경** — default `'sprint'` 유지

## 검증
- `pnpm type-check` 에러 0
- 기존 sprint/story 컴포넌트 인터페이스 완전 호환 (선택 prop, 하위 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)