### PR TITLE
feat: pi-sprintable adapter — 카테고리 B JSONL/stdio 호스트 (#99e3caa8)

### DIFF
--- a/connectors/pi-sprintable/.gitignore
+++ b/connectors/pi-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/pi-sprintable/README.md
+++ b/connectors/pi-sprintable/README.md
@@ -1,0 +1,78 @@
+# Sprintable Adapter for Pi
+
+Pi용 Sprintable Gateway dial-out 어댑터 (카테고리 B — JSONL/stdio 호스트).
+
+**codex/gemini 호스트와 동형 골격** (자식 프로세스 spawn/own + lifetime 관리).
+차이 = 메시지 레이어: pi는 **`pi --mode rpc`** (JSONL/stdio — JSON-RPC 아닌 **줄단위 JSON**).
+`steer`로 mid-stream 주입이 pi 강점.
+
+## 요구사항
+
+- **pi 설치 필수** (`pi --mode rpc` 사용).
+  ```bash
+  npm install -g @earendil-works/pi-coding-agent   # bin: pi
+  pi --version
+  ```
+- Python 3.10+ (asyncio subprocess)
+- `httpx` (공통 SDK 의존)
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+# export PI_BIN=/path/to/pi                  # pi 바이너리 경로 (기본: PATH의 pi)
+
+# 3. 호스트 실행
+python connectors/pi-sprintable/host.py
+```
+
+## 동작 원리
+
+```
+host.py 시작
+  → PiRpcServer.start(): pi --mode rpc spawn (JSONL은 별도 initialize 핸드셰이크 없음)
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → pi.run_turn(ctx.content):
+      → stdin JSONL: {"type":"prompt", "message": text}
+      → stdout JSONL: AgentSessionEvent 스트림 (session.subscribe)
+      → agent_end {messages:[AgentMessage]} 에서 assistant 텍스트 수집
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## 메시지 레이어 (JSONL — JSON-RPC와 차이)
+
+codex/gemini는 JSON-RPC(id/method/params/result)지만, pi는 **줄단위 JSON 명령/이벤트**:
+- 명령(stdin): `{"type":"prompt", "message", "streamingBehavior"?:"steer"|"followUp"}`
+- mid-stream 주입(stdin): `{"type":"steer", "message"}` — pi 강점
+- 응답(stdout): `{"type":"response", "command":"prompt", "success":true}` = ack
+- 이벤트(stdout): `AgentSessionEvent` — `agent_end {messages}`, `turn_end {message}`, `message_update {...}` 등
+
+## 프로세스 관리 (카테고리 B 핵심 — codex/gemini 동형)
+
+- `PiRpcServer`가 자식 프로세스를 spawn/own
+- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
+- `host.py` 종료 시 `finally: pi.stop()` 보장 + reader_task cancel
+
+## 실측 스키마
+
+`@earendil-works/pi-coding-agent@0.78.0` `dist/modes/rpc/rpc-types.d.ts`:
+- `RpcCommand: {type:"prompt"|"steer"|"follow_up", message, streamingBehavior?}`
+- `RpcResponse: {type:"response", command, success}`
+
+`@earendil-works/pi-agent-core@0.78.0` `dist/types.d.ts`:
+- `AgentEvent: agent_end {messages:[AgentMessage]}`, `turn_end {message}`, ...
+
+`@earendil-works/pi-ai@0.78.0`:
+- `AssistantMessage.content: (TextContent{type:"text",text} | ...)[]`
+
+## 단일 세션 주의
+
+현재 모든 conversation을 단일 pi 세션에 주입 (codex/gemini와 동일).
+멀티 conversation 컨텍스트 분리는 후속(ef2603d8)에서 B 어댑터 일괄 보강.

--- a/connectors/pi-sprintable/host.py
+++ b/connectors/pi-sprintable/host.py
@@ -1,0 +1,168 @@
+"""Sprintable Gateway adapter host for Pi — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 셋째 — codex/gemini 호스트와 동형 골격.
+차이 = 메시지 레이어: pi는 `pi --mode rpc` (JSONL/stdio — JSON-RPC 아닌 줄단위 JSON).
+명령은 stdin JSONL, 이벤트/응답은 stdout JSONL.
+
+구조 (codex/gemini와 동일):
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff
+  - pi --mode rpc (JSONL/stdio)를 spawn/own
+  - SSE 이벤트마다 {"type":"prompt", message} 주입 (steer로 mid-stream 가능)
+  - agent_end 이벤트의 assistant 메시지 텍스트 수집 → 응답 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 스키마 (@earendil-works/pi-coding-agent@0.78.0, dist/modes/rpc/rpc-types.d.ts):
+  RpcCommand: {type:"prompt", message, streamingBehavior?:"steer"|"followUp"}
+              {type:"steer", message}  — mid-stream 주입 (pi 강점)
+  stdout JSONL: RpcResponse {type:"response", command:"prompt", success} = ack
+                AgentSessionEvent (session.subscribe) — agent_end {messages:[AgentMessage]}
+  AgentMessage(assistant).content: (TextContent{type:"text",text} | ...)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("pi-sprintable")
+
+PI_BIN = os.getenv("PI_BIN", "pi")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+
+
+class PiRpcServer:
+    """pi --mode rpc JSONL/stdio 자식 프로세스 호스트.
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    codex/gemini host와 동형 — 메시지 레이어만 JSONL로 교체.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reader_task: asyncio.Task | None = None
+        # turn 응답 수집: agent_end 의 assistant 텍스트
+        self._turn_messages: list[str] = []
+        self._turn_done: asyncio.Event | None = None
+
+    async def start(self) -> None:
+        """pi --mode rpc spawn. (JSONL은 별도 initialize 핸드셰이크 없음)"""
+        self._proc = await asyncio.create_subprocess_exec(
+            PI_BIN, "--mode", "rpc",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+        logger.info("pi --mode rpc started")
+
+    async def _read_loop(self) -> None:
+        """stdout JSONL 라인 파싱 → 이벤트/응답 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            self._on_message(msg)
+
+    def _on_message(self, msg: dict) -> None:
+        """JSONL stdout 메시지 처리.
+
+        - AgentSessionEvent: agent_end {messages} → assistant 텍스트 수집 + turn 완료
+        - RpcResponse {type:"response"}: ack (별도 처리 불필요)
+        """
+        mtype = msg.get("type")
+        if mtype == "agent_end":
+            for am in msg.get("messages") or []:
+                if am.get("role") == "assistant":
+                    for block in am.get("content") or []:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text:
+                                self._turn_messages.append(text)
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+
+    async def _send(self, cmd: dict) -> None:
+        """JSONL 명령 stdin 송신."""
+        assert self._proc and self._proc.stdin
+        self._proc.stdin.write((json.dumps(cmd) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+
+    async def run_turn(self, text: str) -> str:
+        """{type:"prompt", message} 주입 → agent_end까지 assistant 텍스트 수집.
+
+        thread 매핑은 단일 세션 (후속 ef2603d8서 B 일괄 보강).
+        """
+        self._turn_messages = []
+        self._turn_done = asyncio.Event()
+
+        await self._send({"type": "prompt", "message": text})
+        # agent_end 대기 (turn 완료 + 응답 수집)
+        await self._turn_done.wait()
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). codex/gemini 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[pi-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    pi = PiRpcServer()
+    await pi.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await pi.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await pi.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
## Summary
- `connectors/pi-sprintable/host.py` — **카테고리 B 셋째** (JSONL/stdio 호스트)
- codex/gemini 호스트 동형 골격 — 메시지 레이어만 **JSONL**(줄단위 JSON)로 교체

## Architecture (codex/gemini와 동형, 메시지 레이어만 차이)
```
host.py
  → PiRpcServer.start(): pi --mode rpc spawn (JSONL은 별도 initialize 핸드셰이크 없음)
  → SprintableSSEClient.run(inject) (공통 SDK 재사용)
  → inject(ctx):
    → stdin JSONL: {"type":"prompt", "message": text}  (steer로 mid-stream 가능)
    → stdout JSONL: AgentSessionEvent 스트림 → agent_end{messages} assistant 텍스트 수집
    → ctx.reply() → POST /conversations/{id}/messages
    → ack: SDK 처리
```

## 메시지 레이어 (JSON-RPC와 차이)
- codex/gemini: JSON-RPC(id/method/params/result)
- **pi: 줄단위 JSON 명령/이벤트**
  - 명령: `{type:"prompt", message, streamingBehavior?:"steer"|"followUp"}`
  - mid-stream: `{type:"steer", message}` (pi 강점)
  - 이벤트: `AgentSessionEvent agent_end{messages:[AgentMessage]}`

## 실측 (추측 0)
- `@earendil-works/pi-coding-agent@0.78.0` `dist/modes/rpc/rpc-types.d.ts` — RpcCommand/RpcResponse
- `@earendil-works/pi-agent-core@0.78.0` `dist/types.d.ts` — AgentEvent `agent_end{messages}`
- `@earendil-works/pi-ai@0.78.0` — AssistantMessage.content `TextContent{type:"text",text}`

## CP3 프로세스 관리 (codex/gemini 동형)
- spawn/own → SIGTERM → 5s → kill (좀비 방지) + finally stop + reader_task cancel

## Test plan
- [ ] CP1: `SprintableSSEClient` SDK 재사용, 재구현 0
- [ ] CP2: JSONL prompt 명령 + agent_end 응답 수집 실측 정합
- [ ] CP3: 프로세스 lifetime/SIGTERM/좀비 방지
- [ ] CP4: README pi 설치 요구사항 + env
- [ ] CI green

라이브: pi 미설치 — 코드+CI+QA(deferred). npm 패키지 스키마 실측이라 시그니처 정합 확보.

🤖 Generated with [Claude Code](https://claude.com/claude-code)