### PR TITLE
[E-CAGE-REFEREE P3] HITL gate 1급 객체 + 상태기계 + verdict 와이어링

### DIFF
--- a/backend/alembic/versions/0067_add_gate.py
+++ b/backend/alembic/versions/0067_add_gate.py
@@ -1,0 +1,69 @@
+"""E-CAGE-REFEREE P3: gate 1급 객체 테이블.
+
+Revision ID: 0067
+Revises: 0066
+Create Date: 2026-05-31
+
+neutral_facts: 관찰값(touches_migration·diff_size 등) — 판정 아님.
+상태기계: pending|approved|rejected|auto_passed.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0067"
+down_revision = "0066"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "gate" in insp.get_table_names():
+        return
+
+    op.create_table(
+        "gate",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("work_item_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("work_item_type", sa.String(20), nullable=False),
+        sa.Column("gate_type", sa.String(50), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default="pending"),
+        sa.Column("resolver_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("neutral_facts", JSONB, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_gate_org_id", "gate", ["org_id"])
+    op.create_index("ix_gate_work_item_id", "gate", ["work_item_id"])
+    op.create_unique_constraint(
+        "uq_gate_work_item_gate_type",
+        "gate",
+        ["org_id", "work_item_id", "work_item_type", "gate_type"],
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "gate" not in insp.get_table_names():
+        return
+    op.drop_constraint("uq_gate_work_item_gate_type", "gate", type_="unique")
+    op.drop_index("ix_gate_work_item_id", table_name="gate")
+    op.drop_index("ix_gate_org_id", table_name="gate")
+    op.drop_table("gate")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -119,6 +119,7 @@ app.include_router(exclusion.router)
 app.include_router(verdict_capture.router)
 app.include_router(trust_scores.router)
 app.include_router(hitl_config.router)
+app.include_router(gates.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
 app.include_router(meetings.router)

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -1,0 +1,50 @@
+"""E-CAGE-REFEREE P3: HITL Gate 1급 객체.
+
+상태기계: pending → approved | rejected (human 해소)
+         auto_passed → (불변, config allow_auto 시 즉시)
+         approved | rejected → (불변)
+
+neutral_facts: 관찰 사실만 (touches_migration, diff_size 등).
+               판정 아님 — 플랫폼은 위험도 판단 안 함.
+"""
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+GATE_STATUSES = frozenset({"pending", "approved", "rejected", "auto_passed"})
+
+# 합법 전이: (from, to)
+_VALID_TRANSITIONS: set[tuple[str, str]] = {
+    ("pending", "approved"),
+    ("pending", "rejected"),
+}
+
+
+def is_valid_transition(from_status: str, to_status: str) -> bool:
+    return (from_status, to_status) in _VALID_TRANSITIONS
+
+
+class Gate(Base):
+    __tablename__ = "gate"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    work_item_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    gate_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
+    resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    neutral_facts: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
+    )

--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -15,7 +15,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.database import Base
-from app.models.base import OrgScopedMixin
 
 POSTURES = frozenset({"conservative", "balanced", "permissive"})
 DISPOSITIONS = frozenset({"allow_auto", "ask", "deny"})

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -1,0 +1,103 @@
+"""E-CAGE-REFEREE P3: HITL Gate CRUD + 전이 엔드포인트."""
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.gate import Gate, is_valid_transition
+from app.services.gate_service import create_gate, transition_gate
+
+router = APIRouter(prefix="/api/v2/gates", tags=["gates"])
+
+
+class GateCreateRequest(BaseModel):
+    work_item_id: uuid.UUID
+    work_item_type: str
+    gate_type: str
+    member_id: uuid.UUID
+    role_id: uuid.UUID
+    neutral_facts: dict[str, Any] | None = None
+
+
+class GateTransitionRequest(BaseModel):
+    status: str
+    resolver_id: uuid.UUID | None = None
+
+
+class GateResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    org_id: uuid.UUID
+    work_item_id: uuid.UUID
+    work_item_type: str
+    gate_type: str
+    status: str
+    resolver_id: uuid.UUID | None = None
+    resolved_at: datetime | None = None
+    neutral_facts: dict[str, Any] | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+@router.post("", response_model=GateResponse, status_code=201)
+async def create_gate_endpoint(
+    body: GateCreateRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> GateResponse:
+    gate = await create_gate(
+        session=session,
+        org_id=org_id,
+        work_item_id=body.work_item_id,
+        work_item_type=body.work_item_type,
+        gate_type=body.gate_type,
+        member_id=body.member_id,
+        role_id=body.role_id,
+        neutral_facts=body.neutral_facts,
+    )
+    await session.commit()
+    return GateResponse.model_validate(gate)
+
+
+@router.get("", response_model=list[GateResponse])
+async def list_gates(
+    work_item_id: uuid.UUID | None = Query(default=None),
+    work_item_type: str | None = Query(default=None),
+    status: str | None = Query(default=None),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> list[GateResponse]:
+    q = select(Gate).where(Gate.org_id == org_id)
+    if work_item_id:
+        q = q.where(Gate.work_item_id == work_item_id)
+    if work_item_type:
+        q = q.where(Gate.work_item_type == work_item_type)
+    if status:
+        q = q.where(Gate.status == status)
+    result = await session.execute(q)
+    return [GateResponse.model_validate(g) for g in result.scalars().all()]
+
+
+@router.post("/{id}/transition", response_model=GateResponse)
+async def transition_gate_endpoint(
+    id: uuid.UUID,
+    body: GateTransitionRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> GateResponse:
+    try:
+        gate = await transition_gate(session, org_id, id, body.status, body.resolver_id)
+        await session.commit()
+        return GateResponse.model_validate(gate)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))

--- a/backend/app/schemas/hitl_config.py
+++ b/backend/app/schemas/hitl_config.py
@@ -32,6 +32,13 @@ class OrgGateOverrideCreate(BaseModel):
     gate_type: str
     disposition: str
 
+    @field_validator("gate_type")
+    @classmethod
+    def validate_gate_type(cls, v: str) -> str:
+        if v not in GATE_TYPES:
+            raise ValueError(f"gate_type must be one of {sorted(GATE_TYPES)}")
+        return v
+
     @field_validator("disposition")
     @classmethod
     def validate_disposition(cls, v: str) -> str:
@@ -55,6 +62,13 @@ class MemberGateOverrideCreate(BaseModel):
     member_id: uuid.UUID
     gate_type: str
     disposition: str
+
+    @field_validator("gate_type")
+    @classmethod
+    def validate_gate_type(cls, v: str) -> str:
+        if v not in GATE_TYPES:
+            raise ValueError(f"gate_type must be one of {sorted(GATE_TYPES)}")
+        return v
 
     @field_validator("disposition")
     @classmethod

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -1,0 +1,156 @@
+"""E-CAGE-REFEREE P3: HITL Gate 생성·전이·verdict 해소 서비스.
+
+게이트 생성: resolve_disposition() 호출 → disposition에 따라 초기 status 결정.
+  allow_auto → auto_passed (숨김, 자동)
+  ask        → pending    (인간 개입 필요)
+  deny       → rejected   (차단)
+
+상태기계 전이: 불법 전이 거부 (pending→approved|rejected만 허용).
+
+verdict→게이트 해소: P1 verdict 포착이 대응 게이트를 실제로 해소.
+  verdict source='pr'|'ci' → gate_type='pr_review'
+  verdict source='qa'       → gate_type='qa'
+  verdict source='design'   → gate_type='deploy'
+  게이트 없으면 graceful skip.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate, is_valid_transition
+from app.services.gate_resolver import resolve_disposition
+
+# verdict source → gate_type 매핑
+_SOURCE_TO_GATE_TYPE: dict[str, str] = {
+    "pr": "pr_review",
+    "ci": "pr_review",
+    "qa": "qa",
+    "design": "deploy",
+}
+
+_DISPOSITION_TO_STATUS: dict[str, str] = {
+    "allow_auto": "auto_passed",
+    "ask": "pending",
+    "deny": "rejected",
+}
+
+
+async def create_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    work_item_type: str,
+    gate_type: str,
+    member_id: uuid.UUID,
+    role_id: uuid.UUID,
+    neutral_facts: dict[str, Any] | None = None,
+) -> Gate:
+    """config 기반 게이트 생성 (멱등: 이미 있으면 기존 반환)."""
+    # 멱등: 이미 존재하면 기존 반환
+    existing_r = await session.execute(
+        select(Gate).where(
+            Gate.org_id == org_id,
+            Gate.work_item_id == work_item_id,
+            Gate.work_item_type == work_item_type,
+            Gate.gate_type == gate_type,
+        ).limit(1)
+    )
+    existing = existing_r.scalar_one_or_none()
+    if existing is not None:
+        return existing
+
+    disposition = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
+    status = _DISPOSITION_TO_STATUS.get(disposition, "pending")
+
+    gate = Gate(
+        id=uuid.uuid4(),
+        org_id=org_id,
+        work_item_id=work_item_id,
+        work_item_type=work_item_type,
+        gate_type=gate_type,
+        status=status,
+        neutral_facts=neutral_facts,
+        resolved_at=datetime.now(timezone.utc) if status != "pending" else None,
+    )
+    session.add(gate)
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def transition_gate(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    gate_id: uuid.UUID,
+    new_status: str,
+    resolver_id: uuid.UUID | None = None,
+) -> Gate:
+    """게이트 상태 전이 — 불법 전이 시 ValueError 발생."""
+    gate_r = await session.execute(
+        select(Gate).where(Gate.id == gate_id, Gate.org_id == org_id)
+    )
+    gate = gate_r.scalar_one_or_none()
+    if gate is None:
+        raise ValueError(f"Gate {gate_id} not found")
+
+    if not is_valid_transition(gate.status, new_status):
+        raise ValueError(
+            f"불법 전이: {gate.status} → {new_status}. "
+            f"pending에서만 approved|rejected로 전이 가능."
+        )
+
+    gate.status = new_status
+    gate.resolver_id = resolver_id
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.flush()
+    await session.refresh(gate)
+    return gate
+
+
+async def resolve_gate_from_verdict(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    work_item_id: uuid.UUID,
+    work_item_type: str,
+    verdict_source: str,
+    verdict_result: str | None,
+    resolver_id: uuid.UUID | None = None,
+) -> Gate | None:
+    """verdict 포착 결과를 대응 게이트 해소로 연결.
+
+    verdict source → gate_type 매핑 후 pending 게이트 탐색.
+    없으면 graceful skip (None 반환).
+    result=None → pending 유지 (미측정 거짓해소 금지).
+    """
+    gate_type = _SOURCE_TO_GATE_TYPE.get(verdict_source)
+    if gate_type is None:
+        return None
+
+    if verdict_result is None:
+        return None  # 미측정 → 강제 해소 금지
+
+    gate_r = await session.execute(
+        select(Gate).where(
+            Gate.org_id == org_id,
+            Gate.work_item_id == work_item_id,
+            Gate.work_item_type == work_item_type,
+            Gate.gate_type == gate_type,
+            Gate.status == "pending",
+        ).limit(1)
+    )
+    gate = gate_r.scalar_one_or_none()
+    if gate is None:
+        return None  # 게이트 없음 → graceful
+
+    new_status = "approved" if verdict_result == "pass" else "rejected"
+    gate.status = new_status
+    gate.resolver_id = resolver_id
+    gate.resolved_at = datetime.now(timezone.utc)
+    await session.flush()
+    await session.refresh(gate)
+    return gate

--- a/backend/app/services/verdict_capture.py
+++ b/backend/app/services/verdict_capture.py
@@ -113,6 +113,8 @@ async def capture_pr_ci_verdict(
 
     recorded: list[str] = []
 
+    from app.services.gate_service import resolve_gate_from_verdict
+
     # source=pr: 머지 여부 + rounds
     if merged:
         rounds = await fetch_pr_review_rounds(repo, pr_number)
@@ -122,6 +124,13 @@ async def capture_pr_ci_verdict(
             result="pass",
             rounds=rounds if rounds > 0 else None,
         )
+        # verdict → 대응 게이트 해소 (게이트 없거나 오류면 graceful skip)
+        try:
+            await resolve_gate_from_verdict(
+                session, org_id, story_id, "story", "pr", "pass"
+            )
+        except Exception:
+            pass
         recorded.append("pr")
 
     # source=ci: CI 결과
@@ -133,6 +142,12 @@ async def capture_pr_ci_verdict(
             result=normalized,
             rounds=None,
         )
+        try:
+            await resolve_gate_from_verdict(
+                session, org_id, story_id, "story", "ci", normalized
+            )
+        except Exception:
+            pass
         recorded.append("ci")
 
     return {"recorded": recorded, "skipped_reason": None}
@@ -200,10 +215,19 @@ async def capture_review_verdict(
     if participation is None:
         return {"recorded": False, "skipped_reason": f"no_{role_key}_role"}
 
+    from app.services.gate_service import resolve_gate_from_verdict
+
     await record_verdict(
         session, org_id, participation.id,
         source=role_key,
         result=result,
         rounds=rounds,
     )
+    # verdict → 대응 게이트 해소 (게이트 없거나 오류면 graceful skip)
+    try:
+        await resolve_gate_from_verdict(
+            session, org_id, story_id, "story", role_key, result
+        )
+    except Exception:
+        pass
     return {"recorded": True, "source": role_key, "result": result, "skipped_reason": None}

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -1,0 +1,323 @@
+"""E-CAGE-REFEREE P3: HITL gate 1급 객체 + 상태기계 + verdict 와이어링 테스트."""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.gate import is_valid_transition
+from app.services.gate_service import resolve_gate_from_verdict
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+GATE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 상태기계 단위 테스트 ───────────────────────────────────────────────────────
+
+def test_valid_transition_pending_approved():
+    assert is_valid_transition("pending", "approved") is True
+
+
+def test_valid_transition_pending_rejected():
+    assert is_valid_transition("pending", "rejected") is True
+
+
+def test_invalid_transition_auto_passed_to_approved():
+    assert is_valid_transition("auto_passed", "approved") is False
+
+
+def test_invalid_transition_approved_to_rejected():
+    assert is_valid_transition("approved", "rejected") is False
+
+
+def test_invalid_transition_rejected_to_approved():
+    assert is_valid_transition("rejected", "approved") is False
+
+
+def test_invalid_self_transition():
+    assert is_valid_transition("pending", "pending") is False
+
+
+# ── create_gate disposition 매핑 테스트 ───────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_gate_ask_gives_pending():
+    """disposition=ask → status=pending."""
+    from app.services.gate_service import create_gate
+
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = None  # 없음
+    session.execute = AsyncMock(return_value=existing_r)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        mock_disp.return_value = "ask"
+
+        gate = MagicMock()
+        gate.status = "pending"
+        session.refresh = AsyncMock(side_effect=lambda obj: None)
+
+        await create_gate(session, ORG_ID, STORY_ID, "story", "pr_review", MEMBER_ID, ROLE_ID)
+
+        mock_disp.assert_called_once()
+        added = session.add.call_args[0][0]
+        assert added.status == "pending"
+
+
+@pytest.mark.anyio
+async def test_create_gate_allow_auto_gives_auto_passed():
+    """disposition=allow_auto → status=auto_passed."""
+    from app.services.gate_service import create_gate
+
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=existing_r)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        mock_disp.return_value = "allow_auto"
+
+        await create_gate(session, ORG_ID, STORY_ID, "story", "pr_review", MEMBER_ID, ROLE_ID)
+
+        added = session.add.call_args[0][0]
+        assert added.status == "auto_passed"
+        assert added.resolved_at is not None
+
+
+@pytest.mark.anyio
+async def test_create_gate_deny_gives_rejected():
+    """disposition=deny → status=rejected."""
+    from app.services.gate_service import create_gate
+
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=existing_r)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    with patch("app.services.gate_service.resolve_disposition", new_callable=AsyncMock) as mock_disp:
+        mock_disp.return_value = "deny"
+
+        await create_gate(session, ORG_ID, STORY_ID, "story", "merge", MEMBER_ID, ROLE_ID)
+
+        added = session.add.call_args[0][0]
+        assert added.status == "rejected"
+
+
+@pytest.mark.anyio
+async def test_create_gate_idempotent():
+    """이미 게이트 있으면 기존 반환."""
+    from app.services.gate_service import create_gate
+
+    existing_gate = MagicMock()
+    existing_gate.status = "pending"
+
+    session = AsyncMock()
+    existing_r = MagicMock()
+    existing_r.scalar_one_or_none.return_value = existing_gate
+    session.execute = AsyncMock(return_value=existing_r)
+
+    result = await create_gate(session, ORG_ID, STORY_ID, "story", "qa", MEMBER_ID, ROLE_ID)
+    assert result == existing_gate
+    session.add.assert_not_called()
+
+
+# ── transition_gate 상태기계 테스트 ───────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_transition_valid_pending_to_approved():
+    """pending → approved 전이 성공."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID)
+    assert gate.status == "approved"
+    assert gate.resolver_id == MEMBER_ID
+
+
+@pytest.mark.anyio
+async def test_transition_invalid_auto_passed_raises():
+    """auto_passed → approved 불법 전이 → ValueError."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.status = "auto_passed"
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+
+    with pytest.raises(ValueError, match="불법 전이"):
+        await transition_gate(session, ORG_ID, GATE_ID, "approved")
+
+
+# ── verdict→게이트 해소 와이어링 ──────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_gate_pr_pass_approves_pr_review_gate():
+    """verdict source='pr' result='pass' → pr_review 게이트 approved."""
+    gate = MagicMock()
+    gate.status = "pending"
+    gate.role_id = ROLE_ID
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    result = await resolve_gate_from_verdict(
+        session, ORG_ID, STORY_ID, "story", "pr", "pass"
+    )
+    assert gate.status == "approved"
+
+
+@pytest.mark.anyio
+async def test_resolve_gate_ci_fail_rejects_pr_review_gate():
+    """verdict source='ci' result='fail' → pr_review 게이트 rejected."""
+    gate = MagicMock()
+    gate.status = "pending"
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await resolve_gate_from_verdict(session, ORG_ID, STORY_ID, "story", "ci", "fail")
+    assert gate.status == "rejected"
+
+
+@pytest.mark.anyio
+async def test_resolve_gate_qa_maps_to_qa_gate():
+    """verdict source='qa' → gate_type='qa' 탐색."""
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = None  # 게이트 없음
+    session.execute = AsyncMock(return_value=gate_r)
+
+    result = await resolve_gate_from_verdict(
+        session, ORG_ID, STORY_ID, "story", "qa", "pass"
+    )
+    assert result is None  # graceful skip
+
+
+@pytest.mark.anyio
+async def test_resolve_gate_null_result_skip():
+    """result=None → 강제 해소 금지 (미측정)."""
+    session = AsyncMock()
+
+    result = await resolve_gate_from_verdict(
+        session, ORG_ID, STORY_ID, "story", "pr", None
+    )
+    assert result is None
+    session.execute.assert_not_called()
+
+
+@pytest.mark.anyio
+async def test_resolve_gate_no_pending_gate_graceful():
+    """pending 게이트 없으면 graceful None."""
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=gate_r)
+
+    result = await resolve_gate_from_verdict(
+        session, ORG_ID, STORY_ID, "story", "pr", "pass"
+    )
+    assert result is None
+
+
+# ── verdict 캡처 시 게이트 해소 와이어링 통합 단언 ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_capture_pr_wires_gate_resolution():
+    """capture_pr_ci_verdict가 resolve_gate_from_verdict를 실제 호출 (dead-path 방지)."""
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    session = AsyncMock()
+    participation = MagicMock()
+    participation.id = uuid.uuid4()
+
+    with patch("app.services.verdict_capture.resolve_implementation_participation", new_callable=AsyncMock) as mock_part, \
+         patch("app.services.verdict_capture.fetch_pr_review_rounds", new_callable=AsyncMock) as mock_rounds, \
+         patch("app.services.verdict_capture.record_verdict", new_callable=AsyncMock), \
+         patch("app.services.gate_service.resolve_gate_from_verdict", new_callable=AsyncMock) as mock_gate:
+        mock_part.return_value = participation
+        mock_rounds.return_value = 0
+        mock_gate.return_value = None  # graceful
+
+        await capture_pr_ci_verdict(
+            session, ORG_ID, STORY_ID, pr_number=1, repo="org/repo",
+            merged=True, ci_result=None
+        )
+
+        mock_gate.assert_called_once_with(session, ORG_ID, STORY_ID, "story", "pr", "pass")
+
+
+# ── org 격리 ──────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_org_isolation_gate():
+    """게이트 조회 시 org_id 스코프 — 다른 org 게이트 미노출."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.scalars.return_value.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_r)
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get(f"/api/v2/gates?work_item_id={STORY_ID}")
+        assert resp.status_code == 200
+        assert resp.json() == []
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary

#1115 WARN 2건 흡수: ⓐ OrgScopedMixin dead import 제거 ⓑ gate_type field_validator 추가

- **migration 0067**: `gate` 테이블(work_item_id/type·gate_type·status·resolver·neutral_facts). idempotent + downgrade IF EXISTS 가드
- **models/gate.py**: `Gate` + `is_valid_transition()` — 상태기계 `pending→approved|rejected`만 허용. auto_passed|approved|rejected 불변.
- **services/gate_service.py**:
  - `create_gate()`: `resolve_disposition()` → disposition → status 자동 결정. 멱등.
  - `transition_gate()`: 상태기계 가드, 불법 전이 → ValueError
  - `resolve_gate_from_verdict()`: verdict source→gate_type 매핑, pending 게이트 해소. 없으면 graceful None.
- **verdict_capture.py**: PR/CI/QA/design verdict 포착 후 `resolve_gate_from_verdict` 실경로 와이어링 (try/except graceful)

## Gate life cycle

```
create_gate(ask)     → pending
create_gate(allow_auto) → auto_passed (숨김)
create_gate(deny)    → rejected

verdict pass → pending gate → approved
verdict fail → pending gate → rejected
```

neutral_facts: 관찰값(touches_migration·diff_size) — 판정 아님

## Test plan

- [ ] 상태기계 6종: valid(pending→approved/rejected) + invalid(auto_passed/approved/rejected/self)
- [ ] create_gate 4종: ask→pending/allow_auto→auto_passed/deny→rejected/idempotent
- [ ] transition 2종: valid + invalid raises
- [ ] verdict→gate 해소 5종: pr-pass/ci-fail/qa/null-skip/no-pending-gate
- [ ] `test_capture_pr_wires_gate_resolution`: 실경로 호출 단언
- [ ] org 격리
- [ ] 전체 pytest 1369 PASS
- [ ] 머지 후 migration 0067 수동 실행 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)