### PR TITLE
[SID:7a80f3a8] fix(member-ssot): AC2-2 인가전환·B하드닝 — 나머지 TeamMember-존재=인가 제거

### DIFF
--- a/backend/alembic/versions/0073_drop_notification_preferences_team_member_fk.py
+++ b/backend/alembic/versions/0073_drop_notification_preferences_team_member_fk.py
@@ -1,0 +1,71 @@
+"""notification_preferences.member_id team_members FK 완화 (AC2-2 grant-only 휴먼).
+
+FK drop: 컬럼·인덱스 유지, 데이터 무변경. 0069(conv/events) 동일 패턴.
+공유 dev/prod DB — idempotent 가드(존재할 때만 drop). 가역: 비-team_member id가
+없을 때만 재추가(데이터 안전).
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0073"
+down_revision = "0072"
+branch_labels = None
+depends_on = None
+
+_TABLE = "notification_preferences"
+_COL = "member_id"
+
+
+def _fks_referencing_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [
+        fk for fk in insp.get_foreign_keys(table)
+        if fk.get("referred_table") == "team_members"
+    ]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if _TABLE not in set(insp.get_table_names()):
+        return
+    # idempotent: member_id를 참조하는 team_members FK가 있을 때만 drop
+    for fk in _fks_referencing_team_members(insp, _TABLE):
+        if _COL in fk.get("constrained_columns", []):
+            fk_name = fk.get("name")
+            if fk_name:
+                op.drop_constraint(fk_name, _TABLE, type_="foreignkey")
+
+
+def downgrade() -> None:
+    """비-team_member id(grant-only org_member.id)가 없을 때만 FK 재추가."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if _TABLE not in set(insp.get_table_names()):
+        return
+
+    existing = {fk["name"] for fk in _fks_referencing_team_members(insp, _TABLE)}
+    fk_name = f"{_TABLE}_{_COL}_fkey"
+    if fk_name in existing:
+        return
+
+    # 데이터 오염(비-team_member id) 있으면 재추가 생략
+    non_tm = conn.execute(
+        sa.text(
+            f"SELECT 1 FROM {_TABLE} t"
+            f" WHERE t.{_COL} IS NOT NULL"
+            f"   AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{_COL})"
+            f" LIMIT 1"
+        )
+    ).scalar_one_or_none()
+    if non_tm is not None:
+        return
+
+    op.create_foreign_key(
+        fk_name, _TABLE, "team_members", [_COL], ["id"], ondelete="CASCADE"
+    )

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -230,8 +230,8 @@ async def get_project_scoped_org_id(
     request: Request = None,
 ) -> uuid.UUID:
     """project_id query param 또는 X-Project-Id 헤더가 있을 때, 해당 project의 org_id로
-    cross-org 접근을 허용. TeamMember.is_active 기반 검증. 미멤버 → 403.
-    project_id가 없으면 get_verified_org_id 동작과 동일."""
+    cross-org 접근을 허용. has_project_access(team_member ∪ grant ∪ owner/admin) 기반 검증.
+    미인가 → 403. project_id가 없으면 get_verified_org_id 동작과 동일."""
     base_org_id = await get_verified_org_id(
         auth=auth, x_org_id=x_org_id, x_project_id=None, db=db, request=request
     )
@@ -246,32 +246,13 @@ async def get_project_scoped_org_id(
     if not project_org_id:
         return base_org_id
 
-    # Org owner/admin은 모든 project에 접근 가능 — team_members 체크 우선 bypass.
-    # project 생성 직후 team_members 미생성 상태(OSS fresh install)에서도 접근 허용.
-    from app.models.project import OrgMember
-    uid = uuid.UUID(auth.user_id)
-    org_role_row = await db.execute(
-        select(OrgMember.role).where(
-            OrgMember.org_id == project_org_id,
-            OrgMember.user_id == uid,
-            OrgMember.deleted_at.is_(None),
-        )
-    )
-    if org_role_row.scalar_one_or_none() in ("owner", "admin"):
-        return project_org_id
-
-    # project_id가 지정된 경우 org 동일 여부 무관하게 TeamMember 검증
-    # (동일 org 내 다른 project 미멤버 우회 방지)
-    from app.models.team import TeamMember
-    from sqlalchemy import or_
-    member = await db.execute(
-        select(TeamMember.id).where(
-            or_(TeamMember.user_id == uid, TeamMember.id == uid),
-            TeamMember.project_id == project_id,
-            TeamMember.is_active.is_(True),
-        ).limit(1)
-    )
-    if member.scalar_one_or_none() is None:
+    # E-MEMBER-SSOT AC2-2: "TeamMember 존재 = 인가" 대신 has_project_access SSOT로 전환.
+    # team_member(active) ∪ project_access(granted) ∪ owner/admin org-wide 3-branch이므로
+    #   - owner/admin은 rowless 접근 유지 (OSS fresh install, team_members 미생성 포함)
+    #   - grant-only 휴먼(project_access)도 project 접근 허용 (740e3b7e 에픽403 해소)
+    #   - 동일 org 내 다른 project 미멤버 우회 방지(project 스코프)는 그대로 유지
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, project_org_id):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="해당 프로젝트의 멤버가 아닌",

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy import DateTime, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,8 +13,10 @@ class NotificationPreference(Base, TimestampMixin):
     __tablename__ = "notification_preferences"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # E-MEMBER-SSOT AC2-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 수용.
+    # 컬럼·인덱스 유지, FK는 migration 0073에서 DROP (0069 conv/events와 동일 패턴).
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     scope_type: Mapped[str] = mapped_column(Text, nullable=False)  # global | project | conversation | thread
     scope_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1179,7 +1179,9 @@ async def switch_organization(
 
     await session.commit()
 
-    project_id = app_metadata.get("project_id") or (str(team_member.project_id) if team_member else None)
+    # E-MEMBER-SSOT AC2-2: undefined team_member 참조 제거 (8a5f260c switch500 해소).
+    # project_id는 위에서 target_project_id(effective access 기반)로 이미 확정/제거됨.
+    project_id = app_metadata.get("project_id")
     return _ok({**tokens, "project_id": project_id})
 
 

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -16,6 +16,7 @@ from app.models.team import TeamMember
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _event_to_payload, _push_to_agent
 from app.services.event_seq import assign_recipient_seq
+from app.services.member_resolver import resolve_member_identity
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/dispatch", tags=["dispatch"])
@@ -92,17 +93,17 @@ async def dispatch_entity(
     # entity의 실제 project_id 사용 (body.project_id 불일치 방지)
     project_id = entity_project_id or body.project_id
 
-    # assignee TeamMember 조회 (type: human/agent)
-    member_result = await db.execute(
-        select(TeamMember.type).where(TeamMember.id == assignee_id, TeamMember.org_id == org_id)
-    )
-    member_row = member_result.one_or_none()
-    if not member_row:
+    # assignee 신원 해소 (type: human/agent)
+    # E-MEMBER-SSOT AC2-2: TeamMember-only 검증 → resolve_member_identity (TM∪OM).
+    #   grant-only 휴먼/polymorphic assignee도 수용해 dispatched:False 오탐 방지 (7f8066a3).
+    assignee_member = await resolve_member_identity(assignee_id, org_id, db)
+    if assignee_member is None:
         return DispatchResponse(dispatched=False, assignee_id=assignee_id)
 
-    member_type = member_row[0]
+    member_type = assignee_member.type
 
-    # sender_id: 현재 auth user의 TeamMember id
+    # sender_id: 현재 auth user의 member id (team_member 우선, grant-only 휴먼은 org_member)
+    # B1 교훈 — assignee뿐 아니라 sender 경로도 일관되게 grant-only 수용.
     sender_id: uuid.UUID | None = None
     try:
         uid = uuid.UUID(auth.user_id)
@@ -113,8 +114,18 @@ async def dispatch_entity(
                 TeamMember.is_active.is_(True),
             ).limit(1)
         )
-        sender_row = sender_result.scalar_one_or_none()
-        sender_id = sender_row
+        sender_id = sender_result.scalar_one_or_none()
+        if sender_id is None:
+            # grant-only 휴먼 디스패처 → org_member.id를 sender로 사용
+            from app.models.project import OrgMember
+            om_result = await db.execute(
+                select(OrgMember.id).where(
+                    OrgMember.user_id == uid,
+                    OrgMember.org_id == org_id,
+                    OrgMember.deleted_at.is_(None),
+                ).limit(1)
+            )
+            sender_id = om_result.scalar_one_or_none()
     except Exception:
         pass
 

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -14,6 +14,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
+from app.services.member_resolver import ResolvedMember, resolve_member
 
 router = APIRouter(prefix="/api/v2/notification-preferences", tags=["notification-preferences"])
 
@@ -37,19 +38,35 @@ class UpsertPreferencesRequest(BaseModel):
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async def _get_member(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> TeamMember:
+async def _get_member(
+    auth: AuthContext, org_id: uuid.UUID, db: AsyncSession
+) -> "ResolvedMember | TeamMember":
+    """현재 인증 주체의 멤버 신원.
+
+    E-MEMBER-SSOT AC2-2: API키→team_member; JWT 휴먼→team_member 우선(기존 preference
+    키 보존), 없으면 org_member(grant-only 휴먼)로 fallback (35a0691e 잔여 해소).
+    """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
-        stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
-    else:
-        stmt = select(TeamMember).where(
+        member = (await db.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )).scalars().first()
+        if member is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return member
+
+    # JWT 휴먼: team_member 우선 (기존 NotificationPreference.member_id 키 보존)
+    member = (await db.execute(
+        select(TeamMember).where(
             TeamMember.user_id == uuid.UUID(auth.user_id),
             TeamMember.org_id == org_id,
         )
-    member = (await db.execute(stmt)).scalars().first()
-    if member is None:
-        raise HTTPException(status_code=400, detail="Team member not found")
-    return member
+    )).scalars().first()
+    if member is not None:
+        return member
+
+    # team_member 없음(grant-only 휴먼) → org_member 신원으로 fallback
+    return await resolve_member(auth, org_id, db)
 
 
 def _pref_to_dict(p: NotificationPreference) -> dict:

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -87,7 +87,29 @@ async def dispatch_notification(
                 TeamMember.org_id == org_id,
             )
         )
-        members = members_result.all()
+        members = list(members_result.all())
+
+        # E-MEMBER-SSOT AC2-2: grant-only 휴먼(team_member 없음)은 org_member로 해소해
+        # in-app Notification 누락(silent drop) 방지. org_member는 project 스코프가 없으므로
+        # human Notification만 생성(Event는 project_id 필요 → skip). Notification은 user_id
+        # 기반이고 FK가 없어 org_member.id 사용에 제약 없음.
+        matched_ids = {m.id for m in members}
+        missing_ids = [mid for mid in enabled_member_ids if mid not in matched_ids]
+        if missing_ids:
+            from types import SimpleNamespace
+
+            from app.models.project import OrgMember
+            om_result = await db.execute(
+                select(OrgMember.id, OrgMember.user_id).where(
+                    OrgMember.id.in_(missing_ids),
+                    OrgMember.org_id == org_id,
+                    OrgMember.deleted_at.is_(None),
+                )
+            )
+            for om in om_result.all():
+                members.append(
+                    SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
+                )
 
         inserted = False
         for member_row in members:

--- a/backend/tests/test_e_org_multi_s2_1_switch_organization.py
+++ b/backend/tests/test_e_org_multi_s2_1_switch_organization.py
@@ -224,6 +224,59 @@ def test_switch_org_unconditionally_sets_org_id():
     assert 'app_metadata["org_id"] = str(body.org_id)' in source
 
 
+# ─── AC2-2 회귀: 접근 가능 project 없는 org 전환 → 500 금지 (8a5f260c) ─────────
+
+@pytest.mark.anyio
+async def test_switch_org_no_accessible_project_returns_200_null_project():
+    """first_accessible_project_id=None(접근 project 없음)이어도 undefined team_member
+    참조로 500나지 않고 200 + project_id null 반환 (8a5f260c switch500 회귀)."""
+    client, session, app = await _client()
+    try:
+        user = _mock_user()
+        org_member = _mock_org_member(ORG_B, USER_ID)
+
+        call_count = 0
+
+        def _execute_side_effect(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = user      # _get_user_by_id
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = org_member  # org 소속 확인
+            else:
+                # 이후 _build_app_metadata 등: project/team_member 미존재
+                result.scalar_one_or_none.return_value = None
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = AsyncMock(side_effect=_execute_side_effect)
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        with patch("app.routers.auth.create_tokens") as mock_create_tokens, \
+             patch("app.routers.auth.create_refresh_token") as mock_crt, \
+             patch("app.routers.auth._store_refresh_token") as mock_store, \
+             patch("app.routers.auth.first_accessible_project_id", new_callable=AsyncMock) as mock_fap:
+            mock_fap.return_value = None  # 접근 가능 project 없음
+            mock_create_tokens.return_value = {
+                "access_token": "new_at", "refresh_token": "new_rt",
+                "token_type": "bearer", "expires_in": 900,
+                "refresh_expires_at": "2026-06-20T00:00:00",
+            }
+            mock_crt.return_value = ("new_rt", datetime(2026, 6, 20, tzinfo=timezone.utc))
+            mock_store.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/auth/switch-org", json={"org_id": str(ORG_B)})
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["project_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── Schema 검증 ─────────────────────────────────────────────────────────────
 
 def test_switch_organization_request_schema():

--- a/backend/tests/test_member_ssot_ac2_2.py
+++ b/backend/tests/test_member_ssot_ac2_2.py
@@ -21,6 +21,18 @@ def anyio_backend():
     return "asyncio"
 
 
+# ── B2: notification_preferences.member_id team_members FK 제거 ───────────────
+
+def test_notification_preferences_member_id_has_no_team_members_fk():
+    """B2 회귀: member_id의 team_members FK가 제거돼 grant-only 휴먼(org_member.id)
+    upsert 시 FK violation 500이 나지 않음 (migration 0073)."""
+    from app.models.notification_preference import NotificationPreference
+
+    member_col = NotificationPreference.__table__.c.member_id
+    referred_tables = {fk.column.table.name for fk in member_col.foreign_keys}
+    assert "team_members" not in referred_tables
+
+
 # ── get_project_scoped_org_id: has_project_access 위임 (740e3b7e) ─────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_member_ssot_ac2_2.py
+++ b/backend/tests/test_member_ssot_ac2_2.py
@@ -1,0 +1,172 @@
+"""E-MEMBER-SSOT AC2-2: 인가전환·B하드닝 회귀 테스트.
+
+get_project_scoped_org_id / dispatch_entity / notification_preferences 가
+TeamMember-존재 대신 has_project_access / resolve_member_identity 기반으로
+전환돼 grant-only 휴먼(org_member)을 수용하는지 검증.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from app.services.member_resolver import ResolvedMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── get_project_scoped_org_id: has_project_access 위임 (740e3b7e) ─────────────
+
+@pytest.mark.anyio
+async def test_get_project_scoped_grant_only_allows():
+    """grant-only 휴먼(team_member 없음, has_project_access=True)도 project org 접근 허용."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(project_org)}}
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+        result = await get_project_scoped_org_id(
+            project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+        )
+    assert result == project_org
+
+
+@pytest.mark.anyio
+async def test_get_project_scoped_no_access_403():
+    """team_member·grant·owner/admin 어디에도 없으면 403."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(project_org)}}
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await get_project_scoped_org_id(
+                project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+            )
+    assert exc.value.status_code == 403
+
+
+# ── dispatch_entity: assignee resolve_member_identity (7f8066a3) ──────────────
+
+async def _dispatch_client(mock_session, org_id):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_dispatch_grant_only_human_assignee_dispatched():
+    """grant-only 휴먼 assignee(team_member 없음)도 dispatched=True (7f8066a3 오탐 해소)."""
+    org_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    # sender 조회 2건(TeamMember, OrgMember) 모두 None
+    sender_result = MagicMock()
+    sender_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=sender_result)
+
+    async def _refresh(obj):
+        pass
+    session.refresh.side_effect = _refresh
+
+    client, app = await _dispatch_client(session, org_id)
+    try:
+        assignee_member = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="grant휴먼",
+            type="human", role="member", org_id=org_id,
+        )
+        with patch("app.routers.dispatch._fetch_entity",
+                   new=AsyncMock(return_value=(assignee_id, "에픽 제목", "설명", project_id))), \
+             patch("app.routers.dispatch.resolve_member_identity",
+                   new=AsyncMock(return_value=assignee_member)), \
+             patch("app.routers.dispatch.dispatch_notification", new=AsyncMock()):
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json={
+                    "entity_type": "epic",
+                    "entity_id": str(uuid.uuid4()),
+                    "project_id": str(project_id),
+                })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatched"] is True
+        assert data["assignee_type"] == "human"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dispatch_assignee_not_in_org_not_dispatched():
+    """assignee가 org 어디에도 없으면(resolve None) dispatched=False."""
+    org_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.execute = AsyncMock()
+
+    client, app = await _dispatch_client(session, org_id)
+    try:
+        with patch("app.routers.dispatch._fetch_entity",
+                   new=AsyncMock(return_value=(assignee_id, "제목", "설명", project_id))), \
+             patch("app.routers.dispatch.resolve_member_identity",
+                   new=AsyncMock(return_value=None)):
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json={
+                    "entity_type": "epic",
+                    "entity_id": str(uuid.uuid4()),
+                    "project_id": str(project_id),
+                })
+        assert resp.status_code == 200
+        assert resp.json()["dispatched"] is False
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -150,6 +150,45 @@ async def test_enabled_setting_creates_notification(mock_session, org_id):
     assert added.is_read is False
 
 
+# ─── AC2-2: grant-only 휴먼(org_member)도 Notification 수신 (silent drop 방지) ──
+
+@pytest.mark.anyio
+async def test_grant_only_human_gets_notification(mock_session, org_id):
+    """team_member 없는 grant-only 휴먼(org_member만)도 in-app Notification 생성."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    om_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    settings = _settings_result([])            # 설정 없음 → 기본 enabled
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    tm_result = _members_result([])            # team_member 없음
+    om_row = MagicMock()
+    om_row.id = om_id
+    om_row.user_id = user_id
+    om_result = MagicMock()
+    om_result.all.return_value = [om_row]      # org_member fallback
+    mock_session.execute.side_effect = [settings, wh_result, tm_result, om_result]
+
+    await dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="dispatched",
+        target_member_ids=[om_id],
+        title="그랜트 알림",
+        body="내용",
+        reference_type="epic",
+        reference_id=uuid.uuid4(),
+    )
+
+    # org_member.user_id 기반 Notification 생성 (silent drop 아님)
+    mock_session.add.assert_called_once()
+    added = mock_session.add.call_args[0][0]
+    assert added.user_id == user_id
+    assert added.title == "그랜트 알림"
+
+
 # ─── 빈 target → 즉시 반환 ────────────────────────────────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 배경
Phase 0(#1163)에 이어, 잔존 **"TeamMember 존재 = 인가"** 핫스팟을 일괄 grant-aware로 전환(B방향, materialize 금지). Phase 0 헬퍼(`has_project_access`/`resolve_member_identity`/`resolve_member`) 재사용. 작일 보고버그 나머지 닫는 배치.

## 변경 4곳

| # | 위치 | Before | After | 해소 버그 |
|---|---|---|---|---|
| 1 | `get_project_scoped_org_id` (`dependencies/auth.py`) | 비owner/admin active TeamMember 요구 | `has_project_access` 3-branch SSOT | **740e3b7e** 에픽403 |
| 2 | `dispatch_entity` (`routers/dispatch.py`) | assignee `TeamMember.type`-only → 없으면 `dispatched:False` | `resolve_member_identity`(TM∪OM); sender도 grant-only면 `org_member.id` fallback | **7f8066a3** Dispatch 실패 |
| 3 | `switch_organization` (`routers/auth.py`) | undefined `team_member` 참조 → NameError | `app_metadata.get("project_id")` | **8a5f260c** switch500 |
| 4 | `notification_preferences._get_member` | TeamMember-only → 없으면 400 | TM 우선(기존 키 보존) + `resolve_member`(org_member) fallback | **35a0691e** 잔여 |

## B1 교훈 적용
Phase 0에서 멘션 필터가 한 분기만 걸려 누수났던 것(B1)을 거울삼아, 각 라우터의 **모든 분기**가 일관 전환됐는지 self-check:
- dispatch는 assignee뿐 아니라 **sender 경로**도 grant-only 수용 (org_member fallback)
- `get_project_scoped`는 owner/admin·grant·team_member 3-branch를 단일 `has_project_access`로 통합 (분기 누락 원천 차단)
- 정식 team_member/에이전트: TM 우선 매칭이라 동작 불변. 기존 notification preference 키(team_member.id) 보존.

## 검증
- 회귀 테스트 추가:
  - `test_member_ssot_ac2_2.py` — get_project_scoped grant-only 허용 / 미접근 403, dispatch grant-only 휴먼 assignee `dispatched=True` / org 미소속 `dispatched=False`
  - switch-org 접근 project 없음 → **200 + project_id null** (8a5f260c 회귀)
- 풀 백엔드 스위트 `CI=true` green (e2e dev는 `skipif(CI)`)
- ⚠️ **AC6 grant-only 휴먼 라이브(에픽 생성·dispatch·switch 200)는 머지·배포 후 실 유저 결과로 확정** 예정

설계 SSOT: Docs `blueprint-member-ssot-anchor` §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)