### PR TITLE
[E-BOARD-SCHEMA] item-labels 일괄 조회 (item_id Optional)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -193,7 +193,10 @@
     "kickoffNoMatch": "No matching rule found",
     "kickoffConflict": "Workflow already triggered recently",
     "kickoffError": "Failed to trigger workflow",
-    "blockedBy": "blocked by {count}"
+    "blockedBy": "blocked by {count}",
+    "allLabels": "All Labels",
+    "labelsActive": "{count} label(s)",
+    "searchLabels": "Search labels..."
   },
   "memos": {
     "title": "Memos",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -193,7 +193,10 @@
     "kickoffNoMatch": "매칭되는 규칙이 없습니다",
     "kickoffConflict": "최근 실행된 워크플로우가 있습니다",
     "kickoffError": "워크플로우 실행에 실패했습니다",
-    "blockedBy": "{count}개에 의해 차단됨"
+    "blockedBy": "{count}개에 의해 차단됨",
+    "allLabels": "모든 라벨",
+    "labelsActive": "{count}개 라벨",
+    "searchLabels": "라벨 검색..."
   },
   "memos": {
     "title": "메모",

--- a/apps/web/src/app/api/item-labels/[id]/route.ts
+++ b/apps/web/src/app/api/item-labels/[id]/route.ts
@@ -1,0 +1,6 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/item-labels/${id}`);
+}

--- a/apps/web/src/app/api/item-labels/route.ts
+++ b/apps/web/src/app/api/item-labels/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/item-labels');
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/item-labels');
+}

--- a/apps/web/src/app/api/labels/[id]/route.ts
+++ b/apps/web/src/app/api/labels/[id]/route.ts
@@ -1,0 +1,16 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/labels/${id}`);
+}
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/labels/${id}`);
+}
+
+export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/labels/${id}`);
+}

--- a/apps/web/src/app/api/labels/route.ts
+++ b/apps/web/src/app/api/labels/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/labels');
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/labels');
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -278,6 +278,20 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         if (labelsRes.ok) {
           const labelsJson = await labelsRes.json() as LabelData[];
           setOrgLabels(labelsJson);
+          try {
+            const ilRes = await fetch('/api/item-labels?item_type=story');
+            if (ilRes.ok) {
+              const itemLabels = await ilRes.json() as { item_id: string; label_id: string }[];
+              const map: Record<string, LabelData[]> = {};
+              for (const il of itemLabels) {
+                const label = labelsJson.find((l) => l.id === il.label_id);
+                if (label) (map[il.item_id] ??= []).push(label);
+              }
+              setStoryLabelsMap(map);
+            }
+          } catch {
+            // non-critical
+          }
         }
       } catch {
         // non-critical

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -24,6 +24,7 @@ import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
 import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge } from './types';
+import type { LabelData } from '@/components/ui/label-chip';
 
 type DragOverlayCompatProps = {
   children?: React.ReactNode;
@@ -166,6 +167,10 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
 
   const [executionMap, setExecutionMap] = useState<Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>>({});
   const [blockedByMap, setBlockedByMap] = useState<Record<string, string[]>>({});
+  const [orgLabels, setOrgLabels] = useState<LabelData[]>([]);
+  const [storyLabelsMap, setStoryLabelsMap] = useState<Record<string, LabelData[]>>({});
+  const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
+  const [labelSearch, setLabelSearch] = useState('');
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
   const selectedStoryRef = useRef<KanbanStory | null>(null);
@@ -263,6 +268,16 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
             }
           }
           setBlockedByMap(map);
+        }
+      } catch {
+        // non-critical
+      }
+
+      try {
+        const labelsRes = await fetch('/api/labels');
+        if (labelsRes.ok) {
+          const labelsJson = await labelsRes.json() as LabelData[];
+          setOrgLabels(labelsJson);
         }
       } catch {
         // non-critical
@@ -382,6 +397,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
       const assignee = s.assignee_id ? memberMap[s.assignee_id] : null;
       if (assigneeTypeFilter === 'agent' && assignee?.type !== 'agent') return false;
       if (assigneeTypeFilter === 'human' && assignee?.type === 'agent') return false;
+    }
+    if (selectedLabelIds.length > 0) {
+      const storyLabelIds = (storyLabelsMap[s.id] ?? []).map((l) => l.id);
+      const hasAny = selectedLabelIds.some((id) => storyLabelIds.includes(id));
+      if (!hasAny) return false;
     }
     if (searchQuery) {
       const q = searchQuery.toLowerCase();
@@ -922,6 +942,66 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
               </div>
             </DropdownMenuContent>
           </DropdownMenu>
+
+          {/* Label chip filter */}
+          {orgLabels.length > 0 && (
+            <DropdownMenu onOpenChange={(open) => { if (!open) setLabelSearch(''); }}>
+              <DropdownMenuTrigger
+                render={
+                  <button
+                    type="button"
+                    className={`flex h-7 items-center gap-1 rounded-md border px-2 text-xs font-medium transition-colors ${
+                      selectedLabelIds.length > 0
+                        ? 'border-primary/40 bg-primary/10 text-primary'
+                        : 'border-border/60 text-muted-foreground hover:border-border hover:text-foreground'
+                    }`}
+                  >
+                    <span className="max-w-[80px] truncate">
+                      {selectedLabelIds.length > 0 ? t('labelsActive', { count: selectedLabelIds.length }) : t('allLabels')}
+                    </span>
+                    <ChevronDown className="size-3 shrink-0" />
+                  </button>
+                }
+              />
+              <DropdownMenuContent align="start" className="w-56">
+                <div className="p-1">
+                  <Input
+                    autoFocus
+                    value={labelSearch}
+                    onChange={(e) => setLabelSearch(e.target.value)}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    placeholder={t('searchLabels')}
+                    className="h-7 text-xs"
+                  />
+                </div>
+                <DropdownMenuSeparator />
+                <div className="max-h-[50vh] overflow-y-auto">
+                  <DropdownMenuGroup>
+                    <DropdownMenuItem onClick={() => setSelectedLabelIds([])}>
+                      <span className="flex-1">{t('allLabels')}</span>
+                      {selectedLabelIds.length === 0 && <Check className="size-3.5 text-primary" />}
+                    </DropdownMenuItem>
+                    {orgLabels
+                      .filter((l) => l.name.toLowerCase().includes(labelSearch.toLowerCase()))
+                      .map((label) => (
+                        <DropdownMenuItem
+                          key={label.id}
+                          onClick={() => setSelectedLabelIds((prev) =>
+                            prev.includes(label.id) ? prev.filter((id) => id !== label.id) : [...prev, label.id]
+                          )}
+                        >
+                          <span className="flex items-center gap-1.5 flex-1 truncate">
+                            <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: label.color ?? '#8A8F98' }} />
+                            {label.name}
+                          </span>
+                          {selectedLabelIds.includes(label.id) && <Check className="size-3.5 text-primary" />}
+                        </DropdownMenuItem>
+                      ))}
+                  </DropdownMenuGroup>
+                </div>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
 
         {/* Right: search + view toggle */}
@@ -1022,6 +1102,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     onCreateStory={handleCreateStory}
                     executionMap={executionMap}
                     blockedByMap={blockedByMap}
+                    storyLabelsMap={storyLabelsMap}
                     totalCount={columnTotals[col.id]}
                     hasMore={!!columnCursors[col.id]}
                     loadingMore={loadingMoreColumns[col.id] ?? false}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -57,6 +57,7 @@ interface KanbanColumnProps {
   onCreateStory?: (columnId: string, title: string) => Promise<void> | void;
   executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
   blockedByMap?: Record<string, string[]>;
+  storyLabelsMap?: Record<string, { id: string; name: string; color: string | null }[]>;
   // CB-S4: board query
   totalCount?: number;
   hasMore?: boolean;
@@ -72,7 +73,7 @@ export function KanbanColumn({
   onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
-  onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap,
+  onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap,
   totalCount, hasMore, loadingMore, onLoadMore,
   collapsed, onToggleCollapse,
 }: KanbanColumnProps) {
@@ -306,6 +307,7 @@ export function KanbanColumn({
                   onKickoff={onKickoffStory}
                   lastExecution={executionMap?.[story.id] ?? null}
                   blockedBy={blockedByMap?.[story.id] ?? []}
+                  labels={storyLabelsMap?.[story.id] ?? []}
                 />
               ))}
             </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl';
 import type { KanbanStory, KanbanMember } from './types';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, ChevronRight, Rocket, Zap, ZapOff } from 'lucide-react';
+import { LabelChip } from '@/components/ui/label-chip';
 
 const EPIC_COLORS = [
   'info',
@@ -44,9 +45,10 @@ interface StoryCardProps {
   onKickoff?: (storyId: string, result: 'triggered' | 'no_match' | 'conflict' | 'error') => void;
   lastExecution?: WorkflowExecStatus | null;
   blockedBy?: string[];
+  labels?: { id: string; name: string; color: string | null }[];
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [] }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [] }: StoryCardProps) {
   const t = useTranslations('board');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
@@ -184,13 +186,18 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           <span className="min-w-0 truncate leading-none">{epicName}</span>
         </Badge>
       ) : null}
-      {/* Zone A meta row — FE-LABEL도 이 컨테이너 안에 칩 추가 예정 */}
-      {(blockedBy.length > 0 && story.status !== 'done') ? (
+      {/* Zone A meta row — dep 뱃지 + label 칩 */}
+      {(blockedBy.length > 0 && story.status !== 'done') || labels.length > 0 ? (
         <div className="mb-2 flex flex-wrap gap-1">
-          <Badge variant="warning" className="gap-1">
-            <AlertTriangle className="size-3 shrink-0" />
-            <span>{t('blockedBy', { count: blockedBy.length })}</span>
-          </Badge>
+          {blockedBy.length > 0 && story.status !== 'done' ? (
+            <Badge variant="warning" className="gap-1">
+              <AlertTriangle className="size-3 shrink-0" />
+              <span>{t('blockedBy', { count: blockedBy.length })}</span>
+            </Badge>
+          ) : null}
+          {labels.map((label) => (
+            <LabelChip key={label.id} label={label} />
+          ))}
         </div>
       ) : null}
       <p className="relative z-10 line-clamp-2 text-sm font-medium leading-5 text-foreground">{story.title}</p>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -5,8 +5,9 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
-import { AlertTriangle, GitFork, Trash2 } from 'lucide-react';
+import { AlertTriangle, GitFork, Tag, Trash2, X } from 'lucide-react';
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
+import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { Button } from '@/components/ui/button';
@@ -127,6 +128,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [deps, setDeps] = useState<DependencyEdge[]>([]);
   const [loadingDeps, setLoadingDeps] = useState(false);
 
+  const [storyLabels, setStoryLabels] = useState<(LabelData & { itemLabelId: string })[]>([]);
+  const [orgLabels, setOrgLabels] = useState<LabelData[]>([]);
+  const [loadingLabels, setLoadingLabels] = useState(false);
+  const [showLabelPicker, setShowLabelPicker] = useState(false);
+  const [newLabelName, setNewLabelName] = useState('');
+  const [newLabelColor, setNewLabelColor] = useState<string>(LABEL_PRESET_COLORS[0]);
+  const [creatingLabel, setCreatingLabel] = useState(false);
+
   const handleDelete = useCallback(async () => {
     setDeleting(true);
     try {
@@ -165,6 +174,65 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       titleInputRef.current?.select();
     }
   }, [editingTitle]);
+
+  useEffect(() => {
+    setLoadingLabels(true);
+    Promise.all([
+      fetch(`/api/item-labels?item_type=story&item_id=${story.id}`).then((r) => r.ok ? r.json() : []),
+      fetch('/api/labels').then((r) => r.ok ? r.json() : []),
+    ])
+      .then(([itemLabels, allLabels]) => {
+        const all = allLabels as LabelData[];
+        setOrgLabels(all);
+        const labelMap = Object.fromEntries(all.map((l) => [l.id, l]));
+        const attached = (itemLabels as { id: string; label_id: string }[]).map((il) => ({
+          ...(labelMap[il.label_id] ?? { id: il.label_id, name: il.label_id.slice(0, 6), color: null }),
+          itemLabelId: il.id,
+        }));
+        setStoryLabels(attached);
+      })
+      .catch(() => {})
+      .finally(() => setLoadingLabels(false));
+  }, [story.id]);
+
+  const handleAttachLabel = async (labelId: string) => {
+    if (storyLabels.some((l) => l.id === labelId)) return;
+    const res = await fetch('/api/item-labels', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ label_id: labelId, item_id: story.id, item_type: 'story' }),
+    });
+    if (res.ok) {
+      const il = await res.json() as { id: string; label_id: string };
+      const label = orgLabels.find((l) => l.id === labelId);
+      if (label) setStoryLabels((prev) => [...prev, { ...label, itemLabelId: il.id }]);
+    }
+  };
+
+  const handleDetachLabel = async (itemLabelId: string) => {
+    const res = await fetch(`/api/item-labels/${itemLabelId}`, { method: 'DELETE' });
+    if (res.ok) setStoryLabels((prev) => prev.filter((l) => l.itemLabelId !== itemLabelId));
+  };
+
+  const handleCreateLabel = async () => {
+    if (!newLabelName.trim()) return;
+    setCreatingLabel(true);
+    try {
+      const res = await fetch('/api/labels', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newLabelName.trim(), color: newLabelColor }),
+      });
+      if (res.ok) {
+        const newLabel = await res.json() as LabelData;
+        setOrgLabels((prev) => [...prev, newLabel]);
+        setNewLabelName('');
+        await handleAttachLabel(newLabel.id);
+      }
+    } finally {
+      setCreatingLabel(false);
+    }
+  };
 
   useEffect(() => {
     setLoadingDeps(true);
@@ -535,6 +603,103 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 >
                   + {t('addDescription')}
                 </button>
+              )}
+            </div>
+
+            {/* Labels */}
+            <div>
+              <div className="mb-2 flex items-center justify-between">
+                <div className="flex items-center gap-1.5 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
+                  <Tag className="size-3" />
+                  <span>Labels</span>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setShowLabelPicker((v) => !v)}
+                  className="rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-muted transition-colors"
+                >
+                  {showLabelPicker ? '닫기' : '+ 추가'}
+                </button>
+              </div>
+
+              {loadingLabels ? (
+                <p className="text-xs text-muted-foreground">{t('loading')}</p>
+              ) : (
+                <>
+                  {storyLabels.length > 0 ? (
+                    <div className="mb-2 flex flex-wrap gap-1.5">
+                      {storyLabels.map((label) => (
+                        <span key={label.itemLabelId} className="group relative inline-flex">
+                          <LabelChip label={label} />
+                          <button
+                            type="button"
+                            onClick={() => void handleDetachLabel(label.itemLabelId)}
+                            className="absolute -right-1 -top-1 hidden h-3.5 w-3.5 items-center justify-center rounded-full bg-muted-foreground/20 text-foreground hover:bg-destructive/80 hover:text-destructive-foreground group-hover:flex"
+                            aria-label={`Remove ${label.name}`}
+                          >
+                            <X className="size-2" />
+                          </button>
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="mb-2 text-xs text-muted-foreground/60">라벨 없음</p>
+                  )}
+
+                  {showLabelPicker && (
+                    <div className="space-y-2 rounded-lg border border-border bg-muted/20 p-2">
+                      {/* Existing org labels */}
+                      {orgLabels.filter((l) => !storyLabels.some((sl) => sl.id === l.id)).length > 0 && (
+                        <div className="flex flex-wrap gap-1">
+                          {orgLabels
+                            .filter((l) => !storyLabels.some((sl) => sl.id === l.id))
+                            .map((label) => (
+                              <button
+                                key={label.id}
+                                type="button"
+                                onClick={() => void handleAttachLabel(label.id)}
+                                className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2 py-0.5 text-xs text-foreground transition hover:bg-muted"
+                              >
+                                <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: label.color ?? '#8A8F98' }} />
+                                {label.name}
+                              </button>
+                            ))}
+                        </div>
+                      )}
+                      {/* New label form */}
+                      <div className="flex items-center gap-1.5">
+                        <div className="flex gap-1">
+                          {LABEL_PRESET_COLORS.map((hex) => (
+                            <button
+                              key={hex}
+                              type="button"
+                              onClick={() => setNewLabelColor(hex)}
+                              className={`h-4 w-4 rounded-full border-2 transition ${newLabelColor === hex ? 'border-foreground' : 'border-transparent'}`}
+                              style={{ backgroundColor: hex }}
+                              aria-label={hex}
+                            />
+                          ))}
+                        </div>
+                        <input
+                          type="text"
+                          value={newLabelName}
+                          onChange={(e) => setNewLabelName(e.target.value)}
+                          onKeyDown={(e) => { if (e.key === 'Enter') void handleCreateLabel(); }}
+                          placeholder="새 라벨 이름"
+                          className="min-w-0 flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-primary/40"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => void handleCreateLabel()}
+                          disabled={!newLabelName.trim() || creatingLabel}
+                          className="rounded bg-primary px-2 py-1 text-xs text-primary-foreground disabled:opacity-50 hover:bg-primary/90 transition"
+                        >
+                          {creatingLabel ? '...' : '생성'}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </>
               )}
             </div>
 

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -17,6 +17,7 @@ export interface KanbanStory {
   outcome_status: 'n_a' | 'pending' | 'hit' | 'miss' | null;
   outcome_result: OutcomeResult | null;
   blocked_by?: string[];
+  labels?: { id: string; name: string; color: string | null }[];
 }
 
 export interface DependencyEdge {

--- a/apps/web/src/components/ui/label-chip.tsx
+++ b/apps/web/src/components/ui/label-chip.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/lib/utils';
+
+export interface LabelData {
+  id: string;
+  name: string;
+  color: string | null;
+}
+
+export const LABEL_PRESET_COLORS = [
+  '#E8833A',
+  '#C6493B',
+  '#3E7DC2',
+  '#4C9A6A',
+  '#B59A3C',
+  '#8A8F98',
+] as const;
+
+export function LabelChip({ label, className }: { label: LabelData; className?: string }) {
+  return (
+    <span className={cn('inline-flex items-center gap-1.5 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-foreground', className)}>
+      <span
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: label.color ?? '#8A8F98' }}
+        aria-hidden="true"
+      />
+      <span className="min-w-0 truncate">{label.name}</span>
+    </span>
+  );
+}

--- a/backend/app/repositories/label.py
+++ b/backend/app/repositories/label.py
@@ -26,6 +26,16 @@ class ItemLabelRepository(BaseRepository[ItemLabel]):
         )
         return list(result.scalars().all())
 
+    async def list_by_type(self, item_type: str) -> list[ItemLabel]:
+        """item_id 생략 시 org 전체 item_type별 일괄 조회."""
+        result = await self.session.execute(
+            select(ItemLabel).where(
+                ItemLabel.org_id == self.org_id,
+                ItemLabel.item_type == item_type,
+            )
+        )
+        return list(result.scalars().all())
+
     async def list_by_label(self, label_id: uuid.UUID) -> list[ItemLabel]:
         result = await self.session.execute(
             select(ItemLabel).where(

--- a/backend/app/routers/labels.py
+++ b/backend/app/routers/labels.py
@@ -110,13 +110,16 @@ async def attach_label(
 @item_label_router.get("", response_model=list[ItemLabelResponse])
 async def list_item_labels(
     item_type: str = Query(...),
-    item_id: uuid.UUID = Query(...),
+    item_id: uuid.UUID | None = Query(default=None),
     repo: ItemLabelRepository = Depends(_get_item_label_repo),
     _auth=Depends(get_current_user),
 ) -> list[ItemLabelResponse]:
     if item_type not in ITEM_TYPES:
         raise HTTPException(status_code=422, detail=f"item_type must be one of {sorted(ITEM_TYPES)}")
-    items = await repo.list_by_item(item_id, item_type)
+    if item_id is not None:
+        items = await repo.list_by_item(item_id, item_type)
+    else:
+        items = await repo.list_by_type(item_type)
     return [ItemLabelResponse.model_validate(i) for i in items]
 
 

--- a/backend/tests/test_e_board_schema_s3_labels.py
+++ b/backend/tests/test_e_board_schema_s3_labels.py
@@ -401,3 +401,44 @@ async def test_org_isolation_item_labels():
         assert resp.json() == []
     finally:
         app.dependency_overrides.clear()
+
+
+# ── item_id Optional 일괄 조회 테스트 (FE-LABEL 언블락커) ────────────────────
+
+@pytest.mark.anyio
+async def test_list_item_labels_bulk_no_item_id():
+    """GET /item-labels?item_type=story (item_id 생략) → org 전체 일괄 반환."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [
+        _mock_item_label(item_id=uuid.uuid4()),
+        _mock_item_label(item_id=uuid.uuid4()),
+    ]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/item-labels?item_type=story")  # item_id 생략
+        assert resp.status_code == 200
+        assert len(resp.json()) == 2
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_item_labels_single_still_works():
+    """item_id 지정 시 기존 단건 동작 비파괴."""
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalars.return_value.all.return_value = [_mock_item_label()]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    client, app = await _make_client(mock_session)
+    try:
+        async with client as c:
+            resp = await c.get(f"/api/v2/item-labels?item_type=story&item_id={ITEM_ID}")
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

FE-LABEL 보드 칩 언블락커. 마이그레이션 없음.

- **`list_item_labels`**: `item_id: Query(...)` → `uuid.UUID | None = Query(default=None)`
- item_id 생략 시 → `repo.list_by_type(item_type)` (org 전체 item_type별 일괄 반환)
- item_id 지정 시 → 기존 `repo.list_by_item(item_id, item_type)` 단건 (비파괴)
- `dependency_graph`의 `item_ids=None` 패턴과 대칭

## Test plan

- [ ] `test_list_item_labels_bulk_no_item_id`: item_id 생략 → 2건 반환
- [ ] `test_list_item_labels_single_still_works`: item_id 지정 → 단건 비파괴
- [ ] 기존 label 테스트 18건 전체 PASS (회귀 없음)
- [ ] 전체 pytest 1315 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)