### PR TITLE
[E-OUTCOME-LOOP S9] GA4 통합 — app.sprintable.ai 사용자 행동 추적

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Geist_Mono, Source_Serif_4 } from "next/font/google";
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import { ThemeProvider } from '@/components/providers/theme-provider';
+import { GoogleAnalytics } from '@/components/google-analytics';
 import "./globals.css";
 
 const inter = Inter({
@@ -45,6 +46,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="h-full">
+        <GoogleAnalytics />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect, Suspense } from 'react';
+
+const GA_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void;
+    dataLayer: unknown[];
+  }
+}
+
+function GoogleAnalyticsInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!GA_ID || typeof window === 'undefined' || !window.gtag) return;
+    const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : '');
+    window.gtag('config', GA_ID, { page_path: url });
+  }, [pathname, searchParams]);
+
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}', { send_page_view: false });
+        `}
+      </Script>
+    </>
+  );
+}
+
+export function GoogleAnalytics() {
+  return (
+    <Suspense fallback={null}>
+      <GoogleAnalyticsInner />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
## 변경 요약

**S9 — GA4 통합 (FE-only, 2파일)**

### 구현

**`apps/web/src/components/google-analytics.tsx` (신규)**

랜딩(`~/sprintable-landing/app/components/google-analytics.tsx`) 패턴 동형.

- `NEXT_PUBLIC_GA4_MEASUREMENT_ID` 미설정 시 `return null` → **dev 자동 제외** (prod Vercel 환경변수에만 `G-RYHFE7XM3X` 설정)
- `next/script` `strategy="afterInteractive"` — 앱 렌더 블로킹 0
- `usePathname` + `useSearchParams` → SPA 라우트 변경 시 `page_view` 이벤트 (App Router 정합)
- `useSearchParams` Suspense 경계 래핑 (App Router 정합 — 없으면 build 경고)

**`apps/web/src/app/layout.tsx`**

`<body>` 최상단에 `<GoogleAnalytics />` 삽입.

### prod-only 보장

env 미설정 시 컴포넌트 자체가 null 반환 → Script 태그 미삽입. `.env.local`(dev)에 키 없음 → 개발 서버 자동 제외. Vercel prod에만 `NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-RYHFE7XM3X` 설정 필요.

## AC 체크리스트

- [x] GA4 gtag `afterInteractive` + SPA page_view 추적
- [x] `NEXT_PUBLIC_GA4_MEASUREMENT_ID` env — 하드코딩 0
- [x] dev 제외 — env 미설정 시 null 반환
- [x] Suspense 경계 — useSearchParams App Router 정합
- [x] `pnpm type-check` 에러 0 / `pnpm build` 성공 (24s)
- [x] 앱 빌드/렌더 영향 0 — script 추가만

## 빌드 결과

```
✅ pnpm type-check (web) — 에러 0
✅ pnpm build (web) — 24s 성공
```

## Vercel 환경변수 설정 필요 (prod만)
```
NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-RYHFE7XM3X
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)