### PR TITLE
fix: gateway_seq GENERATED ALWAYS → GeneratedAlwaysError 차단 (4aab7e85)

### DIFF
--- a/backend/alembic/versions/0072_drop_gateway_seq.py
+++ b/backend/alembic/versions/0072_drop_gateway_seq.py
@@ -1,0 +1,52 @@
+"""events.gateway_seq 컬럼 + 인덱스 DROP.
+
+recipient_seq(0071)로 대체 완료. gateway_seq GENERATED ALWAYS AS IDENTITY가
+ORM INSERT 시 gateway_seq=NULL 충돌(GeneratedAlwaysError)을 유발하므로 제거.
+
+Revision ID: 0072
+Revises: 0071
+Create Date: 2026-06-02
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0072"
+down_revision = "0071"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+
+    # 인덱스 DROP (IF EXISTS 상당)
+    existing_idx = {idx["name"] for idx in insp.get_indexes("events")}
+    if "ix_events_recipient_gateway_seq" in existing_idx:
+        op.drop_index("ix_events_recipient_gateway_seq", table_name="events")
+
+    # 컬럼 DROP
+    event_cols = {c["name"] for c in insp.get_columns("events")}
+    if "gateway_seq" in event_cols:
+        conn.execute(sa.text("ALTER TABLE events DROP COLUMN gateway_seq"))
+
+
+def downgrade() -> None:
+    """gateway_seq 복원 — 기존 행 백필 없이 신규 행만 IDENTITY 채움."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    event_cols = {c["name"] for c in insp.get_columns("events")}
+    if "gateway_seq" not in event_cols:
+        conn.execute(sa.text(
+            "ALTER TABLE events "
+            "ADD COLUMN gateway_seq BIGINT GENERATED ALWAYS AS IDENTITY"
+        ))
+    existing_idx = {idx["name"] for idx in insp.get_indexes("events")}
+    if "ix_events_recipient_gateway_seq" not in existing_idx:
+        op.create_index(
+            "ix_events_recipient_gateway_seq",
+            "events",
+            ["recipient_id", "gateway_seq"],
+        )

--- a/backend/app/models/event.py
+++ b/backend/app/models/event.py
@@ -58,7 +58,6 @@ class Event(Base, OrgScopedMixin):
     recipient_type: Mapped[str] = mapped_column(Text, nullable=False)
     payload: Mapped[dict] = mapped_column(JSONB, nullable=False, default=dict)
     status: Mapped[str] = mapped_column(Text, nullable=False, default=EventStatus.pending.value)
-    gateway_seq: Mapped[int | None] = mapped_column(nullable=True)
     recipient_seq: Mapped[int | None] = mapped_column(nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/tests/test_gateway_realdb_race.py
+++ b/backend/tests/test_gateway_realdb_race.py
@@ -510,3 +510,76 @@ async def test_fetch_events_real_db_recipient_seq():
         await cleanup.close()
         await conn_setup.close()
         await engine.dispose()
+
+@pytest.mark.anyio
+async def test_send_message_creates_event_with_recipient_seq_no_generated_always_error():
+    """통합: conversation 메시지 전송 → ORM Event INSERT → recipient_seq 부여 + GeneratedAlwaysError 0.
+
+    gateway_seq GENERATED ALWAYS 잔존 시 반드시 FAIL (진짜 가드).
+    """
+    import asyncpg
+    from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
+    from sqlalchemy.orm import sessionmaker
+    from app.services.event_seq import assign_recipient_seq
+    from app.models.event import Event
+
+    engine = create_async_engine(
+        _ASYNCPG_URL.replace("postgresql://", "postgresql+asyncpg://"),
+        echo=False,
+    )
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    conn_setup = await asyncpg.connect(_ASYNCPG_URL)
+    agent_id = uuid.uuid4()
+    org_id = None
+    project_id = None
+
+    try:
+        await conn_setup.execute("BEGIN")
+        org_id, project_id = await _make_test_org_and_project(conn_setup)
+        await conn_setup.execute("COMMIT")
+
+        # 실 SQLAlchemy ORM으로 Event INSERT + assign_recipient_seq
+        async with async_session() as db:
+            event = Event(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                project_id=project_id,
+                event_type="conversation.message_created",
+                recipient_id=agent_id,
+                recipient_type="agent",
+                payload={"content": "gw-integration-test"},
+                status="pending",
+            )
+            db.add(event)
+            await db.flush()
+            # per-recipient seq 발급 (같은 트랜잭션)
+            await assign_recipient_seq(db, event)
+            await db.commit()
+
+        # recipient_seq 부여됐는지 확인
+        assert event.recipient_seq is not None and event.recipient_seq > 0, (
+            f"recipient_seq not assigned: {event.recipient_seq}"
+        )
+
+        # _fetch_events로 스트림 조회 가능한지 확인 (CAST fix 검증 포함)
+        from app.routers.agent_gateway import _fetch_events
+        async with async_session() as db:
+            rows = await _fetch_events(db, agent_id, 0, 10)
+
+        assert len(rows) >= 1
+        assert rows[0].recipient_seq == event.recipient_seq
+
+    finally:
+        cleanup = await asyncpg.connect(_ASYNCPG_URL)
+        try:
+            await cleanup.execute("DELETE FROM events WHERE recipient_id = $1", agent_id)
+            await cleanup.execute("DELETE FROM agent_event_seqs WHERE recipient_id = $1", agent_id)
+            if project_id:
+                await cleanup.execute("DELETE FROM projects WHERE id = $1", project_id)
+            if org_id:
+                await cleanup.execute("DELETE FROM organizations WHERE id = $1", org_id)
+        except: pass
+        await cleanup.close()
+        await conn_setup.close()
+        await engine.dispose()


### PR DESCRIPTION
## Root Cause

`event.py`에 `gateway_seq: Mapped[int|None]` 잔존 → SQLAlchemy ORM `Event(...) INSERT` 시 `gateway_seq=NULL` 포함 → `asyncpg.GeneratedAlwaysError: cannot insert a non-DEFAULT value into "gateway_seq"` → `db.flush()` 실패 → 이벤트 생성 전체 dead.

## Fix

1. `event.py`: `gateway_seq` Mapped 컬럼 제거
2. `migration 0072`: `events.gateway_seq` 컬럼 + `ix_events_recipient_gateway_seq` 인덱스 DROP (IF EXISTS 가드)

## Integration Test

실 SQLAlchemy ORM Event INSERT → `assign_recipient_seq` → `_fetch_events` 조회까지 한 번에:
- `gateway_seq` 잔존 시 `GeneratedAlwaysError` → FAIL (진짜 가드)
- CAST fix (#1141) 포함 검증

⚠️ develop까지

🤖 Generated with [Claude Code](https://claude.ai/claude-code)