### PR TITLE
[E-CAGE-REFEREE P1] verdict 스키마 + 기록 인터페이스

### DIFF
--- a/backend/alembic/versions/0064_add_verdict.py
+++ b/backend/alembic/versions/0064_add_verdict.py
@@ -1,0 +1,74 @@
+"""E-CAGE-REFEREE P1: verdict 테이블 생성 (participation 기반 결과 기록).
+
+Revision ID: 0064
+Revises: 0063
+Create Date: 2026-05-31
+
+verdict는 participation_id + source 쌍으로 uq — 멱등 재기록 가능.
+result는 null 허용 — 미측정 시 거짓 pass/fail 금지.
+공개 POST API 없음 — record_verdict() 내부 서비스 함수 전용.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0064"
+down_revision = "0063"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "verdict" in insp.get_table_names():
+        return
+
+    op.create_table(
+        "verdict",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "participation_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("participation.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # source: 확장 가능 String (pr|qa|ci|design — enum 하드코딩 금지)
+        sa.Column("source", sa.String(50), nullable=False),
+        # result: null 허용 — 미측정 시 null (거짓 pass/fail 방지)
+        sa.Column("result", sa.String(20), nullable=True),
+        sa.Column("rounds", sa.Integer(), nullable=True),
+        sa.Column(
+            "recorded_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_verdict_org_id", "verdict", ["org_id"])
+    op.create_index("ix_verdict_participation_id", "verdict", ["participation_id"])
+    op.create_unique_constraint(
+        "uq_verdict_participation_source",
+        "verdict",
+        ["participation_id", "source"],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "verdict" not in insp.get_table_names():
+        return
+    op.drop_constraint("uq_verdict_participation_source", "verdict", type_="unique")
+    op.drop_index("ix_verdict_participation_id", table_name="verdict")
+    op.drop_index("ix_verdict_org_id", table_name="verdict")
+    op.drop_table("verdict")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -114,6 +114,7 @@ app.include_router(dependencies.router)
 app.include_router(labels.router)
 app.include_router(labels.item_label_router)
 app.include_router(participation.router)
+app.include_router(verdicts.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)

--- a/backend/app/models/verdict.py
+++ b/backend/app/models/verdict.py
@@ -1,0 +1,37 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin
+
+
+class Verdict(Base, OrgScopedMixin):
+    """participation별 결과 기록 — 에이전트 신뢰 계측 데이터.
+
+    result=null 허용: 미측정 소스는 null 유지(거짓 pass/fail 금지).
+    공개 POST API 없음 — record_verdict() 내부 서비스 함수만.
+    """
+    __tablename__ = "verdict"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    participation_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("participation.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # source: 확장 가능 (pr|qa|ci|design ...) — enum 하드코딩 금지
+    source: Mapped[str] = mapped_column(String(50), nullable=False)
+    # result: null = 미측정 (pass|fail|null)
+    result: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    rounds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    recorded_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/routers/verdicts.py
+++ b/backend/app/routers/verdicts.py
@@ -1,0 +1,26 @@
+"""verdict 조회 전용 라우터 — 기록은 record_verdict() 내부 서비스만.
+
+POST 엔드포인트 없음: 에이전트 자기 verdict 수동기록 차단.
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.schemas.verdict import VerdictResponse
+from app.services.verdict_recorder import get_verdicts_by_participation
+
+router = APIRouter(prefix="/api/v2/verdicts", tags=["verdicts"])
+
+
+@router.get("", response_model=list[VerdictResponse])
+async def list_verdicts(
+    participation_id: uuid.UUID = Query(...),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> list[VerdictResponse]:
+    verdicts = await get_verdicts_by_participation(session, org_id, participation_id)
+    return [VerdictResponse.model_validate(v) for v in verdicts]

--- a/backend/app/schemas/verdict.py
+++ b/backend/app/schemas/verdict.py
@@ -1,0 +1,17 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class VerdictResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    participation_id: uuid.UUID
+    source: str
+    result: str | None = None
+    rounds: int | None = None
+    recorded_at: datetime
+    created_at: datetime

--- a/backend/app/services/verdict_recorder.py
+++ b/backend/app/services/verdict_recorder.py
@@ -1,0 +1,77 @@
+"""E-CAGE-REFEREE P1: verdict 내부 기록 서비스.
+
+에이전트 자기 verdict 수동기록 공개 API 차단 — 이 함수만 사용.
+게이밍·누락 방지. 신뢰 재는 데이터부터 신뢰가능해야 함.
+
+result=null 허용: 미측정 소스는 null 유지 (거짓 pass/fail 금지).
+uq(participation_id, source) 기반 upsert — 멱등 재기록.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.verdict import Verdict
+
+
+async def record_verdict(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    participation_id: uuid.UUID,
+    source: str,
+    result: str | None,
+    rounds: int | None = None,
+) -> Verdict:
+    """participation + source 쌍으로 verdict upsert.
+
+    이미 존재하면 result·rounds·recorded_at 갱신.
+    없으면 신규 생성.
+    result=None → 미측정 유지 (거짓 채점 금지).
+    """
+    now = datetime.now(timezone.utc)
+
+    existing = await session.execute(
+        select(Verdict).where(
+            Verdict.org_id == org_id,
+            Verdict.participation_id == participation_id,
+            Verdict.source == source,
+        )
+    )
+    verdict = existing.scalar_one_or_none()
+
+    if verdict is not None:
+        verdict.result = result
+        verdict.rounds = rounds
+        verdict.recorded_at = now
+    else:
+        verdict = Verdict(
+            id=uuid.uuid4(),
+            org_id=org_id,
+            participation_id=participation_id,
+            source=source,
+            result=result,
+            rounds=rounds,
+            recorded_at=now,
+        )
+        session.add(verdict)
+
+    await session.flush()
+    await session.refresh(verdict)
+    return verdict
+
+
+async def get_verdicts_by_participation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    participation_id: uuid.UUID,
+) -> list[Verdict]:
+    result = await session.execute(
+        select(Verdict).where(
+            Verdict.org_id == org_id,
+            Verdict.participation_id == participation_id,
+        )
+    )
+    return list(result.scalars().all())

--- a/backend/tests/test_e_cage_referee_p1_verdict.py
+++ b/backend/tests/test_e_cage_referee_p1_verdict.py
@@ -1,0 +1,226 @@
+"""E-CAGE-REFEREE P1: verdict 스키마 + 기록 인터페이스 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.verdict_recorder import record_verdict
+
+ORG_ID = uuid.uuid4()
+PARTICIPATION_ID = uuid.uuid4()
+VERDICT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_verdict(result="pass", rounds=1, source="pr"):
+    v = MagicMock()
+    v.id = VERDICT_ID
+    v.org_id = ORG_ID
+    v.participation_id = PARTICIPATION_ID
+    v.source = source
+    v.result = result
+    v.rounds = rounds
+    v.recorded_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    v.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return v
+
+
+# ── record_verdict 서비스 단위 테스트 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_record_verdict_new_creates():
+    """신규 verdict → INSERT."""
+    session = AsyncMock()
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = None  # 없음
+    session.execute = AsyncMock(return_value=existing_result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+
+    v = _mock_verdict()
+    session.refresh = AsyncMock(side_effect=lambda obj: None)
+
+    with pytest.MonkeyPatch().context() as mp:
+        # refresh 후 verdict 반환 시뮬
+        session.refresh = AsyncMock()
+        result_obj = await record_verdict(session, ORG_ID, PARTICIPATION_ID, "pr", "pass", 1)
+    session.add.assert_called_once()
+    session.flush.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_record_verdict_existing_updates():
+    """기존 verdict → UPDATE (upsert 멱등)."""
+    session = AsyncMock()
+    existing = _mock_verdict(result="fail", rounds=2)
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = existing
+    session.execute = AsyncMock(return_value=existing_result)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await record_verdict(session, ORG_ID, PARTICIPATION_ID, "pr", "pass", 3)
+
+    assert existing.result == "pass"
+    assert existing.rounds == 3
+    session.add.assert_not_called()  # UPDATE이므로 add 없음
+    session.flush.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_record_verdict_null_result():
+    """result=None → 미측정 null 유지 (거짓 pass/fail 금지)."""
+    session = AsyncMock()
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=existing_result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await record_verdict(session, ORG_ID, PARTICIPATION_ID, "ci", None)
+
+    # add된 객체의 result가 None인지 검증
+    added_obj = session.add.call_args[0][0]
+    assert added_obj.result is None
+
+
+@pytest.mark.anyio
+async def test_record_verdict_idempotent_rerecord():
+    """동일 (participation_id, source) 재기록 → 기존 row 갱신, 중복 없음."""
+    session = AsyncMock()
+    existing = _mock_verdict(result="fail", rounds=1)
+    existing_result = MagicMock()
+    existing_result.scalar_one_or_none.return_value = existing
+    session.execute = AsyncMock(return_value=existing_result)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await record_verdict(session, ORG_ID, PARTICIPATION_ID, "pr", "pass", 2)
+
+    # add 호출 없음(기존 갱신)
+    session.add.assert_not_called()
+    assert existing.result == "pass"
+    assert existing.rounds == 2
+
+
+# ── 공개 API 차단 검증 ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_no_public_post_verdict_endpoint():
+    """POST /api/v2/verdicts 엔드포인트 없음 — 에이전트 자기 verdict 수동기록 차단."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/verdicts", json={
+                "participation_id": str(PARTICIPATION_ID),
+                "source": "pr",
+                "result": "pass",
+            })
+        assert resp.status_code == 405, "POST /verdicts must not exist (Method Not Allowed)"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── GET verdict 조회 ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_verdicts_200():
+    """GET /api/v2/verdicts?participation_id=... → 200."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [_mock_verdict()]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(f"/api/v2/verdicts?participation_id={PARTICIPATION_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body) == 1
+        assert body[0]["source"] == "pr"
+        assert body[0]["result"] == "pass"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── org 격리 ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_org_isolation_verdict():
+    """다른 org의 verdict는 조회 안 됨."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(f"/api/v2/verdicts?participation_id={PARTICIPATION_ID}")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

- **migration 0064**: verdict 테이블(participation_id FK→CASCADE·source·result nullable·rounds·recorded_at). uq(participation_id,source). idempotent. **downgrade도 IF EXISTS 가드** (#1104 WARN 패턴 정비).
- **model**: Verdict(OrgScopedMixin) — result=null 허용(미측정 거짓채점 금지), source enum 하드코딩 없음
- **service**: record_verdict() — upsert 멱등 재기록. get_verdicts_by_participation(). **내부 전용**.
- **router**: GET /api/v2/verdicts (조회 전용). **POST 없음** — 에이전트 자기 verdict 수동기록 차단.

## AC2 — 공개 API 차단

POST /api/v2/verdicts 미등록 → 405. record_verdict() 내부만 기록 가능.

## null 가드

result=null 허용 — 미측정 소스 null 유지. 거짓 pass/fail 금지.

## Test plan

- [ ] record_verdict 단위 4건: 신규/갱신/null/멱등
- [ ] POST 차단 405 단언
- [ ] GET 200 + org 격리
- [ ] 전체 pytest 1287 PASS
- [ ] 머지 후 migration 0064 수동 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)