### PR TITLE
[SID:f6907297] feat(member-ssot): AC3-5 PR-A — project_access member FK 가드 VALIDATE (0089)

### DIFF
--- a/backend/alembic/versions/0089_validate_project_access_member_fks.py
+++ b/backend/alembic/versions/0089_validate_project_access_member_fks.py
@@ -1,0 +1,65 @@
+"""E-MEMBER-SSOT AC3-5 ①: project_access member FK 가드된 VALIDATE.
+
+0075가 project_access의 member FK 2종을 **NOT VALID**로 추가("후속 phase에서 VALIDATE"):
+- fk_project_access_member (member_id → members.id, CASCADE)
+- fk_project_access_inherited_member (inherited_from_member_id → members.id, SET NULL)
+
+AC3-2c/2d로 휴먼/에이전트 placement·alias canonicalize가 완료돼 member_id 무결성이 갖춰진 지금
+기존 행을 검증(VALIDATE)한다. NOT VALID FK도 신규 INSERT는 검증했으므로(트랩#7/8), 이건 기존
+행 검증을 마저 켜는 **additive·비파괴** 단계.
+
+⚠️ 가드(0080/0083 패턴): 부재 referent 행이 0건일 때만 VALIDATE(있으면 NOT VALID 유지 + RAISE
+NOTICE — migrate 하드페일 방지). 제약 부재 DB(create_all auto-name 등)면 스킵(pg_constraint 가드).
+data-dependent 분기라 bad>0은 실DB-only 발현(트랩#4b) — parity에 bad>0 가드 테스트 동봉.
+
+⚠️ agent_api_keys.member_id FK는 0083서 bad=0 VALIDATE 완료 — 본 마이그 대상 아님.
+
+Revision ID: 0089
+Revises: 0088
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0089"
+down_revision = "0088"
+branch_labels = None
+depends_on = None
+
+# (제약명, 참조 컬럼) — 0075 NOT VALID FK 2종
+_FKS = [
+    ("fk_project_access_member", "member_id"),
+    ("fk_project_access_inherited_member", "inherited_from_member_id"),
+]
+
+
+def upgrade() -> None:
+    for conname, col in _FKS:
+        op.execute(
+            f"""
+            DO $$
+            DECLARE bad int;
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{conname}') THEN
+                    SELECT count(*) INTO bad
+                    FROM project_access pa
+                    WHERE pa.{col} IS NOT NULL
+                      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = pa.{col});
+                    IF bad = 0 THEN
+                        ALTER TABLE project_access VALIDATE CONSTRAINT {conname};
+                        RAISE NOTICE '{conname} validated (bad=0)';
+                    ELSE
+                        RAISE NOTICE '{conname} NOT VALID 유지: members 부재 referent % 건 — 점검 후 재VALIDATE 필요', bad;
+                    END IF;
+                ELSE
+                    RAISE NOTICE '{conname} 부재 — 스킵(create_all auto-name DB 등)';
+                END IF;
+            END $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    # VALIDATE는 비파괴(제약 상태만 NOT VALID→validated). 역전 불요 — no-op.
+    pass

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -751,3 +751,66 @@ async def test_ac3_4_team_members_projection_view():
             assert legacy_kind == "r", f"team_members_legacy 물리테이블 부재: {legacy_kind}"
     finally:
         await engine.dispose()
+
+
+# ── 0089(AC3-5 ①) project_access FK 가드 VALIDATE의 bad>0 분기(트랩#4b 실DB-only) ───────────────
+_GUARD_DO_0089_MEMBER = """
+DO $$
+DECLARE bad int;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_project_access_member') THEN
+        SELECT count(*) INTO bad FROM project_access pa
+        WHERE pa.member_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = pa.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE project_access VALIDATE CONSTRAINT fk_project_access_member;
+            RAISE NOTICE 'fk_project_access_member validated (bad=0)';
+        ELSE
+            RAISE NOTICE 'fk_project_access_member NOT VALID 유지: members 부재 referent % 건 — 점검 후 재VALIDATE 필요', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0089_guard_validate_project_access_fk_bad_gt0():
+    """⚠️ AC3-5 ① 트랩#4b(실DB-only): 0089 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid·
+    크래시 없이 NOT VALID 유지하는지. 위반행을 FK 추가 전 INSERT(NOT VALID도 신규검증) → 가드 DO 실행.
+    CI fresh-DB는 bad=0(VALIDATE)라 RAISE 분기 미발현 — % placeholder 회귀 가드(0080 교훈 동형)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_pa = uuid.UUID("c0000000-0000-0000-0000-0000000000fa")
+    absent_member = uuid.UUID("c9000000-0000-0000-0000-0000000000fa")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM project_access WHERE id=:i"), {"i": str(bad_pa)})
+            # FK 잠시 DROP → 위반행(member_id가 members에 없음) INSERT → NOT VALID로 재추가(기존행 검증 보류)
+            await s.execute(text("ALTER TABLE project_access DROP CONSTRAINT IF EXISTS fk_project_access_member"))
+            await s.execute(text(
+                "INSERT INTO project_access (id,project_id,org_member_id,member_id,permission,access_source) "
+                "VALUES (:id,:p,NULL,:m,'granted','direct')"
+            ), {"id": str(bad_pa), "p": str(P1), "m": str(absent_member)})
+            await s.execute(text(
+                "ALTER TABLE project_access ADD CONSTRAINT fk_project_access_member "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE NOT VALID"
+            ))
+            await s.commit()
+        # 가드 DO 실행 — bad>0 → RAISE NOTICE 분기(크래시·% 회귀 없이)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0089_MEMBER))
+            await s.commit()
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname='fk_project_access_member'"
+            ))).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM project_access WHERE id=:i"), {"i": str(bad_pa)})
+            await s.commit()
+        await engine.dispose()


### PR DESCRIPTION
## AC3-5 PR-A — project_access member FK 가드 VALIDATE (① · additive·비파괴)

AC3-5 7-AC 중 **① FK VALIDATE**. fresh develop 기준. 0075가 NOT VALID로 추가한 project_access member FK 2종을 canonicalize 완료(AC3-2c/2d) 후 기존 행 검증.

### 대상
- `fk_project_access_member` (member_id → members.id, CASCADE)
- `fk_project_access_inherited_member` (inherited_from_member_id → members.id, SET NULL)

※ agent_api_keys.member_id FK는 0083서 bad=0 VALIDATE 완료 — 대상 아님.

### 가드 (0080/0083 패턴)
부재 referent **0건일 때만** VALIDATE(있으면 NOT VALID 유지 + RAISE NOTICE → migrate 하드페일 방지). 제약 부재 DB(create_all auto-name)는 `pg_constraint` 가드로 스킵.

### 검증 (격리 real PG)
- clean(bad=0): 양 FK `convalidated` f→**t** ✅
- bad>0(위반행 선INSERT): NOT VALID 유지(convalidated=f)·NOTICE·**크래시 0**(트랩#4b 가드) ✅
- parity 신규 `test_0089_guard_validate_project_access_fk_bad_gt0`(실DB 가드, % placeholder 회귀 방지)
- 단일 head 0089·py_compile OK

### 머지 후 / AC3-5 잔여
- `sprintable-migrate-dev` **0089**(가드 VALIDATE, bad=0 기대 — AC3-2c/2d로 무결성 확보)
- 후속 분할 PR: **PR-B**(_v2 vestigial DROP — app 미참조 확인됨[코드 0참조·주석만]) / **PR-C**(dead-org purge + team_member_id deprecated, orphan telemetry 선행) / **②TeamMember-only 신원검증 잔여 제거**(33 select(TeamMember) 사이트 per-site 분석 후 — 대부분 정당 read이라 별도 신중 PR 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)