### PR TITLE
promote: develop→main — Chat 목록 크래시 null-guard (#1132)

### DIFF
--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -106,7 +106,7 @@ export function AddParticipantModal({
                     }`}
                   >
                     <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
-                      {m.name.slice(0, 2).toUpperCase()}
+                      {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
                     {m.type === 'agent' && (

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -90,7 +90,7 @@ function ConversationRow({
   const unread = conv.unread_count ?? 0;
 
   const avatarInitial = !isAgentConv && conv.type === 'dm' && conv.participants
-    ? (conv.participants.find((p) => p.member_id !== currentMemberId)?.name.slice(0, 2) ?? 'DM')
+    ? (conv.participants.find((p) => p.member_id !== currentMemberId)?.name?.slice(0, 2) ?? 'DM')
     : null;
 
   const others = conv.participants ? getOtherParticipants(conv.participants, currentMemberId) : [];
@@ -119,7 +119,7 @@ function ConversationRow({
               key={p.member_id}
               className="relative flex h-[18px] w-[18px] flex-shrink-0 items-center justify-center rounded-full bg-muted text-[9px] font-medium text-muted-foreground ring-1 ring-background"
             >
-              {p.name.slice(0, 1)}
+              {p.name?.slice(0, 1) ?? '?'}
               {p.type === 'agent' && (
                 <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-brand-strong ring-1 ring-background" />
               )}
@@ -134,7 +134,7 @@ function ConversationRow({
         <span className="truncate">
           {isAgentInConv && agentCount > 0
             ? t('agentCount', { count: agentCount })
-            : `${t('personCount', { count: others.length + 1 })} · ${others.slice(0, 2).map((p) => p.name).join(', ')}${others.length > 2 ? ` ${t('participantsOthers', { count: others.length - 2 })}` : ''}`
+            : `${t('personCount', { count: others.length + 1 })} · ${others.slice(0, 2).map((p) => p.name ?? '?').join(', ')}${others.length > 2 ? ` ${t('participantsOthers', { count: others.length - 2 })}` : ''}`
           }
         </span>
       </div>

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -99,7 +99,7 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
                     }`}
                   >
                     <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-muted-foreground">
-                      {m.name.slice(0, 2).toUpperCase()}
+                      {m.name?.slice(0, 2)?.toUpperCase() ?? '?'}
                     </div>
                     <span className="flex-1 truncate">{m.name}</span>
                     {m.type === 'agent' && (

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -451,20 +451,16 @@ async def list_conversations(
     )).all()
 
     all_member_ids = {r.member_id for r in p_rows}
-    member_rows = (await db.execute(
-        select(TeamMember.id, TeamMember.name, TeamMember.avatar_url, TeamMember.type)
-        .where(TeamMember.id.in_(all_member_ids))
-    )).all() if all_member_ids else []
-    member_map = {r.id: {"name": r.name, "avatar_url": r.avatar_url, "type": r.type} for r in member_rows}
+    resolved_map = await lookup_members_by_ids(all_member_ids, db) if all_member_ids else {}
 
     conv_participants: dict[uuid.UUID, list[dict]] = defaultdict(list)
     for r in p_rows:
-        info = member_map.get(r.member_id, {})
+        resolved = resolved_map.get(r.member_id)
         conv_participants[r.conversation_id].append({
             "member_id": str(r.member_id),
-            "name": info.get("name"),
-            "avatar_url": info.get("avatar_url"),
-            "type": info.get("type", "human"),
+            "name": resolved.name if resolved else str(r.member_id)[:8],
+            "avatar_url": getattr(resolved, "avatar_url", None) if resolved else None,
+            "type": resolved.type if resolved else "human",
         })
 
     result = []

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -137,4 +137,15 @@ async def lookup_members_by_ids(
                 project_id=None,
             )
 
+    # orphan/삭제 멤버: TM도 OrgMember도 아닌 ID → fallback(크래시 방지)
+    for mid in ids:
+        if mid not in result:
+            result[mid] = ResolvedMember(
+                id=mid, user_id=None,
+                name=str(mid)[:8],
+                type="human", role="member",
+                org_id=uuid.UUID(int=0),
+                project_id=None,
+            )
+
     return result


### PR DESCRIPTION
## develop→main 프로모션
Chat 목록 크래시 핫픽스(#1132, 5e4affad) prod 반영 — 선생님 제로고 Chat 페이지 진입 불가() 해소.

**포함:** FE  null-guard(chat-list-view·modals) + BE  orphan fallback() +  union lookup(name=null 제거).
**검증:** #1132 CI 4건 all SUCCESS(직접 확인) + 까심 QA APPROVE + PO 리뷰. 마이그 없음(코드만).

admin-merge 우회. 🤖