### PR TITLE
promote: develop→main — E-OUTCOME-LOOP (outcome 루프 전체) + 누적 9커밋

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2194,5 +2194,32 @@
     "doneStories": "Done Stories",
     "assignedStories": "Assigned",
     "avgLeadTime": "Avg Lead Time"
+  },
+  "outcomeLoop": {
+    "resultLabel": "Outcome",
+    "statusHit": "On target",
+    "statusMiss": "Off target",
+    "statusPending": "Awaiting",
+    "hypothesisLabel": "Hypothesis",
+    "target": "Target",
+    "actual": "Actual",
+    "scoredSuffix": "scored",
+    "forwardNote": "A note for the next plan",
+    "pendingNote": "Awaiting measurement — auto-scored when sprint closes.",
+    "addIntent": "Add outcome intent (optional)",
+    "intentLabel": "Outcome intent",
+    "optional": "optional",
+    "hypothesisField": "Success hypothesis",
+    "hypothesisPlaceholder": "What would be different if this sprint succeeds?",
+    "metricField": "Success metric",
+    "dirUp": "Hit if above",
+    "dirDown": "Hit if below",
+    "targetPlaceholder": "Target value",
+    "externalSourceNote": "Only internal_ops metrics are auto-scored on close. Others stay pending.",
+    "measureAfterField": "Measure after",
+    "measureAfterHint": "Leave blank to measure at sprint close.",
+    "metric_velocity": "Velocity",
+    "metric_backlog_remaining": "Backlog remaining",
+    "metric_progress": "Progress"
   }
 }

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1023,7 +1023,8 @@
     "advanceFailed": "Failed to advance phase.",
     "addItemFailed": "Failed to add item.",
     "voteFailed": "Failed to vote.",
-    "addActionFailed": "Failed to add action."
+    "addActionFailed": "Failed to add action.",
+    "linkedSprintOutcome": "Linked sprint outcome"
   },
   "docs": {
     "title": "Documentation",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2220,6 +2220,7 @@
     "measureAfterHint": "Leave blank to measure at sprint close.",
     "metric_velocity": "Velocity",
     "metric_backlog_remaining": "Backlog remaining",
-    "metric_progress": "Progress"
+    "metric_progress": "Progress",
+    "hypothesisPlaceholder_story": "What would be different if this story succeeds?"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2220,6 +2220,7 @@
     "measureAfterHint": "비우면 스프린트 종료 시점에 측정된다.",
     "metric_velocity": "벨로시티",
     "metric_backlog_remaining": "백로그 잔여",
-    "metric_progress": "진행률"
+    "metric_progress": "진행률",
+    "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2194,5 +2194,32 @@
     "doneStories": "완료 스토리",
     "assignedStories": "배정 스토리",
     "avgLeadTime": "평균 리드타임"
+  },
+  "outcomeLoop": {
+    "resultLabel": "결과 기록",
+    "statusHit": "적중",
+    "statusMiss": "빗나감",
+    "statusPending": "측정 대기",
+    "hypothesisLabel": "세웠던 가설",
+    "target": "목표",
+    "actual": "실제",
+    "scoredSuffix": "채점",
+    "forwardNote": "다음 계획의 참고 기록",
+    "pendingNote": "측정 대기 중 — 스프린트 종료 시 자동 채점된다.",
+    "addIntent": "성과 의도 추가 (선택)",
+    "intentLabel": "성과 의도",
+    "optional": "선택",
+    "hypothesisField": "성공 가설",
+    "hypothesisPlaceholder": "이 스프린트가 성공이라면 무엇이 달라지는가?",
+    "metricField": "성과 지표",
+    "dirUp": "이상이면 적중",
+    "dirDown": "이하면 적중",
+    "targetPlaceholder": "목표값",
+    "externalSourceNote": "internal_ops 지표만 종료 시 자동 채점된다. 그 외 소스는 '측정 대기'로 기록된다.",
+    "measureAfterField": "측정 시점",
+    "measureAfterHint": "비우면 스프린트 종료 시점에 측정된다.",
+    "metric_velocity": "벨로시티",
+    "metric_backlog_remaining": "백로그 잔여",
+    "metric_progress": "진행률"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1023,7 +1023,8 @@
     "advanceFailed": "단계 전환에 실패했습니다.",
     "addItemFailed": "항목 추가에 실패했습니다.",
     "voteFailed": "투표에 실패했습니다.",
-    "addActionFailed": "액션 추가에 실패했습니다."
+    "addActionFailed": "액션 추가에 실패했습니다.",
+    "linkedSprintOutcome": "연결된 스프린트 성과"
   },
   "docs": {
     "title": "문서",

--- a/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/retro/[id]/page.tsx
@@ -11,6 +11,8 @@ import { OperatorTextarea } from '@/components/ui/operator-control';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 import type { RetroActionRecord, RetroItemRecord, RetroSessionPhase, RetroSessionRecord } from '@/services/retro-session';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import type { OutcomeStatus } from '@/components/outcome/outcome-status-badge';
 
 type RetroItemCategory = 'good' | 'bad' | 'improve';
 
@@ -47,6 +49,25 @@ export default function RetroSessionPage() {
   const [advancing, setAdvancing] = useState(false);
   const [advanceError, setAdvanceError] = useState<string | null>(null);
   const [votedItemIds, setVotedItemIds] = useState<Set<string>>(new Set());
+
+  const [sprintOutcome, setSprintOutcome] = useState<{
+    status: OutcomeStatus; hypothesis: string | null; result: OutcomeResult | null; metric?: string;
+  } | null>(null);
+
+  useEffect(() => {
+    if (!session?.sprint_id) { setSprintOutcome(null); return; }
+    let cancelled = false;
+    void (async () => {
+      const res = await fetch(`/api/sprints/${session.sprint_id}`);
+      if (!res.ok || cancelled) return;
+      const { data } = await res.json() as { data?: { outcome_status?: string; success_hypothesis?: string | null; outcome_result?: OutcomeResult | null; metric_definition?: { metric?: string } | null } };
+      if (data?.outcome_status && data.outcome_status !== 'n_a') {
+        setSprintOutcome({ status: data.outcome_status as OutcomeStatus, hypothesis: data.success_hypothesis ?? null,
+          result: data.outcome_result ?? null, metric: data.metric_definition?.metric });
+      } else setSprintOutcome(null);
+    })();
+    return () => { cancelled = true; };
+  }, [session?.sprint_id]);
 
   const [newItemText, setNewItemText] = useState<Record<RetroItemCategory, string>>({ good: '', bad: '', improve: '' });
   const [addingItem, setAddingItem] = useState<RetroItemCategory | null>(null);
@@ -277,6 +298,19 @@ export default function RetroSessionPage() {
             />
           ) : (
             <>
+              {/* Linked sprint outcome card */}
+              {sprintOutcome ? (
+                <div className="space-y-2">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('linkedSprintOutcome')}</p>
+                  <OutcomeResultCard
+                    status={sprintOutcome.status}
+                    hypothesis={sprintOutcome.hypothesis}
+                    result={sprintOutcome.result}
+                    pendingMetricLabel={sprintOutcome.metric}
+                  />
+                </div>
+              ) : null}
+
               {/* Items grid */}
               {showItems ? (
                 <div className="grid grid-cols-1 gap-4 md:grid-cols-3">

--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -7,6 +7,9 @@ import { Plus, X, Play, StopCircle, ChevronRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
+import { OutcomeIntentFields, type OutcomeIntentValue, type MetricDefinition } from '@/components/outcome/outcome-intent-fields';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import type { OutcomeStatus } from '@/components/outcome/outcome-status-badge';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -19,6 +22,11 @@ interface Sprint {
   duration: number;
   velocity: number | null;
   report_doc_id: string | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: OutcomeStatus | null;
+  outcome_result: OutcomeResult | null;
 }
 
 interface Story {
@@ -66,6 +74,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
   const [title, setTitle] = useState('');
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
+  const [intent, setIntent] = useState<OutcomeIntentValue>({ success_hypothesis: '', metric_definition: null, measure_after: '' });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -75,10 +84,15 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
     setSubmitting(true);
     setError(null);
     try {
+      const payload = {
+        success_hypothesis: intent.success_hypothesis.trim() || null,
+        metric_definition: intent.metric_definition,
+        measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,
+      };
       const res = await fetch('/api/sprints', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: title.trim(), start_date: startDate, end_date: endDate, project_id: projectId }),
+        body: JSON.stringify({ title: title.trim(), start_date: startDate, end_date: endDate, project_id: projectId, ...payload }),
       });
       if (!res.ok) throw new Error(await res.text());
       const { data } = await res.json() as { data: Sprint };
@@ -134,6 +148,7 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
               />
             </div>
           </div>
+          <OutcomeIntentFields value={intent} onChange={setIntent} />
           {error ? <p className="text-xs text-destructive">{error}</p> : null}
           <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="ghost" size="sm" onClick={onClose}>{t('cancel')}</Button>
@@ -419,6 +434,18 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         </Button>
       ) : null}
       {actionError ? <p className="mb-3 text-xs text-destructive">{actionError}</p> : null}
+
+      {/* Outcome result card */}
+      {selected.outcome_status && selected.outcome_status !== 'n_a' ? (
+        <div className="mb-4">
+          <OutcomeResultCard
+            status={selected.outcome_status}
+            hypothesis={selected.success_hypothesis}
+            result={selected.outcome_result as OutcomeResult | null}
+            pendingMetricLabel={selected.metric_definition?.metric}
+          />
+        </div>
+      ) : null}
 
       {/* Burndown */}
       {loadingBurndown ? (

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, Geist_Mono, Source_Serif_4 } from "next/font/google";
 import { NextIntlClientProvider } from 'next-intl';
 import { getLocale, getMessages } from 'next-intl/server';
 import { ThemeProvider } from '@/components/providers/theme-provider';
+import { GoogleAnalytics } from '@/components/google-analytics';
 import "./globals.css";
 
 const inter = Inter({
@@ -45,6 +46,7 @@ export default async function RootLayout({
       suppressHydrationWarning
     >
       <body className="h-full">
+        <GoogleAnalytics />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/apps/web/src/components/google-analytics.tsx
+++ b/apps/web/src/components/google-analytics.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useEffect, Suspense } from 'react';
+
+const GA_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID;
+
+declare global {
+  interface Window {
+    gtag: (...args: unknown[]) => void;
+    dataLayer: unknown[];
+  }
+}
+
+function GoogleAnalyticsInner() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!GA_ID || typeof window === 'undefined' || !window.gtag) return;
+    const url = pathname + (searchParams?.toString() ? `?${searchParams.toString()}` : '');
+    window.gtag('config', GA_ID, { page_path: url });
+  }, [pathname, searchParams]);
+
+  if (!GA_ID) return null;
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', '${GA_ID}', { send_page_view: false });
+        `}
+      </Script>
+    </>
+  );
+}
+
+export function GoogleAnalytics() {
+  return (
+    <Suspense fallback={null}>
+      <GoogleAnalyticsInner />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -7,6 +7,8 @@ import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
 import { Trash2 } from 'lucide-react';
 import type { KanbanStory, KanbanMember } from './types';
+import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -109,6 +111,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [descriptionDraft, setDescriptionDraft] = useState(story.description ?? '');
   const [savingDescription, setSavingDescription] = useState(false);
 
+  const [intent, setIntent] = useState<OutcomeIntentValue>({
+    success_hypothesis: story.success_hypothesis ?? '',
+    metric_definition: story.metric_definition ?? null,
+    measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
+  });
+  const [savingIntent, setSavingIntent] = useState(false);
+
   const [editingAssignee, setEditingAssignee] = useState(false);
   const [savingAssignee, setSavingAssignee] = useState(false);
 
@@ -136,7 +145,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   useEffect(() => {
     setTitleDraft(story.title);
     setDescriptionDraft(story.description ?? '');
-  }, [story.id, story.title, story.description]);
+    setIntent({
+      success_hypothesis: story.success_hypothesis ?? '',
+      metric_definition: story.metric_definition ?? null,
+      measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
+    });
+  }, [story.id, story.title, story.description, story.success_hypothesis, story.metric_definition, story.measure_after]);
 
   useEffect(() => {
     if (editingTitle) {
@@ -196,6 +210,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setSavingDescription(false);
     setEditingDescription(false);
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
+  };
+
+  const handleSaveIntent = async () => {
+    setSavingIntent(true);
+    await patchStory({
+      success_hypothesis: intent.success_hypothesis.trim() || null,
+      metric_definition: intent.metric_definition,
+      measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,
+    });
+    setSavingIntent(false);
   };
 
   // Fetch comments
@@ -493,6 +517,28 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   + {t('addDescription')}
                 </button>
               )}
+            </div>
+
+            {/* Outcome intent + result */}
+            <div className="space-y-3">
+              {story.outcome_status && story.outcome_status !== 'n_a' ? (
+                <OutcomeResultCard
+                  status={story.outcome_status}
+                  hypothesis={story.success_hypothesis}
+                  result={story.outcome_result as OutcomeResult | null}
+                  pendingMetricLabel={story.metric_definition?.metric}
+                />
+              ) : null}
+              <OutcomeIntentFields
+                value={intent}
+                onChange={setIntent}
+                defaultOpen={!!story.success_hypothesis || !!story.metric_definition}
+              />
+              <div className="flex justify-end gap-2">
+                <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
+                  {savingIntent ? t('loading') : t('save')}
+                </Button>
+              </div>
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -116,6 +116,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     metric_definition: story.metric_definition ?? null,
     measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
   });
+  const [intentOpen, setIntentOpen] = useState(!!story.success_hypothesis || !!story.metric_definition);
   const [savingIntent, setSavingIntent] = useState(false);
 
   const [editingAssignee, setEditingAssignee] = useState(false);
@@ -150,6 +151,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       metric_definition: story.metric_definition ?? null,
       measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
     });
+    setIntentOpen(!!story.success_hypothesis || !!story.metric_definition);
   }, [story.id, story.title, story.description, story.success_hypothesis, story.metric_definition, story.measure_after]);
 
   useEffect(() => {
@@ -532,13 +534,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               <OutcomeIntentFields
                 value={intent}
                 onChange={setIntent}
-                defaultOpen={!!story.success_hypothesis || !!story.metric_definition}
+                open={intentOpen}
+                onOpenChange={setIntentOpen}
+                context="story"
               />
-              <div className="flex justify-end gap-2">
-                <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
-                  {savingIntent ? t('loading') : t('save')}
-                </Button>
-              </div>
+              {intentOpen ? (
+                <div className="flex justify-end gap-2">
+                  <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
+                    {savingIntent ? t('loading') : t('save')}
+                  </Button>
+                </div>
+              ) : null}
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -1,3 +1,5 @@
+import type { MetricDefinition, OutcomeResult } from '@sprintable/core-storage';
+
 export interface KanbanStory {
   id: string;
   title: string;
@@ -9,6 +11,11 @@ export interface KanbanStory {
   sprint_id: string | null;
   description: string | null;
   position: number | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
 }
 
 export interface KanbanEpic {

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+
+export interface MetricDefinition { metric: string; source: 'internal_ops' | 'ga4' | 'manual'; target: number; direction: 'up' | 'down'; }
+export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
+const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
+
+export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
+  { value: OutcomeIntentValue; onChange: (v: OutcomeIntentValue) => void; defaultOpen?: boolean }) {
+  const t = useTranslations('outcomeLoop');
+  const [open, setOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const md = value.metric_definition;
+  const setMd = (patch: Partial<MetricDefinition>) => {
+    const base: MetricDefinition = md ?? { metric: 'velocity', source: 'internal_ops', target: 0, direction: 'up' };
+    onChange({ ...value, metric_definition: { ...base, ...patch } });
+  };
+  if (!open) return (
+    <button type="button" onClick={() => setOpen(true)}
+      className="w-full rounded-xl border border-dashed border-border py-2.5 text-sm text-muted-foreground transition hover:border-primary hover:text-primary">
+      + {t('addIntent')}
+    </button>
+  );
+  const isInternal = !md || md.source === 'internal_ops';
+  return (
+    <div className="space-y-3 rounded-xl border border-border bg-muted/20 p-3">
+      <div className="flex items-center justify-between">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('intentLabel')}</span>
+        <span className="text-[10px] text-muted-foreground">{t('optional')}</span>
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('hypothesisField')}</label>
+        <textarea rows={2} value={value.success_hypothesis} onChange={(e) => onChange({ ...value, success_hypothesis: e.target.value })}
+          placeholder={t('hypothesisPlaceholder')}
+          className="w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('metricField')}</label>
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-[1fr_auto_auto]">
+          <select value={md?.metric ?? 'velocity'} onChange={(e) => setMd({ metric: e.target.value })}
+            className="rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40">
+            {INTERNAL_METRICS.map((m) => <option key={m} value={m}>{t(`metric_${m}` as 'metric_velocity')}</option>)}
+          </select>
+          <div className="flex overflow-hidden rounded-xl border border-border">
+            {(['up', 'down'] as const).map((dir) => (
+              <button key={dir} type="button" onClick={() => setMd({ direction: dir })}
+                className={cn('whitespace-nowrap px-3 py-2 text-xs font-medium transition',
+                  (md?.direction ?? 'up') === dir ? 'bg-primary text-primary-foreground' : 'bg-background text-muted-foreground hover:text-foreground')}>
+                {dir === 'up' ? t('dirUp') : t('dirDown')}
+              </button>
+            ))}
+          </div>
+          <input type="number" inputMode="decimal" value={md?.target ?? ''}
+            onChange={(e) => setMd({ target: e.target.value === '' ? 0 : Number(e.target.value) })} placeholder={t('targetPlaceholder')}
+            className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground tabular-nums placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40 sm:w-24" />
+        </div>
+        {!isInternal ? <p className="text-[11px] text-muted-foreground">{t('externalSourceNote')}</p> : null}
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium text-muted-foreground">{t('measureAfterField')}</label>
+        <input type="date" value={value.measure_after} onChange={(e) => onChange({ ...value, measure_after: e.target.value })}
+          className="w-full rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
+        <p className="text-[11px] text-muted-foreground">{t('measureAfterHint')}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -2,8 +2,9 @@
 import { useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import type { MetricDefinition } from '@sprintable/core-storage';
 
-export interface MetricDefinition { metric: string; source: 'internal_ops' | 'ga4' | 'manual'; target: number; direction: 'up' | 'down'; }
+export type { MetricDefinition };
 export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
 const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
 

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -8,15 +8,29 @@ export type { MetricDefinition };
 export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
 const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
 
-export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
-  { value: OutcomeIntentValue; onChange: (v: OutcomeIntentValue) => void; defaultOpen?: boolean }) {
+interface OutcomeIntentFieldsProps {
+  value: OutcomeIntentValue;
+  onChange: (v: OutcomeIntentValue) => void;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  context?: 'sprint' | 'story';
+}
+
+export function OutcomeIntentFields({ value, onChange, defaultOpen = false, open: controlledOpen, onOpenChange, context = 'sprint' }: OutcomeIntentFieldsProps) {
   const t = useTranslations('outcomeLoop');
-  const [open, setOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const [internalOpen, setInternalOpen] = useState(defaultOpen || !!value.success_hypothesis || !!value.metric_definition);
+  const open = controlledOpen !== undefined ? controlledOpen : internalOpen;
+  const setOpen = (next: boolean) => {
+    setInternalOpen(next);
+    onOpenChange?.(next);
+  };
   const md = value.metric_definition;
   const setMd = (patch: Partial<MetricDefinition>) => {
     const base: MetricDefinition = md ?? { metric: 'velocity', source: 'internal_ops', target: 0, direction: 'up' };
     onChange({ ...value, metric_definition: { ...base, ...patch } });
   };
+  const placeholder = context === 'story' ? t('hypothesisPlaceholder_story') : t('hypothesisPlaceholder');
   if (!open) return (
     <button type="button" onClick={() => setOpen(true)}
       className="w-full rounded-xl border border-dashed border-border py-2.5 text-sm text-muted-foreground transition hover:border-primary hover:text-primary">
@@ -33,7 +47,7 @@ export function OutcomeIntentFields({ value, onChange, defaultOpen = false }:
       <div className="space-y-1">
         <label className="text-xs font-medium text-muted-foreground">{t('hypothesisField')}</label>
         <textarea rows={2} value={value.success_hypothesis} onChange={(e) => onChange({ ...value, success_hypothesis: e.target.value })}
-          placeholder={t('hypothesisPlaceholder')}
+          placeholder={placeholder}
           className="w-full resize-y rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40" />
       </div>
       <div className="space-y-1">

--- a/apps/web/src/components/outcome/outcome-result-card.tsx
+++ b/apps/web/src/components/outcome/outcome-result-card.tsx
@@ -1,0 +1,62 @@
+'use client';
+import { useTranslations } from 'next-intl';
+import { cn } from '@/lib/utils';
+import { OutcomeStatusBadge, type OutcomeStatus } from './outcome-status-badge';
+
+export interface OutcomeResult { metric: string; target: number; actual: number; direction: 'up' | 'down'; scored_at: string; }
+interface Props { status: OutcomeStatus; hypothesis?: string | null; result?: OutcomeResult | null; pendingMetricLabel?: string; }
+const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
+
+export function OutcomeResultCard({ status, hypothesis, result, pendingMetricLabel }: Props) {
+  const t = useTranslations('outcomeLoop');
+  if (status === 'n_a') return null;
+  const isHit = status === 'hit', isMiss = status === 'miss', isPending = status === 'pending';
+  const metricLabel = result ? t(`metric_${result.metric}` as 'metric_velocity') : (pendingMetricLabel ?? '');
+  return (
+    <div className={cn('rounded-2xl border p-4 animate-in fade-in duration-500',
+      isHit && 'border-success-border bg-success-tint',
+      isMiss && 'border-border bg-muted/40',
+      isPending && 'border-dashed border-border bg-muted/20')}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-muted-foreground">{t('resultLabel')}</span>
+        <OutcomeStatusBadge status={status} />
+      </div>
+      {hypothesis ? (
+        <div className="mt-3">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{t('hypothesisLabel')}</span>
+          <p className="mt-0.5 text-sm leading-6 text-foreground">{hypothesis}</p>
+        </div>) : null}
+      {isPending ? (
+        <p className="mt-3 text-sm text-muted-foreground">{t('pendingNote')}</p>
+      ) : result ? (<>
+        <div className="mt-4 flex items-baseline justify-between gap-3 text-sm">
+          <span className="font-medium text-foreground">{metricLabel}</span>
+          <span className="tabular-nums text-muted-foreground">
+            {t('target')} {result.direction === 'up' ? '≥' : '≤'} {fmt(result.target)}
+            <span className="mx-1.5 text-border">·</span>
+            {t('actual')} <span className={cn('font-semibold', isHit ? 'text-success' : 'text-foreground')}>{fmt(result.actual)}</span>
+          </span>
+        </div>
+        <DeltaTrack target={result.target} actual={result.actual} isHit={isHit} targetLabel={t('target')} />
+        <p className="mt-3 text-[11px] text-muted-foreground">
+          {result.scored_at.slice(0, 10)} {t('scoredSuffix')}<span className="mx-1.5 text-border">·</span>{t('forwardNote')}
+        </p>
+      </>) : null}
+    </div>
+  );
+}
+
+function DeltaTrack({ target, actual, isHit, targetLabel }: { target: number; actual: number; isHit: boolean; targetLabel: string }) {
+  const scale = Math.max(Math.abs(target), Math.abs(actual), 1);
+  const offset = Math.max(-42, Math.min(42, ((actual - target) / scale) * 42));
+  return (
+    <div className="mt-3" aria-hidden>
+      <div className="relative h-px w-full bg-border">
+        <span className="absolute top-1/2 h-2.5 w-px -translate-y-1/2 bg-muted-foreground/60" style={{ left: '50%' }} />
+        <span className={cn('absolute top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full ring-2 ring-background animate-in fade-in slide-in-from-left-1 duration-700', isHit ? 'bg-success' : 'bg-foreground')}
+          style={{ left: `${50 + offset}%` }} />
+      </div>
+      <div className="mt-1 text-center text-[10px] text-muted-foreground">{targetLabel}</div>
+    </div>
+  );
+}

--- a/apps/web/src/components/outcome/outcome-result-card.tsx
+++ b/apps/web/src/components/outcome/outcome-result-card.tsx
@@ -1,9 +1,10 @@
 'use client';
 import { useTranslations } from 'next-intl';
 import { cn } from '@/lib/utils';
+import type { OutcomeResult } from '@sprintable/core-storage';
 import { OutcomeStatusBadge, type OutcomeStatus } from './outcome-status-badge';
 
-export interface OutcomeResult { metric: string; target: number; actual: number; direction: 'up' | 'down'; scored_at: string; }
+export type { OutcomeResult };
 interface Props { status: OutcomeStatus; hypothesis?: string | null; result?: OutcomeResult | null; pendingMetricLabel?: string; }
 const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
 

--- a/apps/web/src/components/outcome/outcome-status-badge.tsx
+++ b/apps/web/src/components/outcome/outcome-status-badge.tsx
@@ -1,0 +1,12 @@
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+
+export type OutcomeStatus = 'n_a' | 'pending' | 'hit' | 'miss';
+
+export function OutcomeStatusBadge({ status }: { status: OutcomeStatus }) {
+  const t = useTranslations('outcomeLoop');
+  if (status === 'n_a') return null;
+  if (status === 'hit') return <Badge variant="success">{t('statusHit')}</Badge>;
+  if (status === 'miss') return <Badge variant="chip">{t('statusMiss')}</Badge>;
+  return <Badge variant="outline" className="border-dashed text-muted-foreground">{t('statusPending')}</Badge>;
+}

--- a/apps/web/src/services/sprint.ts
+++ b/apps/web/src/services/sprint.ts
@@ -66,7 +66,7 @@ export class SprintService {
   }
 
   async update(id: string, input: UpdateSprintInput) {
-    const ALLOWED_FIELDS: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size'];
+    const ALLOWED_FIELDS: (keyof UpdateSprintInput)[] = ['title', 'start_date', 'end_date', 'team_size', 'success_hypothesis', 'metric_definition', 'measure_after'];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) { if (key in input) sanitized[key] = input[key]; }
     if (Object.keys(sanitized).length === 0) throw new Error('No valid fields to update');

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -91,6 +91,7 @@ export class StoryService {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
       'epic_id', 'sprint_id', 'assignee_id', 'position',
+      'success_hypothesis', 'metric_definition', 'measure_after',
     ];
     const sanitized: Record<string, unknown> = {};
     for (const key of ALLOWED_FIELDS) {

--- a/backend/alembic/versions/0058_add_outcome_fields.py
+++ b/backend/alembic/versions/0058_add_outcome_fields.py
@@ -1,0 +1,45 @@
+"""E-OUTCOME-LOOP S1: stories·sprints에 outcome 필드 추가.
+
+Revision ID: 0058
+Revises: 0057
+Create Date: 2026-05-30
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0058"
+down_revision = "0057"
+branch_labels = None
+depends_on = None
+
+_OUTCOME_COLS = [
+    ("success_hypothesis", sa.Text, {"nullable": True}),
+    ("metric_definition", JSONB, {"nullable": True}),
+    ("measure_after", sa.DateTime(timezone=True), {"nullable": True}),
+    ("outcome_status", sa.String(20), {"nullable": False, "server_default": "n_a"}),
+    ("outcome_result", JSONB, {"nullable": True}),
+]
+
+
+def _add_cols_idempotent(table: str) -> None:
+    """컬럼이 이미 존재하면 무시 — dev 환경 idempotent (0056·0057 패턴)."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = {c["name"] for c in insp.get_columns(table)}
+    for col_name, col_type, kwargs in _OUTCOME_COLS:
+        if col_name not in existing:
+            op.add_column(table, sa.Column(col_name, col_type, **kwargs))
+
+
+def upgrade() -> None:
+    _add_cols_idempotent("stories")
+    _add_cols_idempotent("sprints")
+
+
+def downgrade() -> None:
+    for col_name, _, _ in reversed(_OUTCOME_COLS):
+        op.drop_column("sprints", col_name)
+        op.drop_column("stories", col_name)

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import date, datetime
 
 from sqlalchemy import BigInteger, Date, DateTime, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.core.database import Base
@@ -26,6 +26,13 @@ class Sprint(Base, OrgScopedMixin, TimestampMixin):
     velocity: Mapped[int | None] = mapped_column(Integer, nullable=True)
     team_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
     duration: Mapped[int] = mapped_column(Integer, nullable=False, default=14)
+    # E-OUTCOME-LOOP: 의도 필드 (intent)
+    success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    measure_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # E-OUTCOME-LOOP: 채점 필드 (outcome, 채점잡 전용)
+    outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="sprints")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="sprint", lazy="select")
@@ -80,6 +87,13 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     acceptance_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
     position: Mapped[int | None] = mapped_column(BigInteger, nullable=True)
+    # E-OUTCOME-LOOP: 의도 필드 (intent)
+    success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    measure_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # E-OUTCOME-LOOP: 채점 필드 (outcome, 채점잡 전용)
+    outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     epic: Mapped[Epic | None] = relationship("Epic", back_populates="stories")
     sprint: Mapped[Sprint | None] = relationship("Sprint", back_populates="stories")

--- a/backend/app/repositories/sprint.py
+++ b/backend/app/repositories/sprint.py
@@ -39,16 +39,25 @@ class SprintRepository(BaseRepository[Sprint]):
         if sprint.status != "active":
             raise ValueError(f"Cannot close sprint with status: {sprint.status}")
 
-        result = await self.session.execute(
+        all_result = await self.session.execute(
             select(Story).where(
                 Story.sprint_id == id,
-                Story.status == "done",
                 Story.deleted_at.is_(None),
             )
         )
-        done_stories = result.scalars().all()
+        all_stories = all_result.scalars().all()
+        done_stories = [s for s in all_stories if s.status == "done"]
         velocity = sum(s.story_points or 0 for s in done_stories)
 
-        updated = await self.update(id, status="closed", velocity=velocity)
+        # E-OUTCOME-LOOP S3: velocity 계산 직후 채점 (비파괴 — 기존 close 로직 무변경)
+        from app.services.outcome_scorer import score_sprint_outcome
+        backlog_remaining = len([s for s in all_stories if s.status != "done"])
+        total_points = sum(s.story_points or 0 for s in all_stories)
+        scoring = score_sprint_outcome(
+            sprint.metric_definition, velocity, backlog_remaining, total_points
+        )
+        extra = scoring if scoring is not None else {}
+
+        updated = await self.update(id, status="closed", velocity=velocity, **extra)
         assert updated is not None
         return updated

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -186,3 +186,76 @@ async def retry_agent_runs(
     except Exception as exc:
         logger.exception("cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── POST /api/v2/internal/cron/score-ga4-outcomes ────────────────────────────
+
+@router.post("/score-ga4-outcomes")
+async def score_ga4_outcomes(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """E-OUTCOME-LOOP S5: GA4 지연 채점 잡.
+
+    measure_after <= now AND outcome_status = 'pending' AND source = 'ga4'인
+    story·sprint를 GA4 Data API로 채점.
+    """
+    verify_cron(request)
+
+    from app.models.pm import Sprint, Story
+    from app.services.outcome_scorer import score_ga4_outcome
+
+    now = datetime.now(timezone.utc)
+    scored: list[dict] = []
+    failed: list[dict] = []
+
+    try:
+        # Sprint GA4 채점
+        sprint_result = await session.execute(
+            select(Sprint).where(
+                Sprint.outcome_status == "pending",
+                Sprint.measure_after.isnot(None),
+                Sprint.measure_after <= now,
+            )
+        )
+        for sprint in sprint_result.scalars().all():
+            md = sprint.metric_definition
+            if not md or md.get("source") != "ga4":
+                continue
+            try:
+                scoring = score_ga4_outcome(md)
+                sprint.outcome_status = scoring["outcome_status"]
+                sprint.outcome_result = scoring["outcome_result"]
+                scored.append({"type": "sprint", "id": str(sprint.id), "outcome_status": scoring["outcome_status"]})
+            except Exception as exc:
+                logger.warning("ga4 sprint scoring failed id=%s: %s", sprint.id, exc)
+                failed.append({"type": "sprint", "id": str(sprint.id), "error": str(exc)})
+
+        # Story GA4 채점
+        story_result = await session.execute(
+            select(Story).where(
+                Story.outcome_status == "pending",
+                Story.measure_after.isnot(None),
+                Story.measure_after <= now,
+                Story.deleted_at.is_(None),
+            )
+        )
+        for story in story_result.scalars().all():
+            md = story.metric_definition
+            if not md or md.get("source") != "ga4":
+                continue
+            try:
+                scoring = score_ga4_outcome(md)
+                story.outcome_status = scoring["outcome_status"]
+                story.outcome_result = scoring["outcome_result"]
+                scored.append({"type": "story", "id": str(story.id), "outcome_status": scoring["outcome_status"]})
+            except Exception as exc:
+                logger.warning("ga4 story scoring failed id=%s: %s", story.id, exc)
+                failed.append({"type": "story", "id": str(story.id), "error": str(exc)})
+
+        await session.commit()
+
+        return _ok({"scored": scored, "failed": failed, "total": len(scored) + len(failed)})
+    except Exception as exc:
+        logger.exception("cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -53,6 +53,9 @@ async def create_sprint(
         start_date=body.start_date,
         end_date=body.end_date,
         team_size=body.team_size,
+        success_hypothesis=body.success_hypothesis,
+        metric_definition=body.metric_definition,
+        measure_after=body.measure_after,
     )
     return SprintResponse.model_validate(sprint)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -130,6 +130,9 @@ async def create_story(
         description=body.description,
         acceptance_criteria=body.acceptance_criteria,
         position=body.position,
+        success_hypothesis=body.success_hypothesis,
+        metric_definition=body.metric_definition,
+        measure_after=body.measure_after,
     )
     return StoryResponse.model_validate(story)
 

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import date, datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -9,6 +10,10 @@ class SprintBase(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     team_size: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class SprintCreate(SprintBase):
@@ -25,6 +30,11 @@ class SprintUpdate(BaseModel):
     velocity: int | None = None
     duration: int | None = None
     report_doc_id: uuid.UUID | None = None
+    # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
 
 
 class SprintResponse(SprintBase):
@@ -37,6 +47,9 @@ class SprintResponse(SprintBase):
     velocity: int | None = None
     duration: int
     report_doc_id: uuid.UUID | None = None
+    # E-OUTCOME-LOOP: 채점 필드
+    outcome_status: str = "n_a"
+    outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -2,7 +2,8 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+from app.schemas.story import _validate_metric_definition
 
 
 class SprintBase(BaseModel):
@@ -14,6 +15,11 @@ class SprintBase(BaseModel):
     success_hypothesis: str | None = None
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class SprintCreate(SprintBase):
@@ -35,6 +41,11 @@ class SprintUpdate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
     # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class SprintResponse(SprintBase):

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -26,6 +27,10 @@ class StoryCreate(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class StoryUpdate(BaseModel):
@@ -39,6 +44,11 @@ class StoryUpdate(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
 
 
 class StoryStatusUpdate(BaseModel):
@@ -62,5 +72,12 @@ class StoryResponse(BaseModel):
     description: str | None = None
     acceptance_criteria: str | None = None
     position: int | None = None
+    # E-OUTCOME-LOOP: 의도 필드
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    # E-OUTCOME-LOOP: 채점 필드
+    outcome_status: str = "n_a"
+    outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -6,10 +6,18 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 _METRIC_SOURCES = frozenset({"internal_ops", "ga4", "manual"})
 _METRIC_DIRECTIONS = frozenset({"up", "down"})
+# GA4 지원 지표명 (모르는 지표 → pending 가드)
+_GA4_SUPPORTED_METRICS = frozenset({
+    "activeUsers", "newUsers", "sessions", "conversions", "eventCount", "screenPageViews",
+})
 
 
 def _validate_metric_definition(v: dict | None) -> dict | None:
-    """metric_definition 구조 검증: {metric, source, target, direction} 필수."""
+    """metric_definition 구조 검증.
+
+    공통 필수: {metric, source, target, direction}
+    GA4 추가 필수: {property_id, ga4_metric, date_range_days}
+    """
     if v is None:
         return v
     missing = {"metric", "source", "target", "direction"} - v.keys()
@@ -19,6 +27,15 @@ def _validate_metric_definition(v: dict | None) -> dict | None:
         raise ValueError(f"metric_definition.source must be one of {_METRIC_SOURCES}")
     if v["direction"] not in _METRIC_DIRECTIONS:
         raise ValueError(f"metric_definition.direction must be one of {_METRIC_DIRECTIONS}")
+    # GA4 전용 필드 검증 (E-OUTCOME-LOOP S5)
+    if v["source"] == "ga4":
+        ga4_missing = {"property_id", "ga4_metric", "date_range_days"} - v.keys()
+        if ga4_missing:
+            raise ValueError(f"GA4 metric_definition에 필수 키 누락: {ga4_missing}")
+        if v["ga4_metric"] not in _GA4_SUPPORTED_METRICS:
+            raise ValueError(f"ga4_metric must be one of {_GA4_SUPPORTED_METRICS}")
+        if not isinstance(v["date_range_days"], int) or v["date_range_days"] <= 0:
+            raise ValueError("date_range_days must be a positive integer")
     return v
 
 STORY_STATUSES = ("backlog", "ready-for-dev", "in-progress", "in-review", "done")

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -2,7 +2,24 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
+
+_METRIC_SOURCES = frozenset({"internal_ops", "ga4", "manual"})
+_METRIC_DIRECTIONS = frozenset({"up", "down"})
+
+
+def _validate_metric_definition(v: dict | None) -> dict | None:
+    """metric_definition 구조 검증: {metric, source, target, direction} 필수."""
+    if v is None:
+        return v
+    missing = {"metric", "source", "target", "direction"} - v.keys()
+    if missing:
+        raise ValueError(f"metric_definition에 필수 키 누락: {missing}")
+    if v["source"] not in _METRIC_SOURCES:
+        raise ValueError(f"metric_definition.source must be one of {_METRIC_SOURCES}")
+    if v["direction"] not in _METRIC_DIRECTIONS:
+        raise ValueError(f"metric_definition.direction must be one of {_METRIC_DIRECTIONS}")
+    return v
 
 STORY_STATUSES = ("backlog", "ready-for-dev", "in-progress", "in-review", "done")
 STATUS_TRANSITIONS: dict[str, str] = {
@@ -32,6 +49,11 @@ class StoryCreate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
 
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
+
 
 class StoryUpdate(BaseModel):
     title: str | None = None
@@ -49,6 +71,11 @@ class StoryUpdate(BaseModel):
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
     # outcome_status/outcome_result는 Update 제외 — 채점잡 전용
+
+    @field_validator("metric_definition")
+    @classmethod
+    def validate_metric_definition(cls, v: dict | None) -> dict | None:
+        return _validate_metric_definition(v)
 
 
 class StoryStatusUpdate(BaseModel):

--- a/backend/app/services/ga4_client.py
+++ b/backend/app/services/ga4_client.py
@@ -1,0 +1,85 @@
+"""E-OUTCOME-LOOP S5: GA4 Data API 클라이언트.
+
+서비스계정 인증 (GOOGLE_APPLICATION_CREDENTIALS 환경변수 또는 ADC).
+property_id 파라미터화 — 권한과 독립적으로 구현.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from datetime import date, timedelta
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _make_date_range(date_range_days: int) -> tuple[str, str]:
+    """date_range_days일 전 ~ 어제 (GA4 데이터 지연 고려)."""
+    end = date.today() - timedelta(days=1)
+    start = end - timedelta(days=date_range_days - 1)
+    return start.isoformat(), end.isoformat()
+
+
+def fetch_ga4_metric(
+    property_id: str,
+    ga4_metric: str,
+    date_range_days: int,
+) -> float | None:
+    """GA4 Data API runReport로 단일 지표 값 회수.
+
+    Args:
+        property_id:    GA4 property ID (예: "291556226")
+        ga4_metric:     GA4 지표명 (예: "activeUsers")
+        date_range_days: 회수 기간 (일수)
+
+    Returns:
+        float 또는 None (인증 불가 / 데이터 없음 / 오류)
+    """
+    # ADC 또는 GOOGLE_APPLICATION_CREDENTIALS 미설정 시 None 반환 (pending 처리)
+    creds_file = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not creds_file and not _has_adc():
+        logger.warning("ga4_client: 인증 정보 없음 → pending 처리 (property_id=%s)", property_id)
+        return None
+
+    try:
+        from google.analytics.data_v1beta import BetaAnalyticsDataClient
+        from google.analytics.data_v1beta.types import (
+            DateRange,
+            Dimension,
+            Metric,
+            RunReportRequest,
+        )
+
+        client = BetaAnalyticsDataClient()
+        start_date, end_date = _make_date_range(date_range_days)
+
+        request = RunReportRequest(
+            property=f"properties/{property_id}",
+            metrics=[Metric(name=ga4_metric)],
+            date_ranges=[DateRange(start_date=start_date, end_date=end_date)],
+        )
+        response = client.run_report(request)
+
+        if not response.rows:
+            logger.info("ga4_client: 데이터 없음 (property=%s, metric=%s)", property_id, ga4_metric)
+            return 0.0
+
+        value_str = response.rows[0].metric_values[0].value
+        return float(value_str)
+
+    except Exception as exc:
+        logger.warning(
+            "ga4_client: 회수 실패 property=%s metric=%s: %s",
+            property_id, ga4_metric, exc,
+        )
+        return None
+
+
+def _has_adc() -> bool:
+    """Application Default Credentials 사용 가능 여부 간단 체크."""
+    try:
+        import google.auth  # type: ignore[import-untyped]
+        google.auth.default()
+        return True
+    except Exception:
+        return False

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -1,13 +1,16 @@
-"""E-OUTCOME-LOOP S3: 스프린트 종료 채점 서비스 (MVP).
+"""E-OUTCOME-LOOP S3/S5: 스프린트·스토리 종료 채점 서비스.
 
-채점 대상: metric_definition 채워진 sprint.
+채점 대상: metric_definition 채워진 sprint/story.
 소스별 처리:
   - source='internal_ops': metric 이름으로 actual 분기.
       velocity          → done story points 합산
       backlog_remaining → 미완료(done 아닌) 스토리 수
       progress          → 완료율 (done_points / total_points * 100)
       그 외             → pending (오채점 차단)
-  - 그 외: pending (외부 소스 MVP 범위 밖).
+  - source='ga4': GA4 Data API runReport로 실제값 회수 (S5).
+      property_id + ga4_metric + date_range_days 필수.
+      인증 불가·데이터 없음·회수 실패 → pending.
+  - 그 외: pending (외부 소스 범위 밖).
   - metric_definition 없음: n_a 유지 (의도 없음).
 
 outcome_status 전이: n_a → pending → hit | miss
@@ -21,36 +24,71 @@ from typing import Any
 _INTERNAL_OPS_METRICS = frozenset({"velocity", "backlog_remaining", "progress"})
 
 
+def _apply_direction(actual: float, target: float, direction: str) -> str | None:
+    """direction 기반 hit/miss 판정. 알 수 없는 direction → None(pending)."""
+    if direction == "up":
+        return "hit" if actual >= target else "miss"
+    if direction == "down":
+        return "hit" if actual <= target else "miss"
+    return None
+
+
+def _build_result(
+    outcome_status: str,
+    metric: Any,
+    target_f: float,
+    actual_f: float,
+    direction: str,
+    outcome_result: dict | None = None,
+) -> dict[str, Any]:
+    if outcome_status in ("hit", "miss"):
+        return {
+            "outcome_status": outcome_status,
+            "outcome_result": outcome_result or {
+                "metric": metric,
+                "target": target_f,
+                "actual": actual_f,
+                "direction": direction,
+                "scored_at": datetime.now(timezone.utc).isoformat(),
+            },
+        }
+    return {"outcome_status": outcome_status, "outcome_result": None}
+
+
 def score_sprint_outcome(
     metric_definition: dict[str, Any] | None,
     velocity: int,
     backlog_remaining: int,
     total_points: int,
 ) -> dict[str, Any] | None:
-    """sprint.metric_definition 기반 채점.
+    """internal_ops 기반 채점 (close() 즉시 호출).
 
     Args:
         metric_definition: sprint.metric_definition JSONB
         velocity:          done story points 합산
         backlog_remaining: done 아닌 스토리 수 (close 시점)
-        total_points:      sprint 전체 story_points 합산 (진행률 분모)
+        total_points:      sprint 전체 story_points 합산
 
     Returns:
-        None                                  → outcome_status 변경 없음 (n_a 유지)
-        {'outcome_status': ..., 'outcome_result': ...} → update에 적용할 kwargs
+        None → n_a 유지
+        dict → update에 적용할 kwargs
     """
     if not metric_definition:
-        return None  # 의도 없음 → n_a 유지
+        return None
 
     source = metric_definition.get("source")
     metric = metric_definition.get("metric")
     target = metric_definition.get("target")
     direction = metric_definition.get("direction")
 
+    if source == "ga4":
+        # GA4는 지연 채점 cron에서 처리 — close 즉시엔 pending
+        return {"outcome_status": "pending", "outcome_result": None}
+
     if source != "internal_ops":
         return {"outcome_status": "pending", "outcome_result": None}
 
-    # metric 이름으로 actual 분기 — 모르는 metric은 오채점 차단
+    # metric 이름으로 actual 분기
     if metric == "velocity":
         actual_raw: float = float(velocity)
     elif metric == "backlog_remaining":
@@ -58,7 +96,6 @@ def score_sprint_outcome(
     elif metric == "progress":
         actual_raw = round((velocity / total_points * 100) if total_points > 0 else 0.0, 2)
     else:
-        # 지원하지 않는 metric → 오채점 방지 pending
         return {"outcome_status": "pending", "outcome_result": None}
 
     try:
@@ -66,20 +103,43 @@ def score_sprint_outcome(
     except (TypeError, ValueError):
         return {"outcome_status": "pending", "outcome_result": None}
 
-    if direction == "up":
-        hit = actual_raw >= target_f
-    elif direction == "down":
-        hit = actual_raw <= target_f
-    else:
+    verdict = _apply_direction(actual_raw, target_f, direction or "")
+    if verdict is None:
         return {"outcome_status": "pending", "outcome_result": None}
 
-    return {
-        "outcome_status": "hit" if hit else "miss",
-        "outcome_result": {
-            "metric": metric,
-            "target": target_f,
-            "actual": actual_raw,
-            "direction": direction,
-            "scored_at": datetime.now(timezone.utc).isoformat(),
-        },
-    }
+    return _build_result(verdict, metric, target_f, actual_raw, direction)
+
+
+def score_ga4_outcome(metric_definition: dict[str, Any]) -> dict[str, Any]:
+    """GA4 Data API 기반 채점 (지연 cron에서 호출).
+
+    Returns:
+        dict → {'outcome_status': ..., 'outcome_result': ...}
+        실패 시 → pending 반환 (인증 불가·회수 실패·데이터 없음)
+    """
+    property_id = metric_definition.get("property_id")
+    ga4_metric = metric_definition.get("ga4_metric")
+    date_range_days = metric_definition.get("date_range_days", 30)
+    target = metric_definition.get("target")
+    direction = metric_definition.get("direction")
+    metric = metric_definition.get("metric")
+
+    if not property_id or not ga4_metric:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    from app.services.ga4_client import fetch_ga4_metric
+    actual = fetch_ga4_metric(str(property_id), str(ga4_metric), int(date_range_days))
+
+    if actual is None:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    try:
+        target_f = float(target)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    verdict = _apply_direction(actual, target_f, direction or "")
+    if verdict is None:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    return _build_result(verdict, metric, target_f, actual, direction)

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -1,0 +1,85 @@
+"""E-OUTCOME-LOOP S3: 스프린트 종료 채점 서비스 (MVP).
+
+채점 대상: metric_definition 채워진 sprint.
+소스별 처리:
+  - source='internal_ops': metric 이름으로 actual 분기.
+      velocity          → done story points 합산
+      backlog_remaining → 미완료(done 아닌) 스토리 수
+      progress          → 완료율 (done_points / total_points * 100)
+      그 외             → pending (오채점 차단)
+  - 그 외: pending (외부 소스 MVP 범위 밖).
+  - metric_definition 없음: n_a 유지 (의도 없음).
+
+outcome_status 전이: n_a → pending → hit | miss
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+# internal_ops에서 지원하는 metric 이름 → 회수 키 매핑
+_INTERNAL_OPS_METRICS = frozenset({"velocity", "backlog_remaining", "progress"})
+
+
+def score_sprint_outcome(
+    metric_definition: dict[str, Any] | None,
+    velocity: int,
+    backlog_remaining: int,
+    total_points: int,
+) -> dict[str, Any] | None:
+    """sprint.metric_definition 기반 채점.
+
+    Args:
+        metric_definition: sprint.metric_definition JSONB
+        velocity:          done story points 합산
+        backlog_remaining: done 아닌 스토리 수 (close 시점)
+        total_points:      sprint 전체 story_points 합산 (진행률 분모)
+
+    Returns:
+        None                                  → outcome_status 변경 없음 (n_a 유지)
+        {'outcome_status': ..., 'outcome_result': ...} → update에 적용할 kwargs
+    """
+    if not metric_definition:
+        return None  # 의도 없음 → n_a 유지
+
+    source = metric_definition.get("source")
+    metric = metric_definition.get("metric")
+    target = metric_definition.get("target")
+    direction = metric_definition.get("direction")
+
+    if source != "internal_ops":
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    # metric 이름으로 actual 분기 — 모르는 metric은 오채점 차단
+    if metric == "velocity":
+        actual_raw: float = float(velocity)
+    elif metric == "backlog_remaining":
+        actual_raw = float(backlog_remaining)
+    elif metric == "progress":
+        actual_raw = round((velocity / total_points * 100) if total_points > 0 else 0.0, 2)
+    else:
+        # 지원하지 않는 metric → 오채점 방지 pending
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    try:
+        target_f = float(target)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    if direction == "up":
+        hit = actual_raw >= target_f
+    elif direction == "down":
+        hit = actual_raw <= target_f
+    else:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    return {
+        "outcome_status": "hit" if hit else "miss",
+        "outcome_result": {
+            "metric": metric,
+            "target": target_f,
+            "actual": actual_raw,
+            "direction": direction,
+            "scored_at": datetime.now(timezone.utc).isoformat(),
+        },
+    }

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "mcp>=1.0.0",
     "resend>=2.0.0",
+    "google-analytics-data>=0.18.0",
 ]
 
 [dependency-groups]

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -562,3 +562,118 @@ async def test_close_sprint_scores_outcome_hit():
         assert data["outcome_status"] == "hit"
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S5: GA4 채점 테스트 ───────────────────────────────────────
+
+from app.services.outcome_scorer import score_ga4_outcome
+
+
+class TestScoreGa4Outcome:
+    """score_ga4_outcome 단위 테스트 (GA4 클라이언트 mock)."""
+
+    def test_ga4_hit_when_actual_ge_target(self):
+        """GA4 회수값 >= target, direction='up' → hit."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        with patch("app.services.ga4_client.fetch_ga4_metric", return_value=1500.0):
+            r = score_ga4_outcome(md)
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 1500.0
+        assert r["outcome_result"]["metric"] == "MAU"
+
+    def test_ga4_miss_when_actual_lt_target(self):
+        """GA4 회수값 < target, direction='up' → miss."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        with patch("app.services.ga4_client.fetch_ga4_metric", return_value=800.0):
+            r = score_ga4_outcome(md)
+        assert r["outcome_status"] == "miss"
+
+    def test_ga4_down_hit(self):
+        """GA4 회수값 <= target, direction='down' → hit."""
+        md = {
+            "source": "ga4", "metric": "bounce", "target": 50, "direction": "down",
+            "property_id": "291556226", "ga4_metric": "sessions", "date_range_days": 7,
+        }
+        with patch("app.services.ga4_client.fetch_ga4_metric", return_value=40.0):
+            r = score_ga4_outcome(md)
+        assert r["outcome_status"] == "hit"
+
+    def test_ga4_fetch_failure_returns_pending(self):
+        """GA4 회수 실패(None) → pending (인증 불가 등)."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        with patch("app.services.ga4_client.fetch_ga4_metric", return_value=None):
+            r = score_ga4_outcome(md)
+        assert r["outcome_status"] == "pending"
+        assert r["outcome_result"] is None
+
+    def test_ga4_boundary_exact_target(self):
+        """경계값: actual == target, direction='up' → hit."""
+        md = {
+            "source": "ga4", "metric": "users", "target": 500, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "newUsers", "date_range_days": 14,
+        }
+        with patch("app.services.ga4_client.fetch_ga4_metric", return_value=500.0):
+            r = score_ga4_outcome(md)
+        assert r["outcome_status"] == "hit"
+
+
+class TestGa4MetricDefinitionValidation:
+    """GA4 metric_definition 구조 검증 테스트."""
+
+    def _validate(self, v):
+        from app.schemas.story import _validate_metric_definition
+        return _validate_metric_definition(v)
+
+    def test_ga4_valid_passes(self):
+        """GA4 필수 필드 모두 있으면 통과."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        assert self._validate(md) is not None
+
+    def test_ga4_missing_property_id_raises(self):
+        """property_id 없으면 ValueError."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        with pytest.raises(ValueError, match="property_id"):
+            self._validate(md)
+
+    def test_ga4_unknown_metric_raises(self):
+        """지원하지 않는 ga4_metric → ValueError (garbage-in 차단)."""
+        md = {
+            "source": "ga4", "metric": "m", "target": 10, "direction": "up",
+            "property_id": "123", "ga4_metric": "customBadMetric", "date_range_days": 30,
+        }
+        with pytest.raises(ValueError, match="ga4_metric"):
+            self._validate(md)
+
+    def test_ga4_invalid_date_range_days_raises(self):
+        """date_range_days <= 0 → ValueError."""
+        md = {
+            "source": "ga4", "metric": "m", "target": 10, "direction": "up",
+            "property_id": "123", "ga4_metric": "activeUsers", "date_range_days": 0,
+        }
+        with pytest.raises(ValueError, match="date_range_days"):
+            self._validate(md)
+
+    def test_ga4_source_in_score_sprint_returns_pending(self):
+        """close() 호출 시 GA4 source → pending (지연 채점 cron으로)."""
+        md = {
+            "source": "ga4", "metric": "MAU", "target": 1000, "direction": "up",
+            "property_id": "291556226", "ga4_metric": "activeUsers", "date_range_days": 30,
+        }
+        r = score_sprint_outcome(md, velocity=30, backlog_remaining=0, total_points=30)
+        assert r is not None
+        assert r["outcome_status"] == "pending"

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -302,3 +302,74 @@ async def test_kickoff_sprint_200():
         assert body["sprint_id"] == str(SPRINT_ID)
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S2: 의도필드 + metric_definition 검증 ──────────────────────
+
+_VALID_METRIC = {"metric": "retention", "source": "internal_ops", "target": 0.8, "direction": "up"}
+
+
+@pytest.mark.anyio
+async def test_create_sprint_with_intent_fields_201():
+    """create에 의도필드 전달 → 201 + repo.create에 의도필드 전달 확인 (AC1/AC2)."""
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint()
+        sprint.success_hypothesis = "Retention 80% 달성"
+        sprint.metric_definition = _VALID_METRIC
+        sprint.measure_after = None
+
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = sprint
+
+            async with client as c:
+                resp = await c.post("/api/v2/sprints", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Outcome Sprint",
+                    "success_hypothesis": "Retention 80% 달성",
+                    "metric_definition": _VALID_METRIC,
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("success_hypothesis") == "Retention 80% 달성"
+        assert kwargs.get("metric_definition") == _VALID_METRIC
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_metric,desc", [
+    ({"source": "manual", "target": 0.8, "direction": "up"}, "metric 키 누락"),
+    ({"metric": "retention", "source": "unknown", "target": 0.8, "direction": "up"}, "source 비정상값"),
+    ({"metric": "retention", "source": "manual", "target": 0.8, "direction": "flat"}, "direction 비정상값"),
+])
+async def test_create_sprint_invalid_metric_definition_422(bad_metric: dict, desc: str):
+    """metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/sprints", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "title": "Test Sprint",
+                "metric_definition": bad_metric,
+            })
+        assert resp.status_code == 422, f"expected 422 for {desc}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_sprint_invalid_metric_definition_422():
+    """update metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={
+                "metric_definition": {"bad": "structure"},
+            })
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -25,6 +25,12 @@ def _mock_sprint(status: str = "planning") -> MagicMock:
     s.team_size = None
     s.duration = 14
     s.report_doc_id = None
+    # E-OUTCOME-LOOP: 신규 필드 (MagicMock 반환 객체가 Pydantic 검증 실패하므로 명시 세팅)
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
     from datetime import datetime, timezone
     s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -373,3 +373,192 @@ async def test_update_sprint_invalid_metric_definition_422():
         assert resp.status_code == 422
     finally:
         app.dependency_overrides.clear()
+
+
+
+
+# ── E-OUTCOME-LOOP S3: 채점 로직 테스트 ──────────────────────────────────────
+
+from app.services.outcome_scorer import score_sprint_outcome
+
+_V = 0  # velocity placeholder
+_B = 0  # backlog_remaining placeholder
+_T = 0  # total_points placeholder
+
+
+class TestScoreSprintOutcome:
+    """outcome_scorer.score_sprint_outcome 단위 테스트 (metric 이름 ↔ actual 분기 포함)."""
+
+    def test_no_metric_definition_returns_none(self):
+        """metric_definition 없음 → None (n_a 유지)."""
+        assert score_sprint_outcome(None, 30, 5, 100) is None
+        assert score_sprint_outcome({}, 30, 5, 100) is None
+
+    def test_external_source_returns_pending(self):
+        """external source(ga4/manual) → pending."""
+        for src in ("ga4", "manual"):
+            r = score_sprint_outcome(
+                {"source": src, "metric": "velocity", "target": 100, "direction": "up"},
+                velocity=50, backlog_remaining=2, total_points=100,
+            )
+            assert r is not None
+            assert r["outcome_status"] == "pending"
+            assert r["outcome_result"] is None
+
+    def test_unknown_metric_returns_pending(self):
+        """지원하지 않는 metric → pending (오채점 차단)."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "custom_metric", "target": 50, "direction": "up"},
+            velocity=60, backlog_remaining=0, total_points=100,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "pending"
+
+    # ── velocity metric ──────────────────────────────────────────────────────
+
+    def test_velocity_up_hit(self):
+        """metric=velocity, direction='up', actual >= target → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 30, "direction": "up"},
+            velocity=30, backlog_remaining=0, total_points=30,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 30.0
+        assert r["outcome_result"]["metric"] == "velocity"
+
+    def test_velocity_up_miss(self):
+        """metric=velocity, direction='up', actual < target → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 50, "direction": "up"},
+            velocity=30, backlog_remaining=0, total_points=50,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+
+    def test_velocity_boundary_exact_target_is_hit(self):
+        """경계값: velocity == target, direction='up' → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 42, "direction": "up"},
+            velocity=42, backlog_remaining=0, total_points=42,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_zero_velocity_miss(self):
+        """velocity=0, direction='up', target>0 → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "velocity", "target": 10, "direction": "up"},
+            velocity=0, backlog_remaining=5, total_points=10,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+
+    # ── backlog_remaining metric ─────────────────────────────────────────────
+
+    def test_backlog_remaining_down_hit(self):
+        """metric=backlog_remaining, direction='down', backlog<=target → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 3, "direction": "down"},
+            velocity=20, backlog_remaining=2, total_points=25,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 2.0
+        assert r["outcome_result"]["metric"] == "backlog_remaining"
+
+    def test_backlog_remaining_down_miss(self):
+        """metric=backlog_remaining, direction='down', backlog>target → miss."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 0, "direction": "down"},
+            velocity=20, backlog_remaining=1, total_points=25,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 1.0
+
+    def test_backlog_remaining_dogfood_zero_target(self):
+        """dogfood: backlog_remaining=0 → target=0, down → hit."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 0, "direction": "down"},
+            velocity=30, backlog_remaining=0, total_points=30,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+
+    def test_backlog_remaining_does_not_use_velocity(self):
+        """backlog_remaining metric은 velocity가 아닌 backlog_remaining을 actual로 사용."""
+        # velocity=999 지만 backlog_remaining=5 → target=3 초과 → miss
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "backlog_remaining", "target": 3, "direction": "down"},
+            velocity=999, backlog_remaining=5, total_points=999,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 5.0
+
+    # ── progress metric ──────────────────────────────────────────────────────
+
+    def test_progress_up_hit(self):
+        """metric=progress, direction='up', progress>=target → hit."""
+        # velocity=80 / total_points=100 → progress=80.0
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "progress", "target": 80, "direction": "up"},
+            velocity=80, backlog_remaining=2, total_points=100,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "hit"
+        assert r["outcome_result"]["actual"] == 80.0
+
+    def test_progress_zero_total_points(self):
+        """total_points=0 → progress=0.0, target>0 → miss (zero division safe)."""
+        r = score_sprint_outcome(
+            {"source": "internal_ops", "metric": "progress", "target": 50, "direction": "up"},
+            velocity=0, backlog_remaining=0, total_points=0,
+        )
+        assert r is not None
+        assert r["outcome_status"] == "miss"
+        assert r["outcome_result"]["actual"] == 0.0
+
+    # ── output 필드 ──────────────────────────────────────────────────────────
+
+    def test_outcome_result_contains_required_fields(self):
+        """outcome_result에 metric·target·actual·direction·scored_at 포함."""
+        md = {"source": "internal_ops", "metric": "velocity", "target": 20, "direction": "up"}
+        r = score_sprint_outcome(md, velocity=25, backlog_remaining=0, total_points=25)
+        assert r is not None
+        result = r["outcome_result"]
+        for key in ("metric", "target", "actual", "direction", "scored_at"):
+            assert key in result, f"outcome_result에 {key} 없음"
+
+
+@pytest.mark.anyio
+async def test_close_sprint_scores_outcome_hit():
+    """sprint close 시 metric_definition 있으면 채점 → outcome_status hit/miss 반영."""
+    client, session, app = await _client()
+    try:
+        sprint = _mock_sprint("active")
+        sprint.metric_definition = {
+            "metric": "velocity", "source": "internal_ops", "target": 10, "direction": "up"
+        }
+        sprint.outcome_status = "n_a"
+
+        closed = _mock_sprint("closed")
+        closed.outcome_status = "hit"
+        closed.outcome_result = {"metric": "velocity", "target": 10.0, "actual": 14.0, "direction": "up", "scored_at": "2026-05-30T00:00:00+00:00"}
+
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = sprint
+        session.execute = AsyncMock(return_value=mock_result)
+
+        with patch("app.repositories.sprint.SprintRepository.close", new_callable=AsyncMock) as mock_close:
+            mock_close.return_value = closed
+
+            async with client as c:
+                resp = await c.post(f"/api/v2/sprints/{SPRINT_ID}/close")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["outcome_status"] == "hit"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -27,6 +27,12 @@ def _mock_story(status: str = "backlog") -> MagicMock:
     s.description = None
     s.acceptance_criteria = None
     s.position = None
+    # E-OUTCOME-LOOP: 신규 필드 (MagicMock이 반환하는 MagicMock 객체가 Pydantic 검증 실패하므로 명시 세팅)
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
     s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return s

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -343,7 +343,7 @@ async def test_status_backward_transition_400(from_status: str, to_status: str):
 
 # ── E-OUTCOME-LOOP S2: 의도필드 + metric_definition 검증 ──────────────────────
 
-_VALID_METRIC = {"metric": "MAU", "source": "ga4", "target": 1000, "direction": "up"}
+_VALID_METRIC = {"metric": "velocity", "source": "internal_ops", "target": 30, "direction": "up"}
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -339,3 +339,102 @@ async def test_status_backward_transition_400(from_status: str, to_status: str):
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+# ── E-OUTCOME-LOOP S2: 의도필드 + metric_definition 검증 ──────────────────────
+
+_VALID_METRIC = {"metric": "MAU", "source": "ga4", "target": 1000, "direction": "up"}
+
+
+@pytest.mark.anyio
+async def test_create_story_with_intent_fields_201():
+    """create에 의도필드(success_hypothesis·metric_definition·measure_after) 전달 → 201 (AC1/AC2)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        story.success_hypothesis = "MAU 10% 증가"
+        story.metric_definition = _VALID_METRIC
+        story.measure_after = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Outcome Story",
+                    "success_hypothesis": "MAU 10% 증가",
+                    "metric_definition": _VALID_METRIC,
+                    "measure_after": "2026-07-01T00:00:00Z",
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert kwargs.get("success_hypothesis") == "MAU 10% 증가"
+        assert kwargs.get("metric_definition") == _VALID_METRIC
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("bad_metric,desc", [
+    ({"source": "ga4", "target": 100, "direction": "up"}, "metric 키 누락"),
+    ({"metric": "MAU", "source": "bad_src", "target": 100, "direction": "up"}, "source 비정상값"),
+    ({"metric": "MAU", "source": "ga4", "target": 100, "direction": "sideways"}, "direction 비정상값"),
+    ({"metric": "MAU", "source": "ga4", "target": 100}, "direction 키 누락"),
+])
+async def test_create_story_invalid_metric_definition_422(bad_metric: dict, desc: str):
+    """metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/stories", json={
+                "project_id": str(PROJECT_ID),
+                "org_id": str(ORG_ID),
+                "title": "Test",
+                "metric_definition": bad_metric,
+            })
+        assert resp.status_code == 422, f"expected 422 for {desc}"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_story_invalid_metric_definition_422():
+    """update metric_definition 구조 오류 → 422 (AC3)."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={
+                "metric_definition": {"bad": "structure"},
+            })
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_story_outcome_fields_ignored():
+    """create 시 outcome_status/outcome_result는 무시 — 채점잡 전용 (AC4)."""
+    client, session, app = await _client()
+    try:
+        story = _mock_story()
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Test",
+                    "outcome_status": "achieved",
+                    "outcome_result": {"score": 90},
+                })
+
+        assert resp.status_code == 201
+        _, kwargs = mock_create.call_args
+        assert "outcome_status" not in kwargs, "outcome_status가 create에 전달되면 안됨"
+        assert "outcome_result" not in kwargs, "outcome_result가 create에 전달되면 안됨"
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
 ]
 
 [[package]]
@@ -276,6 +277,79 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +464,69 @@ wheels = [
 ]
 
 [[package]]
+name = "google-analytics-data"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/46/06df55745208b0084264c57e1fbcc6e8ccd542a1a3f20d34c2cde89ba66a/google_analytics_data-0.22.0.tar.gz", hash = "sha256:16fb155d7d9896d34c786c9147f3ae4ab84f67b34dcc21e7199a54f0850286b9", size = 233436, upload-time = "2026-05-07T08:03:43.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/4f/84e11dcf81a1c3209c14aa0150cfa478404f1ab3c099860a5faf344bfdf1/google_analytics_data-0.22.0-py3-none-any.whl", hash = "sha256:82e5d63deb71335806a942628c8f4c5c09f3a9df86d8ef6bf7504cd27047deef", size = 199904, upload-time = "2026-05-07T08:02:07.768Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -434,6 +571,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
     { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
     { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/e8/a2b749265eb3415abc94f2e619bbd9e9707bebdda787e61c593004ec927a/grpcio-1.80.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:c624cc9f1008361014378c9d776de7182b11fe8b2e5a81bc69f23a295f2a1ad0", size = 6015616, upload-time = "2026-03-30T08:47:13.428Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/97/b1282161a15d699d1e90c360df18d19165a045ce1c343c7f313f5e8a0b77/grpcio-1.80.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:f49eddcac43c3bf350c0385366a58f36bed8cc2c0ec35ef7b74b49e56552c0c2", size = 12014204, upload-time = "2026-03-30T08:47:15.873Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/d319c6e997b50c155ac5a8cb12f5173d5b42677510e886d250d50264949d/grpcio-1.80.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d334591df610ab94714048e0d5b4f3dd5ad1bee74dfec11eee344220077a79de", size = 6563866, upload-time = "2026-03-30T08:47:18.588Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f6/fdd975a2cb4d78eb67769a7b3b3830970bfa2e919f1decf724ae4445f42c/grpcio-1.80.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:0cb517eb1d0d0aaf1d87af7cc5b801d686557c1d88b2619f5e31fab3c2315921", size = 7273060, upload-time = "2026-03-30T08:47:21.113Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f0/a3deb5feba60d9538a962913e37bd2e69a195f1c3376a3dd44fe0427e996/grpcio-1.80.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4e78c4ac0d97dc2e569b2f4bcbbb447491167cb358d1a389fc4af71ab6f70411", size = 6782121, upload-time = "2026-03-30T08:47:23.827Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/84/36c6dcfddc093e108141f757c407902a05085e0c328007cb090d56646cdf/grpcio-1.80.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2ed770b4c06984f3b47eb0517b1c69ad0b84ef3f40128f51448433be904634cd", size = 7383811, upload-time = "2026-03-30T08:47:26.517Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ef/f3a77e3dc5b471a0ec86c564c98d6adfa3510d38f8ee99010410858d591e/grpcio-1.80.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:256507e2f524092f1473071a05e65a5b10d84b82e3ff24c5b571513cfaa61e2f", size = 8393860, upload-time = "2026-03-30T08:47:29.439Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8d/9d4d27ed7f33d109c50d6b5ce578a9914aa68edab75d65869a17e630a8d1/grpcio-1.80.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:9a6284a5d907c37db53350645567c522be314bac859a64a7a5ca63b77bb7958f", size = 7830132, upload-time = "2026-03-30T08:47:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e4/9990b41c6d7a44e1e9dee8ac11d7a9802ba1378b40d77468a7761d1ad288/grpcio-1.80.0-cp312-cp312-win32.whl", hash = "sha256:c71309cfce2f22be26aa4a847357c502db6c621f1a49825ae98aa0907595b193", size = 4140904, upload-time = "2026-03-30T08:47:35.319Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2c/296f6138caca1f4b92a31ace4ae1b87dab692fc16a7a3417af3bb3c805bf/grpcio-1.80.0-cp312-cp312-win_amd64.whl", hash = "sha256:9fe648599c0e37594c4809d81a9e77bd138cc82eb8baa71b6a86af65426723ff", size = 4880944, upload-time = "2026-03-30T08:47:37.831Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
+    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
+    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
+    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
+    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
+    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
+    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
+    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.80.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
 ]
 
 [[package]]
@@ -706,6 +898,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -753,6 +972,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1068,6 +1299,34 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "resend"
+version = "2.30.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/c7/b4c5bee252a2690cadb41063f280f4c09aac663e050e4425df545d28403d/resend-2.30.1.tar.gz", hash = "sha256:a529a019e83be285d855ecf135475dc6a6b9fa1c24f9b710686988e021a535ec", size = 43216, upload-time = "2026-05-13T15:39:18.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/46/f2f5da31f7359dd39672a279f654e6eb86fb1a27aa9c90d0d9efbb962ebb/resend-2.30.1-py2.py3-none-any.whl", hash = "sha256:45da25b86940307e130f8a44d2bac889574362400843e9cd98b49b79a7b3db63", size = 68393, upload-time = "2026-05-13T15:39:17.114Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1189,6 +1448,7 @@ dependencies = [
     { name = "alembic" },
     { name = "asyncpg" },
     { name = "fastapi" },
+    { name = "google-analytics-data" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "passlib", extra = ["argon2", "bcrypt"] },
@@ -1199,6 +1459,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "resend" },
     { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
@@ -1219,6 +1480,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "google-analytics-data", specifier = ">=0.18.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "passlib", extras = ["argon2", "bcrypt"], specifier = ">=1.7.4" },
@@ -1229,6 +1491,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
+    { name = "resend", specifier = ">=2.0.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
@@ -1340,6 +1603,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -1,5 +1,6 @@
 export * from './errors';
 export * from './types';
+export type { MetricDefinition, OutcomeResult } from './interfaces/outcome';
 
 export type {
   IEpicRepository,

--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -1,20 +1,7 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
-
-export interface MetricDefinition {
-  metric: string;
-  source: 'internal_ops' | 'ga4' | 'manual';
-  target: number;
-  direction: 'up' | 'down';
-}
-
-export interface OutcomeResult {
-  metric: string;
-  target: number;
-  actual: number;
-  direction: 'up' | 'down';
-  scored_at: string;
-}
+import type { MetricDefinition, OutcomeResult } from './outcome';
+export type { MetricDefinition, OutcomeResult } from './outcome';
 
 export interface Sprint {
   id: string;

--- a/packages/core-storage/src/interfaces/ISprintRepository.ts
+++ b/packages/core-storage/src/interfaces/ISprintRepository.ts
@@ -1,6 +1,21 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
 
+export interface MetricDefinition {
+  metric: string;
+  source: 'internal_ops' | 'ga4' | 'manual';
+  target: number;
+  direction: 'up' | 'down';
+}
+
+export interface OutcomeResult {
+  metric: string;
+  target: number;
+  actual: number;
+  direction: 'up' | 'down';
+  scored_at: string;
+}
+
 export interface Sprint {
   id: string;
   org_id: string;
@@ -13,6 +28,11 @@ export interface Sprint {
   velocity: number | null;
   duration: number;
   report_doc_id: string | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
   created_at: string;
   updated_at: string;
 }
@@ -24,6 +44,9 @@ export interface CreateSprintInput {
   start_date: string;
   end_date: string;
   team_size?: number;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface UpdateSprintInput {
@@ -35,6 +58,9 @@ export interface UpdateSprintInput {
   velocity?: number | null;
   duration?: number;
   report_doc_id?: string | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface SprintListFilters extends PaginationOptions {

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -1,5 +1,6 @@
 import type { PaginationOptions } from '../types';
 import type { RepositoryScopeContext } from './IEpicRepository';
+import type { MetricDefinition, OutcomeResult } from './outcome';
 
 export interface Story {
   id: string;
@@ -15,6 +16,11 @@ export interface Story {
   description: string | null;
   acceptance_criteria: string | null;
   position: number | null;
+  success_hypothesis: string | null;
+  metric_definition: MetricDefinition | null;
+  measure_after: string | null;
+  outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result: OutcomeResult | null;
   created_at: string;
   updated_at: string;
   deleted_at: string | null;
@@ -33,6 +39,9 @@ export interface CreateStoryInput {
   description?: string | null;
   acceptance_criteria?: string | null;
   meeting_id?: string | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface UpdateStoryInput {
@@ -46,6 +55,9 @@ export interface UpdateStoryInput {
   sprint_id?: string | null;
   assignee_id?: string | null;
   position?: number | null;
+  success_hypothesis?: string | null;
+  metric_definition?: MetricDefinition | null;
+  measure_after?: string | null;
 }
 
 export interface BulkUpdateItem {

--- a/packages/core-storage/src/interfaces/outcome.ts
+++ b/packages/core-storage/src/interfaces/outcome.ts
@@ -1,0 +1,14 @@
+export interface MetricDefinition {
+  metric: string;
+  source: 'internal_ops' | 'ga4' | 'manual';
+  target: number;
+  direction: 'up' | 'down';
+}
+
+export interface OutcomeResult {
+  metric: string;
+  target: number;
+  actual: number;
+  direction: 'up' | 'down';
+  scored_at: string;
+}

--- a/packages/shared/src/schemas/outcome.ts
+++ b/packages/shared/src/schemas/outcome.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod/v4';
+
+export const metricDefinitionSchema = z.object({
+  metric: z.string().min(1),
+  source: z.enum(['internal_ops', 'ga4', 'manual']),
+  target: z.number(),
+  direction: z.enum(['up', 'down']),
+});

--- a/packages/shared/src/schemas/sprints.ts
+++ b/packages/shared/src/schemas/sprints.ts
@@ -1,11 +1,5 @@
 import { z } from 'zod/v4';
-
-const metricDefinitionSchema = z.object({
-  metric: z.string().min(1),
-  source: z.enum(['internal_ops', 'ga4', 'manual']),
-  target: z.number(),
-  direction: z.enum(['up', 'down']),
-});
+import { metricDefinitionSchema } from './outcome';
 
 export const createSprintSchema = z.object({
   project_id: z.string().min(1),

--- a/packages/shared/src/schemas/sprints.ts
+++ b/packages/shared/src/schemas/sprints.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod/v4';
 
+const metricDefinitionSchema = z.object({
+  metric: z.string().min(1),
+  source: z.enum(['internal_ops', 'ga4', 'manual']),
+  target: z.number(),
+  direction: z.enum(['up', 'down']),
+});
+
 export const createSprintSchema = z.object({
   project_id: z.string().min(1),
   org_id: z.string().min(1),
@@ -7,6 +14,9 @@ export const createSprintSchema = z.object({
   start_date: z.string().min(1),
   end_date: z.string().min(1),
   team_size: z.number().optional(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 export const updateSprintSchema = z.object({
@@ -14,4 +24,7 @@ export const updateSprintSchema = z.object({
   start_date: z.string().min(1).optional(),
   end_date: z.string().min(1).optional(),
   team_size: z.number().optional(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { metricDefinitionSchema } from './outcome';
 
 export const STORY_STATUSES = ['backlog', 'ready-for-dev', 'in-progress', 'in-review', 'done'] as const;
 export const STORY_PRIORITIES = ['critical', 'high', 'medium', 'low'] as const;
@@ -36,6 +37,9 @@ export const createStorySchema = z.object({
   description: z.string().optional().nullable(),
   acceptance_criteria: z.string().optional().nullable(),
   meeting_id: z.string().uuid().optional().nullable(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 export const updateStorySchema = z.object({
@@ -49,6 +53,9 @@ export const updateStorySchema = z.object({
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),
   position: z.number().int().optional().nullable(),
+  success_hypothesis: z.string().optional().nullable(),
+  metric_definition: metricDefinitionSchema.optional().nullable(),
+  measure_after: z.string().datetime().optional().nullable(),
 });
 
 const bulkUpdateItemSchema = z.object({


### PR DESCRIPTION
## Promotion: develop → main

E-OUTCOME-LOOP 에픽 전체 + 누적 변경(9 commits) prod 반영.

### 포함 (outcome 루프)
- S1 outcome 필드 스키마 / S2 의도 입력 API / S3 internal_ops 자동 채점
- S4-A·S7·S8 채점 카드 노출(sprint·story·retro) + nit cleanup
- S5 GA4 외부 측정 채점(measure_after cron) / S9 app GA4 통합

### 후속 (prod 반영 후)
- prod 프론트 NEXT_PUBLIC_GA4_MEASUREMENT_ID=G-RYHFE7XM3X (cloudbuild build-arg) — app.sprintable.ai GA4 활성
- GA4 property 서비스계정 뷰어 권한 — S5 GA4 회수

🤖 Generated with [Claude Code](https://claude.com/claude-code)