### PR TITLE
feat: [E-MEMBER-SSOT Phase 0] grant-only 휴먼 대화 생성 지원 (#fc3c2fe3)

### DIFF
--- a/backend/alembic/versions/0069_drop_conversation_team_member_fks.py
+++ b/backend/alembic/versions/0069_drop_conversation_team_member_fks.py
@@ -1,0 +1,89 @@
+"""conversation*/events 테이블의 team_members FK 완화 (Phase 0 grant-only 휴먼 지원).
+
+FK drop: 컬럼·인덱스 유지, 데이터 무변경. 가역: 비-team_member id 없을 때만 재추가.
+
+Revision ID: 0069
+Revises: 0068
+Create Date: 2026-06-01
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0069"
+down_revision = "0068"
+branch_labels = None
+depends_on = None
+
+# (table, column, referencing team_members)
+_FK_TARGETS: list[tuple[str, str]] = [
+    ("conversations", "created_by"),
+    ("conversations", "resolved_by"),
+    ("conversation_participants", "member_id"),
+    ("conversation_messages", "sender_id"),
+    ("events", "sender_id"),
+    ("events", "recipient_id"),
+]
+
+
+def _fks_referencing_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [
+        fk for fk in insp.get_foreign_keys(table)
+        if fk.get("referred_table") == "team_members"
+    ]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col in _FK_TARGETS:
+        if table not in tables:
+            continue
+        for fk in _fks_referencing_team_members(insp, table):
+            if col in fk.get("constrained_columns", []):
+                fk_name = fk.get("name")
+                if fk_name:
+                    op.drop_constraint(fk_name, table, type_="foreignkey")
+
+
+def downgrade() -> None:
+    """비-team_member id가 없는 컬럼에만 FK 재추가 (데이터 안전 확인 후)."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    specs = [
+        ("conversations", "created_by", "SET NULL"),
+        ("conversations", "resolved_by", "SET NULL"),
+        ("conversation_participants", "member_id", "CASCADE"),
+        ("conversation_messages", "sender_id", "SET NULL"),
+        ("events", "sender_id", "SET NULL"),
+        ("events", "recipient_id", "CASCADE"),
+    ]
+
+    for table, col, ondelete in specs:
+        if table not in tables:
+            continue
+        existing = {fk["name"] for fk in _fks_referencing_team_members(insp, table)}
+        fk_name = f"{table}_{col}_fkey"
+        if fk_name in existing:
+            continue
+
+        # 비-team_member id가 있으면 FK 재추가 중단
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t"
+                f" WHERE t.{col} IS NOT NULL"
+                f"   AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col})"
+                f" LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue  # 데이터 오염 — 이 컬럼은 재추가 생략
+
+        op.create_foreign_key(
+            fk_name, table, "team_members", [col], ["id"], ondelete=ondelete
+        )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -20,6 +20,7 @@ from app.models.event import Event
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
+from app.services.member_resolver import ResolvedMember, lookup_members_by_ids, resolve_member
 
 logger = logging.getLogger(__name__)
 
@@ -28,30 +29,55 @@ router = APIRouter(prefix="/api/v2/conversations", tags=["conversations"])
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
+async def _enforce_agent_creator_policy(
+    sender: "ResolvedMember",
+    participant_ids: list[uuid.UUID],
+    db: AsyncSession,
+) -> None:
+    """⭐ 불변식: 휴먼↔에이전트 대화는 에이전트 creator가 참가자여야 함."""
+    if not participant_ids:
+        return
+    agent_tms = (await db.execute(
+        select(TeamMember).where(
+            TeamMember.id.in_(participant_ids),
+            TeamMember.type == "agent",
+        )
+    )).scalars().all()
+    for agent_tm in agent_tms:
+        if agent_tm.created_by is None:
+            raise HTTPException(status_code=403, detail="Agent has no creator — conversation not allowed")
+        requestor_user_id = getattr(sender, "user_id", None)
+        if requestor_user_id is not None and agent_tm.created_by != requestor_user_id:
+            raise HTTPException(status_code=403, detail="Only the agent's creator can start this conversation")
+
+
 async def _resolve_member(
     auth: AuthContext,
     org_id: uuid.UUID,
     db: AsyncSession,
     project_id: uuid.UUID | None = None,
-) -> TeamMember:
+) -> "ResolvedMember | TeamMember":
+    """TeamMember 우선; grant-only 휴먼이면 ResolvedMember(org_member.id) 반환."""
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
-        stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
-    else:
-        filters = [
-            TeamMember.user_id == uuid.UUID(auth.user_id),
-            TeamMember.org_id == org_id,
-        ]
-        if project_id is not None:
-            filters.append(TeamMember.project_id == project_id)
-        stmt = select(TeamMember).where(*filters)
-    member = (await db.execute(stmt)).scalars().first()
-    if member is None:
-        raise HTTPException(status_code=400, detail="Team member not found")
-    return member
+        tm = (await db.execute(select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id)))).scalars().first()
+        if tm is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return tm
+
+    # JWT 휴먼: team_member 먼저 시도
+    filters = [TeamMember.user_id == uuid.UUID(auth.user_id), TeamMember.org_id == org_id]
+    if project_id is not None:
+        filters.append(TeamMember.project_id == project_id)
+    tm = (await db.execute(select(TeamMember).where(*filters))).scalars().first()
+    if tm is not None:
+        return tm
+
+    # team_member 없음 (grant-only 휴먼) → org_member 경로
+    return await resolve_member(auth, org_id, db, project_id=project_id)
 
 
-def _msg_payload(msg: ConversationMessage, sender: TeamMember | None) -> dict:
+def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None") -> dict:
     return {
         "id": str(msg.id),
         "conversation_id": str(msg.conversation_id),
@@ -74,7 +100,7 @@ async def _dispatch_conversation_event(
     conversation: Conversation,
     msg: ConversationMessage,
     org_id: uuid.UUID,
-    sender: TeamMember,
+    sender: "ResolvedMember | TeamMember",
     exclude_ids: set[uuid.UUID] | None = None,
 ) -> list[tuple[str, dict]]:
     """conversation:message → Event INSERT + flush. push 페이로드 반환 (commit 후 호출).
@@ -269,6 +295,9 @@ async def create_conversation(
 ) -> dict:
     """POST /api/v2/conversations — dm/group 생성 (dm 중복 방지)."""
     sender = await _resolve_member(auth, org_id, db, project_id=body.project_id)
+
+    # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
+    await _enforce_agent_creator_policy(sender, body.participant_ids, db)
 
     # DM 중복 방지: 동일 participant pair의 dm이 이미 있으면 반환
     if body.type == "dm" and len(body.participant_ids) == 1:
@@ -485,8 +514,7 @@ async def list_messages(
     msgs = list(reversed(rows[:limit]))
 
     sender_ids = {m.sender_id for m in msgs if m.sender_id}
-    members = (await db.execute(select(TeamMember).where(TeamMember.id.in_(sender_ids)))).scalars().all()
-    member_map = {m.id: m for m in members}
+    member_map = await lookup_members_by_ids(sender_ids, db)
 
     data = [_msg_payload(m, member_map.get(m.sender_id)) for m in msgs]
     next_cursor = msgs[0].created_at.isoformat() if has_more and msgs else None

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -61,7 +61,7 @@ async def _enforce_agent_creator_policy(
 
     # 참가자 집합의 user_id 수집 (sender + 나머지 non-agent participants)
     human_user_ids: set[uuid.UUID] = set()
-    sender_user_id = getattr(sender, "user_id", None) or getattr(sender, "user_id", None)
+    sender_user_id = getattr(sender, "user_id", None)
     if sender_user_id is not None and sender.id in non_agent_ids:
         human_user_ids.add(sender_user_id)
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -17,6 +17,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
+from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
@@ -30,25 +31,63 @@ router = APIRouter(prefix="/api/v2/conversations", tags=["conversations"])
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 async def _enforce_agent_creator_policy(
-    sender: "ResolvedMember",
+    sender: "ResolvedMember | TeamMember",
     participant_ids: list[uuid.UUID],
     db: AsyncSession,
 ) -> None:
-    """⭐ 불변식: 휴먼↔에이전트 대화는 에이전트 creator가 참가자여야 함."""
+    """⭐ 불변식: 휴먼↔에이전트 대화 — 각 에이전트의 creator가 참가자(sender ∪ participant_ids)에 있어야.
+
+    전제: 에이전트 없거나 휴먼 없으면(에이전트↔에이전트) skip.
+    """
     if not participant_ids:
         return
+
+    all_ids = set(participant_ids) | {sender.id}
+
+    # 에이전트 participant 조회
     agent_tms = (await db.execute(
         select(TeamMember).where(
-            TeamMember.id.in_(participant_ids),
+            TeamMember.id.in_(all_ids),
             TeamMember.type == "agent",
         )
     )).scalars().all()
+    if not agent_tms:
+        return  # 에이전트 없음 → skip
+
+    agent_ids = {a.id for a in agent_tms}
+    non_agent_ids = all_ids - agent_ids
+    if not non_agent_ids:
+        return  # 에이전트↔에이전트 → creator 무관 허용
+
+    # 참가자 집합의 user_id 수집 (sender + 나머지 non-agent participants)
+    human_user_ids: set[uuid.UUID] = set()
+    sender_user_id = getattr(sender, "user_id", None) or getattr(sender, "user_id", None)
+    if sender_user_id is not None and sender.id in non_agent_ids:
+        human_user_ids.add(sender_user_id)
+
+    remaining_ids = non_agent_ids - {sender.id}
+    if remaining_ids:
+        # TeamMember에서 user_id 조회
+        tm_humans = (await db.execute(
+            select(TeamMember).where(TeamMember.id.in_(remaining_ids))
+        )).scalars().all()
+        human_user_ids.update(tm.user_id for tm in tm_humans if tm.user_id)
+
+        # OrgMember에서 user_id 조회 (grant-only 휴먼)
+        tm_found_ids = {tm.id for tm in tm_humans}
+        om_ids = remaining_ids - tm_found_ids
+        if om_ids:
+            oms = (await db.execute(
+                select(OrgMember).where(OrgMember.id.in_(om_ids))
+            )).scalars().all()
+            human_user_ids.update(om.user_id for om in oms if om.user_id)
+
+    # 각 에이전트의 created_by가 참가자 user_id 집합에 있는지 확인
     for agent_tm in agent_tms:
         if agent_tm.created_by is None:
             raise HTTPException(status_code=403, detail="Agent has no creator — conversation not allowed")
-        requestor_user_id = getattr(sender, "user_id", None)
-        if requestor_user_id is not None and agent_tm.created_by != requestor_user_id:
-            raise HTTPException(status_code=403, detail="Only the agent's creator can start this conversation")
+        if agent_tm.created_by not in human_user_ids:
+            raise HTTPException(status_code=403, detail="Agent's creator must be a participant in this conversation")
 
 
 async def _resolve_member(

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -1,0 +1,140 @@
+"""E-MEMBER-SSOT Phase 0: JWT 휴먼 → org_member.id, API키 에이전트 → team_member.id.
+
+ResolvedMember를 conversations/events 전반에 사용해 team_member 강요를 제거.
+가역 패치 — 롤백 시 리졸버 교체 + migration downgrade.
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext
+from app.models.project import OrgMember
+from app.models.team import TeamMember
+from app.models.user import User
+from app.services.project_auth import has_project_access
+
+
+@dataclass
+class ResolvedMember:
+    """통합 멤버 신원 — 휴먼(org_member.id) 또는 에이전트(team_member.id)."""
+    id: uuid.UUID
+    user_id: uuid.UUID | None      # users.id (휴먼) | None (에이전트)
+    name: str
+    type: str                      # "human" | "agent"
+    role: str
+    org_id: uuid.UUID
+    project_id: uuid.UUID | None = field(default=None)
+
+
+async def resolve_member(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> ResolvedMember:
+    """멤버 신원 해소 — 인증 방식에 따라 분기.
+
+    API키(에이전트): team_member.id 반환.
+    JWT(휴먼): org_member.id 반환 + has_project_access 검증.
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+
+    if is_api_key:
+        tm = (await session.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )).scalars().first()
+        if tm is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return ResolvedMember(
+            id=tm.id,
+            user_id=None,
+            name=tm.name,
+            type=tm.type,
+            role=tm.role,
+            org_id=tm.org_id,
+            project_id=tm.project_id,
+        )
+
+    # JWT 휴먼
+    user_id = uuid.UUID(auth.user_id)
+
+    if project_id is not None:
+        if not await has_project_access(session, user_id, project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to this project")
+
+    om = (await session.execute(
+        select(OrgMember).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == user_id,
+            OrgMember.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if om is None:
+        raise HTTPException(status_code=400, detail="Organization member not found")
+
+    user = (await session.execute(
+        select(User).where(User.id == user_id)
+    )).scalar_one_or_none()
+    name = user.email if user else str(user_id)
+
+    return ResolvedMember(
+        id=om.id,
+        user_id=user_id,
+        name=name,
+        type="human",
+        role=om.role,
+        org_id=om.org_id,
+        project_id=project_id,
+    )
+
+
+async def lookup_members_by_ids(
+    ids: set[uuid.UUID],
+    session: AsyncSession,
+) -> dict[uuid.UUID, ResolvedMember]:
+    """ID 집합 → ResolvedMember 맵. TeamMember 우선, 없으면 OrgMember."""
+    if not ids:
+        return {}
+
+    tms = (await session.execute(
+        select(TeamMember).where(TeamMember.id.in_(ids))
+    )).scalars().all()
+    result: dict[uuid.UUID, ResolvedMember] = {
+        m.id: ResolvedMember(
+            id=m.id, user_id=m.user_id, name=m.name,
+            type=m.type, role=m.role, org_id=m.org_id, project_id=m.project_id,
+        )
+        for m in tms
+    }
+
+    missing = ids - set(result.keys())
+    if missing:
+        oms = (await session.execute(
+            select(OrgMember).where(OrgMember.id.in_(missing))
+        )).scalars().all()
+        # OrgMember의 display name: user.email 배치 조회
+        user_ids = {m.user_id for m in oms if m.user_id}
+        users_map: dict[uuid.UUID, str] = {}
+        if user_ids:
+            users = (await session.execute(
+                select(User).where(User.id.in_(user_ids))
+            )).scalars().all()
+            users_map = {u.id: u.email for u in users}
+
+        for om in oms:
+            result[om.id] = ResolvedMember(
+                id=om.id,
+                user_id=om.user_id,
+                name=users_map.get(om.user_id, str(om.user_id)) if om.user_id else str(om.id),
+                type="human",
+                role=om.role,
+                org_id=om.org_id,
+                project_id=None,
+            )
+
+    return result

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -54,6 +54,15 @@ def _make_msg(msg_id: uuid.UUID | None = None) -> MagicMock:
     return m
 
 
+
+
+@pytest.fixture(autouse=True)
+def _skip_agent_policy(monkeypatch):
+    """기존 conversations 테스트는 에이전트 인가 불변식을 별도 테스트에서 검증 — 여기서 skip."""
+    async def _noop(*args, **kwargs):
+        pass
+    monkeypatch.setattr("app.routers.conversations._enforce_agent_creator_policy", _noop)
+
 async def _make_client(session=None):
     from app.main import app
     from app.dependencies.auth import get_current_user, get_verified_org_id

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -1,0 +1,278 @@
+"""E-MEMBER-SSOT Phase 0: resolve_member + 인가 불변식 테스트."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.member_resolver import ResolvedMember, lookup_members_by_ids, resolve_member
+
+ORG_ID = uuid.uuid4()
+USER_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+AGENT_TM_ID = uuid.uuid4()
+ORG_MEMBER_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _make_auth(user_id: uuid.UUID = USER_ID, is_api_key: bool = False) -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = str(user_id)
+    if is_api_key:
+        ctx.claims = {"app_metadata": {"api_key_id": "ak_xxx", "org_id": str(ORG_ID)}}
+    else:
+        ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    return ctx
+
+
+def _make_team_member(tid=AGENT_TM_ID, ttype="agent", org_id=ORG_ID):
+    tm = MagicMock()
+    tm.id = tid
+    tm.user_id = None
+    tm.name = "TestAgent"
+    tm.type = ttype
+    tm.role = "agent"
+    tm.org_id = org_id
+    tm.project_id = PROJECT_ID
+    return tm
+
+
+def _make_org_member(oid=ORG_MEMBER_ID, user_id=USER_ID, org_id=ORG_ID):
+    om = MagicMock()
+    om.id = oid
+    om.user_id = user_id
+    om.org_id = org_id
+    om.role = "member"
+    om.deleted_at = None
+    return om
+
+
+# ── API키 에이전트 경로 ───────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_member_api_key_returns_team_member_id():
+    """API키 인증 → team_member.id 반환."""
+    auth = _make_auth(is_api_key=True)
+    tm = _make_team_member()
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = tm
+    session.execute = AsyncMock(return_value=result)
+
+    resolved = await resolve_member(auth, ORG_ID, session)
+    assert resolved.id == AGENT_TM_ID
+    assert resolved.type == "agent"
+    assert resolved.user_id is None
+
+
+@pytest.mark.anyio
+async def test_resolve_member_api_key_not_found_raises_400():
+    """API키이지만 team_member 없음 → 400."""
+    auth = _make_auth(is_api_key=True)
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.first.return_value = None
+    session.execute = AsyncMock(return_value=result)
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc_info:
+        await resolve_member(auth, ORG_ID, session)
+    assert exc_info.value.status_code == 400
+
+
+# ── JWT 휴먼 경로 ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_member_jwt_returns_org_member_id():
+    """JWT 인증 → org_member.id 반환."""
+    auth = _make_auth()
+    om = _make_org_member()
+
+    session = AsyncMock()
+    user_mock = MagicMock()
+    user_mock.email = "user@test.com"
+    om_result = MagicMock(); om_result.scalar_one_or_none.return_value = om
+    user_result = MagicMock(); user_result.scalar_one_or_none.return_value = user_mock
+
+    with patch("app.services.member_resolver.has_project_access", return_value=True):
+        session.execute = AsyncMock(side_effect=[om_result, user_result])
+        resolved = await resolve_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+
+    assert resolved.id == ORG_MEMBER_ID
+    assert resolved.type == "human"
+    assert resolved.user_id == USER_ID
+    assert resolved.name == "user@test.com"
+
+
+@pytest.mark.anyio
+async def test_resolve_member_jwt_no_project_access_403():
+    """JWT 유저가 project에 접근권 없음 → 403."""
+    auth = _make_auth()
+
+    session = AsyncMock()
+    from fastapi import HTTPException
+    with patch("app.services.member_resolver.has_project_access", return_value=False):
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_resolve_member_jwt_no_org_member_400():
+    """JWT 유저가 org_member에 없음 → 400."""
+    auth = _make_auth()
+
+    session = AsyncMock()
+    om_result = MagicMock(); om_result.scalar_one_or_none.return_value = None
+
+    from fastapi import HTTPException
+    with patch("app.services.member_resolver.has_project_access", return_value=True):
+        session.execute = AsyncMock(return_value=om_result)
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert exc_info.value.status_code == 400
+
+
+# ── lookup_members_by_ids ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_lookup_members_team_member_first():
+    """TeamMember 조회 우선 — org_member 조회 없음."""
+    tm = _make_team_member()
+    session = AsyncMock()
+    tm_result = MagicMock(); tm_result.scalars.return_value.all.return_value = [tm]
+    session.execute = AsyncMock(return_value=tm_result)
+
+    result = await lookup_members_by_ids({AGENT_TM_ID}, session)
+    assert AGENT_TM_ID in result
+    assert result[AGENT_TM_ID].type == "agent"
+    assert session.execute.call_count == 1  # TM만 조회
+
+
+@pytest.mark.anyio
+async def test_lookup_members_falls_back_to_org_member():
+    """TeamMember에 없으면 OrgMember에서 fallback."""
+    om = _make_org_member()
+    session = AsyncMock()
+    empty_tm = MagicMock(); empty_tm.scalars.return_value.all.return_value = []
+    om_result = MagicMock(); om_result.scalars.return_value.all.return_value = [om]
+    user_result = MagicMock(); user_result.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(side_effect=[empty_tm, om_result, user_result])
+
+    result = await lookup_members_by_ids({ORG_MEMBER_ID}, session)
+    assert ORG_MEMBER_ID in result
+    assert result[ORG_MEMBER_ID].type == "human"
+
+
+# ── 인가 불변식 (create_conversation) ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_create_conversation_rejects_non_creator():
+    """에이전트 creator가 아닌 휴먼이 대화 생성 시도 → 403."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    agent_id = uuid.uuid4()
+    creator_user_id = uuid.uuid4()  # 에이전트의 실제 creator
+    requestor_user_id = USER_ID     # 요청자 (다른 유저)
+
+    # ResolvedMember for requestor
+    sender = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=requestor_user_id,
+        name="user@test.com", type="human", role="member",
+        org_id=ORG_ID, project_id=PROJECT_ID,
+    )
+
+    agent_tm = MagicMock()
+    agent_tm.id = agent_id
+    agent_tm.type = "agent"
+    agent_tm.created_by = creator_user_id  # 다른 user.id
+
+    session = AsyncMock()
+    agent_result = MagicMock(); agent_result.scalars.return_value.all.return_value = [agent_tm]
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: _make_auth()
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG_ID
+
+    with patch("app.routers.conversations._resolve_member", return_value=sender), \
+         patch("app.routers.conversations.resolve_member", return_value=sender):
+        session.execute = AsyncMock(return_value=agent_result)
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/conversations", json={
+                "type": "dm",
+                "participant_ids": [str(agent_id)],
+                "project_id": str(PROJECT_ID),
+            })
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_create_conversation_creator_allowed():
+    """에이전트 creator가 대화 생성 → 403 아님."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    agent_id = uuid.uuid4()
+    conv_id = uuid.uuid4()
+
+    # sender = creator
+    sender = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=USER_ID,
+        name="creator@test.com", type="human", role="member",
+        org_id=ORG_ID, project_id=PROJECT_ID,
+    )
+
+    agent_tm = MagicMock()
+    agent_tm.id = agent_id
+    agent_tm.type = "agent"
+    agent_tm.created_by = USER_ID  # 동일한 user.id
+
+    conv = MagicMock()
+    conv.id = conv_id
+    conv.type = "dm"
+    conv.title = None
+
+    session = AsyncMock()
+    agent_result = MagicMock(); agent_result.scalars.return_value.all.return_value = [agent_tm]
+    dm_dedup = MagicMock(); dm_dedup.scalars.return_value.all.return_value = []  # 기존 DM 없음
+    session.execute = AsyncMock(side_effect=[agent_result, dm_dedup])
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock(side_effect=lambda obj: setattr(obj, "id", conv_id) or setattr(obj, "type", "dm") or setattr(obj, "title", None))
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: _make_auth()
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG_ID
+
+    with patch("app.routers.conversations._resolve_member", return_value=sender), \
+         patch("app.routers.conversations.resolve_member", return_value=sender):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/conversations", json={
+                "type": "dm",
+                "participant_ids": [str(agent_id)],
+                "project_id": str(PROJECT_ID),
+            })
+
+    app.dependency_overrides.clear()
+    assert resp.status_code != 403

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -171,108 +171,111 @@ async def test_lookup_members_falls_back_to_org_member():
     assert result[ORG_MEMBER_ID].type == "human"
 
 
-# ── 인가 불변식 (create_conversation) ────────────────────────────────────────
+# ── _enforce_agent_creator_policy 유닛 테스트 ────────────────────────────────
 
 @pytest.mark.anyio
-async def test_create_conversation_rejects_non_creator():
-    """에이전트 creator가 아닌 휴먼이 대화 생성 시도 → 403."""
-    from app.main import app
-    from app.dependencies.auth import get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
-    from httpx import ASGITransport, AsyncClient
-
-    agent_id = uuid.uuid4()
-    creator_user_id = uuid.uuid4()  # 에이전트의 실제 creator
-    requestor_user_id = USER_ID     # 요청자 (다른 유저)
-
-    # ResolvedMember for requestor
-    sender = ResolvedMember(
-        id=ORG_MEMBER_ID, user_id=requestor_user_id,
-        name="user@test.com", type="human", role="member",
-        org_id=ORG_ID, project_id=PROJECT_ID,
-    )
-
-    agent_tm = MagicMock()
-    agent_tm.id = agent_id
-    agent_tm.type = "agent"
-    agent_tm.created_by = creator_user_id  # 다른 user.id
-
+async def test_policy_skip_no_agents():
+    """에이전트 없음 → 정책 skip."""
+    from app.routers.conversations import _enforce_agent_creator_policy
     session = AsyncMock()
-    agent_result = MagicMock(); agent_result.scalars.return_value.all.return_value = [agent_tm]
-
-    async def override_db():
-        yield session
-
-    app.dependency_overrides[get_db] = override_db
-    app.dependency_overrides[get_current_user] = lambda: _make_auth()
-    app.dependency_overrides[get_verified_org_id] = lambda: ORG_ID
-
-    with patch("app.routers.conversations._resolve_member", return_value=sender), \
-         patch("app.routers.conversations.resolve_member", return_value=sender):
-        session.execute = AsyncMock(return_value=agent_result)
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "dm",
-                "participant_ids": [str(agent_id)],
-                "project_id": str(PROJECT_ID),
-            })
-
-    app.dependency_overrides.clear()
-    assert resp.status_code == 403
+    no_agents = MagicMock(); no_agents.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(return_value=no_agents)
+    sender = ResolvedMember(id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID)
+    await _enforce_agent_creator_policy(sender, [uuid.uuid4()], session)  # 예외 없음
 
 
 @pytest.mark.anyio
-async def test_create_conversation_creator_allowed():
-    """에이전트 creator가 대화 생성 → 403 아님."""
-    from app.main import app
-    from app.dependencies.auth import get_current_user, get_verified_org_id
-    from app.dependencies.database import get_db
-    from httpx import ASGITransport, AsyncClient
+async def test_policy_skip_agents_only():
+    """에이전트↔에이전트 (휴먼 없음) → creator 무관 허용."""
+    from app.routers.conversations import _enforce_agent_creator_policy
+    agent1_id, agent2_id = uuid.uuid4(), uuid.uuid4()
+    sender_agent = MagicMock()
+    sender_agent.id = agent1_id
+    sender_agent.type = "agent"
+    sender_agent.user_id = None
 
-    agent_id = uuid.uuid4()
-    conv_id = uuid.uuid4()
-
-    # sender = creator
-    sender = ResolvedMember(
-        id=ORG_MEMBER_ID, user_id=USER_ID,
-        name="creator@test.com", type="human", role="member",
-        org_id=ORG_ID, project_id=PROJECT_ID,
-    )
-
-    agent_tm = MagicMock()
-    agent_tm.id = agent_id
-    agent_tm.type = "agent"
-    agent_tm.created_by = USER_ID  # 동일한 user.id
-
-    conv = MagicMock()
-    conv.id = conv_id
-    conv.type = "dm"
-    conv.title = None
+    agent2_tm = MagicMock()
+    agent2_tm.id = agent2_id
+    agent2_tm.type = "agent"
+    agent2_tm.created_by = None  # creator 없어도 OK
 
     session = AsyncMock()
-    agent_result = MagicMock(); agent_result.scalars.return_value.all.return_value = [agent_tm]
-    dm_dedup = MagicMock(); dm_dedup.scalars.return_value.all.return_value = []  # 기존 DM 없음
-    session.execute = AsyncMock(side_effect=[agent_result, dm_dedup])
-    session.add = MagicMock()
-    session.flush = AsyncMock()
-    session.commit = AsyncMock()
-    session.refresh = AsyncMock(side_effect=lambda obj: setattr(obj, "id", conv_id) or setattr(obj, "type", "dm") or setattr(obj, "title", None))
+    agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [sender_agent, agent2_tm]
+    session.execute = AsyncMock(return_value=agents_result)
 
-    async def override_db():
-        yield session
+    await _enforce_agent_creator_policy(sender_agent, [agent2_id], session)  # 403 없음
 
-    app.dependency_overrides[get_db] = override_db
-    app.dependency_overrides[get_current_user] = lambda: _make_auth()
-    app.dependency_overrides[get_verified_org_id] = lambda: ORG_ID
 
-    with patch("app.routers.conversations._resolve_member", return_value=sender), \
-         patch("app.routers.conversations.resolve_member", return_value=sender):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-            resp = await c.post("/api/v2/conversations", json={
-                "type": "dm",
-                "participant_ids": [str(agent_id)],
-                "project_id": str(PROJECT_ID),
-            })
+@pytest.mark.anyio
+async def test_policy_creator_in_participants_group():
+    """그룹: 비-creator 휴먼이 [에이전트+creator+자기] 열기 → 허용(creator가 참가자에 있음)."""
+    from app.routers.conversations import _enforce_agent_creator_policy
+    agent_id = uuid.uuid4()
+    creator_user_id = uuid.uuid4()
+    creator_member_id = uuid.uuid4()
+    requestor_member_id = ORG_MEMBER_ID  # 다른 유저
 
-    app.dependency_overrides.clear()
-    assert resp.status_code != 403
+    sender = ResolvedMember(
+        id=requestor_member_id, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID
+    )
+
+    agent_tm = MagicMock(); agent_tm.id = agent_id; agent_tm.type = "agent"; agent_tm.created_by = creator_user_id
+
+    session = AsyncMock()
+    # 1st execute: agent 조회 (all_ids에서)
+    agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [agent_tm]
+    # 2nd execute: remaining TM 조회 → creator_member_id가 TM
+    creator_tm = MagicMock(); creator_tm.id = creator_member_id; creator_tm.user_id = creator_user_id
+    tms_result = MagicMock(); tms_result.scalars.return_value.all.return_value = [creator_tm]
+    session.execute = AsyncMock(side_effect=[agents_result, tms_result])
+
+    # creator_member_id가 participant_ids에 있음
+    await _enforce_agent_creator_policy(sender, [agent_id, creator_member_id], session)  # 예외 없음
+
+
+@pytest.mark.anyio
+async def test_policy_creator_not_in_participants_403():
+    """그룹: 에이전트 creator가 참가자에 없음 → 403."""
+    from app.routers.conversations import _enforce_agent_creator_policy
+    from fastapi import HTTPException
+    agent_id = uuid.uuid4()
+    creator_user_id = uuid.uuid4()
+
+    sender = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID
+    )
+
+    agent_tm = MagicMock(); agent_tm.id = agent_id; agent_tm.type = "agent"; agent_tm.created_by = creator_user_id
+
+    session = AsyncMock()
+    agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [agent_tm]
+    # remaining TM 없음
+    empty_tms = MagicMock(); empty_tms.scalars.return_value.all.return_value = []
+    empty_oms = MagicMock(); empty_oms.scalars.return_value.all.return_value = []
+    session.execute = AsyncMock(side_effect=[agents_result, empty_tms, empty_oms])
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_policy_no_creator_in_human_conversation_403():
+    """creator 없는 에이전트 + 휴먼 대화 → 403."""
+    from app.routers.conversations import _enforce_agent_creator_policy
+    from fastapi import HTTPException
+    agent_id = uuid.uuid4()
+
+    sender = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID
+    )
+
+    agent_tm = MagicMock(); agent_tm.id = agent_id; agent_tm.type = "agent"; agent_tm.created_by = None
+
+    session = AsyncMock()
+    agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [agent_tm]
+    session.execute = AsyncMock(return_value=agents_result)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Summary

- grant-only 휴먼(org_member+project_access grant, team_member 없음)이 대화 생성 시 "Team member not found" → 수정
- `_resolve_member`를 team_member 우선 + grant-only fallback(org_member.id)으로 패치

## Changes

- **migration 0069**: conversations*/events의 team_members FK drop (idempotent, 가역)
- **services/member_resolver.py** 신규: `resolve_member` + `lookup_members_by_ids` SSOT
- **conversations._resolve_member**: TM 우선 → grant-only 시 `resolve_member` fallback
- **conversations._enforce_agent_creator_policy**: 에이전트 creator 동석 불변식 (⭐)
- **list_messages**: `lookup_members_by_ids`로 TM+OrgMember union sender display
- 테스트 9케이스 + 기존 test_conversations autouse skip fixture

## AC Checklist

- [x] CP1 JWT 휴먼 → org_member.id + has_project_access 검증
- [x] CP1 API키 에이전트 → team_member.id
- [x] CP2 migration 0069 idempotent + downgrade 데이터 안전 가드
- [x] CP3 에이전트 creator 불변식: 비creator 403, creator 허용, creator 없는 에이전트 403
- [x] 회귀: 1326 passed (mcp e2e 제외)

## Test plan

- [ ] dev 마이그 잡(sprintable-migrate-dev) 수동 실행
- [ ] dev 라이브: 하록신이 **자기 소유 에이전트** 대화 생성 성공
- [ ] dev 라이브: **비소유 에이전트**는 정책상 403
- [ ] 기존 team_member 휴먼·에이전트 무영향 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)