### PR TITLE
[SID:4396bf65] feat(member-ssot): AC3-2d 배치1a(🔴) — 잔여 team_members FK 완화 + canonical 정규화 (0085)

### DIFF
--- a/backend/alembic/versions/0085_ac3_2d_red_fk_relax_canonical.py
+++ b/backend/alembic/versions/0085_ac3_2d_red_fk_relax_canonical.py
@@ -1,0 +1,99 @@
+"""E-MEMBER-SSOT AC3-2d 배치1(🔴): 잔여 team_members FK 컬럼 완화 + canonical 정규화.
+
+(A) resolver-cutover 통일. AC3-2c까지 안 닿은 🔴 8테이블 12컬럼의 team_members FK를 완화하고(grant-only
+휴먼 write 500 해소) 기존 legacy 휴먼 team_member.id를 canonical members.id로 정규화(alias). write 경로의
+canonical화(canonicalize_member_id)는 코드에서, 이 마이그는 **FK 완화 + 기존 데이터 정규화**.
+
+대상 (table, column):
+- retro_sessions.created_by / retro_items.author_id / retro_votes.voter_id / retro_actions.assignee_id
+- file_locks.member_id / member_gate_override.member_id (hitl) / invitations.invited_by
+- meetings.created_by / policy_documents.created_by
+- story_comments.created_by / story_activities.created_by (pm.created_by)
+- agent_runs.agent_id
+
+- FK 완화: inspector 기반 idempotent DROP(0069/0079 패턴, 컬럼·데이터·인덱스 유지).
+- 정규화 백필 = alias.member_id (레거시 휴먼 team_member.id → canonical). orphan-safe(트랩#4: alias 없으면
+  legacy 유지 — agent id·org_member.id는 이미 canonical이라 alias 없음→불변). 추가형·가역(FK downgrade는
+  비-team_member 값 없을 때만 재추가).
+
+Revision ID: 0085
+Revises: 0084
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0085"
+down_revision = "0084"
+branch_labels = None
+depends_on = None
+
+# (table, column, downgrade 재추가 ondelete)
+_TARGETS: list[tuple[str, str, str]] = [
+    ("retro_sessions", "created_by", "SET NULL"),
+    ("retro_items", "author_id", "SET NULL"),
+    ("retro_votes", "voter_id", "CASCADE"),
+    ("retro_actions", "assignee_id", "SET NULL"),
+    ("file_locks", "member_id", "CASCADE"),
+    ("member_gate_override", "member_id", "CASCADE"),
+    ("invitations", "invited_by", "CASCADE"),
+    ("meetings", "created_by", "SET NULL"),
+    ("policy_documents", "created_by", "SET NULL"),
+    ("story_comments", "created_by", "CASCADE"),
+    ("story_activities", "created_by", "CASCADE"),
+    ("agent_runs", "agent_id", "CASCADE"),
+]
+
+
+def _drop_tm_fk(insp: sa.Inspector, table: str, col: str) -> None:
+    for fk in insp.get_foreign_keys(table):
+        if fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", []):
+            if fk.get("name"):
+                op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, _ in _TARGETS:
+        if table not in tables:
+            continue
+        # 1. team_members FK 완화
+        _drop_tm_fk(insp, table, col)
+        # 2. 레거시 휴먼 team_member.id → canonical(alias) 정규화. orphan-safe(alias 없으면 불변).
+        op.execute(
+            f"""
+            UPDATE {table} SET {col} = a.member_id
+            FROM member_identity_aliases a
+            WHERE a.alias_id = {table}.{col} AND {table}.{col} <> a.member_id
+            """
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, ondelete in _TARGETS:
+        if table not in tables:
+            continue
+        already = any(
+            fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", [])
+            for fk in insp.get_foreign_keys(table)
+        )
+        if already:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{col} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(f"{table}_{col}_fkey", table, "team_members", [col], ["id"], ondelete=ondelete)

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -19,7 +19,7 @@ class AgentRun(Base):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     deployment_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True

--- a/backend/app/models/file_lock.py
+++ b/backend/app/models/file_lock.py
@@ -19,7 +19,7 @@ class FileLock(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     story_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -70,7 +70,7 @@ class MemberGateOverride(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     gate_type: Mapped[str] = mapped_column(String(50), nullable=False)
     disposition: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -18,7 +18,7 @@ class Invitation(Base):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
     )
     invited_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     email: Mapped[str] = mapped_column(Text, nullable=False)
     role: Mapped[str] = mapped_column(Text, nullable=False, default="member")

--- a/backend/app/models/meeting.py
+++ b/backend/app/models/meeting.py
@@ -17,7 +17,7 @@ class Meeting(Base, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     meeting_type: Mapped[str] = mapped_column(Text, nullable=False, default="general")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -148,7 +148,7 @@ class StoryComment(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -169,7 +169,7 @@ class StoryActivity(Base, OrgScopedMixin):
     old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/policy_document.py
+++ b/backend/app/models/policy_document.py
@@ -27,7 +27,7 @@ class PolicyDocument(Base, OrgScopedMixin):
     legacy_sprint_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     legacy_epic_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -23,7 +23,7 @@ class RetroSession(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     phase: Mapped[str] = mapped_column(Text, nullable=False, default="collect")
@@ -40,7 +40,7 @@ class RetroItem(Base):
         UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
     )
     author_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     category: Mapped[str] = mapped_column(Text, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
@@ -61,7 +61,7 @@ class RetroVote(Base):
         UUID(as_uuid=True), ForeignKey("retro_items.id", ondelete="CASCADE"), nullable=False, index=True
     )
     voter_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -78,7 +78,7 @@ class RetroAction(Base):
         UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
     )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False, default="open")

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -1,0 +1,43 @@
+"""E-MEMBER-SSOT AC3-2d 배치1(🔴): 잔여 team_members FK 완화 구조 회귀.
+
+migration 0085가 12컬럼의 team_members FK를 완화(grant-only 휴먼 write 500 해소) + 기존 데이터 canonical
+정규화. 실데이터 정규화/백필은 test_member_ssot_parity_realdb.py(실 PG). 여기선 모델 FK 부재 구조회귀.
+write 경로 canonicalize는 batch1b(별 PR).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _red_cols():
+    from app.models.agent_run import AgentRun
+    from app.models.file_lock import FileLock
+    from app.models.hitl_config import MemberGateOverride
+    from app.models.invitation import Invitation
+    from app.models.meeting import Meeting
+    from app.models.policy_document import PolicyDocument
+    from app.models.pm import StoryActivity, StoryComment
+    from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+
+    return [
+        (RetroSession, "created_by"),
+        (RetroItem, "author_id"),
+        (RetroVote, "voter_id"),
+        (RetroAction, "assignee_id"),
+        (FileLock, "member_id"),
+        (MemberGateOverride, "member_id"),
+        (Invitation, "invited_by"),
+        (Meeting, "created_by"),
+        (PolicyDocument, "created_by"),
+        (StoryComment, "created_by"),
+        (StoryActivity, "created_by"),
+        (AgentRun, "agent_id"),
+    ]
+
+
+@pytest.mark.parametrize("model,col", _red_cols(), ids=lambda v: getattr(v, "__name__", v))
+def test_ac3_2d_red_col_has_no_team_members_fk(model, col):
+    """0085: 🔴 식별 컬럼 team_members FK 제거 — grant-only 휴먼(canonical members.id) write 시 실DB
+    FK violation 500 방지. canonical 정규화는 0085 백필 + batch1b write canonicalize."""
+    referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
+    assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"


### PR DESCRIPTION
## AC3-2d 배치1a(🔴) — 잔여 team_members FK 완화 + canonical 정규화

(A) resolver-cutover 통일. AC3-2c까지 안 닿은 🔴 **8테이블 12컬럼**의 team_members FK 완화(grant-only 휴먼 write 500 해소) + 기존 legacy 휴먼 team_member.id를 canonical members.id로 정규화.

### 대상 12컬럼
retro_sessions.created_by · retro_items.author_id · retro_votes.voter_id · retro_actions.assignee_id · file_locks.member_id · member_gate_override.member_id(hitl) · invitations.invited_by · meetings.created_by · policy_documents.created_by · story_comments.created_by · story_activities.created_by · agent_runs.agent_id

### 변경
- **migration 0085**: 컬럼별 team_members FK DROP(inspector idempotent, 0069/0079 패턴) + **canonicalize 백필**(`UPDATE col = alias.member_id`, orphan-safe 트랩#4 — alias 없으면 불변 → agent id/canonical은 alias 없어 불변). downgrade는 비-team_member 값 없을 때만 FK 재추가
- **모델**: 8파일 team_members `ForeignKey` 제거(컬럼·nullable·index 유지)
- **구조 테스트 12**: 🔴 컬럼 team_members FK 부재

### 검증
- **격리 PG**: FK 있을 때 grant-only(canonical) write → **500 재현** → DROP 후 **성공** / canonicalize: 휴먼 team_member.id→canonical · agent id 불변
- 풀스위트 **1477 passed**

### ⚠️ 가드(까심 중점)
- 0085 canonicalize는 alias 기반 orphan-safe(트랩#4) — agent/canonical은 alias 없어 불변, 휴먼만 정규화
- FK DROP은 inspector idempotent(0069/0079 동형). 별도 *_v2/VALIDATE 없음((A)는 legacy 컬럼에 canonical 직접)

### 머지 후 / batch1b
- `sprintable-migrate-dev` 0085
- **batch1b(별 PR)** = write canonicalize: retro/hitl/invitation/agent_runs(body 공급)·story_comments/activities(`_resolve_team_member_id`=tm.id) write에 `canonicalize_member_id` 적용(going-forward (A)-write). 0085로 기존 데이터·FK는 정리, 신규 write canonical화는 1b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)