### PR TITLE
[SID:70f3b4e6] feat(member-ssot): AC2-1 신원 앵커 additive 마이그

### DIFF
--- a/backend/alembic/versions/0075_member_ssot_anchor_tables.py
+++ b/backend/alembic/versions/0075_member_ssot_anchor_tables.py
@@ -1,0 +1,236 @@
+"""E-MEMBER-SSOT AC2-1: 신원 앵커 테이블 additive 마이그 (코드 cutover 없음).
+
+blueprint-member-ssot-anchor §4 Phase 1-2. 공유 dev/prod DB — 모든 DDL idempotent
+가드(IF NOT EXISTS / IF EXISTS) + 백필 ID 보존 + 메타데이터-only 가역 롤백.
+
+토대:
+- members(통합 신원), member_identity_aliases(레거시 id 매핑), agent_project_profiles(에이전트 per-project)
+- project_access에 member_id/role/color/can_manage_members/access_source/inherited_from_member_id 추가
+
+백필(ID 보존):
+- 휴먼 members.id = org_members.id (Phase0 ID 보존)
+- 에이전트 members.id = team_members.id (API키/event/participant ID 보존) — team_member별 1:1
+- 에이전트 owner = team_members.created_by → 동org 휴먼 member
+- 휴먼 team_member마다 alias / project_access.member_id=org_member_id / 에이전트 direct placement + agent_project_profiles 시드
+
+Revision ID: 0075
+Revises: 0074
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0075"
+down_revision = "0074"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── 1. 앵커 테이블 (idempotent) ──────────────────────────────────────────
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS members (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            org_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+            type text NOT NULL CHECK (type IN ('human', 'agent')),
+            user_id uuid REFERENCES users(id) ON DELETE SET NULL,
+            owner_member_id uuid REFERENCES members(id) ON DELETE SET NULL,
+            name text NOT NULL,
+            avatar_url text,
+            org_role text,
+            is_active boolean NOT NULL DEFAULT true,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            deleted_at timestamptz
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS member_identity_aliases (
+            alias_id uuid PRIMARY KEY,
+            member_id uuid NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+            org_id uuid NOT NULL,
+            project_id uuid,
+            alias_source text NOT NULL
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS agent_project_profiles (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            member_id uuid NOT NULL REFERENCES members(id) ON DELETE CASCADE,
+            project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            agent_config jsonb,
+            webhook_url text,
+            agent_role text,
+            fakechat_port integer,
+            last_seen_at timestamptz,
+            active_story_id uuid REFERENCES stories(id) ON DELETE SET NULL,
+            agent_status text,
+            created_at timestamptz NOT NULL DEFAULT now(),
+            updated_at timestamptz NOT NULL DEFAULT now(),
+            CONSTRAINT uq_agent_project_profiles_proj_member UNIQUE (project_id, member_id)
+        )
+        """
+    )
+
+    # 인덱스 (members / aliases / agent_project_profiles)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_members_org_id ON members (org_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_members_user_id ON members (user_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_members_owner_member_id ON members (owner_member_id)")
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_members_active_human "
+        "ON members (org_id, user_id) WHERE type = 'human' AND deleted_at IS NULL"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_member_aliases_member ON member_identity_aliases (member_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_member_aliases_org ON member_identity_aliases (org_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_agent_profiles_member ON agent_project_profiles (member_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_agent_profiles_project ON agent_project_profiles (project_id)")
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_agent_profiles_proj_port "
+        "ON agent_project_profiles (project_id, fakechat_port) WHERE fakechat_port IS NOT NULL"
+    )
+
+    # ── 2. project_access placement 컬럼 (additive) ──────────────────────────
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS member_id uuid")
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'member'")
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS color text NOT NULL DEFAULT '#3385f8'")
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS can_manage_members boolean NOT NULL DEFAULT false")
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS access_source text NOT NULL DEFAULT 'direct'")
+    op.execute("ALTER TABLE project_access ADD COLUMN IF NOT EXISTS inherited_from_member_id uuid")
+    # 에이전트 direct placement(org_member 없음)를 수용하기 위해 org_member_id NOT NULL 완화
+    op.execute("ALTER TABLE project_access ALTER COLUMN org_member_id DROP NOT NULL")
+    op.execute("ALTER TABLE project_access ALTER COLUMN org_member_id DROP DEFAULT")
+
+    # ── 3. 백필: members (휴먼 먼저 — 에이전트 owner가 휴먼 member 참조) ────────
+    # 휴먼: members.id = org_members.id (Phase0 ID 보존), org_role = org_members.role
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, org_role, is_active, created_at, updated_at)
+        SELECT om.id, om.org_id, 'human', om.user_id, NULL,
+               COALESCE(u.display_name, u.email, om.user_id::text),
+               om.role, true, om.created_at, now()
+        FROM org_members om
+        LEFT JOIN users u ON u.id = om.user_id
+        WHERE om.deleted_at IS NULL
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+    # 에이전트: members.id = team_members.id (1:1 ID 보존), owner = created_by 휴먼 member
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, avatar_url, org_role, is_active, created_at, updated_at)
+        SELECT tm.id, tm.org_id, 'agent', NULL, owner.id, tm.name, tm.avatar_url, NULL, tm.is_active, tm.created_at, now()
+        FROM team_members tm
+        LEFT JOIN org_members owner
+               ON owner.org_id = tm.org_id AND owner.user_id = tm.created_by AND owner.deleted_at IS NULL
+        WHERE tm.type = 'agent'
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+
+    # ── 4. 백필: aliases (휴먼 team_member.id → 휴먼 member) ───────────────────
+    op.execute(
+        """
+        INSERT INTO member_identity_aliases (alias_id, member_id, org_id, project_id, alias_source)
+        SELECT tm.id, om.id, tm.org_id, tm.project_id, 'human_team_member'
+        FROM team_members tm
+        JOIN org_members om
+          ON om.org_id = tm.org_id AND om.user_id = tm.user_id AND om.deleted_at IS NULL
+        WHERE tm.type = 'human'
+        ON CONFLICT (alias_id) DO NOTHING
+        """
+    )
+
+    # ── 5. 백필: project_access ──────────────────────────────────────────────
+    # 휴먼 기존 grant: member_id = org_member_id (휴먼 members.id = org_members.id)
+    op.execute("UPDATE project_access SET member_id = org_member_id WHERE member_id IS NULL AND org_member_id IS NOT NULL")
+    # 에이전트 direct placement: team_members.type='agent' → project_access 행 신설
+    op.execute(
+        """
+        INSERT INTO project_access (id, project_id, org_member_id, member_id, permission, role, color, can_manage_members, access_source, created_at)
+        SELECT gen_random_uuid(), tm.project_id, NULL, tm.id, 'granted', tm.role, tm.color, tm.can_manage_members, 'direct', tm.created_at
+        FROM team_members tm
+        WHERE tm.type = 'agent' AND tm.is_active = true
+          AND NOT EXISTS (
+              SELECT 1 FROM project_access pa
+              WHERE pa.project_id = tm.project_id AND pa.member_id = tm.id
+          )
+        """
+    )
+
+    # ── 6. 백필: agent_project_profiles (에이전트 team_member 런타임/설정) ──────
+    op.execute(
+        """
+        INSERT INTO agent_project_profiles
+            (id, member_id, project_id, agent_config, webhook_url, agent_role, fakechat_port, last_seen_at, active_story_id, agent_status, created_at, updated_at)
+        SELECT gen_random_uuid(), tm.id, tm.project_id, tm.agent_config, tm.webhook_url, tm.agent_role,
+               tm.fakechat_port, tm.last_seen_at, tm.active_story_id, tm.agent_status, tm.created_at, now()
+        FROM team_members tm
+        WHERE tm.type = 'agent'
+        ON CONFLICT (project_id, member_id) DO NOTHING
+        """
+    )
+
+    # ── 7. project_access placement 유니크 + NOT VALID FK ─────────────────────
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_project_access_project_member_v2 "
+        "ON project_access (project_id, member_id) WHERE member_id IS NOT NULL"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_project_access_member_id ON project_access (member_id)")
+    # NOT VALID FK — 기존 행 검증 보류(후속 phase에서 VALIDATE)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_project_access_member') THEN
+                ALTER TABLE project_access
+                    ADD CONSTRAINT fk_project_access_member
+                    FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE NOT VALID;
+            END IF;
+            IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_project_access_inherited_member') THEN
+                ALTER TABLE project_access
+                    ADD CONSTRAINT fk_project_access_inherited_member
+                    FOREIGN KEY (inherited_from_member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """메타데이터-only 가역 — 신규 테이블 drop + project_access 신규 컬럼/제약 제거.
+
+    org_member_id NOT NULL 복원은 백필된 에이전트 행(org_member_id NULL) 제거 후 수행.
+    """
+    # NOT VALID FK + 인덱스 제거
+    op.execute("ALTER TABLE project_access DROP CONSTRAINT IF EXISTS fk_project_access_member")
+    op.execute("ALTER TABLE project_access DROP CONSTRAINT IF EXISTS fk_project_access_inherited_member")
+    op.execute("DROP INDEX IF EXISTS uq_project_access_project_member_v2")
+    op.execute("DROP INDEX IF EXISTS ix_project_access_member_id")
+
+    # 백필된 에이전트 direct placement 제거(org_member_id NULL 행)
+    op.execute("DELETE FROM project_access WHERE org_member_id IS NULL AND access_source = 'direct'")
+
+    # org_member_id NOT NULL 복원 (잔여 NULL 없을 때만)
+    op.execute(
+        """
+        DO $$ BEGIN
+            IF NOT EXISTS (SELECT 1 FROM project_access WHERE org_member_id IS NULL) THEN
+                ALTER TABLE project_access ALTER COLUMN org_member_id SET NOT NULL;
+            END IF;
+        END $$;
+        """
+    )
+
+    # project_access 신규 컬럼 제거
+    for col in ("member_id", "role", "color", "can_manage_members", "access_source", "inherited_from_member_id"):
+        op.execute(f"ALTER TABLE project_access DROP COLUMN IF EXISTS {col}")
+
+    # 앵커 테이블 drop (의존 역순)
+    op.execute("DROP TABLE IF EXISTS agent_project_profiles")
+    op.execute("DROP TABLE IF EXISTS member_identity_aliases")
+    op.execute("DROP TABLE IF EXISTS members")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -33,8 +33,12 @@ from app.models.team import TeamMember
 from app.models.file_lock import FileLock
 from app.models.org_invite import OrgInvite
 from app.models.project_access import ProjectAccess
+from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 
 __all__ = [
+    "AgentProjectProfile",
+    "Member",
+    "MemberIdentityAlias",
     "AgentAuditLog",
     "AgentDeployment",
     "AgentPersona",

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -1,0 +1,101 @@
+"""E-MEMBER-SSOT AC2-1: 신원 앵커 테이블 (additive only, 코드 cutover 없음).
+
+blueprint-member-ssot-anchor §2/§4 Phase 1-2. 이 모델들은 마이그 0075로 생성되며,
+코드는 아직 이들을 읽지/쓰지 않는다(앵커 토대). 백필로 기존 org_members/team_members
+신원을 보존하며 채운다(휴먼 members.id=org_members.id, 에이전트=team_members.id).
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Integer,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class Member(Base):
+    """org-scoped 통합 신원 — 휴먼/에이전트 단일 멤버 행.
+
+    휴먼: user_id 설정, owner_member_id NULL. 에이전트: owner_member_id(생성 휴먼) 설정.
+    유니크 active (org_id, user_id) 휴먼은 마이그의 부분 유니크 인덱스로 강제.
+    """
+    __tablename__ = "members"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    type: Mapped[str] = mapped_column(Text, nullable=False)  # 'human' | 'agent'
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    owner_member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    org_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+class MemberIdentityAlias(Base):
+    """레거시 식별자 → canonical members.id 매핑.
+
+    alias_id는 레거시 휴먼 team_member.id 등(자동생성 아님 — 백필이 명시 삽입).
+    """
+    __tablename__ = "member_identity_aliases"
+
+    alias_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    project_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    alias_source: Mapped[str] = mapped_column(Text, nullable=False)  # 'human_team_member' 등
+
+
+class AgentProjectProfile(Base):
+    """에이전트 멤버의 per-project 런타임/설정 (member.type='agent')."""
+    __tablename__ = "agent_project_profiles"
+    __table_args__ = (
+        UniqueConstraint("project_id", "member_id", name="uq_agent_project_profiles_proj_member"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    member_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    agent_config: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    webhook_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    fakechat_port: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    last_seen_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    active_story_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True
+    )
+    agent_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/models/project_access.py
+++ b/backend/app/models/project_access.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -35,3 +35,14 @@ class ProjectAccess(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+
+    # E-MEMBER-SSOT AC2-1: 앵커 placement 컬럼 (additive — 코드 cutover 없음, 백필로 채움).
+    # member_id → members.id FK는 마이그 0075에서 NOT VALID로 추가(기존 행 검증 보류).
+    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    role: Mapped[str] = mapped_column(Text, nullable=False, default="member", server_default="member")
+    color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8", server_default="#3385f8")
+    can_manage_members: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false"
+    )
+    access_source: Mapped[str] = mapped_column(Text, nullable=False, default="direct", server_default="direct")
+    inherited_from_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)


### PR DESCRIPTION
## 배경
E-MEMBER-SSOT 앵커 토대 (blueprint §4 Phase 1-2). **additive only — 코드 cutover 없음**. 기존 org_members/team_members 신원을 보존하며 단일 `members` 앵커 + per-project profile + placement 확장을 시드.

## 신설 (migration 0075, idempotent + 가역)
**테이블** (`CREATE TABLE IF NOT EXISTS`):
- `members` — org-scoped 통합 신원(human/agent), `owner_member_id`(에이전트→생성 휴먼), 부분유니크 active 휴먼 `(org_id,user_id)`
- `member_identity_aliases` — 레거시 id → canonical `members.id`
- `agent_project_profiles` — 에이전트 per-project 런타임/설정, 유니크 `(project_id,member_id)` + 부분유니크 `(project_id,fakechat_port)`

**project_access 확장** (`ADD COLUMN IF NOT EXISTS`): `member_id`·`role`·`color`·`can_manage_members`·`access_source`·`inherited_from_member_id`. 에이전트 direct placement 수용 위해 `org_member_id` NOT NULL 완화. `member_id`/`inherited_from_member_id` → `members` **NOT VALID FK**(기존 행 검증 보류).

## 백필 (ID 보존 — 4중 함정 체크리스트 적용)
| 대상 | 규칙 |
|---|---|
| 휴먼 member | `members.id = org_members.id` (Phase0 ID 보존), `org_role` 이관 |
| 에이전트 member | `members.id = team_members.id` (API키/event/participant ID 보존), `owner=created_by→동org 휴먼 member` |
| alias | 휴먼 team_member.id → 휴먼 member (`human_team_member`) |
| project_access | 휴먼 `member_id=org_member_id` UPDATE + 에이전트 direct placement INSERT(color/role 이관) |
| agent_project_profile | 에이전트 team_member 런타임/설정 시드(fakechat_port/agent_role 등) |

## 검증 (실 PG — B3 교훈: 백필은 mocked로 못 잡음)
throwaway PostgreSQL 16에 실제 적용:
- **fresh `alembic upgrade head` clean** (전체 0001→0075 체인, = CI alembic-fresh-db)
- **downgrade 0075→0074 가역** OK (members drop, project_access 신규 컬럼/제약 제거, org_member_id NOT NULL 복원)
- **시드 데이터 백필 정확**: 휴먼2+에이전트1 team_member·휴먼 grant1 → members 3·alias 1·project_access 2(휴먼 grant + 에이전트 placement)·agent_profile 1, **ID 보존·owner 매핑·color/port/role 이관 전부 일치**
- 풀 백엔드 스위트 `CI=true` **1437 passed / 0 failed** (additive 무회귀)

⚠️ CI는 **empty 백필**만 검증 → 실 데이터 백필은 위 로컬 실 PG로 검증. **done = `sprintable-migrate-dev` 실적용 + 백필 row-count 확인 전 금지**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)