### PR TITLE
fix: dispatch _wake_agent NameError — wake_agent import + 교정 (4aab7e85)

### DIFF
--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -13,6 +13,7 @@ from app.models.doc import Doc
 from app.models.event import Event, EventType
 from app.models.pm import Epic, Story
 from app.models.team import TeamMember
+from app.routers.agent_gateway import wake_agent
 from app.routers.events import _event_to_payload, _push_to_agent
 from app.services.event_seq import assign_recipient_seq
 from app.services.notification_dispatch import dispatch_notification
@@ -161,7 +162,7 @@ async def dispatch_entity(
     # agent: commit 후 wake (gateway_seq 확정 보장, 이중전달 방지)
     if member_type == "agent":
         if event.recipient_seq is not None:
-            _wake_agent(str(assignee_id), event.recipient_seq)
+            wake_agent(str(assignee_id), event.recipient_seq)
         else:
             _push_to_agent(str(assignee_id), _event_to_payload(event))
     return DispatchResponse(

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -179,7 +179,7 @@ def test_dispatch_mock_structure_commit_after():
     src = inspect.getsource(dispatch)
     # commit이 wake_agent/push 보다 앞에 나와야 함
     commit_pos = src.find("await db.commit()")
-    wake_pos = src.find("_wake_agent(")
+    wake_pos = src.find("wake_agent(")
     assert commit_pos < wake_pos, "commit must happen before wake_agent"
 
 # ── acked_seq 재스캔 기반 visibility gap 테스트 ─────────────────────────────


### PR DESCRIPTION
## Root Cause

`dispatch.py`가 `_wake_agent`를 호출하는데 정의 없음 + import 없음 → `NameError: name '_wake_agent' is not defined` → dispatch API 500.

recipient_seq=NULL일 때는 dead-code로 숨어 있다가 #1143 fix 후 실행되면서 노출.

## Fix

- `from app.routers.agent_gateway import wake_agent` 추가
- `_wake_agent(` → `wake_agent(` 교정

⚠️ develop까지

🤖 Generated with [Claude Code](https://claude.ai/claude-code)