### PR TITLE
[E-BOARD-SCHEMA S4] Sprint goal/hypothesis 분리 + capacity

### DIFF
--- a/backend/alembic/versions/0062_add_sprint_goal_capacity.py
+++ b/backend/alembic/versions/0062_add_sprint_goal_capacity.py
@@ -1,0 +1,41 @@
+"""E-BOARD-SCHEMA S4: Sprint에 goal·capacity 필드 추가.
+
+Revision ID: 0062
+Revises: 0061
+Create Date: 2026-05-31
+
+goal     = 실행 목표 ("무엇을 한다") — success_hypothesis(효과 가설)와 별개
+capacity = 가용 공수(SP) — team_size(인원수)와 별개
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0062"
+down_revision = "0061"
+branch_labels = None
+depends_on = None
+
+_COLS = [
+    ("goal", sa.Text, {"nullable": True}),
+    ("capacity", sa.Integer, {"nullable": True}),
+]
+
+
+def _add_idempotent(table: str) -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = {c["name"] for c in insp.get_columns(table)}
+    for col_name, col_type, kwargs in _COLS:
+        if col_name not in existing:
+            op.add_column(table, sa.Column(col_name, col_type, **kwargs))
+
+
+def upgrade() -> None:
+    _add_idempotent("sprints")
+
+
+def downgrade() -> None:
+    for col_name, _, _ in reversed(_COLS):
+        op.drop_column("sprints", col_name)

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -26,6 +26,10 @@ class Sprint(Base, OrgScopedMixin, TimestampMixin):
     velocity: Mapped[int | None] = mapped_column(Integer, nullable=True)
     team_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
     duration: Mapped[int] = mapped_column(Integer, nullable=False, default=14)
+    # E-BOARD-SCHEMA S4: 스프린트 목표·공수 (goal=실행목표, success_hypothesis=효과가설과 별개)
+    goal: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # capacity=가용 공수(SP), team_size=인원수와 별개
+    capacity: Mapped[int | None] = mapped_column(Integer, nullable=True)
     # E-OUTCOME-LOOP: 의도 필드 (intent)
     success_hypothesis: Mapped[str | None] = mapped_column(Text, nullable=True)
     metric_definition: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -53,6 +53,8 @@ async def create_sprint(
         start_date=body.start_date,
         end_date=body.end_date,
         team_size=body.team_size,
+        goal=body.goal,
+        capacity=body.capacity,
         success_hypothesis=body.success_hypothesis,
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -11,7 +11,10 @@ class SprintBase(BaseModel):
     start_date: date | None = None
     end_date: date | None = None
     team_size: int | None = None
-    # E-OUTCOME-LOOP: 의도 필드
+    # E-BOARD-SCHEMA S4: 실행 목표(goal)·가용 공수(capacity)
+    goal: str | None = None
+    capacity: int | None = None
+    # E-OUTCOME-LOOP: 효과 가설(success_hypothesis) — goal(실행 목표)과 별개
     success_hypothesis: str | None = None
     metric_definition: dict[str, Any] | None = None
     measure_after: datetime | None = None
@@ -36,6 +39,9 @@ class SprintUpdate(BaseModel):
     velocity: int | None = None
     duration: int | None = None
     report_doc_id: uuid.UUID | None = None
+    # E-BOARD-SCHEMA S4
+    goal: str | None = None
+    capacity: int | None = None
     # E-OUTCOME-LOOP: 의도 필드 (Update 허용)
     success_hypothesis: str | None = None
     metric_definition: dict[str, Any] | None = None

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -25,6 +25,9 @@ def _mock_sprint(status: str = "planning") -> MagicMock:
     s.team_size = None
     s.duration = 14
     s.report_doc_id = None
+    # E-BOARD-SCHEMA S4: 신규 2필드
+    s.goal = None
+    s.capacity = None
     # E-OUTCOME-LOOP: 신규 필드 (MagicMock 반환 객체가 Pydantic 검증 실패하므로 명시 세팅)
     s.success_hypothesis = None
     s.metric_definition = None
@@ -677,3 +680,85 @@ class TestGa4MetricDefinitionValidation:
         r = score_sprint_outcome(md, velocity=30, backlog_remaining=0, total_points=30)
         assert r is not None
         assert r["outcome_status"] == "pending"
+
+
+# ── E-BOARD-SCHEMA S4: goal/capacity round-trip 테스트 ────────────────────────
+
+@pytest.mark.anyio
+async def test_create_sprint_with_goal_capacity_201():
+    """sprint create 시 goal·capacity 필드 전달·반환 검증."""
+    sprint = _mock_sprint()
+    sprint.goal = "유저 온보딩 플로우 완성"
+    sprint.capacity = 40
+
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = sprint
+            async with client as c:
+                resp = await c.post("/api/v2/sprints", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Sprint 1",
+                    "goal": "유저 온보딩 플로우 완성",
+                    "capacity": 40,
+                })
+        assert resp.status_code == 201
+        assert resp.json()["goal"] == "유저 온보딩 플로우 완성"
+        assert resp.json()["capacity"] == 40
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_sprint_goal_capacity_200():
+    """sprint update 시 goal·capacity 업데이트 검증."""
+    updated = _mock_sprint()
+    updated.goal = "API 안정화"
+    updated.capacity = 30
+
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update:
+            mock_update.return_value = updated
+            async with client as c:
+                resp = await c.patch(f"/api/v2/sprints/{SPRINT_ID}", json={
+                    "goal": "API 안정화",
+                    "capacity": 30,
+                })
+        assert resp.status_code == 200
+        assert resp.json()["goal"] == "API 안정화"
+        assert resp.json()["capacity"] == 30
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_sprint_goal_independent_from_success_hypothesis():
+    """goal(실행목표)과 success_hypothesis(효과가설)가 독립 필드임을 검증."""
+    sprint = _mock_sprint()
+    sprint.goal = "온보딩 완성"
+    sprint.success_hypothesis = "DAU 20% 증가 기대"
+    sprint.capacity = 35
+
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = sprint
+            async with client as c:
+                resp = await c.post("/api/v2/sprints", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Sprint 1",
+                    "goal": "온보딩 완성",
+                    "success_hypothesis": "DAU 20% 증가 기대",
+                    "capacity": 35,
+                })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["goal"] == "온보딩 완성"
+        assert body["success_hypothesis"] == "DAU 20% 증가 기대"
+        assert body["goal"] != body["success_hypothesis"]
+        assert body["capacity"] == 35
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_sprints.py
+++ b/backend/tests/test_sprints.py
@@ -686,7 +686,7 @@ class TestGa4MetricDefinitionValidation:
 
 @pytest.mark.anyio
 async def test_create_sprint_with_goal_capacity_201():
-    """sprint create 시 goal·capacity 필드 전달·반환 검증."""
+    """sprint create 시 goal·capacity 필드가 라우터→repo.create까지 실제 전달됨을 검증."""
     sprint = _mock_sprint()
     sprint.goal = "유저 온보딩 플로우 완성"
     sprint.capacity = 40
@@ -706,6 +706,10 @@ async def test_create_sprint_with_goal_capacity_201():
         assert resp.status_code == 201
         assert resp.json()["goal"] == "유저 온보딩 플로우 완성"
         assert resp.json()["capacity"] == 40
+        # 라우터가 실제로 goal/capacity를 repo.create에 전달했는지 검증
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs.get("goal") == "유저 온보딩 플로우 완성"
+        assert call_kwargs.get("capacity") == 40
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

- **migration 0062**: `sprints` 테이블에 `goal`(Text, nullable) + `capacity`(Integer, nullable) 추가. idempotent(inspect 후 조건부 add_column). down_revision='0061'. 기존 `success_hypothesis`·`team_size` 비파괴.
- **model**: `Sprint` 클래스에 2필드 추가. 주석으로 의미 분리 명확히:
  - `goal` = 실행 목표("무엇을 한다") ≠ `success_hypothesis`(효과 가설)
  - `capacity` = 가용 공수(SP) ≠ `team_size`(인원수)
- **schema**: `SprintBase`에 추가 → `SprintCreate`/`SprintUpdate`/`SprintResponse` 자동 반영

## 범위 외 (별도 FE PR)

- AC4 goal/capacity 입력 UI — 유나 경유 FE PR

## Test plan

- [ ] `_mock_sprint()` 2필드 추가 (from_attributes 회귀 방지)
- [ ] `test_create_sprint_with_goal_capacity_201`: create round-trip
- [ ] `test_update_sprint_goal_capacity_200`: update round-trip
- [ ] `test_sprint_goal_independent_from_success_hypothesis`: goal ≠ success_hypothesis 독립성
- [ ] 전체 pytest 1270 PASS
- [ ] 머지 후 migration 0062 수동 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)