### PR TITLE
fix: hermes sender_id fallback — data top-level 우선 (#edaeaa03)

### DIFF
--- a/connectors/hermes-sprintable/README.md
+++ b/connectors/hermes-sprintable/README.md
@@ -23,6 +23,8 @@ hermes plugins enable sprintable-platform
 # 4. 환경 변수 설정
 export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
 export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+export SPRINTABLE_ALLOWED_USERS=0caee743,...  # 허용 member_id (comma-sep, 미설정 시 전체 허용)
+# export SPRINTABLE_ALLOW_ALL_USERS=1       # 모든 발신자 허용 (allowlist 우회)
 
 # 5. Hermes 재시작
 hermes gateway restart

--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -195,7 +195,7 @@ class SprintableAdapter(BasePlatformAdapter):
             return
 
         conversation_id = payload.get("conversation_id") or payload.get("thread_id") or data.get("conversation_id") or ev_id
-        sender = payload.get("sender") or {}
+        sender = data.get("sender") or payload.get("sender") or {}  # AC1: data top-level 우선
         sender_id = sender.get("id") or data.get("sender_id") or "sprintable"
         sender_name = sender.get("name") or sender_id
 
@@ -310,6 +310,8 @@ def register(ctx) -> None:
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["AGENT_API_KEY"],
+        allowed_users_env="SPRINTABLE_ALLOWED_USERS",
+        allow_all_env="SPRINTABLE_ALLOW_ALL_USERS",
         install_hint="pip install httpx   # already a Hermes dependency",
         env_enablement_fn=_env_enablement,
         emoji="🏃",

--- a/connectors/hermes-sprintable/plugin.yaml
+++ b/connectors/hermes-sprintable/plugin.yaml
@@ -21,3 +21,11 @@ optional_env:
     description: "Sprintable backend base URL (default: dev backend)"
     prompt: "Sprintable API URL (or empty for dev)"
     password: false
+  - name: SPRINTABLE_ALLOWED_USERS
+    description: "Comma-separated Sprintable team_member IDs allowed to trigger replies (e.g. 0caee743,...). Empty = allow all."
+    prompt: "Allowed Sprintable member IDs (comma-sep, or empty for all)"
+    password: false
+  - name: SPRINTABLE_ALLOW_ALL_USERS
+    description: "Set to '1' or 'true' to allow all senders regardless of SPRINTABLE_ALLOWED_USERS."
+    prompt: "Allow all users? (1=yes)"
+    password: false


### PR DESCRIPTION
## Summary
라이브 차단 버그: sender_id가 항상 `'sprintable'`로 고정되어 allowlist 차단

**Root cause**: `adapter.py:198` `payload.get("sender")` 단독 사용 → payload에 sender 없는 경우 `sender_id="sprintable"`
**Fix**: `data.get("sender") or payload.get("sender") or {}` — data top-level 우선

## Changes
- `adapter.py:198`: one-line sender fix (AC1)
- `register()`: `allowed_users_env=SPRINTABLE_ALLOWED_USERS`, `allow_all_env=SPRINTABLE_ALLOW_ALL_USERS` (AC2)
- `plugin.yaml`: optional_env 2개 추가 (AC2)
- `README.md`: env 변수 문서화 (AC2)
- Docs `adapter-authoring-guide`: sender top-level 패턴 + scoped allowlist 주의사항 (AC3)

## Test plan
- [ ] CP1: `adapter.py:198` `data.get("sender") or ...` 확인, payload-only 잔존 0
- [ ] CP2: `register()` allowlist env, `plugin.yaml` optional_env, README env 문서화 확인
- [ ] CP3: CI green
- [ ] 라이브: 머지 후 빅터에서 `0caee743` 통과 (오르테가군 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)