### PR TITLE
[SID:6a1e8b1d] fix(standup): self-save PUT 바디에 project_id 추가 — 422 해소

### DIFF
--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -294,6 +294,7 @@ export default function StandupPage() {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          project_id: projectId,
           date,
           done,
           plan,


### PR DESCRIPTION
## Summary

self-save `PUT /api/standup`이 요청 바디에 `project_id` 누락으로 **422** 반환. `handleSave()` PUT 바디에 `project_id: projectId` 한 줄 추가로 해소.

- `projectId`는 `useDashboardContext()`로 컴포넌트 스코프에 이미 존재
- `handleSave` 진입부 `if (!projectId) return` 가드로 non-null 보장
- `author_id`는 **미발신** — BE(#1165)가 인증 유저에서 서버 도출 (타인 스탠드업 위조 차단)
- **UI/디자인 변경 없음** (순수 요청 바디 픽스)

## ⚠️ 동시 머지 필수

BE **#1165**(디디군)와 **동시 머지**해야 라이브 완성:
- FE만 머지 → BE가 `author_id` 필수라 422
- BE만 머지 → FE가 `project_id` 필수라 422

## Test plan

- [ ] BE #1165 머지 동기화 후 Standup 화면 self-save → 200 확인 (PO 라이브)
- [ ] 스탠드업 화면 시각 무변경 회귀 확인
- [x] `pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)