### PR TITLE
promote: develop→main (3차) — E-OUTCOME-LOOP 완주 (S5 GA4채점 + S10보완 + S11 진입점)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -65,7 +65,8 @@
     "goMemos": "Go to Memos",
     "goAgents": "Go to Agents",
     "goDocs": "Go to Docs",
-    "documents": "Documents"
+    "documents": "Documents",
+    "goSprints": "Go to Sprints"
   },
   "channel": {
     "title": "Channel Chat",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -65,7 +65,8 @@
     "goMemos": "메모로 이동",
     "goAgents": "에이전트로 이동",
     "goDocs": "문서로 이동",
-    "documents": "문서"
+    "documents": "문서",
+    "goSprints": "스프린트로 이동"
   },
   "channel": {
     "title": "채널 채팅",

--- a/apps/web/src/components/command-palette/command-palette.tsx
+++ b/apps/web/src/components/command-palette/command-palette.tsx
@@ -7,6 +7,7 @@ import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import {
   BookOpen,
   Bot,
+  CalendarRange,
   FolderKanban,
   Inbox,
   LayoutDashboard,
@@ -36,6 +37,7 @@ const ITEMS: CommandItem[] = [
   { id: 'go-inbox', group: 'navigate', icon: Inbox, labelKey: 'goInbox', href: '/inbox', shortcut: ['G', 'I'] },
   { id: 'go-dashboard', group: 'navigate', icon: LayoutDashboard, labelKey: 'goDashboard', href: '/dashboard', shortcut: ['G', 'D'] },
   { id: 'go-board', group: 'navigate', icon: FolderKanban, labelKey: 'goBoard', href: '/board', shortcut: ['G', 'B'] },
+  { id: 'go-sprints', group: 'navigate', icon: CalendarRange, labelKey: 'goSprints', href: '/sprints' },
   { id: 'go-memos', group: 'navigate', icon: MessageSquareMore, labelKey: 'goMemos', href: '/memos', shortcut: ['G', 'M'] },
   { id: 'go-agents', group: 'navigate', icon: Bot, labelKey: 'goAgents', href: '/agents', shortcut: ['G', 'A'] },
   { id: 'go-docs', group: 'navigate', icon: BookOpen, labelKey: 'goDocs', href: '/docs', shortcut: ['G', 'S'] },

--- a/apps/web/src/components/nav/app-sidebar.tsx
+++ b/apps/web/src/components/nav/app-sidebar.tsx
@@ -8,6 +8,7 @@ import {
   BookOpen,
   Bot,
   CalendarDays,
+  CalendarRange,
   CircleHelp,
   ClipboardList,
   FolderKanban,
@@ -198,6 +199,16 @@ export function AppSidebar({
                   <FolderKanban />
                   <span>{t('board')}</span>
                   <KbdHint>B</KbdHint>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  render={<Link href="/sprints" />}
+                  isActive={isActive('/sprints')}
+                  tooltip={t('sprints')}
+                >
+                  <CalendarRange />
+                  <span>{t('sprints')}</span>
                 </SidebarMenuButton>
               </SidebarMenuItem>
               <SidebarMenuItem>


### PR DESCRIPTION
E-OUTCOME-LOOP 에픽 완주분 prod 반영. S5(GA4 실데이터 채점 — outcome_scorer ga4 분기 + ga4_client + cron score-ga4-outcomes), S10 보완(cloud-build.yml GA4 substitution), S11(GNB+팔레트 스프린트 진입점). GA4 dev 라이브 채점 검증 완료(actual 0.0→miss). prod SA(cloudrun-runtime-prod) GA4 뷰어 + analyticsdata API 활성 완료.

🤖 Generated with [Claude Code](https://claude.com/claude-code)