### PR TITLE
feat: openclaw-sprintable adapter (E-INJECT-ADAPTERS S4 #c3e2cdee)

### DIFF
--- a/connectors/openclaw-sprintable/README.md
+++ b/connectors/openclaw-sprintable/README.md
@@ -1,0 +1,52 @@
+# Sprintable Adapter for OpenClaw
+
+OpenClaw용 Sprintable Gateway dial-out 어댑터 (카테고리 A).
+SSE dial-out → inbound turn 주입 → 응답 → ack. 인바운드 도메인·웹훅·터널 불필요.
+
+Tlon 채널 어댑터(`extensions/tlon/`)와 동형 구조.
+
+## 설치
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. openclaw extensions 폴더에 링크
+ln -sf "$(pwd)/connectors/openclaw-sprintable" ~/.openclaw/extensions/sprintable
+
+# 3. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...
+export SPRINTABLE_API_URL=https://...   # 미설정 시 dev 기본값
+
+# 4. OpenClaw 재시작
+openclaw restart
+```
+
+또는 `~/.openclaw/openclaw.json`에 직접 설정:
+
+```json
+{
+  "channels": {
+    "sprintable": {
+      "enabled": true,
+      "apiKey": "sk_live_...",
+      "apiUrl": "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+    }
+  }
+}
+```
+
+## 동작 원리
+
+```
+GET /api/v2/agent/stream (SSE)
+  → runSprintableSSE (SDK)
+  → onMessage()
+  → runtime.channel.inbound.buildContext(...)
+  → runtime.channel.inbound.dispatchReply(...)
+  → deliver: POST /api/v2/conversations/{id}/messages
+  → ack: POST /api/v2/agent/events/ack
+```
+
+공통 SDK(`connectors/sdk/sprintable-sse.ts`) 재사용 — SSE 소비·dedup·ack·backoff 담당.
+어댑터는 `gateway.startAccount` + inbound turn 주입부만 구현.

--- a/connectors/openclaw-sprintable/index.ts
+++ b/connectors/openclaw-sprintable/index.ts
@@ -1,0 +1,192 @@
+/**
+ * Sprintable Gateway adapter for OpenClaw — E-INJECT-ADAPTERS (카테고리 A).
+ *
+ * SSE dial-out 패턴: /api/v2/agent/stream 소비 → inbound turn 주입 → 응답 → ack.
+ * 공통 SDK(connectors/sdk/sprintable-sse.ts) 재사용.
+ * Tlon 채널 어댑터(extensions/tlon/)와 동형 구조.
+ */
+
+import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/account-id";
+import { createChatChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import type { ChannelPlugin } from "openclaw/plugin-sdk/channel-core";
+import type { PluginRuntime } from "openclaw/plugin-sdk";
+import { runSprintableSSE } from "../sdk/sprintable-sse.js";
+
+const CHANNEL_ID = "sprintable" as const;
+const DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app";
+
+// ── Account shape ─────────────────────────────────────────────────────────────
+
+type SprintableAccount = {
+  accountId: string;
+  enabled: boolean;
+  configured: boolean;
+  apiKey: string;
+  apiUrl: string;
+};
+
+function resolveAccount(cfg: Record<string, unknown>, accountId?: string): SprintableAccount {
+  const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID] as Record<string, unknown> | undefined;
+  const id = accountId ?? DEFAULT_ACCOUNT_ID;
+  return {
+    accountId: id,
+    enabled: section?.enabled !== false,
+    configured: Boolean(section?.apiKey ?? process.env.AGENT_API_KEY),
+    apiKey: String(section?.apiKey ?? process.env.AGENT_API_KEY ?? ""),
+    apiUrl: String(section?.apiUrl ?? process.env.SPRINTABLE_API_URL ?? DEFAULT_API_URL),
+  };
+}
+
+// ── Sprintable channel plugin ─────────────────────────────────────────────────
+
+export const sprintablePlugin: ChannelPlugin<SprintableAccount> = createChatChannelPlugin({
+  base: {
+    id: CHANNEL_ID,
+    meta: {
+      id: CHANNEL_ID,
+      label: "Sprintable",
+      selectionLabel: "Sprintable Agent Gateway",
+      docsPath: "/channels/sprintable",
+      docsLabel: "sprintable",
+      blurb: "Sprintable project management — dial-out SSE gateway",
+      aliases: ["sprintable"],
+      order: 95,
+    },
+    capabilities: {
+      chatTypes: ["direct", "group"],
+      media: false,
+      reply: true,
+      threads: false,
+    },
+    setup: {
+      isConfigured: (account: SprintableAccount) => account.configured,
+      describeAccount: (account: SprintableAccount) => ({
+        accountId: account.accountId,
+        configured: account.configured,
+        enabled: account.enabled,
+      }),
+    },
+    reload: { configPrefixes: [`channels.${CHANNEL_ID}`] },
+    config: {
+      listAccountIds: (cfg) => {
+        const section = (cfg.channels as Record<string, unknown>)?.[CHANNEL_ID];
+        return section ? [DEFAULT_ACCOUNT_ID] : [];
+      },
+      resolveAccount: (cfg, accountId) => resolveAccount(cfg as Record<string, unknown>, accountId),
+      isConfigured: (account: SprintableAccount) => account.configured,
+      describeAccount: (account: SprintableAccount) => ({
+        accountId: account.accountId,
+        configured: account.configured,
+        enabled: account.enabled,
+      }),
+    },
+    messaging: {
+      targetPrefixes: [CHANNEL_ID],
+      normalizeTarget: (target: string) => target.replace(/^sprintable:/, ""),
+      targetResolver: {
+        looksLikeId: (target: string) => target.startsWith("sprintable:") || target.includes("/"),
+        hint: "sprintable:<conversation_id>",
+      },
+      resolveOutboundSessionRoute: ({ to }: { to: string }) => ({
+        agentId: DEFAULT_ACCOUNT_ID,
+        sessionKey: to.replace(/^sprintable:/, ""),
+      }),
+    },
+    gateway: {
+      startAccount: async (ctx) => {
+        const account = ctx.account;
+        if (!account.configured || !account.apiKey) {
+          ctx.log?.warn?.(`[sprintable] account ${account.accountId} not configured — skipping`);
+          return;
+        }
+        ctx.setStatus({
+          accountId: account.accountId,
+          configured: true,
+          enabled: account.enabled,
+        });
+        ctx.log?.info?.(`[sprintable] starting gateway dial-out for account ${account.accountId}`);
+
+        // channelRuntime 접근 (optional —외부 플러그인 호환)
+        const rt = ctx.channelRuntime as unknown as PluginRuntime["channel"] | undefined;
+        if (!rt?.inbound) {
+          ctx.log?.warn?.("[sprintable] channelRuntime.inbound unavailable — skipping turn dispatch");
+          return;
+        }
+
+        // 기본 agentId: cfg.agents.accounts의 첫 번째 에이전트 또는 "main"
+        const agentsCfg = (ctx.cfg as Record<string, unknown>).agents as
+          | { accounts?: Record<string, unknown> } | undefined;
+        const agentId =
+          Object.keys(agentsCfg?.accounts ?? {})[0] ?? DEFAULT_ACCOUNT_ID;
+
+        await runSprintableSSE({
+          apiUrl: account.apiUrl,
+          apiKey: account.apiKey,
+          signal: ctx.abortSignal,
+          onMessage: async (msg) => {
+            const ctxPayload = rt.inbound.buildContext({
+              channel: CHANNEL_ID,
+              accountId: account.accountId,
+              messageId: msg.eventId,
+              timestamp: new Date(),
+              from: `sprintable:${msg.conversationId || msg.senderId}`,
+              sender: {
+                id: msg.senderId,
+                name: msg.senderName,
+              },
+              conversation: {
+                kind: "group",
+                id: msg.conversationId,
+                label: msg.conversationId,
+              },
+              route: {
+                agentId,
+                accountId: account.accountId,
+                routeSessionKey: msg.conversationId,
+              },
+              reply: {
+                to: `sprintable:${msg.conversationId}`,
+              },
+              message: {
+                body: msg.content,
+                bodyForAgent: msg.content,
+                rawBody: msg.content,
+                commandBody: msg.content,
+              },
+            });
+
+            await rt.inbound.dispatchReply({
+              channel: CHANNEL_ID,
+              accountId: account.accountId,
+              cfg: ctx.cfg,
+              agentId,
+              routeSessionKey: msg.conversationId,
+              storePath: undefined,
+              ctxPayload,
+              recordInboundSession: rt.session?.recordInboundSession,
+              dispatchReplyWithBufferedBlockDispatcher:
+                rt.reply?.dispatchReplyWithBufferedBlockDispatcher,
+              delivery: {
+                durable: () => ({ to: `sprintable:${msg.conversationId}` }),
+                deliver: async (payload: { text?: string }) => {
+                  if (payload.text) await msg.reply(payload.text);
+                },
+              },
+            });
+          },
+        });
+      },
+    },
+  },
+  outbound: {
+    deliveryMode: "direct",
+    textChunkLimit: 4000,
+    resolveTarget: ({ to }: { to: string }) => ({
+      ok: true,
+      target: to.replace(/^sprintable:/, ""),
+    }),
+    deliveryCapabilities: {
+      durableFinal: { text: true },
+    },
+  },
+});

--- a/connectors/openclaw-sprintable/package.json
+++ b/connectors/openclaw-sprintable/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@sprintable/openclaw-adapter",
+  "version": "0.1.0",
+  "description": "Sprintable Gateway adapter for OpenClaw",
+  "type": "module",
+  "main": "./index.ts",
+  "peerDependencies": {
+    "openclaw": ">=2026.1.0"
+  },
+  "dependencies": {}
+}

--- a/connectors/sdk/sprintable-sse.ts
+++ b/connectors/sdk/sprintable-sse.ts
@@ -48,7 +48,8 @@ export async function runSprintableSSE(opts: {
   apiUrl?: string
   apiKey: string
   onMessage: OnMessage
-}): Promise<never> {
+  signal?: AbortSignal
+}): Promise<void> {
   const { apiKey, onMessage } = opts
   const apiUrl = (opts.apiUrl ?? DEFAULT_API_URL).replace(/\/$/, '')
 
@@ -195,16 +196,22 @@ export async function runSprintableSSE(opts: {
 
   // main loop
   while (true) {
+    if (opts.signal?.aborted) return
     const t0 = Date.now()
     try {
       await consume()
     } catch (e) {
+      if (opts.signal?.aborted) return
       process.stderr.write(`[sprintable-sse] error: ${e}\n`)
     }
+    if (opts.signal?.aborted) return
     if (Date.now() - t0 >= 60_000) backoffIdx = 0
     const delay = RECONNECT_BACKOFF[Math.min(backoffIdx, RECONNECT_BACKOFF.length - 1)]
     process.stderr.write(`[sprintable-sse] reconnecting in ${delay}ms\n`)
-    await Bun.sleep(delay)
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, delay)
+      opts.signal?.addEventListener('abort', () => { clearTimeout(timer); resolve() }, { once: true })
+    })
     backoffIdx++
   }
 }


### PR DESCRIPTION
## Summary
- `connectors/openclaw-sprintable/` — OpenClaw `ChannelPlugin` 어댑터 (카테고리 A)
- `connectors/sdk/sprintable-sse.ts` — AbortSignal 지원 추가 (S3 포함)

## Architecture
```
gateway.startAccount(ctx)
  → runSprintableSSE(SDK, signal: ctx.abortSignal)
  → onMessage(msg)
  → runtime.channel.inbound.buildContext({route:{agentId,routeSessionKey:conversationId}})
  → runtime.channel.inbound.dispatchReply({delivery.deliver: msg.reply()})
  → POST /agent/events/ack (SDK 처리)
```

## Reference
- Tlon 채널 어댑터(`extensions/tlon/`) 동형 구조
- 공통 SDK(`connectors/sdk/sprintable-sse.ts`) 재사용

## AC
- [x] dial-out (인바운드 도메인 0)
- [x] turn 주입 (`buildContext` + `dispatchReply`)
- [x] 응답 (`delivery.deliver: msg.reply()`)
- [x] ack/idempotent (SDK 처리)
- [ ] CI green + 까심 QA

🤖 Generated with [Claude Code](https://claude.com/claude-code)