### PR TITLE
fix: S10 GA4 Measurement ID GitHub Actions workflow 주입

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -47,11 +47,13 @@ jobs:
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
             echo "backend_max_instances=3" >> "$GITHUB_OUTPUT"
+            echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -59,6 +61,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
             --suppress-logs \
             .


### PR DESCRIPTION
## Summary

`cloud-build.yml` — `gcloud builds submit` 에 GA4 측정 ID 주입.

## 변경

### .github/workflows/cloud-build.yml

`Set deploy environment` step:
- `main` (prod): `ga4_measurement_id=G-RYHFE7XM3X`
- `develop` (dev): `ga4_measurement_id=""` (빈값 → GA4 미활성)

`Submit Cloud Build --substitutions` 끝에:
`,_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}"` 추가

## 연계

- #1095 (머지됨): `cloudbuild.yaml` `_GA4_MEASUREMENT_ID` substitution + build-arg, `Dockerfile` ARG/ENV
- 이 PR: workflow에서 실제 값 주입

story: b461c9da-b088-4c96-a855-04a1d5d6d07a