### PR TITLE
prod 프로모션: E-MEMBER-SSOT grant-only 5버그 + standup422 + i18n + 어댑터/SSE/웹훅UI (14 commits)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -992,7 +992,8 @@
     "selfEditTitle": "Edit my standup",
     "expandSprintStories": "Show sprint stories",
     "collapseSprintStories": "Collapse",
-    "feedbackDialogTitle": "Feedback on {name}"
+    "feedbackDialogTitle": "Feedback on {name}",
+    "history": "📋 Standup History"
   },
   "retro": {
     "title": "Sprint Retro",

--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -698,7 +698,9 @@
     "agentMcpDescription": "Paste this into Claude Code or any MCP client to connect as this agent.",
     "agentMcpKeyRequired": "Generate an API key first to include the real key in the config.",
     "ownershipDenied": "Permission denied. Only the agent owner or admin can edit.",
-    "agentOwner": "my agent"
+    "agentOwner": "my agent",
+    "webhookHelperEmptyHuman": "Set a webhook URL and enable the toggle to receive your mentions and events for this project at an external endpoint. Other projects require separate configuration.",
+    "webhookHelperActiveHuman": "Your mentions and event notifications for this project are forwarded to the configured URL. Other projects require separate configuration."
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -992,7 +992,8 @@
     "selfEditTitle": "내 스탠드업 편집",
     "expandSprintStories": "스프린트 스토리 보기",
     "collapseSprintStories": "접기",
-    "feedbackDialogTitle": "{name} 피드백"
+    "feedbackDialogTitle": "{name} 피드백",
+    "history": "📋 작성 이력"
   },
   "retro": {
     "title": "스프린트 회고",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -698,7 +698,9 @@
     "agentMcpDescription": "Claude Code나 MCP 클라이언트에 붙여넣으면 이 에이전트로 Sprintable에 연결됩니다.",
     "agentMcpKeyRequired": "API Key를 먼저 발급하면 실제 키가 포함된 설정을 복사할 수 있습니다.",
     "ownershipDenied": "권한이 없습니다. 에이전트 소유자 또는 관리자만 수정할 수 있습니다.",
-    "agentOwner": "내 에이전트"
+    "agentOwner": "내 에이전트",
+    "webhookHelperEmptyHuman": "현재 프로젝트의 내 멘션·이벤트를 외부 URL로 받으려면 Webhook URL을 설정하고 토글을 켜세요. 다른 프로젝트는 해당 프로젝트에서 별도 설정이 필요합니다.",
+    "webhookHelperActiveHuman": "현재 프로젝트의 내 멘션·이벤트 알림이 설정된 URL로 전송됩니다. 다른 프로젝트의 멘션은 별도 설정이 필요합니다."
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -12,6 +12,7 @@ import { ProjectAccessSection } from '@/components/settings/project-access-secti
 
 import { AiSettingsSection } from '@/components/settings/ai-settings';
 import { MyProfileSection } from '@/components/settings/my-profile-section';
+import { MyNotificationChannelSection } from '@/components/settings/my-notification-channel-section';
 import { ByomKeyManagement } from '@/components/settings/byom-key-management';
 import { McpConnectionSettings } from '@/components/settings/mcp-connection-settings';
 import { WorkflowTriggerTypesSection } from '@/components/settings/workflow-trigger-types-section';
@@ -863,6 +864,12 @@ export default function SettingsPage() {
                 <MyProfileSection />
                 <SetPasswordSection />
                 <TwoFactorSection />
+                {currentProjectId && (
+                  <MyNotificationChannelSection
+                    projectId={currentProjectId}
+                    projectName={projects.find((p) => p.id === currentProjectId)?.name ?? currentProjectId}
+                  />
+                )}
               </div>
             </TabsContent>
 

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -294,6 +294,7 @@ export default function StandupPage() {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
+          project_id: projectId,
           date,
           done,
           plan,

--- a/apps/web/src/components/settings/my-notification-channel-section.tsx
+++ b/apps/web/src/components/settings/my-notification-channel-section.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { OperatorInput } from '@/components/ui/operator-control';
+import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/toast';
+
+interface WebhookConfig {
+  id: string;
+  member_id: string | null;
+  url: string;
+  project_id: string | null;
+  is_active: boolean;
+}
+
+interface MyNotificationChannelSectionProps {
+  projectId: string;
+  projectName: string;
+}
+
+function getWebhookState(configs: WebhookConfig[]): 'empty' | 'active' | 'paused' {
+  if (!configs.length) return 'empty';
+  return configs[0].is_active ? 'active' : 'paused';
+}
+
+function isWebhookUrlAllowed(url: string): boolean {
+  if (!url) return true;
+  if (/^https:\/\//i.test(url)) return true;
+  return /^http:\/\/(localhost|127\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)/i.test(url);
+}
+
+export function MyNotificationChannelSection({ projectId, projectName }: MyNotificationChannelSectionProps) {
+  const t = useTranslations('settings');
+  const tc = useTranslations('common');
+  const { addToast } = useToast();
+
+  const [memberId, setMemberId] = useState<string | null>(null);
+  const [webhookConfigs, setWebhookConfigs] = useState<WebhookConfig[]>([]);
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [webhookActive, setWebhookActive] = useState(false);
+  const [savingWebhook, setSavingWebhook] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setWebhookUrl(webhookConfigs[0]?.url ?? '');
+    setWebhookActive(webhookConfigs[0]?.is_active ?? false);
+  }, [webhookConfigs]);
+
+  const fetchWebhookConfigs = useCallback(async (mid: string) => {
+    const res = await fetch('/api/webhooks/config');
+    if (!res.ok) return;
+    const json = await res.json() as { data: WebhookConfig[] };
+    const mine = (json.data ?? []).filter(
+      (c) => c.member_id === mid && c.project_id === projectId,
+    );
+    setWebhookConfigs(mine);
+  }, [projectId]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/me');
+        if (!res.ok) return;
+        const json = await res.json() as { data?: { id?: string } };
+        const mid = json.data?.id ?? null;
+        if (!mid) return;
+        setMemberId(mid);
+        await fetchWebhookConfigs(mid);
+      } finally {
+        setLoading(false);
+      }
+    }
+    void load();
+  }, [fetchWebhookConfigs]);
+
+  const handleSaveWebhook = async () => {
+    if (!memberId) return;
+    const trimmed = webhookUrl.trim();
+    if (trimmed && !isWebhookUrlAllowed(trimmed)) {
+      addToast({ type: 'error', title: t('webhookUrlInvalid') });
+      return;
+    }
+    setSavingWebhook(true);
+    try {
+      if (!trimmed) {
+        if (webhookConfigs[0]) {
+          await fetch(`/api/webhooks/config?id=${encodeURIComponent(webhookConfigs[0].id)}`, { method: 'DELETE' });
+          setWebhookConfigs([]);
+        }
+      } else {
+        const res = await fetch('/api/webhooks/config', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ member_id: memberId, url: trimmed, project_id: projectId, is_active: webhookActive }),
+        });
+        if (!res.ok) {
+          const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+          addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+          return;
+        }
+      }
+      addToast({ type: 'success', title: 'Webhook URL saved' });
+      await fetchWebhookConfigs(memberId);
+    } finally {
+      setSavingWebhook(false);
+    }
+  };
+
+  const handleToggle = async (next: boolean) => {
+    if (!memberId) return;
+    setWebhookActive(next);
+    if (!webhookConfigs[0]) return;
+    setSavingWebhook(true);
+    try {
+      await fetch('/api/webhooks/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          member_id: memberId,
+          url: webhookConfigs[0].url,
+          project_id: projectId,
+          is_active: next,
+        }),
+      });
+      await fetchWebhookConfigs(memberId);
+    } finally {
+      setSavingWebhook(false);
+    }
+  };
+
+  if (loading || !projectId) return null;
+
+  const webhookState = getWebhookState(webhookConfigs);
+
+  return (
+    <SectionCard>
+      <SectionCardHeader>
+        <div className="space-y-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h2 className="text-base font-semibold text-foreground">{t('notificationChannel')}</h2>
+            <Badge variant="outline" className="text-xs">{projectName}</Badge>
+            {webhookState === 'empty' && <Badge variant="info">{t('webhookStatusEmpty')}</Badge>}
+            {webhookState === 'active' && <Badge variant="success">{t('webhookStatusActive')}</Badge>}
+            {webhookState === 'paused' && (
+              <>
+                <Badge variant="secondary">{t('webhookStatusInactive')}</Badge>
+                <Badge variant="info">{t('webhookStatusFallback')}</Badge>
+              </>
+            )}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            {webhookState === 'empty' && t('webhookHelperEmptyHuman')}
+            {webhookState === 'active' && t('webhookHelperActiveHuman')}
+            {webhookState === 'paused' && t('webhookHelperPaused')}
+          </p>
+        </div>
+      </SectionCardHeader>
+      <SectionCardBody className="space-y-3">
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium">{t('webhookEnabledToggle')}</p>
+            <p className="text-xs text-muted-foreground mt-0.5">{t('webhookEnabledHelp')}</p>
+          </div>
+          <Switch
+            checked={webhookActive}
+            onCheckedChange={(next) => void handleToggle(next)}
+            disabled={savingWebhook}
+          />
+        </div>
+        <div className="flex gap-2">
+          <OperatorInput
+            type="url"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+            placeholder={t('webhookUrlPlaceholder')}
+            className="flex-1 font-mono text-xs"
+            disabled={!webhookActive}
+          />
+          <Button
+            variant="hero"
+            size="sm"
+            onClick={() => void handleSaveWebhook()}
+            disabled={savingWebhook || !webhookActive || !webhookUrl.trim()}
+          >
+            {savingWebhook ? '...' : tc('save')}
+          </Button>
+        </div>
+      </SectionCardBody>
+    </SectionCard>
+  );
+}

--- a/backend/alembic/versions/0073_drop_notification_preferences_team_member_fk.py
+++ b/backend/alembic/versions/0073_drop_notification_preferences_team_member_fk.py
@@ -1,0 +1,71 @@
+"""notification_preferences.member_id team_members FK 완화 (AC2-2 grant-only 휴먼).
+
+FK drop: 컬럼·인덱스 유지, 데이터 무변경. 0069(conv/events) 동일 패턴.
+공유 dev/prod DB — idempotent 가드(존재할 때만 drop). 가역: 비-team_member id가
+없을 때만 재추가(데이터 안전).
+
+Revision ID: 0073
+Revises: 0072
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0073"
+down_revision = "0072"
+branch_labels = None
+depends_on = None
+
+_TABLE = "notification_preferences"
+_COL = "member_id"
+
+
+def _fks_referencing_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [
+        fk for fk in insp.get_foreign_keys(table)
+        if fk.get("referred_table") == "team_members"
+    ]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if _TABLE not in set(insp.get_table_names()):
+        return
+    # idempotent: member_id를 참조하는 team_members FK가 있을 때만 drop
+    for fk in _fks_referencing_team_members(insp, _TABLE):
+        if _COL in fk.get("constrained_columns", []):
+            fk_name = fk.get("name")
+            if fk_name:
+                op.drop_constraint(fk_name, _TABLE, type_="foreignkey")
+
+
+def downgrade() -> None:
+    """비-team_member id(grant-only org_member.id)가 없을 때만 FK 재추가."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if _TABLE not in set(insp.get_table_names()):
+        return
+
+    existing = {fk["name"] for fk in _fks_referencing_team_members(insp, _TABLE)}
+    fk_name = f"{_TABLE}_{_COL}_fkey"
+    if fk_name in existing:
+        return
+
+    # 데이터 오염(비-team_member id) 있으면 재추가 생략
+    non_tm = conn.execute(
+        sa.text(
+            f"SELECT 1 FROM {_TABLE} t"
+            f" WHERE t.{_COL} IS NOT NULL"
+            f"   AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{_COL})"
+            f" LIMIT 1"
+        )
+    ).scalar_one_or_none()
+    if non_tm is not None:
+        return
+
+    op.create_foreign_key(
+        fk_name, _TABLE, "team_members", [_COL], ["id"], ondelete="CASCADE"
+    )

--- a/backend/alembic/versions/0074_drop_standup_team_member_fks.py
+++ b/backend/alembic/versions/0074_drop_standup_team_member_fks.py
@@ -1,0 +1,81 @@
+"""standup_entries.author_id / standup_feedback.feedback_by_id team_members FK 완화.
+
+resolve_member가 grant-only/정식 휴먼 모두 org_member.id(canonical member.id 방향)를
+반환하므로 standup author/feedback의 team_members FK 제약을 제거. (6a1e8b1d B3)
+
+FK drop: 컬럼·인덱스 유지, 데이터 무변경. 0069(conv/events)·0073(notif) 동일 패턴.
+공유 dev/prod DB — inspector 기반 idempotent(존재할 때만 drop) + 가역(비-team_member
+id 없을 때만 재추가). author_id는 PUT self-save가 실제 OM id 기록(active), feedback_by_id는
+동일 latent 패턴 선제 완화.
+
+Revision ID: 0074
+Revises: 0073
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0074"
+down_revision = "0073"
+branch_labels = None
+depends_on = None
+
+# (table, column, downgrade ondelete)
+_FK_TARGETS: list[tuple[str, str, str]] = [
+    ("standup_entries", "author_id", "CASCADE"),
+    ("standup_feedback", "feedback_by_id", "CASCADE"),
+]
+
+
+def _fks_referencing_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [
+        fk for fk in insp.get_foreign_keys(table)
+        if fk.get("referred_table") == "team_members"
+    ]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, _ in _FK_TARGETS:
+        if table not in tables:
+            continue
+        for fk in _fks_referencing_team_members(insp, table):
+            if col in fk.get("constrained_columns", []):
+                fk_name = fk.get("name")
+                if fk_name:
+                    op.drop_constraint(fk_name, table, type_="foreignkey")
+
+
+def downgrade() -> None:
+    """비-team_member id(grant-only org_member.id)가 없는 컬럼에만 FK 재추가."""
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, ondelete in _FK_TARGETS:
+        if table not in tables:
+            continue
+        existing = {fk["name"] for fk in _fks_referencing_team_members(insp, table)}
+        fk_name = f"{table}_{col}_fkey"
+        if fk_name in existing:
+            continue
+
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t"
+                f" WHERE t.{col} IS NOT NULL"
+                f"   AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col})"
+                f" LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue  # 데이터 오염 — 재추가 생략
+
+        op.create_foreign_key(
+            fk_name, table, "team_members", [col], ["id"], ondelete=ondelete
+        )

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -10,6 +10,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.database import async_session_factory
 from app.core.security import JWTError, decode_jwt, hash_token
 from app.dependencies.database import get_db
 
@@ -400,3 +401,91 @@ async def get_scope_context(
     project_id_raw = jwt_project_id or x_project_id
     project_id = uuid.UUID(str(project_id_raw)) if project_id_raw else None
     return {"org_id": org_id, "project_id": project_id, "user_id": auth.user_id}
+
+
+# ─── SSE/스트림 전용 auth (커넥션 비점유) ──────────────────────────────────────
+# P0 connection leak fix (#abaf6279):
+# get_current_user/get_verified_org_id는 Depends(get_db)로 요청 수명 동안 세션을
+# 점유한다. SSE 같은 long-lived 응답에서는 API key 해석의 team_members 쿼리가
+# 연 커넥션이 yield 구간 내내 idle-in-transaction으로 잔존 → max_connections 포화.
+# 아래 streaming 변형은 자체 단명 세션(async with)으로 즉시 닫아 미점유를 보장한다.
+
+
+async def get_current_user_streaming(
+    credentials: HTTPAuthorizationCredentials | None = Depends(bearer_scheme),
+    x_agent_api_key: str | None = Header(default=None, alias="x-agent-api-key"),
+) -> AuthContext:
+    """get_current_user의 SSE 전용 변형 — get_db 미점유.
+
+    API key 경로는 자체 단명 세션으로 _resolve_api_key 후 즉시 close →
+    스트림 yield 구간에 커넥션을 들고 있지 않음. JWT 경로는 DB 불필요(기존과 동일).
+    """
+    if x_agent_api_key and x_agent_api_key.startswith("sk_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_api_key(x_agent_api_key, db)
+
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing Authorization header")
+
+    token = credentials.credentials
+    if token.startswith("sk_live_"):
+        async with async_session_factory() as db:
+            return await _resolve_api_key(token, db)
+
+    try:
+        payload = decode_jwt(token)
+    except JWTError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token") from exc
+
+    user_id: str | None = payload.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token missing sub claim")
+
+    return AuthContext(
+        user_id=user_id,
+        email=payload.get("email"),
+        claims=payload,
+        org_id=payload.get("app_metadata", {}).get("org_id"),
+    )
+
+
+async def get_verified_org_id_streaming(
+    auth: AuthContext = Depends(get_current_user_streaming),
+    x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    x_project_id: str | None = Header(default=None, alias="X-Project-Id"),
+    request: Request = None,
+) -> uuid.UUID:
+    """get_verified_org_id의 SSE 전용 변형 — get_db 미점유.
+
+    멤버십/프로젝트 검증이 필요한 경우에만 자체 단명 세션으로 검증 후 close.
+    API key + claims org_id(헤더 없음) 경로는 DB 쿼리조차 없음.
+    """
+    if request is not None:
+        _check_api_key_scope(auth, request.method)
+
+    jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
+    raw = x_org_id or jwt_org_id
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="org_id required (X-Org-Id header or JWT app_metadata)",
+        )
+    try:
+        org_id = uuid.UUID(str(raw))
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid org_id format")
+
+    if x_org_id:
+        async with async_session_factory() as db:
+            await _verify_org_membership(auth.user_id, org_id, db, request)
+
+    jwt_project_id = auth.claims.get("app_metadata", {}).get("project_id")
+    if not jwt_project_id and x_project_id:
+        try:
+            project_id = uuid.UUID(x_project_id)
+        except ValueError:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid X-Project-Id format")
+        async with async_session_factory() as db:
+            await _verify_project_in_org(project_id, org_id, db, request)
+
+    return org_id

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -230,8 +230,8 @@ async def get_project_scoped_org_id(
     request: Request = None,
 ) -> uuid.UUID:
     """project_id query param 또는 X-Project-Id 헤더가 있을 때, 해당 project의 org_id로
-    cross-org 접근을 허용. TeamMember.is_active 기반 검증. 미멤버 → 403.
-    project_id가 없으면 get_verified_org_id 동작과 동일."""
+    cross-org 접근을 허용. has_project_access(team_member ∪ grant ∪ owner/admin) 기반 검증.
+    미인가 → 403. project_id가 없으면 get_verified_org_id 동작과 동일."""
     base_org_id = await get_verified_org_id(
         auth=auth, x_org_id=x_org_id, x_project_id=None, db=db, request=request
     )
@@ -246,32 +246,13 @@ async def get_project_scoped_org_id(
     if not project_org_id:
         return base_org_id
 
-    # Org owner/admin은 모든 project에 접근 가능 — team_members 체크 우선 bypass.
-    # project 생성 직후 team_members 미생성 상태(OSS fresh install)에서도 접근 허용.
-    from app.models.project import OrgMember
-    uid = uuid.UUID(auth.user_id)
-    org_role_row = await db.execute(
-        select(OrgMember.role).where(
-            OrgMember.org_id == project_org_id,
-            OrgMember.user_id == uid,
-            OrgMember.deleted_at.is_(None),
-        )
-    )
-    if org_role_row.scalar_one_or_none() in ("owner", "admin"):
-        return project_org_id
-
-    # project_id가 지정된 경우 org 동일 여부 무관하게 TeamMember 검증
-    # (동일 org 내 다른 project 미멤버 우회 방지)
-    from app.models.team import TeamMember
-    from sqlalchemy import or_
-    member = await db.execute(
-        select(TeamMember.id).where(
-            or_(TeamMember.user_id == uid, TeamMember.id == uid),
-            TeamMember.project_id == project_id,
-            TeamMember.is_active.is_(True),
-        ).limit(1)
-    )
-    if member.scalar_one_or_none() is None:
+    # E-MEMBER-SSOT AC2-2: "TeamMember 존재 = 인가" 대신 has_project_access SSOT로 전환.
+    # team_member(active) ∪ project_access(granted) ∪ owner/admin org-wide 3-branch이므로
+    #   - owner/admin은 rowless 접근 유지 (OSS fresh install, team_members 미생성 포함)
+    #   - grant-only 휴먼(project_access)도 project 접근 허용 (740e3b7e 에픽403 해소)
+    #   - 동일 org 내 다른 project 미멤버 우회 방지(project 스코프)는 그대로 유지
+    from app.services.project_auth import has_project_access
+    if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, project_org_id):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="해당 프로젝트의 멤버가 아닌",

--- a/backend/app/models/notification_preference.py
+++ b/backend/app/models/notification_preference.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, func
+from sqlalchemy import DateTime, Text, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -13,8 +13,10 @@ class NotificationPreference(Base, TimestampMixin):
     __tablename__ = "notification_preferences"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # E-MEMBER-SSOT AC2-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 수용.
+    # 컬럼·인덱스 유지, FK는 migration 0073에서 DROP (0069 conv/events와 동일 패턴).
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     scope_type: Mapped[str] = mapped_column(Text, nullable=False)  # global | project | conversation | thread
     scope_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)

--- a/backend/app/models/standup.py
+++ b/backend/app/models/standup.py
@@ -19,8 +19,11 @@ class StandupEntry(Base, OrgScopedMixin, TimestampMixin):
     sprint_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
+    # E-MEMBER-SSOT(6a1e8b1d): team_members FK 완화 — resolve_member가 grant-only 휴먼에
+    # org_member.id(canonical member.id 방향)를 반환하므로 team_members FK 제약 제거.
+    # migration 0074에서 DROP (0069 conv/events·0073 notif 동일 패턴). 컬럼·인덱스 유지.
     author_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     date: Mapped[date] = mapped_column(Date, nullable=False, index=True)
     done: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -48,8 +51,11 @@ class StandupFeedback(Base, OrgScopedMixin, TimestampMixin):
     standup_entry_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("standup_entries.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT(6a1e8b1d): team_members FK 선제 완화 — author_id와 동일 anchor 방향(canonical
+    # member.id). 현재 add_feedback는 클라 body.feedback_by_id를 쓰지만, 동일 latent B-bug
+    # 방지 위해 같은 migration 0074에서 동반 DROP. 컬럼·인덱스 유지.
     feedback_by_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     review_type: Mapped[str] = mapped_column(Text, nullable=False, default="comment")
     feedback_text: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -1,8 +1,8 @@
-"""E-AGENT-GATEWAY Phase 0: per-recipient dense seq 기반 SSE 스트림 + ACK.
+"""E-AGENT-GATEWAY Phase 0: per-recipient dense seq ê¸°ë° SSE ì¤í¸ë¦¼ + ACK.
 
-이중전달 fix: per-recipient dense commit-ordered seq (recipient_seq).
-start_seq = max(acked_seq DB, Last-Event-ID 헤더)
-backfill = live-tail = 동일 쿼리 → 겹침 0.
+ì´ì¤ì ë¬ fix: per-recipient dense commit-ordered seq (recipient_seq).
+start_seq = max(acked_seq DB, Last-Event-ID í¤ë)
+backfill = live-tail = ëì¼ ì¿¼ë¦¬ â ê²¹ì¹¨ 0.
 """
 from __future__ import annotations
 
@@ -18,7 +18,7 @@ from pydantic import BaseModel
 from sqlalchemy import select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user
+from app.dependencies.auth import AuthContext, get_current_user, get_current_user_streaming
 from app.core.database import async_session_factory
 from app.dependencies.database import get_db
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
@@ -31,13 +31,13 @@ router = APIRouter(prefix="/api/v2/agent", tags=["agent-gateway"])
 _SSE_HEARTBEAT: float = float(os.getenv("SSE_HEARTBEAT_TIMEOUT", "30"))
 _BACKFILL_LIMIT: int = int(os.getenv("AGENT_GATEWAY_BACKFILL_LIMIT", "100"))
 
-# ─── wake_agent: commit 후 큐 알림 ────────────────────────────────────────────
+# âââ wake_agent: commit í í ìë¦¼ ââââââââââââââââââââââââââââââââââââââââââââ
 
 def wake_agent(agent_id: str, seq: int, _from_listener: bool = False) -> None:
-    """신규 이벤트 커밋 후 에이전트 SSE 큐에 wake 신호 전송.
+    """ì ê· ì´ë²¤í¸ ì»¤ë° í ìì´ì í¸ SSE íì wake ì í¸ ì ì¡.
 
-    에이전트는 신호 수신 후 recipient_seq > cursor 조회 (payload 미포함).
-    _from_listener=True: pg_notify 재발행 금지.
+    ìì´ì í¸ë ì í¸ ìì  í recipient_seq > cursor ì¡°í (payload ë¯¸í¬í¨).
+    _from_listener=True: pg_notify ì¬ë°í ê¸ì§.
     """
     payload = {"__wake__": True, "seq": seq}
     queues = _agent_connections.get(agent_id)
@@ -67,10 +67,10 @@ async def _fetch_events(
     after_seq: int,
     limit: int,
 ) -> list:
-    """recipient_seq > after_seq인 visible 이벤트 반환 (raw rows).
+    """recipient_seq > after_seqì¸ visible ì´ë²¤í¸ ë°í (raw rows).
 
-    정렬: recipient_seq ASC. per-recipient dense → gap-free.
-    gap-free 보장은 acked_seq 재스캔(caller)이 담당; 이 함수는 단순 조회.
+    ì ë ¬: recipient_seq ASC. per-recipient dense â gap-free.
+    gap-free ë³´ì¥ì acked_seq ì¬ì¤ìº(caller)ì´ ë´ë¹; ì´ í¨ìë ë¨ì ì¡°í.
     """
     rows = await session.execute(
         text("""
@@ -95,7 +95,7 @@ async def _fetch_events(
 
 
 def _row_to_payload(row: object) -> dict:
-    """_fetch_events row → SSE payload dict."""
+    """_fetch_events row â SSE payload dict."""
     return {
         "event_id": row.event_id,  # type: ignore[attr-defined]
         "event_type": row.event_type,  # type: ignore[attr-defined]
@@ -111,29 +111,31 @@ def _row_to_payload(row: object) -> dict:
     }
 
 
-# ─── backward compat: 구 _push_to_agent 호환 래퍼 ────────────────────────────
+# âââ backward compat: êµ¬ _push_to_agent í¸í ëí¼ ââââââââââââââââââââââââââââ
 
 def _push_to_agent_v2(member_id: str, payload: dict, _from_listener: bool = False) -> bool:
-    """구 _push_to_agent 호출부 호환 — gateway_seq 있으면 wake_agent로 위임."""
+    """êµ¬ _push_to_agent í¸ì¶ë¶ í¸í â gateway_seq ìì¼ë©´ wake_agentë¡ ìì."""
     seq = payload.get("recipient_seq") or payload.get("gateway_seq")
     if seq is not None:
         wake_agent(member_id, int(seq), _from_listener=_from_listener)
         return True
-    # gateway_seq 없는 경우(레거시 경로): 기존 큐 직접 push fallback
+    # gateway_seq ìë ê²½ì°(ë ê±°ì ê²½ë¡): ê¸°ì¡´ í ì§ì  push fallback
     from app.routers.events import _push_to_agent as _legacy_push
     return _legacy_push(member_id, payload, _from_listener=_from_listener)
 
 
-# ─── GET /api/v2/agent/stream ─────────────────────────────────────────────────
+# âââ GET /api/v2/agent/stream âââââââââââââââââââââââââââââââââââââââââââââââââ
 
 @router.get("/stream")
 async def agent_stream(
     request: Request,
-    auth: AuthContext = Depends(get_current_user),
+    # P0(#abaf6279 íì): SSE long-lived ìì²­ì´ get_db ì¸ìì ì ì íë©´ API key í´ì
+    # team_members ì¿¼ë¦¬ ì»¤ë¥ìì´ idle-in-transaction ìì¡´ → ë¹ì ì  streaming ë³í ì¬ì©.
+    auth: AuthContext = Depends(get_current_user_streaming),
 ) -> StreamingResponse:
-    """gateway_seq 기반 SSE 스트림 (API키 전용).
+    """gateway_seq ê¸°ë° SSE ì¤í¸ë¦¼ (APIí¤ ì ì©).
 
-    Last-Event-ID 헤더 = 마지막 수신 gateway_seq.
+    Last-Event-ID í¤ë = ë§ì§ë§ ìì  gateway_seq.
     start_seq = max(DB acked_seq, Last-Event-ID).
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
@@ -142,7 +144,7 @@ async def agent_stream(
 
     agent_id = uuid.UUID(auth.user_id)
 
-    # agent_id 검증
+    # agent_id ê²ì¦
     async with async_session_factory() as db:
         tm = (await db.execute(
             select(TeamMember).where(TeamMember.id == agent_id, TeamMember.type == "agent")
@@ -150,13 +152,13 @@ async def agent_stream(
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
-        # acked_seq DB 조회
+        # acked_seq DB ì¡°í
         cursor = (await db.execute(
             select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
         )).scalar_one_or_none()
         acked_seq: int = cursor.acked_seq if cursor else 0
 
-        # 세션 등록
+        # ì¸ì ë±ë¡
         session_rec = AgentGatewaySession(
             id=uuid.uuid4(),
             agent_id=agent_id,
@@ -166,7 +168,7 @@ async def agent_stream(
         db.add(session_rec)
         await db.commit()
 
-    # Last-Event-ID 헤더 파싱 (gateway_seq)
+    # Last-Event-ID í¤ë íì± (gateway_seq)
     last_event_id_hdr = request.headers.get("Last-Event-ID") or request.headers.get("last-event-id")
     header_seq: int = 0
     if last_event_id_hdr:
@@ -182,36 +184,36 @@ async def agent_stream(
     _agent_connections[agent_id_str].add(queue)
 
     async def generate():
-        """gap-free ordered-at-least-once SSE 스트림.
+        """gap-free ordered-at-least-once SSE ì¤í¸ë¦¼.
 
-        커서 전략: acked_seq(durable) 재스캔.
-        - 매 wake마다 `gateway_seq > acked_seq` DB 재스캔 → 늦게 커밋된 낮은 seq도 반드시 잡힘.
-        - wake_floor: 이번 wake 내 yield한 최대 seq (같은 wake 안 중복 방지용).
-        - acked_seq는 클라이언트 POST /ack 로만 전진 — 서버가 자동 전진 안 함.
-        - 클라이언트는 seq 기반 dedup(같은 seq 두 번 받아도 한 번 처리) 필수.
+        ì»¤ì ì ëµ: acked_seq(durable) ì¬ì¤ìº.
+        - ë§¤ wakeë§ë¤ `gateway_seq > acked_seq` DB ì¬ì¤ìº â ë¦ê² ì»¤ë°ë ë®ì seqë ë°ëì ì¡í.
+        - wake_floor: ì´ë² wake ë´ yieldí ìµë seq (ê°ì wake ì ì¤ë³µ ë°©ì§ì©).
+        - acked_seqë í´ë¼ì´ì¸í¸ POST /ack ë¡ë§ ì ì§ â ìë²ê° ìë ì ì§ ì í¨.
+        - í´ë¼ì´ì¸í¸ë seq ê¸°ë° dedup(ê°ì seq ë ë² ë°ìë í ë² ì²ë¦¬) íì.
         """
         try:
             yield "event: heartbeat\ndata: {}\n\n"
 
-            # 초기 백필 — acked_seq(=start_seq)부터 재스캔
+            # ì´ê¸° ë°±í â acked_seq(=start_seq)ë¶í° ì¬ì¤ìº
             async with async_session_factory() as db:
                 rows = await _fetch_events(db, agent_id, start_seq, _BACKFILL_LIMIT)
 
-            backfill_floor = start_seq  # 이번 백필 내 중복 방지
+            backfill_floor = start_seq  # ì´ë² ë°±í ë´ ì¤ë³µ ë°©ì§
             for row in rows:
                 data = _row_to_payload(row)
                 gseq = row.recipient_seq or 0
-                if gseq > backfill_floor:  # 중복 방지
+                if gseq > backfill_floor:  # ì¤ë³µ ë°©ì§
                     _sse = json.dumps({**data, "is_backfill": True})
                     yield f"event: {row.event_type}\nid: {gseq}\ndata: {_sse}\n\n"
                     backfill_floor = gseq
 
-            # 실시간 — wake 신호 → acked_seq부터 DB 재스캔
+            # ì¤ìê° â wake ì í¸ â acked_seqë¶í° DB ì¬ì¤ìº
             while not await request.is_disconnected():
                 try:
                     signal = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT)
                     if signal.get("__wake__"):
-                        # 최신 acked_seq 조회 (클라이언트가 ACK 보냈을 수 있음)
+                        # ìµì  acked_seq ì¡°í (í´ë¼ì´ì¸í¸ê° ACK ë³´ëì ì ìì)
                         async with async_session_factory() as db:
                             cur = (await db.execute(
                                 select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
@@ -219,17 +221,17 @@ async def agent_stream(
                             scan_from = max(start_seq, cur.acked_seq if cur else 0)
                             new_rows = await _fetch_events(db, agent_id, scan_from, _BACKFILL_LIMIT)
 
-                        wake_floor = scan_from  # 이번 wake 내 중복 방지
+                        wake_floor = scan_from  # ì´ë² wake ë´ ì¤ë³µ ë°©ì§
                         for row in new_rows:
                             gseq = row.recipient_seq or 0
                             if gseq > wake_floor:
                                 data = _row_to_payload(row)
                                 _sse = json.dumps({**data, "is_backfill": False})
-                                # AC2: 카논 이벤트명 only
+                                # AC2: ì¹´ë¼ ì´ë²¤í¸ëª only
                                 yield f"event: {row.event_type}\nid: {gseq}\ndata: {_sse}\n\n"
                                 wake_floor = gseq
                     else:
-                        # 레거시 직접 push (AGENT_GATEWAY_V2 미적용 경로)
+                        # ë ê±°ì ì§ì  push (AGENT_GATEWAY_V2 ë¯¸ì ì© ê²½ë¡)
                         event_type = signal.get("event_type", "message")
                         _live_id = signal.get("event_id") or str(uuid.uuid4())
                         _sse = json.dumps({**signal, "is_backfill": False})
@@ -256,7 +258,7 @@ async def agent_stream(
     )
 
 
-# ─── POST /api/v2/agent/events/ack ────────────────────────────────────────────
+# âââ POST /api/v2/agent/events/ack ââââââââââââââââââââââââââââââââââââââââââââ
 
 class AckRequest(BaseModel):
     seq: int
@@ -268,14 +270,14 @@ async def ack_event(
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> dict:
-    """에이전트가 처리 완료한 gateway_seq ACK — agent_event_cursors 갱신."""
+    """ìì´ì í¸ê° ì²ë¦¬ ìë£í gateway_seq ACK â agent_event_cursors ê°±ì ."""
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if not is_api_key:
         raise HTTPException(status_code=403, detail="API key required")
 
     agent_id = uuid.UUID(auth.user_id)
 
-    # UPSERT acked_seq (더 높은 값만 갱신)
+    # UPSERT acked_seq (ë ëì ê°ë§ ê°±ì )
     existing = (await db.execute(
         select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
     )).scalar_one_or_none()

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1179,7 +1179,9 @@ async def switch_organization(
 
     await session.commit()
 
-    project_id = app_metadata.get("project_id") or (str(team_member.project_id) if team_member else None)
+    # E-MEMBER-SSOT AC2-2: undefined team_member 참조 제거 (8a5f260c switch500 해소).
+    # project_id는 위에서 target_project_id(effective access 기반)로 이미 확정/제거됨.
+    project_id = app_metadata.get("project_id")
     return _ok({**tokens, "project_id": project_id})
 
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -22,7 +22,13 @@ from app.models.team import TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
 from app.services.event_seq import assign_recipient_seq
-from app.services.member_resolver import ResolvedMember, lookup_members_by_ids, resolve_member
+from app.services.member_resolver import (
+    ResolvedMember,
+    filter_org_member_ids,
+    lookup_members_by_ids,
+    resolve_member,
+    resolve_member_identity,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -594,9 +600,8 @@ async def add_participant(
         raise HTTPException(status_code=403, detail="Not a participant")
 
     # 추가 대상 멤버가 같은 org인지 확인
-    target = (await db.execute(
-        select(TeamMember).where(TeamMember.id == body.member_id, TeamMember.org_id == org_id)
-    )).scalar_one_or_none()
+    # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 참가자로 추가 허용
+    target = await resolve_member_identity(body.member_id, org_id, db)
     if target is None:
         raise HTTPException(status_code=404, detail="Member not found")
 
@@ -675,16 +680,24 @@ async def send_message(
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
 
+    # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
+    # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.
+    #   grant-only 휴먼(org_member) 멘션은 포함하고, cross-org UUID는 저장/발송 전에 제거.
+    #   group conversation은 fork 분기가 없어 별도 필터가 누락돼 있던 것을 여기서 함께 막는.
+    valid_mentioned_ids: list[uuid.UUID] = []
+    if body.mentioned_ids:
+        _org_member_ids = await filter_org_member_ids(set(body.mentioned_ids), org_id, db)
+        # 원본 순서 보존 + 중복 제거
+        _seen: set[uuid.UUID] = set()
+        for mid in body.mentioned_ids:
+            if mid in _org_member_ids and mid not in _seen:
+                _seen.add(mid)
+                valid_mentioned_ids.append(mid)
+
     # CB-S2: DM + 비참여자 멘션 → 자동 그룹 conversation fork (AC1, AC2)
     fork_info: dict | None = None
-    if conv.type == "dm" and body.mentioned_ids:
-        # cross-org 차단: mentioned_ids를 현재 org 소속 member로 필터링
-        valid_member_ids = set((await db.execute(
-            select(TeamMember.id).where(
-                TeamMember.id.in_(body.mentioned_ids),
-                TeamMember.org_id == org_id,
-            )
-        )).scalars().all())
+    if conv.type == "dm" and valid_mentioned_ids:
+        valid_member_ids = set(valid_mentioned_ids)
 
         current_participant_ids = set((await db.execute(
             select(ConversationParticipant.member_id)
@@ -731,7 +744,7 @@ async def send_message(
         conversation_id=conversation_id,
         sender_id=sender.id,
         content=body.content,
-        mentioned_ids=body.mentioned_ids,
+        mentioned_ids=valid_mentioned_ids,
         thread_id=body.thread_id,
     )
     db.add(msg)

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -16,6 +16,7 @@ from app.models.team import TeamMember
 from app.routers.agent_gateway import wake_agent
 from app.routers.events import _event_to_payload, _push_to_agent
 from app.services.event_seq import assign_recipient_seq
+from app.services.member_resolver import resolve_member_identity
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/dispatch", tags=["dispatch"])
@@ -92,17 +93,17 @@ async def dispatch_entity(
     # entity의 실제 project_id 사용 (body.project_id 불일치 방지)
     project_id = entity_project_id or body.project_id
 
-    # assignee TeamMember 조회 (type: human/agent)
-    member_result = await db.execute(
-        select(TeamMember.type).where(TeamMember.id == assignee_id, TeamMember.org_id == org_id)
-    )
-    member_row = member_result.one_or_none()
-    if not member_row:
+    # assignee 신원 해소 (type: human/agent)
+    # E-MEMBER-SSOT AC2-2: TeamMember-only 검증 → resolve_member_identity (TM∪OM).
+    #   grant-only 휴먼/polymorphic assignee도 수용해 dispatched:False 오탐 방지 (7f8066a3).
+    assignee_member = await resolve_member_identity(assignee_id, org_id, db)
+    if assignee_member is None:
         return DispatchResponse(dispatched=False, assignee_id=assignee_id)
 
-    member_type = member_row[0]
+    member_type = assignee_member.type
 
-    # sender_id: 현재 auth user의 TeamMember id
+    # sender_id: 현재 auth user의 member id (team_member 우선, grant-only 휴먼은 org_member)
+    # B1 교훈 — assignee뿐 아니라 sender 경로도 일관되게 grant-only 수용.
     sender_id: uuid.UUID | None = None
     try:
         uid = uuid.UUID(auth.user_id)
@@ -113,8 +114,18 @@ async def dispatch_entity(
                 TeamMember.is_active.is_(True),
             ).limit(1)
         )
-        sender_row = sender_result.scalar_one_or_none()
-        sender_id = sender_row
+        sender_id = sender_result.scalar_one_or_none()
+        if sender_id is None:
+            # grant-only 휴먼 디스패처 → org_member.id를 sender로 사용
+            from app.models.project import OrgMember
+            om_result = await db.execute(
+                select(OrgMember.id).where(
+                    OrgMember.user_id == uid,
+                    OrgMember.org_id == org_id,
+                    OrgMember.deleted_at.is_(None),
+                ).limit(1)
+            )
+            sender_id = om_result.scalar_one_or_none()
     except Exception:
         pass
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -20,7 +20,13 @@ from pydantic import BaseModel, ConfigDict
 from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.auth import (
+    AuthContext,
+    get_current_user,
+    get_current_user_streaming,
+    get_verified_org_id,
+    get_verified_org_id_streaming,
+)
 from app.dependencies.database import get_db
 from app.models.event import Event
 from app.models.team import TeamMember
@@ -174,8 +180,8 @@ class EventResponse(BaseModel):
 async def agent_event_stream(
     request: Request,
     member_id: uuid.UUID | None = Query(default=None),  # AC2: API key 시 자동 추출, JWT 시 필수
-    auth: AuthContext = Depends(get_current_user),  # AC1: Bearer {API_KEY} 또는 JWT — 없으면 401 (AC3)
-    org_id: uuid.UUID = Depends(get_verified_org_id),
+    auth: AuthContext = Depends(get_current_user_streaming),  # AC1: Bearer {API_KEY} 또는 JWT — 없으면 401 (AC3). P0(#abaf6279): SSE 커넥션 비점유 변형
+    org_id: uuid.UUID = Depends(get_verified_org_id_streaming),
     since_timestamp: datetime | None = Query(default=None),
     last_event_id: uuid.UUID | None = Query(default=None),
 ):
@@ -315,37 +321,37 @@ async def agent_event_stream(
                 for i in range(0, len(pending_events), _SSE_BATCH_SIZE):
                     batch = pending_events[i : i + _SSE_BATCH_SIZE]
                     batch_data = [_event_to_payload(evt) for evt in batch]
-                    # delivered 마킹 먼저 commit → 재연결 시 백필 중복 방지
+                    # 1c22da3e fix: yield 먼저 → 성공 후 delivered 마킹.
+                    # 선마킹 시 yield(클라 disconnect 등) 실패하면 이벤트가 delivered로
+                    # 남아 영구 누락. 후마킹 + 클라 seen_ids dedup 으로 손실 0(재전송 허용).
+                    for data, evt in zip(batch_data, batch):
+                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
                     for evt in batch:
                         evt.status = "delivered"
                         evt.delivered_at = now
                     await db.commit()
-                    for data, evt in zip(batch_data, batch):
-                        yield f"event: {evt.event_type}\nid: {evt.id}\ndata: {json.dumps({**data, 'is_backfill': True})}\n\n"
 
             # 신규 이벤트 리슨 — 대기 구간에서 커넥션 미점유, 이벤트마다 개별 세션
             while not await request.is_disconnected():
                 try:
                     event_data = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT_TIMEOUT)
                     event_type = event_data.get("event_type", "message")
-                    # event_id 있으면 yield 전 pending 선점 — 백필과 실시간 큐 중복 방지
-                    if eid := event_data.get("event_id"):
+                    # 1c22da3e fix: yield 전엔 pending 여부만 확인(skip 판정, 마킹 X),
+                    # delivered 마킹은 yield 성공 후로 미룬다 → yield 실패 시 영구 누락 방지.
+                    eid = event_data.get("event_id")
+                    if eid:
                         try:
                             async with async_session_factory() as db:
                                 r = await db.execute(
-                                    select(Event).where(
+                                    select(Event.status).where(
                                         Event.id == uuid.UUID(eid),
-                                        Event.status == "pending",
                                         Event.org_id == org_id,
                                     )
                                 )
-                                live_evt = r.scalar_one_or_none()
-                                if live_evt is None:
-                                    # 이미 백필에서 delivered 마킹됨 → skip
+                                _status = r.scalar_one_or_none()
+                                if _status is not None and _status != "pending":
+                                    # 이미 백필/타 연결에서 delivered → 중복 skip
                                     continue
-                                live_evt.status = "delivered"
-                                live_evt.delivered_at = datetime.now(timezone.utc)
-                                await db.commit()
                         except Exception:
                             pass
                     # event_id 없는 경로(chats direct push 등)도 id: 보장 — 재연결 추적 약화 방지
@@ -356,6 +362,18 @@ async def agent_event_stream(
                     if event_type == "conversation.message_created":
                         yield f"event: conversation:message\nid: {_live_id}\ndata: {_sse_data}\n\n"
                     yield f"event: {event_type}\nid: {_live_id}\ndata: {_sse_data}\n\n"
+                    # yield 성공 후 delivered 마킹 (1c22da3e: 손실 방지, dup은 클라 dedup)
+                    if eid:
+                        try:
+                            async with async_session_factory() as db:
+                                await db.execute(
+                                    update(Event)
+                                    .where(Event.id == uuid.UUID(eid), Event.status == "pending")
+                                    .values(status="delivered", delivered_at=datetime.now(timezone.utc))
+                                )
+                                await db.commit()
+                        except Exception:
+                            pass
                 except asyncio.TimeoutError:
                     # S20: heartbeat 후 즉시 disconnect 체크 — dead connection 조기 정리
                     yield "event: heartbeat\ndata: {}\n\n"

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -29,7 +29,7 @@ from app.dependencies.auth import (
 )
 from app.dependencies.database import get_db
 from app.models.event import Event
-from app.models.team import TeamMember
+from app.services.member_resolver import resolve_member_identity
 
 router = APIRouter(prefix="/api/v2/events", tags=["events"])
 
@@ -211,18 +211,13 @@ async def agent_event_stream(
         resolved_member_id = member_id
 
     # member_id가 org 소속인지 검증 + AC4: JWT 경로에서 타인 stream 접근 차단
+    # E-MEMBER-SSOT Phase 0: team_member 강요 제거 — grant-only 휴먼(org_member)도 구독 허용
     async with async_session_factory() as db:
-        result = await db.execute(
-            select(TeamMember).where(
-                TeamMember.id == resolved_member_id,
-                TeamMember.org_id == org_id,
-            )
-        )
-        member_row = result.scalar_one_or_none()
+        member_row = await resolve_member_identity(resolved_member_id, org_id, db)
         if member_row is None:
             raise HTTPException(status_code=404, detail="Member not found")
 
-        # AC4: JWT 사용자는 자신의 team_member(user_id 일치)에만 구독 허용
+        # AC4: JWT 사용자는 자신의 신원(user_id 일치)에만 구독 허용
         if not is_api_key:
             if member_row.user_id is None or str(member_row.user_id) != auth.user_id:
                 raise HTTPException(status_code=403, detail="Cannot subscribe to another member's stream")
@@ -414,18 +409,12 @@ async def create_event(
     미연결이면 status=pending 유지.
     Channel Router(S-A6)로 preference 기반 채널 결정 후 전달.
     """
-    from app.models.team import TeamMember
-
     # recipient가 동일 org 소속인지 + type 확정
-    result = await db.execute(
-        select(TeamMember.type).where(
-            TeamMember.id == body.recipient_id,
-            TeamMember.org_id == org_id,
-        )
-    )
-    member_type = result.scalar_one_or_none()
-    if member_type is None:
+    # E-MEMBER-SSOT Phase 0: grant-only 휴먼(org_member)도 수신자로 허용
+    recipient = await resolve_member_identity(body.recipient_id, org_id, db)
+    if recipient is None:
         raise HTTPException(status_code=404, detail="Recipient not found")
+    member_type = recipient.type
 
     event = Event(
         project_id=body.project_id,

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -14,6 +14,7 @@ from app.dependencies.auth import AuthContext, get_current_user, get_verified_or
 from app.dependencies.database import get_db
 from app.models.notification_preference import NotificationPreference
 from app.models.team import TeamMember
+from app.services.member_resolver import ResolvedMember, resolve_member
 
 router = APIRouter(prefix="/api/v2/notification-preferences", tags=["notification-preferences"])
 
@@ -37,19 +38,35 @@ class UpsertPreferencesRequest(BaseModel):
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
-async def _get_member(auth: AuthContext, org_id: uuid.UUID, db: AsyncSession) -> TeamMember:
+async def _get_member(
+    auth: AuthContext, org_id: uuid.UUID, db: AsyncSession
+) -> "ResolvedMember | TeamMember":
+    """현재 인증 주체의 멤버 신원.
+
+    E-MEMBER-SSOT AC2-2: API키→team_member; JWT 휴먼→team_member 우선(기존 preference
+    키 보존), 없으면 org_member(grant-only 휴먼)로 fallback (35a0691e 잔여 해소).
+    """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
-        stmt = select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
-    else:
-        stmt = select(TeamMember).where(
+        member = (await db.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )).scalars().first()
+        if member is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return member
+
+    # JWT 휴먼: team_member 우선 (기존 NotificationPreference.member_id 키 보존)
+    member = (await db.execute(
+        select(TeamMember).where(
             TeamMember.user_id == uuid.UUID(auth.user_id),
             TeamMember.org_id == org_id,
         )
-    member = (await db.execute(stmt)).scalars().first()
-    if member is None:
-        raise HTTPException(status_code=400, detail="Team member not found")
-    return member
+    )).scalars().first()
+    if member is not None:
+        return member
+
+    # team_member 없음(grant-only 휴먼) → org_member 신원으로 fallback
+    return await resolve_member(auth, org_id, db)
 
 
 def _pref_to_dict(p: NotificationPreference) -> dict:

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -16,7 +16,7 @@ from app.schemas.standup import (
     StandupSelfUpdate,
     StandupUpsert,
 )
-from app.services.member_resolver import resolve_member
+from app.services.member_resolver import resolve_auth_member
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
@@ -79,11 +79,15 @@ async def update_standup(
 ) -> StandupEntryResponse:
     """PUT /api/v2/standups — 본인 스탠드업 self-save (SID:6a1e8b1d).
 
-    author_id는 인증 유저(resolve_member)에서 server-side 도출 — 클라 바디 author_id를
+    author_id는 인증 유저(resolve_auth_member)에서 server-side 도출 — 클라 바디 author_id를
     받지 않아 타인 스탠드업 위조를 차단(본인만 수정). project_id는 바디 수용.
-    author_id는 canonical member.id 방향(JWT 휴먼 → org_member.id, AC3-3 정합).
+
+    author_id는 team_member 우선(있으면 team_member.id) → 없으면 org_member.id(grant-only).
+    스탠드업 카드(`/api/team-members` 기반)가 team_member.id로 매칭하므로, team_member가 있는
+    휴먼은 team_member.id로 저장해야 저장분이 카드에 표시된다(org_member.id-always는 카드와
+    어긋나 "미작성"으로 보이던 라이브 2차 버그 해소). grant-only는 org_member.id(카드 표시는 AC3-3).
     """
-    member = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    member = await resolve_auth_member(auth, org_id, session, project_id=body.project_id)
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -13,8 +13,10 @@ from app.schemas.standup import (
     FeedbackCreate,
     FeedbackResponse,
     StandupEntryResponse,
+    StandupSelfUpdate,
     StandupUpsert,
 )
+from app.services.member_resolver import resolve_member
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
@@ -70,15 +72,22 @@ async def upsert_standup(
 
 @router.put("", response_model=StandupEntryResponse)
 async def update_standup(
-    body: StandupUpsert,
+    body: StandupSelfUpdate,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
+    """PUT /api/v2/standups — 본인 스탠드업 self-save (SID:6a1e8b1d).
+
+    author_id는 인증 유저(resolve_member)에서 server-side 도출 — 클라 바디 author_id를
+    받지 않아 타인 스탠드업 위조를 차단(본인만 수정). project_id는 바디 수용.
+    author_id는 canonical member.id 방향(JWT 휴먼 → org_member.id, AC3-3 정합).
+    """
+    member = await resolve_member(auth, org_id, session, project_id=body.project_id)
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
-        author_id=body.author_id,
+        author_id=member.id,
         date=body.date,
         sprint_id=body.sprint_id,
         done=body.done,

--- a/backend/app/schemas/standup.py
+++ b/backend/app/schemas/standup.py
@@ -18,6 +18,21 @@ class StandupUpsert(BaseModel):
     plan_story_ids: list[uuid.UUID] = []
 
 
+class StandupSelfUpdate(BaseModel):
+    """self-save(PUT) 전용 — author_id는 서버가 인증 유저(resolve_member)에서 도출.
+
+    클라 바디 author_id를 받지 않아 타인 스탠드업 위조를 차단(SID:6a1e8b1d).
+    project_id는 바디 수용. (extra 필드는 pydantic 기본 무시 — 클라 author_id 전송돼도 무시됨)
+    """
+    project_id: uuid.UUID
+    date: date
+    sprint_id: uuid.UUID | None = None
+    done: str | None = None
+    plan: str | None = None
+    blockers: str | None = None
+    plan_story_ids: list[uuid.UUID] = []
+
+
 class StandupEntryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -152,6 +152,41 @@ async def lookup_members_by_ids(
     return result
 
 
+async def resolve_auth_member(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> "ResolvedMember | TeamMember":
+    """인증 주체의 멤버 신원 — team_member 우선, 없으면 org_member(grant-only).
+
+    resolve_member(JWT→org_member.id-always)와 달리 team_member가 있으면 그 id를 반환한다.
+    team_member.id로 매칭하는 표시 경로(스탠드업 카드 `/api/team-members`, 대화 참가자 등)와
+    write author/sender id를 일치시키기 위함 — org_member.id-always는 표시 경로와 어긋난다.
+
+    API키(에이전트): team_member.id. JWT 휴먼: team_member(project 스코프) 우선 → org_member.
+    conversations._resolve_member와 동형 — 공유 SSOT.
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+    if is_api_key:
+        tm = (await session.execute(
+            select(TeamMember).where(TeamMember.id == uuid.UUID(auth.user_id))
+        )).scalars().first()
+        if tm is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        return tm
+
+    filters = [TeamMember.user_id == uuid.UUID(auth.user_id), TeamMember.org_id == org_id]
+    if project_id is not None:
+        filters.append(TeamMember.project_id == project_id)
+    tm = (await session.execute(select(TeamMember).where(*filters))).scalars().first()
+    if tm is not None:
+        return tm
+
+    # team_member 없음(grant-only 휴먼) → org_member 경로 (has_project_access 검증 포함)
+    return await resolve_member(auth, org_id, session, project_id=project_id)
+
+
 async def resolve_member_identity(
     member_id: uuid.UUID,
     org_id: uuid.UUID,

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -29,6 +29,7 @@ class ResolvedMember:
     role: str
     org_id: uuid.UUID
     project_id: uuid.UUID | None = field(default=None)
+    avatar_url: str | None = field(default=None)
 
 
 async def resolve_member(
@@ -149,3 +150,81 @@ async def lookup_members_by_ids(
             )
 
     return result
+
+
+async def resolve_member_identity(
+    member_id: uuid.UUID,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> ResolvedMember | None:
+    """단일 member_id(team_member.id | org_member.id)를 org 범위에서 신원 해소.
+
+    TeamMember(에이전트 + 레거시 휴먼) 우선, 없으면 OrgMember(grant-only 휴먼) 조회.
+    org 미소속이면 None — 호출부가 404/403 처리. lookup_members_by_ids와 달리
+    orphan fallback이 없어 인가/존재 검증에 안전하게 쓸 수 있는.
+    """
+    tm = (await session.execute(
+        select(TeamMember).where(
+            TeamMember.id == member_id,
+            TeamMember.org_id == org_id,
+        )
+    )).scalars().first()
+    if tm is not None:
+        return ResolvedMember(
+            id=tm.id, user_id=tm.user_id, name=tm.name, type=tm.type,
+            role=tm.role, org_id=tm.org_id, project_id=tm.project_id,
+            avatar_url=tm.avatar_url,
+        )
+
+    om = (await session.execute(
+        select(OrgMember).where(
+            OrgMember.id == member_id,
+            OrgMember.org_id == org_id,
+            OrgMember.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if om is None:
+        return None
+
+    user = (await session.execute(
+        select(User).where(User.id == om.user_id)
+    )).scalar_one_or_none()
+    return ResolvedMember(
+        id=om.id, user_id=om.user_id,
+        name=user.email if user else str(om.id),
+        type="human", role=om.role, org_id=om.org_id,
+        project_id=None, avatar_url=None,
+    )
+
+
+async def filter_org_member_ids(
+    member_ids: set[uuid.UUID],
+    org_id: uuid.UUID,
+    session: AsyncSession,
+) -> set[uuid.UUID]:
+    """member_ids 중 org 소속(team_member 또는 org_member)인 것만 반환.
+
+    cross-org 차단용 — grant-only 휴먼(org_member)도 포함하므로 멘션/포크에서 누락되지 않는.
+    """
+    if not member_ids:
+        return set()
+
+    tm_ids = set((await session.execute(
+        select(TeamMember.id).where(
+            TeamMember.id.in_(member_ids),
+            TeamMember.org_id == org_id,
+        )
+    )).scalars().all())
+
+    remaining = member_ids - tm_ids
+    om_ids: set[uuid.UUID] = set()
+    if remaining:
+        om_ids = set((await session.execute(
+            select(OrgMember.id).where(
+                OrgMember.id.in_(remaining),
+                OrgMember.org_id == org_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )).scalars().all())
+
+    return tm_ids | om_ids

--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -87,7 +87,29 @@ async def dispatch_notification(
                 TeamMember.org_id == org_id,
             )
         )
-        members = members_result.all()
+        members = list(members_result.all())
+
+        # E-MEMBER-SSOT AC2-2: grant-only 휴먼(team_member 없음)은 org_member로 해소해
+        # in-app Notification 누락(silent drop) 방지. org_member는 project 스코프가 없으므로
+        # human Notification만 생성(Event는 project_id 필요 → skip). Notification은 user_id
+        # 기반이고 FK가 없어 org_member.id 사용에 제약 없음.
+        matched_ids = {m.id for m in members}
+        missing_ids = [mid for mid in enabled_member_ids if mid not in matched_ids]
+        if missing_ids:
+            from types import SimpleNamespace
+
+            from app.models.project import OrgMember
+            om_result = await db.execute(
+                select(OrgMember.id, OrgMember.user_id).where(
+                    OrgMember.id.in_(missing_ids),
+                    OrgMember.org_id == org_id,
+                    OrgMember.deleted_at.is_(None),
+                )
+            )
+            for om in om_result.all():
+                members.append(
+                    SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
+                )
 
         inserted = False
         for member_row in members:

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -356,3 +356,71 @@ async def test_send_message_403_non_participant():
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── QA B1 회귀: cross-org 멘션 저장·발송 필터 (DM fork 외 group 공통 경로) ─────
+
+@pytest.mark.anyio
+async def test_send_message_filters_cross_org_mentions_group():
+    """group 대화에서 cross-org 멘션이 저장·발송 양쪽에서 제거된다 (QA B1)."""
+    from app.models.conversation import ConversationMessage
+
+    client, session, app = await _make_client()
+    try:
+        valid_id = uuid.uuid4()
+        cross_org_id = uuid.uuid4()
+
+        mock_member = _make_member()
+        mock_conv = _make_conv(conv_type="group")
+
+        conv_result = MagicMock()
+        conv_result.scalar_one_or_none.return_value = mock_conv
+        member_result = MagicMock()
+        member_result.scalars.return_value.first.return_value = mock_member
+        participant_result = MagicMock()
+        participant_result.scalar_one_or_none.return_value = uuid.uuid4()
+
+        # 실제 코드 순서: conv → _resolve_member(TM) → participant
+        session.execute = AsyncMock(side_effect=[conv_result, member_result, participant_result])
+
+        captured = {}
+        def _capture_add(obj):
+            if isinstance(obj, ConversationMessage):
+                captured["mentioned_ids"] = list(obj.mentioned_ids or [])
+        session.add.side_effect = _capture_add
+
+        async def _refresh(obj):
+            obj.id = uuid.uuid4()
+            obj.conversation_id = CONV_ID
+            obj.sender_id = MEMBER_ID
+            obj.content = "안녕"
+            obj.created_at = datetime(2026, 5, 14, 12, 0, tzinfo=timezone.utc)
+        session.refresh.side_effect = _refresh
+
+        mention_calls = {}
+        async def _capture_mention(db, conversation, msg, org_id, sender, mention_targets):
+            mention_calls["targets"] = set(mention_targets)
+            return []
+
+        with patch("app.routers.conversations.filter_org_member_ids",
+                   new=AsyncMock(return_value={valid_id})), \
+             patch("app.routers.conversations._dispatch_conversation_event",
+                   new=AsyncMock(return_value=[])), \
+             patch("app.routers.conversations._dispatch_mention_events",
+                   side_effect=_capture_mention), \
+             patch("app.services.channel_router.route_message",
+                   new=AsyncMock(return_value=[])), \
+             patch("app.services.workflow_pipeline.process_event", new=AsyncMock()):
+            async with client as c:
+                resp = await c.post(
+                    f"/api/v2/conversations/{CONV_ID}/messages",
+                    json={"content": "안녕", "mentioned_ids": [str(valid_id), str(cross_org_id)]},
+                )
+
+        assert resp.status_code == 201
+        # 저장: cross-org 제거, org 소속만 + 순서 보존
+        assert captured["mentioned_ids"] == [valid_id]
+        # 멘션 이벤트 발송: cross-org 미포함, valid만
+        assert mention_calls.get("targets") == {valid_id}
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_e_org_multi_s2_1_switch_organization.py
+++ b/backend/tests/test_e_org_multi_s2_1_switch_organization.py
@@ -224,6 +224,59 @@ def test_switch_org_unconditionally_sets_org_id():
     assert 'app_metadata["org_id"] = str(body.org_id)' in source
 
 
+# ─── AC2-2 회귀: 접근 가능 project 없는 org 전환 → 500 금지 (8a5f260c) ─────────
+
+@pytest.mark.anyio
+async def test_switch_org_no_accessible_project_returns_200_null_project():
+    """first_accessible_project_id=None(접근 project 없음)이어도 undefined team_member
+    참조로 500나지 않고 200 + project_id null 반환 (8a5f260c switch500 회귀)."""
+    client, session, app = await _client()
+    try:
+        user = _mock_user()
+        org_member = _mock_org_member(ORG_B, USER_ID)
+
+        call_count = 0
+
+        def _execute_side_effect(stmt, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            result = MagicMock()
+            if call_count == 1:
+                result.scalar_one_or_none.return_value = user      # _get_user_by_id
+            elif call_count == 2:
+                result.scalar_one_or_none.return_value = org_member  # org 소속 확인
+            else:
+                # 이후 _build_app_metadata 등: project/team_member 미존재
+                result.scalar_one_or_none.return_value = None
+                result.scalars.return_value.all.return_value = []
+            return result
+
+        session.execute = AsyncMock(side_effect=_execute_side_effect)
+        session.commit = AsyncMock()
+        session.add = MagicMock()
+
+        with patch("app.routers.auth.create_tokens") as mock_create_tokens, \
+             patch("app.routers.auth.create_refresh_token") as mock_crt, \
+             patch("app.routers.auth._store_refresh_token") as mock_store, \
+             patch("app.routers.auth.first_accessible_project_id", new_callable=AsyncMock) as mock_fap:
+            mock_fap.return_value = None  # 접근 가능 project 없음
+            mock_create_tokens.return_value = {
+                "access_token": "new_at", "refresh_token": "new_rt",
+                "token_type": "bearer", "expires_in": 900,
+                "refresh_expires_at": "2026-06-20T00:00:00",
+            }
+            mock_crt.return_value = ("new_rt", datetime(2026, 6, 20, tzinfo=timezone.utc))
+            mock_store.return_value = None
+
+            async with client as c:
+                resp = await c.post("/api/v2/auth/switch-org", json={"org_id": str(ORG_B)})
+
+        assert resp.status_code == 200
+        assert resp.json()["data"]["project_id"] is None
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── Schema 검증 ─────────────────────────────────────────────────────────────
 
 def test_switch_organization_request_schema():

--- a/backend/tests/test_eventbus_s1.py
+++ b/backend/tests/test_eventbus_s1.py
@@ -130,8 +130,10 @@ async def test_create_event_stores_in_db(client, mock_session):
 
 @pytest.mark.anyio
 async def test_create_event_recipient_not_found_returns_404(client, mock_session):
+    # E-MEMBER-SSOT Phase 0: resolve_member_identity는 TeamMember → OrgMember 순 조회
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = None
+    member_result.scalars.return_value.first.return_value = None  # TeamMember 없음
+    member_result.scalar_one_or_none.return_value = None  # OrgMember 없음
     mock_session.execute.return_value = member_result
 
     payload = {
@@ -206,8 +208,18 @@ async def test_recipient_type_resolved_from_db(client, mock_session):
     recipient_id = uuid.uuid4()
     captured = {}
 
+    # E-MEMBER-SSOT Phase 0: recipient는 resolve_member_identity가 반환한 멤버의 type 사용
+    tm = MagicMock()
+    tm.id = recipient_id
+    tm.type = "human"
+    tm.user_id = uuid.uuid4()
+    tm.name = "휴먼"
+    tm.role = "member"
+    tm.org_id = uuid.uuid4()
+    tm.project_id = None
+    tm.avatar_url = None
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = "human"
+    member_result.scalars.return_value.first.return_value = tm
     mock_session.execute.return_value = member_result
 
     original_add = mock_session.add.side_effect
@@ -271,8 +283,18 @@ async def test_mark_delivered_cross_org_returns_404(client, mock_session):
 async def test_create_event_uses_verified_org(client, mock_session, org_id):
     """POST 시 body의 org_id가 아닌 verified org_id가 Event에 설정돼야 함."""
     captured = {}
+    # E-MEMBER-SSOT Phase 0: agent recipient → resolve_member_identity가 TeamMember 반환
+    tm = MagicMock()
+    tm.id = uuid.uuid4()
+    tm.type = "agent"
+    tm.user_id = None
+    tm.name = "agent"
+    tm.role = "member"
+    tm.org_id = org_id
+    tm.project_id = None
+    tm.avatar_url = None
     member_result = MagicMock()
-    member_result.scalar_one_or_none.return_value = "agent"
+    member_result.scalars.return_value.first.return_value = tm
     mock_session.execute.return_value = member_result
 
     def capture_add(obj):

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -67,7 +67,7 @@ def auth_ctx(org_id):
 
 @pytest.fixture
 async def client(mock_session, auth_ctx, org_id):
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -83,6 +83,8 @@ async def client(mock_session, auth_ctx, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -110,7 +112,7 @@ def test_agent_stream_registers_connection(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -133,6 +135,8 @@ def test_agent_stream_registers_connection(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     try:
         with patch("app.core.database.async_session_factory", _session_factory):
@@ -318,7 +322,7 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -337,6 +341,8 @@ def test_stream_delivers_pending_on_connect(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     @asynccontextmanager
     async def _session_factory():
@@ -413,7 +419,7 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     membership_result.scalar_one_or_none.return_value = None  # org 소속 아님
     mock_session.execute.return_value = membership_result
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -432,6 +438,8 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     from contextlib import asynccontextmanager
 

--- a/backend/tests/test_eventbus_s2.py
+++ b/backend/tests/test_eventbus_s2.py
@@ -415,8 +415,11 @@ async def test_stream_rejects_cross_org_member(mock_session, org_id):
     """다른 org의 member_id로 stream 연결 시 404 반환."""
     foreign_member_id = uuid.uuid4()
 
+    # E-MEMBER-SSOT Phase 0: resolve_member_identity는 TeamMember(.scalars().first())
+    # → OrgMember(.scalar_one_or_none()) 순으로 조회 — 둘 다 미소속이어야 404
     membership_result = MagicMock()
-    membership_result.scalar_one_or_none.return_value = None  # org 소속 아님
+    membership_result.scalars.return_value.first.return_value = None  # TeamMember 미소속
+    membership_result.scalar_one_or_none.return_value = None  # OrgMember 미소속
     mock_session.execute.return_value = membership_result
 
     from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming

--- a/backend/tests/test_eventbus_s3.py
+++ b/backend/tests/test_eventbus_s3.py
@@ -67,7 +67,7 @@ def auth_ctx(org_id):
 
 @pytest.fixture
 async def client(mock_session, auth_ctx, org_id):
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -83,6 +83,8 @@ async def client(mock_session, auth_ctx, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c
     app.dependency_overrides.clear()
@@ -233,7 +235,7 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
 
     mock_session.execute.side_effect = [membership_result, pending_result]
 
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -252,6 +254,8 @@ def test_stream_batch_delivers_over_100_events(mock_session, org_id):
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     @asynccontextmanager
     async def _session_factory():

--- a/backend/tests/test_member_ssot_ac2_2.py
+++ b/backend/tests/test_member_ssot_ac2_2.py
@@ -1,0 +1,184 @@
+"""E-MEMBER-SSOT AC2-2: 인가전환·B하드닝 회귀 테스트.
+
+get_project_scoped_org_id / dispatch_entity / notification_preferences 가
+TeamMember-존재 대신 has_project_access / resolve_member_identity 기반으로
+전환돼 grant-only 휴먼(org_member)을 수용하는지 검증.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from app.services.member_resolver import ResolvedMember
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── B2: notification_preferences.member_id team_members FK 제거 ───────────────
+
+def test_notification_preferences_member_id_has_no_team_members_fk():
+    """B2 회귀: member_id의 team_members FK가 제거돼 grant-only 휴먼(org_member.id)
+    upsert 시 FK violation 500이 나지 않음 (migration 0073)."""
+    from app.models.notification_preference import NotificationPreference
+
+    member_col = NotificationPreference.__table__.c.member_id
+    referred_tables = {fk.column.table.name for fk in member_col.foreign_keys}
+    assert "team_members" not in referred_tables
+
+
+# ── get_project_scoped_org_id: has_project_access 위임 (740e3b7e) ─────────────
+
+@pytest.mark.anyio
+async def test_get_project_scoped_grant_only_allows():
+    """grant-only 휴먼(team_member 없음, has_project_access=True)도 project org 접근 허용."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(project_org)}}
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+        result = await get_project_scoped_org_id(
+            project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+        )
+    assert result == project_org
+
+
+@pytest.mark.anyio
+async def test_get_project_scoped_no_access_403():
+    """team_member·grant·owner/admin 어디에도 없으면 403."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(project_org)}}
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as exc:
+            await get_project_scoped_org_id(
+                project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+            )
+    assert exc.value.status_code == 403
+
+
+# ── dispatch_entity: assignee resolve_member_identity (7f8066a3) ──────────────
+
+async def _dispatch_client(mock_session, org_id):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_dispatch_grant_only_human_assignee_dispatched():
+    """grant-only 휴먼 assignee(team_member 없음)도 dispatched=True (7f8066a3 오탐 해소)."""
+    org_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    # sender 조회 2건(TeamMember, OrgMember) 모두 None
+    sender_result = MagicMock()
+    sender_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=sender_result)
+
+    async def _refresh(obj):
+        pass
+    session.refresh.side_effect = _refresh
+
+    client, app = await _dispatch_client(session, org_id)
+    try:
+        assignee_member = ResolvedMember(
+            id=assignee_id, user_id=uuid.uuid4(), name="grant휴먼",
+            type="human", role="member", org_id=org_id,
+        )
+        with patch("app.routers.dispatch._fetch_entity",
+                   new=AsyncMock(return_value=(assignee_id, "에픽 제목", "설명", project_id))), \
+             patch("app.routers.dispatch.resolve_member_identity",
+                   new=AsyncMock(return_value=assignee_member)), \
+             patch("app.routers.dispatch.dispatch_notification", new=AsyncMock()):
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json={
+                    "entity_type": "epic",
+                    "entity_id": str(uuid.uuid4()),
+                    "project_id": str(project_id),
+                })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatched"] is True
+        assert data["assignee_type"] == "human"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dispatch_assignee_not_in_org_not_dispatched():
+    """assignee가 org 어디에도 없으면(resolve None) dispatched=False."""
+    org_id = uuid.uuid4()
+    assignee_id = uuid.uuid4()
+    project_id = uuid.uuid4()
+
+    session = AsyncMock()
+    session.add = MagicMock()
+    session.execute = AsyncMock()
+
+    client, app = await _dispatch_client(session, org_id)
+    try:
+        with patch("app.routers.dispatch._fetch_entity",
+                   new=AsyncMock(return_value=(assignee_id, "제목", "설명", project_id))), \
+             patch("app.routers.dispatch.resolve_member_identity",
+                   new=AsyncMock(return_value=None)):
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json={
+                    "entity_type": "epic",
+                    "entity_id": str(uuid.uuid4()),
+                    "project_id": str(project_id),
+                })
+        assert resp.status_code == 200
+        assert resp.json()["dispatched"] is False
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -403,3 +403,62 @@ async def test_filter_org_member_ids_empty_short_circuits():
     out = await filter_org_member_ids(set(), ORG_ID, session)
     assert out == set()
     session.execute.assert_not_awaited()
+
+
+# ── 2차 버그 가드: resolve_auth_member team_member-first (스탠드업 카드 매칭) ────
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_prefers_team_member():
+    """JWT 휴먼에 team_member 있으면 team_member.id 반환(카드 매칭) — org_member 조회 안 함."""
+    from app.services.member_resolver import resolve_auth_member
+
+    auth = _make_auth()  # JWT
+    tm = _make_team_member(ttype="human")
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_auth_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert resolved is tm  # team_member.id 그대로 (org_member.id-always 아님)
+    assert session.execute.await_count == 1  # team_member 매칭 시 org_member 조회 스킵
+
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_falls_back_to_org_member():
+    """team_member 없으면(grant-only) resolve_member(org_member.id)로 fallback."""
+    from app.services import member_resolver as mr
+    from app.services.member_resolver import ResolvedMember, resolve_auth_member
+
+    auth = _make_auth()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None  # team_member 없음
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    om_member = ResolvedMember(
+        id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID
+    )
+    with patch.object(mr, "resolve_member", new=AsyncMock(return_value=om_member)) as mock_rm:
+        resolved = await resolve_auth_member(auth, ORG_ID, session, project_id=PROJECT_ID)
+    assert resolved.id == ORG_MEMBER_ID
+    mock_rm.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_resolve_auth_member_api_key_returns_team_member():
+    """API키(에이전트)는 team_member.id 반환."""
+    from app.services.member_resolver import resolve_auth_member
+
+    auth = _make_auth(is_api_key=True)
+    tm = _make_team_member()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_auth_member(auth, ORG_ID, session)
+    assert resolved is tm

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -279,3 +279,127 @@ async def test_policy_no_creator_in_human_conversation_403():
     with pytest.raises(HTTPException) as exc_info:
         await _enforce_agent_creator_policy(sender, [agent_id], session)
     assert exc_info.value.status_code == 403
+
+
+# ── QA B1 보강: resolve_member_identity 2단 조회 + org 필터 독립 검증 ──────────
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_prefers_team_member():
+    """TM 존재 시 OrgMember 조회 없이 TM 반환 (TM 우선, 단 1회 execute)."""
+    from app.services.member_resolver import resolve_member_identity
+
+    tm = _make_team_member(ttype="agent")
+    tm.avatar_url = "http://a/x.png"
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = tm
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    resolved = await resolve_member_identity(AGENT_TM_ID, ORG_ID, session)
+    assert resolved is not None
+    assert resolved.id == AGENT_TM_ID
+    assert resolved.type == "agent"
+    assert resolved.avatar_url == "http://a/x.png"
+    # TM 매칭 시 OrgMember 조회를 하지 않음 — 1회 execute
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_falls_back_to_org_member():
+    """TM 없으면 OrgMember로 fallback — TM→OM→User 3단 독립 조회."""
+    from app.services.member_resolver import resolve_member_identity
+
+    om = _make_org_member()
+    user = MagicMock(); user.email = "human@test.com"; user.id = USER_ID
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None  # TeamMember 미존재
+    om_result = MagicMock()
+    om_result.scalar_one_or_none.return_value = om            # OrgMember 존재
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result, user_result])
+
+    resolved = await resolve_member_identity(ORG_MEMBER_ID, ORG_ID, session)
+    assert resolved is not None
+    assert resolved.id == ORG_MEMBER_ID
+    assert resolved.type == "human"
+    assert resolved.user_id == USER_ID
+    assert resolved.name == "human@test.com"
+    # 2단(+User) 조회 확정
+    assert session.execute.await_count == 3
+
+
+@pytest.mark.anyio
+async def test_resolve_member_identity_none_when_not_in_org():
+    """TM·OM 둘 다 없으면 None — orphan fallback 없음(404 유도)."""
+    from app.services.member_resolver import resolve_member_identity
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.first.return_value = None
+    om_result = MagicMock()
+    om_result.scalar_one_or_none.return_value = None
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result])
+
+    resolved = await resolve_member_identity(uuid.uuid4(), ORG_ID, session)
+    assert resolved is None
+    assert session.execute.await_count == 2
+
+
+# ── QA B1 보강: filter_org_member_ids 2단 조회 + cross-org 차단 검증 ───────────
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_keeps_tm_and_om_drops_foreign():
+    """TM∪OM 소속만 통과, cross-org/orphan은 제거 — 2단 독립 조회."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    tm_id, om_id, foreign_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.all.return_value = [tm_id]   # TeamMember 소속
+    om_result = MagicMock()
+    om_result.scalars.return_value.all.return_value = [om_id]   # OrgMember 소속
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result, om_result])
+
+    out = await filter_org_member_ids({tm_id, om_id, foreign_id}, ORG_ID, session)
+    assert out == {tm_id, om_id}
+    assert foreign_id not in out
+    # TeamMember 후 잔여(om_id, foreign_id)에 대해 OrgMember 2단 조회
+    assert session.execute.await_count == 2
+
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_skips_om_query_when_all_team_members():
+    """전부 TeamMember면 OrgMember 조회 스킵 — 1회 execute."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    a, b = uuid.uuid4(), uuid.uuid4()
+    tm_result = MagicMock()
+    tm_result.scalars.return_value.all.return_value = [a, b]
+
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[tm_result])
+
+    out = await filter_org_member_ids({a, b}, ORG_ID, session)
+    assert out == {a, b}
+    assert session.execute.await_count == 1
+
+
+@pytest.mark.anyio
+async def test_filter_org_member_ids_empty_short_circuits():
+    """빈 입력은 쿼리 없이 빈 집합."""
+    from app.services.member_resolver import filter_org_member_ids
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+
+    out = await filter_org_member_ids(set(), ORG_ID, session)
+    assert out == set()
+    session.execute.assert_not_awaited()

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -150,6 +150,45 @@ async def test_enabled_setting_creates_notification(mock_session, org_id):
     assert added.is_read is False
 
 
+# ─── AC2-2: grant-only 휴먼(org_member)도 Notification 수신 (silent drop 방지) ──
+
+@pytest.mark.anyio
+async def test_grant_only_human_gets_notification(mock_session, org_id):
+    """team_member 없는 grant-only 휴먼(org_member만)도 in-app Notification 생성."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    om_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    settings = _settings_result([])            # 설정 없음 → 기본 enabled
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    tm_result = _members_result([])            # team_member 없음
+    om_row = MagicMock()
+    om_row.id = om_id
+    om_row.user_id = user_id
+    om_result = MagicMock()
+    om_result.all.return_value = [om_row]      # org_member fallback
+    mock_session.execute.side_effect = [settings, wh_result, tm_result, om_result]
+
+    await dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="dispatched",
+        target_member_ids=[om_id],
+        title="그랜트 알림",
+        body="내용",
+        reference_type="epic",
+        reference_id=uuid.uuid4(),
+    )
+
+    # org_member.user_id 기반 Notification 생성 (silent drop 아님)
+    mock_session.add.assert_called_once()
+    added = mock_session.add.call_args[0][0]
+    assert added.user_id == user_id
+    assert added.title == "그랜트 알림"
+
+
 # ─── 빈 target → 즉시 반환 ────────────────────────────────────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_s20.py
+++ b/backend/tests/test_s20.py
@@ -64,7 +64,7 @@ def test_heartbeat_disconnect_check_clears_connection():
     """heartbeat timeout 후 is_disconnected=True → queue가 _agent_connections에서 제거됨."""
     from starlette.testclient import TestClient
     import threading
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
 
@@ -94,6 +94,8 @@ def test_heartbeat_disconnect_check_clears_connection():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     try:
         with patch("app.core.database.async_session_factory", _factory):
@@ -127,7 +129,7 @@ def test_heartbeat_disconnect_check_clears_connection():
 @pytest.mark.anyio
 async def test_sse_connection_limit_returns_503():
     """MAX_SSE_CONNECTIONS 초과 연결 시 503 반환."""
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
     import app.routers.events as ev_module
@@ -157,6 +159,8 @@ async def test_sse_connection_limit_returns_503():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     original_count = ev_module._sse_connection_count
     original_max = ev_module._MAX_SSE_CONNECTIONS
@@ -181,7 +185,7 @@ def test_connection_count_increments_and_decrements():
     from starlette.testclient import TestClient
     import threading
     import time
-    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.auth import get_current_user, get_verified_org_id, get_current_user_streaming, get_verified_org_id_streaming
     from app.dependencies.database import get_db
     from app.main import app
     import app.routers.events as ev_module
@@ -211,6 +215,8 @@ def test_connection_count_increments_and_decrements():
     app.dependency_overrides[get_db] = _db
     app.dependency_overrides[get_current_user] = _auth
     app.dependency_overrides[get_verified_org_id] = _org
+    app.dependency_overrides[get_current_user_streaming] = _auth
+    app.dependency_overrides[get_verified_org_id_streaming] = _org
 
     count_before = ev_module._sse_connection_count
     try:

--- a/backend/tests/test_sse_conn_leak.py
+++ b/backend/tests/test_sse_conn_leak.py
@@ -1,0 +1,107 @@
+"""P0 dev DB connection leak (#abaf6279) 회귀 가드.
+
+근본 원인: get_current_user/get_verified_org_id가 Depends(get_db)로 요청 수명 동안
+세션을 점유 → SSE long-lived yield 구간에 API key 해석 team_members 쿼리 커넥션이
+idle-in-transaction 잔존 → max_connections 포화.
+
+수정: SSE 전용 비점유 변형(get_current_user_streaming / get_verified_org_id_streaming)이
+자체 단명 세션을 써서 즉시 닫음.
+
+추가: 1c22da3e — 백필/라이브 delivered 선마킹 → 후마킹 (yield 실패 시 영구 누락 방지).
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ─── CP1: SSE 핸들러가 비점유 streaming auth dep을 사용 ────────────────────────
+
+def test_agent_event_stream_uses_streaming_auth_deps():
+    """events.agent_event_stream이 get_db 점유형 dep을 쓰지 않고 streaming 변형을 쓴다."""
+    from app.routers import events
+    sig = inspect.signature(events.agent_event_stream)
+    src = inspect.getsource(events.agent_event_stream)
+    # streaming 변형 사용 + 점유형 dep 미사용
+    assert "get_current_user_streaming" in src, "SSE는 비점유 auth(get_current_user_streaming) 사용 필수"
+    assert "get_verified_org_id_streaming" in src, "SSE는 비점유 org dep(get_verified_org_id_streaming) 사용 필수"
+    # 직접 get_db 주입 금지
+    assert "Depends(get_db)" not in src, "SSE 핸들러는 get_db를 요청 수명 동안 점유하면 안 됨"
+
+
+# ─── CP1: streaming auth dep이 get_db를 파라미터로 받지 않음 (비점유 보장) ──────
+
+def test_streaming_auth_deps_do_not_depend_on_get_db():
+    """get_current_user_streaming / get_verified_org_id_streaming 시그니처에 get_db 없음."""
+    from app.dependencies import auth
+    for fn_name in ("get_current_user_streaming", "get_verified_org_id_streaming"):
+        fn = getattr(auth, fn_name)
+        params = inspect.signature(fn).parameters
+        for p in params.values():
+            default = p.default
+            # Depends(get_db) 가 기본값으로 들어있으면 안 됨
+            dep_str = repr(default)
+            assert "get_db" not in dep_str, f"{fn_name}.{p.name} 가 get_db를 점유하면 안 됨"
+        # 본문은 자체 단명 세션(async with async_session_factory) 사용
+        src = inspect.getsource(fn)
+        assert "async_session_factory()" in src, f"{fn_name}은 자체 단명 세션을 써야 함"
+
+
+# ─── CP1: API key 경로에서 세션이 즉시 close 되는지 (점유 0) ───────────────────
+
+@pytest.mark.anyio
+async def test_streaming_auth_api_key_closes_session():
+    """get_current_user_streaming API key 경로 — _resolve_api_key 후 세션 context 종료."""
+    from app.dependencies import auth
+
+    closed = {"v": False}
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return AsyncMock()
+        async def __aexit__(self, *a):
+            closed["v"] = True
+            return False
+
+    fake_ctx = MagicMock()
+    with patch.object(auth, "async_session_factory", return_value=_FakeSession()), \
+         patch.object(auth, "_resolve_api_key", new=AsyncMock(return_value=fake_ctx)) as mock_resolve:
+        result = await auth.get_current_user_streaming(
+            credentials=None, x_agent_api_key="sk_live_abc",
+        )
+    assert result is fake_ctx
+    mock_resolve.assert_awaited_once()
+    assert closed["v"] is True, "API key 해석 후 세션이 즉시 close 되어야 함 (점유 0)"
+
+
+# ─── CP3 (1c22da3e): 백필/라이브 delivered 후마킹 순서 ─────────────────────────
+
+def test_backfill_marks_delivered_after_yield():
+    """백필: yield 후 delivered 마킹 (선마킹 시 yield 실패→영구 누락)."""
+    from app.routers import events
+    src = inspect.getsource(events.agent_event_stream)
+    # yield 라인이 'status = "delivered"' 보다 먼저 와야 함 (후마킹)
+    yield_idx = src.find('is_backfill\': True')
+    mark_idx = src.find('evt.status = "delivered"')
+    assert yield_idx != -1 and mark_idx != -1
+    assert yield_idx < mark_idx, "백필 delivered 마킹은 yield 이후여야 함 (1c22da3e)"
+
+
+def test_live_marks_delivered_after_yield():
+    """라이브: yield 후 delivered 마킹 (선마킹 시 yield 실패→영구 누락)."""
+    from app.routers import events
+    src = inspect.getsource(events.agent_event_stream)
+    # 라이브 yield(_live_id 사용) 가 update(Event)...delivered 마킹보다 먼저
+    yield_idx = src.find('id: {_live_id}')
+    # 라이브 후마킹 블록 (update + values status delivered)
+    mark_idx = src.find('.values(status="delivered"')
+    assert yield_idx != -1 and mark_idx != -1
+    assert yield_idx < mark_idx, "라이브 delivered 마킹은 yield 이후여야 함 (1c22da3e)"

--- a/backend/tests/test_sse_conn_leak.py
+++ b/backend/tests/test_sse_conn_leak.py
@@ -37,6 +37,18 @@ def test_agent_event_stream_uses_streaming_auth_deps():
     assert "Depends(get_db)" not in src, "SSE 핸들러는 get_db를 요청 수명 동안 점유하면 안 됨"
 
 
+def test_agent_gateway_stream_uses_streaming_auth_dep():
+    """agent_gateway.agent_stream(SSE)도 비점유 streaming auth 사용 (#abaf6279 후속).
+
+    잔존 leak: agent_stream이 get_current_user(get_db 점유)를 쓰면 API key 해석
+    team_members 쿼리 커넥션이 SSE 수명 내내 idle-in-transaction 잔존.
+    """
+    from app.routers import agent_gateway
+    src = inspect.getsource(agent_gateway.agent_stream)
+    assert "get_current_user_streaming" in src, "agent SSE 스트림은 비점유 auth 사용 필수"
+    assert "Depends(get_current_user)" not in src, "agent SSE 스트림은 점유형 get_current_user 금지"
+
+
 # ─── CP1: streaming auth dep이 get_db를 파라미터로 받지 않음 (비점유 보장) ──────
 
 def test_streaming_auth_deps_do_not_depend_on_get_db():

--- a/backend/tests/test_standups.py
+++ b/backend/tests/test_standups.py
@@ -219,3 +219,87 @@ async def test_add_feedback_invalid_type_400():
         assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── B3 회귀: standup team_members FK 완화 (migration 0074) ───────────────────
+
+def test_standup_entries_author_id_has_no_team_members_fk():
+    """B3: author_id의 team_members FK 제거 — resolve_member가 반환한 org_member.id
+    upsert 시 실DB FK violation 500이 나지 않음 (migration 0074)."""
+    from app.models.standup import StandupEntry
+
+    col = StandupEntry.__table__.c.author_id
+    referred = {fk.column.table.name for fk in col.foreign_keys}
+    assert "team_members" not in referred
+
+
+def test_standup_feedback_feedback_by_id_has_no_team_members_fk():
+    """feedback_by_id도 동일 anchor 방향 — team_members FK 선제 완화 (migration 0074)."""
+    from app.models.standup import StandupFeedback
+
+    col = StandupFeedback.__table__.c.feedback_by_id
+    referred = {fk.column.table.name for fk in col.foreign_keys}
+    assert "team_members" not in referred
+
+
+# ─── SID:6a1e8b1d 회귀: self-save PUT — author_id server 도출 + 위조 차단 ──────
+
+@pytest.mark.anyio
+async def test_update_standup_self_save_no_author_id_200():
+    """PUT self-save: author_id 없는 바디(date/done/...)도 422 아닌 200 — author_id는
+    resolve_member로 server 도출."""
+    client, session, app = await _client()
+    try:
+        derived_member_id = uuid.uuid4()
+        member = MagicMock()
+        member.id = derived_member_id
+        entry = _mock_entry()
+        entry.author_id = derived_member_id
+
+        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+             patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+            mock_upsert.return_value = entry
+            async with client as c:
+                resp = await c.put("/api/v2/standups", json={
+                    "project_id": str(PROJECT_ID),
+                    "date": str(TODAY),
+                    "done": "오늘 한 일",
+                    "plan": "내일 할 일",
+                    "sprint_id": None,
+                    "plan_story_ids": [],
+                    # author_id 미전송 — 그래도 200
+                })
+        assert resp.status_code == 200
+        # author_id는 resolve_member 도출값으로 upsert
+        assert mock_upsert.call_args.kwargs["author_id"] == derived_member_id
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_standup_ignores_client_author_id():
+    """PUT self-save: 클라가 author_id 위조 전송해도 무시하고 server 도출값 사용(위조 차단)."""
+    client, session, app = await _client()
+    try:
+        derived = uuid.uuid4()
+        forged = uuid.uuid4()
+        member = MagicMock()
+        member.id = derived
+        entry = _mock_entry()
+        entry.author_id = derived
+
+        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+             patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
+            mock_upsert.return_value = entry
+            async with client as c:
+                resp = await c.put("/api/v2/standups", json={
+                    "project_id": str(PROJECT_ID),
+                    "date": str(TODAY),
+                    "author_id": str(forged),  # 위조 시도 — 무시돼야
+                    "done": "x",
+                })
+        assert resp.status_code == 200
+        assert mock_upsert.call_args.kwargs["author_id"] == derived
+        assert mock_upsert.call_args.kwargs["author_id"] != forged
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_standups.py
+++ b/backend/tests/test_standups.py
@@ -256,7 +256,7 @@ async def test_update_standup_self_save_no_author_id_200():
         entry = _mock_entry()
         entry.author_id = derived_member_id
 
-        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:
@@ -288,7 +288,7 @@ async def test_update_standup_ignores_client_author_id():
         entry = _mock_entry()
         entry.author_id = derived
 
-        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:

--- a/connectors/codex-sprintable/.gitignore
+++ b/connectors/codex-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/codex-sprintable/README.md
+++ b/connectors/codex-sprintable/README.md
@@ -1,0 +1,64 @@
+# Sprintable Adapter for Codex
+
+Codex용 Sprintable Gateway dial-out 어댑터 (카테고리 B — stdio JSON-RPC 호스트).
+
+A 카테고리(in-process)와 달리, **자식 프로세스(`codex app-server`)를 spawn/own**하고
+stdio JSON-RPC로 turn을 주입한다. gemini/pi/grok 어댑터가 이 패턴을 따른다.
+
+## 요구사항
+
+- **codex CLI 설치 필수** (`codex app-server` 사용). codex-cli ≥ 0.124.0 권장.
+  ```bash
+  brew install codex   # 또는 공식 설치 경로
+  codex --version
+  ```
+- Python 3.10+ (asyncio subprocess)
+- `httpx` (공통 SDK 의존)
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+# export CODEX_BIN=/path/to/codex           # codex 바이너리 경로 (기본: PATH의 codex)
+
+# 3. 호스트 실행
+python connectors/codex-sprintable/host.py
+```
+
+## 동작 원리
+
+```
+host.py 시작
+  → CodexAppServer.start(): codex app-server spawn + initialize/initialized 핸드셰이크
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → codex.run_turn(ctx.content):
+      → thread/start (최초 1회, thread_id 캐시)
+      → turn/start({threadId, input:[{type:"text", text}]})
+      → item/completed(agentMessage) 텍스트 수집
+      → turn/completed 에서 응답 확정
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## 프로세스 관리 (카테고리 B 핵심)
+
+- `CodexAppServer`가 자식 프로세스를 spawn/own
+- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
+- `host.py` 종료(KeyboardInterrupt/SSE 종료) 시 `finally: codex.stop()` 보장
+- reader_task는 stop 시 cancel
+
+## 실측 프로토콜
+
+`codex app-server generate-ts`로 추출한 실측 JSON-RPC (codex-cli 0.124.0):
+- `initialize` → `initialized` (notification)
+- `thread/start` → `{thread: {id}}`
+- `turn/start({threadId, input: [UserInput]})` — `UserInput = {type:"text", text, text_elements}`
+- `ServerNotification`: `item/completed {item:{type:"agentMessage", text}}`, `turn/completed`
+
+stdio 안정 경로 사용 (실험적 WS 미사용).

--- a/connectors/codex-sprintable/host.py
+++ b/connectors/codex-sprintable/host.py
@@ -1,0 +1,220 @@
+"""Sprintable Gateway adapter host for Codex — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 첫 어댑터 — stdio JSON-RPC 자식 프로세스 호스트 패턴 확립.
+gemini/pi/grok이 이 패턴을 동형으로 따라간다.
+
+구조:
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff
+  - codex app-server (JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 thread/start(최초) + turn/start로 turn 주입
+  - item/completed(agentMessage) 스트림 수집 → turn/completed에서 응답 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 프로토콜 (codex app-server generate-ts, codex-cli 0.124.0):
+  initialize → initialized(notify) → thread/start → turn/start
+  ServerNotification: item/completed {item:{type:"agentMessage",text}}, turn/completed
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("codex-sprintable")
+
+CODEX_BIN = os.getenv("CODEX_BIN", "codex")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+
+
+class CodexAppServer:
+    """codex app-server JSON-RPC/stdio 자식 프로세스 호스트.
+
+    한 번 spawn해서 lifetime 동안 own. AbortSignal/shutdown 시 SIGTERM.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: turn 진행 중 agentMessage 텍스트 누적
+        self._turn_messages: list[str] = []
+        self._turn_done: asyncio.Event | None = None
+        self._reader_task: asyncio.Task | None = None
+        self._thread_id: str | None = None
+
+    async def start(self) -> None:
+        """codex app-server spawn + initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            CODEX_BIN, "app-server",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # initialize 핸드셰이크
+        await self._request("initialize", {
+            "clientInfo": {
+                "name": "sprintable-codex-adapter",
+                "title": "Sprintable Gateway",
+                "version": "0.1.0",
+            },
+            "capabilities": None,
+        })
+        await self._notify("initialized", None)
+        logger.info("codex app-server initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ServerNotification 처리 — turn 응답 수집."""
+        if method == "item/completed":
+            item = params.get("item") or {}
+            if item.get("type") == "agentMessage":
+                text = item.get("text", "")
+                if text:
+                    self._turn_messages.append(text)
+        elif method == "turn/completed":
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+        elif method == "error":
+            logger.warning("codex error notification: %s", params)
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def _notify(self, method: str, params: dict | None) -> None:
+        """JSON-RPC notification 송신 (response 없음)."""
+        assert self._proc and self._proc.stdin
+        payload = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+
+    async def ensure_thread(self) -> str:
+        """thread/start (최초 1회) → thread_id 캐시."""
+        if self._thread_id:
+            return self._thread_id
+        result = await self._request("thread/start", {
+            "experimentalRawEvents": False,
+            "persistExtendedHistory": False,
+        })
+        thread = result.get("thread") or {}
+        self._thread_id = thread.get("id")
+        if not self._thread_id:
+            raise RuntimeError(f"thread/start returned no id: {result}")
+        logger.info("codex thread started: %s", self._thread_id)
+        return self._thread_id
+
+    async def run_turn(self, text: str) -> str:
+        """turn/start로 주입 → turn/completed까지 agentMessage 수집 → 응답 반환."""
+        thread_id = await self.ensure_thread()
+        self._turn_messages = []
+        self._turn_done = asyncio.Event()
+
+        await self._request("turn/start", {
+            "threadId": thread_id,
+            "input": [{"type": "text", "text": text, "text_elements": []}],
+        })
+        # turn/completed 대기 (응답 스트림 수집 완료)
+        await self._turn_done.wait()
+        return "\n".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill)."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[codex-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    codex = CodexAppServer()
+    await codex.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await codex.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await codex.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/cursor-sprintable/.gitignore
+++ b/connectors/cursor-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/cursor-sprintable/README.md
+++ b/connectors/cursor-sprintable/README.md
@@ -1,0 +1,71 @@
+# Sprintable Adapter for Cursor (Cloud Agents)
+
+Cursor용 Sprintable Gateway dial-out 어댑터 (**마지막·유일 카테고리 C** — HTTP sidecar).
+
+**B(stdio 자식 프로세스)와 다름:** 자식 프로세스 없음. Cursor **Cloud Agents API** HTTP 호출.
+B의 프로세스 lifetime 대신 **run 상태 관리**가 핵심.
+
+## ⚠️ 클라우드 에이전트 한정
+
+**로컬 Cursor 에디터 세션은 외부 주입 경로가 없는.**
+이 어댑터는 Cursor **Cloud(Background) Agents API**로만 동작 — GitHub 레포에서 작업하는 클라우드 에이전트.
+로컬 에디터에 메시지를 주입하지 않는.
+
+## 요구사항
+
+- **Cursor 클라우드 API 키** (`CURSOR_API_KEY`) — Cursor 대시보드에서 발급
+- Cursor 클라우드 에이전트는 **GitHub 레포 기반** — `CURSOR_REPO_URL`로 작업 레포 지정 (권장)
+- Python 3.10+ + `httpx`
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+export CURSOR_API_KEY=...                    # Cursor 클라우드 API 키 (필수)
+export CURSOR_REPO_URL=https://github.com/org/repo  # 작업 레포 (권장)
+# export CURSOR_API_BASE=https://api.cursor.com      # (기본값)
+
+# 3. 사이드카 실행
+python connectors/cursor-sprintable/sidecar.py
+```
+
+## 동작 원리
+
+```
+sidecar.py 시작
+  → CursorCloudClient.start() (httpx, 자식 프로세스 없음)
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → cursor.run_turn(conversation_id, content):
+      → 첫 메시지: POST /v1/agents {prompt:{text}, repos?} → {agent.id, run.id}
+      → 이후:      POST /v1/agents/{id}/runs {prompt:{text}} → {run.id}  (409시 완료 대기 후 재시도)
+      → GET /v1/agents/{id}/runs/{runId}/stream (Cursor SSE) → assistant/result 텍스트
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## run 상태 관리 (카테고리 C 핵심)
+
+B의 프로세스 lifetime 대신:
+- **conversation_id → cursor agent_id 매핑** — stateful 에이전트 유지 (멀티턴 컨텍스트)
+- **1-active-run 가드**: run당 1개만 active (409 `agent_busy`)
+  - SDK가 `onMessage`를 순차 await → 한 turn의 stream 완료 전 다음 SSE 이벤트 미처리 = 자연 직렬화
+  - 추가로 followup 409 시 `_wait_idle`(active run terminal 폴링) 후 재시도
+- run status: `CREATING`/`RUNNING`(active) → `FINISHED`/`ERROR`/`CANCELLED`/`EXPIRED`(terminal)
+
+## 실측 API (docs.cursor.com/cloud-agent, api.cursor.com, /v1)
+
+| 용도 | 메서드 | 경로 |
+|------|--------|------|
+| Launch (첫 turn) | POST | `/v1/agents` `{prompt:{text}, repos?}` → `{agent:{id}, run:{id}}` |
+| Follow-up (이후 turn) | POST | `/v1/agents/{id}/runs` `{prompt:{text}}` → `{run:{id,status}}` |
+| 응답 스트림 | GET | `/v1/agents/{id}/runs/{runId}/stream` → SSE `assistant{text}`, `result{text}`, `done` |
+| run 상태 | GET | `/v1/agents/{id}/runs` |
+
+- 인증: `Authorization: Bearer ${CURSOR_API_KEY}`
+- 409 `agent_busy`: run당 1개만 active — 본 어댑터가 완료 대기 후 재시도로 처리

--- a/connectors/cursor-sprintable/sidecar.py
+++ b/connectors/cursor-sprintable/sidecar.py
@@ -1,0 +1,229 @@
+"""Sprintable Gateway adapter sidecar for Cursor — E-INJECT-ADAPTERS (카테고리 C).
+
+마지막·유일 카테고리 C — **자식 프로세스 없음**. Cursor Cloud Agents API HTTP 호출.
+B(stdio 자식 프로세스 lifetime)와 달리 **run 상태 관리**가 핵심.
+
+구조:
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff (A/B 동일)
+  - 주입 = HTTP POST (spawn 없음):
+    - conversation 첫 메시지 → POST /v1/agents (launch) → {agent.id, run.id}
+    - 이후 메시지 → POST /v1/agents/{id}/runs (followup) → {run.id}
+  - 응답 = GET /v1/agents/{id}/runs/{runId}/stream (Cursor SSE) 수집 → assistant/result 텍스트
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+**1-active-run 가드 (C 핵심):** run당 1개만 active(409 agent_busy).
+  SDK가 onMessage를 순차 await하므로 한 turn의 stream 완료 전 다음 SSE 이벤트 미처리 →
+  자연 직렬화. 추가로 launch/followup 409 시 완료 폴링 후 재시도.
+
+⚠️ 로컬 Cursor 에디터 세션은 외부 주입 경로 없음 → **클라우드 에이전트 한정**.
+
+실측 API (docs.cursor.com/cloud-agent, api.cursor.com, /v1):
+  POST /v1/agents {prompt:{text}, repos?} → {agent:{id}, run:{id}}
+  POST /v1/agents/{id}/runs {prompt:{text}} → {run:{id, status}}
+  GET  /v1/agents/{id}/runs/{runId}/stream → SSE: assistant{text}, result{text}, done
+  status: CREATING/RUNNING/FINISHED/ERROR/CANCELLED/EXPIRED
+  409 agent_busy: run 1개만 active
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+import httpx
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("cursor-sprintable")
+
+CURSOR_API_BASE = os.getenv("CURSOR_API_BASE", "https://api.cursor.com").rstrip("/")
+CURSOR_API_KEY = os.getenv("CURSOR_API_KEY", "")
+# Cursor 클라우드 에이전트는 repo 기반 — 선택 env (미설정 시 launch body에서 생략)
+CURSOR_REPO_URL = os.getenv("CURSOR_REPO_URL", "")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+_ACTIVE = {"CREATING", "RUNNING"}
+_TERMINAL = {"FINISHED", "ERROR", "CANCELLED", "EXPIRED"}
+
+
+class CursorCloudClient:
+    """Cursor Cloud Agents API HTTP 클라이언트.
+
+    conversation_id → cursor agent_id 매핑으로 stateful 에이전트 유지.
+    자식 프로세스 없음 — run 상태 관리로 1-active-run 직렬화.
+    """
+
+    def __init__(self) -> None:
+        self._http: httpx.AsyncClient | None = None
+        # conversation_id → cursor agent_id
+        self._agents: dict[str, str] = {}
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {CURSOR_API_KEY}",
+            "Content-Type": "application/json",
+        }
+
+    async def start(self) -> None:
+        self._http = httpx.AsyncClient(timeout=None)
+        logger.info("cursor cloud client ready (base=%s)", CURSOR_API_BASE)
+
+    async def _launch(self, text: str) -> tuple[str, str]:
+        """POST /v1/agents — 첫 turn (agent 생성). → (agent_id, run_id)."""
+        body: dict = {"prompt": {"text": text}}
+        if CURSOR_REPO_URL:
+            body["repos"] = [{"url": CURSOR_REPO_URL}]
+        resp = await self._http.post(
+            f"{CURSOR_API_BASE}/v1/agents", headers=self._headers(), json=body, timeout=30.0,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        agent_id = (data.get("agent") or {}).get("id")
+        run_id = (data.get("run") or {}).get("id")
+        if not agent_id or not run_id:
+            raise RuntimeError(f"launch returned no agent/run id: {data}")
+        return agent_id, run_id
+
+    async def _followup(self, agent_id: str, text: str) -> str:
+        """POST /v1/agents/{id}/runs — 이후 turn. → run_id. 409 시 완료 대기 후 재시도."""
+        for attempt in range(6):
+            resp = await self._http.post(
+                f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs",
+                headers=self._headers(), json={"prompt": {"text": text}}, timeout=30.0,
+            )
+            if resp.status_code == 409:
+                # agent_busy — 이전 run 완료 대기 후 재시도
+                logger.info("agent_busy (attempt %d) — waiting for active run", attempt + 1)
+                await self._wait_idle(agent_id)
+                continue
+            resp.raise_for_status()
+            run_id = (resp.json().get("run") or {}).get("id")
+            if not run_id:
+                raise RuntimeError(f"followup returned no run id: {resp.json()}")
+            return run_id
+        raise RuntimeError("followup failed after retries (agent persistently busy)")
+
+    async def _wait_idle(self, agent_id: str) -> None:
+        """active run이 terminal 될 때까지 폴링 (1-active-run 가드)."""
+        for _ in range(120):  # 최대 ~2분
+            resp = await self._http.get(
+                f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs",
+                headers=self._headers(), timeout=15.0,
+            )
+            if resp.status_code != 200:
+                return
+            runs = resp.json().get("runs") or resp.json().get("data") or []
+            if not any((r.get("status") in _ACTIVE) for r in runs):
+                return
+            await asyncio.sleep(1.0)
+
+    async def _collect_stream(self, agent_id: str, run_id: str) -> str:
+        """GET /v1/agents/{id}/runs/{runId}/stream (Cursor SSE) → assistant/result 텍스트."""
+        url = f"{CURSOR_API_BASE}/v1/agents/{agent_id}/runs/{run_id}/stream"
+        assistant_parts: list[str] = []
+        result_text = ""
+        ev_type, data_lines = "message", []
+        async with self._http.stream(
+            "GET", url,
+            headers={**self._headers(), "Accept": "text/event-stream"},
+            timeout=httpx.Timeout(connect=15.0, read=300.0, write=15.0, pool=15.0),
+        ) as resp:
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                line = raw.rstrip("\n")
+                if line == "":
+                    if data_lines:
+                        self._handle_stream_event(ev_type, "\n".join(data_lines),
+                                                  assistant_parts)
+                        # result/done 은 terminal
+                        if ev_type in ("result", "done"):
+                            try:
+                                rt = json.loads("\n".join(data_lines)).get("text")
+                                if rt:
+                                    result_text = rt
+                            except (json.JSONDecodeError, AttributeError):
+                                pass
+                            if ev_type == "done":
+                                break
+                    ev_type, data_lines = "message", []
+                elif line.startswith(":"):
+                    pass
+                elif line.startswith("event:"):
+                    ev_type = line[6:].strip()
+                elif line.startswith("data:"):
+                    v = line[5:]
+                    data_lines.append(v[1:] if v.startswith(" ") else v)
+        # result.text 우선, 없으면 assistant 델타 합성
+        return (result_text or "".join(assistant_parts)).strip()
+
+    @staticmethod
+    def _handle_stream_event(ev_type: str, data_str: str, assistant_parts: list[str]) -> None:
+        if ev_type != "assistant":
+            return
+        try:
+            text = json.loads(data_str).get("text", "")
+            if text:
+                assistant_parts.append(text)
+        except (json.JSONDecodeError, AttributeError):
+            pass
+
+    async def run_turn(self, conversation_id: str, text: str) -> str:
+        """conversation별 launch-or-followup → stream 수집 → 응답."""
+        agent_id = self._agents.get(conversation_id)
+        if agent_id is None:
+            agent_id, run_id = await self._launch(text)
+            self._agents[conversation_id] = agent_id
+        else:
+            run_id = await self._followup(agent_id, text)
+        return await self._collect_stream(agent_id, run_id)
+
+    async def stop(self) -> None:
+        if self._http:
+            await self._http.aclose()
+            self._http = None
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[cursor-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — sidecar disabled")
+        return
+    if not CURSOR_API_KEY:
+        logger.error("CURSOR_API_KEY not set — sidecar disabled")
+        return
+
+    cursor = CursorCloudClient()
+    await cursor.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await cursor.run_turn(ctx.conversation_id, ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await cursor.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/gemini-sprintable/.gitignore
+++ b/connectors/gemini-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/gemini-sprintable/README.md
+++ b/connectors/gemini-sprintable/README.md
@@ -1,0 +1,69 @@
+# Sprintable Adapter for Gemini
+
+Gemini용 Sprintable Gateway dial-out 어댑터 (카테고리 B — ACP stdio JSON-RPC 호스트).
+
+**codex 호스트와 동형 골격** (자식 프로세스 spawn/own + lifetime 관리).
+차이 = RPC 레이어: gemini는 **`gemini --acp`** (Agent Client Protocol, 표준 JSON-RPC/stdio).
+codex app-server 자체 RPC와 달리 ACP는 표준이라 향후 ACP 런타임에 재사용 가능.
+
+## 요구사항
+
+- **gemini-cli 설치 필수** (`gemini --acp` 사용).
+  ```bash
+  npm install -g @google/gemini-cli   # 또는 공식 설치 경로
+  gemini --version
+  ```
+- Python 3.10+ (asyncio subprocess)
+- `httpx` (공통 SDK 의존)
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+# export GEMINI_BIN=/path/to/gemini         # gemini 바이너리 경로 (기본: PATH의 gemini)
+
+# 3. 호스트 실행
+python connectors/gemini-sprintable/host.py
+```
+
+## 동작 원리
+
+```
+host.py 시작
+  → GeminiAcpServer.start(): gemini --acp spawn + ACP initialize 핸드셰이크
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → gemini.run_turn(ctx.content):
+      → session/new (최초 1회, sessionId 캐시)
+      → session/prompt({sessionId, prompt:[{type:"text", text}]})
+      → session/update(agent_message_chunk) 텍스트 수집
+      → session/prompt 반환(stopReason) = turn 완료
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## 프로세스 관리 (카테고리 B 핵심 — codex 동형)
+
+- `GeminiAcpServer`가 자식 프로세스를 spawn/own
+- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
+- `host.py` 종료 시 `finally: gemini.stop()` 보장 + reader_task cancel
+
+## 실측 ACP 프로토콜
+
+`@zed-industries/agent-client-protocol@0.4.5` 스키마 (PROTOCOL_VERSION=1):
+- `initialize({protocolVersion:1, clientCapabilities})` → response
+- `session/new({cwd, mcpServers:[]})` → `{sessionId}`
+- `session/prompt({sessionId, prompt:[ContentBlock]})` → `{stopReason}`
+- client notification: `session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content:{type:"text",text}}}`
+
+ContentBlock text variant: `{type:"text", text}` (모든 ACP agent 필수 지원).
+
+## 단일 session 주의
+
+현재 모든 conversation을 단일 ACP session에 주입 (codex 단일 thread와 동일).
+멀티 conversation 컨텍스트 분리는 후속(ef2603d8)에서 B 어댑터 일괄 `conversation→session` 매핑으로 보강.

--- a/connectors/gemini-sprintable/host.py
+++ b/connectors/gemini-sprintable/host.py
@@ -1,0 +1,212 @@
+"""Sprintable Gateway adapter host for Gemini — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 둘째 — codex 호스트(connectors/codex-sprintable/host.py)와 동형 골격.
+차이 = RPC 레이어: gemini는 `gemini --acp` (Agent Client Protocol, 표준 JSON-RPC/stdio).
+codex app-server의 자체 RPC와 달리 ACP는 표준이라 향후 ACP 런타임에 재사용 가능.
+
+구조 (codex와 동일):
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff
+  - gemini --acp (JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 session/new(최초) + session/prompt로 turn 주입
+  - session/update(agent_message_chunk) 스트림 수집 → session/prompt 응답(stopReason)에서 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 ACP (@zed-industries/agent-client-protocol 0.4.5, PROTOCOL_VERSION=1):
+  initialize({protocolVersion, clientCapabilities}) → session/new({cwd, mcpServers})
+  → session/prompt({sessionId, prompt:[ContentBlock]}) → {stopReason}
+  client notification: session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content}}
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("gemini-sprintable")
+
+GEMINI_BIN = os.getenv("GEMINI_BIN", "gemini")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+ACP_PROTOCOL_VERSION = 1
+
+
+class GeminiAcpServer:
+    """gemini --acp JSON-RPC/stdio 자식 프로세스 호스트 (ACP 표준).
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    codex host와 동형 — RPC 메서드만 ACP 표준으로 교체.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: session/update agent_message_chunk 누적
+        self._turn_messages: list[str] = []
+        self._reader_task: asyncio.Task | None = None
+        self._session_id: str | None = None
+
+    async def start(self) -> None:
+        """gemini --acp spawn + initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            GEMINI_BIN, "--acp",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # ACP initialize
+        await self._request("initialize", {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": {
+                "fs": {"readTextFile": False, "writeTextFile": False},
+                "terminal": False,
+            },
+        })
+        logger.info("gemini ACP initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ACP client notification 처리 — session/update agent 응답 수집."""
+        if method == "session/update":
+            update = params.get("update") or {}
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                content = update.get("content") or {}
+                # ContentBlock text variant
+                if content.get("type") == "text":
+                    text = content.get("text", "")
+                    if text:
+                        self._turn_messages.append(text)
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def ensure_session(self) -> str:
+        """session/new (최초 1회) → sessionId 캐시.
+
+        thread 매핑은 단일 session (후속 ef2603d8서 B 일괄 conversation→session 보강).
+        """
+        if self._session_id:
+            return self._session_id
+        result = await self._request("session/new", {
+            "cwd": self._cwd,
+            "mcpServers": [],
+        })
+        self._session_id = result.get("sessionId")
+        if not self._session_id:
+            raise RuntimeError(f"session/new returned no sessionId: {result}")
+        logger.info("gemini session created: %s", self._session_id)
+        return self._session_id
+
+    async def run_turn(self, text: str) -> str:
+        """session/prompt로 주입 → 응답(stopReason)까지 agent_message_chunk 수집.
+
+        ACP는 session/prompt가 turn 완료(stopReason) 시점에 반환 →
+        그때까지 수집된 agent_message_chunk를 응답으로 사용.
+        """
+        session_id = await self.ensure_session()
+        self._turn_messages = []
+
+        await self._request("session/prompt", {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": text}],
+        })
+        # session/prompt 반환 = turn 완료 → 수집된 메시지 확정
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). codex와 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[gemini-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    gemini = GeminiAcpServer()
+    await gemini.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await gemini.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await gemini.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/grok-sprintable/.gitignore
+++ b/connectors/grok-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/grok-sprintable/README.md
+++ b/connectors/grok-sprintable/README.md
@@ -1,0 +1,74 @@
+# Sprintable Adapter for Grok (xAI Grok Build)
+
+xAI Grok Build용 Sprintable Gateway dial-out 어댑터 (카테고리 B — Zed ACP stdio 호스트).
+
+**gemini 호스트와 완전 동형** — 동일한 **Zed Agent Client Protocol** 사용.
+차이는 spawn 명령뿐: `gemini --acp` → `grok agent stdio`.
+
+## 인터페이스 분기 (B/C 판정)
+
+**→ 카테고리 B (Zed ACP stdio)** 확정. 근거:
+- `zed.dev/acp/agent/grok-build` — Grok Build이 **Zed ACP 공식 에이전트**로 등재
+- `grok agent stdio` = JSON-RPC 2.0 over stdio (Zed Agent Client Protocol)
+- xAI는 API(`api.x.ai`, OpenAI 호환)도 제공하나, 코딩 에이전트는 **ACP stdio** 제공 → B
+- ACP는 gemini와 동일 표준 → gemini host.py 골격 그대로 재사용
+
+## 요구사항
+
+- **Grok Build 설치 필수** (`grok agent stdio` 사용). SuperGrok / X Premium Plus 구독.
+  ```bash
+  curl -fsSL https://x.ai/cli/install.sh | bash
+  grok --version
+  ```
+- Python 3.10+ (asyncio subprocess)
+- `httpx` (공통 SDK 의존)
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+# export GROK_BIN=/path/to/grok             # grok 바이너리 경로 (기본: PATH의 grok)
+
+# 3. 호스트 실행
+python connectors/grok-sprintable/host.py
+```
+
+## 동작 원리
+
+```
+host.py 시작
+  → GrokAcpServer.start(): grok agent stdio spawn + ACP initialize 핸드셰이크
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → grok.run_turn(ctx.content):
+      → session/new (최초 1회, sessionId 캐시)
+      → session/prompt({sessionId, prompt:[{type:"text", text}]})
+      → session/update(agent_message_chunk) 텍스트 수집
+      → session/prompt 반환(stopReason) = turn 완료
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## 프로세스 관리 (카테고리 B 핵심 — gemini/codex 동형)
+
+- `GrokAcpServer`가 자식 프로세스를 spawn/own
+- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
+- `host.py` 종료 시 `finally: grok.stop()` 보장 + reader_task cancel
+
+## 실측 ACP 프로토콜
+
+`@zed-industries/agent-client-protocol@0.4.5` 스키마 (PROTOCOL_VERSION=1 — gemini와 동일):
+- `initialize({protocolVersion:1, clientCapabilities})` → response
+- `session/new({cwd, mcpServers:[]})` → `{sessionId}`
+- `session/prompt({sessionId, prompt:[ContentBlock]})` → `{stopReason}`
+- client notification: `session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content:{type:"text",text}}}`
+
+## 단일 session 주의
+
+현재 모든 conversation을 단일 ACP session에 주입 (gemini/codex와 동일).
+멀티 conversation 컨텍스트 분리는 후속(ef2603d8)에서 B 어댑터 일괄 `conversation→session` 매핑으로 보강.

--- a/connectors/grok-sprintable/host.py
+++ b/connectors/grok-sprintable/host.py
@@ -1,0 +1,212 @@
+"""Sprintable Gateway adapter host for Grok (xAI Grok Build) — E-INJECT-ADAPTERS (카테고리 B).
+
+xAI Grok Build CLI — **Zed ACP** 에이전트 (zed.dev/acp/agent/grok-build 등재).
+gemini 호스트와 **완전 동형** — 동일 Zed Agent Client Protocol 사용.
+차이는 spawn 명령뿐: `gemini --acp` → `grok agent stdio`.
+
+구조 (gemini/codex와 동일):
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff
+  - grok agent stdio (ACP JSON-RPC/stdio)를 spawn/own
+  - SSE 이벤트마다 session/new(최초) + session/prompt로 turn 주입
+  - session/update(agent_message_chunk) 스트림 수집 → session/prompt 응답(stopReason) 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 ACP (@zed-industries/agent-client-protocol 0.4.5, PROTOCOL_VERSION=1 — gemini와 동일 스키마):
+  initialize({protocolVersion, clientCapabilities}) → session/new({cwd, mcpServers})
+  → session/prompt({sessionId, prompt:[ContentBlock]}) → {stopReason}
+  client notification: session/update {sessionId, update:{sessionUpdate:"agent_message_chunk", content}}
+
+인터페이스 분기 근거 (추측 0):
+  - zed.dev/acp/agent/grok-build — Grok Build이 Zed ACP 공식 에이전트로 등재
+  - `grok agent stdio` = JSON-RPC 2.0 over stdio (Zed ACP)
+  - xAI 공식: API(api.x.ai)도 있으나 코딩 에이전트는 ACP stdio 제공 → 카테고리 B
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("grok-sprintable")
+
+GROK_BIN = os.getenv("GROK_BIN", "grok")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+ACP_PROTOCOL_VERSION = 1
+
+
+class GrokAcpServer:
+    """grok agent stdio JSON-RPC/stdio 자식 프로세스 호스트 (Zed ACP).
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    gemini host와 완전 동형 — spawn 명령만 차이.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._req_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        # turn 응답 수집: session/update agent_message_chunk 누적
+        self._turn_messages: list[str] = []
+        self._reader_task: asyncio.Task | None = None
+        self._session_id: str | None = None
+
+    async def start(self) -> None:
+        """grok agent stdio spawn + ACP initialize 핸드셰이크."""
+        self._proc = await asyncio.create_subprocess_exec(
+            GROK_BIN, "agent", "stdio",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+
+        # ACP initialize
+        await self._request("initialize", {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "clientCapabilities": {
+                "fs": {"readTextFile": False, "writeTextFile": False},
+                "terminal": False,
+            },
+        })
+        logger.info("grok ACP initialized")
+
+    async def _read_loop(self) -> None:
+        """stdout JSON-RPC 라인 파싱 → response 매칭 + notification 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            # response (id 있음 + result/error)
+            if "id" in msg and ("result" in msg or "error" in msg):
+                fut = self._pending.pop(msg["id"], None)
+                if fut and not fut.done():
+                    if "error" in msg:
+                        fut.set_exception(RuntimeError(str(msg["error"])))
+                    else:
+                        fut.set_result(msg.get("result"))
+                continue
+            # notification (method 있음, id 없음)
+            method = msg.get("method")
+            if method:
+                self._on_notification(method, msg.get("params") or {})
+
+    def _on_notification(self, method: str, params: dict) -> None:
+        """ACP client notification 처리 — session/update agent 응답 수집."""
+        if method == "session/update":
+            update = params.get("update") or {}
+            if update.get("sessionUpdate") == "agent_message_chunk":
+                content = update.get("content") or {}
+                if content.get("type") == "text":
+                    text = content.get("text", "")
+                    if text:
+                        self._turn_messages.append(text)
+
+    async def _request(self, method: str, params: dict | None) -> dict:
+        """JSON-RPC request 송신 + response 대기."""
+        assert self._proc and self._proc.stdin
+        self._req_id += 1
+        rid = self._req_id
+        fut: asyncio.Future = asyncio.get_event_loop().create_future()
+        self._pending[rid] = fut
+        payload = {"jsonrpc": "2.0", "id": rid, "method": method}
+        if params is not None:
+            payload["params"] = params
+        self._proc.stdin.write((json.dumps(payload) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+        return await fut
+
+    async def ensure_session(self) -> str:
+        """session/new (최초 1회) → sessionId 캐시.
+
+        thread 매핑은 단일 session (후속 ef2603d8서 B 일괄 conversation→session 보강).
+        """
+        if self._session_id:
+            return self._session_id
+        result = await self._request("session/new", {
+            "cwd": self._cwd,
+            "mcpServers": [],
+        })
+        self._session_id = result.get("sessionId")
+        if not self._session_id:
+            raise RuntimeError(f"session/new returned no sessionId: {result}")
+        logger.info("grok session created: %s", self._session_id)
+        return self._session_id
+
+    async def run_turn(self, text: str) -> str:
+        """session/prompt로 주입 → 응답(stopReason)까지 agent_message_chunk 수집."""
+        session_id = await self.ensure_session()
+        self._turn_messages = []
+
+        await self._request("session/prompt", {
+            "sessionId": session_id,
+            "prompt": [{"type": "text", "text": text}],
+        })
+        # session/prompt 반환 = turn 완료 → 수집된 메시지 확정
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). gemini/codex 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[grok-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    grok = GrokAcpServer()
+    await grok.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await grok.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await grok.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/connectors/pi-sprintable/.gitignore
+++ b/connectors/pi-sprintable/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/connectors/pi-sprintable/README.md
+++ b/connectors/pi-sprintable/README.md
@@ -1,0 +1,78 @@
+# Sprintable Adapter for Pi
+
+Pi용 Sprintable Gateway dial-out 어댑터 (카테고리 B — JSONL/stdio 호스트).
+
+**codex/gemini 호스트와 동형 골격** (자식 프로세스 spawn/own + lifetime 관리).
+차이 = 메시지 레이어: pi는 **`pi --mode rpc`** (JSONL/stdio — JSON-RPC 아닌 **줄단위 JSON**).
+`steer`로 mid-stream 주입이 pi 강점.
+
+## 요구사항
+
+- **pi 설치 필수** (`pi --mode rpc` 사용).
+  ```bash
+  npm install -g @earendil-works/pi-coding-agent   # bin: pi
+  pi --version
+  ```
+- Python 3.10+ (asyncio subprocess)
+- `httpx` (공통 SDK 의존)
+
+## 설치 및 실행
+
+```bash
+# 1. git pull
+git pull origin develop
+
+# 2. 환경 변수 설정
+export AGENT_API_KEY=sk_live_...            # Sprintable agent API key (필수)
+export SPRINTABLE_API_URL=https://...       # Backend URL (미설정 시 dev 기본값)
+# export PI_BIN=/path/to/pi                  # pi 바이너리 경로 (기본: PATH의 pi)
+
+# 3. 호스트 실행
+python connectors/pi-sprintable/host.py
+```
+
+## 동작 원리
+
+```
+host.py 시작
+  → PiRpcServer.start(): pi --mode rpc spawn (JSONL은 별도 initialize 핸드셰이크 없음)
+  → SprintableSSEClient.run(inject) (공통 SDK)
+  → 이벤트마다 inject(ctx):
+    → pi.run_turn(ctx.content):
+      → stdin JSONL: {"type":"prompt", "message": text}
+      → stdout JSONL: AgentSessionEvent 스트림 (session.subscribe)
+      → agent_end {messages:[AgentMessage]} 에서 assistant 텍스트 수집
+    → ctx.reply(response) → POST /api/v2/conversations/{id}/messages
+    → ack: SDK 처리
+```
+
+## 메시지 레이어 (JSONL — JSON-RPC와 차이)
+
+codex/gemini는 JSON-RPC(id/method/params/result)지만, pi는 **줄단위 JSON 명령/이벤트**:
+- 명령(stdin): `{"type":"prompt", "message", "streamingBehavior"?:"steer"|"followUp"}`
+- mid-stream 주입(stdin): `{"type":"steer", "message"}` — pi 강점
+- 응답(stdout): `{"type":"response", "command":"prompt", "success":true}` = ack
+- 이벤트(stdout): `AgentSessionEvent` — `agent_end {messages}`, `turn_end {message}`, `message_update {...}` 등
+
+## 프로세스 관리 (카테고리 B 핵심 — codex/gemini 동형)
+
+- `PiRpcServer`가 자식 프로세스를 spawn/own
+- `stop()`: SIGTERM(`terminate`) → 5s timeout → `kill` — 좀비 방지
+- `host.py` 종료 시 `finally: pi.stop()` 보장 + reader_task cancel
+
+## 실측 스키마
+
+`@earendil-works/pi-coding-agent@0.78.0` `dist/modes/rpc/rpc-types.d.ts`:
+- `RpcCommand: {type:"prompt"|"steer"|"follow_up", message, streamingBehavior?}`
+- `RpcResponse: {type:"response", command, success}`
+
+`@earendil-works/pi-agent-core@0.78.0` `dist/types.d.ts`:
+- `AgentEvent: agent_end {messages:[AgentMessage]}`, `turn_end {message}`, ...
+
+`@earendil-works/pi-ai@0.78.0`:
+- `AssistantMessage.content: (TextContent{type:"text",text} | ...)[]`
+
+## 단일 세션 주의
+
+현재 모든 conversation을 단일 pi 세션에 주입 (codex/gemini와 동일).
+멀티 conversation 컨텍스트 분리는 후속(ef2603d8)에서 B 어댑터 일괄 보강.

--- a/connectors/pi-sprintable/host.py
+++ b/connectors/pi-sprintable/host.py
@@ -1,0 +1,168 @@
+"""Sprintable Gateway adapter host for Pi — E-INJECT-ADAPTERS (카테고리 B).
+
+카테고리 B 셋째 — codex/gemini 호스트와 동형 골격.
+차이 = 메시지 레이어: pi는 `pi --mode rpc` (JSONL/stdio — JSON-RPC 아닌 줄단위 JSON).
+명령은 stdin JSONL, 이벤트/응답은 stdout JSONL.
+
+구조 (codex/gemini와 동일):
+  - 공통 SDK(connectors/sdk/sprintable_sse.py) 재사용 — SSE 소비·dedup·ack·backoff
+  - pi --mode rpc (JSONL/stdio)를 spawn/own
+  - SSE 이벤트마다 {"type":"prompt", message} 주입 (steer로 mid-stream 가능)
+  - agent_end 이벤트의 assistant 메시지 텍스트 수집 → 응답 확정
+  - 응답 → ctx.reply() → POST /api/v2/conversations/{id}/messages
+
+실측 스키마 (@earendil-works/pi-coding-agent@0.78.0, dist/modes/rpc/rpc-types.d.ts):
+  RpcCommand: {type:"prompt", message, streamingBehavior?:"steer"|"followUp"}
+              {type:"steer", message}  — mid-stream 주입 (pi 강점)
+  stdout JSONL: RpcResponse {type:"response", command:"prompt", success} = ack
+                AgentSessionEvent (session.subscribe) — agent_end {messages:[AgentMessage]}
+  AgentMessage(assistant).content: (TextContent{type:"text",text} | ...)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+# 공통 SDK import (connectors/sdk/sprintable_sse.py)
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "sdk"))
+from sprintable_sse import SprintableSSEClient, MessageContext  # noqa: E402
+
+logger = logging.getLogger("pi-sprintable")
+
+PI_BIN = os.getenv("PI_BIN", "pi")
+DEFAULT_API_URL = "https://sprintable-backend-dev-57iommnikq-du.a.run.app"
+
+
+class PiRpcServer:
+    """pi --mode rpc JSONL/stdio 자식 프로세스 호스트.
+
+    한 번 spawn해서 lifetime 동안 own. shutdown 시 SIGTERM→kill.
+    codex/gemini host와 동형 — 메시지 레이어만 JSONL로 교체.
+    """
+
+    def __init__(self, cwd: str | None = None) -> None:
+        self._cwd = cwd or os.getcwd()
+        self._proc: asyncio.subprocess.Process | None = None
+        self._reader_task: asyncio.Task | None = None
+        # turn 응답 수집: agent_end 의 assistant 텍스트
+        self._turn_messages: list[str] = []
+        self._turn_done: asyncio.Event | None = None
+
+    async def start(self) -> None:
+        """pi --mode rpc spawn. (JSONL은 별도 initialize 핸드셰이크 없음)"""
+        self._proc = await asyncio.create_subprocess_exec(
+            PI_BIN, "--mode", "rpc",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self._cwd,
+        )
+        self._reader_task = asyncio.create_task(self._read_loop())
+        logger.info("pi --mode rpc started")
+
+    async def _read_loop(self) -> None:
+        """stdout JSONL 라인 파싱 → 이벤트/응답 처리."""
+        assert self._proc and self._proc.stdout
+        while True:
+            line = await self._proc.stdout.readline()
+            if not line:
+                break
+            try:
+                msg = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            self._on_message(msg)
+
+    def _on_message(self, msg: dict) -> None:
+        """JSONL stdout 메시지 처리.
+
+        - AgentSessionEvent: agent_end {messages} → assistant 텍스트 수집 + turn 완료
+        - RpcResponse {type:"response"}: ack (별도 처리 불필요)
+        """
+        mtype = msg.get("type")
+        if mtype == "agent_end":
+            for am in msg.get("messages") or []:
+                if am.get("role") == "assistant":
+                    for block in am.get("content") or []:
+                        if isinstance(block, dict) and block.get("type") == "text":
+                            text = block.get("text", "")
+                            if text:
+                                self._turn_messages.append(text)
+            if self._turn_done and not self._turn_done.is_set():
+                self._turn_done.set()
+
+    async def _send(self, cmd: dict) -> None:
+        """JSONL 명령 stdin 송신."""
+        assert self._proc and self._proc.stdin
+        self._proc.stdin.write((json.dumps(cmd) + "\n").encode("utf-8"))
+        await self._proc.stdin.drain()
+
+    async def run_turn(self, text: str) -> str:
+        """{type:"prompt", message} 주입 → agent_end까지 assistant 텍스트 수집.
+
+        thread 매핑은 단일 세션 (후속 ef2603d8서 B 일괄 보강).
+        """
+        self._turn_messages = []
+        self._turn_done = asyncio.Event()
+
+        await self._send({"type": "prompt", "message": text})
+        # agent_end 대기 (turn 완료 + 응답 수집)
+        await self._turn_done.wait()
+        return "".join(self._turn_messages).strip()
+
+    async def stop(self) -> None:
+        """자식 프로세스 graceful 종료 (SIGTERM → kill). codex/gemini 동형."""
+        if self._reader_task:
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+                await asyncio.wait_for(self._proc.wait(), timeout=5.0)
+            except (asyncio.TimeoutError, ProcessLookupError):
+                try:
+                    self._proc.kill()
+                except ProcessLookupError:
+                    pass
+
+
+async def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="[pi-sprintable] %(levelname)s %(message)s",
+        stream=sys.stderr,
+    )
+    api_url = (os.getenv("SPRINTABLE_API_URL", DEFAULT_API_URL) or DEFAULT_API_URL).rstrip("/")
+    api_key = os.getenv("SPRINTABLE_API_KEY") or os.getenv("AGENT_API_KEY") or ""
+    if not api_key:
+        logger.error("SPRINTABLE_API_KEY or AGENT_API_KEY not set — host disabled")
+        return
+
+    pi = PiRpcServer()
+    await pi.start()
+
+    sse = SprintableSSEClient(api_url=api_url, api_key=api_key)
+
+    async def inject(ctx: MessageContext) -> None:
+        try:
+            response = await pi.run_turn(ctx.content)
+        except Exception as exc:
+            logger.warning("turn error conv=%s: %s", ctx.conversation_id, exc)
+            return
+        if response:
+            await ctx.reply(response)
+
+    try:
+        await sse.run(inject)
+    finally:
+        await pi.stop()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass


### PR DESCRIPTION
develop→main prod 프로모션 (2026-06-03).

E-MEMBER-SSOT grant-only 5버그(dev grant-only 라이브 검증 PASS):
- #1163 Phase0: events/conversations grant-only 휴먼 지원
- #1164 AC2-2: 나머지 TeamMember-존재=인가 제거 (에픽403·dispatch·switch500·notif)
- #1165/66/67 standup422: self-save 422→FK500→카드표시 3단
- #1168 i18n: standup.history 키

타 세션 분(CI·검증 완료):
- #1155-59 inject-adapters (codex/gemini/pi/grok/cursor)
- #1160,1162 SSE P0 누수 픽스
- #1161 human 웹훅 UI

⚠️ 머지 후 sprintable-migrate(prod) 실행으로 0073/0074(notif·standup FK 완화) prod DB 적용 필수.