### PR TITLE
[SID:2616f4cb] fix: AC3-3 get_missing 키(grant-only 누락) + verify 하네스 setup

### DIFF
--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -19,11 +19,14 @@ _MISSING_SQL = text(
         FROM org_members om
         WHERE om.org_id = :org AND om.deleted_at IS NULL AND om.role IN ('owner','admin')
         UNION
-        -- 2) project_access grant (휴먼: member_id = org_member.id)
-        SELECT pa.member_id AS cid
+        -- 2) project_access grant (휴먼: canonical = org_member.id). ⚠️ 실 grant 플로우
+        --    (create_project_access)는 org_member_id만 세팅하고 member_id는 NULL로 둔다(0075 백필분만
+        --    member_id 채워짐) → member_id 키는 신규 grant-only 휴먼을 누락. org_member_id로 집계.
+        --    (에이전트 direct placement는 org_member_id NULL이라 자연 제외 — 휴먼 grant만.)
+        SELECT pa.org_member_id AS cid
         FROM project_access pa
-        JOIN org_members om2 ON om2.id = pa.member_id AND om2.deleted_at IS NULL
-        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.member_id IS NOT NULL
+        JOIN org_members om2 ON om2.id = pa.org_member_id AND om2.deleted_at IS NULL
+        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.org_member_id IS NOT NULL
         UNION
         -- 3) 레거시 휴먼 team_member → canonical(alias)
         SELECT a.member_id AS cid

--- a/backend/scripts/verify_grant_only_story_assign.py
+++ b/backend/scripts/verify_grant_only_story_assign.py
@@ -68,13 +68,12 @@ async def main() -> int:
             om = OrgMember(org_id=org_id, user_id=u.id, role="member")  # owner/admin 아님 = 순수 grant 의존
             s.add(om)
             await s.flush()
+            # 실 grant 플로우(create_project_access)와 동형: org_member_id만 세팅, member_id는 NULL.
+            # member_id=om.id로 채우면 fk_project_access_member(members 미존재) 위반 — 실 grant은 member_id 안 씀.
             pa = ProjectAccess(
                 project_id=project_id,
                 org_member_id=om.id,
                 permission="granted",
-                member_id=om.id,
-                role="member",
-                access_source="direct",
             )
             s.add(pa)
             story = Story(org_id=org_id, project_id=project_id, title=f"grant-only assign verify {suffix}")

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -339,8 +339,13 @@ async def test_get_missing_canonical_single_identity():
             await _seed(s)
             await s.execute(text("DELETE FROM standup_entries WHERE project_id=:p AND date=:d"),
                             {"p": str(P1), "d": _SD_DATE})
+            # ⚠️ 실 grant 플로우 모사: create_project_access는 member_id를 NULL로 둔다(org_member_id만).
+            # branch2가 member_id 키면 OM_MEM 누락(신규 grant-only 휴먼 미표시) → org_member_id 키여야 함.
+            await s.execute(text(
+                "UPDATE project_access SET member_id=NULL WHERE project_id=:p AND org_member_id=:m"),
+                {"p": str(P1), "m": str(OM_MEM)})
             await s.commit()
-        # roster(P1) = owner(OM_OWNER) ∪ grant(OM_MEM) ∪ 레거시 휴먼 tm(TM_OWNER→OM_OWNER) = {OWNER, MEM}
+        # roster(P1) = owner(OM_OWNER) ∪ grant(OM_MEM, member_id=NULL) ∪ 레거시 휴먼 tm(TM_OWNER→OM_OWNER)
         async with Session() as s:
             missing = set(await StandupEntryRepository(s, ORG).get_missing(P1, _SD_DATE))
         assert missing == {OM_OWNER, OM_MEM}, f"roster 불일치: {missing}"


### PR DESCRIPTION
## AC3-3 get_missing 실버그 + verify 하네스 setup 수정 (develop 신규 PR)

#1180/#1182 머지 후 발견 — 두 수정이 머지 시점 이후 푸시돼 develop 미반영. develop 기준 신규 PR(마이그 0, 코드/tooling).

### ① AC3-3 get_missing 키 버그 (실 grant-only 휴먼 누락)
실 grant 플로우 `create_project_access`(project_access.py)는 `project_access`에 **org_member_id만 세팅, member_id=NULL**(0075 백필분만 member_id 채워짐). `get_missing` branch2가 `pa.member_id`(신규 grant서 NULL) 키 → **신규 grant-only 휴먼을 standup 로스터서 누락** = AC3-3가 해소하려던 핵심 케이스가 깨짐.
→ `pa.org_member_id` 키로(휴먼 grant는 항상 org_member_id set = canonical org_member.id; 에이전트 placement는 org_member_id NULL이라 자연 제외).
테스트: 시드 grant의 member_id를 NULL로 UPDATE(실 grant 모사)해도 OM_MEM이 로스터에 — 수정 전이면 실패.

### ② verify 하네스 setup
`verify_grant_only_story_assign.py`가 임시 grant-only 휴먼의 `ProjectAccess(member_id=om.id)`로 채워 `fk_project_access_member`(members 미존재) 위반(PO in-VPC setup서 발현). → 실 grant 플로우 동형으로 `org_member_id`만(member_id 제거).

### 검증
throwaway PG(get_missing: member_id=NULL grant도 org_member_id 경유 로스터 포함) + 풀스위트 1465 passed + 소스가드.

🤖 Generated with [Claude Code](https://claude.com/claude-code)