### PR TITLE
[SID:6a1e8b1d] fix(standup): self-save author team_member-first — 카드 표시 불일치(2차)

### DIFF
--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -16,7 +16,7 @@ from app.schemas.standup import (
     StandupSelfUpdate,
     StandupUpsert,
 )
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import resolve_auth_member
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
@@ -79,11 +79,15 @@ async def update_standup(
 ) -> StandupEntryResponse:
     """PUT /api/v2/standups — 본인 스탠드업 self-save (SID:6a1e8b1d).
 
-    author_id는 인증 유저(resolve_member)에서 server-side 도출 — 클라 바디 author_id를
+    author_id는 인증 유저(resolve_auth_member)에서 server-side 도출 — 클라 바디 author_id를
     받지 않아 타인 스탠드업 위조를 차단(본인만 수정). project_id는 바디 수용.
-    author_id는 canonical member.id 방향(JWT 휴먼 → org_member.id, AC3-3 정합).
+
+    author_id는 team_member 우선(있으면 team_member.id) → 없으면 org_member.id(grant-only).
+    스탠드업 카드(`/api/team-members` 기반)가 team_member.id로 매칭하므로, team_member가 있는
+    휴먼은 team_member.id로 저장해야 저장분이 카드에 표시된다(org_member.id-always는 카드와
+    어긋나 "미작성"으로 보이던 라이브 2차 버그 해소). grant-only는 org_member.id(카드 표시는 AC3-3).
     """
-    member = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    member = await resolve_auth_member(auth, org_id, session, project_id=body.project_id)
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -152,6 +152,41 @@ async def lookup_members_by_ids(
     return result
 
 
+async def resolve_auth_member(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> "ResolvedMember | TeamMember":
+    """인증 주체의 멤버 신원 — team_member 우선, 없으면 org_member(grant-only).
+
+    resolve_member(JWT→org_member.id-always)와 달리 team_member가 있으면 그 id를 반환한다.
+    team_member.id로 매칭하는 표시 경로(스탠드업 카드 `/api/team-members`, 대화 참가자 등)와
+    write author/sender id를 일치시키기 위함 — org_member.id-always는 표시 경로와 어긋난다.
+
+    API키(에이전트): team_member.id. JWT 휴먼: team_member(project 스코프) 우선 → org_member.
+    conversations._resolve_member와 동형 — 공유 SSOT.
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        tm = (await session.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )).scalars().first()
+        if tm is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return tm
+
+    filters = [TeamMember.user_id == uuid.UUID(auth.user_id), TeamMember.org_id == org_id]
+    if project_id is not None:
+        filters.append(TeamMember.project_id == project_id)
+    tm = (await session.execute(select(TeamMember).where(*filters))).scalars().first()
+    if tm is not None:
+        return tm
+
+    # team_member 없음(grant-only 휴먼) → org_member 경로 (has_project_access 검증 포함)
+    return await resolve_member(auth, org_id, session, project_id=project_id)
+
+
 async def resolve_member_identity(
     member_id: uuid.UUID,
     org_id: uuid.UUID,

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -403,3 +403,62 @@ async def test_filter_org_member_ids_empty_short_circuits():
     out = await filter_org_member_ids(set(), ORG_ID, session)
     assert out == set()
     session.execute.assert_not_awaited()
+
+
+# ── 2차 버그 가드: resolve_auth_member team_member-first (스탠드업 카드 매칭) ────
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_prefers_team_member():
+    """JWT 휴먼에 team_member 있으면 team_member.id 반환(카드 매칭) — org_member 조회 안 함."""
+    from app.services.member_resolver import resolve_auth_member
+
+    auth = _make_auth()  # JWT
+    tm = _make_team_member(ttype="human")
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_auth_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert resolved is tm  # team_member.id 그대로 (org_member.id-always 아님)
+    assert session.execute.await_count == 1  # team_member 매칭 시 org_member 조회 스킵
+
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_falls_back_to_org_member():
+    """team_member 없으면(grant-only) resolve_member(org_member.id)로 fallback."""
+    from app.services import member_resolver as mr
+    from app.services.member_resolver import ResolvedMember, resolve_auth_member
+
+    auth = _make_auth()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None  # team_member 없음
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    om_member = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID
+    )
+    with patch.object(mr, "resolve_member", new=AsyncMock(return_value=om_member)) as mock_rm:
+        resolved = await resolve_auth_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert resolved.id == ORG_MEMBER_ID
+    mock_rm.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_api_key_returns_team_member():
+    """API키(에이전트)는 team_member.id 반환."""
+    from app.services.member_resolver import resolve_auth_member
+
+    auth = _make_auth(is_api_key=True)
+    tm = _make_team_member()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_auth_member(auth, ORG_ID, session)
+    assert resolved is tm

--- a/backend/tests/test_standups.py
+++ b/backend/tests/test_standups.py
@@ -256,7 +256,7 @@ async def test_update_standup_self_save_no_author_id_200():
         entry = _mock_entry()
         entry.author_id = derived_member_id
 
-        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:
@@ -288,7 +288,7 @@ async def test_update_standup_ignores_client_author_id():
         entry = _mock_entry()
         entry.author_id = derived
 
-        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:


### PR DESCRIPTION
## 배경 (라이브 2차 버그, PO 픽셀 검증)
#1165/#1166 머지·0074 적용 후 dev에서 self-save PUT **200**(422/500 해소 ✓). 그러나 **저장 후 본인 스탠드업 카드에 안 뜸**("아직 작성하지 않음" 유지). GET /api/standup엔 저장분 존재(author_id=org_member.id).

**근본**: `update_standup`이 `resolve_member`(JWT→**org_member.id-always**)로 author_id를 저장하는데, 스탠드업 카드(`/api/team-members` 기반 사람 섹션)는 **team_member.id**로 매칭 → 불일치. API 200으론 안 잡히는 표시 레이어 "한쪽만 전환"(WRITE=org_member.id ↔ READ/카드=team_member.id).

## 변경 (resolver만 교체, 계약 유지)
- **신규 공유 헬퍼 `resolve_auth_member`**(`member_resolver`): `team_member` 우선(있으면 `team_member.id` = 카드와 동일) → 없으면 `org_member.id`(grant-only). `conversations._resolve_member`와 **동형 — SSOT 추출**.
- `update_standup`: `resolve_member` → `resolve_auth_member` 교체. **forge 차단·project_id 계약은 그대로**.

→ team_member 보유 휴먼 저장이 **카드에 표시**(2차 버그 해소), grant-only 휴먼은 `org_member.id` 저장(카드의 member화 표시는 AC3-3 anchor 범위).

## 검증
- 회귀: `resolve_auth_member` 단위 3종 — TM-first(team_member 있으면 그 id, org_member 조회 스킵) / OM-fallback(grant-only) / API키. 기존 standup self-save 테스트 patch 갱신.
- 풀 백엔드 스위트 `CI=true` green.
- ⚠️ **done = dev에서 sellerking 저장이 카드에 뜨는지 PO 픽셀 재검 전 금지**. 6a1e8b1d open 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)