### PR TITLE
promote: develop→main — switch_project 컨텍스트 가드(#1128) + 반려 note 영속화(#1124)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2258,6 +2258,7 @@
     "gateInboxLoading": "Loading gates...",
     "gateInboxEmpty": "No pending gates",
     "gateInboxEmptyHint": "Gates awaiting your review will appear here",
+    "gateRejectedHistory": "Recent rejection reasons",
     "cancel": "Cancel",
     "trustScoreLabel": "Clean Pass Rate",
     "trustScoreWindowHint": "Last {days} days",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2258,6 +2258,7 @@
     "gateInboxLoading": "게이트 조회 중...",
     "gateInboxEmpty": "대기 중인 게이트 없음",
     "gateInboxEmptyHint": "검수 대기 중인 게이트가 여기 표시됩니다",
+    "gateRejectedHistory": "최근 반려 사유",
     "cancel": "취소",
     "trustScoreLabel": "무정정 통과율",
     "trustScoreWindowHint": "최근 {days}일",

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -19,14 +19,20 @@ interface RejectModalState {
 export function GateInbox({ memberId }: GateInboxProps) {
   const t = useTranslations('cage');
   const [gates, setGates] = useState<GateItem[]>([]);
+  const [rejectedGates, setRejectedGates] = useState<GateItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [resolving, setResolving] = useState<string | null>(null);
   const [rejectModal, setRejectModal] = useState<RejectModalState | null>(null);
 
   const fetchGates = () => {
-    fetch('/api/gates?status=pending')
-      .then((r) => r.ok ? r.json() : [])
-      .then((json) => setGates(json as GateItem[]))
+    Promise.all([
+      fetch('/api/gates?status=pending').then((r) => r.ok ? r.json() : []),
+      fetch('/api/gates?status=rejected').then((r) => r.ok ? r.json() : []),
+    ])
+      .then(([pending, rejected]) => {
+        setGates(pending as GateItem[]);
+        setRejectedGates((rejected as GateItem[]).filter((g) => g.resolution_note));
+      })
       .catch(() => {})
       .finally(() => setLoading(false));
   };
@@ -54,7 +60,7 @@ export function GateInbox({ memberId }: GateInboxProps) {
       const res = await fetch(`/api/gates/${rejectModal.gateId}/transition`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ status: 'rejected', resolver_id: memberId }),
+        body: JSON.stringify({ status: 'rejected', resolver_id: memberId, note: rejectModal.note || null }),
       });
       if (res.ok) {
         setGates((prev) => prev.filter((g) => g.id !== rejectModal.gateId));
@@ -110,6 +116,22 @@ export function GateInbox({ memberId }: GateInboxProps) {
             </div>
           </div>
         ))
+      )}
+
+      {/* 반려 사유 히스토리 */}
+      {rejectedGates.length > 0 && (
+        <div className="mt-4 space-y-1.5">
+          <p className="text-[11px] font-medium text-muted-foreground">{t('gateRejectedHistory')}</p>
+          {rejectedGates.map((gate) => (
+            <div key={gate.id} className="rounded-xl border border-destructive/20 bg-destructive/5 px-3 py-2">
+              <div className="flex items-center gap-2">
+                <XCircle className="size-3 shrink-0 text-destructive/60" />
+                <span className="text-[10px] text-muted-foreground">{gate.gate_type} · #{gate.work_item_id.slice(0, 6)}</span>
+              </div>
+              <p className="mt-1 text-xs text-foreground/80">{gate.resolution_note}</p>
+            </div>
+          ))}
+        </div>
       )}
 
       {/* 반려 모달 */}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -29,6 +29,7 @@ export interface GateItem {
   status: string;
   resolver_id: string | null;
   resolved_at: string | null;
+  resolution_note: string | null;
   neutral_facts: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;

--- a/backend/alembic/versions/0068_add_gate_resolution_note.py
+++ b/backend/alembic/versions/0068_add_gate_resolution_note.py
@@ -1,0 +1,31 @@
+"""gate.resolution_note 컬럼 추가 (반려 사유 영속화).
+
+Revision ID: 0068
+Revises: 0067
+Create Date: 2026-06-01
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0068"
+down_revision = "0067"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("gate")}
+    if "resolution_note" not in cols:
+        op.add_column("gate", sa.Column("resolution_note", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("gate")}
+    if "resolution_note" in cols:
+        op.drop_column("gate", "resolution_note")

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, String, func
+from sqlalchemy import DateTime, String, Text, func
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -41,6 +41,7 @@ class Gate(Base):
     status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="pending")
     resolver_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    resolution_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     neutral_facts: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1095,8 +1095,10 @@ async def switch_project(
     if not await has_project_access(session, user.id, body.project_id):
         return _err("NOT_MEMBER", "Not an active member of this project", 403)
 
-    # last_project_id 갱신
-    user.last_project_id = body.project_id
+    # target 캡처 — _build_app_metadata가 내부 fallback으로 last_project_id를 덮어쓰므로 먼저 고정
+    # (switch_org auth.py:1158-1165 동일 패턴)
+    target_project_id = body.project_id
+    user.last_project_id = target_project_id
 
     # 기존 refresh token 무효화
     await session.execute(
@@ -1105,8 +1107,11 @@ async def switch_project(
         .values(revoked_at=datetime.now(timezone.utc))
     )
 
-    # 새 토큰 발급
+    # 새 토큰 발급 — _build_app_metadata 후 project_id override (grant-only 유저 fallback 무효화)
     app_metadata = await _build_app_metadata(user, session)
+    app_metadata["project_id"] = str(target_project_id)
+    user.last_project_id = target_project_id  # _build_app_metadata가 덮어쓴 경우 재설정
+
     tokens = create_tokens(str(user.id), email=user.email, app_metadata=app_metadata)
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -36,6 +36,7 @@ class GateCreateRequest(BaseModel):
 class GateTransitionRequest(BaseModel):
     status: str
     resolver_id: uuid.UUID | None = None
+    note: str | None = None
 
     @field_validator("status")
     @classmethod
@@ -57,6 +58,7 @@ class GateResponse(BaseModel):
     status: str
     resolver_id: uuid.UUID | None = None
     resolved_at: datetime | None = None
+    resolution_note: str | None = None
     neutral_facts: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
@@ -112,7 +114,7 @@ async def transition_gate_endpoint(
     _auth=Depends(get_current_user),
 ) -> GateResponse:
     try:
-        gate = await transition_gate(session, org_id, id, body.status, body.resolver_id)
+        gate = await transition_gate(session, org_id, id, body.status, body.resolver_id, body.note)
         await session.commit()
         return GateResponse.model_validate(gate)
     except ValueError as e:

--- a/backend/app/services/gate_service.py
+++ b/backend/app/services/gate_service.py
@@ -89,6 +89,7 @@ async def transition_gate(
     gate_id: uuid.UUID,
     new_status: str,
     resolver_id: uuid.UUID | None = None,
+    note: str | None = None,
 ) -> Gate:
     """게이트 상태 전이 — 불법 전이 시 ValueError 발생."""
     gate_r = await session.execute(
@@ -107,6 +108,8 @@ async def transition_gate(
     gate.status = new_status
     gate.resolver_id = resolver_id
     gate.resolved_at = datetime.now(timezone.utc)
+    if new_status == "rejected" and note:
+        gate.resolution_note = note
     await session.flush()
     await session.refresh(gate)
     return gate

--- a/backend/tests/test_auth_switch_project.py
+++ b/backend/tests/test_auth_switch_project.py
@@ -252,3 +252,61 @@ def test_migration_0026_exists():
 def test_user_model_has_last_project_id():
     from app.models.user import User
     assert hasattr(User, "last_project_id")
+
+# ─── grant-only 유저 컨텍스트 가드 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_switch_project_grant_only_user_token_has_target_project_id(client, mock_session, auth_ctx):
+    """grant-only 유저(team_member 없는 프로젝트) switch → 반환 토큰 project_id == target.
+
+    _build_app_metadata fallback이 last_project_id를 덮어써도 app_metadata override로 수정 보장.
+    """
+    user = _make_user()
+    auth_ctx.user_id = str(user.id)
+    target_project = uuid.uuid4()
+
+    # has_project_access → True (grant 존재)
+    access_result = MagicMock()
+    access_result.scalar_one_or_none.return_value = 1
+    # revoke
+    revoke_result = MagicMock()
+    # _build_app_metadata: last_project_id 기반 TM 없음 → fallback TM(sprintable)
+    fallback_member = _make_member(project_id=uuid.uuid4())  # 다른 project!
+    fallback_result = MagicMock()
+    fallback_result.scalar_one_or_none.return_value = fallback_member
+    # org roles
+    org_roles_result = MagicMock(); org_roles_result.all.return_value = []
+    # all_members
+    all_scalars = MagicMock(); all_scalars.all.return_value = [fallback_member]
+    all_result = MagicMock(); all_result.scalars.return_value = all_scalars
+
+    mock_session.execute.side_effect = [
+        MagicMock(**{"scalar_one_or_none.return_value": user}),  # _get_user_by_id
+        access_result,      # has_project_access
+        revoke_result,      # revoke tokens
+        fallback_result,    # _build_app_metadata TM 조회 (fallback → 다른 project)
+        org_roles_result,   # _build_app_metadata org roles
+        all_result,         # _build_app_metadata all projects
+    ]
+
+    captured_metadata = {}
+
+    def mock_create_tokens(user_id, *, email, app_metadata):
+        captured_metadata.update(app_metadata)
+        return {
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "token_type": "bearer",
+            "refresh_expires_at": "2026-06-12T00:00:00Z",
+        }
+
+    with patch("app.routers.auth.create_tokens", side_effect=mock_create_tokens), \
+         patch("app.routers.auth._store_refresh_token"):
+        resp = await client.post("/api/v2/auth/switch-project", json={"project_id": str(target_project)})
+
+    assert resp.status_code == 200
+    # 핵심: app_metadata.project_id가 fallback(sprintable)이 아닌 target이어야 함
+    assert captured_metadata.get("project_id") == str(target_project)
+    # user.last_project_id도 target으로 재설정됐는지
+    assert user.last_project_id == target_project
+

--- a/backend/tests/test_e_cage_referee_p3_gate_object.py
+++ b/backend/tests/test_e_cage_referee_p3_gate_object.py
@@ -285,6 +285,75 @@ async def test_capture_pr_wires_gate_resolution():
         mock_gate.assert_called_once_with(session, ORG_ID, STORY_ID, "story", "pr", "pass")
 
 
+# ── resolution_note 영속화 ────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_transition_rejected_saves_note():
+    """rejected 전이 시 note가 resolution_note로 저장."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID, "코드 품질 미달")
+    assert gate.status == "rejected"
+    assert gate.resolution_note == "코드 품질 미달"
+
+
+@pytest.mark.anyio
+async def test_transition_approved_does_not_save_note():
+    """approved 전이 시 note 전달해도 resolution_note 저장 안 함."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await transition_gate(session, ORG_ID, GATE_ID, "approved", MEMBER_ID, "의미없는 노트")
+    assert gate.status == "approved"
+    assert not hasattr(gate, "resolution_note") or gate.resolution_note != "의미없는 노트"
+
+
+@pytest.mark.anyio
+async def test_transition_rejected_empty_note_graceful():
+    """rejected 전이 시 note=None이면 resolution_note 건드리지 않음."""
+    from app.services.gate_service import transition_gate
+
+    gate = MagicMock()
+    gate.id = GATE_ID
+    gate.org_id = ORG_ID
+    gate.status = "pending"
+    gate.resolution_note = None
+
+    session = AsyncMock()
+    gate_r = MagicMock()
+    gate_r.scalar_one_or_none.return_value = gate
+    session.execute = AsyncMock(return_value=gate_r)
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+
+    await transition_gate(session, ORG_ID, GATE_ID, "rejected", MEMBER_ID, None)
+    assert gate.status == "rejected"
+    assert gate.resolution_note is None
+
+
 # ── org 격리 ──────────────────────────────────────────────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## develop→main 프로모션 (2 commits)
인시던트 2차 픽스 prod 반영 + note 영속화.

**포함:**
- **#1128 (인시던트 2차)** — switch_project 컨텍스트 가드: grant-only 유저 전환 시 `_build_app_metadata` fallback이 last_project_id를 덮어써 스위치 무효되던 것 → switch_org 패턴 미러(target 캡처→override). **#1125(인가)는 prod에 있으나 이 컨텍스트 가드 누락분.**
- **#1124** — gate 반려 사유(resolution_note) 영속화. migration 0068은 **공유 DB에 이미 적용**(컬럼 존재·alembic 0068).

**마이그:** prod 별도 불요(공유 DB·0068 적용됨, #1128 마이그 없음). 코드만.
**검증:** 양 PR CI green + 까심 QA APPROVE + PO 리뷰. #1128은 fallback override 회귀 테스트 포함.

admin-merge 우회(required-check 'CI' 불일치, 실 체크 green 확인 후). 🤖 prod 승격