### PR TITLE
[SID:1154dd9e] feat(member-ssot): AC3-2 Batch 2 — assignee_id team_members FK 완화 + v2 (0078)

### DIFF
--- a/backend/alembic/versions/0078_assignee_v2_fk_relax.py
+++ b/backend/alembic/versions/0078_assignee_v2_fk_relax.py
@@ -1,0 +1,85 @@
+"""E-MEMBER-SSOT AC3-2 Batch 2: stories/tasks/epics assignee_id team_members FK 완화 + v2.
+
+blueprint §4 Phase4. assignee_id가 team_members FK라 grant-only 휴먼(org_member.id) 할당 시
+FK 위반 500(AC6 라이브 근거 1154dd9e). FK DROP으로 해소 + assignee_id_v2(canonical) + alias 백필.
+
+- assignee_id team_members FK(ondelete SET NULL) DROP — 0069/0073/0074 inspector 패턴(컬럼·데이터 유지).
+- assignee_id_v2 + 백필=COALESCE(alias.member_id, legacy)(orphan-safe 트랩#4): 레거시 휴먼 tm→canonical,
+  agent/org-member 보존.
+- ⚠️ assignee_id_v2 FK 보류(트랩#7): write 경로(할당 API)가 _v2 미사용 → 신규행 _v2 NULL → FK 신규검증 회피.
+  read-cut 후 cutover서 추가. 추가형·가역.
+
+Revision ID: 0078
+Revises: 0077
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0078"
+down_revision = "0077"
+branch_labels = None
+depends_on = None
+
+_TARGETS = ["epics", "stories", "tasks"]
+_COL = "assignee_id"
+
+
+def _fks_to_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [fk for fk in insp.get_foreign_keys(table) if fk.get("referred_table") == "team_members"]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _TARGETS:
+        if table not in tables:
+            continue
+        # 1. assignee_id team_members FK DROP (grant-only 할당 500 해소)
+        for fk in _fks_to_team_members(insp, table):
+            if _COL in fk.get("constrained_columns", []):
+                fk_name = fk.get("name")
+                if fk_name:
+                    op.drop_constraint(fk_name, table, type_="foreignkey")
+        # 2. assignee_id_v2 + alias 백필(orphan-safe)
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {_COL}_v2 uuid")
+        op.execute(
+            f"""
+            UPDATE {table} SET {_COL}_v2 = COALESCE(
+                (SELECT a.member_id FROM member_identity_aliases a WHERE a.alias_id = {table}.{_COL}),
+                {table}.{_COL}
+            )
+            WHERE {_COL} IS NOT NULL AND {_COL}_v2 IS NULL
+            """
+        )
+        op.execute(f"CREATE INDEX IF NOT EXISTS ix_{table}_assignee_id_v2 ON {table} ({_COL}_v2)")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _TARGETS:
+        if table not in tables:
+            continue
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_assignee_id_v2")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {_COL}_v2")
+        # 비-team_member assignee_id가 없을 때만 FK 재추가(데이터 안전)
+        existing = {fk["name"] for fk in _fks_to_team_members(insp, table)}
+        fk_name = f"{table}_{_COL}_fkey"
+        if fk_name in existing:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{_COL} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{_COL}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(fk_name, table, "team_members", [_COL], ["id"], ondelete="SET NULL")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -49,8 +49,10 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
@@ -85,8 +87,10 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     sprint_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     meeting_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
@@ -120,8 +124,10 @@ class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="todo")

--- a/backend/tests/test_e_entity_cleanup_s5_human_cleanup.py
+++ b/backend/tests/test_e_entity_cleanup_s5_human_cleanup.py
@@ -63,20 +63,24 @@ def test_invitations_keeps_org_member_creation():
     assert "OrgMember" in source or "org_members" in source
 
 
-# ─── AC3: story assignee FK 정상 동작 ────────────────────────────────────────
+# ─── AC3: story/task assignee — E-MEMBER-SSOT AC3-2(0078)에서 계약 변경 ──────────
+# S5 당시: assignee_id team_members FK 유지(agent 배정).
+# AC3-2(1154dd9e, migration 0078): 그 FK가 grant-only 휴먼(org_member.id) 배정 시 실DB FK
+#   violation 500을 유발 → FK 제거. canonical 식별자는 assignee_id_v2. agent 배정은 id 값으로
+#   계속 동작(FK 강제만 해제). 따라서 team_members FK가 **없어야** 정상. [[feedback_one_sided_transition]]
 
-def test_story_assignee_fk_still_defined():
-    """Story.assignee_id FK는 team_members.id로 유지됨 (agent 배정 정상 동작)."""
+def test_story_assignee_has_no_team_members_fk():
+    """AC3-2: Story.assignee_id team_members FK 제거 — grant-only 배정 500 해소."""
     from app.models.pm import Story
-    fk_targets = [str(fk.target_fullname) for fk in Story.__table__.foreign_keys]
-    assert any("team_members" in t for t in fk_targets)
+    referred = {fk.column.table.name for fk in Story.__table__.c.assignee_id.foreign_keys}
+    assert "team_members" not in referred
 
 
-def test_task_assignee_fk_still_defined():
-    """Task.assignee_id FK는 team_members.id로 유지됨."""
+def test_task_assignee_has_no_team_members_fk():
+    """AC3-2: Task.assignee_id team_members FK 제거 — grant-only 배정 500 해소."""
     from app.models.pm import Task
-    fk_targets = [str(fk.target_fullname) for fk in Task.__table__.foreign_keys]
-    assert any("team_members" in t for t in fk_targets)
+    referred = {fk.column.table.name for fk in Task.__table__.c.assignee_id.foreign_keys}
+    assert "team_members" not in referred
 
 
 # ─── AC4: agent 영향 없음 ────────────────────────────────────────────────────

--- a/backend/tests/test_member_ssot_ac3_2.py
+++ b/backend/tests/test_member_ssot_ac3_2.py
@@ -1,0 +1,20 @@
+"""E-MEMBER-SSOT AC3-2: 식별 컬럼 v2 + team_members FK 완화 구조 회귀.
+
+Batch2: stories/tasks/epics assignee_id team_members FK 제거(grant-only 할당 500 해소, migration 0078).
+실데이터 백필/parity는 test_member_ssot_parity_realdb.py(실 PG) 및 격리 PG 하네스로 검증.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize("model_name", ["Epic", "Story", "Task"])
+def test_assignee_id_has_no_team_members_fk(model_name):
+    """assignee_id의 team_members FK 제거 — grant-only 휴먼(org_member.id) 할당 시 실DB FK violation
+    500이 나지 않음 (migration 0078). canonical은 assignee_id_v2."""
+    import app.models.pm as pm
+
+    model = getattr(pm, model_name)
+    col = model.__table__.c.assignee_id
+    referred = {fk.column.table.name for fk in col.foreign_keys}
+    assert "team_members" not in referred, f"{model_name}.assignee_id still has team_members FK"


### PR DESCRIPTION
## E-MEMBER-SSOT AC3-2 Batch 2 (assignee_id)

epics/stories/tasks.`assignee_id`가 team_members FK라 **grant-only 휴먼(org_member.id) 배정 시 실DB FK violation 500**(AC6 라이브 근거). FK 제거로 해소 + canonical 이행 토대.

### 변경
- **migration 0078**
  - `assignee_id` team_members FK(SET NULL) **DROP** — inspector 기반 idempotent (0069/0073/0074 패턴), 컬럼·데이터·인덱스 유지
  - `assignee_id_v2` 추가 + alias 백필 `COALESCE(alias.member_id, legacy)` (orphan-safe, 트랩#4) + v2 인덱스
  - downgrade: v2 컬럼 drop + 비-team_member 값 없을 때만 FK 재추가(데이터 안전)
- **모델** `pm.py`: epics/stories/tasks.`assignee_id` team_members `ForeignKey` 제거(컬럼/nullable 유지). canonical은 `assignee_id_v2`
- **테스트**: `test_member_ssot_ac3_2.py` 신설(FK 부재 구조회귀 3) + S5 `test_e_entity_cleanup` "FK 유지" 단언 2건을 새 계약("FK 없음")으로 갱신

### 트랩 적용
- #4 orphan-safe 백필(COALESCE alias→legacy)
- #7 `assignee_id_v2` FK 보류 — write 경로가 _v2 미사용 → 신규행 _v2 NULL → FK 신규검증 회피. cutover서 추가
- #6 parity는 read-cut 후속 배치

### 검증
- **격리 PG**: FK 있을 때 grant-only 배정 → FK violation 500 **재현** → FK DROP 후 **성공**. v2 백필: org_member 보존 / legacy_tm→canonical / agent 보존
- 풀스위트 **1448 passed**, 21 skipped

### ⚠️ 머지 후
`sprintable-migrate-dev` 0078 PO 체인 필수 (머지-migrate 한 쌍, 0076 누락 인시던트 교훈)

🤖 Generated with [Claude Code](https://claude.com/claude-code)