### PR TITLE
[E-OUTCOME-LOOP S8] 회고 채점 카드 (PR-C)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1023,7 +1023,8 @@
     "advanceFailed": "Failed to advance phase.",
     "addItemFailed": "Failed to add item.",
     "voteFailed": "Failed to vote.",
-    "addActionFailed": "Failed to add action."
+    "addActionFailed": "Failed to add action.",
+    "linkedSprintOutcome": "Linked sprint outcome"
   },
   "docs": {
     "title": "Documentation",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1023,7 +1023,8 @@
     "advanceFailed": "단계 전환에 실패했습니다.",
     "addItemFailed": "항목 추가에 실패했습니다.",
     "voteFailed": "투표에 실패했습니다.",
-    "addActionFailed": "액션 추가에 실패했습니다."
+    "addActionFailed": "액션 추가에 실패했습니다.",
+    "linkedSprintOutcome": "연결된 스프린트 성과"
   },
   "docs": {
     "title": "문서",

--- a/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
@@ -11,6 +11,8 @@ import { OperatorTextarea } from '@/components/ui/operator-control';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 import type { RetroActionRecord, RetroItemRecord, RetroSessionPhase, RetroSessionRecord } from '@/services/retro-session';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import type { OutcomeStatus } from '@/components/outcome/outcome-status-badge';
 
 type RetroItemCategory = 'good' | 'bad' | 'improve';
 
@@ -47,6 +49,25 @@ export default function RetroSessionPage() {
   const [advancing, setAdvancing] = useState(false);
   const [advanceError, setAdvanceError] = useState<string | null>(null);
   const [votedItemIds, setVotedItemIds] = useState<Set<string>>(new Set());
+
+  const [sprintOutcome, setSprintOutcome] = useState<{
+    status: OutcomeStatus; hypothesis: string | null; result: OutcomeResult | null; metric?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!session?.sprint_id) { setSprintOutcome(null); return; }
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(`/api/sprints/${session.sprint_id}`);
+      if (!res.ok || cancelled) return;
+      const { data } = await res.json() as { data?: { outcome_status?: string; success_hypothesis?: string | null; outcome_result?: OutcomeResult | null; metric_definition?: { metric?: string } | null } };
+      if (data?.outcome_status && data.outcome_status !== 'n_a') {
+        setSprintOutcome({ status: data.outcome_status as OutcomeStatus, hypothesis: data.success_hypothesis ?? null,
+          result: data.outcome_result ?? null, metric: data.metric_definition?.metric });
+      } else setSprintOutcome(null);
+    })();
+    return () => { cancelled = true; };
+  }, [session?.sprint_id]);
 
   const [newItemText, setNewItemText] = useState<Record<RetroItemCategory, string>>({ good: '', bad: '', improve: '' });
   const [addingItem, setAddingItem] = useState<RetroItemCategory | null>(null);
@@ -277,6 +298,19 @@ export default function RetroSessionPage() {
             />
           ) : (
             <>
+              {/* Linked sprint outcome card */}
+              {sprintOutcome ? (
+                <div className="space-y-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('linkedSprintOutcome')}</p>
+                  <OutcomeResultCard
+                    status={sprintOutcome.status}
+                    hypothesis={sprintOutcome.hypothesis}
+                    result={sprintOutcome.result}
+                    pendingMetricLabel={sprintOutcome.metric}
+                  />
+                </div>
+              ) : null}
+
               {/* Items grid */}
               {showItems ? (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">


### PR DESCRIPTION
## 변경 요약

**PR-C (Retro)** — E-OUTCOME-LOOP S8. **FE-only** (BE 작업 0). PR-A/#1088 + PR-B/#1089 머지 후 develop 기반.

### 구현

`apps/web/src/app/(authenticated)/retro/[id]/page.tsx` (+34 lines)

- `session.sprint_id` 있을 때 `/api/sprints/{id}` 조회 → `outcome_status !== 'n_a'`면 `OutcomeResultCard` 표시
- **sprint_id 없음 / outcome_status = n_a / fetch 실패 → 완전 비노출**
- 렌더 위치: phase stepper 아래 / items grid 위 (`space-y-6 p-6` 블록 첫 번째 섹션)
- `OutcomeResultCard` **재사용** — 중복 정의 0
- `retro.linkedSprintOutcome` i18n 키 en + ko

### FE-only인 이유
`RetroSessionRecord.sprint_id: string | null` 이미 존재 (services/retro-session.ts:10). BE/타입 변경 0.

## AC 체크리스트

- [x] ① `session.sprint_id` 시 sprint fetch → `outcome_status ≠ n_a`면 카드 노출
- [x] ② `sprint_id` 없음 / n_a / fetch 실패 → 비노출
- [x] ③ `OutcomeResultCard` 재사용 — 정의 1 / import 위치 3 (sprints + story + retro)
- [x] ④ 신규 블록 destructive 0건 / hex 0건
- [x] ⑤ i18n `retro.linkedSprintOutcome` en + ko
- [x] ⑥ `pnpm type-check` 에러 0 / `pnpm build` 성공 (25s)

## 빌드 결과

```
✅ pnpm type-check (web) — 에러 0
✅ pnpm build (web) — 25s 성공
✅ grep OutcomeResultCard — 정의 1, import 3곳
✅ destructive/hex in retro 신규 블록 — 0건
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)