### PR TITLE
[SID:abf0b83f] [E-BOARD-SCHEMA][FE-DEP] 의존성 뱃지 + 그래프 (보드 카드)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -192,7 +192,8 @@
     "kickoffTriggered": "Workflow triggered",
     "kickoffNoMatch": "No matching rule found",
     "kickoffConflict": "Workflow already triggered recently",
-    "kickoffError": "Failed to trigger workflow"
+    "kickoffError": "Failed to trigger workflow",
+    "blockedBy": "blocked by {count}"
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -192,7 +192,8 @@
     "kickoffTriggered": "워크플로우가 실행되었습니다",
     "kickoffNoMatch": "매칭되는 규칙이 없습니다",
     "kickoffConflict": "최근 실행된 워크플로우가 있습니다",
-    "kickoffError": "워크플로우 실행에 실패했습니다"
+    "kickoffError": "워크플로우 실행에 실패했습니다",
+    "blockedBy": "{count}개에 의해 차단됨"
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/app/api/dependencies/graph/route.ts
+++ b/apps/web/src/app/api/dependencies/graph/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/dependencies/graph');
+}

--- a/apps/web/src/app/api/dependencies/route.ts
+++ b/apps/web/src/app/api/dependencies/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/dependencies');
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/dependencies');
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -23,7 +23,7 @@ import { KanbanListView } from './kanban-list-view';
 import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
-import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId } from './types';
+import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge } from './types';
 
 type DragOverlayCompatProps = {
   children?: React.ReactNode;
@@ -165,6 +165,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   }, [projectId]);
 
   const [executionMap, setExecutionMap] = useState<Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>>({});
+  const [blockedByMap, setBlockedByMap] = useState<Record<string, string[]>>({});
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
   const selectedStoryRef = useRef<KanbanStory | null>(null);
@@ -248,6 +249,23 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         } catch {
           // non-critical — skip silently
         }
+      }
+
+      try {
+        const graphRes = await fetch('/api/dependencies/graph?item_type=story');
+        if (graphRes.ok) {
+          const graphJson = await graphRes.json() as { edges?: DependencyEdge[] };
+          const map: Record<string, string[]> = {};
+          for (const edge of graphJson.edges ?? []) {
+            if (edge.dep_type === 'blocks') {
+              if (!map[edge.to_id]) map[edge.to_id] = [];
+              map[edge.to_id].push(edge.from_id);
+            }
+          }
+          setBlockedByMap(map);
+        }
+      } catch {
+        // non-critical
       }
     } finally {
       setLoading(false);
@@ -1003,6 +1021,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onWipDraftChange={(v) => handleWipLimitDraftChange(col.id, v)}
                     onCreateStory={handleCreateStory}
                     executionMap={executionMap}
+                    blockedByMap={blockedByMap}
                     totalCount={columnTotals[col.id]}
                     hasMore={!!columnCursors[col.id]}
                     loadingMore={loadingMoreColumns[col.id] ?? false}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1137,6 +1137,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             setStories((prev) => prev.filter((s) => s.id !== id));
             setSelectedStory(null);
           }}
+          storyMap={Object.fromEntries(stories.map((s) => [s.id, { title: s.title, status: s.status }]))}
+          onNavigate={(storyId) => {
+            const s = stories.find((x) => x.id === storyId);
+            if (s) void handleStoryClick(s);
+          }}
         />
       )}
     </div>

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -56,6 +56,7 @@ interface KanbanColumnProps {
   // Inline create
   onCreateStory?: (columnId: string, title: string) => Promise<void> | void;
   executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
+  blockedByMap?: Record<string, string[]>;
   // CB-S4: board query
   totalCount?: number;
   hasMore?: boolean;
@@ -71,7 +72,7 @@ export function KanbanColumn({
   onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
-  onCreateStory, projectId, onKickoffStory, executionMap,
+  onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap,
   totalCount, hasMore, loadingMore, onLoadMore,
   collapsed, onToggleCollapse,
 }: KanbanColumnProps) {
@@ -304,6 +305,7 @@ export function KanbanColumn({
                   projectId={projectId}
                   onKickoff={onKickoffStory}
                   lastExecution={executionMap?.[story.id] ?? null}
+                  blockedBy={blockedByMap?.[story.id] ?? []}
                 />
               ))}
             </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -6,7 +6,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { useTranslations } from 'next-intl';
 import type { KanbanStory, KanbanMember } from './types';
 import { Badge } from '@/components/ui/badge';
-import { ChevronRight, Rocket, Zap, ZapOff } from 'lucide-react';
+import { AlertTriangle, ChevronRight, Rocket, Zap, ZapOff } from 'lucide-react';
 
 const EPIC_COLORS = [
   'info',
@@ -43,9 +43,10 @@ interface StoryCardProps {
   projectId?: string;
   onKickoff?: (storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => void;
   lastExecution?: WorkflowExecStatus | null;
+  blockedBy?: string[];
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [] }: StoryCardProps) {
   const t = useTranslations('board');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
@@ -179,9 +180,17 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
         <div className="absolute inset-0 pointer-events-none rounded-lg border border-transparent bg-gradient-to-r from-accent-claim/10 to-purple-500/10 opacity-50" />
       )}
       {epicName && story.epic_id ? (
-        <Badge variant={getEpicColor(story.epic_id)} className="mb-3 max-w-full">
+        <Badge variant={getEpicColor(story.epic_id)} className="mb-2 max-w-full">
           <span className="min-w-0 truncate leading-none">{epicName}</span>
         </Badge>
+      ) : null}
+      {blockedBy.length > 0 && story.status !== 'done' ? (
+        <div className="mb-2 flex flex-wrap gap-1">
+          <Badge variant="warning" className="gap-1">
+            <AlertTriangle className="size-3 shrink-0" />
+            <span>{t('blockedBy', { count: blockedBy.length })}</span>
+          </Badge>
+        </div>
       ) : null}
       <p className="relative z-10 line-clamp-2 text-sm font-medium leading-5 text-foreground">{story.title}</p>
       <div className="relative z-10 mt-3 flex items-center justify-between gap-2">

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -184,7 +184,8 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           <span className="min-w-0 truncate leading-none">{epicName}</span>
         </Badge>
       ) : null}
-      {blockedBy.length > 0 && story.status !== 'done' ? (
+      {/* Zone A meta row — FE-LABEL도 이 컨테이너 안에 칩 추가 예정 */}
+      {(blockedBy.length > 0 && story.status !== 'done') ? (
         <div className="mb-2 flex flex-wrap gap-1">
           <Badge variant="warning" className="gap-1">
             <AlertTriangle className="size-3 shrink-0" />

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -5,8 +5,8 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
-import { Trash2 } from 'lucide-react';
-import type { KanbanStory, KanbanMember } from './types';
+import { AlertTriangle, GitFork, Trash2 } from 'lucide-react';
+import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
 import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { Button } from '@/components/ui/button';
@@ -122,6 +122,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [editingAssignee, setEditingAssignee] = useState(false);
   const [savingAssignee, setSavingAssignee] = useState(false);
 
+  const [deps, setDeps] = useState<DependencyEdge[]>([]);
+  const [loadingDeps, setLoadingDeps] = useState(false);
+
   const handleDelete = useCallback(async () => {
     setDeleting(true);
     try {
@@ -160,6 +163,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       titleInputRef.current?.select();
     }
   }, [editingTitle]);
+
+  useEffect(() => {
+    setLoadingDeps(true);
+    fetch(`/api/dependencies?item_type=story&item_id=${story.id}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json) => {
+        const raw = Array.isArray(json) ? json : [];
+        setDeps(raw as DependencyEdge[]);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingDeps(false));
+  }, [story.id]);
 
   const statusKeyMap: Record<string, 'backlog' | 'readyForDev' | 'inProgress' | 'inReview' | 'done'> = {
     backlog: 'backlog',
@@ -520,6 +535,36 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </button>
               )}
             </div>
+
+            {/* Dependencies — per-item graph v1 */}
+            {(loadingDeps || deps.length > 0) && (
+              <div>
+                <div className="mb-2 flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+                  <GitFork className="size-3" />
+                  <span>Dependencies</span>
+                </div>
+                {loadingDeps ? (
+                  <p className="text-xs text-muted-foreground">{t('loading')}</p>
+                ) : (
+                  <div className="space-y-1.5">
+                    {deps.filter((d) => d.dep_type === 'blocks' && d.to_id === story.id).map((d) => (
+                      <div key={d.id} className="flex items-center gap-2 rounded-md border border-warning-border bg-warning-tint px-2.5 py-1.5 text-xs text-warning">
+                        <AlertTriangle className="size-3 shrink-0" />
+                        <span className="font-medium">Blocked by</span>
+                        <span className="font-mono text-warning/80">#{d.from_id.slice(0, 6)}</span>
+                      </div>
+                    ))}
+                    {deps.filter((d) => d.dep_type === 'blocks' && d.from_id === story.id).map((d) => (
+                      <div key={d.id} className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
+                        <GitFork className="size-3 shrink-0" />
+                        <span className="font-medium">Blocking</span>
+                        <span className="font-mono">#{d.to_id.slice(0, 6)}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Outcome intent + result */}
             <div className="space-y-3">

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -51,6 +51,8 @@ interface StoryDetailPanelProps {
   onDeleteSuccess?: (storyId: string) => void;
   memberMap?: Record<string, KanbanMember>;
   members?: KanbanMember[];
+  storyMap?: Record<string, { title: string; status: string }>;
+  onNavigate?: (storyId: string) => void;
 }
 
 function taskTone(status: string) {
@@ -86,7 +88,7 @@ function DescriptionViewer({ description }: { description: string }) {
   );
 }
 
-export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [] }: StoryDetailPanelProps) {
+export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loadingMoreTasks = false, onLoadMoreTasks, onClose, onStoryUpdate, onDeleteSuccess, memberMap = {}, members = [], storyMap = {}, onNavigate }: StoryDetailPanelProps) {
   const t = useTranslations('board');
   const { toasts, addToast, dismissToast } = useToast();
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -547,20 +549,40 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <p className="text-xs text-muted-foreground">{t('loading')}</p>
                 ) : (
                   <div className="space-y-1.5">
-                    {deps.filter((d) => d.dep_type === 'blocks' && d.to_id === story.id).map((d) => (
-                      <div key={d.id} className="flex items-center gap-2 rounded-md border border-warning-border bg-warning-tint px-2.5 py-1.5 text-xs text-warning">
-                        <AlertTriangle className="size-3 shrink-0" />
-                        <span className="font-medium">Blocked by</span>
-                        <span className="font-mono text-warning/80">#{d.from_id.slice(0, 6)}</span>
-                      </div>
-                    ))}
-                    {deps.filter((d) => d.dep_type === 'blocks' && d.from_id === story.id).map((d) => (
-                      <div key={d.id} className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
-                        <GitFork className="size-3 shrink-0" />
-                        <span className="font-medium">Blocking</span>
-                        <span className="font-mono">#{d.to_id.slice(0, 6)}</span>
-                      </div>
-                    ))}
+                    {deps.filter((d) => d.dep_type === 'blocks' && d.to_id === story.id).map((d) => {
+                      const blocker = storyMap[d.from_id];
+                      return (
+                        <button
+                          key={d.id}
+                          type="button"
+                          onClick={() => onNavigate?.(d.from_id)}
+                          className="flex w-full items-center gap-2 rounded-md border border-warning-border bg-warning-tint px-2.5 py-1.5 text-xs text-warning transition hover:bg-warning-tint/70 disabled:pointer-events-none"
+                          disabled={!onNavigate}
+                        >
+                          <AlertTriangle className="size-3 shrink-0" />
+                          <span className="font-medium shrink-0">Blocked by</span>
+                          <span className="min-w-0 truncate text-left">{blocker?.title ?? `#${d.from_id.slice(0, 6)}`}</span>
+                          {blocker?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocker.status}</span> : null}
+                        </button>
+                      );
+                    })}
+                    {deps.filter((d) => d.dep_type === 'blocks' && d.from_id === story.id).map((d) => {
+                      const blocked = storyMap[d.to_id];
+                      return (
+                        <button
+                          key={d.id}
+                          type="button"
+                          onClick={() => onNavigate?.(d.to_id)}
+                          className="flex w-full items-center gap-2 rounded-md border border-border bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground transition hover:bg-muted/60 disabled:pointer-events-none"
+                          disabled={!onNavigate}
+                        >
+                          <GitFork className="size-3 shrink-0" />
+                          <span className="font-medium shrink-0">Blocking</span>
+                          <span className="min-w-0 truncate text-left">{blocked?.title ?? `#${d.to_id.slice(0, 6)}`}</span>
+                          {blocked?.status ? <span className="ml-auto shrink-0 font-mono text-[10px] opacity-60">{blocked.status}</span> : null}
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -16,6 +16,14 @@ export interface KanbanStory {
   measure_after: string | null;
   outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
   outcome_result: OutcomeResult | null;
+  blocked_by?: string[];
+}
+
+export interface DependencyEdge {
+  id: string;
+  from_id: string;
+  to_id: string;
+  dep_type: 'blocks' | 'depends_on';
 }
 
 export interface KanbanEpic {

--- a/apps/web/src/components/ui/badge.tsx
+++ b/apps/web/src/components/ui/badge.tsx
@@ -21,6 +21,7 @@ const badgeVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         success: "border-success-border bg-success-tint text-success",
         info: "border-info-border bg-info-tint text-info",
+        warning: "border-warning-border bg-warning-tint text-warning",
         chip: "border-border/80 bg-muted/70 text-muted-foreground",
         counter: "border-transparent bg-destructive text-destructive-foreground",
       },


### PR DESCRIPTION
## 변경 사항

- **badge.tsx**: `warning` variant 신설 (`border-warning-border bg-warning-tint text-warning`) — 가산적, 무회귀
- **types.ts**: `KanbanStory.blocked_by?: string[]` + `DependencyEdge` 인터페이스
- **api/dependencies**: FE 프록시 신설 (`GET /api/dependencies`, `GET /api/dependencies/graph`, `POST /api/dependencies`)
- **kanban-board**: 보드 로드 시 `/api/dependencies/graph?item_type=story` 일괄 조회 → `blockedByMap` 빌드
- **kanban-column**: `blockedByMap` prop 스레딩
- **story-card**: Zone A 메타 로우 컨테이너 (`flex flex-wrap gap-1`) 신설, "blocked by N" 뱃지 (AlertTriangle + warning variant, N>0 && status≠done)
- **story-detail-panel**: per-item 의존 그래프 v1 — "Blocked by" / "Blocking" 섹션 (story 오픈 시 deps 자동 조회)
- **i18n**: `board.blockedBy` en/ko

## AC 확인

| AC | 내용 | 상태 |
|---|---|---|
| AC1 | "blocked by N" 뱃지 + 의존 항목 표시 | ✅ |
| AC2 | warning 뱃지 variant (신규 DS variant) | ✅ |
| AC3 | per-item 의존 그래프 v1 (story-detail-panel 섹션) | ✅ |

## 반응형 확인

- 보드 카드: epic 뱃지 아래 / 타이틀 위 Zone A 메타 로우 — 모바일/데스크톱 동일 레이아웃
- story-detail-panel: 패널 내 Dependencies 섹션, Outcome 위

## 사후 grep

```
warning variant 추가: badge.tsx 1건
AlertTriangle import: story-card.tsx, story-detail-panel.tsx
DependencyEdge 사용: kanban-board.tsx, story-detail-panel.tsx
/api/dependencies 신규 2파일: route.ts + graph/route.ts
기존 badge variants 회귀: 0건
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)