### PR TITLE
[SID:59947165] feat(member-ssot): AC3-2c — grant write-sync (project_access.member_id canonical + 휴먼 anchor)

### DIFF
--- a/backend/alembic/versions/0084_grant_member_id_backfill.py
+++ b/backend/alembic/versions/0084_grant_member_id_backfill.py
@@ -1,0 +1,57 @@
+"""E-MEMBER-SSOT AC3-2c: grant write-sync — 휴먼 members 재조정 + project_access.member_id 백필.
+
+create_project_access가 anchor 후에도 project_access.member_id를 NULL로 두어(org_member_id만 세팅),
+신규 grant-only 휴먼이 member_id 없이 남는다 → AC3-3 get_missing 등 member_id 가정 코드가 누락(이미
+org_member_id로 우회했으나, AC3-4 projection은 member_id 읽기 토대 필요). 코드는 ensure_human_member로
+신규 grant부터 세팅하고, 이 마이그는 **기존 데이터** 보정.
+
+전제: 신규 휴먼(0075 이후)은 members 행이 없을 수 있다(휴먼 write-sync 부재) → member_id=org_member_id를
+넣으려면 members 행 선행 필요(fk_project_access_member). 따라서:
+1. 휴먼 members 재조정(0075 §3 human 백필 idempotent 재실행) — post-0075 휴먼 포착.
+2. project_access.member_id = org_member_id 백필(member_id NULL·org_member_id 有·members 실재 시만, orphan-safe 트랩#4).
+
+추가형·가역(downgrade no-op, 0075/0082 정책). FK VALIDATE는 별도(다른 phase — agent placement 등 surface 큼).
+
+Revision ID: 0084
+Revises: 0083
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0084"
+down_revision = "0083"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. 휴먼 members 재조정 — 0075 §3 human 백필 동형(idempotent). post-0075 신규 휴먼 포착.
+    #    members.id = org_member.id, name=users.display_name/email(orphan user→user_id NULL), orphan org 스킵.
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, org_role, is_active, created_at, updated_at)
+        SELECT om.id, om.org_id, 'human', u.id, NULL,
+               COALESCE(u.display_name, u.email, om.user_id::text),
+               om.role, true, om.created_at, now()
+        FROM org_members om
+        JOIN organizations o ON o.id = om.org_id
+        LEFT JOIN users u ON u.id = om.user_id
+        WHERE om.deleted_at IS NULL
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+    # 2. project_access.member_id = org_member_id 백필(휴먼 grant). members 실재 시만(orphan-safe).
+    op.execute(
+        """
+        UPDATE project_access SET member_id = org_member_id
+        WHERE member_id IS NULL AND org_member_id IS NOT NULL
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = project_access.org_member_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 백필(휴먼 members + project_access.member_id) — 역삭제는 정상분과 구분 불가. no-op(0075 정책).
+    pass

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -86,10 +86,16 @@ async def create_project_access(
     )
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Access record already exists")
+    # AC3-2c grant write-sync: canonical member_id(=org_member.id) 세팅 — AC3-4 projection의 member_id
+    # 읽기 토대 + (A) resolver-cutover 통일. 휴먼 members 행을 선행 보장(fk_project_access_member NOT VALID이나
+    # 신규 INSERT 검증). members 보장 실패(org_member 부재) 시 member_id 미세팅(레거시 호환).
+    from app.services.agent_anchor_sync import ensure_human_member
+    member_ok = await ensure_human_member(session, body.org_member_id)
     record = ProjectAccess(
         project_id=project_id,
         org_member_id=body.org_member_id,
         permission=body.permission,
+        member_id=body.org_member_id if member_ok else None,
     )
     session.add(record)
     await session.commit()

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -19,8 +19,11 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import select
+
 from app.models.member import AgentProjectProfile, Member
 from app.models.project import OrgMember
+from app.models.user import User
 
 
 async def sync_agent_anchor_on_create(
@@ -91,3 +94,43 @@ async def sync_agent_anchor_on_create(
 
     # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
     await session.flush()
+
+
+async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -> bool:
+    """휴먼 org_member의 앵커 members 행을 멱등 보장(AC3-2c grant write-sync).
+
+    members.id = org_member.id (0075 휴먼 불변식). 0075 백필 동형(name=users.email/display_name).
+    project_access.member_id=org_member.id를 세팅하기 전 호출 — fk_project_access_member(NOT VALID이나
+    신규 INSERT 검증)가 members 행을 요구하므로. 신규 휴먼(0075 이후)은 members 행이 없을 수 있다.
+
+    반환: members 행이 (이미 있거나) 보장되면 True, org_member 부재/삭제면 False(호출부 미세팅).
+    """
+    om = (
+        await session.execute(
+            select(OrgMember).where(OrgMember.id == org_member_id, OrgMember.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if om is None:
+        return False
+
+    user = (
+        await session.execute(select(User).where(User.id == om.user_id))
+    ).scalar_one_or_none()
+    name = (getattr(user, "display_name", None) or getattr(user, "email", None) or str(om.user_id)) if user else str(om.user_id)
+
+    await session.execute(
+        pg_insert(Member.__table__)
+        .values(
+            id=om.id,  # 0075 불변식: 휴먼 members.id = org_member.id
+            org_id=om.org_id,
+            type="human",
+            user_id=om.user_id,
+            owner_member_id=None,
+            name=name,
+            org_role=om.role,
+            is_active=True,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await session.flush()
+    return True

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -103,8 +103,14 @@ async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -
     project_access.member_id=org_member.id를 세팅하기 전 호출 — fk_project_access_member(NOT VALID이나
     신규 INSERT 검증)가 members 행을 요구하므로. 신규 휴먼(0075 이후)은 members 행이 없을 수 있다.
 
-    반환: members 행이 (이미 있거나) 보장되면 True, org_member 부재/삭제면 False(호출부 미세팅).
+    반환: members 행이 (이미 있거나) 보장되면 True, org_member 부재/삭제 **또는 orphan org**면
+    False(호출부 미세팅 — member_id NULL 레거시 호환).
+
+    ⚠️ orphan-safe(QA E1, 0084 §1 동형): members.org_id NOT NULL FK라 **org 부재 시 INSERT 불가**
+    → org 존재 확인 후만 INSERT(아니면 False). user_id는 users FK라 **orphan user면 NULL**(user.id|NULL).
     """
+    from app.models.organization import Organization
+
     om = (
         await session.execute(
             select(OrgMember).where(OrgMember.id == org_member_id, OrgMember.deleted_at.is_(None))
@@ -113,9 +119,18 @@ async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -
     if om is None:
         return False
 
+    # org 존재 확인 — orphan org면 members.org_id FK 위반(500) 회피로 미보장(False)
+    org_exists = (
+        await session.execute(select(Organization.id).where(Organization.id == om.org_id))
+    ).scalar_one_or_none()
+    if org_exists is None:
+        return False
+
     user = (
         await session.execute(select(User).where(User.id == om.user_id))
     ).scalar_one_or_none()
+    # orphan user면 user_id=NULL(members.user_id FK 위반 회피, 0084 LEFT JOIN u.id 동형)
+    user_id_val = user.id if user is not None else None
     name = (getattr(user, "display_name", None) or getattr(user, "email", None) or str(om.user_id)) if user else str(om.user_id)
 
     await session.execute(
@@ -124,7 +139,7 @@ async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -
             id=om.id,  # 0075 불변식: 휴먼 members.id = org_member.id
             org_id=om.org_id,
             type="human",
-            user_id=om.user_id,
+            user_id=user_id_val,
             owner_member_id=None,
             name=name,
             org_role=om.role,

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -643,3 +643,50 @@ async def test_ensure_human_member_creates_anchor_idempotent():
             await s.execute(text("DELETE FROM users WHERE id=:i"), {"i": str(new_user)})
             await s.commit()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ensure_human_member_orphan_safe():
+    """⚠️ E1(QA): ensure_human_member orphan-safe — orphan org면 False(members.org_id FK 500 회피),
+    orphan user면 user_id=NULL(members.user_id FK 회피). 0084 §1 동형(트랩#3 실DB orphan)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import ensure_human_member
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    om_orphan_org = uuid.UUID("b3000000-0000-0000-0000-0000000000f1")   # org_id가 organizations에 없음
+    om_orphan_user = uuid.UUID("b3000000-0000-0000-0000-0000000000f2")  # user_id가 users에 없음
+    orphan_user = uuid.UUID("b2000000-0000-0000-0000-0000000000f2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for i in (om_orphan_org, om_orphan_user):
+                await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
+                await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
+            # org_members.org_id/user_id는 FK 없음 → orphan 삽입 가능(실DB 정합 모사)
+            await s.execute(text(
+                "INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+                "(:o1,'cccccccc-0000-0000-0000-0000000000cc',:u0,'member'),"  # orphan org
+                "(:o2,:org,:uo,'member')"                                      # orphan user
+            ), {"o1": str(om_orphan_org), "u0": str(U_MEM), "o2": str(om_orphan_user), "org": str(ORG), "uo": str(orphan_user)})
+            await s.commit()
+        # orphan org → False, members 미생성(500 없이)
+        async with Session() as s:
+            assert await ensure_human_member(s, om_orphan_org) is False, "orphan org인데 True"
+            await s.commit()
+            cnt = (await s.execute(text("SELECT count(*) FROM members WHERE id=:i"), {"i": str(om_orphan_org)})).scalar_one()
+            assert cnt == 0, "orphan org members 생성됨(FK 위험)"
+        # orphan user → True, members 생성·user_id NULL
+        async with Session() as s:
+            assert await ensure_human_member(s, om_orphan_user) is True
+            await s.commit()
+            row = (await s.execute(text("SELECT user_id FROM members WHERE id=:i"), {"i": str(om_orphan_user)})).first()
+            assert row is not None and row[0] is None, f"orphan user인데 user_id 비-NULL: {row}"
+    finally:
+        async with Session() as s:
+            for i in (om_orphan_org, om_orphan_user):
+                await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
+                await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -591,3 +591,55 @@ async def test_0083_revoke_orphan_org_apikey_and_validate():
             ))
             await s.commit()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ensure_human_member_creates_anchor_idempotent():
+    """AC3-2c: ensure_human_member가 members 없는 휴먼 org_member에 members 행(id=om.id·type=human·
+    name=email)을 멱등 생성 — create_project_access가 member_id=org_member.id 세팅 전 호출(FK 충족)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import ensure_human_member
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    new_user = uuid.UUID("b2000000-0000-0000-0000-0000000000e1")
+    new_om = uuid.UUID("b3000000-0000-0000-0000-0000000000e1")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # members 없는 신규 휴먼 org_member(0075 이후 생성 모사)
+            await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM users WHERE id=:i"), {"i": str(new_user)})
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+                "VALUES (:u,'newhuman@pg.test','x','NewHuman',true,true,0,false,0)"), {"u": str(new_user)})
+            await s.execute(text(
+                "INSERT INTO org_members (id,org_id,user_id,role) VALUES (:om,:o,:u,'member')"),
+                {"om": str(new_om), "o": str(ORG), "u": str(new_user)})
+            await s.commit()
+        async with Session() as s:
+            ok = await ensure_human_member(s, new_om)
+            await s.commit()
+            assert ok is True
+            m = (await s.execute(text(
+                "SELECT type, name, user_id FROM members WHERE id=:i"), {"i": str(new_om)})).first()
+        assert m is not None and m.type == "human", "휴먼 members 미생성"
+        assert m.name == "NewHuman" and str(m.user_id) == str(new_user)
+        # 멱등: 재호출 무에러·중복 0
+        async with Session() as s:
+            await ensure_human_member(s, new_om)
+            await s.commit()
+            cnt = (await s.execute(text("SELECT count(*) FROM members WHERE id=:i"), {"i": str(new_om)})).scalar_one()
+            assert cnt == 1
+        # org_member 부재 → False(미세팅)
+        async with Session() as s:
+            assert await ensure_human_member(s, uuid.UUID("b3000000-0000-0000-0000-0000000000ee")) is False
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM users WHERE id=:i"), {"i": str(new_user)})
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## AC3-2c — grant write-sync (킥1, (A) resolver-cutover 통일 정합)

`create_project_access`가 anchor 후에도 `project_access.member_id`를 **NULL**로 둬(org_member_id만 세팅) → 신규 grant-only 휴먼이 member_id 없이 남던 갭. `get_missing`은 org_member_id로 우회했으나 **AC3-4 projection은 member_id 읽기 토대**가 필요. 코드+백필로 member_id를 canonical(=org_member.id)로 채운다.

### 변경
- **`ensure_human_member`** (agent_anchor_sync): 휴먼 org_member의 `members` 행 멱등 upsert(id=om.id [0075 불변식]·type=human·name=users.display_name/email·org_role). 신규 휴먼(휴먼 write-sync 부재로 members 없을 수 있음) 보장. 0075 §3 human 백필 동형
- **create_project_access**: `ensure_human_member` 후 `member_id=org_member.id` 세팅(보장 실패=org_member 부재 시 NULL 레거시 호환). `fk_project_access_member`(NOT VALID이나 신규 INSERT 검증) 충족
- **migration 0084**: 휴먼 members 재조정(0075 §3 idempotent 재실행 — post-0075 휴먼 포착) + `project_access.member_id=org_member_id` 백필(member_id NULL·org_member_id 有·members 실재 시만, orphan-safe 트랩#4)

### 검증
- **격리 PG**: valid-org 신규 휴먼 → members 생성 + member_id 세팅 / **orphan-org 휴먼 → 스킵**(INNER JOIN organizations + EXISTS guard)
- **실DB parity** `test_ensure_human_member`: 멱등 생성 + org_member 부재 시 False
- 풀스위트 **1465 passed**

### ⚠️ 머지 후 / 잔여
- `sprintable-migrate-dev` 0084
- FK VALIDATE는 별도(agent placement 등 surface 큼)
- **휴먼 write-sync를 org_member 생성 사이트(organizations/projects/invite)에도 확장** = AC3-4 projection prereq(전 휴먼 members 보장) — 별도 플래그(AC3-2d/AC3-4 입력)

🤖 Generated with [Claude Code](https://claude.com/claude-code)