### PR TITLE
[SID:550198ca] fix(member-ssot): AC3-4 repo.get 결정적 ORDER BY (휴먼 multi-row 비결정성 제거)

### DIFF
--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -26,8 +26,14 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
     async def get(self, id: uuid.UUID) -> TeamMember | None:  # type: ignore[override]
         # AC3-4 2-2: team_members가 뷰 — 휴먼은 members.id=org_member.id가 project_access 다행이라 동일
         # id로 여러 행 가능(프로젝트별). scalar_one_or_none RAISE 회피 위해 first()(에이전트는 1:1 단일행).
+        # ⚠️ order_by(project_id)로 **결정적** row 선택(휴먼 multi-project 비결정성 제거 — QA 소크 안정).
+        # 휴먼 project-specific(role/color)은 team-members 단일조회/PATCH 비-플로우(=project_access 그랜트
+        # 경로로 관리); first()는 is_active/name(members 공통) 안전망 + RAISE 회피가 목적.
         result = await self.session.execute(
-            select(TeamMember).where(self._org_filter(), TeamMember.id == id).limit(1)
+            select(TeamMember)
+            .where(self._org_filter(), TeamMember.id == id)
+            .order_by(TeamMember.project_id)
+            .limit(1)
         )
         return result.scalars().first()
 


### PR DESCRIPTION
## AC3-4 후속 — repo.get 결정적 ORDER BY (코드-only, 1파일)

#1191(2-2 뷰 cutover) 머지 후 까심 QA 소크 항목 처리. **fresh develop(f7044faa) 기준**(stale-base 함정 회피 — 87eec6c5는 머지된 feature 브랜치에만 얹혀 develop 미포함이라 fresh PR로 재적용).

### 문제
repo.get `limit(1)`이 휴먼 multi-project(members.id=org_member.id가 project_access N행→뷰 N행) 시 **비결정적** project row 반환 → PATCH role/color·claim story 검증이 임의 project 사용 위험.

### 수정
repo.get에 `order_by(TeamMember.project_id)` 추가 → 최소 project_id row **결정적** 선택.
- 에이전트: 1:1(members.id=tm.id, profile 1행) → 무영향
- 휴먼 project-specific(role/color): team-members 단일 PATCH는 비-플로우 — 휴먼 role/권한은 **project_access 그랜트 경로**(create_project_access·org-members)가 SSOT. first()는 is_active/name(members 공통값) 안전망 + scalar_one_or_none RAISE 회피가 목적.

### 검증
- diff: 1파일 +7/-1
- 테스트 green (test_team_members·test_s2_2_passive_heartbeat·test_s2_4_claim_unclaim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)