### PR TITLE
[E-CAGE-REFEREE P1] PR·CI verdict 자동 포착

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -116,6 +116,7 @@ app.include_router(labels.item_label_router)
 app.include_router(participation.router)
 app.include_router(verdicts.router)
 app.include_router(exclusion.router)
+app.include_router(verdict_capture.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -1,0 +1,75 @@
+"""E-CAGE-REFEREE P1: PR·CI verdict 캡처 내부 엔드포인트.
+
+CRON_SECRET 인증 필요. 외부 노출 없음.
+풀 GitHub webhook은 후속 — MVP는 머지 후 수동/cron 트리거.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.database import get_db
+from app.models.pm import Story
+from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
+from app.services.verdict_capture import capture_pr_ci_verdict, parse_story_id
+from fastapi import Depends
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/internal/verdict", tags=["verdict-capture"])
+
+
+class CaptureBody(BaseModel):
+    pr_title: str
+    pr_number: int
+    repo: str = "moonklabs/sprintable"
+    merged: bool = True
+    ci_result: str | None = None
+
+
+@router.post("/capture-pr")
+async def capture_pr_verdict(
+    request: Request,
+    body: CaptureBody,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """머지된 PR 기준 PR·CI verdict 포착.
+
+    [SID:story_uuid] 태그가 없거나 participation이 없으면 skip(거짓기록 금지).
+    """
+    verify_cron(request)
+
+    # SID 파싱
+    story_id = parse_story_id(body.pr_title)
+    if story_id is None:
+        return _ok({"skipped_reason": "no_sid_tag", "recorded": []})
+
+    # story 조회 → org_id 획득
+    story_r = await session.execute(
+        select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
+    )
+    story = story_r.scalar_one_or_none()
+    if story is None:
+        return _ok({"skipped_reason": "story_not_found", "recorded": []})
+
+    try:
+        result = await capture_pr_ci_verdict(
+            session=session,
+            org_id=story.org_id,
+            story_id=story_id,
+            pr_number=body.pr_number,
+            repo=body.repo,
+            merged=body.merged,
+            ci_result=body.ci_result,
+        )
+        await session.commit()
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("verdict capture failed: %s", exc)
+        return _err("INTERNAL_ERROR", "verdict capture failed", 500)

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -1,0 +1,138 @@
+"""E-CAGE-REFEREE P1: PR·CI verdict 자동 포착 서비스.
+
+[SID:story_uuid] 태그 파싱 → story → implementation participation → record_verdict.
+SID/participation 없으면 skip(거짓기록 금지). garbage-in 차단.
+멱등: record_verdict uq upsert가 보장.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.participation import Participation, ParticipationRole
+from app.models.pm import Story
+from app.services.verdict_recorder import record_verdict
+
+logger = logging.getLogger(__name__)
+
+_SID_RE = re.compile(r"\[SID:([0-9a-f\-]{36})\]", re.IGNORECASE)
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
+
+
+def parse_story_id(text: str) -> uuid.UUID | None:
+    """PR/커밋 제목에서 [SID:uuid] 태그 파싱. 없으면 None(skip 신호)."""
+    m = _SID_RE.search(text)
+    if not m:
+        return None
+    try:
+        return uuid.UUID(m.group(1))
+    except ValueError:
+        return None
+
+
+async def resolve_implementation_participation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+) -> Participation | None:
+    """스토리의 implementation(default) 역할 participation 탐색.
+
+    없으면 None → 호출자가 skip 처리.
+    """
+    role_r = await session.execute(
+        select(ParticipationRole).where(
+            ParticipationRole.org_id == org_id,
+            ParticipationRole.is_default.is_(True),
+        ).limit(1)
+    )
+    default_role = role_r.scalar_one_or_none()
+    if default_role is None:
+        return None
+
+    p_r = await session.execute(
+        select(Participation).where(
+            Participation.org_id == org_id,
+            Participation.story_id == story_id,
+            Participation.role_id == default_role.id,
+        ).limit(1)
+    )
+    return p_r.scalar_one_or_none()
+
+
+async def fetch_pr_review_rounds(repo: str, pr_number: int) -> int:
+    """GitHub API에서 changes-requested 라운드 수 조회.
+
+    GITHUB_TOKEN 없거나 실패 시 0 반환(거짓 rounds 대신 null 처리).
+    rate limit·네트워크 오류는 조용히 0 처리.
+    """
+    if not GITHUB_TOKEN:
+        return 0
+    try:
+        import httpx
+        url = f"https://api.github.com/repos/{repo}/pulls/{pr_number}/reviews"
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                url,
+                headers={
+                    "Authorization": f"Bearer {GITHUB_TOKEN}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+        if resp.status_code != 200:
+            return 0
+        reviews: list[dict[str, Any]] = resp.json()
+        return sum(1 for r in reviews if r.get("state") == "CHANGES_REQUESTED")
+    except Exception as exc:
+        logger.warning("GitHub review fetch failed repo=%s pr=%d: %s", repo, pr_number, exc)
+        return 0
+
+
+async def capture_pr_ci_verdict(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    pr_number: int,
+    repo: str,
+    merged: bool,
+    ci_result: str | None,
+) -> dict[str, Any]:
+    """PR/CI verdict 포착 진입점.
+
+    Returns:
+        {"recorded": [...], "skipped_reason": str | None}
+    """
+    participation = await resolve_implementation_participation(session, org_id, story_id)
+    if participation is None:
+        return {"recorded": [], "skipped_reason": "no_implementation_participation"}
+
+    recorded: list[str] = []
+
+    # source=pr: 머지 여부 + rounds
+    if merged:
+        rounds = await fetch_pr_review_rounds(repo, pr_number)
+        await record_verdict(
+            session, org_id, participation.id,
+            source="pr",
+            result="pass",
+            rounds=rounds if rounds > 0 else None,
+        )
+        recorded.append("pr")
+
+    # source=ci: CI 결과
+    if ci_result is not None:
+        normalized = "pass" if ci_result.lower() in ("pass", "success") else "fail"
+        await record_verdict(
+            session, org_id, participation.id,
+            source="ci",
+            result=normalized,
+            rounds=None,
+        )
+        recorded.append("ci")
+
+    return {"recorded": recorded, "skipped_reason": None}

--- a/backend/tests/test_e_cage_referee_p1_verdict_capture.py
+++ b/backend/tests/test_e_cage_referee_p1_verdict_capture.py
@@ -1,0 +1,245 @@
+"""E-CAGE-REFEREE P1: PR·CI verdict 자동 포착 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.verdict_capture import parse_story_id
+
+ORG_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+PARTICIPATION_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── SID 태그 파싱 단위 테스트 ─────────────────────────────────────────────────
+
+def test_parse_story_id_valid():
+    sid = uuid.uuid4()
+    title = f"[SID:{sid}] feat: some feature"
+    result = parse_story_id(title)
+    assert result == sid
+
+
+def test_parse_story_id_no_tag_returns_none():
+    assert parse_story_id("feat: no sid here") is None
+    assert parse_story_id("") is None
+
+
+def test_parse_story_id_invalid_uuid_returns_none():
+    assert parse_story_id("[SID:not-a-uuid] title") is None
+
+
+def test_parse_story_id_case_insensitive():
+    sid = uuid.uuid4()
+    assert parse_story_id(f"[sid:{sid}] title") == sid
+
+
+def test_parse_story_id_in_middle():
+    sid = uuid.uuid4()
+    assert parse_story_id(f"prefix [SID:{sid}] suffix") == sid
+
+
+# ── resolve_implementation_participation 단위 테스트 ─────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_returns_participation_when_found():
+    from app.services.verdict_capture import resolve_implementation_participation
+
+    session = AsyncMock()
+    role = MagicMock()
+    role.id = ROLE_ID
+
+    participation = MagicMock()
+    participation.id = PARTICIPATION_ID
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        r = MagicMock()
+        if call_count == 1:
+            r.scalar_one_or_none.return_value = role
+        else:
+            r.scalar_one_or_none.return_value = participation
+        return r
+
+    session.execute = mock_execute
+    result = await resolve_implementation_participation(session, ORG_ID, STORY_ID)
+    assert result == participation
+
+
+@pytest.mark.anyio
+async def test_resolve_returns_none_when_no_default_role():
+    from app.services.verdict_capture import resolve_implementation_participation
+
+    session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=mock_r)
+
+    result = await resolve_implementation_participation(session, ORG_ID, STORY_ID)
+    assert result is None
+
+
+# ── capture_pr_ci_verdict 서비스 테스트 ───────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_capture_merged_pr_records_pr_verdict():
+    """머지된 PR → source=pr result=pass verdict 기록."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+    participation = MagicMock()
+    participation.id = PARTICIPATION_ID
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.services.verdict_capture.fetch_pr_review_rounds", new_callable=AsyncMock) as mock_rounds, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_resolve.return_value = participation
+        mock_rounds.return_value = 2  # 2회 RC
+
+        result = await capture_pr_ci_verdict(
+            session, ORG_ID, STORY_ID, pr_number=1108,
+            repo="moonklabs/sprintable", merged=True, ci_result=None
+        )
+
+        assert "pr" in result["recorded"]
+        assert result["skipped_reason"] is None
+        # record_verdict(_, 'pr', 'pass', rounds=2)
+        mock_record.assert_called_once()
+        call_kwargs = mock_record.call_args[1]
+        assert call_kwargs["source"] == "pr"
+        assert call_kwargs["result"] == "pass"
+        assert call_kwargs["rounds"] == 2
+
+
+@pytest.mark.anyio
+async def test_capture_ci_fail_records_ci_verdict():
+    """CI fail → source=ci result=fail verdict 기록."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+    participation = MagicMock()
+    participation.id = PARTICIPATION_ID
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_resolve.return_value = participation
+
+        result = await capture_pr_ci_verdict(
+            session, ORG_ID, STORY_ID, pr_number=1108,
+            repo="moonklabs/sprintable", merged=False, ci_result="failure"
+        )
+
+        assert "ci" in result["recorded"]
+        call_kwargs_list = [c[1] for c in mock_record.call_args_list]
+        ci_call = next(k for k in call_kwargs_list if k["source"] == "ci")
+        assert ci_call["result"] == "fail"
+
+
+@pytest.mark.anyio
+async def test_capture_no_participation_skips():
+    """participation 없으면 skip (거짓기록 금지)."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_resolve.return_value = None
+
+        result = await capture_pr_ci_verdict(
+            session, ORG_ID, STORY_ID, pr_number=999,
+            repo="moonklabs/sprintable", merged=True, ci_result="success"
+        )
+
+        assert result["skipped_reason"] == "no_implementation_participation"
+        mock_record.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_capture_idempotent_via_record_verdict():
+    """record_verdict(uq upsert)로 멱등 보장 — 동일 호출 2회 = upsert."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+    participation = MagicMock()
+    participation.id = PARTICIPATION_ID
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_resolve, \
+         patch("app.services.verdict_capture.fetch_pr_review_rounds", new_callable=AsyncMock) as mock_rounds, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_resolve.return_value = participation
+        mock_rounds.return_value = 0
+
+        await capture_pr_ci_verdict(session, ORG_ID, STORY_ID, 1108, "org/repo", True, "success")
+        await capture_pr_ci_verdict(session, ORG_ID, STORY_ID, 1108, "org/repo", True, "success")
+
+        # record_verdict 2회 호출 (upsert이므로 내부에서 update 처리)
+        assert mock_record.call_count == 4  # pr+ci 각 2번
+
+
+# ── 내부 캡처 엔드포인트 통합 테스트 ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_capture_pr_endpoint_no_sid_skips():
+    """SID 없는 PR → skipped_reason=no_sid_tag."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v2/internal/verdict/capture-pr",
+                json={"pr_title": "feat: no sid tag", "pr_number": 999, "merged": True},
+                headers={"Authorization": "Bearer "},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["skipped_reason"] == "no_sid_tag"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_capture_pr_endpoint_story_not_found_skips():
+    """SID 있지만 story 없음 → skipped_reason=story_not_found."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None  # story 없음
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v2/internal/verdict/capture-pr",
+                json={"pr_title": f"[SID:{STORY_ID}] title", "pr_number": 999, "merged": True},
+                headers={"Authorization": "Bearer "},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["skipped_reason"] == "story_not_found"
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

마이그레이션 없음 (verdict 테이블 0064 라이브).

- **`parse_story_id()`**: `[SID:uuid]` 태그 파싱. 없으면 None → skip
- **`resolve_implementation_participation()`**: org default role(is_default=True) → participation 탐색. 없으면 None → skip (거짓기록 금지)
- **`fetch_pr_review_rounds()`**: GitHub API `/pulls/{n}/reviews` → CHANGES_REQUESTED 라운드 수. GITHUB_TOKEN 없거나 실패 시 0 (조용히 graceful)
- **`capture_pr_ci_verdict()`**: merged=True → source=pr result=pass, ci_result → source=ci result=pass/fail. `record_verdict()` 호출 (uq upsert 멱등)
- **`POST /api/v2/internal/verdict/capture-pr`**: CRON_SECRET 인증. SID없음·story없음·participation없음 각각 skipped_reason으로 skip

## 거짓기록 방지 (garbage-in 차단)

3단계 skip gate: SID 파싱 실패 → story_not_found → participation 없음. 각 단계서 즉시 skip 반환.

## Test plan

- [ ] parse_story_id 5종: valid/no-tag/invalid-uuid/case-insensitive/in-middle
- [ ] resolve 2종: found/no-default-role
- [ ] capture: PR rounds + CI fail + no-participation skip + idempotent
- [ ] endpoint: no-sid skip + story-not-found skip
- [ ] 전체 pytest 1313 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)