### PR TITLE
[SID:1154dd9e] feat(member-ssot): AC3-2 Batch 3 — 잔여 식별 컬럼 team_members FK 완화 + v2 (0079)

### DIFF
--- a/backend/alembic/versions/0079_identity_v2_rest_fk_relax.py
+++ b/backend/alembic/versions/0079_identity_v2_rest_fk_relax.py
@@ -1,0 +1,114 @@
+"""E-MEMBER-SSOT AC3-2 Batch 3: 잔여 식별 컬럼 team_members FK 완화 + v2.
+
+blueprint §4 Phase4 마무리. participation/webhook_configs/reward_ledger/docs/doc_comments/
+doc_revisions/notification_preferences의 legacy team_member.id 식별 컬럼을 canonical members.id로
+이행. Batch2(assignee_id)와 동형 — team_members FK가 grant-only 휴먼(org_member.id) write 시
+실DB FK violation 500을 유발하는 동일 버그 클래스 → FK DROP + *_v2 + alias 백필.
+
+대상 (table, column):
+- participation.member_id            (CASCADE, NOT NULL) — 스토리 참가
+- notification_preferences.member_id (FK는 0073서 이미 DROP — v2만)
+- webhook_configs.member_id          (CASCADE, NOT NULL) — 생성자
+- reward_ledger.member_id            (CASCADE, NOT NULL) — 수령자
+- reward_ledger.granted_by           (SET NULL, NULL)    — 지급자
+- docs.created_by / docs.assignee_id (SET NULL, NULL)
+- doc_comments.created_by            (CASCADE, NOT NULL)
+- doc_revisions.created_by           (SET NULL, NULL)
+
+백필 = COALESCE(alias.member_id, legacy): 레거시 휴먼 tm→canonical, agent/org-member 보존(orphan-safe 트랩#4).
+⚠️ *_v2 FK 보류(트랩#7): write 경로가 _v2 미사용 → 신규행 _v2 NULL → FK 신규검증 회피. 추가형·가역.
+
+Revision ID: 0079
+Revises: 0078
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0079"
+down_revision = "0078"
+branch_labels = None
+depends_on = None
+
+# (table, column, downgrade 재추가용 ondelete | None=재추가 안 함[0073 소유])
+_TARGETS: list[tuple[str, str, str | None]] = [
+    ("participation", "member_id", "CASCADE"),
+    ("notification_preferences", "member_id", None),  # FK는 0073가 소유 — 0079 downgrade서 재추가 안 함
+    ("webhook_configs", "member_id", "CASCADE"),
+    ("reward_ledger", "member_id", "CASCADE"),
+    ("reward_ledger", "granted_by", "SET NULL"),
+    ("docs", "created_by", "SET NULL"),
+    ("docs", "assignee_id", "SET NULL"),
+    ("doc_comments", "created_by", "CASCADE"),
+    ("doc_revisions", "created_by", "SET NULL"),
+]
+# 필터/조회 hot 컬럼에 v2 인덱스(member_id_v2)
+_V2_MEMBER_INDEX = ["participation", "notification_preferences", "webhook_configs", "reward_ledger"]
+
+
+def _drop_tm_fk(insp: sa.Inspector, table: str, col: str) -> None:
+    for fk in insp.get_foreign_keys(table):
+        if fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", []):
+            if fk.get("name"):
+                op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, _ in _TARGETS:
+        if table not in tables:
+            continue
+        _drop_tm_fk(insp, table, col)
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid")
+        op.execute(
+            f"""
+            UPDATE {table} SET {col}_v2 = COALESCE(
+                (SELECT a.member_id FROM member_identity_aliases a WHERE a.alias_id = {table}.{col}),
+                {table}.{col}
+            )
+            WHERE {col} IS NOT NULL AND {col}_v2 IS NULL
+            """
+        )
+
+    for table in _V2_MEMBER_INDEX:
+        if table in tables:
+            op.execute(
+                f"CREATE INDEX IF NOT EXISTS ix_{table}_member_id_v2 ON {table} (member_id_v2)"
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _V2_MEMBER_INDEX:
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_member_id_v2")
+
+    for table, col, ondelete in _TARGETS:
+        if table not in tables:
+            continue
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+        if ondelete is None:
+            continue
+        # 비-team_member 값이 없을 때만 FK 재추가(데이터 안전)
+        already = any(
+            fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", [])
+            for fk in insp.get_foreign_keys(table)
+        )
+        if already:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{col} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(f"{table}_{col}_fkey", table, "team_members", [col], ["id"], ondelete=ondelete)

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -23,10 +23,10 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("docs.id", ondelete="SET NULL"), nullable=True, index=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
@@ -65,7 +65,7 @@ class DocComment(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -84,7 +84,7 @@ class DocRevision(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/participation.py
+++ b/backend/app/models/participation.py
@@ -30,8 +30,9 @@ class Participation(Base, OrgScopedMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     role_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("participation_role.id", ondelete="CASCADE"), nullable=False

--- a/backend/app/models/reward.py
+++ b/backend/app/models/reward.py
@@ -16,11 +16,12 @@ class RewardLedger(Base, OrgScopedMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical=*_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     granted_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     amount: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
     currency: Mapped[str] = mapped_column(Text, nullable=False, default="TJSB")

--- a/backend/app/models/webhook_config.py
+++ b/backend/app/models/webhook_config.py
@@ -15,8 +15,9 @@ class WebhookConfig(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True

--- a/backend/tests/test_member_ssot_ac3_2.py
+++ b/backend/tests/test_member_ssot_ac3_2.py
@@ -10,11 +10,37 @@ import pytest
 
 @pytest.mark.parametrize("model_name", ["Epic", "Story", "Task"])
 def test_assignee_id_has_no_team_members_fk(model_name):
-    """assignee_id의 team_members FK 제거 — grant-only 휴먼(org_member.id) 할당 시 실DB FK violation
-    500이 나지 않음 (migration 0078). canonical은 assignee_id_v2."""
+    """Batch2(0078): assignee_id team_members FK 제거 — grant-only 휴먼(org_member.id) 배정 시 실DB
+    FK violation 500이 나지 않음. canonical은 assignee_id_v2."""
     import app.models.pm as pm
 
     model = getattr(pm, model_name)
     col = model.__table__.c.assignee_id
     referred = {fk.column.table.name for fk in col.foreign_keys}
     assert "team_members" not in referred, f"{model_name}.assignee_id still has team_members FK"
+
+
+def _batch3_identity_cols():
+    from app.models.doc import Doc, DocComment, DocRevision
+    from app.models.participation import Participation
+    from app.models.reward import RewardLedger
+    from app.models.webhook_config import WebhookConfig
+
+    return [
+        (Participation, "member_id"),
+        (WebhookConfig, "member_id"),
+        (RewardLedger, "member_id"),
+        (RewardLedger, "granted_by"),
+        (Doc, "created_by"),
+        (Doc, "assignee_id"),
+        (DocComment, "created_by"),
+        (DocRevision, "created_by"),
+    ]
+
+
+@pytest.mark.parametrize("model,col", _batch3_identity_cols(), ids=lambda v: getattr(v, "__name__", v))
+def test_batch3_identity_col_has_no_team_members_fk(model, col):
+    """Batch3(0079): participation/webhook/reward/docs 식별 컬럼 team_members FK 제거 —
+    grant-only 휴먼 write 시 실DB FK violation 500 방지. canonical은 *_v2. (notif는 0073서 기제거)"""
+    referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
+    assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"


### PR DESCRIPTION
## E-MEMBER-SSOT AC3-2 Batch 3 (잔여 식별 컬럼) — AC3-2 스토리 완주

Batch1(conv/events)·Batch2(assignee_id)에 이어 **나머지 legacy team_member.id 식별 컬럼**을 canonical로 이행. 이 컬럼들도 team_members FK라 grant-only 휴먼(org_member.id) write 시 **동일 버그 클래스(실DB FK violation 500)** → FK DROP + `*_v2` + alias 백필.

### 대상 (9개 컬럼)
| table | column | 기존 FK |
|---|---|---|
| participation | member_id | team_members (CASCADE) |
| notification_preferences | member_id | (0073서 기DROP — v2만) |
| webhook_configs | member_id | team_members (CASCADE) |
| reward_ledger | member_id / granted_by | team_members |
| docs | created_by / assignee_id | team_members |
| doc_comments | created_by | team_members |
| doc_revisions | created_by | team_members |

### 변경
- **migration 0079**: 일반화 루프 — 컬럼별 team_members FK DROP(inspector idempotent, **다중-FK-per-table**[reward_ledger·docs] 컬럼 정밀 매칭) + `{col}_v2` + `COALESCE(alias, legacy)` 백필(orphan-safe) + `member_id_v2` 인덱스. downgrade: 비-tm 값 없을 때만 FK 재추가(notif는 0073 소유라 제외)
- **모델**: 8개 컬럼 team_members `ForeignKey` 제거(컬럼/nullable/index 유지). canonical은 `*_v2`
- **테스트**: Batch3 FK-부재 구조회귀 8 추가

### 트랩 적용
- #4 orphan-safe 백필 / #7 `*_v2` FK 보류(write 미사용→신규행 NULL→신규검증 회피) / #6 parity는 read-cut 후속

### 검증
- **격리 PG**: 다중-FK-per-table(reward_ledger member_id+granted_by) FK 있을 때 grant-only → **500 재현** → DROP 후 **성공**. v2 백필: org_member 보존 / legacy_tm→canonical / NULL 보존
- 풀스위트 **1459 passed**, 21 skipped

### ⚠️ 머지 후
`sprintable-migrate-dev` 0079 PO 체인 필수 (머지-migrate 한 쌍)

🤖 Generated with [Claude Code](https://claude.com/claude-code)