### PR TITLE
[E-CAGE-REFEREE P3 ④] 신뢰 기반 동적 조절 추천 엔진

### DIFF
--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy import DateTime, String, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,10 +24,26 @@ class GateCreateRequest(BaseModel):
     role_id: uuid.UUID
     neutral_facts: dict[str, Any] | None = None
 
+    @field_validator("gate_type")
+    @classmethod
+    def validate_gate_type(cls, v: str) -> str:
+        from app.models.hitl_config import GATE_TYPES
+        if v not in GATE_TYPES:
+            raise ValueError(f"gate_type must be one of {sorted(GATE_TYPES)}")
+        return v
+
 
 class GateTransitionRequest(BaseModel):
     status: str
     resolver_id: uuid.UUID | None = None
+
+    @field_validator("status")
+    @classmethod
+    def validate_status(cls, v: str) -> str:
+        from app.models.gate import GATE_STATUSES
+        if v not in GATE_STATUSES:
+            raise ValueError(f"status must be one of {sorted(GATE_STATUSES)}")
+        return v
 
 
 class GateResponse(BaseModel):

--- a/backend/app/routers/hitl_config.py
+++ b/backend/app/routers/hitl_config.py
@@ -2,6 +2,7 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +20,7 @@ from app.schemas.hitl_config import (
     ResolveRequest,
     ResolveResponse,
 )
+from app.services.disposition_advisor import DEFAULT_MIN_VERDICTS, get_disposition_recommendation
 from app.services.gate_resolver import resolve_disposition
 
 router = APIRouter(prefix="/api/v2/gate-config", tags=["gate-config"])
@@ -195,3 +197,111 @@ async def resolve(
         role_id=body.role_id,
         gate_type=body.gate_type,
     )
+
+
+# ── 동적 조절 추천 + 적용 ──────────────────────────────────────────────────────
+
+class RecommendRequest(BaseModel):
+    member_id: uuid.UUID
+    role_id: uuid.UUID
+    role_key: str
+    gate_type: str
+    min_verdicts: int = DEFAULT_MIN_VERDICTS
+    window_days: int = 90
+
+
+class ApplyRecommendationRequest(BaseModel):
+    member_id: uuid.UUID
+    gate_type: str
+    disposition: str
+    apply_as: str = "member"  # "member" | "org_role"
+    role_id: uuid.UUID | None = None
+
+
+@router.post("/recommendations/suggest")
+async def suggest_adjustment(
+    body: RecommendRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> dict:
+    """신뢰점수 기반 disposition 조정 추천 (조회만, 자동 적용 없음).
+
+    인간이 추천을 검토 후 /recommendations/apply로 승인해야 반영됨.
+    저표본 가드: min_verdicts 미달 시 추천 없음.
+    """
+    return await get_disposition_recommendation(
+        session=session,
+        org_id=org_id,
+        member_id=body.member_id,
+        role_id=body.role_id,
+        role_key=body.role_key,
+        gate_type=body.gate_type,
+        min_verdicts=body.min_verdicts,
+        window_days=body.window_days,
+    )
+
+
+@router.post("/recommendations/apply")
+async def apply_adjustment(
+    body: ApplyRecommendationRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth=Depends(get_current_user),
+) -> dict:
+    """인간 승인 후 override 적용.
+
+    ⚠️ 자동 호출 금지 — 반드시 인간이 추천 검토 후 명시 호출.
+    apply_as='member': member_gate_override upsert.
+    apply_as='org_role': org_gate_override upsert (role_id 필수).
+    """
+    from app.models.hitl_config import DISPOSITIONS
+
+    if body.disposition not in DISPOSITIONS:
+        raise HTTPException(status_code=422, detail=f"disposition must be one of {sorted(DISPOSITIONS)}")
+
+    if body.apply_as == "member":
+        r = await session.execute(
+            select(MemberGateOverride).where(
+                MemberGateOverride.org_id == org_id,
+                MemberGateOverride.member_id == body.member_id,
+                MemberGateOverride.gate_type == body.gate_type,
+            ).limit(1)
+        )
+        mo = r.scalar_one_or_none()
+        if mo is None:
+            mo = MemberGateOverride(
+                id=uuid.uuid4(), org_id=org_id,
+                member_id=body.member_id, gate_type=body.gate_type,
+                disposition=body.disposition,
+            )
+            session.add(mo)
+        else:
+            mo.disposition = body.disposition
+        await session.flush()
+        return {"applied": True, "apply_as": "member", "disposition": body.disposition}
+
+    if body.apply_as == "org_role":
+        if body.role_id is None:
+            raise HTTPException(status_code=422, detail="role_id required for org_role apply")
+        r = await session.execute(
+            select(OrgGateOverride).where(
+                OrgGateOverride.org_id == org_id,
+                OrgGateOverride.role_id == body.role_id,
+                OrgGateOverride.gate_type == body.gate_type,
+            ).limit(1)
+        )
+        oo = r.scalar_one_or_none()
+        if oo is None:
+            oo = OrgGateOverride(
+                id=uuid.uuid4(), org_id=org_id,
+                role_id=body.role_id, gate_type=body.gate_type,
+                disposition=body.disposition,
+            )
+            session.add(oo)
+        else:
+            oo.disposition = body.disposition
+        await session.flush()
+        return {"applied": True, "apply_as": "org_role", "disposition": body.disposition}
+
+    raise HTTPException(status_code=422, detail="apply_as must be 'member' or 'org_role'")

--- a/backend/app/services/disposition_advisor.py
+++ b/backend/app/services/disposition_advisor.py
@@ -1,0 +1,144 @@
+"""E-CAGE-REFEREE P3 ④: 신뢰 기반 disposition 동적 조절 추천 엔진.
+
+추천만 — 인간 승인 후 override 적용. 자동 적용 절대 금지.
+저표본 가드: verdict 부족 시 추천 안 함(책상발명 금지).
+온더플라이 집계 (추가 마이그 없음).
+
+추천 기준 (보수적 MVP):
+  완화 추천: clean_pass_rate >= HIGH_THRESHOLD AND total_verdicts >= min_verdicts
+             AND current_disposition != 'allow_auto'
+             → allow_auto 추천
+  강화 추천: clean_pass_rate < LOW_THRESHOLD AND total_verdicts >= min_verdicts
+             AND current_disposition == 'allow_auto'
+             → ask 추천
+  그 외: 추천 없음 (데이터 더 쌓인 뒤)
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.gate_resolver import resolve_disposition
+from app.services.trust_score import compute_member_trust_scores
+
+DEFAULT_MIN_VERDICTS = 10  # 저표본 임계값 — 보수적 기본
+HIGH_THRESHOLD = 0.90      # 완화 추천: 90% 이상 무정정 통과
+LOW_THRESHOLD = 0.70       # 강화 추천: 70% 미만
+
+
+async def get_disposition_recommendation(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    member_id: uuid.UUID,
+    role_id: uuid.UUID,
+    role_key: str,
+    gate_type: str,
+    min_verdicts: int = DEFAULT_MIN_VERDICTS,
+    window_days: int = 90,
+) -> dict[str, Any]:
+    """(member, role, gate_type)별 disposition 조정 추천.
+
+    Args:
+        role_key: participation_role.key — trust_score role 필터용
+        min_verdicts: 저표본 가드 임계값
+
+    Returns:
+        {
+            "has_recommendation": bool,
+            "current_disposition": str,
+            "recommended_disposition": str | None,
+            "reason": str,
+            "clean_pass_rate": float | None,
+            "total_verdicts": int,
+            "skipped_reason": str | None,
+        }
+    """
+    # 1. 현재 disposition 해소
+    current = await resolve_disposition(session, org_id, member_id, role_id, gate_type)
+
+    # 2. 신뢰점수 조회
+    trust = await compute_member_trust_scores(
+        session=session,
+        org_id=org_id,
+        member_id=member_id,
+        role_key=role_key,
+        window_days=window_days,
+    )
+
+    role_score = next(
+        (s for s in trust.get("scores", []) if s["role_key"] == role_key),
+        None,
+    )
+
+    total_verdicts = role_score["total_verdicts"] if role_score else 0
+    clean_pass_rate = role_score.get("clean_pass_rate") if role_score else None
+
+    # 3. 저표본 가드
+    if total_verdicts < min_verdicts:
+        return {
+            "has_recommendation": False,
+            "current_disposition": current,
+            "recommended_disposition": None,
+            "reason": f"표본 부족 (verdicts={total_verdicts} < min={min_verdicts}). 더 쌓인 뒤 추천 가능.",
+            "clean_pass_rate": clean_pass_rate,
+            "total_verdicts": total_verdicts,
+            "skipped_reason": "low_sample",
+        }
+
+    # 4. 추천 산출
+    if clean_pass_rate is None:
+        return {
+            "has_recommendation": False,
+            "current_disposition": current,
+            "recommended_disposition": None,
+            "reason": "clean_pass_rate 없음 (verdict 있으나 SP 데이터 없음).",
+            "clean_pass_rate": None,
+            "total_verdicts": total_verdicts,
+            "skipped_reason": "no_rate",
+        }
+
+    # 완화 추천
+    if clean_pass_rate >= HIGH_THRESHOLD and current != "allow_auto":
+        return {
+            "has_recommendation": True,
+            "current_disposition": current,
+            "recommended_disposition": "allow_auto",
+            "reason": (
+                f"무정정 통과율 {clean_pass_rate:.0%} ({total_verdicts}건) — "
+                f"신뢰 충분, {current} → allow_auto 완화 추천."
+            ),
+            "clean_pass_rate": clean_pass_rate,
+            "total_verdicts": total_verdicts,
+            "skipped_reason": None,
+        }
+
+    # 강화 추천
+    if clean_pass_rate < LOW_THRESHOLD and current == "allow_auto":
+        return {
+            "has_recommendation": True,
+            "current_disposition": current,
+            "recommended_disposition": "ask",
+            "reason": (
+                f"무정정 통과율 {clean_pass_rate:.0%} ({total_verdicts}건) — "
+                f"통과율 하락, allow_auto → ask 강화 추천."
+            ),
+            "clean_pass_rate": clean_pass_rate,
+            "total_verdicts": total_verdicts,
+            "skipped_reason": None,
+        }
+
+    # 추천 없음
+    return {
+        "has_recommendation": False,
+        "current_disposition": current,
+        "recommended_disposition": None,
+        "reason": (
+            f"통과율 {clean_pass_rate:.0%} ({total_verdicts}건) — "
+            f"현 disposition({current}) 적합, 조정 불필요."
+        ),
+        "clean_pass_rate": clean_pass_rate,
+        "total_verdicts": total_verdicts,
+        "skipped_reason": "no_adjustment_needed",
+    }

--- a/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
+++ b/backend/tests/test_e_cage_referee_p3_dynamic_adjustment.py
@@ -1,0 +1,264 @@
+"""E-CAGE-REFEREE P3 ④: 신뢰 기반 동적 조절 추천 엔진 테스트."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.disposition_advisor import (
+    DEFAULT_MIN_VERDICTS,
+    HIGH_THRESHOLD,
+    LOW_THRESHOLD,
+    get_disposition_recommendation,
+)
+
+ORG_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+ROLE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _trust_result(clean_pass_rate, total_verdicts, role_key="implementation"):
+    return {
+        "member_id": str(MEMBER_ID),
+        "scores": [
+            {
+                "role_key": role_key,
+                "role_label": "구현",
+                "clean_pass_verdicts": int(clean_pass_rate * total_verdicts),
+                "total_verdicts": total_verdicts,
+                "clean_pass_rate": clean_pass_rate,
+                "total_sp": total_verdicts * 5,
+                "clean_sp": int(clean_pass_rate * total_verdicts * 5),
+                "weighted_score": clean_pass_rate,
+            }
+        ],
+        "window_days": 90,
+    }
+
+
+# ── 완화 추천 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_recommend_relax_ask_to_allow_auto():
+    """현 disposition=ask + pass_rate>=0.9 + 충분한 표본 → allow_auto 완화 추천."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "ask"
+        mock_trust.return_value = _trust_result(0.95, 20)
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is True
+    assert result["recommended_disposition"] == "allow_auto"
+    assert result["current_disposition"] == "ask"
+    assert result["clean_pass_rate"] == 0.95
+
+
+@pytest.mark.anyio
+async def test_no_recommend_when_already_allow_auto_high_rate():
+    """이미 allow_auto인데 pass_rate 높음 → 추천 없음."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "allow_auto"
+        mock_trust.return_value = _trust_result(0.98, 20)
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is False
+    assert result["skipped_reason"] == "no_adjustment_needed"
+
+
+# ── 강화 추천 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_recommend_tighten_allow_auto_to_ask():
+    """현 disposition=allow_auto + pass_rate<0.7 → ask 강화 추천."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "allow_auto"
+        mock_trust.return_value = _trust_result(0.60, 15)
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is True
+    assert result["recommended_disposition"] == "ask"
+    assert result["current_disposition"] == "allow_auto"
+
+
+@pytest.mark.anyio
+async def test_no_recommend_tighten_when_ask():
+    """현 disposition=ask인데 pass_rate 낮음 → 이미 ask, 추천 없음."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "ask"
+        mock_trust.return_value = _trust_result(0.50, 15)
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is False
+    assert result["skipped_reason"] == "no_adjustment_needed"
+
+
+# ── 저표본 가드 ───────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_low_sample_guard_no_recommendation():
+    """verdicts < min_verdicts → 추천 없음 (저표본 가드)."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "ask"
+        mock_trust.return_value = _trust_result(0.99, 3)  # 3건 < DEFAULT 10건
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is False
+    assert result["skipped_reason"] == "low_sample"
+    assert result["total_verdicts"] == 3
+
+
+@pytest.mark.anyio
+async def test_custom_min_verdicts():
+    """min_verdicts 커스텀 — 3건으로 낮추면 추천 가능."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "ask"
+        mock_trust.return_value = _trust_result(0.95, 3)
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review",
+            min_verdicts=3,
+        )
+
+    assert result["has_recommendation"] is True
+    assert result["recommended_disposition"] == "allow_auto"
+
+
+@pytest.mark.anyio
+async def test_no_verdicts_low_sample():
+    """verdict 0건 → 저표본 가드."""
+    session = AsyncMock()
+
+    with patch("app.services.disposition_advisor.resolve_disposition", new_callable=AsyncMock) as mock_disp, \
+         patch("app.services.disposition_advisor.compute_member_trust_scores", new_callable=AsyncMock) as mock_trust:
+        mock_disp.return_value = "ask"
+        mock_trust.return_value = {"member_id": str(MEMBER_ID), "scores": [], "window_days": 90}
+
+        result = await get_disposition_recommendation(
+            session, ORG_ID, MEMBER_ID, ROLE_ID, "implementation", "pr_review"
+        )
+
+    assert result["has_recommendation"] is False
+    assert result["skipped_reason"] == "low_sample"
+    assert result["total_verdicts"] == 0
+
+
+# ── 자동 적용 없음 단언 ────────────────────────────────────────────────────────
+
+def test_advisor_returns_only_recommendation_not_apply():
+    """advisor 서비스는 추천만 반환 — override 적용 코드 없음."""
+    import inspect
+    import app.services.disposition_advisor as m
+    src = inspect.getsource(m)
+    # 서비스 코드에 upsert/add/create override 로직 없음
+    assert "session.add" not in src
+    assert "MemberGateOverride" not in src
+    assert "OrgGateOverride" not in src
+
+
+# ── apply 엔드포인트 — 인간 승인 후만 ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_apply_endpoint_member_override():
+    """POST /gate-config/recommendations/apply → member_gate_override upsert."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    mock_session = AsyncMock()
+    mock_r = MagicMock()
+    mock_r.scalar_one_or_none.return_value = None  # 없음 → 신규 생성
+    mock_session.execute = AsyncMock(return_value=mock_r)
+    mock_session.add = MagicMock()
+    mock_session.flush = AsyncMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/gate-config/recommendations/apply", json={
+                "member_id": str(MEMBER_ID),
+                "gate_type": "pr_review",
+                "disposition": "allow_auto",
+                "apply_as": "member",
+            })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["applied"] is True
+        assert body["disposition"] == "allow_auto"
+        mock_session.add.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── #1116 WARN 흡수 확인 ─────────────────────────────────────────────────────
+
+def test_gate_no_foreignkey_import():
+    """gate.py에 ForeignKey dead import 없음."""
+    import app.models.gate as m
+    import inspect
+    src = inspect.getsource(m)
+    assert "ForeignKey" not in src
+
+
+def test_gate_create_request_validates_gate_type():
+    """GateCreateRequest gate_type field_validator → 422."""
+    from app.routers.gates import GateCreateRequest
+    from pydantic import ValidationError
+    import pytest
+    with pytest.raises(ValidationError):
+        GateCreateRequest(
+            work_item_id=uuid.uuid4(),
+            work_item_type="story",
+            gate_type="invalid_type",
+            member_id=uuid.uuid4(),
+            role_id=uuid.uuid4(),
+        )


### PR DESCRIPTION
## Summary

#1116 WARN 흡수: gate.py ForeignKey dead import 제거 + GateCreate/Transition field_validator 추가(422)

- **`disposition_advisor.py`**: `get_disposition_recommendation()` — 현 disposition vs trust_score 비교 → 조정 추천.
  - 완화: clean_pass_rate >= 0.90 AND verdicts >= min AND current != allow_auto → allow_auto 추천
  - 강화: clean_pass_rate < 0.70 AND verdicts >= min AND current == allow_auto → ask 추천
  - 저표본 가드: verdicts < min_verdicts(기본 10) → 추천 없음. 커스텀 가능.
  - **자동 적용 없음** — 서비스 코드에 session.add/override 로직 0건

- **`POST /gate-config/recommendations/suggest`**: 추천 조회만 (자동 적용 없음)
- **`POST /gate-config/recommendations/apply`**: 인간 승인 후 override upsert. apply_as=member|org_role.

## 자동 적용 절대 금지

advisor 서비스 소스에 `session.add`, `MemberGateOverride`, `OrgGateOverride` 없음 — `test_advisor_returns_only_recommendation_not_apply`로 소스 레벨 단언.

## Test plan

- [ ] 완화 추천(ask→allow_auto)/강화 추천(allow_auto→ask)/현상유지
- [ ] 저표본 가드 3종: default/custom/zero_verdicts
- [ ] 자동 적용 없음 소스 단언
- [ ] apply endpoint member_override upsert
- [ ] #1116 WARN 흡수(ForeignKey/field_validator)
- [ ] 전체 pytest 1380 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)