### PR TITLE
[SID:1fe2602c] fix: chat name null-safe 잔여 경로 보완 (#1132 후속)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -10,7 +10,7 @@ import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 
 interface Participant {
   member_id: string;
-  name: string;
+  name: string | null;
   avatar_url?: string | null;
 }
 
@@ -24,10 +24,10 @@ function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string): str
   if (meta.title) return meta.title;
   const others = meta.participants.filter((p) => p.member_id !== currentMemberId);
   if (others.length === 0) return meta.type === 'dm' ? 'DM' : '그룹 채팅';
-  if (meta.type === 'dm') return others[0]!.name;
+  if (meta.type === 'dm') return others[0]?.name ?? '?';
   const MAX = 3;
-  if (others.length <= MAX) return others.map((p) => p.name).join(', ');
-  return `${others.slice(0, MAX).map((p) => p.name).join(', ')} 외 ${others.length - MAX}명`;
+  if (others.length <= MAX) return others.map((p) => p.name ?? '?').join(', ');
+  return `${others.slice(0, MAX).map((p) => p.name ?? '?').join(', ')} 외 ${others.length - MAX}명`;
 }
 
 export default function ConversationPage() {

--- a/apps/web/src/components/chat/chat-list-view.tsx
+++ b/apps/web/src/components/chat/chat-list-view.tsx
@@ -11,7 +11,7 @@ import { useChatSse } from '@/hooks/use-chat-sse';
 
 interface Participant {
   member_id: string;
-  name: string;
+  name: string | null;
   avatar_url?: string | null;
   type?: 'agent' | 'human';
 }
@@ -52,10 +52,10 @@ function formatParticipantNames(
 ): string {
   const others = participants.filter((p) => p.member_id !== currentMemberId);
   if (others.length === 0) return type === 'dm' ? 'DM' : t('groupSection');
-  if (type === 'dm') return others[0]!.name;
+  if (type === 'dm') return others[0]?.name ?? '?';
   const MAX = 3;
-  if (others.length <= MAX) return others.map((p) => p.name).join(', ');
-  const visible = others.slice(0, MAX).map((p) => p.name).join(', ');
+  if (others.length <= MAX) return others.map((p) => p.name ?? '?').join(', ');
+  const visible = others.slice(0, MAX).map((p) => p.name ?? '?').join(', ');
   return `${visible} ${t('participantsOthers', { count: others.length - MAX })}`;
 }
 


### PR DESCRIPTION
## 변경 사항

#1132에서 `.slice()` 크래시 방어는 완료됐으나, `formatParticipantNames` / `formatHeaderTitle` 함수가 `name=null` 참가자에 대해 `null`을 그대로 반환하는 경로가 잔존했습니다.

### 수정 내용

**`chat-list-view.tsx`**
- `Participant.name: string` → `string | null` (인터페이스 정확도)
- `formatParticipantNames` DM: `others[0]!.name` → `others[0]?.name ?? '?'`
- `formatParticipantNames` group map: `p.name` → `p.name ?? '?'`

**`chats/[conversation_id]/page.tsx`**
- `Participant.name: string` → `string | null`
- `formatHeaderTitle` 동일 패턴 전량 보완

### Before / After

| 케이스 | Before | After |
|--------|--------|-------|
| DM 참가자 name=null | 헤더·목록 빈 문자열 | `?` fallback |
| 그룹 참가자 name=null | `"null, Alice"` | `"?, Alice"` |
| `.slice()` 직접 호출 | 크래시 | n/a (이미 #1132 처리) |

## 반응형 확인

- 데스크톱/모바일 목록 레이아웃 미변경 (텍스트 fallback만 추가)

## 관련 스토리

`1fe2602c` — Chat 목록 크래시 (#1132 후속 잔여 보완)

🤖 Generated with [Claude Code](https://claude.com/claude-code)