### PR TITLE
[SID:f5ee8387] fix(member-ssot): AC2 마무리 — orphan-org dead agent api_key revoke + FK VALIDATE (0083)

### DIFF
--- a/backend/alembic/versions/0083_revoke_orphan_org_apikeys.py
+++ b/backend/alembic/versions/0083_revoke_orphan_org_apikeys.py
@@ -1,0 +1,64 @@
+"""E-MEMBER-SSOT AC3-1b AC2 마무리: orphan-org dead agent api_key revoke + FK VALIDATE.
+
+AC2 재감사(post-0082): a52b4ccd 1건 여전 members 부재 — **org_id가 organizations에 없는 orphan-org
+agent**(0075·0082 모두 INNER JOIN organizations로 의도 스킵, members.org_id NOT NULL FK라 생성 불가).
+실 동작 불가한 dead agent이므로 그 api_key를 revoke. (5 inactive 키는 member_exists=True라 무영향.)
+
+⚠️ revoke(revoked_at)만으론 FK VALIDATE가 안 됨 — VALIDATE는 revoked 무관 **전 행**의 member_id를
+검사하므로 orphan member_id가 남으면 위반. 따라서 **member_id=NULL도 함께**(미러 컬럼, FK는 NULL 허용)
+→ bad=0 → 0080/0082 FK 가드 VALIDATE 통과 + flag-on 안전.
+
+idempotent: 재실행 시 이미 revoke+NULL된 행은 member_id NULL이라 NOT EXISTS 매치 안 됨 → no-op.
+범위 안전: post-0082라 valid-org agent는 members 백필됨 → members 부재 = orphan-org dead만 매치(legit
+agent 무영향). 데이터 보정·가역(downgrade no-op, revoke/NULL 복원 불가·불요).
+
+Revision ID: 0083
+Revises: 0082
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0083"
+down_revision = "0082"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        DO $$
+        DECLARE revoked int; bad int;
+        BEGIN
+            -- 1. orphan-org dead agent 키 revoke + member_id NULL(FK 위반 정리)
+            UPDATE agent_api_keys SET revoked_at = now(), member_id = NULL
+            WHERE revoked_at IS NULL
+              AND member_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = agent_api_keys.member_id);
+            GET DIAGNOSTICS revoked = ROW_COUNT;
+            RAISE NOTICE 'orphan-org dead agent api_key revoke + member_id NULL: % 건', revoked;
+
+            -- 2. 가드 VALIDATE — 이제 members 부재 referent 0건이면 검증
+            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK}' AND NOT convalidated) THEN
+                SELECT count(*) INTO bad FROM agent_api_keys ak
+                WHERE ak.member_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+                IF bad = 0 THEN
+                    ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+                    RAISE NOTICE 'agent_api_keys.member_id FK validated (bad=0)';
+                ELSE
+                    RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지 (bad=% 잔여 — 점검 필요)', bad;
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 보정(revoke + member_id NULL) — 역복원 불가·불요(dead-org agent). no-op.
+    pass

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -511,3 +511,83 @@ async def test_0082_guard_validate_raise_branch_bad_gt0():
             ))
             await s.commit()
         await engine.dispose()
+
+
+# ── 0083: orphan-org dead agent api_key revoke + member_id NULL + FK VALIDATE ──────────────────────
+_DO_0083 = f"""
+DO $$
+DECLARE revoked int; bad int;
+BEGIN
+    UPDATE agent_api_keys SET revoked_at = now(), member_id = NULL
+    WHERE revoked_at IS NULL AND member_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = agent_api_keys.member_id);
+    GET DIAGNOSTICS revoked = ROW_COUNT;
+    RAISE NOTICE 'orphan-org dead agent api_key revoke + member_id NULL: % 건', revoked;
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK_0080}' AND NOT convalidated) THEN
+        SELECT count(*) INTO bad FROM agent_api_keys ak
+        WHERE ak.member_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+        ELSE
+            RAISE NOTICE 'FK NOT VALID 유지 (bad=% 잔여)', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0083_revoke_orphan_org_apikey_and_validate():
+    """⚠️ AC2 마무리: 0083이 orphan-org dead agent 키(members 부재 member_id)를 revoke+member_id NULL로
+    정리하고 FK를 VALIDATE하되, **legit 키(member_id 존재)는 안 건드린다**. revoke만으론 FK 위반이 남으므로
+    member_id=NULL이 핵심(VALIDATE는 revoked 무관 전 행 검사)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    legit_key = uuid.UUID("b7000000-0000-0000-0000-0000000000d1")   # member_id=AG1(존재) — 무영향
+    orphan_key = uuid.UUID("b7000000-0000-0000-0000-0000000000d2")  # member_id=orphan — revoke 대상
+    orphan_member = uuid.UUID("b9000000-0000-0000-0000-0000000000d2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for k in (legit_key, orphan_key):
+                await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(k)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) VALUES "
+                "(:lk,:tm,:lm,'sk_live_d1','hd1',ARRAY['read','write']),"
+                "(:ok,:tm,:om,'sk_live_d2','hd2',ARRAY['read','write'])"
+            ), {"lk": str(legit_key), "ok": str(orphan_key), "tm": str(AG1), "lm": str(AG1), "om": str(orphan_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        async with Session() as s:
+            await s.execute(text(_DO_0083))
+            await s.commit()
+        async with Session() as s:
+            legit = (await s.execute(text(
+                "SELECT member_id, revoked_at IS NULL FROM agent_api_keys WHERE id=:i"), {"i": str(legit_key)})).first()
+            orphan = (await s.execute(text(
+                "SELECT member_id, revoked_at IS NULL FROM agent_api_keys WHERE id=:i"), {"i": str(orphan_key)})).first()
+            conval = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert str(legit[0]) == str(AG1) and legit[1] is True, f"legit 키 영향받음: {legit}"
+        assert orphan[0] is None and orphan[1] is False, f"orphan 키 revoke+NULL 안 됨: {orphan}"
+        assert conval is True, "orphan 정리 후에도 FK 미validate"
+    finally:
+        async with Session() as s:
+            for k in (legit_key, orphan_key):
+                await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(k)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## AC2 마무리 — orphan-org dead agent api_key revoke + FK VALIDATE (0083)

post-0082 재audit: **a52b4ccd 1건 여전 members 부재**. 진단: org_id가 `organizations`에 없는 **orphan-org agent**(0075·0082 모두 `JOIN organizations`(INNER)로 의도 스킵 — `members.org_id` NOT NULL FK라 생성 불가). 실 동작 불가 dead agent → api_key revoke.

### ⚠️ PO 제안 보정
revoke(`revoked_at`)**만으론 FK VALIDATE 안 됨** — VALIDATE는 revoked 무관 **전 행**의 member_id를 검사하므로 orphan member_id가 남으면 위반. → **`member_id=NULL` 동반**(미러 컬럼, FK NULL 허용)으로 bad=0 → 가드 VALIDATE 통과.

### 0083 (idempotent 데이터 보정)
1. members 부재 referent 활성 키 `revoked_at=now(), member_id=NULL` (GET DIAGNOSTICS 건수 NOTICE)
2. 가드 VALIDATE (bad=0이면 VALIDATE, 아니면 NOT VALID 유지+NOTICE)
- post-0082라 valid-org agent는 백필됨 → members 부재 = **orphan-org dead만 매치**(legit agent 무영향). 재실행 멱등(이미 NULL→NOT EXISTS 미매치). 0082 체인.

### 검증
격리 PG + 실DB parity `test_0083_revoke_orphan_org_apikey_and_validate`: legit 키(member_id 존재) **무영향** / orphan 키 revoke+member_id NULL / FK `convalidated=true`. 10 passed.

### ⚠️ 시퀀스
**#1184(0082) 머지 후** 적용(0082 체인). 머지 후 migrate 0083 → PO 재audit(bad=0) → **flag-on 안전**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)