### PR TITLE
[SID:d83e9716] [E-CAGE FE ③] HITL 게이트 웹 노출 — 카드 뱃지 + 개입 큐 + 승인/반려

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2236,5 +2236,17 @@
     "hypothesisPlaceholder_story": "What would be different if this story succeeds?",
     "metric_completion_pct": "Completion %",
     "hypothesisPlaceholder_epic": "What outcome do we expect by completing this epic?"
+  },
+  "cage": {
+    "gatePending": "gate pending",
+    "gateApprove": "Approve",
+    "gateReject": "Reject",
+    "gateRejectTitle": "Reject gate",
+    "gateRejectNotePlaceholder": "Reason (optional)",
+    "gateRejectConfirm": "Confirm reject",
+    "gateInboxLoading": "Loading gates...",
+    "gateInboxEmpty": "No pending gates",
+    "gateInboxEmptyHint": "Gates awaiting your review will appear here",
+    "cancel": "Cancel"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2236,5 +2236,17 @@
     "hypothesisPlaceholder_story": "이 스토리가 성공이라면 무엇이 달라지는가?",
     "metric_completion_pct": "완료율 %",
     "hypothesisPlaceholder_epic": "이 에픽을 완수하면 어떤 성과를 기대하는가?"
+  },
+  "cage": {
+    "gatePending": "게이트 대기",
+    "gateApprove": "승인",
+    "gateReject": "반려",
+    "gateRejectTitle": "게이트 반려",
+    "gateRejectNotePlaceholder": "사유 (선택)",
+    "gateRejectConfirm": "반려 확정",
+    "gateInboxLoading": "게이트 조회 중...",
+    "gateInboxEmpty": "대기 중인 게이트 없음",
+    "gateInboxEmptyHint": "검수 대기 중인 게이트가 여기 표시됩니다",
+    "cancel": "취소"
   }
 }

--- a/apps/web/src/app/api/gates/[id]/transition/route.ts
+++ b/apps/web/src/app/api/gates/[id]/transition/route.ts
@@ -1,0 +1,6 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }): Promise<Response> {
+  const { id } = await params;
+  return proxyToFastapi(request, `/api/v2/gates/${id}/transition`);
+}

--- a/apps/web/src/app/api/gates/route.ts
+++ b/apps/web/src/app/api/gates/route.ts
@@ -1,0 +1,9 @@
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+export async function GET(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/gates');
+}
+
+export async function POST(request: Request): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/gates');
+}

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { CheckCircle, XCircle } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import type { GateItem } from '@/components/kanban/types';
+
+interface GateInboxProps {
+  memberId: string;
+}
+
+interface RejectModalState {
+  gateId: string;
+  note: string;
+}
+
+export function GateInbox({ memberId }: GateInboxProps) {
+  const t = useTranslations('cage');
+  const [gates, setGates] = useState<GateItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [resolving, setResolving] = useState<string | null>(null);
+  const [rejectModal, setRejectModal] = useState<RejectModalState | null>(null);
+
+  const fetchGates = () => {
+    fetch('/api/gates?status=pending')
+      .then((r) => r.ok ? r.json() : [])
+      .then((json) => setGates(json as GateItem[]))
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => { fetchGates(); }, []);
+
+  const handleApprove = async (gateId: string) => {
+    setResolving(gateId);
+    try {
+      const res = await fetch(`/api/gates/${gateId}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'approved', resolver_id: memberId }),
+      });
+      if (res.ok) setGates((prev) => prev.filter((g) => g.id !== gateId));
+    } finally {
+      setResolving(null);
+    }
+  };
+
+  const handleReject = async () => {
+    if (!rejectModal) return;
+    setResolving(rejectModal.gateId);
+    try {
+      const res = await fetch(`/api/gates/${rejectModal.gateId}/transition`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'rejected', resolver_id: memberId }),
+      });
+      if (res.ok) {
+        setGates((prev) => prev.filter((g) => g.id !== rejectModal.gateId));
+        setRejectModal(null);
+      }
+    } finally {
+      setResolving(null);
+    }
+  };
+
+  if (loading) return <p className="text-xs text-muted-foreground">{t('gateInboxLoading')}</p>;
+
+  return (
+    <div className="space-y-2">
+      {gates.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border bg-muted/20 px-4 py-5 text-center">
+          <p className="text-sm text-muted-foreground">{t('gateInboxEmpty')}</p>
+          <p className="mt-1 text-xs text-muted-foreground/60">{t('gateInboxEmptyHint')}</p>
+        </div>
+      ) : (
+        gates.map((gate) => (
+          <div key={gate.id} className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3">
+            <div className="min-w-0 space-y-1">
+              <div className="flex items-center gap-2">
+                <Badge variant="info" className="shrink-0">
+                  <span className="mr-1">⏸</span>{gate.gate_type}
+                </Badge>
+                <span className="truncate text-xs text-muted-foreground">#{gate.work_item_id.slice(0, 6)}</span>
+              </div>
+              <p className="text-[10px] text-muted-foreground">{new Date(gate.created_at).toLocaleDateString()}</p>
+            </div>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                disabled={resolving === gate.id}
+                onClick={() => void handleApprove(gate.id)}
+              >
+                <CheckCircle className="size-3.5" />
+                {t('gateApprove')}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                disabled={resolving === gate.id}
+                onClick={() => setRejectModal({ gateId: gate.id, note: '' })}
+              >
+                <XCircle className="size-3.5" />
+                {t('gateReject')}
+              </Button>
+            </div>
+          </div>
+        ))
+      )}
+
+      {/* 반려 모달 */}
+      {rejectModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/50 backdrop-blur-[2px]"
+            onClick={() => setRejectModal(null)}
+            aria-label={t('cancel')}
+          />
+          <div className="relative z-10 w-full max-w-sm rounded-2xl border border-border bg-background p-5 shadow-xl">
+            <h3 className="mb-3 text-sm font-semibold">{t('gateRejectTitle')}</h3>
+            <textarea
+              rows={3}
+              value={rejectModal.note}
+              onChange={(e) => setRejectModal((prev) => prev ? { ...prev, note: e.target.value } : null)}
+              placeholder={t('gateRejectNotePlaceholder')}
+              className="w-full resize-none rounded-xl border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+            <div className="mt-3 flex justify-end gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setRejectModal(null)}>{t('cancel')}</Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                disabled={!!resolving}
+                onClick={() => void handleReject()}
+              >
+                {resolving ? '...' : t('gateRejectConfirm')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -23,7 +23,7 @@ import { KanbanListView } from './kanban-list-view';
 import { KanbanSkeleton } from './kanban-skeleton';
 import { StoryDetailPanel } from './story-detail-panel';
 import { StoryCard } from './story-card';
-import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge } from './types';
+import { COLUMNS, VALID_TRANSITIONS, type KanbanStory, type KanbanSprint, type KanbanEpic, type KanbanMember, type ColumnId, type DependencyEdge, type GateItem } from './types';
 import type { LabelData } from '@/components/ui/label-chip';
 
 type DragOverlayCompatProps = {
@@ -171,6 +171,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [storyLabelsMap, setStoryLabelsMap] = useState<Record<string, LabelData[]>>({});
   const [selectedLabelIds, setSelectedLabelIds] = useState<string[]>([]);
   const [labelSearch, setLabelSearch] = useState('');
+  const [storyGatesMap, setStoryGatesMap] = useState<Record<string, { id: string; gate_type: string; status: string }[]>>({});
 
   const [selectedStory, setSelectedStory] = useState<KanbanStory | null>(null);
   const selectedStoryRef = useRef<KanbanStory | null>(null);
@@ -292,6 +293,21 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
           } catch {
             // non-critical
           }
+        }
+      } catch {
+        // non-critical
+      }
+
+      try {
+        const gatesRes = await fetch('/api/gates?status=pending&work_item_type=story');
+        if (gatesRes.ok) {
+          const gatesJson = await gatesRes.json() as GateItem[];
+          const gmap: Record<string, { id: string; gate_type: string; status: string }[]> = {};
+          for (const g of gatesJson) {
+            if (!gmap[g.work_item_id]) gmap[g.work_item_id] = [];
+            gmap[g.work_item_id].push({ id: g.id, gate_type: g.gate_type, status: g.status });
+          }
+          setStoryGatesMap(gmap);
         }
       } catch {
         // non-critical
@@ -1117,6 +1133,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     executionMap={executionMap}
                     blockedByMap={blockedByMap}
                     storyLabelsMap={storyLabelsMap}
+                    storyGatesMap={storyGatesMap}
                     totalCount={columnTotals[col.id]}
                     hasMore={!!columnCursors[col.id]}
                     loadingMore={loadingMoreColumns[col.id] ?? false}

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -58,6 +58,7 @@ interface KanbanColumnProps {
   executionMap?: Record<string, { status: string; rule_name?: string | null; completed_at?: string | null }>;
   blockedByMap?: Record<string, string[]>;
   storyLabelsMap?: Record<string, { id: string; name: string; color: string | null }[]>;
+  storyGatesMap?: Record<string, { id: string; gate_type: string; status: string }[]>;
   // CB-S4: board query
   totalCount?: number;
   hasMore?: boolean;
@@ -73,7 +74,7 @@ export function KanbanColumn({
   onEditStory, onChangeStatus, onAssignStory, onDeleteStory,
   wipLimit, wipExceeded, wipEditing, wipDraft,
   onWipLimitEdit, onWipLimitSave, onWipLimitRemove, onWipDraftChange,
-  onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap,
+  onCreateStory, projectId, onKickoffStory, executionMap, blockedByMap, storyLabelsMap, storyGatesMap,
   totalCount, hasMore, loadingMore, onLoadMore,
   collapsed, onToggleCollapse,
 }: KanbanColumnProps) {
@@ -308,6 +309,7 @@ export function KanbanColumn({
                   lastExecution={executionMap?.[story.id] ?? null}
                   blockedBy={blockedByMap?.[story.id] ?? []}
                   labels={storyLabelsMap?.[story.id] ?? []}
+                  gates={storyGatesMap?.[story.id] ?? []}
                 />
               ))}
             </div>

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -46,9 +46,10 @@ interface StoryCardProps {
   lastExecution?: WorkflowExecStatus | null;
   blockedBy?: string[];
   labels?: { id: string; name: string; color: string | null }[];
+  gates?: { id: string; gate_type: string; status: string }[];
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [] }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [] }: StoryCardProps) {
   const t = useTranslations('board');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
@@ -186,8 +187,8 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           <span className="min-w-0 truncate leading-none">{epicName}</span>
         </Badge>
       ) : null}
-      {/* Zone A meta row — dep 뱃지 + label 칩 */}
-      {(blockedBy.length > 0 && story.status !== 'done') || labels.length > 0 ? (
+      {/* Zone A meta row — dep 뱃지 + label 칩 + gate 뱃지 */}
+      {(blockedBy.length > 0 && story.status !== 'done') || labels.length > 0 || gates.filter((g) => g.status === 'pending').length > 0 ? (
         <div className="mb-2 flex flex-wrap gap-1">
           {blockedBy.length > 0 && story.status !== 'done' ? (
             <Badge variant="warning" className="gap-1">
@@ -197,6 +198,12 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           ) : null}
           {labels.map((label) => (
             <LabelChip key={label.id} label={label} />
+          ))}
+          {gates.filter((g) => g.status === 'pending').map((gate) => (
+            <Badge key={gate.id} variant="info" className="gap-1">
+              <span>⏸</span>
+              <span>{gate.gate_type} {t('gatePending')}</span>
+            </Badge>
           ))}
         </div>
       ) : null}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -51,6 +51,7 @@ interface StoryCardProps {
 
 export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [] }: StoryCardProps) {
   const t = useTranslations('board');
+  const tCage = useTranslations('cage');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
   const [triggering, setTriggering] = useState(false);
@@ -202,7 +203,7 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
           {gates.filter((g) => g.status === 'pending').map((gate) => (
             <Badge key={gate.id} variant="info" className="gap-1">
               <span>⏸</span>
-              <span>{gate.gate_type} {t('gatePending')}</span>
+              <span>{gate.gate_type} {tCage('gatePending')}</span>
             </Badge>
           ))}
         </div>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -18,6 +18,20 @@ export interface KanbanStory {
   outcome_result: OutcomeResult | null;
   blocked_by?: string[];
   labels?: { id: string; name: string; color: string | null }[];
+  gates?: { id: string; gate_type: string; status: string }[];
+}
+
+export interface GateItem {
+  id: string;
+  work_item_id: string;
+  work_item_type: string;
+  gate_type: string;
+  status: string;
+  resolver_id: string | null;
+  resolved_at: string | null;
+  neutral_facts: Record<string, unknown> | null;
+  created_at: string;
+  updated_at: string;
 }
 
 export interface DependencyEdge {


### PR DESCRIPTION
⚠️ **이 PR은 P2 #1120 머지 후 머지 (PO 지시 순서).**

## 변경 사항 (+234/-5, 9파일)

### FE 프록시 신설
- `api/gates/route.ts` (GET + POST)
- `api/gates/[id]/transition/route.ts` (POST)

### types.ts
- `KanbanStory.gates?: { id, gate_type, status }[]`
- `GateItem` 인터페이스 추가

### story-card.tsx — Zone A 게이트 뱃지
- 컨테이너 조건: `|| gates.filter(g=>g.status==='pending').length > 0` 추가
- pending 게이트별 info Badge + ⏸ + `{gate_type} 게이트 대기`
- dep warning / label 중립칩 / gate info 3종 공존 (색 구분으로 충돌 0)
- auto_passed 숨김 (status=pending만)

### kanban-board.tsx
- `GET /api/gates?status=pending&work_item_type=story` 배치 조회 → `storyGatesMap` 빌드

### gate-inbox.tsx (신규 개입 큐)
- pending gates 목록 (dashed 빈상태)
- 승인: success 톤, 반려: 기본 톤(hover시만 destructive) + note 모달
- transition POST `/api/gates/{id}/transition`

## AC 확인

| AC | 상태 |
|---|---|
| 카드 게이트 뱃지 (info·⏸·pending만) | ✅ |
| Zone A 3종 공존 (dep warning / label 중립 / gate info) | ✅ |
| 개입 큐 인박스 (빈상태 dashed) | ✅ |
| 승인 success / 반려 기본+note | ✅ |
| magic hex 0 | ✅ |
| pnpm type-check 에러 0 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)