### PR TITLE
[E-CAGE-REFEREE P1] participation API + 자동기록 훅

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -103,6 +103,20 @@ async def list_stories(
     return [StoryResponse.model_validate(s) for s in stories]
 
 
+async def _upsert_assignee_participation(
+    session: AsyncSession, org_id: uuid.UUID, story_id: uuid.UUID, assignee_id: uuid.UUID
+) -> None:
+    """assignee 설정 시 implementation(default) 역할 participation 자동 upsert (멱등)."""
+    from app.repositories.participation import ParticipationRepository, ParticipationRoleRepository
+    role_repo = ParticipationRoleRepository(session, org_id)
+    default_role = await role_repo.get_default()
+    if default_role is None:
+        return
+    p_repo = ParticipationRepository(session, org_id)
+    if not await p_repo.exists(story_id, assignee_id, default_role.id):
+        await p_repo.create(story_id=story_id, member_id=assignee_id, role_id=default_role.id)
+
+
 @router.post("", response_model=StoryResponse, status_code=201)
 async def create_story(
     body: StoryCreate,
@@ -134,6 +148,9 @@ async def create_story(
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,
     )
+    # E-CAGE-REFEREE: assignee 설정 시 implementation 역할 participation 자동 생성
+    if body.assignee_id:
+        await _upsert_assignee_participation(session, org_id, story.id, body.assignee_id)
     return StoryResponse.model_validate(story)
 
 
@@ -166,6 +183,10 @@ async def update_story(
     story = await repo.update(id, **data)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
+
+    # E-CAGE-REFEREE: assignee 변경(신규 세팅) 시 implementation 역할 participation 자동 upsert
+    if "assignee_id" in data and story.assignee_id:
+        await _upsert_assignee_participation(db, repo.org_id, story.id, story.assignee_id)
 
     # 변경사항 먼저 commit — side effects 에러가 rollback시키지 않도록
     await db.commit()

--- a/backend/tests/test_e_cage_referee_p1_participation_api.py
+++ b/backend/tests/test_e_cage_referee_p1_participation_api.py
@@ -1,0 +1,242 @@
+"""E-CAGE-REFEREE P1: participation API + 자동기록 훅 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_story_obj(assignee_id=None):
+    s = MagicMock()
+    s.id = STORY_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.epic_id = None
+    s.sprint_id = None
+    s.assignee_id = assignee_id
+    s.meeting_id = None
+    s.title = "Story 1"
+    s.status = "backlog"
+    s.priority = "medium"
+    s.story_points = 3
+    s.description = None
+    s.acceptance_criteria = None
+    s.position = None
+    s.is_excluded = False
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
+    s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return s
+
+
+def _mock_role():
+    r = MagicMock()
+    r.id = ROLE_ID
+    r.org_id = ORG_ID
+    r.key = "implementation"
+    r.label = "구현"
+    r.is_default = True
+    r.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return r
+
+
+async def _make_client(mock_session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}}
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+# ── 자동기록 훅 — create_story ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_story_with_assignee_auto_creates_participation():
+    """create_story + assignee → _upsert_assignee_participation 호출 단언."""
+    mock_session = AsyncMock()
+    story = _mock_story_obj(assignee_id=MEMBER_ID)
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert:
+            mock_create.return_value = story
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Story 1",
+                    "assignee_id": str(MEMBER_ID),
+                })
+            assert resp.status_code == 201
+            # _upsert_assignee_participation이 실제 호출됐는지 단언
+            mock_upsert.assert_called_once()
+            call_args = mock_upsert.call_args[0]
+            assert call_args[2] == story.id   # story_id
+            assert call_args[3] == MEMBER_ID   # assignee_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_create_story_without_assignee_no_participation():
+    """create_story + assignee 없음 → participation 자동기록 없음."""
+    mock_session = AsyncMock()
+    story = _mock_story_obj(assignee_id=None)
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert:
+            mock_create.return_value = story
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Story 1",
+                })
+            assert resp.status_code == 201
+            mock_upsert.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── 자동기록 훅 — update_story ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_update_story_assignee_auto_creates_participation():
+    """update_story assignee 변경 → _upsert_assignee_participation 호출 단언."""
+    mock_session = AsyncMock()
+    story = _mock_story_obj(assignee_id=MEMBER_ID)
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock) as mock_update, \
+             patch("app.repositories.story.StoryRepository.get", new_callable=AsyncMock) as mock_get, \
+             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock) as mock_upsert, \
+             patch("app.routers.stories._resolve_team_member_id", new_callable=AsyncMock, return_value=None), \
+             patch("app.routers.stories._resolve_actor_info", new_callable=AsyncMock, return_value=(None, None, None)):
+            mock_update.return_value = story
+            mock_get.return_value = _mock_story_obj(assignee_id=None)
+            mock_session.commit = AsyncMock()
+            async with client as c:
+                resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={
+                    "assignee_id": str(MEMBER_ID),
+                })
+            assert resp.status_code == 200
+            mock_upsert.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── _upsert_assignee_participation 멱등성 단위 테스트 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_upsert_assignee_participation_idempotent():
+    """이미 participation 존재 → 중복 생성 안 함."""
+    from app.routers.stories import _upsert_assignee_participation
+
+    session = AsyncMock()
+    default_role = _mock_role()
+
+    with patch("app.repositories.participation.ParticipationRoleRepository.get_default", new_callable=AsyncMock) as mock_role, \
+         patch("app.repositories.participation.ParticipationRepository.exists", new_callable=AsyncMock) as mock_exists, \
+         patch("app.repositories.participation.ParticipationRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_role.return_value = default_role
+        mock_exists.return_value = True  # 이미 존재
+
+        await _upsert_assignee_participation(session, ORG_ID, STORY_ID, MEMBER_ID)
+
+        mock_create.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_upsert_assignee_participation_creates_when_not_exists():
+    """participation 없음 → 신규 생성."""
+    from app.routers.stories import _upsert_assignee_participation
+
+    session = AsyncMock()
+    default_role = _mock_role()
+
+    with patch("app.repositories.participation.ParticipationRoleRepository.get_default", new_callable=AsyncMock) as mock_role, \
+         patch("app.repositories.participation.ParticipationRepository.exists", new_callable=AsyncMock) as mock_exists, \
+         patch("app.repositories.participation.ParticipationRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_role.return_value = default_role
+        mock_exists.return_value = False  # 없음
+
+        await _upsert_assignee_participation(session, ORG_ID, STORY_ID, MEMBER_ID)
+
+        mock_create.assert_called_once()
+        call_kwargs = mock_create.call_args[1]
+        assert call_kwargs["story_id"] == STORY_ID
+        assert call_kwargs["member_id"] == MEMBER_ID
+        assert call_kwargs["role_id"] == default_role.id
+
+
+@pytest.mark.anyio
+async def test_upsert_no_default_role_skips():
+    """org에 default role 없으면 조용히 스킵."""
+    from app.routers.stories import _upsert_assignee_participation
+
+    session = AsyncMock()
+
+    with patch("app.repositories.participation.ParticipationRoleRepository.get_default", new_callable=AsyncMock) as mock_role, \
+         patch("app.repositories.participation.ParticipationRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_role.return_value = None  # default role 없음
+
+        await _upsert_assignee_participation(session, ORG_ID, STORY_ID, MEMBER_ID)
+
+        mock_create.assert_not_called()
+
+
+# ── 기존 story create/update 비파괴 ───────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_story_without_assignee_still_201():
+    """assignee 없이 create_story → 정상 201 (기존 동작 비파괴)."""
+    mock_session = AsyncMock()
+    story = _mock_story_obj(assignee_id=None)
+
+    client, app = await _make_client(mock_session)
+    try:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+            mock_create.return_value = story
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "Story without assignee",
+                })
+        assert resp.status_code == 201
+        assert resp.json()["title"] == "Story 1"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

마이그레이션 없음 (스키마 0063 이미 라이브).

- **_upsert_assignee_participation()**: org default role 탐색 → exists 체크 → 멱등 upsert
- **create_story**: assignee_id 세팅 시 자동 participation 생성. dead-path 처음부터 와이어링.
- **update_story**: assignee_id 변경 시 → db.commit() 전 동일 트랜잭션 내 호출.

## dead-path 방지

create/update 핸들러에 즉시 와이어링. 테스트 호출 단언(assert_called_once) — seed 우회 없음.

## Test plan

- [ ] create+assignee → _upsert 호출 (story_id·assignee_id 검증)
- [ ] create-no-assignee → 자동기록 없음
- [ ] update+assignee → 자동기록 호출
- [ ] 멱등성(exists=true) + 신규생성(exists=false) + no-default-role skip
- [ ] create 기존 동작 비파괴
- [ ] 전체 pytest 1300 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)