### PR TITLE
[E-CAGE-REFEREE P1] QA·디자인 게이트 verdict 포착

### DIFF
--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
-from app.services.verdict_capture import capture_pr_ci_verdict, parse_story_id
+from app.services.verdict_capture import capture_pr_ci_verdict, capture_review_verdict, parse_story_id
 from fastapi import Depends
 
 logger = logging.getLogger(__name__)
@@ -73,3 +73,58 @@ async def capture_pr_verdict(
     except Exception as exc:
         logger.exception("verdict capture failed: %s", exc)
         return _err("INTERNAL_ERROR", "verdict capture failed", 500)
+
+
+# ── QA·디자인 게이트 verdict 캡처 ─────────────────────────────────────────────
+
+_VALID_REVIEW_ROLES = frozenset({"qa", "design"})
+
+
+class CaptureReviewBody(BaseModel):
+    story_id: uuid.UUID
+    role: str                # 'qa' | 'design'
+    member_id: uuid.UUID
+    result: str | None = None  # 'pass' | 'fail' | None
+    rounds: int | None = None
+
+
+@router.post("/capture-review")
+async def capture_review(
+    request: Request,
+    body: CaptureReviewBody,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """QA·디자인 게이트 결과 → verdict 기록 (CRON_SECRET 인증).
+
+    트리거 경위: send_chat_message review_type 자동 훅 불가(FastAPI 스키마 미노출·
+    Conversation에 story_id 링크 없음)→ MVP 내부 엔드포인트 택일.
+    role 없거나 story 없으면 skip(거짓기록 금지). uq(participation,source) 멱등.
+    """
+    verify_cron(request)
+
+    if body.role not in _VALID_REVIEW_ROLES:
+        return _err("INVALID_ROLE", f"role must be one of {sorted(_VALID_REVIEW_ROLES)}", 422)
+
+    # story 조회 → org_id 획득
+    story_r = await session.execute(
+        select(Story).where(Story.id == body.story_id, Story.deleted_at.is_(None))
+    )
+    story = story_r.scalar_one_or_none()
+    if story is None:
+        return _ok({"skipped_reason": "story_not_found", "recorded": False})
+
+    try:
+        result = await capture_review_verdict(
+            session=session,
+            org_id=story.org_id,
+            story_id=body.story_id,
+            role_key=body.role,
+            member_id=body.member_id,
+            result=body.result,
+            rounds=body.rounds,
+        )
+        await session.commit()
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("review verdict capture failed: %s", exc)
+        return _err("INTERNAL_ERROR", "review verdict capture failed", 500)

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -136,3 +136,74 @@ async def capture_pr_ci_verdict(
         recorded.append("ci")
 
     return {"recorded": recorded, "skipped_reason": None}
+
+
+# ── QA·디자인 게이트 verdict 포착 ───────────────────────────────────────────────
+
+async def ensure_review_participation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    member_id: uuid.UUID,
+    role_key: str,
+) -> Participation | None:
+    """QA·디자인 역할 participation ensure — 없으면 생성, 있으면 반환.
+
+    implementation(default) 역할 upsert와 달리, QA/디자인은 assignee가 아닌
+    게이트키퍼가 별도로 생성되므로 ensure(없으면 create).
+    role_key가 org에 없으면 None → skip.
+    """
+    from app.repositories.participation import ParticipationRepository
+
+    role_r = await session.execute(
+        select(ParticipationRole).where(
+            ParticipationRole.org_id == org_id,
+            ParticipationRole.key == role_key,
+        ).limit(1)
+    )
+    role = role_r.scalar_one_or_none()
+    if role is None:
+        return None
+
+    p_repo = ParticipationRepository(session, org_id)
+    if not await p_repo.exists(story_id, member_id, role.id):
+        return await p_repo.create(story_id=story_id, member_id=member_id, role_id=role.id)
+
+    existing_r = await session.execute(
+        select(Participation).where(
+            Participation.org_id == org_id,
+            Participation.story_id == story_id,
+            Participation.member_id == member_id,
+            Participation.role_id == role.id,
+        ).limit(1)
+    )
+    return existing_r.scalar_one_or_none()
+
+
+async def capture_review_verdict(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    story_id: uuid.UUID,
+    role_key: str,
+    member_id: uuid.UUID,
+    result: str | None,
+    rounds: int | None = None,
+) -> dict[str, Any]:
+    """QA/디자인 게이트 결과를 verdict로 기록.
+
+    role_key: 'qa' | 'design' (org participation_role.key)
+    result: 'pass' | 'fail' | None
+    멱등: record_verdict uq(participation_id, source) upsert.
+    role 없거나 story 없으면 skip(거짓기록 금지).
+    """
+    participation = await ensure_review_participation(session, org_id, story_id, member_id, role_key)
+    if participation is None:
+        return {"recorded": False, "skipped_reason": f"no_{role_key}_role"}
+
+    await record_verdict(
+        session, org_id, participation.id,
+        source=role_key,
+        result=result,
+        rounds=rounds,
+    )
+    return {"recorded": True, "source": role_key, "result": result, "skipped_reason": None}

--- a/backend/tests/test_e_cage_referee_p1_review_verdict.py
+++ b/backend/tests/test_e_cage_referee_p1_review_verdict.py
@@ -1,0 +1,274 @@
+"""E-CAGE-REFEREE P1: QA·디자인 게이트 verdict 포착 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+PARTICIPATION_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_role(key="qa"):
+    r = MagicMock()
+    r.id = ROLE_ID
+    r.org_id = ORG_ID
+    r.key = key
+    r.label = "QA" if key == "qa" else "디자인"
+    r.is_default = False
+    return r
+
+
+def _mock_participation():
+    p = MagicMock()
+    p.id = PARTICIPATION_ID
+    p.org_id = ORG_ID
+    p.story_id = STORY_ID
+    p.member_id = MEMBER_ID
+    p.role_id = ROLE_ID
+    return p
+
+
+# ── ensure_review_participation 단위 테스트 ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_ensure_creates_participation_when_not_exists():
+    """QA participation 없으면 신규 생성."""
+    from app.services.verdict_capture import ensure_review_participation
+
+    session = AsyncMock()
+    role = _mock_role("qa")
+    new_p = _mock_participation()
+
+    async def mock_execute(stmt, *args, **kwargs):
+        r = MagicMock()
+        r.scalar_one_or_none.return_value = role
+        return r
+
+    session.execute = mock_execute
+
+    with patch("app.repositories.participation.ParticipationRepository.exists", new_callable=AsyncMock) as mock_exists, \
+         patch("app.repositories.participation.ParticipationRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_exists.return_value = False
+        mock_create.return_value = new_p
+
+        result = await ensure_review_participation(session, ORG_ID, STORY_ID, MEMBER_ID, "qa")
+
+        mock_create.assert_called_once()
+        assert result == new_p
+
+
+@pytest.mark.anyio
+async def test_ensure_returns_existing_when_found():
+    """이미 QA participation 있으면 신규 생성 안 함."""
+    from app.services.verdict_capture import ensure_review_participation
+
+    session = AsyncMock()
+    role = _mock_role("qa")
+    existing_p = _mock_participation()
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        r = MagicMock()
+        if call_count == 1:
+            r.scalar_one_or_none.return_value = role
+        else:
+            r.scalar_one_or_none.return_value = existing_p
+        return r
+
+    session.execute = mock_execute
+
+    with patch("app.repositories.participation.ParticipationRepository.exists", new_callable=AsyncMock) as mock_exists, \
+         patch("app.repositories.participation.ParticipationRepository.create", new_callable=AsyncMock) as mock_create:
+        mock_exists.return_value = True
+        mock_create.return_value = None
+
+        result = await ensure_review_participation(session, ORG_ID, STORY_ID, MEMBER_ID, "qa")
+
+        mock_create.assert_not_called()
+        assert result == existing_p
+
+
+@pytest.mark.anyio
+async def test_ensure_returns_none_when_role_not_found():
+    """org에 qa/design role 없으면 None → skip."""
+    from app.services.verdict_capture import ensure_review_participation
+
+    session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.scalar_one_or_none.return_value = None  # role 없음
+    session.execute = AsyncMock(return_value=mock_r)
+
+    result = await ensure_review_participation(session, ORG_ID, STORY_ID, MEMBER_ID, "qa")
+    assert result is None
+
+
+# ── capture_review_verdict 서비스 테스트 ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_capture_qa_verdict_pass():
+    """QA 게이트 pass → source=qa result=pass verdict 기록."""
+    from app.services.verdict_capture import capture_review_verdict
+
+    session = AsyncMock()
+    participation = _mock_participation()
+
+    with patch("app.services.verdict_capture.ensure_review_participation", new_callable=AsyncMock) as mock_ensure, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_ensure.return_value = participation
+
+        result = await capture_review_verdict(session, ORG_ID, STORY_ID, "qa", MEMBER_ID, "pass", rounds=1)
+
+        assert result["recorded"] is True
+        assert result["source"] == "qa"
+        assert result["result"] == "pass"
+        mock_record.assert_called_once()
+        kw = mock_record.call_args[1]
+        assert kw["source"] == "qa"
+        assert kw["result"] == "pass"
+        assert kw["rounds"] == 1
+
+
+@pytest.mark.anyio
+async def test_capture_design_verdict_fail():
+    """디자인 게이트 fail → source=design result=fail verdict 기록."""
+    from app.services.verdict_capture import capture_review_verdict
+
+    session = AsyncMock()
+    participation = _mock_participation()
+
+    with patch("app.services.verdict_capture.ensure_review_participation", new_callable=AsyncMock) as mock_ensure, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_ensure.return_value = participation
+
+        result = await capture_review_verdict(session, ORG_ID, STORY_ID, "design", MEMBER_ID, "fail")
+
+        assert result["recorded"] is True
+        assert result["source"] == "design"
+        kw = mock_record.call_args[1]
+        assert kw["source"] == "design"
+        assert kw["result"] == "fail"
+
+
+@pytest.mark.anyio
+async def test_capture_review_skips_when_no_role():
+    """role 없으면 skip (거짓기록 금지)."""
+    from app.services.verdict_capture import capture_review_verdict
+
+    session = AsyncMock()
+
+    with patch("app.services.verdict_capture.ensure_review_participation", new_callable=AsyncMock) as mock_ensure, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_ensure.return_value = None  # role 없음
+
+        result = await capture_review_verdict(session, ORG_ID, STORY_ID, "qa", MEMBER_ID, "pass")
+
+        assert result["recorded"] is False
+        assert "no_qa_role" in result["skipped_reason"]
+        mock_record.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_capture_review_null_result():
+    """result=None → null 유지 (미측정 거짓채점 금지)."""
+    from app.services.verdict_capture import capture_review_verdict
+
+    session = AsyncMock()
+    participation = _mock_participation()
+
+    with patch("app.services.verdict_capture.ensure_review_participation", new_callable=AsyncMock) as mock_ensure, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock) as mock_record:
+        mock_ensure.return_value = participation
+
+        await capture_review_verdict(session, ORG_ID, STORY_ID, "qa", MEMBER_ID, None)
+
+        kw = mock_record.call_args[1]
+        assert kw["result"] is None
+
+
+# ── 내부 엔드포인트 테스트 ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_capture_review_endpoint_invalid_role_422():
+    """잘못된 role → 422."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v2/internal/verdict/capture-review",
+                json={"story_id": str(STORY_ID), "role": "implementation", "member_id": str(MEMBER_ID)},
+                headers={"Authorization": "Bearer "},
+            )
+        assert resp.status_code == 422
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_capture_review_endpoint_story_not_found():
+    """story 없으면 skipped_reason=story_not_found."""
+    from app.main import app
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = None
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.commit = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post(
+                "/api/v2/internal/verdict/capture-review",
+                json={"story_id": str(STORY_ID), "role": "qa", "member_id": str(MEMBER_ID), "result": "pass"},
+                headers={"Authorization": "Bearer "},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"]["skipped_reason"] == "story_not_found"
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── 트리거 방식 근거 명시 ────────────────────────────────────────────────────────
+
+def test_trigger_rationale_is_internal_endpoint():
+    """트리거 근거 명시: send_chat_message 자동 훅 불가 이유.
+
+    조사 결과:
+    1. FastAPI SendMessageRequest 스키마에 review_type/metadata 미노출
+       (app/routers/conversations.py L247)
+    2. ConversationMessage 생성 시 review_type 저장 안 됨 (L658-664)
+    3. Conversation 모델에 story_id FK 없음 — conv→story 링크 불가
+    4. workflow process_event에 review_type 미전달
+
+    → ⒝ MVP 내부 엔드포인트 /capture-review (CRON_SECRET) 택일.
+    """
+    # 조사 근거 문서화 테스트 (코드 실행 없음, 주석으로 검증)
+    from app.routers.verdict_capture import _VALID_REVIEW_ROLES
+    assert "qa" in _VALID_REVIEW_ROLES
+    assert "design" in _VALID_REVIEW_ROLES
+    assert "implementation" not in _VALID_REVIEW_ROLES


### PR DESCRIPTION
## Summary

마이그레이션 없음.

- **ensure_review_participation()**: qa/design role → participation ensure(없으면 생성). role 없으면 None → skip.
- **capture_review_verdict()**: qa/design → record_verdict. role 없으면 skip. result=null 허용.
- **POST /api/v2/internal/verdict/capture-review**: CRON_SECRET 인증. role invalid 422, story_not_found skip, no_role skip. 멱등(uq upsert).

## 트리거 방식 근거 (코드 조사 후 명시)

send_chat_message 자동 훅 불가 — 3가지 이유:
1. FastAPI SendMessageRequest 스키마에 review_type/metadata 미노출 (conversations.py:247)
2. ConversationMessage 생성 시 review_type 저장 안 됨 (L658-664)
3. Conversation 모델에 story_id FK 없음 → conv→story 링크 불가
→ ⒝ MVP 내부 엔드포인트 /capture-review (CRON_SECRET). test_trigger_rationale_is_internal_endpoint에 근거 문서화.

## Test plan

- [ ] ensure 3종: 신규생성/기존반환/role없음
- [ ] capture 4종: qa-pass/design-fail/no-role-skip/null
- [ ] endpoint 2종: invalid-role 422/story-not-found skip
- [ ] 트리거 근거 단언 (_VALID_REVIEW_ROLES 검증)
- [ ] 전체 pytest 1323 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)