### PR TITLE
[SID:0a1c1476] [E-BOARD-SCHEMA][FE-EPIC] Epic outcome 표시 + intent 입력

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2224,6 +2224,8 @@
     "metric_velocity": "Velocity",
     "metric_backlog_remaining": "Backlog remaining",
     "metric_progress": "Progress",
-    "hypothesisPlaceholder_story": "What would be different if this story succeeds?"
+    "hypothesisPlaceholder_story": "What would be different if this story succeeds?",
+    "metric_completion_pct": "Completion %",
+    "hypothesisPlaceholder_epic": "What outcome do we expect by completing this epic?"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2224,6 +2224,8 @@
     "metric_velocity": "벨로시티",
     "metric_backlog_remaining": "백로그 잔여",
     "metric_progress": "진행률",
-    "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?"
+    "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?",
+    "metric_completion_pct": "완료율 %",
+    "hypothesisPlaceholder_epic": "이 에픽을 완수하면 어떤 성과를 기대하는가?"
   }
 }

--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -15,6 +15,9 @@ import {
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
+import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 
 type EpicStatus = 'draft' | 'active' | 'done' | 'archived';
 type EpicPriority = 'critical' | 'high' | 'medium' | 'low';
@@ -42,6 +45,11 @@ interface Epic {
   project_id?: string;
   created_at: string;
   stories?: Story[];
+  success_hypothesis?: string | null;
+  metric_definition?: Record<string, unknown> | null;
+  measure_after?: string | null;
+  outcome_status?: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result?: Record<string, unknown> | null;
 }
 
 // ─── Story status order for grouping ─────────────────────────────────────────
@@ -143,6 +151,11 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
   const [priority, setPriority] = useState<EpicPriority>(epic.priority);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined && epic.target_sp !== null ? String(epic.target_sp) : '');
+  const [intent, setIntent] = useState<OutcomeIntentValue>({
+    success_hypothesis: epic.success_hypothesis ?? '',
+    metric_definition: (epic.metric_definition as import('@sprintable/core-storage').MetricDefinition | null) ?? null,
+    measure_after: epic.measure_after?.slice(0, 10) ?? '',
+  });
   const [saving, setSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
@@ -159,6 +172,9 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
           success_criteria: successCriteria.trim() || undefined,
           status,
           priority,
+          success_hypothesis: intent.success_hypothesis.trim() || null,
+          metric_definition: intent.metric_definition ?? null,
+          measure_after: intent.measure_after || null,
           ...(targetDate ? { target_date: targetDate } : {}),
           ...(targetSp ? { target_sp: Number(targetSp) } : {}),
         }),
@@ -169,7 +185,7 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
     } finally {
       setSaving(false);
     }
-  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, epic, onSaved]);
+  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, intent, epic, onSaved]);
 
   const inputCls = 'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
 
@@ -195,6 +211,7 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
         <input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} className={inputCls} />
         <input type="number" min="0" value={targetSp} onChange={(e) => setTargetSp(e.target.value)} className={inputCls} placeholder="목표 SP" />
       </div>
+      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
       <div className="flex justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>취소</Button>
         <Button size="sm" disabled={saving || !title.trim()} onClick={() => void handleSave()}>
@@ -303,6 +320,7 @@ export default function EpicDetailPage() {
           <div className="flex flex-wrap items-center gap-2">
             <Badge variant={statusBadgeVariant(epic.status)}>{epic.status}</Badge>
             <Badge variant={priorityBadgeVariant(epic.priority)}>{epic.priority}</Badge>
+            {epic.outcome_status && epic.outcome_status !== 'n_a' ? <OutcomeStatusBadge status={epic.outcome_status} /> : null}
             {epic.target_date && <span className="text-xs text-muted-foreground">마감: {formatDate(epic.target_date)}</span>}
             {epic.target_sp != null && <span className="text-xs text-muted-foreground">목표 SP: {epic.target_sp}</span>}
           </div>
@@ -335,6 +353,16 @@ export default function EpicDetailPage() {
 
         {!isEditing && (
           <>
+            {/* Outcome result */}
+            {epic.outcome_status && epic.outcome_status !== 'n_a' ? (
+              <OutcomeResultCard
+                status={epic.outcome_status}
+                hypothesis={epic.success_hypothesis ?? null}
+                result={(epic.outcome_result as OutcomeResult | null) ?? null}
+                pendingMetricLabel={(epic.metric_definition as { metric?: string } | null)?.metric ?? undefined}
+              />
+            ) : null}
+
             {/* Description */}
             <section className="space-y-2">
               <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground">설명</h2>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -13,6 +13,8 @@ import {
   DialogFooter, DialogHeader, DialogTitle,
 } from '@/components/ui/dialog';
 import { ToastContainer, useToast } from '@/components/ui/toast';
+import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
+import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -36,6 +38,11 @@ interface Epic {
   target_sp?: number;
   created_at: string;
   stories?: Story[];
+  success_hypothesis?: string | null;
+  metric_definition?: Record<string, unknown> | null;
+  measure_after?: string | null;
+  outcome_status?: 'n_a' | 'pending' | 'hit' | 'miss' | null;
+  outcome_result?: Record<string, unknown> | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -130,6 +137,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
   const [priority, setPriority] = useState<EpicPriority>('medium');
   const [targetDate, setTargetDate] = useState('');
   const [targetSp, setTargetSp] = useState('');
+  const [intent, setIntent] = useState<OutcomeIntentValue>({ success_hypothesis: '', metric_definition: null, measure_after: '' });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -150,6 +158,9 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
       };
       if (targetDate) body.target_date = targetDate;
       if (targetSp) body.target_sp = Number(targetSp);
+      if (intent.success_hypothesis.trim()) body.success_hypothesis = intent.success_hypothesis.trim();
+      if (intent.metric_definition) body.metric_definition = intent.metric_definition;
+      if (intent.measure_after) body.measure_after = intent.measure_after;
 
       const res = await fetch('/api/epics', {
         method: 'POST',
@@ -166,7 +177,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
     } finally {
       setSubmitting(false);
     }
-  }, [title, description, priority, targetDate, targetSp, projectId, orgId, onCreated]);
+  }, [title, description, priority, targetDate, targetSp, intent, projectId, orgId, onCreated]);
 
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
@@ -231,6 +242,8 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
         />
       </div>
 
+      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
+
       {error ? <p className="text-xs text-destructive">{error}</p> : null}
 
       <div className="flex justify-end gap-2 pt-2">
@@ -261,6 +274,11 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
   const [status, setStatus] = useState<EpicStatus>(epic.status);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined ? String(epic.target_sp) : '');
+  const [intent, setIntent] = useState<OutcomeIntentValue>({
+    success_hypothesis: epic.success_hypothesis ?? '',
+    metric_definition: (epic.metric_definition as import('@sprintable/core-storage').MetricDefinition | null) ?? null,
+    measure_after: epic.measure_after?.slice(0, 10) ?? '',
+  });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -277,6 +295,9 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
         description: description.trim() || undefined,
         priority,
         status,
+        success_hypothesis: intent.success_hypothesis.trim() || null,
+        metric_definition: intent.metric_definition ?? null,
+        measure_after: intent.measure_after || null,
       };
       if (targetDate) body.target_date = targetDate;
       if (targetSp) body.target_sp = Number(targetSp);
@@ -296,7 +317,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
     } finally {
       setSubmitting(false);
     }
-  }, [title, description, priority, status, targetDate, targetSp, epic.id, epic.stories, onSaved]);
+  }, [title, description, priority, status, targetDate, targetSp, intent, epic.id, epic.stories, onSaved]);
 
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
@@ -374,6 +395,8 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           />
         </div>
       </div>
+
+      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
 
       {error ? <p className="text-xs text-destructive">{error}</p> : null}
 
@@ -471,6 +494,11 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
               className="h-full rounded-full bg-primary transition-all duration-300"
               style={{ width: `${pct}%` }}
             />
+          </div>
+        ) : null}
+        {epic.outcome_status && epic.outcome_status !== 'n_a' ? (
+          <div className="pt-0.5">
+            <OutcomeStatusBadge status={epic.outcome_status} />
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/outcome/outcome-intent-fields.tsx
+++ b/apps/web/src/components/outcome/outcome-intent-fields.tsx
@@ -6,7 +6,7 @@ import type { MetricDefinition } from '@sprintable/core-storage';
 
 export type { MetricDefinition };
 export interface OutcomeIntentValue { success_hypothesis: string; metric_definition: MetricDefinition | null; measure_after: string; }
-const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress'] as const;
+const INTERNAL_METRICS = ['velocity', 'backlog_remaining', 'progress', 'completion_pct'] as const;
 
 interface OutcomeIntentFieldsProps {
   value: OutcomeIntentValue;
@@ -14,7 +14,7 @@ interface OutcomeIntentFieldsProps {
   defaultOpen?: boolean;
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
-  context?: 'sprint' | 'story';
+  context?: 'sprint' | 'story' | 'epic';
 }
 
 export function OutcomeIntentFields({ value, onChange, defaultOpen = false, open: controlledOpen, onOpenChange, context = 'sprint' }: OutcomeIntentFieldsProps) {
@@ -30,7 +30,7 @@ export function OutcomeIntentFields({ value, onChange, defaultOpen = false, open
     const base: MetricDefinition = md ?? { metric: 'velocity', source: 'internal_ops', target: 0, direction: 'up' };
     onChange({ ...value, metric_definition: { ...base, ...patch } });
   };
-  const placeholder = context === 'story' ? t('hypothesisPlaceholder_story') : t('hypothesisPlaceholder');
+  const placeholder = context === 'story' ? t('hypothesisPlaceholder_story') : context === 'epic' ? t('hypothesisPlaceholder_epic') : t('hypothesisPlaceholder');
   if (!open) return (
     <button type="button" onClick={() => setOpen(true)}
       className="w-full rounded-xl border border-dashed border-border py-2.5 text-sm text-muted-foreground transition hover:border-primary hover:text-primary">


### PR DESCRIPTION
## 변경 사항

- **outcome-intent-fields.tsx**: context='epic' 추가 + completion_pct metric 옵션 (sprint/story 무회귀)
- **epics/[id]/page.tsx**: Epic 타입 outcome 필드 추가, 헤더 OutcomeStatusBadge, 본문 OutcomeResultCard, EpicEditInline OutcomeIntentFields(context='epic')
- **epics-client.tsx**: Epic 타입 outcome 필드, EpicRow 풋터 OutcomeStatusBadge, EpicCreateForm + EpicEditForm OutcomeIntentFields
- **i18n**: outcomeLoop.metric_completion_pct + hypothesisPlaceholder_epic en/ko

## AC 확인

| 항목 | 상태 |
|---|---|
| Epic 상세 헤더 OutcomeStatusBadge | ✅ |
| Epic 상세 본문 OutcomeResultCard | ✅ |
| Epic 리스트 카드 OutcomeStatusBadge (n_a 자동 미표시) | ✅ |
| EpicCreateForm OutcomeIntentFields(context='epic') | ✅ |
| EpicEditInline OutcomeIntentFields(context='epic') | ✅ |
| completion_pct metric + sprint/story 무회귀 | ✅ |
| miss=중립 ink — OutcomeResultCard 재사용 무변경 | ✅ |
| pnpm type-check 에러 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)