### PR TITLE
[SID:7665013d] feat(member-ssot): AC2-3 anchor resolver shadow (config 플래그, 가역)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
             "SELECT count(*) FROM information_schema.tables WHERE table_schema='public' AND table_type='BASE TABLE';" \
             | grep -E "^\s+[0-9]+"
 
+      - name: member-ssot resolver parity (real-DB legacy vs anchor 0-diff)
+        working-directory: backend
+        env:
+          ALEMBIC_DATABASE_URL: postgresql+psycopg2://sprintable:sprintable@localhost:5432/sprintable_test
+          JWT_SECRET: ci-test-secret-at-least-32-chars-long
+        run: uv run pytest tests/test_member_ssot_parity_realdb.py -q
+
   backend-test:
     name: Backend pytest
     runs-on: ubuntu-latest

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -43,6 +43,11 @@ class Settings(BaseSettings):
     # E-EVENTBUS: dev=true, prod=false (기존 웹훅 병행 운영)
     eventbus_enabled: bool = False
 
+    # E-MEMBER-SSOT AC2-3: 신원 해소를 anchor(members+member_identity_aliases) 기반으로 전환하는
+    # shadow 플래그. off(기본)=레거시 resolver(org_members/team_members). on=anchor resolver.
+    # 라이브 cutover는 AC3-1 — 여기선 shadow(parity 검증용), 기본 off라 실 read 경로 무변경.
+    member_ssot_resolver_shadow: bool = False
+
     # Polar Billing SDK
     polar_access_token: str = ""
     polar_sandbox: bool = True  # dev=True(sandbox), prod=False

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -132,12 +132,17 @@ async def _resolve_member_anchor(
         )).scalars().first()
         if m is None:
             raise HTTPException(status_code=400, detail="Team member not found")
-        # placement(역할/프로젝트) — 에이전트 member.id = team_member.id (1:1)
+        # placement(역할/프로젝트) — 0075에서 에이전트 member.id = team_member.id **1:1**(team_member별
+        # 1 member)이라 placement/profile도 1행. 멀티프로젝트 에이전트는 N개의 (member,team_member)로
+        # 분리되며 API키 auth.user_id는 그중 하나를 지정 → 단일 placement 해소(legacy tm.role/project_id와 동일).
+        # ORDER BY created_at: 1:1 위반(미래 데이터) 시에도 결정적 — parity 안정성.
         role = (await session.execute(
-            select(ProjectAccess.role).where(ProjectAccess.member_id == m.id).limit(1)
+            select(ProjectAccess.role).where(ProjectAccess.member_id == m.id)
+            .order_by(ProjectAccess.created_at.asc()).limit(1)
         )).scalar_one_or_none()
         proj = (await session.execute(
-            select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id).limit(1)
+            select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id)
+            .order_by(AgentProjectProfile.created_at.asc()).limit(1)
         )).scalar_one_or_none()
         return ResolvedMember(
             id=m.id,

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -298,19 +298,33 @@ async def _lookup_members_by_ids_anchor(
             if tgt is not None:
                 resolved_member_for[alias_id] = tgt
 
-    # 에이전트 placement(role/project_id) 배치 조회
+    # 에이전트 placement(role/project_id) 배치 조회 — H1: ORDER BY created_at ASC로 결정성
+    # (단일 resolve와 동일 기준). setdefault + 정렬이라 member별 earliest placement가 선택됨.
     agent_ids = [m.id for m in resolved_member_for.values() if m.type == "agent"]
     role_by_member: dict[uuid.UUID, str] = {}
     proj_by_member: dict[uuid.UUID, uuid.UUID] = {}
     if agent_ids:
         for mid_, role in (await session.execute(
-            select(ProjectAccess.member_id, ProjectAccess.role).where(ProjectAccess.member_id.in_(agent_ids))
+            select(ProjectAccess.member_id, ProjectAccess.role)
+            .where(ProjectAccess.member_id.in_(agent_ids))
+            .order_by(ProjectAccess.created_at.asc())
         )).all():
             role_by_member.setdefault(mid_, role)
         for mid_, pid in (await session.execute(
-            select(AgentProjectProfile.member_id, AgentProjectProfile.project_id).where(AgentProjectProfile.member_id.in_(agent_ids))
+            select(AgentProjectProfile.member_id, AgentProjectProfile.project_id)
+            .where(AgentProjectProfile.member_id.in_(agent_ids))
+            .order_by(AgentProjectProfile.created_at.asc())
         )).all():
             proj_by_member.setdefault(mid_, pid)
+
+    # M1: 휴먼 display name은 users.email로 정합(레거시 OrgMember path + 단일 resolve와 동일).
+    human_user_ids = {m.user_id for m in resolved_member_for.values() if m.type == "human" and m.user_id}
+    email_by_user: dict[uuid.UUID, str] = {}
+    if human_user_ids:
+        for uid_, email in (await session.execute(
+            select(User.id, User.email).where(User.id.in_(human_user_ids))
+        )).all():
+            email_by_user[uid_] = email
 
     for orig_id, m in resolved_member_for.items():
         if m.type == "agent":
@@ -321,8 +335,9 @@ async def _lookup_members_by_ids_anchor(
             )
         else:
             result[orig_id] = ResolvedMember(
-                id=m.id, user_id=m.user_id, name=m.name, type="human",
-                role=m.org_role or "member", org_id=m.org_id, project_id=None,
+                id=m.id, user_id=m.user_id,
+                name=email_by_user.get(m.user_id) if m.user_id else str(m.id),
+                type="human", role=m.org_role or "member", org_id=m.org_id, project_id=None,
             )
 
     # 3. 진짜 orphan(member/alias 모두 없음) — telemetry-only + 크래시 방지 placeholder

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -5,6 +5,7 @@ ResolvedMember를 conversations/events 전반에 사용해 team_member 강요를
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass, field
 
@@ -12,11 +13,16 @@ from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.auth import AuthContext
+from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
 from app.models.project import OrgMember
+from app.models.project_access import ProjectAccess
 from app.models.team import TeamMember
 from app.models.user import User
 from app.services.project_auth import has_project_access
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -38,11 +44,23 @@ async def resolve_member(
     session: AsyncSession,
     project_id: uuid.UUID | None = None,
 ) -> ResolvedMember:
-    """멤버 신원 해소 — 인증 방식에 따라 분기.
+    """멤버 신원 해소 — AC2-3 shadow 플래그로 레거시/앵커 분기.
 
-    API키(에이전트): team_member.id 반환.
-    JWT(휴먼): org_member.id 반환 + has_project_access 검증.
+    플래그 off(기본): org_members/team_members 기반(레거시).
+    플래그 on(shadow): members(+aliases) 앵커 기반. 0075 ID 보존으로 출력 동일(parity).
     """
+    if settings.member_ssot_resolver_shadow:
+        return await _resolve_member_anchor(auth, org_id, session, project_id)
+    return await _resolve_member_legacy(auth, org_id, session, project_id)
+
+
+async def _resolve_member_legacy(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> ResolvedMember:
+    """레거시 신원 해소 — API키(에이전트): team_member.id / JWT(휴먼): org_member.id + has_project_access."""
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
 
     if is_api_key:
@@ -94,11 +112,94 @@ async def resolve_member(
     )
 
 
+async def _resolve_member_anchor(
+    auth: AuthContext,
+    org_id: uuid.UUID,
+    session: AsyncSession,
+    project_id: uuid.UUID | None = None,
+) -> ResolvedMember:
+    """앵커 신원 해소 — members(+placement) 기반. 0075 ID 보존으로 레거시와 출력 동일(parity).
+
+    에이전트(API키): members.id(=team_member.id), role=project_access.role, project_id=agent_project_profiles.project_id.
+    휴먼(JWT): members.id(=org_member.id), role=members.org_role, name=users.email(레거시 정합).
+    """
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+
+    if is_api_key:
+        member_id = uuid.UUID(auth.user_id)
+        m = (await session.execute(
+            select(Member).where(Member.id == member_id, Member.type == "agent")
+        )).scalars().first()
+        if m is None:
+            raise HTTPException(status_code=400, detail="Team member not found")
+        # placement(역할/프로젝트) — 에이전트 member.id = team_member.id (1:1)
+        role = (await session.execute(
+            select(ProjectAccess.role).where(ProjectAccess.member_id == m.id).limit(1)
+        )).scalar_one_or_none()
+        proj = (await session.execute(
+            select(AgentProjectProfile.project_id).where(AgentProjectProfile.member_id == m.id).limit(1)
+        )).scalar_one_or_none()
+        return ResolvedMember(
+            id=m.id,
+            user_id=None,
+            name=m.name,
+            type=m.type,
+            role=role or "member",
+            org_id=m.org_id,
+            project_id=proj,
+        )
+
+    # JWT 휴먼
+    user_id = uuid.UUID(auth.user_id)
+
+    if project_id is not None:
+        if not await has_project_access(session, user_id, project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to this project")
+
+    m = (await session.execute(
+        select(Member).where(
+            Member.org_id == org_id,
+            Member.user_id == user_id,
+            Member.type == "human",
+            Member.deleted_at.is_(None),
+        )
+    )).scalar_one_or_none()
+    if m is None:
+        raise HTTPException(status_code=400, detail="Organization member not found")
+
+    user = (await session.execute(
+        select(User).where(User.id == user_id)
+    )).scalar_one_or_none()
+    name = user.email if user else str(user_id)
+
+    return ResolvedMember(
+        id=m.id,
+        user_id=user_id,
+        name=name,
+        type="human",
+        role=m.org_role or "member",
+        org_id=m.org_id,
+        project_id=project_id,
+    )
+
+
 async def lookup_members_by_ids(
     ids: set[uuid.UUID],
     session: AsyncSession,
 ) -> dict[uuid.UUID, ResolvedMember]:
-    """ID 집합 → ResolvedMember 맵. TeamMember 우선, 없으면 OrgMember."""
+    """ID 집합 → ResolvedMember 맵. AC2-3 shadow 플래그로 레거시/앵커 분기."""
+    if not ids:
+        return {}
+    if settings.member_ssot_resolver_shadow:
+        return await _lookup_members_by_ids_anchor(ids, session)
+    return await _lookup_members_by_ids_legacy(ids, session)
+
+
+async def _lookup_members_by_ids_legacy(
+    ids: set[uuid.UUID],
+    session: AsyncSession,
+) -> dict[uuid.UUID, ResolvedMember]:
+    """레거시 ID 집합 → ResolvedMember 맵. TeamMember 우선, 없으면 OrgMember, 그래도 없으면 orphan fallback."""
     if not ids:
         return {}
 
@@ -148,6 +249,84 @@ async def lookup_members_by_ids(
                 org_id=uuid.UUID(int=0),
                 project_id=None,
             )
+
+    return result
+
+
+async def _lookup_members_by_ids_anchor(
+    ids: set[uuid.UUID],
+    session: AsyncSession,
+) -> dict[uuid.UUID, ResolvedMember]:
+    """앵커 ID 집합 → ResolvedMember 맵. members 직접 → member_identity_aliases resolve(908075db
+    de-fallback) → 진짜 orphan(member/alias 모두 없음)만 telemetry-only.
+
+    레거시 휴먼 team_member.id는 alias를 통해 canonical 휴먼 member(=org_member.id)로 해소되며,
+    맵의 key는 호출자가 넘긴 원본 id 유지(callers가 원본 id로 조회). .id 필드는 canonical member.id.
+    """
+    if not ids:
+        return {}
+
+    result: dict[uuid.UUID, ResolvedMember] = {}
+    resolved_member_for: dict[uuid.UUID, Member] = {}
+
+    # 1. members 직접 매칭 (id가 곧 member.id)
+    members = (await session.execute(select(Member).where(Member.id.in_(ids)))).scalars().all()
+    member_by_id = {m.id: m for m in members}
+    for mid in ids:
+        if mid in member_by_id:
+            resolved_member_for[mid] = member_by_id[mid]
+
+    # 2. alias 매칭 (레거시 team_member.id → canonical member) — 908075db de-fallback
+    missing = ids - set(resolved_member_for.keys())
+    if missing:
+        alias_rows = (await session.execute(
+            select(MemberIdentityAlias.alias_id, MemberIdentityAlias.member_id)
+            .where(MemberIdentityAlias.alias_id.in_(missing))
+        )).all()
+        target_ids = {row[1] for row in alias_rows}
+        target_members: dict[uuid.UUID, Member] = {}
+        if target_ids:
+            tms = (await session.execute(select(Member).where(Member.id.in_(target_ids)))).scalars().all()
+            target_members = {m.id: m for m in tms}
+        for alias_id, member_id in alias_rows:
+            tgt = target_members.get(member_id)
+            if tgt is not None:
+                resolved_member_for[alias_id] = tgt
+
+    # 에이전트 placement(role/project_id) 배치 조회
+    agent_ids = [m.id for m in resolved_member_for.values() if m.type == "agent"]
+    role_by_member: dict[uuid.UUID, str] = {}
+    proj_by_member: dict[uuid.UUID, uuid.UUID] = {}
+    if agent_ids:
+        for mid_, role in (await session.execute(
+            select(ProjectAccess.member_id, ProjectAccess.role).where(ProjectAccess.member_id.in_(agent_ids))
+        )).all():
+            role_by_member.setdefault(mid_, role)
+        for mid_, pid in (await session.execute(
+            select(AgentProjectProfile.member_id, AgentProjectProfile.project_id).where(AgentProjectProfile.member_id.in_(agent_ids))
+        )).all():
+            proj_by_member.setdefault(mid_, pid)
+
+    for orig_id, m in resolved_member_for.items():
+        if m.type == "agent":
+            result[orig_id] = ResolvedMember(
+                id=m.id, user_id=None, name=m.name, type="agent",
+                role=role_by_member.get(m.id, "member"), org_id=m.org_id,
+                project_id=proj_by_member.get(m.id),
+            )
+        else:
+            result[orig_id] = ResolvedMember(
+                id=m.id, user_id=m.user_id, name=m.name, type="human",
+                role=m.org_role or "member", org_id=m.org_id, project_id=None,
+            )
+
+    # 3. 진짜 orphan(member/alias 모두 없음) — telemetry-only + 크래시 방지 placeholder
+    for oid in ids - set(result.keys()):
+        logger.warning("member_resolver(anchor): unresolved orphan id=%s — no member/alias", oid)
+        result[oid] = ResolvedMember(
+            id=oid, user_id=None, name=str(oid)[:8],
+            type="human", role="member", org_id=uuid.UUID(int=0), project_id=None,
+        )
 
     return result
 

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -1,0 +1,162 @@
+"""E-MEMBER-SSOT AC2-3 (H2): 실행 가능 real-DB parity 테스트.
+
+legacy(org_members/team_members) vs anchor(members/aliases) resolver를 **동일 실 데이터**로
+대조해 0-diff 입증. mocked로는 못 잡는 실데이터 정합(orphan·멀티프로젝트·휴먼 name)을 검증.
+
+DB env(ALEMBIC_DATABASE_URL 또는 PARITY_TEST_DATABASE_URL) 없으면 skip — CI alembic-fresh-db
+잡(postgres + alembic upgrade head)에서 실행되며, 로컬은 throwaway PG로 실행.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_RAW_URL = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+# alembic은 sync(psycopg2) URL — async 드라이버로 변환
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="parity real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# 고정 UUID — 시드/검증 공유
+ORG = uuid.UUID("b1000000-0000-0000-0000-000000000001")
+U_OWNER = uuid.UUID("b2000000-0000-0000-0000-000000000001")
+U_MEM = uuid.UUID("b2000000-0000-0000-0000-000000000002")
+OM_OWNER = uuid.UUID("b3000000-0000-0000-0000-000000000001")
+OM_MEM = uuid.UUID("b3000000-0000-0000-0000-000000000002")
+P1 = uuid.UUID("b4000000-0000-0000-0000-000000000001")
+P2 = uuid.UUID("b4000000-0000-0000-0000-000000000002")
+TM_OWNER = uuid.UUID("b5000000-0000-0000-0000-000000000001")  # 레거시 휴먼 team_member
+AG1 = uuid.UUID("b5000000-0000-0000-0000-0000000000a1")       # 멀티프로젝트 agent — proj1
+AG2 = uuid.UUID("b5000000-0000-0000-0000-0000000000a2")       # 멀티프로젝트 agent — proj2
+ORPHAN = uuid.UUID("bf000000-0000-0000-0000-000000000000")
+
+
+def _auth(uid, api_key=False):
+    c = MagicMock()
+    c.user_id = str(uid)
+    c.claims = {"app_metadata": ({"api_key_id": "ak"} if api_key else {})}
+    return c
+
+
+def _tup(r):
+    return (str(r.id), str(r.user_id) if r.user_id else None, r.name, r.type, r.role,
+            str(r.org_id), str(r.project_id) if r.project_id else None)
+
+
+async def _seed(session):
+    """legacy + anchor를 일관되게 시드(0075 백필 결과 모사 — members.id=org_member/team_member.id)."""
+    from sqlalchemy import text
+    stmts = [
+        # 방어: fresh `alembic upgrade head`에선 0075 DROP NOT NULL이 미지속되는 관찰(별건 flag)이 있어,
+        # 에이전트 placement(org_member_id NULL) 시드를 위해 idempotent하게 nullable 보장(테스트 신뢰성).
+        "ALTER TABLE project_access ALTER COLUMN org_member_id DROP NOT NULL",
+        # 의존 역순 정리(이전 실행 잔여) — 단일 트랜잭션, 유효 문만(실패 시 tx abort 방지)
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{AG1}','{AG2}')",
+        f"DELETE FROM member_identity_aliases WHERE org_id='{ORG}'",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM project_access WHERE project_id IN ('{P1}','{P2}')",
+        f"DELETE FROM team_members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM org_members WHERE org_id='{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{U_OWNER}','{U_MEM}')",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','PG','pgorg','free')",
+        f"INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{U_OWNER}','owner@pg.test','x','Owner',true,true,0,false,0),('{U_MEM}','mem@pg.test','x','Mem',true,true,0,false,0)",
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_OWNER}','{ORG}','{U_OWNER}','owner'),('{OM_MEM}','{ORG}','{U_MEM}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0),('{P2}','{ORG}','P2',0)",
+        f"INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) VALUES "
+        f"('{TM_OWNER}','{P1}','{ORG}','{U_OWNER}','human','Owner','owner','#3385f8',true,true,NULL),"
+        f"('{AG1}','{P1}','{ORG}',NULL,'agent','Bot','member','#ff0000',false,true,'{U_OWNER}'),"
+        f"('{AG2}','{P2}','{ORG}',NULL,'agent','Bot','reviewer','#00ff00',false,true,'{U_OWNER}')",
+        f"INSERT INTO project_access (id,project_id,org_member_id,member_id,permission,role,access_source) VALUES "
+        f"(gen_random_uuid(),'{P1}','{OM_MEM}','{OM_MEM}','granted','member','direct'),"
+        f"(gen_random_uuid(),'{P1}',NULL,'{AG1}','granted','member','direct'),"
+        f"(gen_random_uuid(),'{P2}',NULL,'{AG2}','granted','reviewer','direct')",
+        # anchor: members(휴먼 id=org_member.id, agent id=team_member.id)
+        f"INSERT INTO members (id,org_id,type,user_id,name,org_role,is_active) VALUES "
+        f"('{OM_OWNER}','{ORG}','human','{U_OWNER}','owner@pg.test','owner',true),"
+        f"('{OM_MEM}','{ORG}','human','{U_MEM}','mem@pg.test','member',true),"
+        f"('{AG1}','{ORG}','agent',NULL,'Bot',NULL,true),"
+        f"('{AG2}','{ORG}','agent',NULL,'Bot',NULL,true)",
+        f"INSERT INTO member_identity_aliases (alias_id,member_id,org_id,project_id,alias_source) VALUES "
+        f"('{TM_OWNER}','{OM_OWNER}','{ORG}','{P1}','human_team_member')",
+        f"INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port) VALUES "
+        f"(gen_random_uuid(),'{AG1}','{P1}','dev',9101),(gen_random_uuid(),'{AG2}','{P2}','qa',9102)",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_resolve_member_parity_legacy_vs_anchor():
+    """resolve_member: legacy vs anchor 0-diff (agent 멀티프로젝트·human owner·grant member)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services import member_resolver as mr
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        cases = [
+            (_auth(AG1, api_key=True), None),      # agent proj1
+            (_auth(AG2, api_key=True), None),      # agent proj2 (멀티프로젝트)
+            (_auth(U_OWNER), P1),                  # human owner
+            (_auth(U_MEM), P1),                    # human grant member
+        ]
+        for auth, pid in cases:
+            mr.settings.member_ssot_resolver_shadow = False
+            async with Session() as s:
+                legacy = await mr.resolve_member(auth, ORG, s, project_id=pid)
+            mr.settings.member_ssot_resolver_shadow = True
+            async with Session() as s:
+                anchor = await mr.resolve_member(auth, ORG, s, project_id=pid)
+            assert _tup(legacy) == _tup(anchor), f"parity DIFF: legacy={_tup(legacy)} anchor={_tup(anchor)}"
+    finally:
+        mr.settings.member_ssot_resolver_shadow = False
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_lookup_members_parity_identity_and_canonicalization():
+    """lookup: 직접 member·agent·orphan은 id/type 동일, 레거시 휴먼 team_member.id는 canonical 전환."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services import member_resolver as mr
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+        ids = {AG1, AG2, OM_OWNER, OM_MEM, TM_OWNER, ORPHAN}
+        mr.settings.member_ssot_resolver_shadow = False
+        async with Session() as s:
+            legacy = await mr.lookup_members_by_ids(ids, s)
+        mr.settings.member_ssot_resolver_shadow = True
+        async with Session() as s:
+            anchor = await mr.lookup_members_by_ids(ids, s)
+
+        # 직접 member(휴먼/에이전트) + orphan: id·type 동일
+        for k in (AG1, AG2, OM_OWNER, OM_MEM, ORPHAN):
+            assert (str(legacy[k].id), legacy[k].type) == (str(anchor[k].id), anchor[k].type), f"{k} 불일치"
+        # 휴먼 direct name = email (M1 정합, 단일/batch 일관)
+        assert anchor[OM_MEM].name == "mem@pg.test"
+        # 레거시 휴먼 team_member.id → canonical 휴먼 member(org_member.id)
+        assert anchor[TM_OWNER].id == OM_OWNER
+    finally:
+        mr.settings.member_ssot_resolver_shadow = False
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -20,6 +20,14 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _pin_legacy_resolver(monkeypatch):
+    """이 파일은 레거시 resolver(org_members/team_members) 경로를 검증 — AC2-3 shadow
+    플래그가 전역 on이어도 레거시 경로로 고정(anchor 경로는 test_member_ssot_resolver_shadow.py)."""
+    import app.services.member_resolver as _mr
+    monkeypatch.setattr(_mr.settings, "member_ssot_resolver_shadow", False)
+
+
 def _make_auth(user_id: uuid.UUID = USER_ID, is_api_key: bool = False) -> MagicMock:
     ctx = MagicMock()
     ctx.user_id = str(user_id)

--- a/backend/tests/test_member_ssot_resolver_shadow.py
+++ b/backend/tests/test_member_ssot_resolver_shadow.py
@@ -1,0 +1,165 @@
+"""E-MEMBER-SSOT AC2-3: anchor resolver shadow (members+aliases) 단위 테스트.
+
+플래그 on(per-test monkeypatch)으로 anchor 경로 검증. 기본 off는 레거시(다른 테스트가 커버).
+parity(legacy vs anchor 0-diff)는 실 PG 하네스로 별도 검증.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(user_id, is_api_key=False):
+    ctx = MagicMock()
+    ctx.user_id = str(user_id)
+    ctx.claims = {"app_metadata": ({"api_key_id": "ak"} if is_api_key else {})}
+    return ctx
+
+
+def _result(scalar=None, first=None, all_=None, rows=None):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = scalar
+    r.scalars.return_value.first.return_value = first
+    r.scalars.return_value.all.return_value = all_ if all_ is not None else []
+    r.all.return_value = rows if rows is not None else []  # 2+컬럼 select(.all()) 용
+    return r
+
+
+# ── resolve_member anchor (flag on) ───────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_anchor_resolve_member_agent(monkeypatch):
+    """API키 에이전트 → members(type=agent) + project_access.role + agent_project_profiles.project_id."""
+    import app.services.member_resolver as mr
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    agent_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    proj_id = uuid.uuid4()
+    member = MagicMock()
+    member.id = agent_id
+    member.name = "Agent Bot"
+    member.type = "agent"
+    member.org_id = org_id
+
+    session = AsyncMock()
+    # Member(agent) → ProjectAccess.role → AgentProjectProfile.project_id
+    session.execute = AsyncMock(side_effect=[_result(first=member), _result(scalar="member"), _result(scalar=proj_id)])
+
+    resolved = await mr.resolve_member(_auth(agent_id, is_api_key=True), org_id, session)
+    assert resolved.id == agent_id
+    assert resolved.type == "agent"
+    assert resolved.role == "member"
+    assert resolved.project_id == proj_id
+    assert resolved.user_id is None
+
+
+@pytest.mark.anyio
+async def test_anchor_resolve_member_human(monkeypatch):
+    """JWT 휴먼 → members(type=human, org_role) + name=users.email (레거시 정합)."""
+    import app.services.member_resolver as mr
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    member = MagicMock()
+    member.id = uuid.uuid4()
+    member.user_id = user_id
+    member.org_id = org_id
+    member.org_role = "admin"
+    user = MagicMock()
+    user.email = "human@test.com"
+
+    session = AsyncMock()
+    # Member(human) → User(email)
+    session.execute = AsyncMock(side_effect=[_result(scalar=member), _result(scalar=user)])
+
+    resolved = await mr.resolve_member(_auth(user_id), org_id, session, project_id=None)
+    assert resolved.type == "human"
+    assert resolved.user_id == user_id
+    assert resolved.role == "admin"   # org_role
+    assert resolved.name == "human@test.com"
+
+
+@pytest.mark.anyio
+async def test_anchor_resolve_member_human_not_found_400(monkeypatch):
+    import app.services.member_resolver as mr
+    from fastapi import HTTPException
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_result(scalar=None)])  # member 없음
+    with pytest.raises(HTTPException) as exc:
+        await mr.resolve_member(_auth(uuid.uuid4()), uuid.uuid4(), session, project_id=None)
+    assert exc.value.status_code == 400
+
+
+# ── lookup_members_by_ids anchor (flag on) ────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_anchor_lookup_direct_member(monkeypatch):
+    """id가 곧 member.id면 직접 해소 (휴먼)."""
+    import app.services.member_resolver as mr
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    mid = uuid.uuid4()
+    m = MagicMock()
+    m.id = mid; m.user_id = uuid.uuid4(); m.name = "H"; m.type = "human"; m.org_role = "member"; m.org_id = uuid.uuid4()
+
+    session = AsyncMock()
+    # Member.in_(ids) → [m]
+    session.execute = AsyncMock(side_effect=[_result(all_=[m])])
+
+    out = await mr.lookup_members_by_ids({mid}, session)
+    assert out[mid].id == mid
+    assert out[mid].type == "human"
+    assert out[mid].role == "member"
+
+
+@pytest.mark.anyio
+async def test_anchor_lookup_alias_canonicalizes(monkeypatch):
+    """레거시 team_member.id는 alias로 canonical member(org_member.id)로 해소 (908075db de-fallback)."""
+    import app.services.member_resolver as mr
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    legacy_tm_id = uuid.uuid4()
+    canonical_id = uuid.uuid4()
+    canon = MagicMock()
+    canon.id = canonical_id; canon.user_id = uuid.uuid4(); canon.name = "H"; canon.type = "human"; canon.org_role = "member"; canon.org_id = uuid.uuid4()
+
+    session = AsyncMock()
+    # 1) Member.in_ → [] (직접 매칭 없음)  2) alias rows → [(legacy_tm_id, canonical_id)]  3) Member.in_(target) → [canon]
+    session.execute = AsyncMock(side_effect=[
+        _result(all_=[]),                              # Member.in_ → 직접 매칭 없음
+        _result(rows=[(legacy_tm_id, canonical_id)]),  # alias rows (.all())
+        _result(all_=[canon]),                         # Member.in_(target) → canonical
+    ])
+
+    out = await mr.lookup_members_by_ids({legacy_tm_id}, session)
+    # key는 원본 id, .id는 canonical
+    assert legacy_tm_id in out
+    assert out[legacy_tm_id].id == canonical_id
+
+
+@pytest.mark.anyio
+async def test_anchor_lookup_true_orphan_telemetry(monkeypatch):
+    """member·alias 모두 없으면 telemetry-only + 크래시 방지 placeholder (가짜 resolve 아님)."""
+    import app.services.member_resolver as mr
+
+    monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
+    orphan = uuid.uuid4()
+    session = AsyncMock()
+    # Member.in_ → []  / alias → []
+    session.execute = AsyncMock(side_effect=[_result(all_=[]), _result(all_=[])])
+
+    with patch.object(mr.logger, "warning") as mock_warn:
+        out = await mr.lookup_members_by_ids({orphan}, session)
+    assert orphan in out  # placeholder
+    assert mock_warn.called  # telemetry 로그

--- a/backend/tests/test_member_ssot_resolver_shadow.py
+++ b/backend/tests/test_member_ssot_resolver_shadow.py
@@ -115,12 +115,14 @@ async def test_anchor_lookup_direct_member(monkeypatch):
 
     session = AsyncMock()
     # Member.in_(ids) → [m]
-    session.execute = AsyncMock(side_effect=[_result(all_=[m])])
+    # Member.in_ → [m]  /  User email batch(M1) → [(user_id, email)]
+    session.execute = AsyncMock(side_effect=[_result(all_=[m]), _result(rows=[(m.user_id, "h@test.com")])])
 
     out = await mr.lookup_members_by_ids({mid}, session)
     assert out[mid].id == mid
     assert out[mid].type == "human"
     assert out[mid].role == "member"
+    assert out[mid].name == "h@test.com"  # M1: 휴먼 name=email
 
 
 @pytest.mark.anyio
@@ -140,6 +142,7 @@ async def test_anchor_lookup_alias_canonicalizes(monkeypatch):
         _result(all_=[]),                              # Member.in_ → 직접 매칭 없음
         _result(rows=[(legacy_tm_id, canonical_id)]),  # alias rows (.all())
         _result(all_=[canon]),                         # Member.in_(target) → canonical
+        _result(rows=[(canon.user_id, "c@test.com")]), # User email batch(M1, canon=human)
     ])
 
     out = await mr.lookup_members_by_ids({legacy_tm_id}, session)


### PR DESCRIPTION
## 배경
blueprint §4 Phase3. 신원 해소를 polymorphic id → canonical `members.id`(anchor)로 전환하되 **config 플래그 뒤 shadow** — off(기본)=레거시 유지(가역), on=anchor. **라이브 cutover는 AC3-1** (여기선 shadow, 기본 off라 실 read 경로 무변경).

## 변경
- config `member_ssot_resolver_shadow: bool = False` (env `MEMBER_SSOT_RESOLVER_SHADOW`).
- `resolve_member` → 플래그 dispatch (`_resolve_member_legacy` / `_resolve_member_anchor`):
  - agent: `members`(id=team_member.id) + `project_access.role` + `agent_project_profiles.project_id`
  - human: `members`(id=org_member.id, `org_role`) + `users.email`(name)
  - 0075 ID 보존으로 legacy와 **0-diff**.
- `lookup_members_by_ids` → dispatch (`_lookup_..._legacy` / `_lookup_..._anchor`):
  - `members` 직접 → `member_identity_aliases` resolve(레거시 휴먼 team_member.id → canonical member) → 진짜 orphan만 **telemetry-only** (**908075db de-fallback** — 가짜 resolve 제거).

## 검증
- **anchor 단위 6종**: agent / human / not-found 400 / lookup direct·alias-canonicalize·orphan-telemetry.
- **실 PG16 parity 하네스** (legacy vs anchor, seed: 휴먼 owner+member·레거시 휴먼 team_member·에이전트·grant·orphan):
  - `resolve_member` → **0-DIFF ✅** (agent API키 / human grant)
  - `lookup_members_by_ids` → agent·orphan 동일, **레거시 휴먼 team_member.id → canonical member.id(의도된 anchor 전환, alias resolve)**, 휴먼 name은 canonical `members.name`(display_name 우선 — id/type 동일)
- **플래그 on/off 양쪽 전체 스위트 green** (각 **1448 passed / 0 failed**). 레거시 테스트 파일(`test_member_ssot_phase0.py`)은 autouse fixture로 off 고정(anchor는 `test_member_ssot_resolver_shadow.py`).

⚠️ **shadow — 기본 off라 프로덕션 read 경로 무변경**. 라이브 cutover(플래그 on 기본화 + dual-write)는 AC3-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)