### PR TITLE
[SID:1eb8e311] feat: event-stream Last-Event-ID passthrough

### DIFF
--- a/apps/web/src/app/api/event-stream/route.ts
+++ b/apps/web/src/app/api/event-stream/route.ts
@@ -14,13 +14,16 @@ export async function GET(request: NextRequest): Promise<Response> {
 
   const { searchParams } = new URL(request.url);
   const memberId = searchParams.get('member_id');
+  const lastEventId = searchParams.get('last_event_id') ?? request.headers.get('Last-Event-ID');
 
   const upstreamUrl = new URL(`${FASTAPI_URL()}/api/v2/events/stream`);
   if (memberId) upstreamUrl.searchParams.set('member_id', memberId);
+  if (lastEventId) upstreamUrl.searchParams.set('last_event_id', lastEventId);
 
-  const upstream = await fetch(upstreamUrl.toString(), {
-    headers: { Authorization: `Bearer ${session.access_token}` },
-  });
+  const upstreamHeaders: Record<string, string> = { Authorization: `Bearer ${session.access_token}` };
+  if (lastEventId) upstreamHeaders['Last-Event-ID'] = lastEventId;
+
+  const upstream = await fetch(upstreamUrl.toString(), { headers: upstreamHeaders });
 
   if (!upstream.ok) {
     return NextResponse.json(


### PR DESCRIPTION
## 변경 요약

E-AGENT-GATEWAY Phase 0 FE 스토리 — `event-stream/route.ts` 프록시가 브라우저 재연결 커서를 FastAPI upstream으로 전달하지 않던 버그 수정.

## 변경 내용

`apps/web/src/app/api/event-stream/route.ts` 1파일:
- `Last-Event-ID` 헤더 → upstream 헤더로 passthrough
- `last_event_id` 쿼리 파라미터 → upstream URL 쿼리로 passthrough
- 둘 다 없으면 기존 동작 유지 (무영향)

## 검증
- `pnpm build` ✓
- ⚠️ develop까지만 — prod 승격 절대 금지

🤖 Generated with [Claude Code](https://claude.ai/claude-code)