### PR TITLE
[E-CAGE-REFEREE P2] 신뢰 점수 집계 엔진

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, health, hitl, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -117,6 +117,7 @@ app.include_router(participation.router)
 app.include_router(verdicts.router)
 app.include_router(exclusion.router)
 app.include_router(verdict_capture.router)
+app.include_router(trust_scores.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)

--- a/backend/app/routers/trust_scores.py
+++ b/backend/app/routers/trust_scores.py
@@ -1,0 +1,28 @@
+import uuid
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.services.trust_score import DEFAULT_WINDOW_DAYS, compute_member_trust_scores
+
+router = APIRouter(prefix="/api/v2/trust-scores", tags=["trust-scores"])
+
+
+@router.get("")
+async def get_trust_scores(
+    member_id: uuid.UUID = Query(...),
+    role: str | None = Query(default=None),
+    window_days: int = Query(default=DEFAULT_WINDOW_DAYS, ge=1, le=365),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> dict:
+    return await compute_member_trust_scores(
+        session=session,
+        org_id=org_id,
+        member_id=member_id,
+        role_key=role,
+        window_days=window_days,
+    )

--- a/backend/app/services/trust_score.py
+++ b/backend/app/services/trust_score.py
@@ -1,0 +1,165 @@
+"""E-CAGE-REFEREE P2: 신뢰 점수 집계 엔진.
+
+(member, role)별 무정정 통과율 × SP 가중.
+  - 무정정 통과 = verdict.result='pass' AND (rounds IS NULL OR rounds=0)
+  - SP 가중 = story_points (null→1 fallback). is_excluded 스토리 제외.
+  - 온더플라이 집계 (마이그 없음) — verdict 조인 쿼리.
+  - outcome(hit/miss)은 포함 안 함 — 효과≠실행품질.
+  - 빈데이터 graceful: verdict 없으면 score=None (0 아님, 구분 필요).
+  - MVP 이진 산식. 데이터 쌓인 뒤 튜닝.
+
+반환 구조:
+  {
+      "member_id": uuid,
+      "scores": [
+          {
+              "role_key": str,
+              "role_label": str,
+              "clean_pass_verdicts": int,
+              "total_verdicts": int,
+              "clean_pass_rate": float | None,
+              "total_sp": int,
+              "clean_sp": int,
+              "weighted_score": float | None,
+          },
+          ...
+      ]
+  }
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.participation import Participation, ParticipationRole
+from app.models.pm import Story
+from app.models.verdict import Verdict
+
+DEFAULT_WINDOW_DAYS = 90
+
+
+def _is_clean_pass(result: str | None, rounds: int | None) -> bool:
+    """무정정 통과 판정: pass + 정정 라운드 없음."""
+    return result == "pass" and (rounds is None or rounds == 0)
+
+
+async def compute_member_trust_scores(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    role_key: str | None = None,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+) -> dict[str, Any]:
+    """(member, role)별 신뢰점수 온더플라이 집계.
+
+    Args:
+        role_key: 특정 역할만 집계. None이면 전 역할.
+        window_days: verdict 기준 최근 N일 윈도우.
+
+    Returns:
+        {"member_id": ..., "scores": [...], "window_days": ..., "computed_at": ...}
+    """
+    window_start = datetime.now(timezone.utc) - timedelta(days=window_days)
+
+    # 1. 조회: (participation, story, role, verdict) 조인
+    p_q = (
+        select(Participation, Story, ParticipationRole)
+        .join(Story, Story.id == Participation.story_id)
+        .join(ParticipationRole, ParticipationRole.id == Participation.role_id)
+        .where(
+            Participation.org_id == org_id,
+            Participation.member_id == member_id,
+            Story.is_excluded.is_(False),
+            Story.deleted_at.is_(None),
+        )
+    )
+    if role_key is not None:
+        p_q = p_q.where(ParticipationRole.key == role_key)
+
+    p_result = await session.execute(p_q)
+    rows = p_result.all()
+
+    if not rows:
+        return {
+            "member_id": str(member_id),
+            "scores": [],
+            "window_days": window_days,
+        }
+
+    # participation_id → (story_points, role_key, role_label) 매핑
+    p_map: dict[uuid.UUID, dict] = {}
+    for p, s, r in rows:
+        p_map[p.id] = {
+            "story_points": s.story_points or 1,
+            "role_key": r.key,
+            "role_label": r.label,
+        }
+
+    # 2. 해당 participation들의 verdict 조회 (윈도우 내)
+    verdict_r = await session.execute(
+        select(Verdict).where(
+            Verdict.org_id == org_id,
+            Verdict.participation_id.in_(list(p_map.keys())),
+            Verdict.recorded_at >= window_start,
+        )
+    )
+    verdicts = verdict_r.scalars().all()
+
+    # 3. role별 집계
+    role_buckets: dict[str, dict] = {}
+    for p_id, meta in p_map.items():
+        rk = meta["role_key"]
+        if rk not in role_buckets:
+            role_buckets[rk] = {
+                "role_key": rk,
+                "role_label": meta["role_label"],
+                "clean_pass_verdicts": 0,
+                "total_verdicts": 0,
+                "clean_sp": 0,
+                "total_sp": 0,
+            }
+
+    for v in verdicts:
+        meta = p_map.get(v.participation_id)
+        if meta is None:
+            continue
+        rk = meta["role_key"]
+        sp = meta["story_points"]
+        bucket = role_buckets[rk]
+        bucket["total_verdicts"] += 1
+        bucket["total_sp"] += sp
+        if _is_clean_pass(v.result, v.rounds):
+            bucket["clean_pass_verdicts"] += 1
+            bucket["clean_sp"] += sp
+
+    # 4. 점수 계산
+    scores: list[dict[str, Any]] = []
+    for rk, b in role_buckets.items():
+        tv = b["total_verdicts"]
+        tsp = b["total_sp"]
+        cp = b["clean_pass_verdicts"]
+        csp = b["clean_sp"]
+
+        clean_pass_rate: float | None = (cp / tv) if tv > 0 else None
+        weighted_score: float | None = (csp / tsp) if tsp > 0 else None
+
+        scores.append({
+            "role_key": b["role_key"],
+            "role_label": b["role_label"],
+            "clean_pass_verdicts": cp,
+            "total_verdicts": tv,
+            "clean_pass_rate": round(clean_pass_rate, 4) if clean_pass_rate is not None else None,
+            "total_sp": tsp,
+            "clean_sp": csp,
+            "weighted_score": round(weighted_score, 4) if weighted_score is not None else None,
+        })
+
+    return {
+        "member_id": str(member_id),
+        "scores": scores,
+        "window_days": window_days,
+    }

--- a/backend/tests/test_e_cage_referee_p2_trust_score.py
+++ b/backend/tests/test_e_cage_referee_p2_trust_score.py
@@ -1,0 +1,320 @@
+"""E-CAGE-REFEREE P2: 신뢰 점수 집계 엔진 테스트."""
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.trust_score import _is_clean_pass, compute_member_trust_scores
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+P_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── _is_clean_pass 단위 ───────────────────────────────────────────────────────
+
+def test_clean_pass_pass_no_rounds():
+    assert _is_clean_pass("pass", None) is True
+    assert _is_clean_pass("pass", 0) is True
+
+
+def test_clean_pass_pass_with_rounds():
+    assert _is_clean_pass("pass", 1) is False
+    assert _is_clean_pass("pass", 3) is False
+
+
+def test_clean_pass_fail():
+    assert _is_clean_pass("fail", None) is False
+    assert _is_clean_pass("fail", 0) is False
+
+
+def test_clean_pass_null_result():
+    assert _is_clean_pass(None, None) is False
+
+
+# ── compute_member_trust_scores 단위 ──────────────────────────────────────────
+
+def _mock_participation(p_id=None, role_key="implementation"):
+    p = MagicMock()
+    p.id = p_id or P_ID
+    p.org_id = ORG_ID
+    p.member_id = MEMBER_ID
+    p.story_id = STORY_ID
+    p.role_id = ROLE_ID
+    return p
+
+
+def _mock_story(sp=5, is_excluded=False):
+    s = MagicMock()
+    s.id = STORY_ID
+    s.story_points = sp
+    s.is_excluded = is_excluded
+    s.deleted_at = None
+    return s
+
+
+def _mock_role(key="implementation", label="구현"):
+    r = MagicMock()
+    r.id = ROLE_ID
+    r.key = key
+    r.label = label
+    return r
+
+
+def _mock_verdict(p_id, result="pass", rounds=0):
+    v = MagicMock()
+    v.participation_id = p_id
+    v.result = result
+    v.rounds = rounds
+    v.recorded_at = datetime.now(timezone.utc)
+    return v
+
+
+@pytest.mark.anyio
+async def test_compute_no_participation_returns_empty():
+    """participation 없으면 scores=[] graceful."""
+    session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.all.return_value = []
+    session.execute = AsyncMock(return_value=mock_r)
+
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+    assert result["scores"] == []
+    assert result["member_id"] == str(MEMBER_ID)
+
+
+@pytest.mark.anyio
+async def test_compute_clean_pass_all_verdicts():
+    """모든 verdict가 clean pass → weighted_score=1.0."""
+    session = AsyncMock()
+    p = _mock_participation()
+    s = _mock_story(sp=10)
+    r = _mock_role()
+
+    verdicts = [_mock_verdict(p.id, result="pass", rounds=0)]
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p, s, r)]
+        else:
+            result.scalars.return_value.all.return_value = verdicts
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    assert len(result["scores"]) == 1
+    score = result["scores"][0]
+    assert score["clean_pass_verdicts"] == 1
+    assert score["total_verdicts"] == 1
+    assert score["weighted_score"] == 1.0
+    assert score["clean_pass_rate"] == 1.0
+
+
+@pytest.mark.anyio
+async def test_compute_no_clean_pass():
+    """verdict 있지만 모두 RC(rounds>0) → weighted_score=0.0."""
+    session = AsyncMock()
+    p = _mock_participation()
+    s = _mock_story(sp=5)
+    r = _mock_role()
+    verdicts = [_mock_verdict(p.id, result="pass", rounds=2)]
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p, s, r)]
+        else:
+            result.scalars.return_value.all.return_value = verdicts
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    score = result["scores"][0]
+    assert score["clean_pass_verdicts"] == 0
+    assert score["weighted_score"] == 0.0
+
+
+@pytest.mark.anyio
+async def test_compute_no_verdicts_returns_none_score():
+    """participation 있지만 verdict 없음 → score=None (graceful 빈데이터)."""
+    session = AsyncMock()
+    p = _mock_participation()
+    s = _mock_story(sp=5)
+    r = _mock_role()
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p, s, r)]
+        else:
+            result.scalars.return_value.all.return_value = []  # no verdicts
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    score = result["scores"][0]
+    assert score["total_verdicts"] == 0
+    assert score["clean_pass_rate"] is None
+    assert score["weighted_score"] is None
+
+
+@pytest.mark.anyio
+async def test_compute_sp_weighting():
+    """SP 가중 확인 — sp=10인 clean pass + sp=5인 dirty → weighted=10/15."""
+    session = AsyncMock()
+    p1 = _mock_participation(p_id=uuid.uuid4())
+    p2 = _mock_participation(p_id=uuid.uuid4())
+    s1 = _mock_story(sp=10)
+    s2 = _mock_story(sp=5)
+    r = _mock_role()
+
+    p1.story_id = uuid.uuid4()
+    p2.story_id = uuid.uuid4()
+
+    v1 = _mock_verdict(p1.id, result="pass", rounds=0)
+    v2 = _mock_verdict(p2.id, result="pass", rounds=1)  # dirty
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p1, s1, r), (p2, s2, r)]
+        else:
+            result.scalars.return_value.all.return_value = [v1, v2]
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    score = result["scores"][0]
+    assert score["total_sp"] == 15
+    assert score["clean_sp"] == 10
+    assert abs(score["weighted_score"] - 10/15) < 0.001
+
+
+@pytest.mark.anyio
+async def test_compute_null_sp_fallback_to_1():
+    """story_points=None → 1 fallback."""
+    session = AsyncMock()
+    p = _mock_participation()
+    s = _mock_story(sp=None)
+    r = _mock_role()
+    verdicts = [_mock_verdict(p.id, result="pass", rounds=0)]
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p, s, r)]
+        else:
+            result.scalars.return_value.all.return_value = verdicts
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID)
+
+    score = result["scores"][0]
+    assert score["total_sp"] == 1  # fallback
+    assert score["weighted_score"] == 1.0
+
+
+@pytest.mark.anyio
+async def test_compute_outcome_not_in_score():
+    """outcome(hit/miss)은 verdict result에 안 들어감 → clean pass 체크 안전."""
+    # result='hit' / 'miss'는 outcome_status 필드, verdict.result에 없음
+    # verdict.result = 'pass' | 'fail' | None 만 사용
+    # 이 테스트는 outcome이 섞여도 clean_pass 집계가 오염 안 됨을 검증
+    assert _is_clean_pass("hit", None) is False  # outcome은 clean pass 아님
+    assert _is_clean_pass("miss", None) is False
+
+
+@pytest.mark.anyio
+async def test_compute_role_filter():
+    """role_key 필터 → 해당 역할만 집계."""
+    session = AsyncMock()
+    # implementation role만 포함
+    p = _mock_participation(role_key="implementation")
+    s = _mock_story(sp=5)
+    r = _mock_role(key="implementation")
+
+    call_count = 0
+    async def mock_execute(stmt, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        result = MagicMock()
+        if call_count == 1:
+            result.all.return_value = [(p, s, r)]
+        else:
+            result.scalars.return_value.all.return_value = []
+        return result
+
+    session.execute = mock_execute
+    result = await compute_member_trust_scores(session, ORG_ID, MEMBER_ID, role_key="implementation")
+
+    assert result["scores"][0]["role_key"] == "implementation"
+
+
+# ── GET 엔드포인트 통합 테스트 ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_get_trust_scores_endpoint_200():
+    """GET /api/v2/trust-scores?member_id=... → 200."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_r)
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(f"/api/v2/trust-scores?member_id={MEMBER_ID}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["member_id"] == str(MEMBER_ID)
+        assert body["scores"] == []
+        assert "window_days" in body
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

마이그레이션 없음 (온더플라이 집계).

- **`compute_member_trust_scores()`**: (member, role)별 무정정통과율 × SP 가중 집계
  - 무정정 통과 = verdict.result='pass' AND (rounds IS NULL OR rounds=0)
  - SP 가중 = story_points (null→1 fallback). is_excluded=true 스토리 제외.
  - 최근 window_days(기본 90일) 내 verdict만
  - outcome(hit/miss)은 미포함 — 효과≠실행품질
  - verdict 없으면 score=None (0과 구분)
  - 역할별 분리 scores[]로 반환
- **`GET /api/v2/trust-scores?member_id&role&window_days`**: 조회 엔드포인트

## Formula

```
clean_sp = sum(story_points where clean_pass_verdict)
total_sp = sum(story_points where any_verdict)
weighted_score = clean_sp / total_sp (None if no verdicts)
```

## Test plan

- [ ] _is_clean_pass 4종: pass-no-rounds/pass-with-rounds/fail/null
- [ ] compute 빈participation/all-clean/no-clean/no-verdict(None graceful)/SP가중/null-sp-fallback/outcome-not-in-score/role-filter
- [ ] GET endpoint 200
- [ ] 전체 pytest 1336 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)