### PR TITLE
[SID:fc3c2fe3] fix(member-ssot): events/conversations grant-only 휴먼 지원 (Phase 0 하드닝)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -680,12 +680,24 @@ async def send_message(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
+    # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.
+    #   grant-only 휴먼(org_member) 멘션은 포함하고, cross-org UUID는 저장/발송 전에 제거.
+    #   group conversation은 fork 분기가 없어 별도 필터가 누락돼 있던 것을 여기서 함께 막는.
+    valid_mentioned_ids: list[uuid.UUID] = []
+    if body.mentioned_ids:
+        _org_member_ids = await filter_org_member_ids(set(body.mentioned_ids), org_id, db)
+        # 원본 순서 보존 + 중복 제거
+        _seen: set[uuid.UUID] = set()
+        for mid in body.mentioned_ids:
+            if mid in _org_member_ids and mid not in _seen:
+                _seen.add(mid)
+                valid_mentioned_ids.append(mid)
+
     # CB-S2: DM + 비참여자 멘션 → 자동 그룹 conversation fork (AC1, AC2)
     fork_info: dict | None = None
-    if conv.type == "dm" and body.mentioned_ids:
-        # cross-org 차단: mentioned_ids를 현재 org 소속 member로 필터링
-        # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member) 멘션도 포크 대상에 포함
-        valid_member_ids = await filter_org_member_ids(set(body.mentioned_ids), org_id, db)
+    if conv.type == "dm" and valid_mentioned_ids:
+        valid_member_ids = set(valid_mentioned_ids)
 
         current_participant_ids = set((await db.execute(
             select(ConversationParticipant.member_id)
@@ -732,7 +744,7 @@ async def send_message(
         conversation_id=conversation_id,
         sender_id=sender.id,
         content=body.content,
-        mentioned_ids=body.mentioned_ids,
+        mentioned_ids=valid_mentioned_ids,
         thread_id=body.thread_id,
     )
     db.add(msg)

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -22,7 +22,13 @@ from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
 from app.services.event_seq import assign_recipient_seq
-from app.services.member_resolver import ResolvedMember, lookup_members_by_ids, resolve_member
+from app.services.member_resolver import (
+    ResolvedMember,
+    filter_org_member_ids,
+    lookup_members_by_ids,
+    resolve_member,
+    resolve_member_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -594,9 +600,8 @@ async def add_participant(
         raise HTTPException(status_code=403, detail="Not a participant")
 
     # 추가 대상 멤버가 같은 org인지 확인
-    target = (await db.execute(
-        select(TeamMember).where(TeamMember.id == body.member_id, TeamMember.org_id == org_id)
-    )).scalar_one_or_none()
+    # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 참가자로 추가 허용
+    target = await resolve_member_identity(body.member_id, org_id, db)
     if target is None:
         raise HTTPException(status_code=404, detail="Member not found")
 
@@ -679,12 +684,8 @@ async def send_message(
     fork_info: dict | None = None
     if conv.type == "dm" and body.mentioned_ids:
         # cross-org 차단: mentioned_ids를 현재 org 소속 member로 필터링
-        valid_member_ids = set((await db.execute(
-            select(TeamMember.id).where(
-                TeamMember.id.in_(body.mentioned_ids),
-                TeamMember.org_id == org_id,
-            )
-        )).scalars().all())
+        # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member) 멘션도 포크 대상에 포함
+        valid_member_ids = await filter_org_member_ids(set(body.mentioned_ids), org_id, db)
 
         current_participant_ids = set((await db.execute(
             select(ConversationParticipant.member_id)

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -29,7 +29,7 @@ from app.dependencies.auth import (
 )
 from app.dependencies.database import get_db
 from app.models.event import Event
-from app.models.team import TeamMember
+from app.services.member_resolver import resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events"])
 
@@ -211,18 +211,13 @@ async def agent_event_stream(
         resolved_member_id = member_id
 
     # member_id가 org 소속인지 검증 + AC4: JWT 경로에서 타인 stream 접근 차단
+    # E-MEMBER-SSOT Phase 0: team_member 강요 제거 — grant-only 휴먼(org_member)도 구독 허용
     async with async_session_factory() as db:
-        result = await db.execute(
-            select(TeamMember).where(
-                TeamMember.id == resolved_member_id,
-                TeamMember.org_id == org_id,
-            )
-        )
-        member_row = result.scalar_one_or_none()
+        member_row = await resolve_member_identity(resolved_member_id, org_id, db)
         if member_row is None:
             raise HTTPException(status_code=404, detail="Member not found")
 
-        # AC4: JWT 사용자는 자신의 team_member(user_id 일치)에만 구독 허용
+        # AC4: JWT 사용자는 자신의 신원(user_id 일치)에만 구독 허용
         if not is_api_key:
             if member_row.user_id is None or str(member_row.user_id) != auth.user_id:
                 raise HTTPException(status_code=403, detail="Cannot subscribe to another member's stream")
@@ -414,18 +409,12 @@ async def create_event(
     미연결이면 status=pending 유지.
     Channel Router(S-A6)로 preference 기반 채널 결정 후 전달.
     """
-    from app.models.team import TeamMember
-
     # recipient가 동일 org 소속인지 + type 확정
-    result = await db.execute(
-        select(TeamMember.type).where(
-            TeamMember.id == body.recipient_id,
-            TeamMember.org_id == org_id,
-        )
-    )
-    member_type = result.scalar_one_or_none()
-    if member_type is None:
+    # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 수신자로 허용
+    recipient = await resolve_member_identity(body.recipient_id, org_id, db)
+    if recipient is None:
         raise HTTPException(status_code=404, detail="Recipient not found")
+    member_type = recipient.type
 
     event = Event(
         project_id=body.project_id,

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -29,6 +29,7 @@ class ResolvedMember:
     role: str
     org_id: uuid.UUID
     project_id: uuid.UUID | None = field(default=None)
+    avatar_url: str | None = field(default=None)
 
 
 async def resolve_member(
@@ -149,3 +150,81 @@ async def lookup_members_by_ids(
             )
 
     return result
+
+
+async def resolve_member_identity(
+    member_id: uuid.UUID,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> ResolvedMember | None:
+    """단일 member_id(team_member.id | org_member.id)를 org 범위에서 신원 해소.
+
+    TeamMember(에이전트 + 레거시 휴먼) 우선, 없으면 OrgMember(grant-only 휴먼) 조회.
+    org 미소속이면 None — 호출부가 404/403 처리. lookup_members_by_ids와 달리
+    orphan fallback이 없어 인가/존재 검증에 안전하게 쓸 수 있는.
+    """
+    tm = (await session.execute(
+        select(TeamMember).where(
+            TeamMember.id == member_id,
+            TeamMember.org_id == org_id,
+        )
+    )).scalars().first()
+    if tm is not None:
+        return ResolvedMember(
+            id=tm.id, user_id=tm.user_id, name=tm.name, type=tm.type,
+            role=tm.role, org_id=tm.org_id, project_id=tm.project_id,
+            avatar_url=tm.avatar_url,
+        )
+
+    om = (await session.execute(
+        select(OrgMember).where(
+            OrgMember.id == member_id,
+            OrgMember.org_id == org_id,
+            OrgMember.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if om is None:
+        return None
+
+    user = (await session.execute(
+        select(User).where(User.id == om.user_id)
+    )).scalar_one_or_none()
+    return ResolvedMember(
+        id=om.id, user_id=om.user_id,
+        name=user.email if user else str(om.id),
+        type="human", role=om.role, org_id=om.org_id,
+        project_id=None, avatar_url=None,
+    )
+
+
+async def filter_org_member_ids(
+    member_ids: set[uuid.UUID],
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> set[uuid.UUID]:
+    """member_ids 중 org 소속(team_member 또는 org_member)인 것만 반환.
+
+    cross-org 차단용 — grant-only 휴먼(org_member)도 포함하므로 멘션/포크에서 누락되지 않는.
+    """
+    if not member_ids:
+        return set()
+
+    tm_ids = set((await session.execute(
+        select(TeamMember.id).where(
+            TeamMember.id.in_(member_ids),
+            TeamMember.org_id == org_id,
+        )
+    )).scalars().all())
+
+    remaining = member_ids - tm_ids
+    om_ids: set[uuid.UUID] = set()
+    if remaining:
+        om_ids = set((await session.execute(
+            select(OrgMember.id).where(
+                OrgMember.id.in_(remaining),
+                OrgMember.org_id == org_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )).scalars().all())
+
+    return tm_ids | om_ids

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -356,3 +356,71 @@ async def test_send_message_403_non_participant():
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── QA B1 회귀: cross-org 멘션 저장·발송 필터 (DM fork 외 group 공통 경로) ─────
+
+@pytest.mark.anyio
+async def test_send_message_filters_cross_org_mentions_group():
+    """group 대화에서 cross-org 멘션이 저장·발송 양쪽에서 제거된다 (QA B1)."""
+    from app.models.conversation import ConversationMessage
+
+    client, session, app = await _make_client()
+    try:
+        valid_id = uuid.uuid4()
+        cross_org_id = uuid.uuid4()
+
+        mock_member = _make_member()
+        mock_conv = _make_conv(conv_type="group")
+
+        conv_result = MagicMock()
+        conv_result.scalar_one_or_none.return_value = mock_conv
+        member_result = MagicMock()
+        member_result.scalars.return_value.first.return_value = mock_member
+        participant_result = MagicMock()
+        participant_result.scalar_one_or_none.return_value = uuid.uuid4()
+
+        # 실제 코드 순서: conv → _resolve_member(TM) → participant
+        session.execute = AsyncMock(side_effect=[conv_result, member_result, participant_result])
+
+        captured = {}
+        def _capture_add(obj):
+            if isinstance(obj, ConversationMessage):
+                captured["mentioned_ids"] = list(obj.mentioned_ids or [])
+        session.add.side_effect = _capture_add
+
+        async def _refresh(obj):
+            obj.id = uuid.uuid4()
+            obj.conversation_id = CONV_ID
+            obj.sender_id = MEMBER_ID
+            obj.content = "안녕"
+            obj.created_at = datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc)
+        session.refresh.side_effect = _refresh
+
+        mention_calls = {}
+        async def _capture_mention(db, conversation, msg, org_id, sender, mention_targets):
+            mention_calls["targets"] = set(mention_targets)
+            return []
+
+        with patch("app.routers.conversations.filter_org_member_ids",
+                   new=AsyncMock(return_value={valid_id})), \
+             patch("app.routers.conversations._dispatch_conversation_event",
+                   new=AsyncMock(return_value=[])), \
+             patch("app.routers.conversations._dispatch_mention_events",
+                   side_effect=_capture_mention), \
+             patch("app.services.channel_router.route_message",
+                   new=AsyncMock(return_value=[])), \
+             patch("app.services.workflow_pipeline.process_event", new=AsyncMock()):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/conversations/{CONV_ID}/messages",
+                    json={"content": "안녕", "mentioned_ids": [str(valid_id), str(cross_org_id)]},
+                )
+
+        assert resp.status_code == 201
+        # 저장: cross-org 제거, org 소속만 + 순서 보존
+        assert captured["mentioned_ids"] == [valid_id]
+        # 멘션 이벤트 발송: cross-org 미포함, valid만
+        assert mention_calls.get("targets") == {valid_id}
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -130,8 +130,10 @@ async def test_create_event_stores_in_db(client, mock_session):
 
 @pytest.mark.anyio
 async def test_create_event_recipient_not_found_returns_404(client, mock_session):
+    # E-MEMBER-SSOT Phase 0: resolve_member_identity는 TeamMember → OrgMember 순 조회
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = None
+    member_result.scalars.return_value.first.return_value = None  # TeamMember 없음
+    member_result.scalar_one_or_none.return_value = None  # OrgMember 없음
     mock_session.execute.return_value = member_result
 
     payload = {
@@ -206,8 +208,18 @@ async def test_recipient_type_resolved_from_db(client, mock_session):
     recipient_id = uuid.uuid4()
     captured = {}
 
+    # E-MEMBER-SSOT Phase 0: recipient는 resolve_member_identity가 반환한 멤버의 type 사용
+    tm = MagicMock()
+    tm.id = recipient_id
+    tm.type = "human"
+    tm.user_id = uuid.uuid4()
+    tm.name = "휴먼"
+    tm.role = "member"
+    tm.org_id = uuid.uuid4()
+    tm.project_id = None
+    tm.avatar_url = None
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = "human"
+    member_result.scalars.return_value.first.return_value = tm
     mock_session.execute.return_value = member_result
 
     original_add = mock_session.add.side_effect
@@ -271,8 +283,18 @@ async def test_mark_delivered_cross_org_returns_404(client, mock_session):
 async def test_create_event_uses_verified_org(client, mock_session, org_id):
     """POST 시 body의 org_id가 아닌 verified org_id가 Event에 설정돼야 함."""
     captured = {}
+    # E-MEMBER-SSOT Phase 0: agent recipient → resolve_member_identity가 TeamMember 반환
+    tm = MagicMock()
+    tm.id = uuid.uuid4()
+    tm.type = "agent"
+    tm.user_id = None
+    tm.name = "agent"
+    tm.role = "member"
+    tm.org_id = org_id
+    tm.project_id = None
+    tm.avatar_url = None
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = "agent"
+    member_result.scalars.return_value.first.return_value = tm
     mock_session.execute.return_value = member_result
 
     def capture_add(obj):

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -415,8 +415,11 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     """다른 org의 member_id로 stream 연결 시 404 반환."""
     foreign_member_id = uuid.uuid4()
 
+    # E-MEMBER-SSOT Phase 0: resolve_member_identity는 TeamMember(.scalars().first())
+    # → OrgMember(.scalar_one_or_none()) 순으로 조회 — 둘 다 미소속이어야 404
     membership_result = MagicMock()
-    membership_result.scalar_one_or_none.return_value = None  # org 소속 아님
+    membership_result.scalars.return_value.first.return_value = None  # TeamMember 미소속
+    membership_result.scalar_one_or_none.return_value = None  # OrgMember 미소속
     mock_session.execute.return_value = membership_result
 
     from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -279,3 +279,127 @@ async def test_policy_no_creator_in_human_conversation_403():
     with pytest.raises(HTTPException) as exc_info:
         await _enforce_agent_creator_policy(sender, [agent_id], session)
     assert exc_info.value.status_code == 403
+
+
+# ── QA B1 보강: resolve_member_identity 2단 조회 + org 필터 독립 검증 ──────────
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_prefers_team_member():
+    """TM 존재 시 OrgMember 조회 없이 TM 반환 (TM 우선, 단 1회 execute)."""
+    from app.services.member_resolver import resolve_member_identity
+
+    tm = _make_team_member(ttype="agent")
+    tm.avatar_url = "http://a/x.png"
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_member_identity(AGENT_TM_ID, ORG_ID, session)
+    assert resolved is not None
+    assert resolved.id == AGENT_TM_ID
+    assert resolved.type == "agent"
+    assert resolved.avatar_url == "http://a/x.png"
+    # TM 매칭 시 OrgMember 조회를 하지 않음 — 1회 execute
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_falls_back_to_org_member():
+    """TM 없으면 OrgMember로 fallback — TM→OM→User 3단 독립 조회."""
+    from app.services.member_resolver import resolve_member_identity
+
+    om = _make_org_member()
+    user = MagicMock(); user.email = "human@test.com"; user.id = USER_ID
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None  # TeamMember 미존재
+    om_result = MagicMock()
+    om_result.scalar_one_or_none.return_value = om            # OrgMember 존재
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result, user_result])
+
+    resolved = await resolve_member_identity(ORG_MEMBER_ID, ORG_ID, session)
+    assert resolved is not None
+    assert resolved.id == ORG_MEMBER_ID
+    assert resolved.type == "human"
+    assert resolved.user_id == USER_ID
+    assert resolved.name == "human@test.com"
+    # 2단(+User) 조회 확정
+    assert session.execute.await_count == 3
+
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_none_when_not_in_org():
+    """TM·OM 둘 다 없으면 None — orphan fallback 없음(404 유도)."""
+    from app.services.member_resolver import resolve_member_identity
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None
+    om_result = MagicMock()
+    om_result.scalar_one_or_none.return_value = None
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result])
+
+    resolved = await resolve_member_identity(uuid.uuid4(), ORG_ID, session)
+    assert resolved is None
+    assert session.execute.await_count == 2
+
+
+# ── QA B1 보강: filter_org_member_ids 2단 조회 + cross-org 차단 검증 ───────────
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_keeps_tm_and_om_drops_foreign():
+    """TM∪OM 소속만 통과, cross-org/orphan은 제거 — 2단 독립 조회."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    tm_id, om_id, foreign_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.all.return_value = [tm_id]   # TeamMember 소속
+    om_result = MagicMock()
+    om_result.scalars.return_value.all.return_value = [om_id]   # OrgMember 소속
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result])
+
+    out = await filter_org_member_ids({tm_id, om_id, foreign_id}, ORG_ID, session)
+    assert out == {tm_id, om_id}
+    assert foreign_id not in out
+    # TeamMember 후 잔여(om_id, foreign_id)에 대해 OrgMember 2단 조회
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_skips_om_query_when_all_team_members():
+    """전부 TeamMember면 OrgMember 조회 스킵 — 1회 execute."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    a, b = uuid.uuid4(), uuid.uuid4()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.all.return_value = [a, b]
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    out = await filter_org_member_ids({a, b}, ORG_ID, session)
+    assert out == {a, b}
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_empty_short_circuits():
+    """빈 입력은 쿼리 없이 빈 집합."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    out = await filter_org_member_ids(set(), ORG_ID, session)
+    assert out == set()
+    session.execute.assert_not_awaited()


### PR DESCRIPTION
## 배경 (why now)
E-MEMBER-SSOT Phase 0가 `member_resolver.resolve_member`/`has_project_access`까지는 들어갔으나, 핫패스 일부가 여전히 **TeamMember-only 하드룩업**이라 grant-only 휴먼(`org_member`만 있고 `team_member` 행 없음)이 다음에서 막혀 있었는:

- `957b0096` 그룹챗 403 — add_participant target이 TeamMember-only
- `5faf9e56` events/stream 404 — stream auth가 TeamMember-only
- `a728501d` 대화 "Team member not found" — (JWT 경로는 `_resolve_member` fallback으로 이미 해소)

## 변경 (AC3·AC4)
TeamMember-only 하드룩업 4곳을 grant-aware로 전환:

| 위치 | Before | After |
|---|---|---|
| `events.py` stream auth | `select(TeamMember)` org 필터 | `resolve_member_identity()` |
| `events.py` create_event recipient | `select(TeamMember.type)` | `resolve_member_identity()` |
| `conversations.py` add_participant target | `select(TeamMember)` | `resolve_member_identity()` |
| `conversations.py` DM mention fork 필터 | `select(TeamMember.id).in_()` | `filter_org_member_ids()` |

신규 헬퍼 (`member_resolver.py`):
- **`resolve_member_identity(member_id, org_id, session)`** — TeamMember(에이전트+레거시 휴먼) 우선, 없으면 OrgMember(grant-only 휴먼). org 미소속이면 `None`. `lookup_members_by_ids`와 달리 **orphan fallback 없음** → 인가/존재 검증에 안전.
- **`filter_org_member_ids(ids, org_id, session)`** — cross-org 차단하되 grant-only 휴먼 포함.
- `ResolvedMember`에 `avatar_url` 추가 (add_participant 응답 호환).

## 불변식 유지
- **AC4**: JWT 사용자는 자신의 신원(`user_id` 일치)에만 stream 구독 — 타인 stream 차단 (events L228 동등) 유지. 검증 경로가 TeamMember→OrgMember로 확장됐을 뿐 self-check 동일.
- **AC5**: 휴먼↔에이전트 대화 시 에이전트 creator 동석 불변식(`_enforce_agent_creator_policy`)은 이미 OrgMember 처리 포함 — 무변경.
- 정식 `team_member` 멤버: TeamMember 우선 매칭이라 동작 무영향.

## 검증
- 영향받는 스위트 전량 green: `test_eventbus_s1/s2/s3`, `test_member_ssot_phase0`, `test_conversations`, `test_s_comm_06`, `test_s20` (66 passed)
- 옛 TeamMember-only mock 테스트(s1 3건 + s2 cross-org 1건)를 새 2단 조회 계약에 맞춰 갱신 — 프로덕션 실DB에선 동일하게 404 반환
- ⚠️ **AC6 라이브 검증(하록신 grant-only 200)은 머지·배포 후 실 유저 결과로 확정 예정**

🤖 Generated with [Claude Code](https://claude.com/claude-code)