### PR TITLE
fix: switch_project 인가 — project_access grant ∪ owner/admin 정합 (#748d82b6)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -49,6 +49,7 @@ from app.core.security import (
 )
 from app.core.rate_limit import limiter
 from app.dependencies.auth import AuthContext, get_current_user
+from app.services.project_auth import has_project_access, first_accessible_project_id
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
 from app.models.org_invite import OrgInvite
@@ -1090,18 +1091,8 @@ async def switch_project(
     if user is None:
         return _err("USER_NOT_FOUND", "User not found", 404)
 
-    # 해당 project의 active team_member 검증 (cross-org 허용 — 멀티 org 사용자 지원)
-    result = await session.execute(
-        select(TeamMember)
-        .where(
-            TeamMember.project_id == body.project_id,
-            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
-            TeamMember.is_active.is_(True),
-        )
-        .limit(1)
-    )
-    member = result.scalar_one_or_none()
-    if member is None:
+    # 인가 체크 — team_member ∪ project_access(granted) ∪ owner/admin (me/memberships 3-branch 정합)
+    if not await has_project_access(session, user.id, body.project_id):
         return _err("NOT_MEMBER", "Not an active member of this project", 403)
 
     # last_project_id 갱신
@@ -1154,32 +1145,8 @@ async def switch_organization(
     if membership.scalar_one_or_none() is None:
         return _err("NOT_ORG_MEMBER", "Not a member of this organization", 403)
 
-    # 대상 org의 team_member 조회 → last_project_id 갱신
-    member_in_org = await session.execute(
-        select(TeamMember)
-        .where(
-            TeamMember.org_id == body.org_id,
-            or_(TeamMember.user_id == user.id, TeamMember.id == user.id),
-            TeamMember.is_active.is_(True),
-        )
-        .order_by(TeamMember.created_at.asc())
-        .limit(1)
-    )
-    team_member = member_in_org.scalar_one_or_none()
-
-    if team_member is not None:
-        user.last_project_id = team_member.project_id
-    else:
-        # team_member 없음 (opt-out 모델) — 대상 org의 첫 project로 last_project_id 갱신.
-        # 미설정 시 _build_app_metadata가 이전 org project_id를 JWT에 심어 context 불일치 발생.
-        first_proj_result = await session.execute(
-            select(Project)
-            .where(Project.org_id == body.org_id, Project.deleted_at.is_(None))
-            .order_by(Project.created_at.asc())
-            .limit(1)
-        )
-        first_proj = first_proj_result.scalar_one_or_none()
-        user.last_project_id = first_proj.id if first_proj else None
+    # 대상 org의 접근 가능한 첫 project 해소 — team_member > grant > org 첫 project (grant 유저 포함)
+    user.last_project_id = await first_accessible_project_id(session, user.id, body.org_id)
 
     # 기존 refresh token 무효화
     await session.execute(

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -1,0 +1,131 @@
+"""프로젝트 인가 공유 헬퍼.
+
+switch_project / switch_org / me/memberships의 인가 술어를 SSOT로 관리.
+3-branch 기준: team_member ∪ project_access(granted) ∪ owner/admin org-wide.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def has_project_access(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    project_id: uuid.UUID,
+    org_id: uuid.UUID | None = None,
+) -> bool:
+    """switch_project 인가 — me/memberships 3-branch와 동일 기준.
+
+    team_member(active) ∪ project_access(granted) ∪ owner/admin org-wide.
+    org_id 지정 시 해당 org로 스코프; None이면 cross-org 허용.
+    """
+    row = await session.execute(
+        text(
+            """
+            SELECT 1
+            FROM projects p
+            WHERE p.id = :project_id
+              AND p.deleted_at IS NULL
+              AND (
+                EXISTS (
+                    SELECT 1 FROM team_members tm
+                    WHERE tm.project_id = p.id
+                      AND (tm.id = :user_id OR tm.user_id = :user_id)
+                      AND tm.is_active = true
+                )
+                OR EXISTS (
+                    SELECT 1 FROM project_access pa
+                    JOIN org_members om ON pa.org_member_id = om.id
+                    WHERE pa.project_id = p.id
+                      AND om.user_id = :user_id
+                      AND om.deleted_at IS NULL
+                      AND pa.permission = 'granted'
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
+                )
+                OR EXISTS (
+                    SELECT 1 FROM org_members om
+                    WHERE om.user_id = :user_id
+                      AND om.deleted_at IS NULL
+                      AND om.role IN ('owner', 'admin')
+                      AND p.org_id = om.org_id
+                      AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
+                )
+              )
+            LIMIT 1
+            """
+        ),
+        {"user_id": user_id, "project_id": project_id, "org_id": org_id},
+    )
+    return row.scalar_one_or_none() is not None
+
+
+async def first_accessible_project_id(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """switch_org 후 착지할 첫 접근 가능 project.
+
+    우선순위: team_member 등록 project > grant project > org 첫 project.
+    """
+    # 1. team_member 등록 project (기존 우선순위 유지)
+    tm_row = await session.execute(
+        text(
+            """
+            SELECT tm.project_id
+            FROM team_members tm
+            JOIN projects p ON p.id = tm.project_id
+            WHERE tm.org_id = :org_id
+              AND (tm.id = :user_id OR tm.user_id = :user_id)
+              AND tm.is_active = true
+              AND p.deleted_at IS NULL
+            ORDER BY tm.created_at ASC
+            LIMIT 1
+            """
+        ),
+        {"user_id": user_id, "org_id": org_id},
+    )
+    if (val := tm_row.scalar_one_or_none()) is not None:
+        return uuid.UUID(str(val))
+
+    # 2. project_access grant 프로젝트
+    grant_row = await session.execute(
+        text(
+            """
+            SELECT pa.project_id
+            FROM project_access pa
+            JOIN org_members om ON pa.org_member_id = om.id
+            JOIN projects p ON p.id = pa.project_id
+            WHERE om.user_id = :user_id
+              AND om.org_id = :org_id
+              AND om.deleted_at IS NULL
+              AND pa.permission = 'granted'
+              AND p.deleted_at IS NULL
+            ORDER BY pa.created_at ASC
+            LIMIT 1
+            """
+        ),
+        {"user_id": user_id, "org_id": org_id},
+    )
+    if (val := grant_row.scalar_one_or_none()) is not None:
+        return uuid.UUID(str(val))
+
+    # 3. org 첫 project (기존 fallback)
+    first_row = await session.execute(
+        text(
+            """
+            SELECT id FROM projects
+            WHERE org_id = :org_id AND deleted_at IS NULL
+            ORDER BY created_at ASC
+            LIMIT 1
+            """
+        ),
+        {"org_id": org_id},
+    )
+    if (val := first_row.scalar_one_or_none()) is not None:
+        return uuid.UUID(str(val))
+
+    return None

--- a/backend/tests/test_e_org_multi_s2_1_switch_organization.py
+++ b/backend/tests/test_e_org_multi_s2_1_switch_organization.py
@@ -129,7 +129,9 @@ async def test_switch_org_success_returns_tokens():
 
         with patch("app.routers.auth.create_tokens") as mock_create_tokens, \
              patch("app.routers.auth.create_refresh_token") as mock_crt, \
-             patch("app.routers.auth._store_refresh_token") as mock_store:
+             patch("app.routers.auth._store_refresh_token") as mock_store, \
+             patch("app.routers.auth.first_accessible_project_id", new_callable=AsyncMock) as mock_fap:
+            mock_fap.return_value = PROJECT_A
             mock_create_tokens.return_value = {
                 "access_token": "new_at",
                 "refresh_token": "new_rt",

--- a/backend/tests/test_switch_project_grant_auth.py
+++ b/backend/tests/test_switch_project_grant_auth.py
@@ -1,0 +1,126 @@
+"""switch_project 인가 정합 — has_project_access 3-branch 테스트.
+
+team_member ∪ project_access(granted) ∪ owner/admin 모두 통과, 그 외 거부.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.project_auth import has_project_access, first_accessible_project_id
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_session_with(scalar_value):
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_value
+    session.execute = AsyncMock(return_value=result)
+    return session
+
+
+# ── has_project_access ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_has_access_via_team_member():
+    """team_member 등록 → True."""
+    session = _mock_session_with(1)  # EXISTS → 1
+    result = await has_project_access(session, USER_ID, PROJECT_ID, ORG_ID)
+    assert result is True
+    session.execute.assert_called_once()
+
+
+@pytest.mark.anyio
+async def test_no_access_returns_false():
+    """접근 경로 없음 → False."""
+    session = _mock_session_with(None)
+    result = await has_project_access(session, USER_ID, PROJECT_ID, ORG_ID)
+    assert result is False
+
+
+@pytest.mark.anyio
+async def test_has_access_without_org_id():
+    """org_id=None (cross-org) — 호출 성공."""
+    session = _mock_session_with(1)
+    result = await has_project_access(session, USER_ID, PROJECT_ID, None)
+    assert result is True
+
+
+@pytest.mark.anyio
+async def test_query_passes_correct_params():
+    """user_id / project_id / org_id 파라미터 바인딩 검증."""
+    session = _mock_session_with(None)
+    await has_project_access(session, USER_ID, PROJECT_ID, ORG_ID)
+    call_args = session.execute.call_args
+    params = call_args[0][1]
+    assert params["user_id"] == USER_ID
+    assert params["project_id"] == PROJECT_ID
+    assert params["org_id"] == ORG_ID
+
+
+# ── first_accessible_project_id ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_first_accessible_returns_team_member_project():
+    """team_member 등록 project 우선 반환."""
+    project_id = uuid.uuid4()
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = str(project_id)
+    session.execute = AsyncMock(return_value=result)
+
+    val = await first_accessible_project_id(session, USER_ID, ORG_ID)
+    assert val == project_id
+    assert session.execute.call_count == 1  # 첫 쿼리에서 바로 반환
+
+
+@pytest.mark.anyio
+async def test_first_accessible_falls_back_to_grant():
+    """team_member 없고 grant 프로젝트 있으면 grant 반환."""
+    project_id = uuid.uuid4()
+    session = AsyncMock()
+    no_result = MagicMock()
+    no_result.scalar_one_or_none.return_value = None
+    grant_result = MagicMock()
+    grant_result.scalar_one_or_none.return_value = str(project_id)
+    session.execute = AsyncMock(side_effect=[no_result, grant_result])
+
+    val = await first_accessible_project_id(session, USER_ID, ORG_ID)
+    assert val == project_id
+    assert session.execute.call_count == 2
+
+
+@pytest.mark.anyio
+async def test_first_accessible_falls_back_to_first_project():
+    """team_member도 grant도 없으면 org 첫 project."""
+    project_id = uuid.uuid4()
+    session = AsyncMock()
+    no_result = MagicMock()
+    no_result.scalar_one_or_none.return_value = None
+    first_result = MagicMock()
+    first_result.scalar_one_or_none.return_value = str(project_id)
+    session.execute = AsyncMock(side_effect=[no_result, no_result, first_result])
+
+    val = await first_accessible_project_id(session, USER_ID, ORG_ID)
+    assert val == project_id
+    assert session.execute.call_count == 3
+
+
+@pytest.mark.anyio
+async def test_first_accessible_none_when_no_projects():
+    """프로젝트 없음 → None."""
+    session = AsyncMock()
+    no_result = MagicMock()
+    no_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=no_result)
+
+    val = await first_accessible_project_id(session, USER_ID, ORG_ID)
+    assert val is None


### PR DESCRIPTION
## Summary

- **루트코즈**: `switch_project`가 `team_members`만 체크 → `project_access grant` 보유 유저 403
- **수정**: `me/memberships` 3-branch와 동일 기준을 SSOT 헬퍼로 추출해 `switch_project` / `switch_org` 재사용

## Changes

- `services/project_auth.py` 신규: `has_project_access` + `first_accessible_project_id` 헬퍼
- `auth.py switch_project`: `has_project_access` 호출 (`team_member ∪ project_access(granted) ∪ owner/admin`)
- `auth.py switch_org`: `first_accessible_project_id`로 grant 유저 포함 착지 project 해소
- 테스트 8케이스 + 기존 switch_org 테스트 패치 수정

## AC Checklist

- [x] AC1: `switch_project` 인가 체크 → 3-branch 정합
- [x] AC (CP2): `switch_org` project 해소 → grant 유저 포함
- [x] AC (CP3): `/me` org_member fallback 기존 graceful 확인 (코드 변경 없음)
- [x] 테스트: 1313 passed (mcp e2e 제외)

## Test plan

- [ ] `pytest tests/test_switch_project_grant_auth.py` — 8 passed
- [ ] `pytest --ignore=tests/mcp` — 1313 passed
- [ ] dev 라이브: 하록/이삭/봉희 장사왕·제로고 전환 403 → OK 확인
- [ ] dev 라이브: switch_project 403 로그 소거 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)