### PR TITLE
[SID:f5ee8387] feat(member-ssot): AC3-1b — 신규 agent anchor write-sync + apikey member FK 재추가

### DIFF
--- a/backend/alembic/versions/0080_agent_api_keys_member_fk.py
+++ b/backend/alembic/versions/0080_agent_api_keys_member_fk.py
@@ -1,0 +1,66 @@
+"""E-MEMBER-SSOT AC3-1b AC3: agent_api_keys.member_id → members(id) FK 재추가.
+
+AC3-1(0076)에서 member_id를 추가·dual-write 했으나, NOT VALID FK라도 **신규 INSERT는 검증**(트랩#7/8)
+→ 신규 agent가 members 부재 시 api_key INSERT 위반 500(생명선)이라 FK를 제거했다(QA H1). AC3-1b AC1
+(신규 agent anchor write-sync)이 members 행을 api_key 생성 전 선행 보장하므로 이제 FK 재추가 안전.
+
+- FK NOT VALID: 기존 행 검증은 skip(신규 INSERT만 검증 — AC1로 referent 선행).
+- VALIDATE는 **가드**: members 부재 referent를 가진 기존 행이 0건일 때만(있으면 NOT VALID 유지 +
+  RAISE NOTICE — migrate 하드페일 방지, 머지-migrate 인시던트 교훈). 잔여 시 AC2 감사·보정 후 재VALIDATE.
+- ondelete SET NULL: member_id는 nullable 미러 — 실삭제는 team_member_id FK(CASCADE)가 처리.
+
+Revision ID: 0080
+Revises: 0079
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0080"
+down_revision = "0079"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "agent_api_keys" not in insp.get_table_names():
+        return
+    existing = {fk.get("name") for fk in insp.get_foreign_keys("agent_api_keys")}
+    if _FK not in existing:
+        op.execute(
+            f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK} "
+            f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+        )
+    # 가드된 VALIDATE: members 부재 referent 0건일 때만
+    op.execute(
+        f"""
+        DO $$
+        DECLARE bad int;
+        BEGIN
+            SELECT count(*) INTO bad FROM agent_api_keys ak
+            WHERE ak.member_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+            IF bad = 0 THEN
+                ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+            ELSE
+                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row %% 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "agent_api_keys" not in insp.get_table_names():
+        return
+    existing = {fk.get("name") for fk in insp.get_foreign_keys("agent_api_keys")}
+    if _FK in existing:
+        op.drop_constraint(_FK, "agent_api_keys", type_="foreignkey")

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -16,8 +16,11 @@ class ApiKey(Base):
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-1: canonical members.id 미러 (team_member_id와 1:1 dual-write, 0075 ID 보존).
-    # FK는 신규 agent 생성 깨짐(QA H1) 방지로 현재 무FK — AC3-1b(anchor write-sync) 후 재추가. nullable.
-    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    # AC3-1b(0080): anchor write-sync로 신규 agent members 선행 보장 → FK 재추가(QA H1 해소).
+    # ondelete SET NULL(미러 — 실삭제는 team_member_id CASCADE가 처리). nullable.
+    member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
     key_hash: Mapped[str] = mapped_column(Text, nullable=False)
     scope: Mapped[list | None] = mapped_column(ARRAY(Text), nullable=True)

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -177,6 +177,12 @@ async def create_team_member(
         fakechat_port=fakechat_port,
     )
 
+    # E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync(members + agent_project_profiles).
+    # ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.member_id→members FK(0080) 충족 + cut-on 무중단.
+    if body.type == "agent":
+        from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+        await sync_agent_anchor_on_create(session, member, created_by)
+
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
 

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -1,0 +1,93 @@
+"""E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync.
+
+신규 agent(team_member type='agent') 생성 시 앵커 신원(members) + per-project 런타임
+(agent_project_profiles)을 함께 dual-write 한다. 0075 백필과 **동형**(members.id=team_member.id,
+owner_member_id=생성 휴먼 member, agent_project_profiles는 team_member 런타임 필드 미러).
+
+왜 foundational:
+- members 부재 → `member_ssot_apikey_cut=on`에서 _resolve_api_key가 401(생명선 차단).
+- agent_project_profiles 부재 → cut-on의 project_id=None(M1).
+- 둘 부재 → agent_api_keys.member_id→members FK 재추가(0080) 시 신규 INSERT가 referent 없어 위반(트랩#7/8).
+
+⚠️ 호출 위치: team_member 생성 직후 ~ **api_key 자동생성 이전**(FK 선행 충족). create_team_member에서 보장.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.member import AgentProjectProfile, Member
+from app.models.project import OrgMember
+
+
+async def sync_agent_anchor_on_create(
+    session: AsyncSession,
+    team_member,
+    created_by: uuid.UUID | None,
+) -> None:
+    """agent team_member의 앵커(members + agent_project_profiles)를 멱등 dual-write.
+
+    team_member.type != 'agent'이면 no-op. 멱등(ON CONFLICT DO NOTHING) — 재호출/백필 중복 안전.
+    """
+    if getattr(team_member, "type", None) != "agent":
+        return
+
+    # owner_member_id = 생성 휴먼의 member.id (= org_member.id, 0075 불변식).
+    #   휴먼 org_member이고 members 행이 실재할 때만; 그 외(agent 생성자·orphan) NULL(SET NULL 컬럼).
+    owner_member_id: uuid.UUID | None = None
+    if created_by is not None:
+        owner_member_id = (
+            await session.execute(
+                select(OrgMember.id)
+                .where(OrgMember.org_id == team_member.org_id)
+                .where(OrgMember.user_id == created_by)
+                .where(OrgMember.deleted_at.is_(None))
+            )
+        ).scalar_one_or_none()
+        if owner_member_id is not None:
+            member_exists = (
+                await session.execute(select(Member.id).where(Member.id == owner_member_id))
+            ).scalar_one_or_none()
+            if member_exists is None:
+                owner_member_id = None
+
+    # 1. members (id=team_member.id, type='agent') — 0075 에이전트 백필 동형
+    await session.execute(
+        pg_insert(Member.__table__)
+        .values(
+            id=team_member.id,
+            org_id=team_member.org_id,
+            type="agent",
+            user_id=None,
+            owner_member_id=owner_member_id,
+            name=team_member.name,
+            avatar_url=team_member.avatar_url,
+            org_role=None,
+            is_active=team_member.is_active,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+
+    # 2. agent_project_profiles (member_id=team_member.id) — 런타임/설정 미러
+    await session.execute(
+        pg_insert(AgentProjectProfile.__table__)
+        .values(
+            id=uuid.uuid4(),
+            member_id=team_member.id,
+            project_id=team_member.project_id,
+            agent_config=team_member.agent_config,
+            webhook_url=team_member.webhook_url,
+            agent_role=team_member.agent_role,
+            fakechat_port=team_member.fakechat_port,
+            last_seen_at=team_member.last_seen_at,
+            active_story_id=team_member.active_story_id,
+            agent_status=team_member.agent_status,
+        )
+        .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 모두 흡수
+    )
+
+    # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
+    await session.flush()

--- a/backend/scripts/audit_apikey_member_anchor.py
+++ b/backend/scripts/audit_apikey_member_anchor.py
@@ -1,0 +1,75 @@
+"""E-MEMBER-SSOT AC3-1b AC2: agent_api_keys 앵커 정합 감사 (H2).
+
+`member_ssot_apikey_cut=on`의 _resolve_api_key는 `members(id=api_key.member_id, type='agent',
+is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 member_id=team_member_id를
+dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
+(a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
+
+이 스크립트는 그런 **위반 active key**를 나열한다.
+- 0건  → flag-on 안전 + 0080 FK VALIDATE 통과.
+- 1건+ → 처리 필요: 정당 agent면 members 보정(또는 agent_anchor_sync 재실행), human/오용 key면 무효화.
+
+env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
+실행: cd backend && DATABASE_URL=... python -m scripts.audit_apikey_member_anchor
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from sqlalchemy import text
+
+from app.core.database import async_session_factory
+
+# active(미revoke·미만료) key 중 cut-on이 깨질 row: members(agent,active) 부재
+AUDIT_SQL = """
+SELECT ak.id            AS api_key_id,
+       ak.team_member_id,
+       ak.member_id,
+       tm.type          AS tm_type,
+       tm.is_active     AS tm_active,
+       (m.id IS NOT NULL) AS member_exists,
+       (m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
+FROM agent_api_keys ak
+LEFT JOIN team_members tm ON tm.id = ak.team_member_id
+LEFT JOIN members m       ON m.id = ak.member_id
+WHERE ak.revoked_at IS NULL
+  AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+ORDER BY ak.created_at
+"""
+
+# 0080 FK VALIDATE 가드와 동일 기준: member_id referent 부재(active 무관 전 row)
+FK_VIOLATION_SQL = """
+SELECT count(*) FROM agent_api_keys ak
+WHERE ak.member_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id)
+"""
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("[FAIL] DATABASE_URL 필요", file=sys.stderr)
+        return 2
+    async with async_session_factory() as s:
+        rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
+        fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
+
+    print(f"=== AC2 H2 감사: cut-on 위반 active key {len(rows)}건 ===")
+    for r in rows:
+        print(
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
+            f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
+        )
+    print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
+
+    if len(rows) == 0 and fk_bad == 0:
+        print("[PASS] 위반 0건 — flag-on 안전 + 0080 FK VALIDATE 통과 예상")
+        return 0
+    print("[WARN] 위반 존재 — flag-on 전 처리 필요(정당 agent: members 보정 / human·오용: key 무효화)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_member_ssot_ac3_1b.py
+++ b/backend/tests/test_member_ssot_ac3_1b.py
@@ -1,0 +1,39 @@
+"""E-MEMBER-SSOT AC3-1b: 신규 agent anchor write-sync + agent_api_keys.member_id FK 재추가.
+
+실데이터 기능(write-sync가 members/profile 생성·FK 충족)은 test_member_ssot_parity_realdb.py(실 PG)에서.
+여기선 항상 도는 구조회귀 + 헬퍼 no-op 가드.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_apikey_member_id_has_members_fk():
+    """AC3(0080): agent_api_keys.member_id → members FK 재추가(QA H1 해소). write-sync로 referent 선행."""
+    from app.models.api_key import ApiKey
+
+    referred = {fk.column.table.name for fk in ApiKey.__table__.c.member_id.foreign_keys}
+    assert "members" in referred, "agent_api_keys.member_id의 members FK가 없음(0080 재추가 누락)"
+
+
+@pytest.mark.anyio
+async def test_sync_agent_anchor_noop_for_non_agent():
+    """type != 'agent'면 write-sync는 no-op(어떤 INSERT/flush도 안 함)."""
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    tm = MagicMock()
+    tm.type = "human"
+    await sync_agent_anchor_on_create(session, tm, created_by=uuid.uuid4())
+    session.execute.assert_not_called()
+    session.flush.assert_not_called()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -203,41 +203,99 @@ async def test_apikey_resolve_parity_legacy_vs_anchor():
         await engine.dispose()
 
 
+NEW_TM = uuid.UUID("b5000000-0000-0000-0000-0000000000b9")
+NEW_APIKEY = uuid.UUID("b7000000-0000-0000-0000-0000000000b9")
+
+
+async def _make_new_agent_tm(session):
+    """members/profile/apikey 없는 신규 agent team_member 삽입(재실행 정리 포함). TeamMember ORM 반환."""
+    from sqlalchemy import select, text
+    from app.models.team import TeamMember
+    await session.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(NEW_APIKEY)})
+    await session.execute(text("DELETE FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text("DELETE FROM team_members WHERE id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text(
+        "INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by,agent_role,fakechat_port) "
+        "VALUES (:id,:p,:o,NULL,'agent','NewBot','member','#fff',false,true,:cb,'dev',9199)"
+    ), {"id": str(NEW_TM), "p": str(P1), "o": str(ORG), "cb": str(U_OWNER)})
+    await session.commit()
+    return (await session.execute(select(TeamMember).where(TeamMember.id == NEW_TM))).scalar_one()
+
+
 @pytest.mark.anyio
-async def test_apikey_insert_without_member_row_no_fk_violation():
-    """⚠️ H1 회귀: agent_api_keys.member_id에 members 없는 값(신규 agent 시뮬) INSERT가 FK 위반
-    없이 성공 — dual-write가 신규 agent 생성(auto API key)을 깨지 않음(생명선·머지 안전)."""
+async def test_agent_anchor_writesync_creates_members_and_profile():
+    """⚠️ 생명선 AC3-1b AC1: 신규 agent 생성 write-sync가 members(id=tm.id·type=agent·owner=생성휴먼)
+    + agent_project_profiles(member=tm.id·런타임 미러)를 만든다 → cut-on 무중단·project_id 해소·FK 충족."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
 
     engine = create_async_engine(_ASYNC_URL)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
             await _seed(s)
-        # members에 없는 team_member(AG1은 members 있으니 새 tm 생성) + 그 id로 api_key dual-write
-        new_tm = uuid.UUID("b5000000-0000-0000-0000-0000000000b9")
+            tm = await _make_new_agent_tm(s)
+            await sync_agent_anchor_on_create(s, tm, created_by=U_OWNER)
+            await s.commit()
         async with Session() as s:
-            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": "b7000000-0000-0000-0000-0000000000b9"})
-            await s.execute(text("DELETE FROM team_members WHERE id=:i"), {"i": str(new_tm)})
-            await s.execute(text(
-                "INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) "
-                "VALUES (:id,:p,:o,NULL,'agent','NewBot','member','#fff',false,true,:cb)"
-            ), {"id": str(new_tm), "p": str(P1), "o": str(ORG), "cb": str(U_OWNER)})
-            # dual-write: member_id=team_member_id (members 행 없음) — FK 없으므로 성공해야
+            m = (await s.execute(text(
+                "SELECT type, owner_member_id, name, is_active FROM members WHERE id=:i"), {"i": str(NEW_TM)})).first()
+            prof = (await s.execute(text(
+                "SELECT project_id, agent_role, fakechat_port FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
+        assert m is not None and m.type == "agent" and m.is_active is True, "members(agent) 미생성"
+        assert str(m.owner_member_id) == str(OM_OWNER), f"owner_member_id=생성 휴먼 member 아님: {m.owner_member_id}"
+        assert prof is not None and str(prof.project_id) == str(P1) and prof.agent_role == "dev", "agent_project_profiles 미생성/미러 불일치"
+
+        # 멱등: 재호출해도 중복/에러 없음
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.team import TeamMember
+            tmobj = (await s.execute(select(TeamMember).where(TeamMember.id == NEW_TM))).scalar_one()
+            await sync_agent_anchor_on_create(s, tmobj, created_by=U_OWNER)
+            await s.commit()
+            prof_cnt = (await s.execute(text(
+                "SELECT count(*) FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).scalar_one()
+            assert prof_cnt == 1, f"멱등 위반: profile {prof_cnt}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apikey_insert_after_writesync_succeeds_and_absent_member_violates_fk():
+    """⚠️ 생명선 AC3-1b AC3: 0080 FK 재추가 후 — write-sync로 members 선행 시 신규 agent api_key
+    INSERT 성공(H1을 올바른 방식으로 해소), members 부재 member_id는 FK 위반(트랩#7/8 가드)."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            tm = await _make_new_agent_tm(s)
+            await sync_agent_anchor_on_create(s, tm, created_by=U_OWNER)  # members 선행
+            await s.commit()
+        # write-sync 후 api_key INSERT(member_id=tm.id) → FK 충족 성공
+        async with Session() as s:
             await s.execute(text(
                 "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
                 "VALUES (:id,:tm,:m,'sk_live_b9','hashb9',ARRAY['read','write'])"
-            ), {"id": "b7000000-0000-0000-0000-0000000000b9", "tm": str(new_tm), "m": str(new_tm)})
+            ), {"id": str(NEW_APIKEY), "tm": str(NEW_TM), "m": str(NEW_TM)})
             await s.commit()
-        # 검증: 삽입됨 + member_id가 members에 없음(FK 미적용 확인)
+            cnt = (await s.execute(text("SELECT count(*) FROM agent_api_keys WHERE id=:i"), {"i": str(NEW_APIKEY)})).scalar_one()
+            assert cnt == 1, "write-sync 후 api_key INSERT 실패(H1 회귀)"
+        # members 부재 member_id → FK 위반(0080 재추가 입증)
+        absent = uuid.UUID("b5000000-0000-0000-0000-0000000000ba")
         async with Session() as s:
-            cnt = (await s.execute(text(
-                "SELECT count(*) FROM agent_api_keys WHERE id='b7000000-0000-0000-0000-0000000000b9'"
-            ))).scalar_one()
-            assert cnt == 1
-            orphan = (await s.execute(text(
-                "SELECT count(*) FROM members WHERE id=:i"), {"i": str(new_tm)})).scalar_one()
-            assert orphan == 0  # members 없음에도 INSERT 성공 = FK 없음
+            with pytest.raises(IntegrityError):
+                await s.execute(text(
+                    "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash) "
+                    "VALUES (gen_random_uuid(),:tm,:m,'sk_live_ba','hashba')"
+                ), {"tm": str(absent), "m": str(absent)})
+                await s.commit()
     finally:
         await engine.dispose()


### PR DESCRIPTION
## E-MEMBER-SSOT AC3-1b — `member_ssot_apikey_cut` flag-on 전제 (foundational·생명선)

신규 agent(team_member type=agent)가 앵커(members/agent_project_profiles) 없이 만들어지면 cut-on에서 **401(생명선 차단)**·project_id=None·agent_api_keys FK 위반이 모두 발생. AC1 write-sync가 이를 근본 차단하고, 그 위에서 FK를 안전하게 재추가.

### AC1 — 신규 agent anchor write-sync (`agent_anchor_sync.py`)
- agent 생성 시 `members`(id=tm.id·type='agent'·owner_member_id=생성 휴먼 member·런타임 미러) + `agent_project_profiles`(member=tm.id) **멱등 dual-write** (0075 백필 동형, ON CONFLICT DO NOTHING)
- `create_team_member`에서 **api_key 자동생성 이전** 호출 → `agent_api_keys.member_id→members` FK 선행 충족
- non-agent no-op

### AC2 — H2 감사 (`scripts/audit_apikey_member_anchor.py`, 읽기 전용)
- active api_key 중 `tm.type != 'agent'` 또는 members(agent) 부재 → cut-on 401 위험 row 나열 + 0080 FK VALIDATE 위반 카운트
- `[PASS]` 0건=flag-on 안전. 위반 시: 정당 agent → members 보정 / human·오용 → key 무효화. **PO in-VPC 실행**

### AC3 — FK 재추가 (migration 0080)
- `agent_api_keys.member_id→members(id)` FK **NOT VALID → 가드된 VALIDATE**(members 부재 referent 0건일 때만; 있으면 NOT VALID 유지 + RAISE NOTICE — migrate 하드페일 방지, 인시던트 교훈)
- 모델 FK 재추가(ondelete SET NULL — 미러, 실삭제는 team_member_id CASCADE). AC1로 신규 referent 선행 → **QA H1(트랩 #7/#8) 해소**

### AC4 — flag-on (이번 PR 미포함)
additive(flag off 유지). dev `member_ssot_apikey_cut=on` soak→prod는 **별도 후속 단계**(전 에이전트 comms 걸린 cut, 선생님 awareness 권장, PO 리드)

### 검증
- **격리 PG**: FK NOT VALID도 신규 INSERT 검증(트랩#7/8) / write-sync 선행 시 신규 agent api_key INSERT 성공(H1 해소) / 가드 VALIDATE `convalidated=t`
- **실DB parity 5 passed**: resolve/lookup/apikey-resolve 무중단 + write-sync가 members/profile 생성(owner·멱등) + 부재 member FK 위반
- 풀스위트 **1461 passed**. 구 계약 테스트(apikey FK 없음) → 신규 계약으로 갱신(no-defer)

### ⚠️ 머지 후
`sprintable-migrate-dev` 0080 PO 체인 (머지-migrate 한 쌍). flag-on(AC4)은 후속.

🤖 Generated with [Claude Code](https://claude.com/claude-code)