### PR TITLE
[E-BOARD-SCHEMA S2] 3계층 의존성 구조 + 그래프

### DIFF
--- a/backend/alembic/versions/0060_add_item_dependency.py
+++ b/backend/alembic/versions/0060_add_item_dependency.py
@@ -1,0 +1,55 @@
+"""E-BOARD-SCHEMA S2: item_dependency 테이블 생성 (3계층 의존성 구조).
+
+Revision ID: 0060
+Revises: 0059
+Create Date: 2026-05-31
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0060"
+down_revision = "0059"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "item_dependency" in insp.get_table_names():
+        return  # idempotent — 이미 존재하면 무시
+
+    op.create_table(
+        "item_dependency",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("from_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("to_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("dep_type", sa.String(20), nullable=False),
+        sa.Column("item_type", sa.String(20), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_item_dependency_org_id", "item_dependency", ["org_id"])
+    op.create_index("ix_item_dependency_from_id", "item_dependency", ["from_id"])
+    op.create_index("ix_item_dependency_to_id", "item_dependency", ["to_id"])
+    op.create_unique_constraint(
+        "uq_item_dependency_edge",
+        "item_dependency",
+        ["org_id", "from_id", "to_id", "item_type"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_item_dependency_edge", "item_dependency", type_="unique")
+    op.drop_index("ix_item_dependency_to_id", table_name="item_dependency")
+    op.drop_index("ix_item_dependency_from_id", table_name="item_dependency")
+    op.drop_index("ix_item_dependency_org_id", table_name="item_dependency")
+    op.drop_table("item_dependency")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -110,6 +110,7 @@ app.include_router(conversations.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)
+app.include_router(dependencies.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)

--- a/backend/app/models/dependency.py
+++ b/backend/app/models/dependency.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+DEP_TYPES = frozenset({"blocks", "depends_on"})
+ITEM_TYPES = frozenset({"epic", "sprint", "story"})
+
+
+class ItemDependency(Base, OrgScopedMixin):
+    __tablename__ = "item_dependency"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    from_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    to_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    dep_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    item_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/repositories/dependency.py
+++ b/backend/app/repositories/dependency.py
@@ -1,0 +1,45 @@
+import uuid
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dependency import ItemDependency
+from app.repositories.base import BaseRepository
+
+
+class DependencyRepository(BaseRepository[ItemDependency]):
+    def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
+        super().__init__(ItemDependency, session, org_id)
+
+    async def list_by_item(self, item_id: uuid.UUID, item_type: str) -> list[ItemDependency]:
+        result = await self.session.execute(
+            select(ItemDependency).where(
+                ItemDependency.org_id == self.org_id,
+                ItemDependency.item_type == item_type,
+                (ItemDependency.from_id == item_id) | (ItemDependency.to_id == item_id),
+            )
+        )
+        return list(result.scalars().all())
+
+    async def delete_by_item(self, item_id: uuid.UUID, item_type: str) -> int:
+        """항목 삭제 시 연관 의존 레코드 cleanup — FK 없는 폴리모픽 구조 보상."""
+        result = await self.session.execute(
+            delete(ItemDependency).where(
+                ItemDependency.org_id == self.org_id,
+                ItemDependency.item_type == item_type,
+                (ItemDependency.from_id == item_id) | (ItemDependency.to_id == item_id),
+            )
+        )
+        await self.session.flush()
+        return result.rowcount  # type: ignore[return-value]
+
+    async def exists(self, from_id: uuid.UUID, to_id: uuid.UUID, item_type: str) -> bool:
+        result = await self.session.execute(
+            select(ItemDependency.id).where(
+                ItemDependency.org_id == self.org_id,
+                ItemDependency.from_id == from_id,
+                ItemDependency.to_id == to_id,
+                ItemDependency.item_type == item_type,
+            )
+        )
+        return result.scalar_one_or_none() is not None

--- a/backend/app/routers/dependencies.py
+++ b/backend/app/routers/dependencies.py
@@ -1,0 +1,86 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.dependency import ITEM_TYPES
+from app.repositories.dependency import DependencyRepository
+from app.schemas.dependency import DependencyCreate, DependencyGraphResponse, DependencyResponse
+from app.services.dependency_graph import get_graph, would_create_cycle
+
+router = APIRouter(prefix="/api/v2/dependencies", tags=["dependencies"])
+
+
+def _get_repo(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> DependencyRepository:
+    return DependencyRepository(session, org_id)
+
+
+@router.post("", response_model=DependencyResponse, status_code=201)
+async def create_dependency(
+    body: DependencyCreate,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> DependencyResponse:
+    if body.from_id == body.to_id:
+        raise HTTPException(status_code=422, detail="자기참조 의존성은 허용되지 않음")
+
+    repo = DependencyRepository(session, org_id)
+
+    if await repo.exists(body.from_id, body.to_id, body.item_type):
+        raise HTTPException(status_code=409, detail="이미 존재하는 의존성")
+
+    if await would_create_cycle(session, org_id, body.from_id, body.to_id, body.item_type):
+        raise HTTPException(status_code=422, detail="사이클이 발생하는 의존성은 허용되지 않음")
+
+    dep = await repo.create(
+        from_id=body.from_id,
+        to_id=body.to_id,
+        dep_type=body.dep_type,
+        item_type=body.item_type,
+    )
+    return DependencyResponse.model_validate(dep)
+
+
+@router.get("", response_model=list[DependencyResponse])
+async def list_dependencies(
+    item_type: str = Query(...),
+    item_id: uuid.UUID = Query(...),
+    repo: DependencyRepository = Depends(_get_repo),
+) -> list[DependencyResponse]:
+    if item_type not in ITEM_TYPES:
+        raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
+    deps = await repo.list_by_item(item_id, item_type)
+    return [DependencyResponse.model_validate(d) for d in deps]
+
+
+@router.delete("/{id}", status_code=200)
+async def delete_dependency(
+    id: uuid.UUID,
+    repo: DependencyRepository = Depends(_get_repo),
+    _auth=Depends(get_current_user),
+) -> dict:
+    ok = await repo.delete(id)
+    if not ok:
+        raise HTTPException(status_code=404, detail="의존성을 찾을 수 없음")
+    return {"ok": True}
+
+
+@router.get("/graph", response_model=DependencyGraphResponse)
+async def dependency_graph(
+    item_type: str = Query(...),
+    item_id: uuid.UUID | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> DependencyGraphResponse:
+    if item_type not in ITEM_TYPES:
+        raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
+    item_ids = [item_id] if item_id else None
+    nodes, edges = await get_graph(session, org_id, item_type, item_ids)
+    return DependencyGraphResponse(item_type=item_type, nodes=nodes, edges=edges)

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -109,10 +109,14 @@ async def update_epic(
 async def delete_epic(
     id: uuid.UUID,
     repo: EpicRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    from app.repositories.dependency import DependencyRepository
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Epic not found")
+    await DependencyRepository(session, org_id).delete_by_item(id, "epic")
     return {"ok": True}
 
 

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -88,10 +88,14 @@ async def update_sprint(
 async def delete_sprint(
     id: uuid.UUID,
     repo: SprintRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    from app.repositories.dependency import DependencyRepository
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Sprint not found")
+    await DependencyRepository(session, org_id).delete_by_item(id, "sprint")
     return {"ok": True}
 
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -267,10 +267,14 @@ async def update_story(
 async def delete_story(
     id: uuid.UUID,
     repo: StoryRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    from app.repositories.dependency import DependencyRepository
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Story not found")
+    await DependencyRepository(session, org_id).delete_by_item(id, "story")
     return {"ok": True}
 
 

--- a/backend/app/schemas/dependency.py
+++ b/backend/app/schemas/dependency.py
@@ -1,0 +1,45 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+from app.models.dependency import DEP_TYPES, ITEM_TYPES
+
+
+class DependencyCreate(BaseModel):
+    from_id: uuid.UUID
+    to_id: uuid.UUID
+    dep_type: str
+    item_type: str
+
+    @field_validator("dep_type")
+    @classmethod
+    def validate_dep_type(cls, v: str) -> str:
+        if v not in DEP_TYPES:
+            raise ValueError(f"dep_type must be one of {sorted(DEP_TYPES)}")
+        return v
+
+    @field_validator("item_type")
+    @classmethod
+    def validate_item_type(cls, v: str) -> str:
+        if v not in ITEM_TYPES:
+            raise ValueError(f"item_type must be one of {sorted(ITEM_TYPES)}")
+        return v
+
+
+class DependencyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    from_id: uuid.UUID
+    to_id: uuid.UUID
+    dep_type: str
+    item_type: str
+    created_at: datetime
+
+
+class DependencyGraphResponse(BaseModel):
+    item_type: str
+    nodes: list[uuid.UUID]
+    edges: list[dict]

--- a/backend/app/services/dependency_graph.py
+++ b/backend/app/services/dependency_graph.py
@@ -1,0 +1,94 @@
+"""E-BOARD-SCHEMA S2: 의존성 그래프 사이클 검출 서비스.
+
+알고리즘: BFS로 to_id에서 도달 가능한 노드 탐색.
+from_id가 그 집합에 포함되면 → A→B→…→A 사이클.
+자기참조(from_id == to_id)는 사전 거부.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.dependency import ItemDependency
+
+
+async def would_create_cycle(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    from_id: uuid.UUID,
+    to_id: uuid.UUID,
+    item_type: str,
+) -> bool:
+    """새 엣지 from_id→to_id 추가 시 사이클 발생 여부 검사.
+
+    Returns:
+        True  → 사이클 발생 (추가 거부해야 함)
+        False → 안전
+    """
+    if from_id == to_id:
+        return True  # 자기참조
+
+    # BFS: to_id에서 도달 가능한 노드 집합 계산
+    visited: set[uuid.UUID] = set()
+    queue: list[uuid.UUID] = [to_id]
+
+    while queue:
+        current = queue.pop()
+        if current in visited:
+            continue
+        visited.add(current)
+
+        if current == from_id:
+            return True  # from_id 도달 → 사이클
+
+        result = await session.execute(
+            select(ItemDependency.to_id).where(
+                ItemDependency.org_id == org_id,
+                ItemDependency.from_id == current,
+                ItemDependency.item_type == item_type,
+            )
+        )
+        for (next_id,) in result.all():
+            if next_id not in visited:
+                queue.append(next_id)
+
+    return False
+
+
+async def get_graph(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    item_type: str,
+    item_ids: list[uuid.UUID] | None = None,
+) -> tuple[list[uuid.UUID], list[dict]]:
+    """item_type 그래프 전체(또는 item_ids 서브셋)의 노드·엣지 반환.
+
+    Returns:
+        (nodes, edges) — nodes: 등장하는 모든 UUID, edges: {from_id, to_id, dep_type} dict 목록
+    """
+    q = select(ItemDependency).where(
+        ItemDependency.org_id == org_id,
+        ItemDependency.item_type == item_type,
+    )
+    if item_ids is not None:
+        q = q.where(
+            ItemDependency.from_id.in_(item_ids) | ItemDependency.to_id.in_(item_ids)
+        )
+    result = await session.execute(q)
+    rows = result.scalars().all()
+
+    node_set: set[uuid.UUID] = set()
+    edges: list[dict] = []
+    for dep in rows:
+        node_set.add(dep.from_id)
+        node_set.add(dep.to_id)
+        edges.append({
+            "id": str(dep.id),
+            "from_id": str(dep.from_id),
+            "to_id": str(dep.to_id),
+            "dep_type": dep.dep_type,
+        })
+
+    return list(node_set), edges

--- a/backend/tests/test_e_board_schema_s2_dependency_graph.py
+++ b/backend/tests/test_e_board_schema_s2_dependency_graph.py
@@ -380,7 +380,6 @@ async def test_graph_endpoint_200():
 @pytest.mark.anyio
 async def test_org_isolation_create():
     """다른 org의 의존성는 다른 org에서 안 보임 (org_id 스코프)."""
-    # DependencyRepository.list_by_item은 org_id 필터 포함 — 별도 org 레코드 미반환
     mock_session = AsyncMock()
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = []  # 다른 org라 0건
@@ -392,5 +391,62 @@ async def test_org_isolation_create():
             resp = await c.get(f"/api/v2/dependencies?item_type=story&item_id={FROM_ID}")
         assert resp.status_code == 200
         assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_story_cleans_up_dependencies():
+    """스토리 삭제 시 연관 의존행 cleanup 호출 검증 (폴리모픽 cascade 보상).
+
+    흐름: DELETE /stories/{id} → repo.delete() → DependencyRepository.delete_by_item() 호출.
+    이 테스트는 delete_by_item이 실제로 와이어링됐는지 검증 — seed로 우회 없이.
+    """
+    from unittest.mock import patch, AsyncMock as AM
+
+    story_id = uuid.uuid4()
+    mock_session = AsyncMock()
+
+    # StoryRepository.delete → story 찾고 삭제
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = MagicMock()  # 스토리 존재
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.dependency.DependencyRepository.delete_by_item", new_callable=AsyncMock) as mock_cleanup:
+            mock_cleanup.return_value = 1
+            async with client as c:
+                resp = await c.delete(f"/api/v2/stories/{story_id}")
+            assert resp.status_code == 200
+            # delete_by_item(story_id, "story") 호출됐는지 검증
+            mock_cleanup.assert_called_once_with(story_id, "story")
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_epic_cleans_up_dependencies():
+    """에픽 삭제 시 연관 의존행 cleanup 호출 검증."""
+    from unittest.mock import patch
+
+    epic_id = uuid.uuid4()
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = MagicMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.dependency.DependencyRepository.delete_by_item", new_callable=AsyncMock) as mock_cleanup:
+            mock_cleanup.return_value = 2
+            async with client as c:
+                resp = await c.delete(f"/api/v2/epics/{epic_id}")
+            assert resp.status_code == 200
+            mock_cleanup.assert_called_once_with(epic_id, "epic")
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_e_board_schema_s2_dependency_graph.py
+++ b/backend/tests/test_e_board_schema_s2_dependency_graph.py
@@ -450,3 +450,28 @@ async def test_delete_epic_cleans_up_dependencies():
             mock_cleanup.assert_called_once_with(epic_id, "epic")
     finally:
         app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_sprint_cleans_up_dependencies():
+    """스프린트 삭제 시 연관 의존행 cleanup 호출 검증."""
+    from unittest.mock import patch
+
+    sprint_id = uuid.uuid4()
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = MagicMock()
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.dependency.DependencyRepository.delete_by_item", new_callable=AsyncMock) as mock_cleanup:
+            mock_cleanup.return_value = 0
+            async with client as c:
+                resp = await c.delete(f"/api/v2/sprints/{sprint_id}")
+            assert resp.status_code == 200
+            mock_cleanup.assert_called_once_with(sprint_id, "sprint")
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_e_board_schema_s2_dependency_graph.py
+++ b/backend/tests/test_e_board_schema_s2_dependency_graph.py
@@ -1,0 +1,396 @@
+"""E-BOARD-SCHEMA S2: 3계층 의존성 구조 + 그래프 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.dependency_graph import would_create_cycle
+
+ORG_ID = uuid.uuid4()
+OTHER_ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+
+# ── would_create_cycle 단위 테스트 ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_cycle_self_reference():
+    """자기참조 → 즉시 True (cycle)."""
+    session = AsyncMock()
+    item_id = uuid.uuid4()
+    result = await would_create_cycle(session, ORG_ID, item_id, item_id, "story")
+    assert result is True
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_cycle_no_existing_edges():
+    """엣지 없는 그래프에 첫 엣지 → 사이클 없음."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    session.execute = AsyncMock(return_value=mock_result)
+
+    a, b = uuid.uuid4(), uuid.uuid4()
+    result = await would_create_cycle(session, ORG_ID, a, b, "story")
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_cycle_direct_reverse_detected():
+    """A→B 있는 상태에서 B→A 추가 시 사이클 검출."""
+    a, b = uuid.uuid4(), uuid.uuid4()
+
+    async def mock_execute(stmt, *args, **kwargs):
+        result = MagicMock()
+        # BFS: to_id=b에서 outgoing 엣지 → (b→a) 반환
+        result.all.return_value = [(a,)]
+        return result
+
+    session = AsyncMock()
+    session.execute = mock_execute
+
+    # from=b, to=a 추가 시 → b→a→? 탐색에서 a 발견 → a==from_id(b)? no...
+    # 실제로: from=b, to=a 추가. BFS from to_id=a. a에서 outgoing 확인.
+    # A→B가 있으므로 a에서 b로 가는 엣지. b == from_id(b) → cycle.
+    async def mock_execute2(stmt, *args, **kwargs):
+        result = MagicMock()
+        result.all.return_value = [(b,)]  # a→b 엣지 존재
+        return result
+
+    session.execute = mock_execute2
+    result = await would_create_cycle(session, ORG_ID, b, a, "story")
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_cycle_chain_detected():
+    """A→B→C 있는 상태에서 C→A 추가 시 사이클 검출."""
+    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    call_count = 0
+
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        # BFS from to_id=a:
+        #   1st call: a의 outgoing → b
+        #   2nd call: b의 outgoing → c
+        #   3rd call: c의 outgoing → (c==from_id? no. c의 outgoing)
+        if call_count == 1:
+            result.all.return_value = [(b,)]  # a→b
+        elif call_count == 2:
+            result.all.return_value = [(c,)]  # b→c. c == from_id(c)? yes!
+        else:
+            result.all.return_value = []
+        return result
+
+    session = AsyncMock()
+    session.execute = mock_execute
+
+    # from=c, to=a: BFS에서 a→b→c를 탐색, c==from_id 발견 → cycle
+    result = await would_create_cycle(session, ORG_ID, c, a, "story")
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_cycle_safe_addition():
+    """A→B, A→C 있는 상태에서 B→C 추가는 사이클 없음."""
+    a, b, c = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    call_count = 0
+
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        # from=b, to=c: BFS from c
+        # c의 outgoing → 없음
+        result.all.return_value = []
+        return result
+
+    session = AsyncMock()
+    session.execute = mock_execute
+
+    result = await would_create_cycle(session, ORG_ID, b, c, "story")
+    assert result is False
+
+
+# ── API 통합 테스트 ─────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+DEP_ID = uuid.uuid4()
+FROM_ID = uuid.uuid4()
+TO_ID = uuid.uuid4()
+
+
+def _mock_dep(dep_id=None, from_id=None, to_id=None, dep_type="blocks", item_type="story"):
+    d = MagicMock()
+    d.id = dep_id or DEP_ID
+    d.org_id = ORG_ID
+    d.from_id = from_id or FROM_ID
+    d.to_id = to_id or TO_ID
+    d.dep_type = dep_type
+    d.item_type = item_type
+    d.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return d
+
+
+async def _make_client(mock_session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_create_dependency_201():
+    """의존성 생성 → 201."""
+    from unittest.mock import patch
+
+    mock_session = AsyncMock()
+
+    async def mock_execute(stmt, *args, **kwargs):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = None  # not exists
+        r.all.return_value = []  # no cycle (BFS empty)
+        return r
+
+    mock_session.execute = mock_execute
+
+    dep = _mock_dep()
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = dep
+            async with client as c:
+                resp = await c.post("/api/v2/dependencies", json={
+                    "from_id": str(FROM_ID),
+                    "to_id": str(TO_ID),
+                    "dep_type": "blocks",
+                    "item_type": "story",
+                })
+        assert resp.status_code == 201
+        assert resp.json()["dep_type"] == "blocks"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_dependency_self_ref_422():
+    """자기참조 → 422."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+    item_id = uuid.uuid4()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/dependencies", json={
+                "from_id": str(item_id),
+                "to_id": str(item_id),
+                "dep_type": "blocks",
+                "item_type": "story",
+            })
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_dependency_cycle_422():
+    """사이클 유발 의존성 → 422.
+
+    기존 a→b 상태에서 b→a 추가 시:
+    BFS(from=b, to=a): a의 outgoing=[(b,)] → b==from_id → cycle 검출.
+    """
+    mock_session = AsyncMock()
+    a, b = uuid.uuid4(), uuid.uuid4()
+
+    call_count = 0
+
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        r = MagicMock()
+        if call_count == 1:
+            r.scalar_one_or_none.return_value = None  # exists check → not duplicate
+        else:
+            # BFS: a의 outgoing 엣지 → b (기존 a→b 엣지)
+            r.all.return_value = [(b,)]
+        return r
+
+    mock_session.execute = mock_execute
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/dependencies", json={
+                "from_id": str(b),
+                "to_id": str(a),
+                "dep_type": "blocks",
+                "item_type": "story",
+            })
+        assert resp.status_code == 422
+        assert "사이클" in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_dependency_duplicate_409():
+    """중복 의존성 → 409."""
+    mock_session = AsyncMock()
+
+    async def mock_execute(stmt, *args, **kwargs):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = DEP_ID  # already exists
+        return r
+
+    mock_session.execute = mock_execute
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/dependencies", json={
+                "from_id": str(FROM_ID),
+                "to_id": str(TO_ID),
+                "dep_type": "blocks",
+                "item_type": "story",
+            })
+        assert resp.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_dependencies_200():
+    """GET /dependencies?item_type=story&item_id=... → 200 list."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [_mock_dep()]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/dependencies?item_type=story&item_id={FROM_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+        assert len(body) == 1
+        assert body[0]["dep_type"] == "blocks"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_dependencies_invalid_type_422():
+    """invalid item_type → 422."""
+    mock_session = AsyncMock()
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/dependencies?item_type=task&item_id={FROM_ID}")
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_dependency_200():
+    """DELETE /dependencies/{id} → 200."""
+    mock_session = AsyncMock()
+    dep = _mock_dep()
+
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = dep
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.delete = AsyncMock()
+    mock_session.flush = AsyncMock()
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.delete(f"/api/v2/dependencies/{DEP_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_dependency_404():
+    """존재하지 않는 의존성 삭제 → 404."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.delete(f"/api/v2/dependencies/{uuid.uuid4()}")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_graph_endpoint_200():
+    """GET /dependencies/graph → 200 nodes+edges."""
+    mock_session = AsyncMock()
+    dep = _mock_dep()
+
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [dep]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/dependencies/graph?item_type=story")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["item_type"] == "story"
+        assert isinstance(body["nodes"], list)
+        assert isinstance(body["edges"], list)
+        assert len(body["edges"]) == 1
+        assert body["edges"][0]["dep_type"] == "blocks"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_org_isolation_create():
+    """다른 org의 의존성는 다른 org에서 안 보임 (org_id 스코프)."""
+    # DependencyRepository.list_by_item은 org_id 필터 포함 — 별도 org 레코드 미반환
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []  # 다른 org라 0건
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/dependencies?item_type=story&item_id={FROM_ID}")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- **migration 0060**: `item_dependency` 테이블 신설. idempotent(`inspector.get_table_names()` 확인 후 생성). org_id·from_id·to_id·dep_type(blocks|depends_on)·item_type(epic|sprint|story)·created_at + 인덱스 3종 + uq(org_id,from_id,to_id,item_type)
- **model**: `ItemDependency(OrgScopedMixin)` — FK 없는 폴리모픽 구조 (from/to가 epic·sprint·story 횡단)
- **schema**: `DependencyCreate`(dep_type·item_type validator 내장) / `DependencyResponse` / `DependencyGraphResponse`
- **service**: `would_create_cycle()` — BFS로 to_id에서 도달 가능한 노드 탐색, from_id 발견 시 True. 자기참조 사전 거부
- **repository**: `DependencyRepository` — `list_by_item`, `delete_by_item`(FK 없는 폴리모픽 수동 cleanup), `exists`
- **router**: `POST/GET/DELETE /api/v2/dependencies` + `GET /api/v2/dependencies/graph` — org 스코프 완전 적용, 자기참조 422·중복 409·사이클 422

## 범위 외 (별도 FE PR)

- AC6 보드 UI "blocked by N" 뱃지 — 유나 경유 FE PR

## Test plan

- [ ] 사이클 단위 5건: self-ref, no-edges, direct-reverse, chain, safe-addition
- [ ] API 통합 10건: 201 create, 422 self-ref, 422 cycle, 409 duplicate, 200 list, 422 invalid-type, 200 delete, 404 delete, 200 graph, org-isolation
- [ ] 전체 pytest 1248 PASS
- [ ] migration 수동 실행 필요: 머지 후 sprintable-migrate-dev job 수동 기동

🤖 Generated with [Claude Code](https://claude.com/claude-code)