### PR TITLE
[SID:f5ee8387] fix(member-ssot): AC2 보정 — window agent anchor 재조정 (0082)

### DIFF
--- a/backend/alembic/versions/0082_reconcile_window_agent_anchors.py
+++ b/backend/alembic/versions/0082_reconcile_window_agent_anchors.py
@@ -1,0 +1,84 @@
+"""E-MEMBER-SSOT AC3-1b AC2 보정: window agent anchor 재조정(members + agent_project_profiles).
+
+AC2 감사(in-VPC): cut-on 위반 active api_key 중 1건(a52b4ccd, agent active=True·members 부재) = 실 회귀
++ 0080 FK VALIDATE 블로커. 원인: **0075 agent 백필 ↔ AC3-1b write-sync(코드) 배포 사이 window에 생성된
+agent** — 0075엔 아직 없었고 write-sync 배포 전이라 members/profile 미생성. (나머지 5건은 inactive agent
+= legacy도 is_active 요구로 401 = 무회귀.)
+
+해소: 0075 agent 백필 로직을 idempotent 재실행해 members 없는 agent team_member를 모두 재조정. write-sync
+배포로 window는 닫혔으므로 신규 agent는 정상; 이 마이그는 과거 window agent를 소급 보정한다.
+
+- members(id=tm.id·type='agent'·owner=생성휴먼·런타임 미러) ON CONFLICT (id) DO NOTHING.
+- agent_project_profiles(member=tm.id) ON CONFLICT (project_id, member_id) DO NOTHING.
+- 보정 후 0080 FK 가드 VALIDATE: members 부재 referent 0건이면 VALIDATE(아니면 NOT VALID 유지+NOTICE).
+
+orphan-safe(트랙#4): organizations JOIN으로 orphan org 스킵, owner는 members 실재 시만(LEFT JOIN). 추가형·가역.
+
+Revision ID: 0082
+Revises: 0081
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0082"
+down_revision = "0081"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    # 1. members 재조정 — 0075 §3 agent 백필 동형(idempotent)
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, avatar_url, org_role, is_active, created_at, updated_at)
+        SELECT tm.id, tm.org_id, 'agent', NULL, owner.id, tm.name, tm.avatar_url, NULL, tm.is_active, tm.created_at, now()
+        FROM team_members tm
+        JOIN organizations o ON o.id = tm.org_id
+        LEFT JOIN org_members owner
+               ON owner.org_id = tm.org_id AND owner.user_id = tm.created_by AND owner.deleted_at IS NULL
+              AND EXISTS (SELECT 1 FROM members m WHERE m.id = owner.id)
+        WHERE tm.type = 'agent'
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+    # 2. agent_project_profiles 재조정 — 0075 §6 동형(idempotent)
+    op.execute(
+        """
+        INSERT INTO agent_project_profiles
+            (id, member_id, project_id, agent_config, webhook_url, agent_role, fakechat_port, last_seen_at, active_story_id, agent_status, created_at, updated_at)
+        SELECT gen_random_uuid(), tm.id, tm.project_id, tm.agent_config, tm.webhook_url, tm.agent_role,
+               tm.fakechat_port, tm.last_seen_at, tm.active_story_id, tm.agent_status, tm.created_at, now()
+        FROM team_members tm
+        WHERE tm.type = 'agent'
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = tm.id)
+        ON CONFLICT (project_id, member_id) DO NOTHING
+        """
+    )
+    # 3. 0080 FK 가드 VALIDATE — 보정 후 members 부재 referent 0건이면 검증(아니면 NOT VALID 유지)
+    op.execute(
+        f"""
+        DO $$
+        DECLARE bad int;
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK}' AND NOT convalidated) THEN
+                SELECT count(*) INTO bad FROM agent_api_keys ak
+                WHERE ak.member_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+                IF bad = 0 THEN
+                    ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+                ELSE
+                    RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 (window 보정 후에도 잔여 — 점검 필요)', bad;
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 일방향 재조정 백필(0075 동형) — 역삭제는 정상 0075 백필분과 구분 불가라 위험. no-op(0075 정책).
+    pass

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -436,3 +436,73 @@ async def test_0080_guard_validate_raise_branch_bad_gt0():
             ))
             await s.commit()
         await engine.dispose()
+
+
+# ── 0082 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기 syntax 검증(트랩#4 실DB-only) ──────────────────
+_GUARD_DO_0082 = f"""
+DO $$
+DECLARE bad int;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK_0080}' AND NOT convalidated) THEN
+        SELECT count(*) INTO bad FROM agent_api_keys ak
+        WHERE ak.member_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+        ELSE
+            RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 (window 보정 후에도 잔여 — 점검 필요)', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0082_guard_validate_raise_branch_bad_gt0():
+    """⚠️ 트랩#4(실DB-only): 0082 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid해야 한다.
+    0082 백필은 team_members 기반이라 team_member 없는 orphan api_key member_id는 보정 못 함 → bad>0
+    잔여 시 RAISE 분기를 탄다(0080과 동일 % 회귀 가드, IF EXISTS NOT convalidated 래퍼 포함). 위반행을
+    FK 추가 전 INSERT(NOT VALID도 신규검증) → FK NOT VALID → 가드 DO 크래시 없이 NOT VALID 유지하는지."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_key = uuid.UUID("b7000000-0000-0000-0000-0000000000c2")
+    # member_id가 members에도 없고 team_member.id도 아닌 orphan — 0082 백필(members.id=team_member.id 기반)
+    # 으로도 생성 불가 → bad>0 잔여. team_member_id는 실존 AG1(agent_api_keys.team_member_id FK 충족).
+    orphan_member = uuid.UUID("b9000000-0000-0000-0000-0000000000c2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+                "VALUES (:id,:tm,:m,'sk_live_c2','hashc2',ARRAY['read','write'])"
+            ), {"id": str(bad_key), "tm": str(AG1), "m": str(orphan_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        # 0082 가드 DO 실행 — bad>0 → RAISE NOTICE 분기. SyntaxError 없이 통과해야(% 회귀 가드)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0082))
+            await s.commit()
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## AC2 보정 — window agent anchor 재조정 (migration 0082)

AC2 감사(in-VPC) 결과: cut-on 위반 active api_key 6건 중 **1건(`a52b4ccd`, agent active=True·members 부재) = 실 회귀 + 0080 FK VALIDATE 블로커**. (나머지 5건 = inactive agent — legacy `_resolve_api_key`도 `is_active=True` 요구로 401 = 무회귀, 죽은 키.)

**원인**: 0075 agent 백필 ↔ AC3-1b write-sync 배포 **사이 window에 생성된 agent** — 0075엔 아직 없었고 write-sync 배포 전이라 members/profile 미생성.

### 0082
0075 agent 백필 로직을 **idempotent 재실행** — members 없는 agent team_member에 `members`(id=tm.id·type='agent'·owner=생성휴먼·런타임 미러) + `agent_project_profiles` 소급 생성(ON CONFLICT DO NOTHING) + **0080 FK 가드 VALIDATE**(보정 후 members 부재 referent 0건이면 VALIDATE, 아니면 NOT VALID 유지+NOTICE). write-sync 배포로 window는 닫혔으므로 신규 agent는 정상 — 이건 과거 window agent 소급 보정. orphan-safe(트랩#4). 0081 체인(단일 head).

### 검증
격리 PG: window agent(members 부재)+api_key(FK NOT VALID) → 0082 → members(owner 정확)+profile 생성 + FK `convalidated=true`(bad=0).

### ⚠️ 머지 후
`sprintable-migrate-dev` 0082 → PO 재감사(bad가 inactive-only=무회귀로 떨어지는지). a52b4ccd active=True라 백필 보존(defunct 판정이면 PO가 key 무효화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)