### PR TITLE
[SID:91fd44ec] [E-CAGE FE P2] 신뢰점수 가시화 — 프로필 카드 + 대시보드 칩

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2236,5 +2236,17 @@
     "hypothesisPlaceholder_story": "What would be different if this story succeeds?",
     "metric_completion_pct": "Completion %",
     "hypothesisPlaceholder_epic": "What outcome do we expect by completing this epic?"
+  },
+  "cage": {
+    "trustScoreLabel": "Clean Pass Rate",
+    "trustScoreWindowHint": "Last {days} days",
+    "trustScoreNoData": "No review data yet",
+    "trustScoreNoDataHint": "Score will appear after first review",
+    "trustScorePending": "Pending",
+    "totalReviews": "Reviews",
+    "cleanPasses": "Clean",
+    "corrections": "Rounds",
+    "correctionRounds": "{count} correction(s)",
+    "byRole": "By Role"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2236,5 +2236,17 @@
     "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?",
     "metric_completion_pct": "완료율 %",
     "hypothesisPlaceholder_epic": "이 에픽을 완수하면 어떤 성과를 기대하는가?"
+  },
+  "cage": {
+    "trustScoreLabel": "무정정 통과율",
+    "trustScoreWindowHint": "최근 {days}일",
+    "trustScoreNoData": "검수 데이터 없음",
+    "trustScoreNoDataHint": "첫 검수 후 점수가 표시됩니다",
+    "trustScorePending": "측정 대기",
+    "totalReviews": "전체",
+    "cleanPasses": "무정정",
+    "corrections": "정정",
+    "correctionRounds": "정정 {count}회",
+    "byRole": "역할별"
   }
 }

--- a/apps/web/src/app/api/trust-scores/route.ts
+++ b/apps/web/src/app/api/trust-scores/route.ts
@@ -1,0 +1,5 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/trust-scores');
+}

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Button } from '@/components/ui/button';
 import { formatLocaleDateOnly } from '@/lib/i18n';
 import { DashboardActivityTimeline } from '@/components/activity/dashboard-activity-timeline';
+import { TrustScoreCard } from '@/components/cage/trust-score-card';
 
 export default async function DashboardPage() {
   const fetchedAt = new Date().toISOString();
@@ -96,11 +97,16 @@ export default async function DashboardPage() {
           />
           <div className="relative flex flex-col gap-5 lg:flex-row lg:items-center lg:justify-between">
             <div className="space-y-3">
-              {activeSprint && (
-                <span className="inline-flex items-center gap-1.5 rounded-full border border-brand/30 bg-brand/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-brand">
-                  {activeSprint.title} · DAY {sprintDay} / {sprintTotal}
-                </span>
-              )}
+              <div className="flex flex-wrap items-center gap-2">
+                {activeSprint && (
+                  <span className="inline-flex items-center gap-1.5 rounded-full border border-brand/30 bg-brand/10 px-3 py-1 text-[11px] font-semibold uppercase tracking-widest text-brand">
+                    {activeSprint.title} · DAY {sprintDay} / {sprintTotal}
+                  </span>
+                )}
+                <Link href="/settings" className="inline-flex items-center gap-1.5">
+                  <TrustScoreCard memberId={teamMemberId} compact />
+                </Link>
+              </div>
               <div className="flex flex-wrap gap-2">
                 <Button asChild size="sm">
                   <Link href="/board">{t('openBoard')}</Link>

--- a/apps/web/src/components/cage/trust-score-card.tsx
+++ b/apps/web/src/components/cage/trust-score-card.tsx
@@ -56,7 +56,7 @@ export function TrustScoreCard({ memberId, compact = false }: TrustScoreCardProp
   useEffect(() => {
     fetch(`/api/trust-scores?member_id=${memberId}`)
       .then((r) => r.ok ? r.json() : null)
-      .then((json) => setData(((json as { data?: TrustScoreData } | null)?.data ?? null)))
+      .then((json) => setData((json as TrustScoreData | null)))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [memberId]);

--- a/apps/web/src/components/cage/trust-score-card.tsx
+++ b/apps/web/src/components/cage/trust-score-card.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+interface RoleScore {
+  role_key: string;
+  role_label: string;
+  clean_pass_verdicts: number;
+  total_verdicts: number;
+  clean_pass_rate: number | null;
+  total_sp: number;
+  clean_sp: number;
+  weighted_score: number | null;
+}
+
+interface TrustScoreData {
+  member_id: string;
+  scores: RoleScore[];
+  window_days: number;
+  computed_at: string;
+}
+
+interface TrustScoreCardProps {
+  memberId: string;
+  compact?: boolean;
+}
+
+function pct(rate: number | null): string {
+  if (rate === null) return '—';
+  return `${Math.round(rate * 100)}%`;
+}
+
+function TrustScoreEmpty({ compact }: { compact?: boolean }) {
+  const t = useTranslations('cage');
+  if (compact) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full border border-dashed border-border px-2 py-0.5 text-[10px] text-muted-foreground">
+        {t('trustScorePending')}
+      </span>
+    );
+  }
+  return (
+    <div className="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-5 text-center">
+      <p className="text-sm font-medium text-muted-foreground">{t('trustScoreNoData')}</p>
+      <p className="mt-1 text-xs text-muted-foreground/60">{t('trustScoreNoDataHint')}</p>
+    </div>
+  );
+}
+
+export function TrustScoreCard({ memberId, compact = false }: TrustScoreCardProps) {
+  const t = useTranslations('cage');
+  const [data, setData] = useState<TrustScoreData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/trust-scores?member_id=${memberId}`)
+      .then((r) => r.ok ? r.json() : null)
+      .then((json) => setData(json as TrustScoreData | null))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, [memberId]);
+
+  if (loading) {
+    return compact ? null : <div className="h-20 animate-pulse rounded-xl bg-muted/30" />;
+  }
+
+  const hasData = (data?.scores ?? []).some((s) => s.total_verdicts > 0);
+
+  if (!hasData) {
+    return <TrustScoreEmpty compact={compact} />;
+  }
+
+  const scores = data!.scores;
+  const totalVerdicts = scores.reduce((s, r) => s + r.total_verdicts, 0);
+  const cleanPasses = scores.reduce((s, r) => s + r.clean_pass_verdicts, 0);
+  const corrections = totalVerdicts - cleanPasses;
+  const overallRate = totalVerdicts > 0 ? cleanPasses / totalVerdicts : null;
+
+  if (compact) {
+    const hasCorrections = corrections > 0;
+    return (
+      <span
+        className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium tabular-nums ${
+          hasCorrections
+            ? 'border-warning-border bg-warning-tint text-warning'
+            : 'border-border bg-muted/40 text-foreground'
+        }`}
+      >
+        {pct(overallRate)}
+      </span>
+    );
+  }
+
+  return (
+    <div className="space-y-4 rounded-xl border border-border bg-card p-4">
+      {/* 주지표 */}
+      <div className="flex items-end justify-between">
+        <div>
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('trustScoreLabel')}</p>
+          <p className="mt-1 text-3xl font-bold tabular-nums text-foreground">{pct(overallRate)}</p>
+          <p className="text-xs text-muted-foreground">{t('trustScoreWindowHint', { days: data!.window_days })}</p>
+        </div>
+        {corrections > 0 && (
+          <span className="rounded-md border border-warning-border bg-warning-tint px-2 py-1 text-xs font-medium text-warning">
+            {t('correctionRounds', { count: corrections })}
+          </span>
+        )}
+      </div>
+
+      {/* 전적 trio */}
+      <div className="grid grid-cols-3 gap-2">
+        {([
+          { label: t('totalReviews'), value: totalVerdicts },
+          { label: t('cleanPasses'), value: cleanPasses },
+          { label: t('corrections'), value: corrections },
+        ] as { label: string; value: number }[]).map(({ label, value }) => (
+          <div key={label} className="rounded-lg border border-border bg-muted/30 p-2 text-center">
+            <p className="text-lg font-bold tabular-nums text-foreground">{value}</p>
+            <p className="text-[10px] text-muted-foreground">{label}</p>
+          </div>
+        ))}
+      </div>
+
+      {/* 역할별 bar */}
+      {scores.filter((s) => s.total_verdicts > 0).length > 0 && (
+        <div className="space-y-2">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('byRole')}</p>
+          {scores.filter((s) => s.total_verdicts > 0).map((role) => (
+            <div key={role.role_key} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">{role.role_label}</span>
+                <span className="tabular-nums text-foreground">{pct(role.clean_pass_rate)}</span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-border">
+                <div
+                  className="h-full rounded-full bg-foreground/40 transition-all"
+                  style={{ width: role.clean_pass_rate !== null ? `${Math.round(role.clean_pass_rate * 100)}%` : '0%' }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/cage/trust-score-card.tsx
+++ b/apps/web/src/components/cage/trust-score-card.tsx
@@ -56,7 +56,7 @@ export function TrustScoreCard({ memberId, compact = false }: TrustScoreCardProp
   useEffect(() => {
     fetch(`/api/trust-scores?member_id=${memberId}`)
       .then((r) => r.ok ? r.json() : null)
-      .then((json) => setData(json as TrustScoreData | null))
+      .then((json) => setData(((json as { data?: TrustScoreData } | null)?.data ?? null)))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, [memberId]);

--- a/apps/web/src/components/settings/my-profile-section.tsx
+++ b/apps/web/src/components/settings/my-profile-section.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { OperatorInput } from '@/components/ui/operator-control';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { TrustScoreCard } from '@/components/cage/trust-score-card';
 
 interface MyProfile {
   id: string;
@@ -99,6 +100,12 @@ export function MyProfileSection() {
             <span className="w-20 shrink-0 text-muted-foreground">역할</span>
             <span>{profile.role}</span>
           </div>
+        </div>
+
+        {/* 신뢰점수 카드 */}
+        <div className="pt-2">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">신뢰 점수</p>
+          <TrustScoreCard memberId={profile.id} />
         </div>
       </SectionCardBody>
     </SectionCard>


### PR DESCRIPTION
## 변경 사항 (+194/-5, 6파일)

### api/trust-scores/route.ts (신규)
- `GET /api/v2/trust-scores?member_id&role&window_days` 프록시

### components/cage/trust-score-card.tsx (신규)
- **주지표**: `clean_pass_rate` 큰 숫자 표시
- **전적 trio**: 총 reviews / clean passes / corrections
- **역할별 bar**: `scores` 배열 (데이터 있는 역할만)
- **데이터 없음**: dashed border + muted "측정 대기" — 0%/빨강 금지 (없음≠나쁨)
- corrections > 0 → warning(amber) 칩만, 주지표는 중립 ink
- `compact` prop: 인라인 칩 (값 or "측정 대기")
- magic hex 0 — 토큰만

### my-profile-section.tsx
- TrustScoreCard 임베드 (memberId=profile.id)

### dashboard/page.tsx
- Hero Strip: TrustScoreCard compact + 클릭 → /settings

## AC 확인

| 항목 | 상태 |
|---|---|
| 프로필 신뢰점수 카드 (주지표+trio+역할별bar) | ✅ |
| 데이터 없음 상태 (dashed+muted, 0%/빨강 금지) | ✅ |
| 대시보드 컴팩트 칩 (값 or "측정 대기") | ✅ |
| Ledger 계승 (correction만 warning, 저점 중립) | ✅ |
| magic hex 0 | ✅ |
| pnpm type-check 에러 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)