### PR TITLE
[SID:f6907297] feat(member-ssot): AC3-5 PR-B — vestigial *_v2 식별 컬럼 DROP (0090)

### DIFF
--- a/backend/alembic/versions/0090_drop_vestigial_v2_columns.py
+++ b/backend/alembic/versions/0090_drop_vestigial_v2_columns.py
@@ -1,0 +1,85 @@
+"""E-MEMBER-SSOT AC3-5 ⑤: vestigial *_v2 식별 컬럼 DROP.
+
+AC3-2(0077/0078/0079)가 legacy team_member.id 식별 컬럼을 canonical members.id로 옮기는 *_v2 컬럼 +
+alias 백필을 추가했으나, 최종 채택 전략은 **(A) resolver-cutover**(legacy 컬럼이 canonicalize로 canonical
+보유) — *_v2 read-cut은 미착수(app 코드 *_v2 참조 0건). 즉 *_v2는 **백필-only vestigial**.
+
+app 전수 grep 재확인(develop 0089 기준): *_v2 식별 컬럼 코드 참조 0건(모델 주석만 — 동반 갱신). 파괴적
+DROP이나 미참조 확정 → 안전. canonical 진실은 legacy 컬럼(canonicalize_member_id) 유지, 본 DROP은 미사용
+중복 컬럼/인덱스 소거(곱연산 잔재 정리). 가역: DOWN은 nullable 컬럼+인덱스 재추가(백필-only라 데이터 손실 0).
+
+⚠️ 0077 conv/events·0078 assignee·0079 participation/notif/webhook/reward/docs 전수.
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0090"
+down_revision = "0089"
+branch_labels = None
+depends_on = None
+
+# scalar uuid *_v2 컬럼 (table, base_col) — 0077/0078/0079 전수
+_V2_SCALAR: list[tuple[str, str]] = [
+    # 0077 conv/events
+    ("conversations", "created_by"),
+    ("conversations", "resolved_by"),
+    ("conversation_participants", "member_id"),
+    ("conversation_messages", "sender_id"),
+    ("events", "sender_id"),
+    ("events", "recipient_id"),
+    # 0078 assignee
+    ("epics", "assignee_id"),
+    ("stories", "assignee_id"),
+    ("tasks", "assignee_id"),
+    # 0079 rest
+    ("participation", "member_id"),
+    ("notification_preferences", "member_id"),
+    ("webhook_configs", "member_id"),
+    ("reward_ledger", "member_id"),
+    ("reward_ledger", "granted_by"),
+    ("docs", "created_by"),
+    ("docs", "assignee_id"),
+    ("doc_comments", "created_by"),
+    ("doc_revisions", "created_by"),
+]
+# 배열 *_v2 컬럼 (0077 mentioned_ids)
+_V2_ARRAY: list[tuple[str, str]] = [
+    ("conversation_messages", "mentioned_ids"),
+]
+# *_v2 인덱스 (index, table, v2_col) — DROP COLUMN이 자동 제거하나 명시적·가역 재생성 위해 보유
+_V2_INDEXES: list[tuple[str, str, str]] = [
+    ("ix_events_recipient_id_v2", "events", "recipient_id_v2"),
+    ("ix_conv_participants_member_id_v2", "conversation_participants", "member_id_v2"),
+    ("ix_epics_assignee_id_v2", "epics", "assignee_id_v2"),
+    ("ix_stories_assignee_id_v2", "stories", "assignee_id_v2"),
+    ("ix_tasks_assignee_id_v2", "tasks", "assignee_id_v2"),
+    ("ix_participation_member_id_v2", "participation", "member_id_v2"),
+    ("ix_notification_preferences_member_id_v2", "notification_preferences", "member_id_v2"),
+    ("ix_webhook_configs_member_id_v2", "webhook_configs", "member_id_v2"),
+    ("ix_reward_ledger_member_id_v2", "reward_ledger", "member_id_v2"),
+]
+
+
+def upgrade() -> None:
+    # 인덱스 먼저 명시 제거(컬럼 DROP이 자동 제거하나 멱등·명시), 그 뒤 컬럼 DROP
+    for idx, _table, _col in _V2_INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {idx}")
+    for table, col in _V2_SCALAR:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+    for table, col in _V2_ARRAY:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+
+
+def downgrade() -> None:
+    # 가역: nullable 컬럼+인덱스 재추가(백필-only였으므로 데이터 손실 0 — canonical 진실은 legacy 컬럼).
+    for table, col in _V2_SCALAR:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid")
+    for table, col in _V2_ARRAY:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid[]")
+    for idx, table, v2col in _V2_INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON {table} ({v2col})")

--- a/backend/app/models/participation.py
+++ b/backend/app/models/participation.py
@@ -30,7 +30,7 @@ class Participation(Base, OrgScopedMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -50,7 +50,8 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
@@ -88,7 +89,8 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
@@ -125,7 +127,8 @@ class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )

--- a/backend/app/models/reward.py
+++ b/backend/app/models/reward.py
@@ -16,7 +16,7 @@ class RewardLedger(Base, OrgScopedMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical=*_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2/granted_by_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/models/webhook_config.py
+++ b/backend/app/models/webhook_config.py
@@ -15,7 +15,7 @@ class WebhookConfig(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )


### PR DESCRIPTION
## AC3-5 PR-B — vestigial *_v2 식별 컬럼 DROP (⑤ · fresh develop 0089)

AC3-2(0077/0078/0079)가 추가한 *_v2 식별 컬럼은 최종 **(A) resolver-cutover** 전략 채택으로 **백필-only vestigial**(read-cut 미착수, app 코드 *_v2 참조 **0건**). 미사용 중복 컬럼/인덱스 소거.

### 미참조 재확인 (develop 0089 기준)
`assignee_id_v2|member_id_v2|granted_by_v2|created_by_v2|resolved_by_v2|sender_id_v2|recipient_id_v2|mentioned_ids_v2` grep → **코드 0건**(모델 주석 5건뿐 → 동반 갱신, `_push_to_agent_v2`는 무관 함수).

### DROP 대상 (0090): 20 컬럼 + 9 인덱스
| migration | 컬럼 |
|---|---|
| 0077 | conversations(created_by·resolved_by)·conversation_participants(member_id)·conversation_messages(sender_id·mentioned_ids[])·events(sender_id·recipient_id) |
| 0078 | epics/stories/tasks(assignee_id) |
| 0079 | participation/notification_preferences/webhook_configs/reward_ledger(member_id)·reward_ledger(granted_by)·docs(created_by·assignee_id)·doc_comments/doc_revisions(created_by) |

### 가역 (G5)
DOWN = nullable 컬럼 + 인덱스 재추가. **데이터 손실 0**(백필-only였고 canonical 진실은 legacy 컬럼이 `canonicalize_member_id`로 보유). 모델 주석 4파일((A) 전략 반영).

### 검증 (격리 real PG)
- upgrade: _v2 컬럼 DROP(대표 7→0)·**legacy 컬럼 보존**·멱등 재실행 ✅
- downgrade: nullable 재추가(mentioned_ids_v2=uuid[] 포함)·인덱스 재생성 ✅
- 모델 _v2 미선언 → 풀스위트 무영향(smoke pass)·단일 head 0090·py_compile OK

### 머지 후
- `sprintable-migrate-dev` **0090**(DROP, 멱등)
- 다음: **②** TeamMember-only 신원검증 per-site(별도 신중 PR) → **PR-C**(④dead-org+⑥telemetry+③deprecated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)