### PR TITLE
[SID:4396bf65] feat(member-ssot): AC3-2d 배치2(🟡+notif) — canonicalize 데이터+write (0086)

### DIFF
--- a/backend/alembic/versions/0086_ac3_2d_yellow_canonicalize.py
+++ b/backend/alembic/versions/0086_ac3_2d_yellow_canonicalize.py
@@ -1,0 +1,65 @@
+"""E-MEMBER-SSOT AC3-2d 배치2(🟡): webhook/reward/docs/notif_prefs 식별 컬럼 canonical 정규화.
+
+(A) resolver-cutover 통일. 🟡 그룹(0079서 FK 기완화) + notification_preferences.member_id(0073서 FK 기완화,
+0085 _TARGETS 누락분)의 기존 legacy 휴먼 team_member.id를 canonical members.id로 정규화. FK DROP 없음
+(이미 완화) — alias 기반 canonicalize UPDATE만(0085 §2 동형).
+
+⚠️ write canonical(코드)과 **동반 필수**(특히 notif_prefs): 데이터만 canonicalize하고 write/read가 tm.id-first면
+기존 휴먼 prefs가 매칭 실패로 유실(split-brain). 같은 PR에서 write도 canonical 전환.
+
+대상 (table, column):
+- webhook_configs.member_id
+- reward_ledger.member_id / reward_ledger.granted_by
+- docs.created_by / docs.assignee_id
+- doc_comments.created_by / doc_revisions.created_by
+- notification_preferences.member_id
+
+정규화 = alias.member_id (레거시 휴먼 tm.id → canonical). orphan-safe(트랩#4: alias 없으면 불변 →
+agent id·canonical은 alias 없어 불변). 잔존 휴먼 tm.id-키 행 없는 컬럼은 0행 UPDATE(무해). 추가형·가역(no-op down).
+
+Revision ID: 0086
+Revises: 0085
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0086"
+down_revision = "0085"
+branch_labels = None
+depends_on = None
+
+_TARGETS: list[tuple[str, str]] = [
+    ("webhook_configs", "member_id"),
+    ("reward_ledger", "member_id"),
+    ("reward_ledger", "granted_by"),
+    ("docs", "created_by"),
+    ("docs", "assignee_id"),
+    ("doc_comments", "created_by"),
+    ("doc_revisions", "created_by"),
+    ("notification_preferences", "member_id"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+    for table, col in _TARGETS:
+        if table not in tables:
+            continue
+        # 레거시 휴먼 team_member.id → canonical(alias). orphan-safe(alias 없으면 불변).
+        op.execute(
+            f"""
+            UPDATE {table} SET {col} = a.member_id
+            FROM member_identity_aliases a
+            WHERE a.alias_id = {table}.{col} AND {table}.{col} <> a.member_id
+            """
+        )
+
+
+def downgrade() -> None:
+    # 일방향 canonical 정규화 — 역변환 불가·불요(0075/0085 정책). no-op.
+    pass

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -11,6 +11,7 @@ from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
 from app.repositories.doc import DocRepository
+from app.services.member_resolver import canonicalize_member_id
 from app.schemas.doc import DocCreate, DocResponse, DocSummaryResponse, DocUpdate
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
@@ -77,6 +78,8 @@ async def create_doc(
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
     )
+    # AC3-2d(2): created_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    created_by = (await canonicalize_member_id(body.created_by, session)) if body.created_by else None
     repo = DocRepository(session, org_id)
     doc = await repo.create(
         project_id=body.project_id,
@@ -84,7 +87,7 @@ async def create_doc(
         slug=body.slug,
         content=body.content,
         parent_id=body.parent_id,
-        created_by=body.created_by,
+        created_by=created_by,
         icon=body.icon,
         sort_order=body.sort_order,
         doc_type=body.doc_type,
@@ -302,6 +305,7 @@ async def add_doc_comment(
     if not doc:
         raise HTTPException(status_code=404, detail="Doc not found")
     created_by = await _resolve_doc_member_id(auth, repo.org_id, db)
+    created_by = await canonicalize_member_id(created_by, db)  # AC3-2d(2): canonical 정규화
     comment = DocComment(
         doc_id=id,
         org_id=repo.org_id,

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -55,17 +55,9 @@ async def _get_member(
             raise HTTPException(status_code=400, detail="Team member not found")
         return member
 
-    # JWT 휴먼: team_member 우선 (기존 NotificationPreference.member_id 키 보존)
-    member = (await db.execute(
-        select(TeamMember).where(
-            TeamMember.user_id == uuid.UUID(auth.user_id),
-            TeamMember.org_id == org_id,
-        )
-    )).scalars().first()
-    if member is not None:
-        return member
-
-    # team_member 없음(grant-only 휴먼) → org_member 신원으로 fallback
+    # AC3-2d(2): JWT 휴먼 → canonical members.id(=org_member.id). 0086이 notification_preferences.member_id를
+    # canonical로 정규화하므로 read/write도 canonical이어야 split-brain(기존 휴먼 prefs 유실) 0.
+    # (이전엔 team_member 우선=tm.id 반환이었으나 (A) 통일로 canonical 단일화 — grant-only도 동일 경로.)
     return await resolve_member(auth, org_id, db)
 
 

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -43,12 +43,16 @@ async def grant_reward(
     body: GrantReward,
     repo: RewardRepository = Depends(_get_repo),
 ) -> RewardLedgerResponse:
+    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write. agent id는 no-op.
+    from app.services.member_resolver import canonicalize_member_id
+    member_id = await canonicalize_member_id(body.member_id, repo.session)
+    granted_by = (await canonicalize_member_id(body.granted_by, repo.session)) if body.granted_by else None
     entry = await repo.grant(
         project_id=body.project_id,
-        member_id=body.member_id,
+        member_id=member_id,
         amount=body.amount,
         reason=body.reason,
-        granted_by=body.granted_by,
+        granted_by=granted_by,
         reference_type=body.reference_type,
         reference_id=body.reference_id,
     )

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -48,8 +48,11 @@ async def upsert_webhook_config(
     body: UpsertWebhookConfig,
     repo: WebhookConfigRepository = Depends(_get_repo),
 ) -> WebhookConfigResponse:
+    # AC3-2d(2): member_id canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write. agent id는 no-op.
+    from app.services.member_resolver import canonicalize_member_id
+    member_id = await canonicalize_member_id(body.member_id, repo.session)
     config = await repo.upsert(
-        member_id=body.member_id,
+        member_id=member_id,
         url=body.url,
         project_id=body.project_id,
         events=body.events,

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -69,3 +69,22 @@ def test_batch1b_activity_log_uses_lookup_members():
     src = inspect.getsource(activity_log)
     assert "lookup_members_by_ids" in src, "activity_log lookup_members 전환 누락"
     assert "select(TeamMember)" not in src, "activity_log에 raw TeamMember 조회 잔존"
+
+
+# ── 배치2(🟡+notif): write canonicalize + notif_prefs canonical 소스 가드 ──────────────────────────
+def test_batch2_yellow_write_canonicalize():
+    """배치2: 🟡 write 라우터(webhook/reward/docs) + notif_prefs가 canonical 통일(canonicalize_member_id /
+    notif _get_member=resolve_member). 휴먼-context body/resolved id의 (A) write."""
+    import inspect
+
+    from app.routers import docs, notification_preferences, rewards, webhooks
+
+    for mod, name in [(webhooks, "webhooks"), (rewards, "rewards"), (docs, "docs")]:
+        assert "canonicalize_member_id" in inspect.getsource(mod), f"{name} write canonicalize 누락"
+    # reward: member_id + granted_by 둘 다
+    assert inspect.getsource(rewards).count("canonicalize_member_id(") >= 2, "reward member_id+granted_by 미흡"
+    # notif_prefs _get_member: tm-first 제거 + resolve_member(canonical) 통일
+    nsrc = inspect.getsource(notification_preferences._get_member)
+    assert "resolve_member(" in nsrc, "notif _get_member canonical 전환 누락"
+    # JWT 휴먼 tm-first lookup(TeamMember.user_id 매칭) 제거됨 — api_key 분기의 TeamMember.id만 잔존
+    assert "TeamMember.user_id" not in nsrc, "notif _get_member에 JWT-휴먼 tm-first 잔존(split-brain 위험)"


### PR DESCRIPTION
## AC3-2d 배치2(🟡+notif) — canonicalize 데이터 + write ((A) 통일 마무리)

🟡 그룹(webhook/reward/docs, 0079 FK 기완화) + notification_preferences(0073 FK 기완화, 0085 _TARGETS 누락분)의 기존 데이터 canonicalize + write canonical. **데이터+write 동반**(특히 notif_prefs — split-brain[기존 휴먼 prefs 유실] 방지).

### migration 0086 (0085 §2 alias 동형, FK DROP 없음)
8컬럼 alias 기반 canonicalize UPDATE(orphan-safe — alias 없으면 불변, 잔존 휴먼 tm.id 없는 컬럼은 0행):
webhook_configs.member_id · reward_ledger.member_id+granted_by · docs.created_by+assignee_id · doc_comments.created_by · doc_revisions.created_by · notification_preferences.member_id

### write canonicalize (휴먼-context, (A) write)
- webhooks.member_id · rewards.member_id+granted_by · docs.created_by(body + `_resolve_doc_member_id`) → `canonicalize_member_id` (agent id는 no-op)
- **notif_prefs `_get_member`**: JWT 휴먼 tm-first(tm.id 반환) → **`resolve_member`(canonical)** 통일 → 0086 데이터 canonical과 read 정합(**split-brain 0**). api_key(agent) 분기 유지

### 검증
- throwaway PG: head=0086 적용(0085→0086 체인) + parity 12 passed
- 풀스위트 **1480 passed** + 소스가드(write canonicalize·notif tm-first 제거)

### ⚠️ 머지 후 / 잔여
- `sprintable-migrate-dev` 0086
- **배치2 후 잔여 team_members FK = api_key.team_member_id(dual 유지)만 → AC3-4 projection 가능**
- _v2 vestigial(0077/0079)·dead-org cleanup = AC3-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)