### PR TITLE
[E-BOARD-SCHEMA S1] Epic outcome 필드 + 자동 채점 편입

### DIFF
--- a/backend/alembic/versions/0059_add_outcome_fields_to_epic.py
+++ b/backend/alembic/versions/0059_add_outcome_fields_to_epic.py
@@ -1,0 +1,43 @@
+"""E-BOARD-SCHEMA S1: epics에 outcome 필드 추가.
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2026-05-31
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0059"
+down_revision = "0058"
+branch_labels = None
+depends_on = None
+
+_OUTCOME_COLS = [
+    ("success_hypothesis", sa.Text, {"nullable": True}),
+    ("metric_definition", JSONB, {"nullable": True}),
+    ("measure_after", sa.DateTime(timezone=True), {"nullable": True}),
+    ("outcome_status", sa.String(20), {"nullable": False, "server_default": "n_a"}),
+    ("outcome_result", JSONB, {"nullable": True}),
+]
+
+
+def _add_cols_idempotent(table: str) -> None:
+    """컬럼이 이미 존재하면 무시 — dev 환경 idempotent."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = {c["name"] for c in insp.get_columns(table)}
+    for col_name, col_type, kwargs in _OUTCOME_COLS:
+        if col_name not in existing:
+            op.add_column(table, sa.Column(col_name, col_type, **kwargs))
+
+
+def upgrade() -> None:
+    _add_cols_idempotent("epics")
+
+
+def downgrade() -> None:
+    for col_name, _, _ in reversed(_OUTCOME_COLS):
+        op.drop_column("epics", col_name)

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -56,6 +56,13 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
     success_criteria: Mapped[str | None] = mapped_column(Text, nullable=True)
     target_sp: Mapped[int | None] = mapped_column(Integer, nullable=True)
     target_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    # E-BOARD-SCHEMA: 의도 필드 (intent)
+    success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    measure_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    # E-BOARD-SCHEMA: 채점 필드 (outcome, 채점잡 전용)
+    outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     project: Mapped["Project"] = relationship("Project", back_populates="epics")
     stories: Mapped[list["Story"]] = relationship("Story", back_populates="epic", lazy="select")

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -281,7 +281,7 @@ async def score_ga4_outcomes(
                     total = len(rows)
                     done = sum(1 for s in rows if s == "done")
                     pct = round((done / total * 100) if total > 0 else 0.0, 2)
-                    result = score_epic_outcome(md, pct, total, done)
+                    result = score_epic_outcome(md, pct)
                     if result is None:
                         continue
                     scoring = result

--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -202,8 +202,8 @@ async def score_ga4_outcomes(
     """
     verify_cron(request)
 
-    from app.models.pm import Sprint, Story
-    from app.services.outcome_scorer import score_ga4_outcome
+    from app.models.pm import Epic, Sprint, Story
+    from app.services.outcome_scorer import score_epic_outcome, score_ga4_outcome
 
     now = datetime.now(timezone.utc)
     scored: list[dict] = []
@@ -252,6 +252,48 @@ async def score_ga4_outcomes(
             except Exception as exc:
                 logger.warning("ga4 story scoring failed id=%s: %s", story.id, exc)
                 failed.append({"type": "story", "id": str(story.id), "error": str(exc)})
+
+        # Epic 채점 (GA4 + internal_ops)
+        epic_result = await session.execute(
+            select(Epic).where(
+                Epic.outcome_status == "pending",
+                Epic.measure_after.isnot(None),
+                Epic.measure_after <= now,
+            )
+        )
+        for epic in epic_result.scalars().all():
+            md = epic.metric_definition
+            if not md:
+                continue
+            source = md.get("source")
+            try:
+                if source == "ga4":
+                    scoring = score_ga4_outcome(md)
+                elif source == "internal_ops":
+                    # 하위 스토리 진행률 계산
+                    story_rows = await session.execute(
+                        select(Story.status).where(
+                            Story.epic_id == epic.id,
+                            Story.deleted_at.is_(None),
+                        )
+                    )
+                    rows = story_rows.scalars().all()
+                    total = len(rows)
+                    done = sum(1 for s in rows if s == "done")
+                    pct = round((done / total * 100) if total > 0 else 0.0, 2)
+                    result = score_epic_outcome(md, pct, total, done)
+                    if result is None:
+                        continue
+                    scoring = result
+                else:
+                    scoring = {"outcome_status": "pending", "outcome_result": None}
+                # status는 건드리지 않음 — outcome_status/outcome_result만 기록
+                epic.outcome_status = scoring["outcome_status"]
+                epic.outcome_result = scoring["outcome_result"]
+                scored.append({"type": "epic", "id": str(epic.id), "outcome_status": scoring["outcome_status"]})
+            except Exception as exc:
+                logger.warning("epic scoring failed id=%s: %s", epic.id, exc)
+                failed.append({"type": "epic", "id": str(epic.id), "error": str(exc)})
 
         await session.commit()
 

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -33,6 +33,13 @@ async def list_epics(
     return [EpicResponse.model_validate(e) for e in epics]
 
 
+def _resolve_outcome_status(metric_definition: object, measure_after: object, current_status: str = "n_a") -> str:
+    """intent가 완전히 선언(md+ma 둘 다 세팅)되면 n_a→pending 전이."""
+    if metric_definition and measure_after and current_status == "n_a":
+        return "pending"
+    return current_status
+
+
 @router.post("", response_model=EpicResponse, status_code=201)
 async def create_epic(
     body: EpicCreate,
@@ -57,6 +64,10 @@ async def create_epic(
         success_criteria=body.success_criteria,
         target_sp=body.target_sp,
         target_date=body.target_date,
+        success_hypothesis=body.success_hypothesis,
+        metric_definition=body.metric_definition,
+        measure_after=body.measure_after,
+        outcome_status=_resolve_outcome_status(body.metric_definition, body.measure_after),
     )
     return EpicResponse.model_validate(epic)
 
@@ -78,7 +89,16 @@ async def update_epic(
     body: EpicUpdate,
     repo: EpicRepository = Depends(_get_repo),
 ) -> EpicResponse:
+    current = await repo.get(id)
+    if current is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
     data = body.model_dump(exclude_unset=True)
+    # intent가 이번 업데이트로 완성되면 n_a→pending 전이
+    effective_md = data.get("metric_definition", current.metric_definition)
+    effective_ma = data.get("measure_after", current.measure_after)
+    new_status = _resolve_outcome_status(effective_md, effective_ma, current.outcome_status)
+    if new_status != current.outcome_status:
+        data["outcome_status"] = new_status
     epic = await repo.update(id, **data)
     if epic is None:
         raise HTTPException(status_code=404, detail="Epic not found")

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import date, datetime
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -18,6 +19,9 @@ class EpicCreate(BaseModel):
     success_criteria: str | None = None
     target_sp: int | None = None
     target_date: date | None = None
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class EpicUpdate(BaseModel):
@@ -30,6 +34,9 @@ class EpicUpdate(BaseModel):
     target_sp: int | None = None
     target_date: date | None = None
     assignee_id: uuid.UUID | None = None
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
 
 
 class EpicResponse(BaseModel):
@@ -47,6 +54,11 @@ class EpicResponse(BaseModel):
     success_criteria: str | None = None
     target_sp: int | None = None
     target_date: date | None = None
+    success_hypothesis: str | None = None
+    metric_definition: dict[str, Any] | None = None
+    measure_after: datetime | None = None
+    outcome_status: str = "n_a"
+    outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -114,16 +114,12 @@ def score_sprint_outcome(
 def score_epic_outcome(
     metric_definition: dict[str, Any] | None,
     completion_pct: float,
-    total_stories: int,
-    done_stories: int,
 ) -> dict[str, Any] | None:
     """internal_ops 기반 에픽 채점 (cron 호출).
 
     Args:
         metric_definition: epic.metric_definition JSONB
-        completion_pct:    하위 스토리 완료율 (done_stories / total_stories * 100)
-        total_stories:     에픽 하위 전체 스토리 수
-        done_stories:      완료(done) 스토리 수
+        completion_pct:    하위 스토리 완료율 (done_stories / total_stories * 100), 호출자가 계산
 
     Returns:
         None → n_a 유지

--- a/backend/app/services/outcome_scorer.py
+++ b/backend/app/services/outcome_scorer.py
@@ -1,11 +1,10 @@
-"""E-OUTCOME-LOOP S3/S5: 스프린트·스토리 종료 채점 서비스.
+"""E-OUTCOME-LOOP S3/S5 + E-BOARD-SCHEMA S1: 스프린트·스토리·에픽 종료 채점 서비스.
 
-채점 대상: metric_definition 채워진 sprint/story.
+채점 대상: metric_definition 채워진 sprint/story/epic.
 소스별 처리:
   - source='internal_ops': metric 이름으로 actual 분기.
-      velocity          → done story points 합산
-      backlog_remaining → 미완료(done 아닌) 스토리 수
-      progress          → 완료율 (done_points / total_points * 100)
+      [sprint/story] velocity, backlog_remaining, progress
+      [epic]         completion_pct → 하위 스토리 완료율 (done_stories / total_stories * 100)
       그 외             → pending (오채점 차단)
   - source='ga4': GA4 Data API runReport로 실제값 회수 (S5).
       property_id + ga4_metric + date_range_days 필수.
@@ -20,8 +19,10 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-# internal_ops에서 지원하는 metric 이름 → 회수 키 매핑
+# internal_ops에서 지원하는 metric 이름 (sprint/story 전용)
 _INTERNAL_OPS_METRICS = frozenset({"velocity", "backlog_remaining", "progress"})
+# internal_ops에서 지원하는 epic 전용 metric
+_EPIC_INTERNAL_OPS_METRICS = frozenset({"completion_pct"})
 
 
 def _apply_direction(actual: float, target: float, direction: str) -> str | None:
@@ -95,6 +96,55 @@ def score_sprint_outcome(
         actual_raw = float(backlog_remaining)
     elif metric == "progress":
         actual_raw = round((velocity / total_points * 100) if total_points > 0 else 0.0, 2)
+    else:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    try:
+        target_f = float(target)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    verdict = _apply_direction(actual_raw, target_f, direction or "")
+    if verdict is None:
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    return _build_result(verdict, metric, target_f, actual_raw, direction)
+
+
+def score_epic_outcome(
+    metric_definition: dict[str, Any] | None,
+    completion_pct: float,
+    total_stories: int,
+    done_stories: int,
+) -> dict[str, Any] | None:
+    """internal_ops 기반 에픽 채점 (cron 호출).
+
+    Args:
+        metric_definition: epic.metric_definition JSONB
+        completion_pct:    하위 스토리 완료율 (done_stories / total_stories * 100)
+        total_stories:     에픽 하위 전체 스토리 수
+        done_stories:      완료(done) 스토리 수
+
+    Returns:
+        None → n_a 유지
+        dict → update에 적용할 kwargs
+    """
+    if not metric_definition:
+        return None
+
+    source = metric_definition.get("source")
+    metric = metric_definition.get("metric")
+    target = metric_definition.get("target")
+    direction = metric_definition.get("direction")
+
+    if source == "ga4":
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    if source != "internal_ops":
+        return {"outcome_status": "pending", "outcome_result": None}
+
+    if metric == "completion_pct":
+        actual_raw: float = round(completion_pct, 2)
     else:
         return {"outcome_status": "pending", "outcome_result": None}
 

--- a/backend/tests/test_e_board_schema_s1_epic_outcome.py
+++ b/backend/tests/test_e_board_schema_s1_epic_outcome.py
@@ -1,0 +1,222 @@
+"""E-BOARD-SCHEMA S1: Epic outcome 필드 + 자동 채점 편입 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.outcome_scorer import score_epic_outcome
+
+
+# ── score_epic_outcome 단위 테스트 ─────────────────────────────────────────────
+
+def test_score_epic_outcome_no_metric_returns_none():
+    assert score_epic_outcome(None, 50.0, 4, 2) is None
+    assert score_epic_outcome({}, 50.0, 4, 2) is None
+
+
+def test_score_epic_outcome_completion_pct_hit():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
+    result = score_epic_outcome(md, 100.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "hit"
+    assert result["outcome_result"]["actual"] == 100.0
+    assert result["outcome_result"]["target"] == 80.0
+
+
+def test_score_epic_outcome_completion_pct_miss():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
+    result = score_epic_outcome(md, 50.0, 4, 2)
+    assert result is not None
+    assert result["outcome_status"] == "miss"
+
+
+def test_score_epic_outcome_direction_down_hit():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 30, "direction": "down"}
+    result = score_epic_outcome(md, 20.0, 5, 1)
+    assert result is not None
+    assert result["outcome_status"] == "hit"
+
+
+def test_score_epic_outcome_unknown_metric_pending():
+    md = {"source": "internal_ops", "metric": "velocity", "target": 50, "direction": "up"}
+    result = score_epic_outcome(md, 80.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "pending"
+    assert result["outcome_result"] is None
+
+
+def test_score_epic_outcome_ga4_source_pending():
+    md = {"source": "ga4", "property_id": "123", "ga4_metric": "sessions", "target": 1000, "direction": "up"}
+    result = score_epic_outcome(md, 80.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "pending"
+
+
+def test_score_epic_outcome_unknown_source_pending():
+    md = {"source": "manual", "metric": "completion_pct", "target": 80, "direction": "up"}
+    result = score_epic_outcome(md, 90.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "pending"
+
+
+def test_score_epic_outcome_bad_target_pending():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": "not_a_number", "direction": "up"}
+    result = score_epic_outcome(md, 80.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "pending"
+
+
+def test_score_epic_outcome_unknown_direction_pending():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "sideways"}
+    result = score_epic_outcome(md, 90.0, 4, 4)
+    assert result is not None
+    assert result["outcome_status"] == "pending"
+
+
+def test_score_epic_outcome_zero_stories():
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
+    result = score_epic_outcome(md, 0.0, 0, 0)
+    assert result is not None
+    assert result["outcome_status"] == "miss"
+
+
+# ── cron score-ga4-outcomes Epic 채점 통합 테스트 ────────────────────────────
+
+ORG_ID = uuid.uuid4()
+EPIC_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_epic_obj(metric_definition=None, outcome_status="pending"):
+    e = MagicMock()
+    e.id = EPIC_ID
+    e.org_id = ORG_ID
+    e.metric_definition = metric_definition
+    e.outcome_status = outcome_status
+    e.outcome_result = None
+    e.measure_after = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return e
+
+
+@pytest.mark.anyio
+async def test_cron_epic_internal_ops_hit():
+    """internal_ops completion_pct hit → outcome_status='hit'."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 50, "direction": "up"}
+    epic = _mock_epic_obj(metric_definition=md)
+
+    call_count = 0
+
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count <= 2:
+            # Sprint + Story GA4 쿼리 → 빈 결과
+            result.scalars.return_value.all.return_value = []
+        elif call_count == 3:
+            # Epic 쿼리
+            result.scalars.return_value.all.return_value = [epic]
+        else:
+            # 하위 스토리 상태 조회 (4개 중 3개 done)
+            result.scalars.return_value.all.return_value = ["done", "done", "done", "backlog"]
+        return result
+
+    mock_session = AsyncMock()
+    mock_session.execute = mock_execute
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v2/internal/cron/score-ga4-outcomes",
+                headers={"Authorization": "Bearer "},
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"]["total"] == 1
+        assert body["data"]["scored"][0]["type"] == "epic"
+        assert body["data"]["scored"][0]["outcome_status"] == "hit"
+        # Epic status는 변경 금지 확인
+        assert epic.status is not None  # status 필드 자체는 존재하지만 변경 없음
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_cron_epic_does_not_change_status():
+    """채점 후 epic.status는 그대로 유지되어야 함."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
+    epic = _mock_epic_obj(metric_definition=md)
+    original_status = epic.status
+
+    call_count = 0
+
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count <= 2:
+            result.scalars.return_value.all.return_value = []
+        elif call_count == 3:
+            result.scalars.return_value.all.return_value = [epic]
+        else:
+            result.scalars.return_value.all.return_value = ["done", "done"]
+        return result
+
+    mock_session = AsyncMock()
+    mock_session.execute = mock_execute
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            await c.post(
+                "/api/v2/internal/cron/score-ga4-outcomes",
+                headers={"Authorization": "Bearer "},
+            )
+        # status는 채점잡이 건드리지 않음
+        assert epic.status == original_status
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_e_board_schema_s1_epic_outcome.py
+++ b/backend/tests/test_e_board_schema_s1_epic_outcome.py
@@ -11,13 +11,13 @@ from app.services.outcome_scorer import score_epic_outcome
 # ── score_epic_outcome 단위 테스트 ─────────────────────────────────────────────
 
 def test_score_epic_outcome_no_metric_returns_none():
-    assert score_epic_outcome(None, 50.0, 4, 2) is None
-    assert score_epic_outcome({}, 50.0, 4, 2) is None
+    assert score_epic_outcome(None, 50.0) is None
+    assert score_epic_outcome({}, 50.0) is None
 
 
 def test_score_epic_outcome_completion_pct_hit():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
-    result = score_epic_outcome(md, 100.0, 4, 4)
+    result = score_epic_outcome(md, 100.0)
     assert result is not None
     assert result["outcome_status"] == "hit"
     assert result["outcome_result"]["actual"] == 100.0
@@ -26,21 +26,21 @@ def test_score_epic_outcome_completion_pct_hit():
 
 def test_score_epic_outcome_completion_pct_miss():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
-    result = score_epic_outcome(md, 50.0, 4, 2)
+    result = score_epic_outcome(md, 50.0)
     assert result is not None
     assert result["outcome_status"] == "miss"
 
 
 def test_score_epic_outcome_direction_down_hit():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 30, "direction": "down"}
-    result = score_epic_outcome(md, 20.0, 5, 1)
+    result = score_epic_outcome(md, 20.0)
     assert result is not None
     assert result["outcome_status"] == "hit"
 
 
 def test_score_epic_outcome_unknown_metric_pending():
     md = {"source": "internal_ops", "metric": "velocity", "target": 50, "direction": "up"}
-    result = score_epic_outcome(md, 80.0, 4, 4)
+    result = score_epic_outcome(md, 80.0)
     assert result is not None
     assert result["outcome_status"] == "pending"
     assert result["outcome_result"] is None
@@ -48,42 +48,43 @@ def test_score_epic_outcome_unknown_metric_pending():
 
 def test_score_epic_outcome_ga4_source_pending():
     md = {"source": "ga4", "property_id": "123", "ga4_metric": "sessions", "target": 1000, "direction": "up"}
-    result = score_epic_outcome(md, 80.0, 4, 4)
+    result = score_epic_outcome(md, 80.0)
     assert result is not None
     assert result["outcome_status"] == "pending"
 
 
 def test_score_epic_outcome_unknown_source_pending():
     md = {"source": "manual", "metric": "completion_pct", "target": 80, "direction": "up"}
-    result = score_epic_outcome(md, 90.0, 4, 4)
+    result = score_epic_outcome(md, 90.0)
     assert result is not None
     assert result["outcome_status"] == "pending"
 
 
 def test_score_epic_outcome_bad_target_pending():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": "not_a_number", "direction": "up"}
-    result = score_epic_outcome(md, 80.0, 4, 4)
+    result = score_epic_outcome(md, 80.0)
     assert result is not None
     assert result["outcome_status"] == "pending"
 
 
 def test_score_epic_outcome_unknown_direction_pending():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "sideways"}
-    result = score_epic_outcome(md, 90.0, 4, 4)
+    result = score_epic_outcome(md, 90.0)
     assert result is not None
     assert result["outcome_status"] == "pending"
 
 
-def test_score_epic_outcome_zero_stories():
+def test_score_epic_outcome_zero_pct_miss():
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
-    result = score_epic_outcome(md, 0.0, 0, 0)
+    result = score_epic_outcome(md, 0.0)
     assert result is not None
     assert result["outcome_status"] == "miss"
 
 
-# ── cron score-ga4-outcomes Epic 채점 통합 테스트 ────────────────────────────
+# ── n_a→pending 전이 테스트 (create/update API 경로) ─────────────────────────
 
 ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
 EPIC_ID = uuid.uuid4()
 
 
@@ -92,20 +93,184 @@ def anyio_backend():
     return "asyncio"
 
 
-def _mock_epic_obj(metric_definition=None, outcome_status="pending"):
+def _base_epic_mock(outcome_status: str = "n_a") -> MagicMock:
+    e = MagicMock()
+    e.id = EPIC_ID
+    e.org_id = ORG_ID
+    e.project_id = PROJECT_ID
+    e.assignee_id = None
+    e.title = "Epic with intent"
+    e.status = "active"
+    e.priority = "medium"
+    e.description = None
+    e.objective = None
+    e.success_criteria = None
+    e.target_sp = None
+    e.target_date = None
+    e.success_hypothesis = "완료율 80% 달성"
+    e.metric_definition = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
+    e.measure_after = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    e.outcome_status = outcome_status
+    e.outcome_result = None
+    e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return e
+
+
+async def _make_client(mock_session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_create_epic_with_intent_sets_pending():
+    """create_epic에서 metric_definition+measure_after 선언 시 outcome_status=pending으로 전이."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+
+    pending_epic = _base_epic_mock(outcome_status="pending")
+
+    with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = pending_epic
+        try:
+            async with client as c:
+                resp = await c.post("/api/v2/epics", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Epic with intent",
+                    "metric_definition": {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"},
+                    "measure_after": "2026-06-01T00:00:00Z",
+                })
+            assert resp.status_code == 201
+            # create 호출 시 outcome_status="pending" 전달됐는지 검증
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs.get("outcome_status") == "pending"
+            assert call_kwargs.get("metric_definition") is not None
+            assert call_kwargs.get("measure_after") is not None
+        finally:
+            app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_epic_without_intent_stays_na():
+    """metric_definition 없이 create → outcome_status=n_a 유지."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+
+    na_epic = _base_epic_mock(outcome_status="n_a")
+    na_epic.metric_definition = None
+    na_epic.measure_after = None
+
+    with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = na_epic
+        try:
+            async with client as c:
+                resp = await c.post("/api/v2/epics", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Epic without intent",
+                })
+            assert resp.status_code == 201
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs.get("outcome_status") == "n_a"
+        finally:
+            app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_epic_intent_triggers_pending_transition():
+    """update_epic에서 intent 완성 시 n_a→pending 전이."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+
+    # 현재 에픽: metric_definition 없음(n_a)
+    current = _base_epic_mock(outcome_status="n_a")
+    current.metric_definition = None
+    current.measure_after = None
+
+    # 업데이트 후: pending으로 전이된 에픽
+    updated = _base_epic_mock(outcome_status="pending")
+
+    with patch("app.repositories.epic.EpicRepository.get", new_callable=AsyncMock) as mock_get, \
+         patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update:
+        mock_get.return_value = current
+        mock_update.return_value = updated
+        try:
+            async with client as c:
+                resp = await c.patch(f"/api/v2/epics/{EPIC_ID}", json={
+                    "metric_definition": {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"},
+                    "measure_after": "2026-06-01T00:00:00Z",
+                })
+            assert resp.status_code == 200
+            # update 호출 시 outcome_status="pending" 포함됐는지 검증
+            call_kwargs = mock_update.call_args[1]
+            assert call_kwargs.get("outcome_status") == "pending"
+        finally:
+            app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_epic_does_not_downgrade_from_hit():
+    """이미 hit인 에픽은 update로 pending 재전이 안 됨."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+
+    current = _base_epic_mock(outcome_status="hit")
+    updated = _base_epic_mock(outcome_status="hit")
+
+    with patch("app.repositories.epic.EpicRepository.get", new_callable=AsyncMock) as mock_get, \
+         patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update:
+        mock_get.return_value = current
+        mock_update.return_value = updated
+        try:
+            async with client as c:
+                resp = await c.patch(f"/api/v2/epics/{EPIC_ID}", json={
+                    "metric_definition": {"source": "internal_ops", "metric": "completion_pct", "target": 90, "direction": "up"},
+                    "measure_after": "2026-07-01T00:00:00Z",
+                })
+            assert resp.status_code == 200
+            # outcome_status는 업데이트 data에 포함되지 않음 (hit 유지)
+            call_kwargs = mock_update.call_args[1]
+            assert "outcome_status" not in call_kwargs
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ── cron score-ga4-outcomes Epic 채점 테스트 ─────────────────────────────────
+
+def _pending_epic_obj(metric_definition=None):
+    """cron 테스트용 — 이미 pending 상태인 에픽 (전이는 별도 테스트에서 검증)."""
     e = MagicMock()
     e.id = EPIC_ID
     e.org_id = ORG_ID
     e.metric_definition = metric_definition
-    e.outcome_status = outcome_status
+    e.outcome_status = "pending"
     e.outcome_result = None
     e.measure_after = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    e.status = "active"
     return e
 
 
 @pytest.mark.anyio
 async def test_cron_epic_internal_ops_hit():
-    """internal_ops completion_pct hit → outcome_status='hit'."""
+    """pending 에픽 + 하위 스토리 75% 완료 → completion_pct=75 → hit(target=50)."""
     from app.main import app
     from app.dependencies.auth import get_current_user
     from app.dependencies.database import get_db
@@ -117,7 +282,8 @@ async def test_cron_epic_internal_ops_hit():
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
 
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 50, "direction": "up"}
-    epic = _mock_epic_obj(metric_definition=md)
+    epic = _pending_epic_obj(metric_definition=md)
+    original_status = epic.status
 
     call_count = 0
 
@@ -126,13 +292,10 @@ async def test_cron_epic_internal_ops_hit():
         call_count += 1
         result = MagicMock()
         if call_count <= 2:
-            # Sprint + Story GA4 쿼리 → 빈 결과
             result.scalars.return_value.all.return_value = []
         elif call_count == 3:
-            # Epic 쿼리
             result.scalars.return_value.all.return_value = [epic]
         else:
-            # 하위 스토리 상태 조회 (4개 중 3개 done)
             result.scalars.return_value.all.return_value = ["done", "done", "done", "backlog"]
         return result
 
@@ -160,15 +323,15 @@ async def test_cron_epic_internal_ops_hit():
         assert body["data"]["total"] == 1
         assert body["data"]["scored"][0]["type"] == "epic"
         assert body["data"]["scored"][0]["outcome_status"] == "hit"
-        # Epic status는 변경 금지 확인
-        assert epic.status is not None  # status 필드 자체는 존재하지만 변경 없음
+        # epic.status는 cron이 건드리지 않음
+        assert epic.status == original_status
     finally:
         app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
-async def test_cron_epic_does_not_change_status():
-    """채점 후 epic.status는 그대로 유지되어야 함."""
+async def test_cron_epic_does_not_change_epic_status():
+    """채점 후 epic.status(active/done 등)는 절대 변경되지 않음."""
     from app.main import app
     from app.dependencies.auth import get_current_user
     from app.dependencies.database import get_db
@@ -180,8 +343,8 @@ async def test_cron_epic_does_not_change_status():
     ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
 
     md = {"source": "internal_ops", "metric": "completion_pct", "target": 80, "direction": "up"}
-    epic = _mock_epic_obj(metric_definition=md)
-    original_status = epic.status
+    epic = _pending_epic_obj(metric_definition=md)
+    epic.status = "active"
 
     call_count = 0
 
@@ -216,7 +379,6 @@ async def test_cron_epic_does_not_change_status():
                 "/api/v2/internal/cron/score-ga4-outcomes",
                 headers={"Authorization": "Bearer "},
             )
-        # status는 채점잡이 건드리지 않음
-        assert epic.status == original_status
+        assert epic.status == "active"
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -25,6 +25,12 @@ def _mock_epic(status: str = "active") -> MagicMock:
     e.success_criteria = None
     e.target_sp = None
     e.target_date = None
+    # E-BOARD-SCHEMA S1: outcome 필드
+    e.success_hypothesis = None
+    e.metric_definition = None
+    e.measure_after = None
+    e.outcome_status = "n_a"
+    e.outcome_result = None
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e


### PR DESCRIPTION
## Summary

- **migration 0059**: `epics` 테이블에 `success_hypothesis`, `metric_definition`, `measure_after`, `outcome_status`, `outcome_result` 5필드 추가. idempotent (inspect 후 조건부 add_column). `down_revision='0058'`
- **model**: `Epic` 클래스에 outcome 5필드 추가 (Sprint/Story 패턴 동일)
- **schema**: `EpicCreate` / `EpicUpdate` / `EpicResponse`에 outcome 필드 반영
- **scorer**: `score_epic_outcome()` 신설. internal_ops metric = `completion_pct` (하위 스토리 완료율). 미지원 metric → pending 가드 (거짓채점 차단)
- **cron**: `score-ga4-outcomes` 엔드포인트에 Epic 채점 편입. GA4 + internal_ops 양방향 지원. **epic.status는 절대 변경하지 않음 — outcome_status/outcome_result만 기록**

## 보존된 기존 필드

- `objective` / `success_criteria`: 기존 자유서술 필드 그대로 공존. 건드리지 않음
- `org_id`: OrgScopedMixin 상속분 그대로. 신규 추가 없음

## Test plan

- [ ] `test_e_board_schema_s1_epic_outcome.py` 12건: scorer 단위 10건 + cron 통합 2건
- [ ] `test_epics.py` 기존 7건: `_mock_epic` 5필드 추가로 from_attributes 회귀 방지
- [ ] 전체 pytest 1229 PASS 확인 (mcp e2e 2건은 서버 미기동 시 SKIP — 기존 동일)
- [ ] migration 수동 실행 필요: PR 머지 후 `sprintable-migrate-dev` job 수동 기동

🤖 Generated with [Claude Code](https://claude.com/claude-code)