### PR TITLE
[E-OUTCOME-LOOP S11] GNB 스프린트 진입점 (/sprints 메뉴 + 팔레트)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -65,7 +65,8 @@
     "goMemos": "Go to Memos",
     "goAgents": "Go to Agents",
     "goDocs": "Go to Docs",
-    "documents": "Documents"
+    "documents": "Documents",
+    "goSprints": "Go to Sprints"
   },
   "channel": {
     "title": "Channel Chat",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -65,7 +65,8 @@
     "goMemos": "메모로 이동",
     "goAgents": "에이전트로 이동",
     "goDocs": "문서로 이동",
-    "documents": "문서"
+    "documents": "문서",
+    "goSprints": "스프린트로 이동"
   },
   "channel": {
     "title": "채널 채팅",

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -7,6 +7,7 @@ import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import {
   BookOpen,
   Bot,
+  CalendarRange,
   FolderKanban,
   Inbox,
   LayoutDashboard,
@@ -36,6 +37,7 @@ const ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
   { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
   { id: 'go-board', group: 'navigate', icon: FolderKanban, labelKey: 'goBoard', href: '/board', shortcut: ['G', 'B'] },
+  { id: 'go-sprints', group: 'navigate', icon: CalendarRange, labelKey: 'goSprints', href: '/sprints' },
   { id: 'go-memos', group: 'navigate', icon: MessageSquareMore, labelKey: 'goMemos', href: '/memos', shortcut: ['G', 'M'] },
   { id: 'go-agents', group: 'navigate', icon: Bot, labelKey: 'goAgents', href: '/agents', shortcut: ['G', 'A'] },
   { id: 'go-docs', group: 'navigate', icon: BookOpen, labelKey: 'goDocs', href: '/docs', shortcut: ['G', 'S'] },

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   Bot,
   CalendarDays,
+  CalendarRange,
   CircleHelp,
   ClipboardList,
   FolderKanban,
@@ -198,6 +199,16 @@ export function AppSidebar({
                   <FolderKanban />
                   <span>{t('board')}</span>
                   <KbdHint>B</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/sprints" />}
+                  isActive={isActive('/sprints')}
+                  tooltip={t('sprints')}
+                >
+                  <CalendarRange />
+                  <span>{t('sprints')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>


### PR DESCRIPTION
## 변경 요약

GNB에 `/sprints` 진입점 2곳 — 사이드바 + 커맨드 팔레트. **4파일 +17/-2**.

### 1. 사이드바 (`app-sidebar.tsx`)

Sprint 그룹 Board 다음(2번째) 위치:
```
Board → Sprints → Epics → Standup → Retro
```
- 아이콘: `CalendarRange` (lucide-react)
- 라벨: `t('sprints')` — 기존 `nav.sprints` 키 재사용 (신규 i18n 불요)
- `isActive('/sprints')` — `startsWith` 라 딥링크 `/sprints?id=...` 하이라이트 포함
- KbdHint 없음 (Sprint 그룹 선례 + 'S' Standup 충돌 방지)

### 2. 커맨드 팔레트 (`command-palette.tsx`)

`go-board` 다음:
```ts
{ id: 'go-sprints', group: 'navigate', icon: CalendarRange, labelKey: 'goSprints', href: '/sprints' }
```
- shortcut 없음 (동일 이유)
- `commandPalette.goSprints` i18n 신규 (en "Go to Sprints" / ko "스프린트로 이동")

## AC 체크리스트

- [x] ① Sprint 그룹 Board 다음 /sprints 항목
- [x] ② CalendarRange 아이콘
- [x] ③ `t('sprints')` 라벨
- [x] ④ isActive 하이라이트
- [x] ⑤ KbdHint 없음
- [x] ⑥ 기존 4개 메뉴와 동일 구조
- [x] ⑦ 커맨드 팔레트 go-sprints + goSprints i18n en+ko
- [x] ⑧ `pnpm type-check` 에러 0 / `pnpm build` 25s 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)