### PR TITLE
[SID:f5ee8387] hotfix(migrate): 0080 가드 RAISE NOTICE %% → % (실DB bad>0 분기 syntax 오류)

### DIFF
--- a/backend/alembic/versions/0080_agent_api_keys_member_fk.py
+++ b/backend/alembic/versions/0080_agent_api_keys_member_fk.py
@@ -49,7 +49,7 @@ def upgrade() -> None:
             IF bad = 0 THEN
                 ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
             ELSE
-                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row %% 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
             END IF;
         END $$;
         """

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -299,3 +299,73 @@ async def test_apikey_insert_after_writesync_succeeds_and_absent_member_violates
                 await s.commit()
     finally:
         await engine.dispose()
+
+
+# ── 0080 hotfix: 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기 syntax 검증(트랩#4 실DB-only) ──────────
+_FK_0080 = "fk_agent_api_keys_member_id_members"
+_GUARD_DO_0080 = f"""
+DO $$
+DECLARE bad int;
+BEGIN
+    SELECT count(*) INTO bad FROM agent_api_keys ak
+    WHERE ak.member_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+    IF bad = 0 THEN
+        ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+    ELSE
+        RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0080_guard_validate_raise_branch_bad_gt0():
+    """⚠️ 트랩#4(실DB-only): 0080 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid해야 한다.
+    CI fresh-DB는 bad=0(VALIDATE 분기)라 RAISE 분기 미발현 — members 부재 active key가 실재하는 dev에서만
+    터졌던 `too many parameters for RAISE`(%% vs % 회귀) 가드. 위반행을 FK 추가 전 INSERT(NOT VALID도
+    신규검증) → FK NOT VALID → 가드 DO 실행이 크래시 없이 NOT VALID 유지하는지."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_key = uuid.UUID("b7000000-0000-0000-0000-0000000000c0")
+    absent_member = uuid.UUID("b9000000-0000-0000-0000-0000000000c0")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            # FK 부재 상태에서 위반행 INSERT(member_id가 members에 없음) — bad>0 모사
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+                "VALUES (:id,:tm,:m,'sk_live_c0','hashc0',ARRAY['read','write'])"
+            ), {"id": str(bad_key), "tm": str(AG1), "m": str(absent_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        # 가드 DO 실행 — bad>0 → RAISE NOTICE 분기. SyntaxError 없이 통과해야(%% 회귀 가드)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0080))
+            await s.commit()
+        # FK는 NOT VALID 유지(가드가 VALIDATE 안 함)
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            # 모델 baseline FK 복원(NOT VALID — 검증 실패 없이 재실행/타테스트 오염 방지)
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## 🔥 Hotfix — migrate-dev 0080 실패 차단 해소

reauth 후 첫 `sprintable-migrate-dev`에서 **0080 실패** → 전체 migrate 체인(0080·0081) 차단.

### 원인
`0080:52` 가드 VALIDATE의 `RAISE NOTICE`:
```
RAISE NOTICE '... members 부재 row %% 건 ...', bad;
```
`%%`(리터럴 %, placeholder 0)인데 arg `bad`(1개) → `psycopg2.errors.SyntaxError: too many parameters specified for RAISE`. `op.execute`는 bind param이 없어 psycopg2 %-치환을 안 해 `%%`가 postgres에 **raw 전달** → placeholder 0.

### 왜 CI가 못 잡았나 (트랩#4: 실DB-only)
RAISE 분기는 **`bad > 0`(members-부재 active agent_api_keys 실존)** 일 때만 탄다. CI fresh-DB는 `bad=0`(VALIDATE 분기) → RAISE 미발현. members-부재 api_key가 실재하는 dev에서만 터짐.

### 중대 부수확인
`bad>0` 발현 = **H2(members-부재 agent_api_keys) 실존 확정** → AC3-1b **AC2 감사·보정이 flag-on(AC4) 전 진짜 load-bearing**. 가드가 올바로 NOT VALID 유지를 시도한 것(설계 의도대로) — 단지 NOTICE 문구가 깨졌을 뿐.

### 수정
`%%` → `%` (placeholder 1 = arg 1 정합). 0080은 **dev 실패(롤백)·prod 미적용**이라 어디에도 적용 0 → 파일 직접 수정 안전.

### 테스트 (실DB bad>0 경로 — 트랩#4 회귀 가드)
`test_0080_guard_validate_raise_branch_bad_gt0`: 위반행을 FK 추가 **전** INSERT(NOT VALID도 신규검증) → FK NOT VALID → 가드 DO 실행이 **크래시 없이** NOT VALID 유지하는지. throwaway PG parity **6 passed**.

### ⚠️ 머지 후
`sprintable-migrate-dev` 재실행(0079 멱등, 0080까지 적용). 이후 #1180(0081). `bad>0` 잔여 members-부재 api_key는 **AC2 감사·보정**(audit_apikey_member_anchor.py) 별도 — flag-on(AC4) 전제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)