### PR TITLE
[SID:f6907297] fix(member-ssot): AC3-5 ② identity capstone — 뷰-write 잠재버그 2건 + multi-row 하드닝

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -52,6 +52,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.services.project_auth import has_project_access, first_accessible_project_id
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
+from app.models.member import Member
 from app.models.org_invite import OrgInvite
 from app.models.project import OrgMember
 from app.models.team import TeamMember
@@ -286,7 +287,9 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member = result.scalar_one_or_none()
 
     if member and member.user_id is None:
-        member.user_id = user.id
+        # AC3-5 ②: team_members가 뷰(0088) — ORM mutation+flush(UPDATE view 실패) 대신 members 앵커 UPDATE.
+        # member.user_id is None은 사실상 미발현(뷰 휴먼 브랜치 user_id 채워짐); 레거시 미링크분만 보정.
+        await session.execute(update(Member).where(Member.id == member.id).values(user_id=user.id))
 
     if not member:
         # 2. 이메일로 pending 초대 조회 → 자동 수락 + org_member 생성

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -102,10 +102,11 @@ async def lock_files(
     _auth=Depends(get_current_user),
 ) -> dict:
     """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환."""
+    # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
     member_result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id)
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
     )
-    member = member_result.scalar_one_or_none()
+    member = member_result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,12 +1,14 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import or_, select, text
+from sqlalchemy import func, or_, select, text
+from sqlalchemy import update as sa_update
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.member import Member
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import User
@@ -182,13 +184,19 @@ async def update_me(
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id)
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
     )
-    member = result.scalar_one_or_none()
+    member = result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
-    member.name = body.name
-    await session.flush()
-    await session.refresh(member)
-    return MeResponse.model_validate(member)
+    # AC3-5 ②: 뷰는 write 불가 — ORM mutation+flush 대신 name을 members 앵커에 UPDATE. expire 후 뷰 재조회.
+    await session.execute(
+        sa_update(Member).where(Member.id == member_id).values(name=body.name, updated_at=func.now())
+    )
+    session.expire(member)
+    refreshed = (await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
+    )).scalars().first()
+    return MeResponse.model_validate(refreshed or member)


### PR DESCRIPTION
## AC3-5 ② identity capstone (마지막 · fresh develop 0091)

TeamMember=인가 안티패턴 capstone. AC3-4 뷰 cutover(0088) 후 잔여 `select(TeamMember)` 33사이트 정밀 분석.

### 핵심 통찰
**뷰 cutover가 안티패턴을 구조적으로 중화** — 휴먼은 project_access 있어야 뷰에 출현(team_members 존재 ≈ has-access), 신원해소는 canonical id 자동 반환. 대부분 사이트 변경 불요(뷰-safe).

### ⚠️ 발견: 뷰-write 잠재버그 2건 (2-2 write-scan 미검출)
2-2 write 전수조사는 raw SQL·repo.update·session.add를 봤으나 **ORM-mutation+flush 패턴**을 놓침. team_members가 뷰라 ORM 객체 mutation 후 flush = UPDATE view → 실패. **테스트는 create_all 스키마(team_members=테이블)라 통과 = 라이브(뷰)서만 실패하는 잠재버그**:
- **me.py `update_me`**: `member.name=body.name; flush()` → `members` 앵커 UPDATE + expire 후 뷰 재조회
- **auth.py 로그인 user-link**: `member.user_id=user.id` mutation → `members` 앵커 UPDATE (미발현 레거시 보정분, 뷰 휴먼 user_id 채워짐)

### multi-row 하드닝
휴먼 multi-project → 뷰 N행 → `scalar_one_or_none` RAISE(500) 회피:
- **file_locks.py**: `.limit(1).scalars().first()` (+ me.py 동일). workflow_executions는 이미 `.limit(1)` safe.

### 변경 불요 (뷰-safe·구조 중화)
나머지 31 사이트 = agent 1:1 fetch / 뷰 canonical 휴먼 / OrgMember fallback(dispatch) — 전부 뷰서 동작.

### 검증
- 풀스위트 **1482 passed**(me/auth/file_locks 타겟 478 포함). mcp e2e 2건은 env 라이브 dev 네트워크 무관.

### 머지 후 / E-MEMBER-SSOT 종착
- ② 머지 = AC3-5 ①②⑤⑥④③ 전량 완료 → **에픽 본체 종결**
- **선생님 prod 승격**(미팅 후): 0088~0091 + dev cutover. ⚠️prod-flip 0088 asyncpg 트랜지언트 완화(backend 리비전 재시작=fresh pool)

🤖 Generated with [Claude Code](https://claude.com/claude-code)