### PR TITLE
[SID:8d2455e2] fix(i18n): standup.history 키 누락 추가 (ko/en)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -990,7 +990,8 @@
     "selfEditTitle": "Edit my standup",
     "expandSprintStories": "Show sprint stories",
     "collapseSprintStories": "Collapse",
-    "feedbackDialogTitle": "Feedback on {name}"
+    "feedbackDialogTitle": "Feedback on {name}",
+    "history": "📋 Standup History"
   },
   "retro": {
     "title": "Sprint Retro",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -990,7 +990,8 @@
     "selfEditTitle": "내 스탠드업 편집",
     "expandSprintStories": "스프린트 스토리 보기",
     "collapseSprintStories": "접기",
-    "feedbackDialogTitle": "{name} 피드백"
+    "feedbackDialogTitle": "{name} 피드백",
+    "history": "📋 작성 이력"
   },
   "retro": {
     "title": "스프린트 회고",


### PR DESCRIPTION
## Summary

`standup-history-section.tsx:51`의 `t('history', {defaultValue:'📋 작성 이력'})`가 `standup` 네임스페이스에 `history` 키 부재로:
- 콘솔 `MISSING_MESSAGE` 경고
- **en 로케일에서 한글 fallback(`📋 작성 이력`)이 그대로 노출** (실버그)

`standup` 객체에 `history` 키 추가로 해소.

- ko: `"history": "📋 작성 이력"`
- en: `"history": "📋 Standup History"`
- ⚠️ wallet/거래 네임스페이스의 `history`(line 1164, "거래 내역")와 **별개** — `standup` 객체에만 추가
- **UI 변경 0** (키 추가만, 화면 텍스트 동일)

## Test plan

- [x] 두 JSON 파일 파싱 유효성 확인
- [ ] en 로케일 Standup 화면 → "📋 Standup History" 노출 + 콘솔 MISSING_MESSAGE 0 (유나 회귀)
- [ ] 스탠드업 화면 시각 무변경 회귀

🤖 Generated with [Claude Code](https://claude.com/claude-code)