### PR TITLE
[SID:4396bf65] feat(member-ssot): AC3-2d 배치1b — 🔴 write 경로 canonicalize ((A) write 완성)

### DIFF
--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -59,10 +59,13 @@ async def create_invitation(
     _: None = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> InvitationResponse:
+    # AC3-2d(1b): invited_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    from app.services.member_resolver import canonicalize_member_id
+    invited_by = (await canonicalize_member_id(body.invited_by, session)) if body.invited_by else body.invited_by
     inv = await repo.create(
         email=body.email,
         role=body.role,
-        invited_by=body.invited_by,
+        invited_by=invited_by,
         project_id=body.project_id,
     )
     await session.commit()

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -53,6 +53,10 @@ async def create_meeting(
     )
     repo = MeetingRepository(session, body.project_id)
     data = body.model_dump(exclude={"project_id"}, exclude_none=False)
+    # AC3-2d(1b): created_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    if data.get("created_by"):
+        from app.services.member_resolver import canonicalize_member_id
+        data["created_by"] = await canonicalize_member_id(data["created_by"], session)
     meeting = await repo.create(**{k: v for k, v in data.items() if v is not None or k in ("participants", "decisions", "action_items")})
     return MeetingResponse.model_validate(meeting)
 

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.services.member_resolver import canonicalize_member_id
 from app.repositories.retro import (
     RetroActionRepository,
     RetroItemRepository,
@@ -61,7 +62,8 @@ async def create_session(
         project_id=body.project_id,
         title=body.title,
         sprint_id=body.sprint_id,
-        created_by=body.created_by,
+        # AC3-2d(1b): 작성자 식별자 canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+        created_by=(await canonicalize_member_id(body.created_by, db)) if body.created_by else None,
     )
     return SessionListResponse.model_validate(session)
 
@@ -120,8 +122,9 @@ async def add_item(
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
     item_repo = RetroItemRepository(db)
+    author_id = (await canonicalize_member_id(body.author_id, db)) if body.author_id else None
     item = await item_repo.create(
-        session_id=id, category=body.category, text=body.text, author_id=body.author_id
+        session_id=id, category=body.category, text=body.text, author_id=author_id
     )
     return ItemResponse.model_validate(item)
 
@@ -154,6 +157,7 @@ async def vote_item(
     session = await repo.get(id)
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
+    voter_id = await canonicalize_member_id(voter_id, db)  # AC3-2d(1b): canonical 정규화
     vote_repo = RetroVoteRepository(db)
     try:
         vote = await vote_repo.vote(item_id, voter_id)
@@ -189,8 +193,9 @@ async def create_action(
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
     action_repo = RetroActionRepository(db)
+    assignee_id = (await canonicalize_member_id(body.assignee_id, db)) if body.assignee_id else None
     action = await action_repo.create(
-        session_id=id, title=body.title, assignee_id=body.assignee_id
+        session_id=id, title=body.title, assignee_id=assignee_id
     )
     return ActionResponse.model_validate(action)
 

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -13,6 +13,7 @@ from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.routers.events import publish_event
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.services.member_resolver import canonicalize_member_id
 from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
@@ -261,7 +262,7 @@ async def update_story(
                     activity_type="assignee_changed",
                     old_value=str(old_assignee_id) if old_assignee_id else None,
                     new_value=str(story.assignee_id) if story.assignee_id else None,
-                    created_by=actor_id,
+                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
                 ))
                 await db.flush()
             except Exception:
@@ -433,7 +434,7 @@ async def update_story_status(
                     activity_type="status_changed",
                     old_value=old_status,
                     new_value=story.status,
-                    created_by=actor_id,
+                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
                 ))
                 await db.flush()
             except Exception:
@@ -539,6 +540,7 @@ async def add_comment(
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     created_by = await _resolve_team_member_id(auth, repo.org_id, db)
+    created_by = await canonicalize_member_id(created_by, db)  # AC3-2d(1b): canonical 정규화
     comment = StoryComment(
         story_id=id,
         org_id=repo.org_id,

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -5,7 +5,6 @@ import uuid
 import logging
 from typing import Literal
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity_log import ActivityLog
@@ -28,17 +27,17 @@ async def record_activity_bg(
 ) -> None:
     """BackgroundTask용 activity log 기록. 실패해도 caller에 영향 없음 (AC6)."""
     from app.core.database import async_session_factory
-    from app.models.team import TeamMember
 
     try:
         async with async_session_factory() as db:
             resolved_type: ActorType = actor_type or "human"
             if actor_type is None and actor_id is not None:
-                tm = (await db.execute(
-                    select(TeamMember).where(TeamMember.id == actor_id).limit(1)
-                )).scalar_one_or_none()
-                if tm and tm.type in ("agent", "human"):
-                    resolved_type = tm.type  # type: ignore[assignment]
+                # AC3-2d(1b): canonical 정합 — TeamMember 직접 조회는 0085 후 canonical 휴먼(≠tm.id)을 못 찾아
+                # "human" 기본 fallback만. lookup_members_by_ids(anchor)는 canonical/legacy 모두 해소.
+                from app.services.member_resolver import lookup_members_by_ids
+                m = (await lookup_members_by_ids({actor_id}, db)).get(actor_id)
+                if m and m.type in ("agent", "human"):
+                    resolved_type = m.type  # type: ignore[assignment]
 
             await ActivityLogService(db).record(
                 org_id=org_id,

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -41,3 +41,31 @@ def test_ac3_2d_red_col_has_no_team_members_fk(model, col):
     FK violation 500 방지. canonical 정규화는 0085 백필 + batch1b write canonicalize."""
     referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
     assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"
+
+
+# ── 배치1b: write 경로 canonicalize 소스 가드 ──────────────────────────────────────
+def test_batch1b_write_routers_canonicalize():
+    """1b: 휴먼-보유 컬럼 write 라우터가 canonicalize_member_id 적용(레거시 tm.id→canonical, (A) write).
+    agent-context(hitl/file_locks/agent_runs)·policy(no-create)는 0085 no-op이라 제외."""
+    import inspect
+
+    from app.routers import invitations, meetings, retros, stories
+
+    for mod, name in [(retros, "retros"), (invitations, "invitations"), (meetings, "meetings"), (stories, "stories")]:
+        src = inspect.getsource(mod)
+        assert "canonicalize_member_id" in src, f"{name} write canonicalize 누락"
+    # retro 4 식별 컬럼 전부 canonicalize(created_by/author_id/voter_id/assignee_id)
+    rsrc = inspect.getsource(retros)
+    assert rsrc.count("canonicalize_member_id(") >= 4, "retro 4컬럼 canonicalize 미흡"
+
+
+def test_batch1b_activity_log_uses_lookup_members():
+    """1b 노트#1: activity_log actor_type 해소가 raw TeamMember 조회 → lookup_members_by_ids(anchor)로
+    전환(0085 후 canonical 휴먼도 정확 해소; 'human' 기본 fallback 의존 제거)."""
+    import inspect
+
+    from app.services import activity_log
+
+    src = inspect.getsource(activity_log)
+    assert "lookup_members_by_ids" in src, "activity_log lookup_members 전환 누락"
+    assert "select(TeamMember)" not in src, "activity_log에 raw TeamMember 조회 잔존"


### PR DESCRIPTION
## AC3-2d 배치1b — 🔴 write 경로 canonicalize (마이그 0, 코드 only)

배치1a(0085)가 FK완화 + 기존 데이터 canonicalize. **1b는 going-forward (A)-write** — 휴먼-보유 컬럼 write에 `canonicalize_member_id` 적용(레거시 휴먼 tm.id 신규 유입 차단, 저장값=canonical members.id).

### write canonicalize (휴먼-context)
- **retros**: created_by · author_id · voter_id · assignee_id (body 공급)
- **invitations**.invited_by (body)
- **meetings**.created_by (body, model_dump)
- **story_comments/activities**.created_by (`_resolve_team_member_id`=tm.id 반환 → canonicalize 래핑; actor_id 자체는 actor 매칭 유지 위해 불변, **created_by 저장값만** 정규화)

### 노트 2건 (PO 지시)
1. **activity_log** actor_type 해소: raw `select(TeamMember)` → **`lookup_members_by_ids`(anchor)** — 0085 후 canonical 휴먼도 정확 해소("human" 기본 fallback 의존 제거). 미사용 select import 제거
2. **file_locks**: 엔드포인트가 `/team-members/{member_id}/file-lock` + TeamMember 검증 = **설계상 agent team_member.id**(휴먼 lock 경로 없음) → 0085 no-op, canonicalize 불요(검증 404 깨짐 방지)

### 변경 불요 (agent-context/no-create)
- **member_gate_override(hitl)·agent_runs.agent_id**: agent id 불변(alias 없어 0085/canonicalize no-op). HITL gate=agent 대상, agent_runs는 type='agent' 검증
- **policy_documents**: create 엔드포인트 없음(read-only, 0085가 기존 처리)

### 검증
- 풀스위트 **1477 passed** + 소스 가드 2(write canonicalize 라우터·activity_log lookup_members)
- (1a 0085 dev verified: 14 휴먼 remap·잔존 alias 0·agent 불변)

🤖 Generated with [Claude Code](https://claude.com/claude-code)