### PR TITLE
[SID:550198ca] feat(member-ssot): AC3-4 단계2-2 — team_members 물리→projection 뷰 cutover (0088)

### DIFF
--- a/backend/alembic/versions/0088_team_members_projection_view.py
+++ b/backend/alembic/versions/0088_team_members_projection_view.py
@@ -1,0 +1,66 @@
+"""E-MEMBER-SSOT AC3-4 2-2: team_members 물리테이블 → members 기반 projection 뷰 강등.
+
+곱연산 물리 소거. team_members를 team_members_legacy로 rename하고, members/project_access/
+agent_project_profiles 기반 VIEW로 재정의. 2-1 dual-write로 anchor가 이미 최신이라 안전. READ는 뷰로
+투명 동작(19컬럼 전 재현). write는 코드에서 anchor-only로 전환(같은 PR).
+
+뷰 멤버십(의도된 SSOT): 휴먼=project_access 보유분(grant-only 출현·access 회수 시 live 제외),
+에이전트=agent_project_profiles per-project(1:1). created_by = owner.user_id(D1: 옛 auth.user_id 동일값
+재현, FE 소유자 배지 무변경).
+
+⚠️ 가역(G5): downgrade = DROP VIEW + team_members_legacy → team_members rename 복원.
+
+Revision ID: 0088
+Revises: 0087
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0088"
+down_revision = "0087"
+branch_labels = None
+depends_on = None
+
+# team_members 19 식별/속성 컬럼 + created_at/updated_at = 21. 모델 컬럼명과 동일해야 ORM 매핑.
+_CREATE_VIEW = """
+CREATE VIEW team_members AS
+-- 휴먼: members ⋈ project_access (per-project). agent 런타임 컬럼은 NULL.
+SELECT
+    m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, NULL::text AS webhook_url, m.is_active,
+    pa.color, NULL::text AS agent_role, NULL::integer AS fakechat_port,
+    owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN project_access pa ON pa.member_id = m.id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+-- 에이전트: members ⋈ agent_project_profiles (per-project runtime) LEFT JOIN project_access (role/color).
+SELECT
+    m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, app.webhook_url, m.is_active,
+    COALESCE(pa.color, '#3385f8') AS color, app.agent_role, app.fakechat_port,
+    owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN agent_project_profiles app ON app.member_id = m.id
+LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE team_members RENAME TO team_members_legacy")
+    op.execute(_CREATE_VIEW)
+
+
+def downgrade() -> None:
+    # G5 가역: 뷰 제거 후 물리테이블 복원.
+    op.execute("DROP VIEW IF EXISTS team_members")
+    op.execute("ALTER TABLE team_members_legacy RENAME TO team_members")

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,16 +1,35 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.member import AgentProjectProfile, Member
+from app.models.project_access import ProjectAccess
 from app.models.team import TeamMember
 from app.repositories.base import BaseRepository
+
+# AC3-4 2-2: team_members가 projection 뷰로 강등됨 → write를 앵커 테이블로 라우팅(anchor-only).
+# PATCH 필드 → 앵커 매핑(0088 뷰 정의와 정합):
+#   name/avatar_url/is_active → members,  role/color/can_manage_members → project_access(per-project),
+#   agent_config/webhook_url/agent_role → agent_project_profiles.
+_MEMBERS_FIELDS = {"name", "avatar_url", "is_active"}
+_ACCESS_FIELDS = {"role", "color", "can_manage_members"}
+_PROFILE_FIELDS = {"agent_config", "webhook_url", "agent_role"}
 
 
 class TeamMemberRepository(BaseRepository[TeamMember]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(TeamMember, session, org_id)
+
+    async def get(self, id: uuid.UUID) -> TeamMember | None:  # type: ignore[override]
+        # AC3-4 2-2: team_members가 뷰 — 휴먼은 members.id=org_member.id가 project_access 다행이라 동일
+        # id로 여러 행 가능(프로젝트별). scalar_one_or_none RAISE 회피 위해 first()(에이전트는 1:1 단일행).
+        result = await self.session.execute(
+            select(TeamMember).where(self._org_filter(), TeamMember.id == id).limit(1)
+        )
+        return result.scalars().first()
 
     async def list(self, limit: int = 1000, **filters: Any) -> list[TeamMember]:  # type: ignore[override]
         q = select(TeamMember).where(self._org_filter())
@@ -19,15 +38,49 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
 
+    async def apply_anchor_update(self, member: TeamMember, data: dict[str, Any]) -> None:
+        """AC3-4 2-2: PATCH 필드를 앵커 테이블로 라우팅(anchor-only write, 레거시 team_members UPDATE 없음).
+
+        뷰가 읽는 소스에 직접 write: members(신원·is_active) / project_access(per-project role·color·권한) /
+        agent_project_profiles(에이전트 설정). JSONB(agent_config)는 ORM 컬럼 타입으로 안전 직렬화.
+        """
+        m_set = {k: v for k, v in data.items() if k in _MEMBERS_FIELDS}
+        a_set = {k: v for k, v in data.items() if k in _ACCESS_FIELDS}
+        p_set = {k: v for k, v in data.items() if k in _PROFILE_FIELDS}
+        if m_set:
+            await self.session.execute(
+                sa_update(Member)
+                .where(Member.id == member.id)
+                .values(**m_set, updated_at=func.now())
+            )
+        if a_set:
+            await self.session.execute(
+                sa_update(ProjectAccess)
+                .where(
+                    ProjectAccess.member_id == member.id,
+                    ProjectAccess.project_id == member.project_id,
+                )
+                .values(**a_set)
+            )
+        if p_set:
+            await self.session.execute(
+                sa_update(AgentProjectProfile)
+                .where(AgentProjectProfile.member_id == member.id)
+                .values(**p_set, updated_at=func.now())
+            )
+        await self.session.flush()
+
     async def deactivate(self, id: uuid.UUID) -> bool:
-        """DELETE 대신 is_active=False soft deactivate."""
+        """DELETE 대신 is_active=False soft deactivate.
+
+        AC3-4 2-2: team_members 뷰 전환 — anchor-only. members.is_active=false로 반영(에이전트
+        members.id=tm.id 1:1). 휴먼은 members.id=org_member.id라 미매치=0건(무해; 휴먼 비활성은
+        org_members 경로에서 처리). 레거시 team_members UPDATE 제거(뷰는 write 불가).
+        """
         member = await self.get(id)
         if member is None:
             return False
-        await self.update(id, is_active=False)
-        # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(에이전트 members.id=tm.id;
-        # 휴먼은 members.id=org_member.id라 미매치=0건 무해, 휴먼 비활성은 org_members 경로에서 처리).
         await self.session.execute(
-            text("UPDATE members SET is_active = false WHERE id = :id"), {"id": str(id)}
+            sa_update(Member).where(Member.id == id).values(is_active=False, updated_at=func.now())
         )
         return True

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -25,14 +25,7 @@ async def delete_account(
         text("UPDATE org_members SET deleted_at = :now WHERE user_id = :uid::uuid"),
         {"now": now, "uid": str(uid)},
     )
-    await session.execute(
-        text(
-            "UPDATE team_members SET deleted_at = :now, is_active = false, updated_at = :now"
-            " WHERE user_id = :uid::uuid"
-        ),
-        {"now": now, "uid": str(uid)},
-    )
-    # AC3-4 2-1 dual-write: 뷰가 is_active/deleted_at을 members서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 전환 — anchor-only. members가 is_active/deleted_at 유일 소스.
     await session.execute(
         text(
             "UPDATE members SET deleted_at = :now, is_active = false, updated_at = :now"

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -172,18 +172,7 @@ async def delete_org_member(
     if existing.role == "owner":
         raise HTTPException(status_code=403, detail="조직 owner는 삭제할 수 없습니다")
     await _revoke_user_refresh_tokens(repo.session, existing.user_id)
-    # cascade — team_members is_active = False
-    await session.execute(
-        text(
-            """
-            UPDATE team_members
-            SET is_active = false
-            WHERE org_id = :org_id AND user_id = :user_id AND is_active = true
-            """
-        ),
-        {"org_id": str(org_id), "user_id": str(existing.user_id)},
-    )
-    # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 전환 — anchor-only. members가 is_active 유일 소스(레거시 cascade 제거).
     await session.execute(
         text(
             "UPDATE members SET is_active = false"

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -142,7 +142,6 @@ async def create_team_member(
             detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
         )
 
-    repo = TeamMemberRepository(session, org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 
     # AC1/AC2: agent 생성 시 fakechat_port 자동 할당 (project 내 중복 방지)
@@ -162,8 +161,13 @@ async def create_team_member(
             port += 1
         fakechat_port = port
 
-    member = await repo.create(
+    # AC3-4 2-2: team_members가 projection 뷰로 강등됨 → INSERT 불가. transient TeamMember(미persist)로
+    # 신원/응답을 표현하고, 실제 영속은 앵커(members + agent_project_profiles + project_access)로만 한다.
+    now = datetime.now(timezone.utc)
+    member = TeamMember(
+        id=uuid.uuid4(),
         project_id=body.project_id,
+        org_id=org_id,
         type=body.type,
         name=body.name,
         role=body.role,
@@ -175,10 +179,18 @@ async def create_team_member(
         agent_role=body.agent_role,
         created_by=created_by,
         fakechat_port=fakechat_port,
-    )
+        is_active=True,
+        can_manage_members=False,
+        last_seen_at=None,
+        active_story_id=None,
+        agent_status=None,
+        created_at=now,
+        updated_at=now,
+    )  # NOT session.add — 앵커 write-sync가 유일 영속 경로(아래)
 
-    # E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync(members + agent_project_profiles).
-    # ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.member_id→members FK(0080) 충족 + cut-on 무중단.
+    # E-MEMBER-SSOT AC3-1b/AC3-4 2-2: 신규 agent 앵커 write-sync(members + agent_project_profiles +
+    # project_access placement) = 유일 영속 경로. ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.
+    # member_id→members FK(0080) 충족 + cut-on 무중단.
     if body.type == "agent":
         from app.services.agent_anchor_sync import sync_agent_anchor_on_create
         await sync_agent_anchor_on_create(session, member, created_by)
@@ -282,8 +294,11 @@ async def update_team_member(
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
     data = body.model_dump(exclude_unset=True)
-    updated = await repo.update(id, **data)
-    return TeamMemberResponse.model_validate(updated)
+    # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
+    await repo.apply_anchor_update(member, data)
+    session.expire(member)
+    updated = await repo.get(id)
+    return TeamMemberResponse.model_validate(updated or member)
 
 
 @router.patch("/{id}/heartbeat")
@@ -298,8 +313,7 @@ async def heartbeat(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     now = datetime.now(timezone.utc)
-    await repo.update(id, last_seen_at=now, agent_status="online")
-    # AC3-4 2-1 dual-write: 뷰가 presence를 agent_project_profiles서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 — presence는 agent_project_profiles가 유일 소스(anchor-only).
     from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, last_seen_at=now, agent_status="online")
     return {"ok": True, "last_seen_at": now.isoformat()}
@@ -327,8 +341,8 @@ async def claim_story(
         raise HTTPException(status_code=400, detail="Story not found in this project")
 
     now = datetime.now(timezone.utc)
-    await repo.update(id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
-    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
     return {"claimed": True, "story_id": str(body.story_id)}
 
@@ -344,8 +358,8 @@ async def unclaim_story(
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
-    await repo.update(id, active_story_id=None)
-    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=None)
     # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
     from app.routers.file_locks import release_all_file_locks

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -60,6 +60,12 @@ def _tup(r):
 async def _seed(session):
     """legacy + anchor를 일관되게 시드(0075 백필 결과 모사 — members.id=org_member/team_member.id)."""
     from sqlalchemy import text
+    # AC3-4 2-2: cutover(0088) 후 team_members는 projection 뷰 → INSERT 불가. 물리 레거시 행은
+    # team_members_legacy에 시드. 미적용 DB(pre-0088)면 team_members가 물리테이블 — 동적 선택(양립).
+    physical_tm = (await session.execute(text(
+        "SELECT CASE WHEN to_regclass('public.team_members_legacy') IS NOT NULL "
+        "THEN 'team_members_legacy' ELSE 'team_members' END"
+    ))).scalar()
     stmts = [
         # 방어: fresh `alembic upgrade head`에선 0075 DROP NOT NULL이 미지속되는 관찰(별건 flag)이 있어,
         # 에이전트 placement(org_member_id NULL) 시드를 위해 idempotent하게 nullable 보장(테스트 신뢰성).
@@ -69,7 +75,7 @@ async def _seed(session):
         f"DELETE FROM member_identity_aliases WHERE org_id='{ORG}'",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id IN ('{P1}','{P2}')",
-        f"DELETE FROM team_members WHERE org_id='{ORG}'",
+        f"DELETE FROM {physical_tm} WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id IN ('{U_OWNER}','{U_MEM}')",
@@ -79,7 +85,7 @@ async def _seed(session):
         f"('{U_OWNER}','owner@pg.test','x','Owner',true,true,0,false,0),('{U_MEM}','mem@pg.test','x','Mem',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_OWNER}','{ORG}','{U_OWNER}','owner'),('{OM_MEM}','{ORG}','{U_MEM}','member')",
         f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0),('{P2}','{ORG}','P2',0)",
-        f"INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) VALUES "
+        f"INSERT INTO {physical_tm} (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) VALUES "
         f"('{TM_OWNER}','{P1}','{ORG}','{U_OWNER}','human','Owner','owner','#3385f8',true,true,NULL),"
         f"('{AG1}','{P1}','{ORG}',NULL,'agent','Bot','member','#ff0000',false,true,'{U_OWNER}'),"
         f"('{AG2}','{P2}','{ORG}',NULL,'agent','Bot','reviewer','#00ff00',false,true,'{U_OWNER}')",
@@ -693,4 +699,55 @@ async def test_ensure_human_member_orphan_safe():
                 await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
                 await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
             await s.commit()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3_4_team_members_projection_view():
+    """AC3-4 2-2: team_members가 projection 뷰(0088)로 강등됨을 검증(migrate 0088 적용 DB 전제).
+
+    ⚠️ migrate head<0088이면 team_members가 물리테이블 → relkind!='v'이라 skip(가드).
+    검증: ① relkind='v'(뷰) ② agent(AG1) 행 = anchor 소스(role=project_access, agent_role/presence=profile)
+    ③ 에이전트는 id로 단일행(1:1) ④ deleted members 제외 ⑤ team_members_legacy 물리 잔존(가역 자산).
+    """
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            relkind = (await s.execute(text(
+                "SELECT relkind FROM pg_class WHERE relname='team_members'"
+            ))).scalar()
+        if relkind != "v":
+            pytest.skip(f"team_members relkind={relkind} — migrate 0088 미적용, AC3-4 cutover 전")
+
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            # ② AG1(agent) 행 = anchor 소스 재현: role(project_access P1=member), agent_role/port(profile=dev/9101)
+            row = (await s.execute(text(
+                "SELECT type, role, agent_role, fakechat_port FROM team_members WHERE id=:id"
+            ), {"id": str(AG1)})).first()
+            assert row is not None, "AG1 뷰 미출현"
+            assert row[0] == "agent" and row[1] == "member" and row[2] == "dev" and row[3] == 9101, f"AG1 매핑 불일치: {row}"
+            # ③ 에이전트 id 단일행(1:1)
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE id=:id"), {"id": str(AG1)})).scalar_one()
+            assert cnt == 1, f"agent 다중행: {cnt}"
+            # ④ deleted members 제외 — 임시 soft-delete 후 뷰 미출현
+            await s.execute(text("UPDATE members SET deleted_at=now() WHERE id=:id"), {"id": str(AG1)})
+            await s.commit()
+            gone = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE id=:id"), {"id": str(AG1)})).scalar_one()
+            assert gone == 0, "deleted member가 뷰에 잔존"
+            await s.execute(text("UPDATE members SET deleted_at=NULL WHERE id=:id"), {"id": str(AG1)})
+            await s.commit()
+            # ⑤ team_members_legacy 물리테이블 잔존(G5 가역 자산)
+            legacy_kind = (await s.execute(text(
+                "SELECT relkind FROM pg_class WHERE relname='team_members_legacy'"
+            ))).scalar()
+            assert legacy_kind == "r", f"team_members_legacy 물리테이블 부재: {legacy_kind}"
+    finally:
         await engine.dispose()

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -237,12 +237,11 @@ async def test_soft_delete_200():
             result = MagicMock()
             # call 1: router get(id) for existing check
             # call 2: revoke refresh tokens (UPDATE)
-            # call 3: cascade UPDATE team_members is_active=false
-            # call 4: AC3-4 2-1 dual-write UPDATE members is_active=false (NEW)
-            # call 5: S-MBR-10 AC5 DELETE project_access
-            # call 6: soft_delete internal get(id)
-            # call 7: soft_delete UPDATE deleted_at
-            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 6) else None
+            # call 3: AC3-4 2-2 anchor-only UPDATE members is_active=false (레거시 team_members UPDATE 제거)
+            # call 4: S-MBR-10 AC5 DELETE project_access
+            # call 5: soft_delete internal get(id)
+            # call 6: soft_delete UPDATE deleted_at
+            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 5) else None
             result.scalars.return_value.all.return_value = []
             return result
 

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -151,7 +151,7 @@ async def test_heartbeat_404_if_not_found():
     client, session, app = await _heartbeat_client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:

--- a/backend/tests/test_s38.py
+++ b/backend/tests/test_s38.py
@@ -126,8 +126,8 @@ async def test_account_delete_updates_org_and_team_members():
         async with client as c:
             await c.post("/api/v2/account/delete")
 
-        # AC3-4 2-1 dual-write: org_members + team_members + **members**(anchor) UPDATE = 3
-        assert session.execute.call_count == 3
+        # AC3-4 2-2 anchor-only: org_members + **members**(anchor) UPDATE = 2 (레거시 team_members UPDATE 제거)
+        assert session.execute.call_count == 2
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -142,7 +142,8 @@ async def test_get_team_member_200():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
+        # AC3-4 2-2: repo.get은 뷰 multi-row 방어로 scalars().first() 사용
+        mock_result.scalars.return_value.first.return_value = _mock_member()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:
@@ -159,7 +160,7 @@ async def test_get_team_member_404():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:
@@ -177,8 +178,10 @@ async def test_update_team_member_200():
         updated = _mock_member()
         updated.color = "#ff0000"
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = updated
+        # AC3-4 2-2: PATCH = repo.get(scalars().first()) → apply_anchor_update → expire → repo.get
+        mock_result.scalars.return_value.first.return_value = updated
         session.execute = AsyncMock(return_value=mock_result)
+        session.expire = MagicMock()  # sync 메서드(AsyncMock 코루틴 경고 회피)
 
         async with client as c:
             resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
@@ -227,7 +230,7 @@ async def test_deactivate_not_found_404():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: deactivate→get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:


### PR DESCRIPTION
## AC3-4 단계2-2 — team_members 물리테이블 → projection 뷰 cutover (critical 플립)

team_members를 `team_members_legacy`로 rename + members/project_access/agent_project_profiles 기반 **VIEW**로 재정의. 2-1 dual-write로 anchor가 최신이라 READ 투명. write는 **anchor-only** 전환(레거시 team_members write 전수 제거).

### 🔴 G: 뷰 정의 완전성 (0088)
- 21컬럼 전 재현(19 식별/속성 + created_at/updated_at), `type`/`deleted_at` 필터
- `created_by = owner.user_id` (`LEFT JOIN members owner ON owner.id=m.owner_member_id`, **D1**)
- 휴먼: `members ⋈ project_access` / 에이전트: `members ⋈ agent_project_profiles LEFT JOIN project_access`(role/color/can_manage)

### 🔴 G: write 제거 누락 0 (anchor-only)
| 경로 | 전 | 후(anchor) |
|---|---|---|
| create_team_member | repo.create(INSERT) | transient + 앵커 write-sync(members+profile+placement) |
| PATCH update | repo.update | `apply_anchor_update` 라우팅(members/project_access/agent_project_profiles) + expire 재조회 |
| heartbeat/claim/unclaim | repo.update | `sync_agent_profile_presence`(agent_project_profiles)만 |
| deactivate | team_members UPDATE | members.is_active=false만 |
| account.py / org_members.py | team_members UPDATE | members만 |

`repo.get`: 휴먼 multi-project 동일 id 다행 → scalar_one_or_none RAISE 회피로 `scalars().first()`.

### ⚠️ 발견 즉시 수정(트랩#7 — write cutover→전 write 표면)
- **PATCH(repo.update)도 뷰 write라 깨짐** — PO 게이트 미포함분, `apply_anchor_update`로 처리
- **휴먼 multi-row id-space**(members.id=org_member.id가 project_access 다행) — get `.first()` 방어
- **parity `_seed`** team_members INSERT가 뷰라 깨짐 → 물리(team_members_legacy) **동적 타겟**(pre/post-0088 양립)

### ✅ 검증 (격리 real Postgres)
- 21컬럼 / 4행(H1×2 multi-project·A1·A2; H2·A3 deleted 제외) / H1 multi-row=2 / created_by=owner.user_id / A2 placement없음 COALESCE 기본 / per-project list=3 / **write 라우팅 3종**(role·presence·is_active 뷰 반영) / **G5 downgrade**(BASE TABLE 복원) 전부 PASS
- 핫 경로 인덱스 prod 존재: `ix_project_access_project_id`·`ix_agent_profiles_project/member`·members PK/owner
- parity 신규 `test_ac3_4_team_members_projection_view`(relkind=v·anchor 매핑·1:1·deleted 제외·legacy 잔존, migrate 0088 가드 skip)
- **풀스위트 1482 passed**(team_members get→first() mock·dual-write 카운트 갱신). mcp e2e 2건은 env 라이브 dev 연결(네트워크) 무관

### ⚠️ G4 EXPLAIN / G1 회귀 (PO 실DB)
- 격리 EXPLAIN은 미니 스키마라 seq-scan — **prod는 위 인덱스로 index-scan**. 실DB EXPLAIN은 migrate-dev 0088 후 PO in-VPC.
- G1 소비자 회귀(41파일 grant-only 출현 무파손)는 실DB·FE 소크에서 확인.

### 머지 후 / 2-3
- `sprintable-migrate-dev` **0088** → 실DB EXPLAIN(G4)·소비자 회귀(G1) PO 검증 → parity 재실행(real-DB, 로컬 미실행)
- **2-3 소크**: FE 픽셀(미르코)·알림 fanout 안전·노이즈 모니터·prod flip 선생님 FYI

🤖 Generated with [Claude Code](https://claude.com/claude-code)