### PR TITLE
[SID:c042edd2] feat: human member 웹훅 설정 UI — Profile 탭 알림 채널 카드

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -698,7 +698,9 @@
     "agentMcpDescription": "Paste this into Claude Code or any MCP client to connect as this agent.",
     "agentMcpKeyRequired": "Generate an API key first to include the real key in the config.",
     "ownershipDenied": "Permission denied. Only the agent owner or admin can edit.",
-    "agentOwner": "my agent"
+    "agentOwner": "my agent",
+    "webhookHelperEmptyHuman": "Set a webhook URL and enable the toggle to receive your mentions and events for this project at an external endpoint. Other projects require separate configuration.",
+    "webhookHelperActiveHuman": "Your mentions and event notifications for this project are forwarded to the configured URL. Other projects require separate configuration."
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -698,7 +698,9 @@
     "agentMcpDescription": "Claude Code나 MCP 클라이언트에 붙여넣으면 이 에이전트로 Sprintable에 연결됩니다.",
     "agentMcpKeyRequired": "API Key를 먼저 발급하면 실제 키가 포함된 설정을 복사할 수 있습니다.",
     "ownershipDenied": "권한이 없습니다. 에이전트 소유자 또는 관리자만 수정할 수 있습니다.",
-    "agentOwner": "내 에이전트"
+    "agentOwner": "내 에이전트",
+    "webhookHelperEmptyHuman": "현재 프로젝트의 내 멘션·이벤트를 외부 URL로 받으려면 Webhook URL을 설정하고 토글을 켜세요. 다른 프로젝트는 해당 프로젝트에서 별도 설정이 필요합니다.",
+    "webhookHelperActiveHuman": "현재 프로젝트의 내 멘션·이벤트 알림이 설정된 URL로 전송됩니다. 다른 프로젝트의 멘션은 별도 설정이 필요합니다."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -12,6 +12,7 @@ import { ProjectAccessSection } from '@/components/settings/project-access-secti
 
 import { AiSettingsSection } from '@/components/settings/ai-settings';
 import { MyProfileSection } from '@/components/settings/my-profile-section';
+import { MyNotificationChannelSection } from '@/components/settings/my-notification-channel-section';
 import { ByomKeyManagement } from '@/components/settings/byom-key-management';
 import { McpConnectionSettings } from '@/components/settings/mcp-connection-settings';
 import { WorkflowTriggerTypesSection } from '@/components/settings/workflow-trigger-types-section';
@@ -863,6 +864,12 @@ export default function SettingsPage() {
                 <MyProfileSection />
                 <SetPasswordSection />
                 <TwoFactorSection />
+                {currentProjectId && (
+                  <MyNotificationChannelSection
+                    projectId={currentProjectId}
+                    projectName={projects.find((p) => p.id === currentProjectId)?.name ?? currentProjectId}
+                  />
+                )}
               </div>
             </TabsContent>
 

--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { OperatorInput } from '@/components/ui/operator-control';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/toast';
+
+interface WebhookConfig {
+  id: string;
+  member_id: string | null;
+  url: string;
+  project_id: string | null;
+  is_active: boolean;
+}
+
+interface MyNotificationChannelSectionProps {
+  projectId: string;
+  projectName: string;
+}
+
+function getWebhookState(configs: WebhookConfig[]): 'empty' | 'active' | 'paused' {
+  if (!configs.length) return 'empty';
+  return configs[0].is_active ? 'active' : 'paused';
+}
+
+function isWebhookUrlAllowed(url: string): boolean {
+  if (!url) return true;
+  if (/^https:\/\//i.test(url)) return true;
+  return /^http:\/\/(localhost|127\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)/i.test(url);
+}
+
+export function MyNotificationChannelSection({ projectId, projectName }: MyNotificationChannelSectionProps) {
+  const t = useTranslations('settings');
+  const tc = useTranslations('common');
+  const { addToast } = useToast();
+
+  const [memberId, setMemberId] = useState<string | null>(null);
+  const [webhookConfigs, setWebhookConfigs] = useState<WebhookConfig[]>([]);
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [webhookActive, setWebhookActive] = useState(false);
+  const [savingWebhook, setSavingWebhook] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setWebhookUrl(webhookConfigs[0]?.url ?? '');
+    setWebhookActive(webhookConfigs[0]?.is_active ?? false);
+  }, [webhookConfigs]);
+
+  const fetchWebhookConfigs = useCallback(async (mid: string) => {
+    const res = await fetch('/api/webhooks/config');
+    if (!res.ok) return;
+    const json = await res.json() as { data: WebhookConfig[] };
+    const mine = (json.data ?? []).filter(
+      (c) => c.member_id === mid && c.project_id === projectId,
+    );
+    setWebhookConfigs(mine);
+  }, [projectId]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/me');
+        if (!res.ok) return;
+        const json = await res.json() as { data?: { id?: string } };
+        const mid = json.data?.id ?? null;
+        if (!mid) return;
+        setMemberId(mid);
+        await fetchWebhookConfigs(mid);
+      } finally {
+        setLoading(false);
+      }
+    }
+    void load();
+  }, [fetchWebhookConfigs]);
+
+  const handleSaveWebhook = async () => {
+    if (!memberId) return;
+    const trimmed = webhookUrl.trim();
+    if (trimmed && !isWebhookUrlAllowed(trimmed)) {
+      addToast({ type: 'error', title: t('webhookUrlInvalid') });
+      return;
+    }
+    setSavingWebhook(true);
+    try {
+      if (!trimmed) {
+        if (webhookConfigs[0]) {
+          await fetch(`/api/webhooks/config?id=${encodeURIComponent(webhookConfigs[0].id)}`, { method: 'DELETE' });
+          setWebhookConfigs([]);
+        }
+      } else {
+        const res = await fetch('/api/webhooks/config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ member_id: memberId, url: trimmed, project_id: projectId, is_active: webhookActive }),
+        });
+        if (!res.ok) {
+          const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+          addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+          return;
+        }
+      }
+      addToast({ type: 'success', title: 'Webhook URL saved' });
+      await fetchWebhookConfigs(memberId);
+    } finally {
+      setSavingWebhook(false);
+    }
+  };
+
+  const handleToggle = async (next: boolean) => {
+    if (!memberId || !webhookConfigs[0]) return;
+    setWebhookActive(next);
+    setSavingWebhook(true);
+    try {
+      await fetch('/api/webhooks/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          member_id: memberId,
+          url: webhookConfigs[0].url,
+          project_id: projectId,
+          is_active: next,
+        }),
+      });
+      await fetchWebhookConfigs(memberId);
+    } finally {
+      setSavingWebhook(false);
+    }
+  };
+
+  if (loading || !projectId) return null;
+
+  const webhookState = getWebhookState(webhookConfigs);
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-base font-semibold text-foreground">{t('notificationChannel')}</h2>
+            <Badge variant="outline" className="text-xs">{projectName}</Badge>
+            {webhookState === 'empty' && <Badge variant="info">{t('webhookStatusEmpty')}</Badge>}
+            {webhookState === 'active' && <Badge variant="success">{t('webhookStatusActive')}</Badge>}
+            {webhookState === 'paused' && (
+              <>
+                <Badge variant="secondary">{t('webhookStatusInactive')}</Badge>
+                <Badge variant="info">{t('webhookStatusFallback')}</Badge>
+              </>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {webhookState === 'empty' && t('webhookHelperEmptyHuman')}
+            {webhookState === 'active' && t('webhookHelperActiveHuman')}
+            {webhookState === 'paused' && t('webhookHelperPaused')}
+          </p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">{t('webhookEnabledToggle')}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{t('webhookEnabledHelp')}</p>
+          </div>
+          <Switch
+            checked={webhookActive}
+            onCheckedChange={(next) => void handleToggle(next)}
+            disabled={savingWebhook}
+          />
+        </div>
+        <div className="flex gap-2">
+          <OperatorInput
+            type="url"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+            placeholder="https://your-endpoint.example.com/webhook"
+            className="flex-1 font-mono text-xs"
+            disabled={!webhookActive}
+          />
+          <Button
+            variant="hero"
+            size="sm"
+            onClick={() => void handleSaveWebhook()}
+            disabled={savingWebhook || !webhookActive || !webhookUrl.trim()}
+          >
+            {savingWebhook ? '...' : tc('save')}
+          </Button>
+        </div>
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -111,8 +111,9 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
   };
 
   const handleToggle = async (next: boolean) => {
-    if (!memberId || !webhookConfigs[0]) return;
+    if (!memberId) return;
     setWebhookActive(next);
+    if (!webhookConfigs[0]) return;
     setSavingWebhook(true);
     try {
       await fetch('/api/webhooks/config', {
@@ -175,7 +176,7 @@ export function MyNotificationChannelSection({ projectId, projectName }: MyNotif
             type="url"
             value={webhookUrl}
             onChange={(e) => setWebhookUrl(e.target.value)}
-            placeholder="https://your-endpoint.example.com/webhook"
+            placeholder={t('webhookUrlPlaceholder')}
             className="flex-1 font-mono text-xs"
             disabled={!webhookActive}
           />


### PR DESCRIPTION
## Summary

- `MyNotificationChannelSection` 컴포넌트 신규 — `settings/members/agents/[id]/page.tsx` Notification channel SectionCard 패턴 이식 (PR #1027)
- Settings → Profile 탭 하단에 추가 (`currentProjectId` 있을 때만 렌더)
- `GET /api/me` → `data.id` (memberId) 확보 → `GET /api/webhooks/config` 조회 (해당 멤버·프로젝트 필터) → `PUT /api/webhooks/config { member_id, url, project_id, is_active }`
- 카드 헤더에 현재 프로젝트 컨텍스트 배지 (member_id per-project 한계 명시, No Overpromise)
- i18n 신규 2종 (`webhookHelperEmptyHuman` / `webhookHelperActiveHuman`) ko + en
- 기존 `SectionCard·Switch·OperatorInput·Button hero·Badge` 재사용, magic number 0
- Self authz: `memberId`는 `/api/me` 응답값 고정, 사용자 입력 없음

## Design

유나군 핸드오프 `handoff-human-member-webhook-ui-c042edd2` 기반. (a) Phase1 — 현재 프로젝트 단일 카드.

Phase2(user_id 기반 전체 프로젝트 글로벌 커버 — dispatch_router BE 확장)는 별도 스토리 예정.

## Test plan

- [ ] Settings → Profile 탭 진입 → 알림 채널 카드 노출 확인
- [ ] Webhook URL 입력 → 토글 ON → 저장 → Badge `외부 웹훅 활성` 확인
- [ ] URL 비움 → 저장 → DELETE 호출 + Badge `내장 알림` 복귀 확인
- [ ] 토글 OFF → Badge `내장 알림 사용 중` 확인
- [ ] 프로젝트 배지 표시 확인 (현재 프로젝트명)
- [ ] projectId 없는 환경 — 카드 미노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)