### PR TITLE
[SID:550198ca] feat(member-ssot): AC3-4 단계2-1 — team_members write anchor dual-write (0087)

### DIFF
--- a/backend/alembic/versions/0087_agent_placement_backfill.py
+++ b/backend/alembic/versions/0087_agent_placement_backfill.py
@@ -1,0 +1,44 @@
+"""E-MEMBER-SSOT AC3-4 2-1: window agent project_access placement 백필.
+
+AC3-4 뷰가 에이전트 role/can_manage를 project_access(placement)서 읽는다(런타임은 agent_project_profiles
+LEFT JOIN). 0075 §5가 기존 agent placement를 만들었으나, 0075↔AC3-1b write-sync 사이 window agent +
+write-sync에 placement 미포함이던 신규 agent는 placement 누락 가능. create write-sync(2-1)에 placement를
+추가했고, 이 마이그는 기존 누락분 소급 백필(0075 §5 동형, idempotent).
+
+조건: type='agent' active + members 존재(0082 보정분) + placement 미존재. ON CONFLICT 대신 NOT EXISTS 가드.
+orphan-safe. 추가형·가역(no-op down — 정상 placement와 구분 불가).
+
+Revision ID: 0087
+Revises: 0086
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0087"
+down_revision = "0086"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO project_access
+            (id, project_id, org_member_id, member_id, permission, role, color, can_manage_members, access_source, created_at)
+        SELECT gen_random_uuid(), tm.project_id, NULL, tm.id, 'granted', tm.role, tm.color,
+               tm.can_manage_members, 'direct', tm.created_at
+        FROM team_members tm
+        WHERE tm.type = 'agent' AND tm.is_active = true
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = tm.id)
+          AND NOT EXISTS (
+              SELECT 1 FROM project_access pa WHERE pa.project_id = tm.project_id AND pa.member_id = tm.id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 백필(0075 §5 동형) — 역삭제는 정상 placement와 구분 불가. no-op.
+    pass

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.team import TeamMember
@@ -25,4 +25,9 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         if member is None:
             return False
         await self.update(id, is_active=False)
+        # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(에이전트 members.id=tm.id;
+        # 휴먼은 members.id=org_member.id라 미매치=0건 무해, 휴먼 비활성은 org_members 경로에서 처리).
+        await self.session.execute(
+            text("UPDATE members SET is_active = false WHERE id = :id"), {"id": str(id)}
+        )
         return True

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -32,5 +32,13 @@ async def delete_account(
         ),
         {"now": now, "uid": str(uid)},
     )
+    # AC3-4 2-1 dual-write: 뷰가 is_active/deleted_at을 members서 읽으므로 동시 반영(cutover 전 동기).
+    await session.execute(
+        text(
+            "UPDATE members SET deleted_at = :now, is_active = false, updated_at = :now"
+            " WHERE user_id = :uid::uuid"
+        ),
+        {"now": now, "uid": str(uid)},
+    )
 
     return AccountDeleteResponse(ok=True, grace_period_days=30)

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -183,6 +183,14 @@ async def delete_org_member(
         ),
         {"org_id": str(org_id), "user_id": str(existing.user_id)},
     )
+    # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(cutover 전 동기).
+    await session.execute(
+        text(
+            "UPDATE members SET is_active = false"
+            " WHERE org_id = :org_id AND user_id = :user_id AND is_active = true"
+        ),
+        {"org_id": str(org_id), "user_id": str(existing.user_id)},
+    )
     # S-MBR-10 AC5: project_access grant 레코드 삭제 (soft delete는 FK CASCADE 미트리거)
     await session.execute(
         text("DELETE FROM project_access WHERE org_member_id = :om_id"),

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -299,6 +299,9 @@ async def heartbeat(
         raise HTTPException(status_code=404, detail="Team member not found")
     now = datetime.now(timezone.utc)
     await repo.update(id, last_seen_at=now, agent_status="online")
+    # AC3-4 2-1 dual-write: 뷰가 presence를 agent_project_profiles서 읽으므로 동시 반영(cutover 전 동기).
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+    await sync_agent_profile_presence(session, id, last_seen_at=now, agent_status="online")
     return {"ok": True, "last_seen_at": now.isoformat()}
 
 
@@ -325,6 +328,8 @@ async def claim_story(
 
     now = datetime.now(timezone.utc)
     await repo.update(id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
+    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    await sync_agent_profile_presence(session, id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
     return {"claimed": True, "story_id": str(body.story_id)}
 
 
@@ -340,6 +345,8 @@ async def unclaim_story(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     await repo.update(id, active_story_id=None)
+    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    await sync_agent_profile_presence(session, id, active_story_id=None)
     # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
     from app.routers.file_locks import release_all_file_locks
     await release_all_file_locks(session, id)

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from sqlalchemy import select
 
 from app.models.member import AgentProjectProfile, Member
 from app.models.project import OrgMember
@@ -92,6 +91,26 @@ async def sync_agent_anchor_on_create(
         .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 모두 흡수
     )
 
+    # 3. project_access direct placement (AC3-4 2-1, G3): 0075 §5 에이전트 placement 동형.
+    #    AC3-4 뷰가 role/can_manage를 project_access서 읽으므로 신규 agent도 placement 필요(누락 시 뷰서
+    #    role 기본값). member_id=tm.id(canonical), org_member_id=NULL(에이전트). ON CONFLICT 멱등.
+    from app.models.project_access import ProjectAccess
+    await session.execute(
+        pg_insert(ProjectAccess.__table__)
+        .values(
+            id=uuid.uuid4(),
+            project_id=team_member.project_id,
+            org_member_id=None,
+            member_id=team_member.id,
+            permission="granted",
+            role=team_member.role,
+            color=team_member.color,
+            can_manage_members=team_member.can_manage_members,
+            access_source="direct",
+        )
+        .on_conflict_do_nothing()  # (project_id, member_id) 부분 UNIQUE 흡수(멱등)
+    )
+
     # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
     await session.flush()
 
@@ -149,3 +168,21 @@ async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -
     )
     await session.flush()
     return True
+
+
+async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUID, **fields) -> None:
+    """AC3-4 2-1 dual-write: 에이전트 presence를 agent_project_profiles에도 반영(team_members UPDATE와 동시).
+
+    AC3-4 뷰가 last_seen_at/active_story_id/agent_status를 agent_project_profiles서 읽으므로 cutover 전
+    동기 유지. member_id(=agent team_member.id, 1:1)로 단일 profile 행 UPDATE. 행 없으면 0건(무해).
+    cutover(2-2) 후 레거시 team_members UPDATE 제거 시 이 경로가 유일 write가 된다.
+    """
+    allowed = {"last_seen_at", "active_story_id", "agent_status"}
+    upd = {k: v for k, v in fields.items() if k in allowed}
+    if not upd:
+        return
+    await session.execute(
+        sa_update(AgentProjectProfile.__table__)
+        .where(AgentProjectProfile.__table__.c.member_id == member_id)
+        .values(**upd)
+    )

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -245,9 +245,13 @@ async def test_agent_anchor_writesync_creates_members_and_profile():
                 "SELECT type, owner_member_id, name, is_active FROM members WHERE id=:i"), {"i": str(NEW_TM)})).first()
             prof = (await s.execute(text(
                 "SELECT project_id, agent_role, fakechat_port FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
+            # AC3-4 2-1: write-sync가 project_access placement도 생성(뷰 role/can_manage 소스)
+            pa = (await s.execute(text(
+                "SELECT project_id, role, access_source FROM project_access WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
         assert m is not None and m.type == "agent" and m.is_active is True, "members(agent) 미생성"
         assert str(m.owner_member_id) == str(OM_OWNER), f"owner_member_id=생성 휴먼 member 아님: {m.owner_member_id}"
         assert prof is not None and str(prof.project_id) == str(P1) and prof.agent_role == "dev", "agent_project_profiles 미생성/미러 불일치"
+        assert pa is not None and str(pa.project_id) == str(P1) and pa.access_source == "direct", "project_access placement 미생성(AC3-4 2-1)"
 
         # 멱등: 재호출해도 중복/에러 없음
         async with Session() as s:

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -238,10 +238,11 @@ async def test_soft_delete_200():
             # call 1: router get(id) for existing check
             # call 2: revoke refresh tokens (UPDATE)
             # call 3: cascade UPDATE team_members is_active=false
-            # call 4: S-MBR-10 AC5 DELETE project_access
-            # call 5: soft_delete internal get(id)
-            # call 6: soft_delete UPDATE deleted_at
-            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 5) else None
+            # call 4: AC3-4 2-1 dual-write UPDATE members is_active=false (NEW)
+            # call 5: S-MBR-10 AC5 DELETE project_access
+            # call 6: soft_delete internal get(id)
+            # call 7: soft_delete UPDATE deleted_at
+            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 6) else None
             result.scalars.return_value.all.return_value = []
             return result
 

--- a/backend/tests/test_s38.py
+++ b/backend/tests/test_s38.py
@@ -126,7 +126,8 @@ async def test_account_delete_updates_org_and_team_members():
         async with client as c:
             await c.post("/api/v2/account/delete")
 
-        assert session.execute.call_count == 2
+        # AC3-4 2-1 dual-write: org_members + team_members + **members**(anchor) UPDATE = 3
+        assert session.execute.call_count == 3
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## AC3-4 단계2-1 — team_members write anchor dual-write

뷰 cutover(2-2) 전제. team_members write를 anchor에도 **dual-write**(G2 준수: 레거시 team_members 유지 + anchor 동시 — **anchor-only 조기전환 금지**, cutover까지 레거시 primary·anchor 동기). 뷰가 읽는 anchor 소스를 항상 최신으로 유지.

### 변경
- **create_team_member** write-sync: **project_access placement 추가**(0075 §5 동형, member_id=tm.id·role/color/can_manage 미러·ON CONFLICT 멱등) — 뷰 role/can_manage 소스 (G3)
- **presence**(heartbeat/claim/unclaim): repo.update(team_members) 유지 + `sync_agent_profile_presence`로 **agent_project_profiles** 동시 UPDATE(last_seen_at/active_story_id/agent_status) — 뷰 presence 소스. ※agent_gateway:166은 AgentGatewaySession 테이블이라 무관(제외)
- **is_active/deleted_at**(account·org_members·repo.deactivate): 레거시 유지 + **members** 동시 UPDATE — 뷰 is_active 소스
- **migration 0087**: window agent project_access placement 소급 백필(0075 §5 동형 idempotent, NOT EXISTS 가드, orphan-safe)

### 검증
- 격리 PG: 0087 placement 백필(role 미러)·presence dual UPDATE
- parity: write-sync **project_access placement 단언** 추가(head=0087)
- 풀스위트 **1480 passed**. dual-write로 execute 카운트 변한 test_s38(2→3)·test_org_members(call_count 시퀀스) 갱신(no-defer)

### G2(dual-write) 준수
2-1은 레거시 team_members write를 **유지**하면서 anchor 동시 write. anchor-only 전환은 2-2(cutover)서. → cutover 전 레거시 primary + anchor 검증 가능.

### ⚠️ 머지 후 / 2-2
- `sprintable-migrate-dev` 0087
- **2-2(뷰 cutover)**: rename team_members→team_members_legacy + CREATE VIEW(created_by=`owner.user_id` LEFT JOIN[D1]) + write anchor-only 전환 + EXPLAIN(G4) + 소비자 회귀표(G1) → 2-3 소크(FE 픽셀·알림 fanout·노이즈·prod flip 선생님 FYI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)