### PR TITLE
fix: SSE connection leak — 비점유 streaming auth + delivered 후마킹 (P0 #abaf6279)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -10,6 +10,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.dependencies.database import get_db
 
@@ -400,3 +401,91 @@ async def get_scope_context(
     project_id_raw = jwt_project_id or x_project_id
     project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
     return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}
+
+
+# ─── SSE/스트림 전용 auth (커넥션 비점유) ──────────────────────────────────────
+# P0 connection leak fix (#abaf6279):
+# get_current_user/get_verified_org_id는 Depends(get_db)로 요청 수명 동안 세션을
+# 점유한다. SSE 같은 long-lived 응답에서는 API key 해석의 team_members 쿼리가
+# 연 커넥션이 yield 구간 내내 idle-in-transaction으로 잔존 → max_connections 포화.
+# 아래 streaming 변형은 자체 단명 세션(async with)으로 즉시 닫아 미점유를 보장한다.
+
+
+async def get_current_user_streaming(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+) -> AuthContext:
+    """get_current_user의 SSE 전용 변형 — get_db 미점유.
+
+    API key 경로는 자체 단명 세션으로 _resolve_api_key 후 즉시 close →
+    스트림 yield 구간에 커넥션을 들고 있지 않음. JWT 경로는 DB 불필요(기존과 동일).
+    """
+    if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_api_key(x_agent_api_key, db)
+
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+
+    token = credentials.credentials
+    if token.startswith("sk_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_api_key(token, db)
+
+    try:
+        payload = decode_jwt(token)
+    except JWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    user_id: str | None = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
+
+    return AuthContext(
+        user_id=user_id,
+        email=payload.get("email"),
+        claims=payload,
+        org_id=payload.get("app_metadata", {}).get("org_id"),
+    )
+
+
+async def get_verified_org_id_streaming(
+    auth: AuthContext = Depends(get_current_user_streaming),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """get_verified_org_id의 SSE 전용 변형 — get_db 미점유.
+
+    멤버십/프로젝트 검증이 필요한 경우에만 자체 단명 세션으로 검증 후 close.
+    API key + claims org_id(헤더 없음) 경로는 DB 쿼리조차 없음.
+    """
+    if request is not None:
+        _check_api_key_scope(auth, request.method)
+
+    jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
+    raw = x_org_id or jwt_org_id
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    try:
+        org_id = uuid.UUID(str(raw))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid org_id format")
+
+    if x_org_id:
+        async with async_session_factory() as db:
+            await _verify_org_membership(auth.user_id, org_id, db, request)
+
+    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    if not jwt_project_id and x_project_id:
+        try:
+            project_id = uuid.UUID(x_project_id)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
+        async with async_session_factory() as db:
+            await _verify_project_in_org(project_id, org_id, db, request)
+
+    return org_id

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -20,7 +20,13 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import (
+    AuthContext,
+    get_current_user,
+    get_current_user_streaming,
+    get_verified_org_id,
+    get_verified_org_id_streaming,
+)
 from app.dependencies.database import get_db
 from app.models.event import Event
 from app.models.team import TeamMember
@@ -174,8 +180,8 @@ class EventResponse(BaseModel):
 async def agent_event_stream(
     request: Request,
     member_id: uuid.UUID | None = Query(default=None),  # AC2: API key 시 자동 추출, JWT 시 필수
-    auth: AuthContext = Depends(get_current_user),  # AC1: Bearer {API_KEY} 또는 JWT — 없으면 401 (AC3)
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user_streaming),  # AC1: Bearer {API_KEY} 또는 JWT — 없으면 401 (AC3). P0(#abaf6279): SSE 커넥션 비점유 변형
+    org_id: uuid.UUID = Depends(get_verified_org_id_streaming),
     since_timestamp: datetime | None = Query(default=None),
     last_event_id: uuid.UUID | None = Query(default=None),
 ):
@@ -315,37 +321,37 @@ async def agent_event_stream(
                 for i in range(0, len(pending_events), _SSE_BATCH_SIZE):
                     batch = pending_events[i : i + _SSE_BATCH_SIZE]
                     batch_data = [_event_to_payload(evt) for evt in batch]
-                    # delivered 마킹 먼저 commit → 재연결 시 백필 중복 방지
+                    # 1c22da3e fix: yield 먼저 → 성공 후 delivered 마킹.
+                    # 선마킹 시 yield(클라 disconnect 등) 실패하면 이벤트가 delivered로
+                    # 남아 영구 누락. 후마킹 + 클라 seen_ids dedup 으로 손실 0(재전송 허용).
+                    for data, evt in zip(batch_data, batch):
+                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
                     for evt in batch:
                         evt.status = "delivered"
                         evt.delivered_at = now
                     await db.commit()
-                    for data, evt in zip(batch_data, batch):
-                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():
                 try:
                     event_data = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT_TIMEOUT)
                     event_type = event_data.get("event_type", "message")
-                    # event_id 있으면 yield 전 pending 선점 — 백필과 실시간 큐 중복 방지
-                    if eid := event_data.get("event_id"):
+                    # 1c22da3e fix: yield 전엔 pending 여부만 확인(skip 판정, 마킹 X),
+                    # delivered 마킹은 yield 성공 후로 미룬다 → yield 실패 시 영구 누락 방지.
+                    eid = event_data.get("event_id")
+                    if eid:
                         try:
                             async with async_session_factory() as db:
                                 r = await db.execute(
-                                    select(Event).where(
+                                    select(Event.status).where(
                                         Event.id == uuid.UUID(eid),
-                                        Event.status == "pending",
                                         Event.org_id == org_id,
                                     )
                                 )
-                                live_evt = r.scalar_one_or_none()
-                                if live_evt is None:
-                                    # 이미 백필에서 delivered 마킹됨 → skip
+                                _status = r.scalar_one_or_none()
+                                if _status is not None and _status != "pending":
+                                    # 이미 백필/타 연결에서 delivered → 중복 skip
                                     continue
-                                live_evt.status = "delivered"
-                                live_evt.delivered_at = datetime.now(timezone.utc)
-                                await db.commit()
                         except Exception:
                             pass
                     # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
@@ -356,6 +362,18 @@ async def agent_event_stream(
                     if event_type == "conversation.message_created":
                         yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
                     yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                    # yield 성공 후 delivered 마킹 (1c22da3e: 손실 방지, dup은 클라 dedup)
+                    if eid:
+                        try:
+                            async with async_session_factory() as db:
+                                await db.execute(
+                                    update(Event)
+                                    .where(Event.id == uuid.UUID(eid), Event.status == "pending")
+                                    .values(status="delivered", delivered_at=datetime.now(timezone.utc))
+                                )
+                                await db.commit()
+                        except Exception:
+                            pass
                 except asyncio.TimeoutError:
                     # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
                     yield "event: heartbeat\ndata: {}\n\n"

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -67,7 +67,7 @@ def auth_ctx(org_id):
 
 @pytest.fixture
 async def client(mock_session, auth_ctx, org_id):
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -83,6 +83,8 @@ async def client(mock_session, auth_ctx, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -110,7 +112,7 @@ def test_agent_stream_registers_connection(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -133,6 +135,8 @@ def test_agent_stream_registers_connection(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
@@ -318,7 +322,7 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -337,6 +341,8 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     @asynccontextmanager
     async def _session_factory():
@@ -413,7 +419,7 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     membership_result.scalar_one_or_none.return_value = None  # org 소속 아님
     mock_session.execute.return_value = membership_result
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -432,6 +438,8 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     from contextlib import asynccontextmanager
 

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -67,7 +67,7 @@ def auth_ctx(org_id):
 
 @pytest.fixture
 async def client(mock_session, auth_ctx, org_id):
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -83,6 +83,8 @@ async def client(mock_session, auth_ctx, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -233,7 +235,7 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -252,6 +254,8 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     @asynccontextmanager
     async def _session_factory():

--- a/backend/tests/test_s20.py
+++ b/backend/tests/test_s20.py
@@ -64,7 +64,7 @@ def test_heartbeat_disconnect_check_clears_connection():
     """heartbeat timeout 후 is_disconnected=True → queue가 _agent_connections에서 제거됨."""
     from starlette.testclient import TestClient
     import threading
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -94,6 +94,8 @@ def test_heartbeat_disconnect_check_clears_connection():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     try:
         with patch("app.core.database.async_session_factory", _factory):
@@ -127,7 +129,7 @@ def test_heartbeat_disconnect_check_clears_connection():
 @pytest.mark.anyio
 async def test_sse_connection_limit_returns_503():
     """MAX_SSE_CONNECTIONS 초과 연결 시 503 반환."""
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
     import app.routers.events as ev_module
@@ -157,6 +159,8 @@ async def test_sse_connection_limit_returns_503():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     original_count = ev_module._sse_connection_count
     original_max = ev_module._MAX_SSE_CONNECTIONS
@@ -181,7 +185,7 @@ def test_connection_count_increments_and_decrements():
     from starlette.testclient import TestClient
     import threading
     import time
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
     import app.routers.events as ev_module
@@ -211,6 +215,8 @@ def test_connection_count_increments_and_decrements():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     count_before = ev_module._sse_connection_count
     try:

--- a/backend/tests/test_sse_conn_leak.py
+++ b/backend/tests/test_sse_conn_leak.py
@@ -1,0 +1,107 @@
+"""P0 dev DB connection leak (#abaf6279) 회귀 가드.
+
+근본 원인: get_current_user/get_verified_org_id가 Depends(get_db)로 요청 수명 동안
+세션을 점유 → SSE long-lived yield 구간에 API key 해석 team_members 쿼리 커넥션이
+idle-in-transaction 잔존 → max_connections 포화.
+
+수정: SSE 전용 비점유 변형(get_current_user_streaming / get_verified_org_id_streaming)이
+자체 단명 세션을 써서 즉시 닫음.
+
+추가: 1c22da3e — 백필/라이브 delivered 선마킹 → 후마킹 (yield 실패 시 영구 누락 방지).
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── CP1: SSE 핸들러가 비점유 streaming auth dep을 사용 ────────────────────────
+
+def test_agent_event_stream_uses_streaming_auth_deps():
+    """events.agent_event_stream이 get_db 점유형 dep을 쓰지 않고 streaming 변형을 쓴다."""
+    from app.routers import events
+    sig = inspect.signature(events.agent_event_stream)
+    src = inspect.getsource(events.agent_event_stream)
+    # streaming 변형 사용 + 점유형 dep 미사용
+    assert "get_current_user_streaming" in src, "SSE는 비점유 auth(get_current_user_streaming) 사용 필수"
+    assert "get_verified_org_id_streaming" in src, "SSE는 비점유 org dep(get_verified_org_id_streaming) 사용 필수"
+    # 직접 get_db 주입 금지
+    assert "Depends(get_db)" not in src, "SSE 핸들러는 get_db를 요청 수명 동안 점유하면 안 됨"
+
+
+# ─── CP1: streaming auth dep이 get_db를 파라미터로 받지 않음 (비점유 보장) ──────
+
+def test_streaming_auth_deps_do_not_depend_on_get_db():
+    """get_current_user_streaming / get_verified_org_id_streaming 시그니처에 get_db 없음."""
+    from app.dependencies import auth
+    for fn_name in ("get_current_user_streaming", "get_verified_org_id_streaming"):
+        fn = getattr(auth, fn_name)
+        params = inspect.signature(fn).parameters
+        for p in params.values():
+            default = p.default
+            # Depends(get_db) 가 기본값으로 들어있으면 안 됨
+            dep_str = repr(default)
+            assert "get_db" not in dep_str, f"{fn_name}.{p.name} 가 get_db를 점유하면 안 됨"
+        # 본문은 자체 단명 세션(async with async_session_factory) 사용
+        src = inspect.getsource(fn)
+        assert "async_session_factory()" in src, f"{fn_name}은 자체 단명 세션을 써야 함"
+
+
+# ─── CP1: API key 경로에서 세션이 즉시 close 되는지 (점유 0) ───────────────────
+
+@pytest.mark.anyio
+async def test_streaming_auth_api_key_closes_session():
+    """get_current_user_streaming API key 경로 — _resolve_api_key 후 세션 context 종료."""
+    from app.dependencies import auth
+
+    closed = {"v": False}
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+        async def __aexit__(self, *a):
+            closed["v"] = True
+            return False
+
+    fake_ctx = MagicMock()
+    with patch.object(auth, "async_session_factory", return_value=_FakeSession()), \
+         patch.object(auth, "_resolve_api_key", new=AsyncMock(return_value=fake_ctx)) as mock_resolve:
+        result = await auth.get_current_user_streaming(
+            credentials=None, x_agent_api_key="sk_live_abc",
+        )
+    assert result is fake_ctx
+    mock_resolve.assert_awaited_once()
+    assert closed["v"] is True, "API key 해석 후 세션이 즉시 close 되어야 함 (점유 0)"
+
+
+# ─── CP3 (1c22da3e): 백필/라이브 delivered 후마킹 순서 ─────────────────────────
+
+def test_backfill_marks_delivered_after_yield():
+    """백필: yield 후 delivered 마킹 (선마킹 시 yield 실패→영구 누락)."""
+    from app.routers import events
+    src = inspect.getsource(events.agent_event_stream)
+    # yield 라인이 'status = "delivered"' 보다 먼저 와야 함 (후마킹)
+    yield_idx = src.find('is_backfill\': True')
+    mark_idx = src.find('evt.status = "delivered"')
+    assert yield_idx != -1 and mark_idx != -1
+    assert yield_idx < mark_idx, "백필 delivered 마킹은 yield 이후여야 함 (1c22da3e)"
+
+
+def test_live_marks_delivered_after_yield():
+    """라이브: yield 후 delivered 마킹 (선마킹 시 yield 실패→영구 누락)."""
+    from app.routers import events
+    src = inspect.getsource(events.agent_event_stream)
+    # 라이브 yield(_live_id 사용) 가 update(Event)...delivered 마킹보다 먼저
+    yield_idx = src.find('id: {_live_id}')
+    # 라이브 후마킹 블록 (update + values status delivered)
+    mark_idx = src.find('.values(status="delivered"')
+    assert yield_idx != -1 and mark_idx != -1
+    assert yield_idx < mark_idx, "라이브 delivered 마킹은 yield 이후여야 함 (1c22da3e)"


### PR DESCRIPTION
## Root Cause (PO DB 단서 확정)
`events.py /events/stream`의 `Depends(get_current_user)` + `Depends(get_verified_org_id)`가
**`get_db` 세션을 요청(=long-lived SSE) 수명 동안 점유**. API key 경로 `_resolve_api_key`의
`SELECT team_members` 커넥션이 yield 구간 내내 **idle-in-transaction 잔존** → SSE 재연결마다
1개씩 누적 → `max_connections=100` 포화 → `TooManyConnectionsError` → events/stream·unread_count 전반 장애.

(JWT 경로는 DB 쿼리 없음 → 미점유. 정확히 **API key 에이전트**가 누적 — PO 단서와 일치.)

## Fix
### CP1/CP2 — 비점유 streaming auth (leak 차단)
- `auth.py`: `get_current_user_streaming` / `get_verified_org_id_streaming` 신설
  - `Depends(get_db)` 제거 → API key/멤버십 검증을 **자체 단명 `async_session_factory()`**로 즉시 close
  - SSE yield 구간 커넥션 **미점유**. JWT 경로 DB 불필요(동일)
- `events.py agent_event_stream`: 두 dep을 streaming 변형으로 교체
  - 다른 비-SSE 엔드포인트(391/456/486/515)는 기존 점유형 유지 (정상)

### CP3 — 1c22da3e delivered 후마킹
- 백필/라이브 delivered **선마킹 → 후마킹**: yield 성공 후 마킹 → yield(클라 disconnect) 실패 시 **영구 누락 방지**. dup은 클라 seen_ids dedup

## Reference 패턴 일치
`agent_gateway.py agent_stream`의 generate 루프(per-fetch `async with async_session_factory()`, 대기 구간 미점유)와 동일 원리 — events.py auth dep까지 비점유로 정렬.

## Test plan
- [x] `test_sse_conn_leak.py` 5종: streaming dep 비점유 + API key 세션 close + 백필/라이브 후마킹 순서
- [x] 기존 73 passed, regression 0
- [ ] CI green
- [ ] 라이브: dev DB idle-in-tx 미누적 확인 (PO/배포 후)

🤖 Generated with [Claude Code](https://claude.com/claude-code)