### PR TITLE
feat: [E-AGENT-GATEWAY Phase 0] gateway_seq 커서 + 이중전달 fix (#4aab7e85)

### DIFF
--- a/backend/alembic/versions/0070_agent_gateway_seq.py
+++ b/backend/alembic/versions/0070_agent_gateway_seq.py
@@ -1,0 +1,105 @@
+"""E-AGENT-GATEWAY Phase 0: gateway_seq 단조 커서 + 커서 테이블.
+
+events.gateway_seq: BIGINT GENERATED ALWAYS AS IDENTITY (단조 불변 커서)
+  - 기존 행 백필: ADD COLUMN 시 자동 채워짐
+  - (recipient_id, gateway_seq) 인덱스: 에이전트 스트림 조회 최적화
+
+agent_event_cursors: per-agent acked_seq 영속화
+agent_gateway_sessions: 세션 메타 (연결 추적용)
+
+Revision ID: 0070
+Revises: 0069
+Create Date: 2026-06-01
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0070"
+down_revision = "0069"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    # ── 1. events.gateway_seq ─────────────────────────────────────────────────
+    event_cols = {c["name"] for c in insp.get_columns("events")}
+    if "gateway_seq" not in event_cols:
+        # GENERATED ALWAYS AS IDENTITY: 기존 행에도 자동으로 순차값 채워짐 (백필)
+        conn.execute(sa.text(
+            "ALTER TABLE events "
+            "ADD COLUMN gateway_seq BIGINT GENERATED ALWAYS AS IDENTITY"
+        ))
+
+    # (recipient_id, gateway_seq) 복합 인덱스
+    existing_idx = {idx["name"] for idx in insp.get_indexes("events")}
+    if "ix_events_recipient_gateway_seq" not in existing_idx:
+        op.create_index(
+            "ix_events_recipient_gateway_seq",
+            "events",
+            ["recipient_id", "gateway_seq"],
+        )
+
+    # ── 2. agent_event_cursors ────────────────────────────────────────────────
+    tables = set(insp.get_table_names())
+    if "agent_event_cursors" not in tables:
+        op.create_table(
+            "agent_event_cursors",
+            sa.Column("agent_id", UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "acked_seq", sa.BigInteger, nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+        )
+
+    # ── 3. agent_gateway_sessions ─────────────────────────────────────────────
+    if "agent_gateway_sessions" not in tables:
+        op.create_table(
+            "agent_gateway_sessions",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column("agent_id", UUID(as_uuid=True), nullable=False, index=True),
+            sa.Column(
+                "connected_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "last_seen_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "last_ack_seq", sa.BigInteger, nullable=False, server_default="0"
+            ),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    if "agent_gateway_sessions" in tables:
+        op.drop_table("agent_gateway_sessions")
+    if "agent_event_cursors" in tables:
+        op.drop_table("agent_event_cursors")
+
+    existing_idx = {idx["name"] for idx in insp.get_indexes("events")}
+    if "ix_events_recipient_gateway_seq" in existing_idx:
+        op.drop_index("ix_events_recipient_gateway_seq", table_name="events")
+
+    event_cols = {c["name"] for c in insp.get_columns("events")}
+    if "gateway_seq" in event_cols:
+        conn.execute(sa.text("ALTER TABLE events DROP COLUMN gateway_seq"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -105,6 +105,7 @@ app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(activity_logs.router)
 app.include_router(events.router)
+app.include_router(agent_gateway.router)
 app.include_router(dispatch.router)
 app.include_router(conversations.router)
 app.include_router(presence.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.agent_deployment import AgentAuditLog, AgentDeployment, AgentPersona
 from app.models.agent_routing_rule import AgentRoutingRule
 from app.models.agent_run import AgentRun

--- a/backend/app/models/agent_gateway.py
+++ b/backend/app/models/agent_gateway.py
@@ -1,0 +1,35 @@
+"""E-AGENT-GATEWAY Phase 0: 커서 + 세션 모델."""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class AgentEventCursor(Base):
+    """per-agent acked_seq 영속화 — 재연결 시 중복 없는 커서."""
+    __tablename__ = "agent_event_cursors"
+
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    acked_seq: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+
+class AgentGatewaySession(Base):
+    """에이전트 SSE 세션 추적 (연결 메타)."""
+    __tablename__ = "agent_gateway_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    connected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_seen_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    last_ack_seq: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -58,6 +58,7 @@ class Event(Base, OrgScopedMixin):
     recipient_type: Mapped[str] = mapped_column(Text, nullable=False)
     payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     status: Mapped[str] = mapped_column(Text, nullable=False, default=EventStatus.pending.value)
+    gateway_seq: Mapped[int | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -1,0 +1,244 @@
+"""E-AGENT-GATEWAY Phase 0: gateway_seq 기반 SSE 스트림 + ACK.
+
+이중전달 fix: status 변이 폐기 → gateway_seq > start_seq 단조 커서.
+start_seq = max(acked_seq DB, Last-Event-ID 헤더)
+backfill = live-tail = 동일 쿼리 → 겹침 0.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.core.database import async_session_factory
+from app.dependencies.database import get_db
+from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
+from app.models.event import Event
+from app.models.team import TeamMember
+from app.routers.events import _agent_connections, _event_to_payload
+
+router = APIRouter(prefix="/api/v2/agent", tags=["agent-gateway"])
+
+_SSE_HEARTBEAT: float = float(os.getenv("SSE_HEARTBEAT_TIMEOUT", "30"))
+_BACKFILL_LIMIT: int = int(os.getenv("AGENT_GATEWAY_BACKFILL_LIMIT", "100"))
+
+# ─── wake_agent: commit 후 큐 알림 ────────────────────────────────────────────
+
+def wake_agent(agent_id: str, seq: int, _from_listener: bool = False) -> None:
+    """신규 이벤트 커밋 후 에이전트 SSE 큐에 wake 신호 전송.
+
+    에이전트는 신호 수신 후 gateway_seq > current_seq 조회 (payload 미포함).
+    _from_listener=True: pg_notify 재발행 금지.
+    """
+    payload = {"__wake__": True, "seq": seq}
+    queues = _agent_connections.get(agent_id)
+    if queues:
+        dead = []
+        for q in list(queues):
+            try:
+                q.put_nowait(payload)
+            except asyncio.QueueFull:
+                dead.append(q)
+        for q in dead:
+            queues.discard(q)
+    if not _from_listener:
+        try:
+            from app.services.pg_pubsub import pg_notify
+            asyncio.get_running_loop().create_task(
+                pg_notify("agent", agent_id, "__wake__", {"seq": seq})
+            )
+        except RuntimeError:
+            pass
+
+
+# ─── backward compat: 구 _push_to_agent 호환 래퍼 ────────────────────────────
+
+def _push_to_agent_v2(member_id: str, payload: dict, _from_listener: bool = False) -> bool:
+    """구 _push_to_agent 호출부 호환 — gateway_seq 있으면 wake_agent로 위임."""
+    seq = payload.get("gateway_seq")
+    if seq is not None:
+        wake_agent(member_id, int(seq), _from_listener=_from_listener)
+        return True
+    # gateway_seq 없는 경우(레거시 경로): 기존 큐 직접 push fallback
+    from app.routers.events import _push_to_agent as _legacy_push
+    return _legacy_push(member_id, payload, _from_listener=_from_listener)
+
+
+# ─── GET /api/v2/agent/stream ─────────────────────────────────────────────────
+
+@router.get("/stream")
+async def agent_stream(
+    request: Request,
+    auth: AuthContext = Depends(get_current_user),
+) -> StreamingResponse:
+    """gateway_seq 기반 SSE 스트림 (API키 전용).
+
+    Last-Event-ID 헤더 = 마지막 수신 gateway_seq.
+    start_seq = max(DB acked_seq, Last-Event-ID).
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if not is_api_key:
+        raise HTTPException(status_code=403, detail="API key required for agent stream")
+
+    agent_id = uuid.UUID(auth.user_id)
+
+    # agent_id 검증
+    async with async_session_factory() as db:
+        tm = (await db.execute(
+            select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
+        )).scalar_one_or_none()
+        if tm is None:
+            raise HTTPException(status_code=404, detail="Agent not found")
+
+        # acked_seq DB 조회
+        cursor = (await db.execute(
+            select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
+        )).scalar_one_or_none()
+        acked_seq: int = cursor.acked_seq if cursor else 0
+
+        # 세션 등록
+        session_rec = AgentGatewaySession(
+            id=uuid.uuid4(),
+            agent_id=agent_id,
+            connected_at=datetime.now(timezone.utc),
+            last_seen_at=datetime.now(timezone.utc),
+        )
+        db.add(session_rec)
+        await db.commit()
+
+    # Last-Event-ID 헤더 파싱 (gateway_seq)
+    last_event_id_hdr = request.headers.get("Last-Event-ID") or request.headers.get("last-event-id")
+    header_seq: int = 0
+    if last_event_id_hdr:
+        try:
+            header_seq = int(last_event_id_hdr)
+        except (ValueError, TypeError):
+            pass
+
+    start_seq = max(acked_seq, header_seq)
+    agent_id_str = str(agent_id)
+
+    queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=200)
+    _agent_connections[agent_id_str].add(queue)
+
+    async def generate():
+        nonlocal start_seq
+        try:
+            yield "event: heartbeat\ndata: {}\n\n"
+
+            # 초기 백필 — gateway_seq > start_seq
+            async with async_session_factory() as db:
+                rows = (await db.execute(
+                    select(Event)
+                    .where(
+                        Event.recipient_id == agent_id,
+                        Event.gateway_seq > start_seq,
+                    )
+                    .order_by(Event.gateway_seq.asc())
+                    .limit(_BACKFILL_LIMIT)
+                )).scalars().all()
+
+            for evt in rows:
+                data = _event_to_payload(evt)
+                gseq = evt.gateway_seq or 0
+                _sse = json.dumps({**data, "gateway_seq": gseq, "is_backfill": True})
+                yield f"event: {evt.event_type}\nid: {gseq}\ndata: {_sse}\n\n"
+                if gseq > start_seq:
+                    start_seq = gseq
+
+            # 실시간 — wake 신호 → DB 재조회 (status 변이 폐기)
+            while not await request.is_disconnected():
+                try:
+                    signal = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT)
+                    if signal.get("__wake__"):
+                        # wake 신호: DB에서 새 이벤트 조회
+                        async with async_session_factory() as db:
+                            new_rows = (await db.execute(
+                                select(Event)
+                                .where(
+                                    Event.recipient_id == agent_id,
+                                    Event.gateway_seq > start_seq,
+                                )
+                                .order_by(Event.gateway_seq.asc())
+                                .limit(_BACKFILL_LIMIT)
+                            )).scalars().all()
+                        for evt in new_rows:
+                            data = _event_to_payload(evt)
+                            gseq = evt.gateway_seq or 0
+                            _sse = json.dumps({**data, "gateway_seq": gseq, "is_backfill": False})
+                            if evt.event_type == "conversation.message_created":
+                                yield f"event: conversation:message\nid: {gseq}\ndata: {_sse}\n\n"
+                            yield f"event: {evt.event_type}\nid: {gseq}\ndata: {_sse}\n\n"
+                            if gseq > start_seq:
+                                start_seq = gseq
+                    else:
+                        # 레거시 직접 push (AGENT_GATEWAY_V2 미적용 경로)
+                        event_type = signal.get("event_type", "message")
+                        _live_id = signal.get("event_id") or str(uuid.uuid4())
+                        _sse = json.dumps({**signal, "is_backfill": False})
+                        if event_type == "conversation.message_created":
+                            yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse}\n\n"
+                        yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse}\n\n"
+                except asyncio.TimeoutError:
+                    yield "event: heartbeat\ndata: {}\n\n"
+                    if await request.is_disconnected():
+                        break
+        except (asyncio.CancelledError, GeneratorExit):
+            pass
+        finally:
+            _agent_connections[agent_id_str].discard(queue)
+            if not _agent_connections[agent_id_str]:
+                _agent_connections.pop(agent_id_str, None)
+
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )
+
+
+# ─── POST /api/v2/agent/events/ack ────────────────────────────────────────────
+
+class AckRequest(BaseModel):
+    seq: int
+
+
+@router.post("/events/ack")
+async def ack_event(
+    body: AckRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """에이전트가 처리 완료한 gateway_seq ACK — agent_event_cursors 갱신."""
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if not is_api_key:
+        raise HTTPException(status_code=403, detail="API key required")
+
+    agent_id = uuid.UUID(auth.user_id)
+
+    # UPSERT acked_seq (더 높은 값만 갱신)
+    existing = (await db.execute(
+        select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
+    )).scalar_one_or_none()
+
+    if existing is None:
+        db.add(AgentEventCursor(agent_id=agent_id, acked_seq=body.seq))
+    elif body.seq > existing.acked_seq:
+        existing.acked_seq = body.seq
+        existing.updated_at = datetime.now(timezone.utc)
+
+    await db.commit()
+    return {"acked_seq": body.seq}

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -141,9 +141,7 @@ async def dispatch_entity(
     await db.flush()
     await db.refresh(event)
 
-    if member_type == "agent":
-        _push_to_agent(str(assignee_id), _event_to_payload(event))
-    else:
+    if member_type != "agent":
         await dispatch_notification(
             db,
             org_id=org_id,
@@ -155,7 +153,13 @@ async def dispatch_entity(
             reference_id=body.entity_id,
         )
 
-    await db.commit()
+    await db.commit()  # commit 후 seq 확정
+
+    # agent: commit 후 wake (gateway_seq 확정 보장, 이중전달 방지)
+    if member_type == "agent" and event.gateway_seq is not None:
+        _wake_agent(str(assignee_id), event.gateway_seq)
+    elif member_type == "agent":
+        _push_to_agent(str(assignee_id), _event_to_payload(event))
     return DispatchResponse(
         dispatched=True,
         event_id=event.id,

--- a/backend/sprintable_mcp/sse_bridge.py
+++ b/backend/sprintable_mcp/sse_bridge.py
@@ -3,6 +3,7 @@
 REST용 SprintableClient와 완전히 분리된 SSE 전용 httpx.AsyncClient 사용.
 """
 from __future__ import annotations
+import os
 
 import asyncio
 import json
@@ -303,15 +304,26 @@ async def _connect_once(
     `async with client.stream(...)` context manager가 response.aclose() 보장.
     last_event_id 전달 시 서버가 해당 이벤트 이후 backfill만 반환.
     """
-    params: dict[str, str] = {"member_id": member_id}
-    if last_event_id:
-        params["last_event_id"] = last_event_id
+    # AGENT_GATEWAY_V2: 신 엔드포인트 우선 + 구 fallback
+    _use_v2 = os.getenv("AGENT_GATEWAY_V2", "0") not in ("0", "false", "")
+    if _use_v2:
+        _path = "/api/v2/agent/stream"
+        _headers: dict = {"Accept": "text/event-stream", "Cache-Control": "no-cache"}
+        if last_event_id:
+            _headers["Last-Event-ID"] = last_event_id
+        _params: dict[str, str] = {}
+    else:
+        _path = "/api/v2/events/stream"
+        _params = {"member_id": member_id}
+        _headers = {"Accept": "text/event-stream", "Cache-Control": "no-cache"}
+        if last_event_id:
+            _params["last_event_id"] = last_event_id
 
     async with client.stream(
         "GET",
-        "/api/v2/events/stream",
-        params=params,
-        headers={"Accept": "text/event-stream", "Cache-Control": "no-cache"},
+        _path,
+        params=_params,
+        headers=_headers,
     ) as response:
         if response.status_code != 200:
             raise RuntimeError(f"SSE connect failed: HTTP {response.status_code}")

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -1,0 +1,183 @@
+"""E-AGENT-GATEWAY Phase 0: gateway_seq 커서 + ACK + 이중전달 fix 테스트."""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers.agent_gateway import wake_agent, _push_to_agent_v2
+
+AGENT_ID = uuid.uuid4()
+ORG_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── wake_agent ────────────────────────────────────────────────────────────────
+
+def test_wake_agent_no_connection():
+    """연결 없으면 큐 없이 반환 (예외 없음)."""
+    from app.routers.events import _agent_connections
+    _agent_connections.pop(str(AGENT_ID), None)
+    wake_agent(str(AGENT_ID), 42)  # 예외 없어야 함
+
+
+def test_wake_agent_puts_wake_signal():
+    """연결 중인 큐에 __wake__ 신호 전달."""
+    import asyncio
+    from app.routers.events import _agent_connections
+    q = asyncio.Queue(maxsize=10)
+    agent_id_str = str(AGENT_ID)
+    _agent_connections[agent_id_str].add(q)
+    try:
+        with patch("app.routers.agent_gateway.asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.create_task = MagicMock()
+            wake_agent(agent_id_str, 99)
+        assert not q.empty()
+        signal = q.get_nowait()
+        assert signal["__wake__"] is True
+        assert signal["seq"] == 99
+    finally:
+        _agent_connections.pop(agent_id_str, None)
+
+
+# ── _push_to_agent_v2 backward compat ─────────────────────────────────────────
+
+def test_push_v2_with_gateway_seq_calls_wake():
+    """gateway_seq 있는 payload → wake_agent 호출."""
+    with patch("app.routers.agent_gateway.wake_agent") as mock_wake:
+        _push_to_agent_v2(str(AGENT_ID), {"event_type": "test", "gateway_seq": 5})
+        mock_wake.assert_called_once_with(str(AGENT_ID), 5, _from_listener=False)
+
+
+def test_push_v2_without_gateway_seq_falls_back():
+    """gateway_seq 없는 payload → 레거시 _push_to_agent 호출."""
+    with patch("app.routers.events._push_to_agent") as mock_legacy:
+        mock_legacy.return_value = False
+        _push_to_agent_v2(str(AGENT_ID), {"event_type": "test"})
+        mock_legacy.assert_called_once()
+
+
+# ── ACK 엔드포인트 ────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_ack_creates_cursor():
+    """ACK POST → agent_event_cursors UPSERT."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(AGENT_ID)
+    ctx.claims = {"app_metadata": {"api_key_id": "ak_test"}}
+
+    session = AsyncMock()
+    existing_result = MagicMock(); existing_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=existing_result)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: ctx
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/agent/events/ack", json={"seq": 42})
+        assert resp.status_code == 200
+        assert resp.json()["acked_seq"] == 42
+        session.add.assert_called_once()
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_ack_updates_cursor_if_higher():
+    """기존 cursor < 새 seq → acked_seq 갱신."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+    from app.models.agent_gateway import AgentEventCursor
+
+    ctx = MagicMock()
+    ctx.user_id = str(AGENT_ID)
+    ctx.claims = {"app_metadata": {"api_key_id": "ak_test"}}
+
+    existing_cursor = MagicMock(spec=AgentEventCursor)
+    existing_cursor.acked_seq = 10
+
+    session = AsyncMock()
+    result = MagicMock(); result.scalar_one_or_none.return_value = existing_cursor
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: ctx
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/agent/events/ack", json={"seq": 55})
+        assert resp.status_code == 200
+        assert existing_cursor.acked_seq == 55
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_ack_ignores_lower_seq():
+    """기존 cursor > 새 seq → acked_seq 유지 (역행 방지)."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+    from app.models.agent_gateway import AgentEventCursor
+
+    ctx = MagicMock()
+    ctx.user_id = str(AGENT_ID)
+    ctx.claims = {"app_metadata": {"api_key_id": "ak_test"}}
+
+    existing_cursor = MagicMock(spec=AgentEventCursor)
+    existing_cursor.acked_seq = 100
+
+    session = AsyncMock()
+    result = MagicMock(); result.scalar_one_or_none.return_value = existing_cursor
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = lambda: ctx
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.post("/api/v2/agent/events/ack", json={"seq": 5})
+        assert resp.status_code == 200
+        assert existing_cursor.acked_seq == 100  # 역행 없음
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── dispatch 순서 (commit 후 wake) ────────────────────────────────────────────
+
+def test_dispatch_mock_structure_commit_after():
+    """dispatch.py: commit 후 wake_agent 호출 구조 확인 (소스 검사)."""
+    import inspect
+    from app.routers import dispatch
+    src = inspect.getsource(dispatch)
+    # commit이 wake_agent/push 보다 앞에 나와야 함
+    commit_pos = src.find("await db.commit()")
+    wake_pos = src.find("_wake_agent(")
+    assert commit_pos < wake_pos, "commit must happen before wake_agent"


### PR DESCRIPTION
## Summary

SSE 이중전달 버그 수정 + gateway_seq 단조 커서 기반 at-least-once 스트림.

## Changes

- **migration 0070**: `events.gateway_seq` BIGINT GENERATED ALWAYS AS IDENTITY + `(recipient_id, gateway_seq)` 인덱스 + `agent_event_cursors` + `agent_gateway_sessions` (모두 idempotent 가드)
- **Event 모델**: `gateway_seq` 컬럼 추가
- **agent_gateway.py** 신규:
  - `GET /api/v2/agent/stream` — `start_seq = max(acked_seq, Last-Event-ID)` → `gateway_seq > start_seq ASC` (backfill=live-tail 동일 쿼리, 겹침0)
  - `POST /api/v2/agent/events/ack {seq}` — cursor UPSERT
- **dispatch.py**: commit 전 push → **commit 후 wake_agent** (이중전달 fix)
- **sse_bridge.py**: `AGENT_GATEWAY_V2=1`이면 `/api/v2/agent/stream` 우선 + 구 `/events/stream` fallback
- `events.status` 변이: 신 경로에서 폐기, 구 경로 유지 (가역)

## AC Checklist

- [x] CP1 migration 0070 idempotent 가드
- [x] CP2 start_seq = max(acked_seq, Last-Event-ID) + gateway_seq > start_seq 쿼리
- [x] CP3 dispatch commit 후 wake_agent
- [x] CP5 AGENT_GATEWAY_V2 신엔드포인트 우선 + fallback
- [x] 테스트 8케이스 + 전체 1337 passed

## ⚠️ develop까지만 — prod 승격 절대 금지

🤖 Generated with [Claude Code](https://claude.ai/claude-code)