### PR TITLE
prod 승격: E-MEMBER-SSOT AC3-x — team_members 뷰 cutover 코드 호환 (공유 DB write-risk 해소)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -16,6 +16,10 @@ COPY alembic.ini .
 COPY alembic/ alembic/
 COPY bootstrap.py .
 COPY scripts/migrate.sh scripts/migrate.sh
+# E-MEMBER-SSOT 검증/감사 스크립트 — migrate-dev 잡 클론(command 오버라이드)으로 in-VPC 실행
+# (scripts는 namespace 패키지 — `python -m scripts.<name>`로 /app 기준 실행)
+COPY scripts/verify_grant_only_story_assign.py scripts/verify_grant_only_story_assign.py
+COPY scripts/audit_apikey_member_anchor.py scripts/audit_apikey_member_anchor.py
 
 # non-root 사용자 생성 + /app 소유권 변경 (uv .venv 포함)
 RUN useradd --create-home --shell /bin/bash appuser \

--- a/backend/alembic/versions/0076_apikey_member_id.py
+++ b/backend/alembic/versions/0076_apikey_member_id.py
@@ -1,0 +1,37 @@
+"""E-MEMBER-SSOT AC3-1: agent_api_keys.member_id 추가 + 백필 (canonical members.id).
+
+0075에서 agent member.id = team_member.id **1:1**이라 member_id = team_member_id 백필이
+ID 보존 = API key 인증 신원 불변(무중단 핵심). member_id FK는 신규 INSERT 검증이 신규 agent
+생성을 깨므로(QA H1) **생략** — AC3-1b(anchor write-sync) 후 cutover에서 재추가.
+additive·가역 — 코드 cut은 config 플래그(member_ssot_apikey_cut, 기본 off) 뒤.
+
+Revision ID: 0076
+Revises: 0075
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0076"
+down_revision = "0075"
+branch_labels = None
+depends_on = None
+
+_TABLE = "agent_api_keys"
+
+
+def upgrade() -> None:
+    op.execute(f"ALTER TABLE {_TABLE} ADD COLUMN IF NOT EXISTS member_id uuid")
+    # 백필: member_id = team_member_id (1:1 ID 보존)
+    op.execute(f"UPDATE {_TABLE} SET member_id = team_member_id WHERE member_id IS NULL")
+    op.execute(f"CREATE INDEX IF NOT EXISTS ix_agent_api_keys_member_id ON {_TABLE} (member_id)")
+    # ⚠️ FK는 의도적으로 생략(QA H1): NOT VALID FK도 신규 INSERT는 검증하므로, 신규 agent 생성 시
+    # auto API key dual-write(member_id=team_member_id)가 아직 members 행이 없어 FK 위반→agent 생성
+    # 500(생명선). dual-write는 유지(forward-compat, 기존 agent는 0075 members 보존)하되 FK는
+    # 신규 agent의 members/agent_project_profiles 동기화(AC3-x anchor write-sync) 완료 후 cutover에서 추가.
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_agent_api_keys_member_id")
+    op.execute(f"ALTER TABLE {_TABLE} DROP COLUMN IF EXISTS member_id")

--- a/backend/alembic/versions/0077_identity_v2_conv_events.py
+++ b/backend/alembic/versions/0077_identity_v2_conv_events.py
@@ -1,0 +1,85 @@
+"""E-MEMBER-SSOT AC3-2 Batch 1: conversations/events 식별 컬럼 v2 (canonical members.id 이행).
+
+blueprint §4 Phase4. legacy 식별자(휴먼 team_member.id)를 canonical members.id로 옮기는 *_v2 컬럼 +
+별칭(member_identity_aliases) 백필. 읽기 COALESCE(col_v2, alias_resolve(col))는 후속 배치(read-cut).
+
+대상(Phase0서 FK 이미 완화된 conv/events 선행):
+- conversations.created_by_v2 / resolved_by_v2
+- conversation_participants.member_id_v2
+- conversation_messages.sender_id_v2 / mentioned_ids_v2(배열)
+- events.sender_id_v2 / recipient_id_v2
+
+백필 = COALESCE(alias.member_id, legacy): 에이전트/org-member id는 이미 canonical(legacy 보존),
+레거시 휴먼 team_member.id만 alias로 canonical member.id 치환. orphan-safe(alias 없으면 legacy 유지).
+⚠️ *_v2 FK는 보류(트랩#7): write 경로가 아직 _v2를 안 쓰므로 신규행 _v2 NULL — FK 신규검증 회피.
+cutover 후 추가. 추가형(legacy 컬럼 미삭제)·가역.
+
+Revision ID: 0077
+Revises: 0076
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0077"
+down_revision = "0076"
+branch_labels = None
+depends_on = None
+
+# (table, scalar column) — _v2 컬럼 + COALESCE(alias) 백필
+_SCALAR: list[tuple[str, str]] = [
+    ("conversations", "created_by"),
+    ("conversations", "resolved_by"),
+    ("conversation_participants", "member_id"),
+    ("conversation_messages", "sender_id"),
+    ("events", "sender_id"),
+    ("events", "recipient_id"),
+]
+
+
+def upgrade() -> None:
+    for table, col in _SCALAR:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid")
+        # 백필: 레거시 휴먼 team_member.id는 alias로 canonical화, 그 외(agent/org-member)는 legacy 보존(orphan-safe)
+        op.execute(
+            f"""
+            UPDATE {table} SET {col}_v2 = COALESCE(
+                (SELECT a.member_id FROM member_identity_aliases a WHERE a.alias_id = {table}.{col}),
+                {table}.{col}
+            )
+            WHERE {col} IS NOT NULL AND {col}_v2 IS NULL
+            """
+        )
+
+    # mentioned_ids(배열): 원소별 alias 치환
+    op.execute("ALTER TABLE conversation_messages ADD COLUMN IF NOT EXISTS mentioned_ids_v2 uuid[]")
+    # E1(QA): 빈 배열 '{}'도 v2='{}'로 보존(array_length>0 제거 + COALESCE) — NULL(필드없음) vs
+    # '{}'(빈 멘션) 의미 불일치 방지. unnest('{}')→0행→array_agg=NULL→COALESCE로 '{}'.
+    op.execute(
+        """
+        UPDATE conversation_messages SET mentioned_ids_v2 = COALESCE(
+            (SELECT array_agg(COALESCE(a.member_id, t.e) ORDER BY ord)
+             FROM unnest(mentioned_ids) WITH ORDINALITY AS t(e, ord)
+             LEFT JOIN member_identity_aliases a ON a.alias_id = t.e),
+            '{}'::uuid[]
+        )
+        WHERE mentioned_ids IS NOT NULL AND mentioned_ids_v2 IS NULL
+        """
+    )
+
+    # hot lookup: events.recipient_id_v2 (SSE 백필/poll)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_events_recipient_id_v2 ON events (recipient_id_v2)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_conv_participants_member_id_v2 ON conversation_participants (member_id_v2)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_events_recipient_id_v2")
+    op.execute("DROP INDEX IF EXISTS ix_conv_participants_member_id_v2")
+    op.execute("ALTER TABLE conversation_messages DROP COLUMN IF EXISTS mentioned_ids_v2")
+    for table, col in _SCALAR:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")

--- a/backend/alembic/versions/0078_assignee_v2_fk_relax.py
+++ b/backend/alembic/versions/0078_assignee_v2_fk_relax.py
@@ -1,0 +1,85 @@
+"""E-MEMBER-SSOT AC3-2 Batch 2: stories/tasks/epics assignee_id team_members FK 완화 + v2.
+
+blueprint §4 Phase4. assignee_id가 team_members FK라 grant-only 휴먼(org_member.id) 할당 시
+FK 위반 500(AC6 라이브 근거 1154dd9e). FK DROP으로 해소 + assignee_id_v2(canonical) + alias 백필.
+
+- assignee_id team_members FK(ondelete SET NULL) DROP — 0069/0073/0074 inspector 패턴(컬럼·데이터 유지).
+- assignee_id_v2 + 백필=COALESCE(alias.member_id, legacy)(orphan-safe 트랩#4): 레거시 휴먼 tm→canonical,
+  agent/org-member 보존.
+- ⚠️ assignee_id_v2 FK 보류(트랩#7): write 경로(할당 API)가 _v2 미사용 → 신규행 _v2 NULL → FK 신규검증 회피.
+  read-cut 후 cutover서 추가. 추가형·가역.
+
+Revision ID: 0078
+Revises: 0077
+Create Date: 2026-06-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0078"
+down_revision = "0077"
+branch_labels = None
+depends_on = None
+
+_TARGETS = ["epics", "stories", "tasks"]
+_COL = "assignee_id"
+
+
+def _fks_to_team_members(insp: sa.Inspector, table: str) -> list[dict]:
+    return [fk for fk in insp.get_foreign_keys(table) if fk.get("referred_table") == "team_members"]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _TARGETS:
+        if table not in tables:
+            continue
+        # 1. assignee_id team_members FK DROP (grant-only 할당 500 해소)
+        for fk in _fks_to_team_members(insp, table):
+            if _COL in fk.get("constrained_columns", []):
+                fk_name = fk.get("name")
+                if fk_name:
+                    op.drop_constraint(fk_name, table, type_="foreignkey")
+        # 2. assignee_id_v2 + alias 백필(orphan-safe)
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {_COL}_v2 uuid")
+        op.execute(
+            f"""
+            UPDATE {table} SET {_COL}_v2 = COALESCE(
+                (SELECT a.member_id FROM member_identity_aliases a WHERE a.alias_id = {table}.{_COL}),
+                {table}.{_COL}
+            )
+            WHERE {_COL} IS NOT NULL AND {_COL}_v2 IS NULL
+            """
+        )
+        op.execute(f"CREATE INDEX IF NOT EXISTS ix_{table}_assignee_id_v2 ON {table} ({_COL}_v2)")
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _TARGETS:
+        if table not in tables:
+            continue
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_assignee_id_v2")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {_COL}_v2")
+        # 비-team_member assignee_id가 없을 때만 FK 재추가(데이터 안전)
+        existing = {fk["name"] for fk in _fks_to_team_members(insp, table)}
+        fk_name = f"{table}_{_COL}_fkey"
+        if fk_name in existing:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{_COL} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{_COL}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(fk_name, table, "team_members", [_COL], ["id"], ondelete="SET NULL")

--- a/backend/alembic/versions/0079_identity_v2_rest_fk_relax.py
+++ b/backend/alembic/versions/0079_identity_v2_rest_fk_relax.py
@@ -1,0 +1,114 @@
+"""E-MEMBER-SSOT AC3-2 Batch 3: 잔여 식별 컬럼 team_members FK 완화 + v2.
+
+blueprint §4 Phase4 마무리. participation/webhook_configs/reward_ledger/docs/doc_comments/
+doc_revisions/notification_preferences의 legacy team_member.id 식별 컬럼을 canonical members.id로
+이행. Batch2(assignee_id)와 동형 — team_members FK가 grant-only 휴먼(org_member.id) write 시
+실DB FK violation 500을 유발하는 동일 버그 클래스 → FK DROP + *_v2 + alias 백필.
+
+대상 (table, column):
+- participation.member_id            (CASCADE, NOT NULL) — 스토리 참가
+- notification_preferences.member_id (FK는 0073서 이미 DROP — v2만)
+- webhook_configs.member_id          (CASCADE, NOT NULL) — 생성자
+- reward_ledger.member_id            (CASCADE, NOT NULL) — 수령자
+- reward_ledger.granted_by           (SET NULL, NULL)    — 지급자
+- docs.created_by / docs.assignee_id (SET NULL, NULL)
+- doc_comments.created_by            (CASCADE, NOT NULL)
+- doc_revisions.created_by           (SET NULL, NULL)
+
+백필 = COALESCE(alias.member_id, legacy): 레거시 휴먼 tm→canonical, agent/org-member 보존(orphan-safe 트랩#4).
+⚠️ *_v2 FK 보류(트랩#7): write 경로가 _v2 미사용 → 신규행 _v2 NULL → FK 신규검증 회피. 추가형·가역.
+
+Revision ID: 0079
+Revises: 0078
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0079"
+down_revision = "0078"
+branch_labels = None
+depends_on = None
+
+# (table, column, downgrade 재추가용 ondelete | None=재추가 안 함[0073 소유])
+_TARGETS: list[tuple[str, str, str | None]] = [
+    ("participation", "member_id", "CASCADE"),
+    ("notification_preferences", "member_id", None),  # FK는 0073가 소유 — 0079 downgrade서 재추가 안 함
+    ("webhook_configs", "member_id", "CASCADE"),
+    ("reward_ledger", "member_id", "CASCADE"),
+    ("reward_ledger", "granted_by", "SET NULL"),
+    ("docs", "created_by", "SET NULL"),
+    ("docs", "assignee_id", "SET NULL"),
+    ("doc_comments", "created_by", "CASCADE"),
+    ("doc_revisions", "created_by", "SET NULL"),
+]
+# 필터/조회 hot 컬럼에 v2 인덱스(member_id_v2)
+_V2_MEMBER_INDEX = ["participation", "notification_preferences", "webhook_configs", "reward_ledger"]
+
+
+def _drop_tm_fk(insp: sa.Inspector, table: str, col: str) -> None:
+    for fk in insp.get_foreign_keys(table):
+        if fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", []):
+            if fk.get("name"):
+                op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, _ in _TARGETS:
+        if table not in tables:
+            continue
+        _drop_tm_fk(insp, table, col)
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid")
+        op.execute(
+            f"""
+            UPDATE {table} SET {col}_v2 = COALESCE(
+                (SELECT a.member_id FROM member_identity_aliases a WHERE a.alias_id = {table}.{col}),
+                {table}.{col}
+            )
+            WHERE {col} IS NOT NULL AND {col}_v2 IS NULL
+            """
+        )
+
+    for table in _V2_MEMBER_INDEX:
+        if table in tables:
+            op.execute(
+                f"CREATE INDEX IF NOT EXISTS ix_{table}_member_id_v2 ON {table} (member_id_v2)"
+            )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table in _V2_MEMBER_INDEX:
+        op.execute(f"DROP INDEX IF EXISTS ix_{table}_member_id_v2")
+
+    for table, col, ondelete in _TARGETS:
+        if table not in tables:
+            continue
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+        if ondelete is None:
+            continue
+        # 비-team_member 값이 없을 때만 FK 재추가(데이터 안전)
+        already = any(
+            fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", [])
+            for fk in insp.get_foreign_keys(table)
+        )
+        if already:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{col} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(f"{table}_{col}_fkey", table, "team_members", [col], ["id"], ondelete=ondelete)

--- a/backend/alembic/versions/0080_agent_api_keys_member_fk.py
+++ b/backend/alembic/versions/0080_agent_api_keys_member_fk.py
@@ -1,0 +1,66 @@
+"""E-MEMBER-SSOT AC3-1b AC3: agent_api_keys.member_id → members(id) FK 재추가.
+
+AC3-1(0076)에서 member_id를 추가·dual-write 했으나, NOT VALID FK라도 **신규 INSERT는 검증**(트랩#7/8)
+→ 신규 agent가 members 부재 시 api_key INSERT 위반 500(생명선)이라 FK를 제거했다(QA H1). AC3-1b AC1
+(신규 agent anchor write-sync)이 members 행을 api_key 생성 전 선행 보장하므로 이제 FK 재추가 안전.
+
+- FK NOT VALID: 기존 행 검증은 skip(신규 INSERT만 검증 — AC1로 referent 선행).
+- VALIDATE는 **가드**: members 부재 referent를 가진 기존 행이 0건일 때만(있으면 NOT VALID 유지 +
+  RAISE NOTICE — migrate 하드페일 방지, 머지-migrate 인시던트 교훈). 잔여 시 AC2 감사·보정 후 재VALIDATE.
+- ondelete SET NULL: member_id는 nullable 미러 — 실삭제는 team_member_id FK(CASCADE)가 처리.
+
+Revision ID: 0080
+Revises: 0079
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0080"
+down_revision = "0079"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "agent_api_keys" not in insp.get_table_names():
+        return
+    existing = {fk.get("name") for fk in insp.get_foreign_keys("agent_api_keys")}
+    if _FK not in existing:
+        op.execute(
+            f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK} "
+            f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+        )
+    # 가드된 VALIDATE: members 부재 referent 0건일 때만
+    op.execute(
+        f"""
+        DO $$
+        DECLARE bad int;
+        BEGIN
+            SELECT count(*) INTO bad FROM agent_api_keys ak
+            WHERE ak.member_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+            IF bad = 0 THEN
+                ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+            ELSE
+                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row %% 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "agent_api_keys" not in insp.get_table_names():
+        return
+    existing = {fk.get("name") for fk in insp.get_foreign_keys("agent_api_keys")}
+    if _FK in existing:
+        op.drop_constraint(_FK, "agent_api_keys", type_="foreignkey")

--- a/backend/alembic/versions/0080_agent_api_keys_member_fk.py
+++ b/backend/alembic/versions/0080_agent_api_keys_member_fk.py
@@ -49,7 +49,7 @@ def upgrade() -> None:
             IF bad = 0 THEN
                 ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
             ELSE
-                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row %% 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+                RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
             END IF;
         END $$;
         """

--- a/backend/alembic/versions/0081_standup_author_canonical.py
+++ b/backend/alembic/versions/0081_standup_author_canonical.py
@@ -1,0 +1,88 @@
+"""E-MEMBER-SSOT AC3-3: standup author/feedback 식별자를 canonical members.id로 정규화.
+
+blueprint §6. 기존 standup_entries.author_id·standup_feedback.feedback_by_id는 #1167 transitional로
+레거시 휴먼 team_member.id가 섞여 있다. AC3-3 코드가 write/missing/카드를 canonical로 옮기므로,
+기존 행도 canonical(org_member.id)로 정규화해야 신/구 데이터가 한 신원으로 정합(멀티프로젝트 휴먼 단일
+신원, 48e653e9). 백필 = COALESCE(alias.member_id, legacy) (orphan-safe 트랩#4). FK는 0074서 이미 DROP.
+
+⚠️ preflight 병합: author_id→canonical 매핑이 (org,project,date)에서 충돌하면(레거시 tm.id 행 +
+이미 canonical 행) 최신(updated_at) 1행만 남기고 나머지의 feedback을 keeper로 재귀속 후 삭제 —
+중복 author_id로 upsert SELECT(scalar_one)가 깨지지 않도록.
+
+Revision ID: 0081
+Revises: 0080
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0081"
+down_revision = "0080"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. preflight 병합: canonical 충돌 그룹에서 keeper(최신) 외 행의 feedback 재귀속 후 삭제
+    op.execute(
+        """
+        WITH canon AS (
+            SELECT se.id, se.org_id, se.project_id, se.date,
+                   COALESCE(a.member_id, se.author_id) AS cid, se.updated_at
+            FROM standup_entries se
+            LEFT JOIN member_identity_aliases a ON a.alias_id = se.author_id
+        ),
+        ranked AS (
+            SELECT id,
+                   row_number() OVER (PARTITION BY org_id, project_id, date, cid
+                                      ORDER BY updated_at DESC, id DESC) AS rn,
+                   first_value(id) OVER (PARTITION BY org_id, project_id, date, cid
+                                         ORDER BY updated_at DESC, id DESC) AS keeper_id
+            FROM canon
+        )
+        UPDATE standup_feedback sf SET standup_entry_id = r.keeper_id
+        FROM ranked r
+        WHERE sf.standup_entry_id = r.id AND r.rn > 1
+        """
+    )
+    op.execute(
+        """
+        WITH canon AS (
+            SELECT se.id, se.org_id, se.project_id, se.date,
+                   COALESCE(a.member_id, se.author_id) AS cid, se.updated_at
+            FROM standup_entries se
+            LEFT JOIN member_identity_aliases a ON a.alias_id = se.author_id
+        ),
+        ranked AS (
+            SELECT id,
+                   row_number() OVER (PARTITION BY org_id, project_id, date, cid
+                                      ORDER BY updated_at DESC, id DESC) AS rn
+            FROM canon
+        )
+        DELETE FROM standup_entries se USING ranked r WHERE se.id = r.id AND r.rn > 1
+        """
+    )
+
+    # 2. canonical 정규화(레거시 휴먼 team_member.id → alias의 member_id). orphan-safe(alias 없으면 유지).
+    op.execute(
+        """
+        UPDATE standup_entries se SET author_id = a.member_id
+        FROM member_identity_aliases a
+        WHERE a.alias_id = se.author_id AND se.author_id <> a.member_id
+        """
+    )
+    op.execute(
+        """
+        UPDATE standup_feedback sf SET feedback_by_id = a.member_id
+        FROM member_identity_aliases a
+        WHERE a.alias_id = sf.feedback_by_id AND sf.feedback_by_id <> a.member_id
+        """
+    )
+
+
+def downgrade() -> None:
+    # 일방향 데이터 정규화(canonical) — 역변환 불가(alias는 N 레거시→1 canonical, project별 team_member.id
+    # 복원이 모호). canonical id는 유효 식별자로 유지; 코드 롤백(resolve_member→resolve_auth_member)이
+    # 가역 부분. no-op(0075 백필과 동일 정책).
+    pass

--- a/backend/alembic/versions/0082_reconcile_window_agent_anchors.py
+++ b/backend/alembic/versions/0082_reconcile_window_agent_anchors.py
@@ -1,0 +1,84 @@
+"""E-MEMBER-SSOT AC3-1b AC2 보정: window agent anchor 재조정(members + agent_project_profiles).
+
+AC2 감사(in-VPC): cut-on 위반 active api_key 중 1건(a52b4ccd, agent active=True·members 부재) = 실 회귀
++ 0080 FK VALIDATE 블로커. 원인: **0075 agent 백필 ↔ AC3-1b write-sync(코드) 배포 사이 window에 생성된
+agent** — 0075엔 아직 없었고 write-sync 배포 전이라 members/profile 미생성. (나머지 5건은 inactive agent
+= legacy도 is_active 요구로 401 = 무회귀.)
+
+해소: 0075 agent 백필 로직을 idempotent 재실행해 members 없는 agent team_member를 모두 재조정. write-sync
+배포로 window는 닫혔으므로 신규 agent는 정상; 이 마이그는 과거 window agent를 소급 보정한다.
+
+- members(id=tm.id·type='agent'·owner=생성휴먼·런타임 미러) ON CONFLICT (id) DO NOTHING.
+- agent_project_profiles(member=tm.id) ON CONFLICT (project_id, member_id) DO NOTHING.
+- 보정 후 0080 FK 가드 VALIDATE: members 부재 referent 0건이면 VALIDATE(아니면 NOT VALID 유지+NOTICE).
+
+orphan-safe(트랙#4): organizations JOIN으로 orphan org 스킵, owner는 members 실재 시만(LEFT JOIN). 추가형·가역.
+
+Revision ID: 0082
+Revises: 0081
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0082"
+down_revision = "0081"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    # 1. members 재조정 — 0075 §3 agent 백필 동형(idempotent)
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, avatar_url, org_role, is_active, created_at, updated_at)
+        SELECT tm.id, tm.org_id, 'agent', NULL, owner.id, tm.name, tm.avatar_url, NULL, tm.is_active, tm.created_at, now()
+        FROM team_members tm
+        JOIN organizations o ON o.id = tm.org_id
+        LEFT JOIN org_members owner
+               ON owner.org_id = tm.org_id AND owner.user_id = tm.created_by AND owner.deleted_at IS NULL
+              AND EXISTS (SELECT 1 FROM members m WHERE m.id = owner.id)
+        WHERE tm.type = 'agent'
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+    # 2. agent_project_profiles 재조정 — 0075 §6 동형(idempotent)
+    op.execute(
+        """
+        INSERT INTO agent_project_profiles
+            (id, member_id, project_id, agent_config, webhook_url, agent_role, fakechat_port, last_seen_at, active_story_id, agent_status, created_at, updated_at)
+        SELECT gen_random_uuid(), tm.id, tm.project_id, tm.agent_config, tm.webhook_url, tm.agent_role,
+               tm.fakechat_port, tm.last_seen_at, tm.active_story_id, tm.agent_status, tm.created_at, now()
+        FROM team_members tm
+        WHERE tm.type = 'agent'
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = tm.id)
+        ON CONFLICT (project_id, member_id) DO NOTHING
+        """
+    )
+    # 3. 0080 FK 가드 VALIDATE — 보정 후 members 부재 referent 0건이면 검증(아니면 NOT VALID 유지)
+    op.execute(
+        f"""
+        DO $$
+        DECLARE bad int;
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK}' AND NOT convalidated) THEN
+                SELECT count(*) INTO bad FROM agent_api_keys ak
+                WHERE ak.member_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+                IF bad = 0 THEN
+                    ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+                ELSE
+                    RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 (window 보정 후에도 잔여 — 점검 필요)', bad;
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 일방향 재조정 백필(0075 동형) — 역삭제는 정상 0075 백필분과 구분 불가라 위험. no-op(0075 정책).
+    pass

--- a/backend/alembic/versions/0083_revoke_orphan_org_apikeys.py
+++ b/backend/alembic/versions/0083_revoke_orphan_org_apikeys.py
@@ -1,0 +1,64 @@
+"""E-MEMBER-SSOT AC3-1b AC2 마무리: orphan-org dead agent api_key revoke + FK VALIDATE.
+
+AC2 재감사(post-0082): a52b4ccd 1건 여전 members 부재 — **org_id가 organizations에 없는 orphan-org
+agent**(0075·0082 모두 INNER JOIN organizations로 의도 스킵, members.org_id NOT NULL FK라 생성 불가).
+실 동작 불가한 dead agent이므로 그 api_key를 revoke. (5 inactive 키는 member_exists=True라 무영향.)
+
+⚠️ revoke(revoked_at)만으론 FK VALIDATE가 안 됨 — VALIDATE는 revoked 무관 **전 행**의 member_id를
+검사하므로 orphan member_id가 남으면 위반. 따라서 **member_id=NULL도 함께**(미러 컬럼, FK는 NULL 허용)
+→ bad=0 → 0080/0082 FK 가드 VALIDATE 통과 + flag-on 안전.
+
+idempotent: 재실행 시 이미 revoke+NULL된 행은 member_id NULL이라 NOT EXISTS 매치 안 됨 → no-op.
+범위 안전: post-0082라 valid-org agent는 members 백필됨 → members 부재 = orphan-org dead만 매치(legit
+agent 무영향). 데이터 보정·가역(downgrade no-op, revoke/NULL 복원 불가·불요).
+
+Revision ID: 0083
+Revises: 0082
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0083"
+down_revision = "0082"
+branch_labels = None
+depends_on = None
+
+_FK = "fk_agent_api_keys_member_id_members"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        DO $$
+        DECLARE revoked int; bad int;
+        BEGIN
+            -- 1. orphan-org dead agent 키 revoke + member_id NULL(FK 위반 정리)
+            UPDATE agent_api_keys SET revoked_at = now(), member_id = NULL
+            WHERE revoked_at IS NULL
+              AND member_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = agent_api_keys.member_id);
+            GET DIAGNOSTICS revoked = ROW_COUNT;
+            RAISE NOTICE 'orphan-org dead agent api_key revoke + member_id NULL: % 건', revoked;
+
+            -- 2. 가드 VALIDATE — 이제 members 부재 referent 0건이면 검증
+            IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK}' AND NOT convalidated) THEN
+                SELECT count(*) INTO bad FROM agent_api_keys ak
+                WHERE ak.member_id IS NOT NULL
+                  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+                IF bad = 0 THEN
+                    ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK};
+                    RAISE NOTICE 'agent_api_keys.member_id FK validated (bad=0)';
+                ELSE
+                    RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지 (bad=% 잔여 — 점검 필요)', bad;
+                END IF;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 보정(revoke + member_id NULL) — 역복원 불가·불요(dead-org agent). no-op.
+    pass

--- a/backend/alembic/versions/0084_grant_member_id_backfill.py
+++ b/backend/alembic/versions/0084_grant_member_id_backfill.py
@@ -1,0 +1,57 @@
+"""E-MEMBER-SSOT AC3-2c: grant write-sync — 휴먼 members 재조정 + project_access.member_id 백필.
+
+create_project_access가 anchor 후에도 project_access.member_id를 NULL로 두어(org_member_id만 세팅),
+신규 grant-only 휴먼이 member_id 없이 남는다 → AC3-3 get_missing 등 member_id 가정 코드가 누락(이미
+org_member_id로 우회했으나, AC3-4 projection은 member_id 읽기 토대 필요). 코드는 ensure_human_member로
+신규 grant부터 세팅하고, 이 마이그는 **기존 데이터** 보정.
+
+전제: 신규 휴먼(0075 이후)은 members 행이 없을 수 있다(휴먼 write-sync 부재) → member_id=org_member_id를
+넣으려면 members 행 선행 필요(fk_project_access_member). 따라서:
+1. 휴먼 members 재조정(0075 §3 human 백필 idempotent 재실행) — post-0075 휴먼 포착.
+2. project_access.member_id = org_member_id 백필(member_id NULL·org_member_id 有·members 실재 시만, orphan-safe 트랩#4).
+
+추가형·가역(downgrade no-op, 0075/0082 정책). FK VALIDATE는 별도(다른 phase — agent placement 등 surface 큼).
+
+Revision ID: 0084
+Revises: 0083
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0084"
+down_revision = "0083"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. 휴먼 members 재조정 — 0075 §3 human 백필 동형(idempotent). post-0075 신규 휴먼 포착.
+    #    members.id = org_member.id, name=users.display_name/email(orphan user→user_id NULL), orphan org 스킵.
+    op.execute(
+        """
+        INSERT INTO members (id, org_id, type, user_id, owner_member_id, name, org_role, is_active, created_at, updated_at)
+        SELECT om.id, om.org_id, 'human', u.id, NULL,
+               COALESCE(u.display_name, u.email, om.user_id::text),
+               om.role, true, om.created_at, now()
+        FROM org_members om
+        JOIN organizations o ON o.id = om.org_id
+        LEFT JOIN users u ON u.id = om.user_id
+        WHERE om.deleted_at IS NULL
+        ON CONFLICT (id) DO NOTHING
+        """
+    )
+    # 2. project_access.member_id = org_member_id 백필(휴먼 grant). members 실재 시만(orphan-safe).
+    op.execute(
+        """
+        UPDATE project_access SET member_id = org_member_id
+        WHERE member_id IS NULL AND org_member_id IS NOT NULL
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = project_access.org_member_id)
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 백필(휴먼 members + project_access.member_id) — 역삭제는 정상분과 구분 불가. no-op(0075 정책).
+    pass

--- a/backend/alembic/versions/0085_ac3_2d_red_fk_relax_canonical.py
+++ b/backend/alembic/versions/0085_ac3_2d_red_fk_relax_canonical.py
@@ -1,0 +1,99 @@
+"""E-MEMBER-SSOT AC3-2d 배치1(🔴): 잔여 team_members FK 컬럼 완화 + canonical 정규화.
+
+(A) resolver-cutover 통일. AC3-2c까지 안 닿은 🔴 8테이블 12컬럼의 team_members FK를 완화하고(grant-only
+휴먼 write 500 해소) 기존 legacy 휴먼 team_member.id를 canonical members.id로 정규화(alias). write 경로의
+canonical화(canonicalize_member_id)는 코드에서, 이 마이그는 **FK 완화 + 기존 데이터 정규화**.
+
+대상 (table, column):
+- retro_sessions.created_by / retro_items.author_id / retro_votes.voter_id / retro_actions.assignee_id
+- file_locks.member_id / member_gate_override.member_id (hitl) / invitations.invited_by
+- meetings.created_by / policy_documents.created_by
+- story_comments.created_by / story_activities.created_by (pm.created_by)
+- agent_runs.agent_id
+
+- FK 완화: inspector 기반 idempotent DROP(0069/0079 패턴, 컬럼·데이터·인덱스 유지).
+- 정규화 백필 = alias.member_id (레거시 휴먼 team_member.id → canonical). orphan-safe(트랩#4: alias 없으면
+  legacy 유지 — agent id·org_member.id는 이미 canonical이라 alias 없음→불변). 추가형·가역(FK downgrade는
+  비-team_member 값 없을 때만 재추가).
+
+Revision ID: 0085
+Revises: 0084
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0085"
+down_revision = "0084"
+branch_labels = None
+depends_on = None
+
+# (table, column, downgrade 재추가 ondelete)
+_TARGETS: list[tuple[str, str, str]] = [
+    ("retro_sessions", "created_by", "SET NULL"),
+    ("retro_items", "author_id", "SET NULL"),
+    ("retro_votes", "voter_id", "CASCADE"),
+    ("retro_actions", "assignee_id", "SET NULL"),
+    ("file_locks", "member_id", "CASCADE"),
+    ("member_gate_override", "member_id", "CASCADE"),
+    ("invitations", "invited_by", "CASCADE"),
+    ("meetings", "created_by", "SET NULL"),
+    ("policy_documents", "created_by", "SET NULL"),
+    ("story_comments", "created_by", "CASCADE"),
+    ("story_activities", "created_by", "CASCADE"),
+    ("agent_runs", "agent_id", "CASCADE"),
+]
+
+
+def _drop_tm_fk(insp: sa.Inspector, table: str, col: str) -> None:
+    for fk in insp.get_foreign_keys(table):
+        if fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", []):
+            if fk.get("name"):
+                op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, _ in _TARGETS:
+        if table not in tables:
+            continue
+        # 1. team_members FK 완화
+        _drop_tm_fk(insp, table, col)
+        # 2. 레거시 휴먼 team_member.id → canonical(alias) 정규화. orphan-safe(alias 없으면 불변).
+        op.execute(
+            f"""
+            UPDATE {table} SET {col} = a.member_id
+            FROM member_identity_aliases a
+            WHERE a.alias_id = {table}.{col} AND {table}.{col} <> a.member_id
+            """
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+
+    for table, col, ondelete in _TARGETS:
+        if table not in tables:
+            continue
+        already = any(
+            fk.get("referred_table") == "team_members" and col in fk.get("constrained_columns", [])
+            for fk in insp.get_foreign_keys(table)
+        )
+        if already:
+            continue
+        non_tm = conn.execute(
+            sa.text(
+                f"SELECT 1 FROM {table} t WHERE t.{col} IS NOT NULL"
+                f" AND NOT EXISTS (SELECT 1 FROM team_members tm WHERE tm.id = t.{col}) LIMIT 1"
+            )
+        ).scalar_one_or_none()
+        if non_tm is not None:
+            continue
+        op.create_foreign_key(f"{table}_{col}_fkey", table, "team_members", [col], ["id"], ondelete=ondelete)

--- a/backend/alembic/versions/0086_ac3_2d_yellow_canonicalize.py
+++ b/backend/alembic/versions/0086_ac3_2d_yellow_canonicalize.py
@@ -1,0 +1,65 @@
+"""E-MEMBER-SSOT AC3-2d 배치2(🟡): webhook/reward/docs/notif_prefs 식별 컬럼 canonical 정규화.
+
+(A) resolver-cutover 통일. 🟡 그룹(0079서 FK 기완화) + notification_preferences.member_id(0073서 FK 기완화,
+0085 _TARGETS 누락분)의 기존 legacy 휴먼 team_member.id를 canonical members.id로 정규화. FK DROP 없음
+(이미 완화) — alias 기반 canonicalize UPDATE만(0085 §2 동형).
+
+⚠️ write canonical(코드)과 **동반 필수**(특히 notif_prefs): 데이터만 canonicalize하고 write/read가 tm.id-first면
+기존 휴먼 prefs가 매칭 실패로 유실(split-brain). 같은 PR에서 write도 canonical 전환.
+
+대상 (table, column):
+- webhook_configs.member_id
+- reward_ledger.member_id / reward_ledger.granted_by
+- docs.created_by / docs.assignee_id
+- doc_comments.created_by / doc_revisions.created_by
+- notification_preferences.member_id
+
+정규화 = alias.member_id (레거시 휴먼 tm.id → canonical). orphan-safe(트랩#4: alias 없으면 불변 →
+agent id·canonical은 alias 없어 불변). 잔존 휴먼 tm.id-키 행 없는 컬럼은 0행 UPDATE(무해). 추가형·가역(no-op down).
+
+Revision ID: 0086
+Revises: 0085
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0086"
+down_revision = "0085"
+branch_labels = None
+depends_on = None
+
+_TARGETS: list[tuple[str, str]] = [
+    ("webhook_configs", "member_id"),
+    ("reward_ledger", "member_id"),
+    ("reward_ledger", "granted_by"),
+    ("docs", "created_by"),
+    ("docs", "assignee_id"),
+    ("doc_comments", "created_by"),
+    ("doc_revisions", "created_by"),
+    ("notification_preferences", "member_id"),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    tables = set(insp.get_table_names())
+    for table, col in _TARGETS:
+        if table not in tables:
+            continue
+        # 레거시 휴먼 team_member.id → canonical(alias). orphan-safe(alias 없으면 불변).
+        op.execute(
+            f"""
+            UPDATE {table} SET {col} = a.member_id
+            FROM member_identity_aliases a
+            WHERE a.alias_id = {table}.{col} AND {table}.{col} <> a.member_id
+            """
+        )
+
+
+def downgrade() -> None:
+    # 일방향 canonical 정규화 — 역변환 불가·불요(0075/0085 정책). no-op.
+    pass

--- a/backend/alembic/versions/0087_agent_placement_backfill.py
+++ b/backend/alembic/versions/0087_agent_placement_backfill.py
@@ -1,0 +1,44 @@
+"""E-MEMBER-SSOT AC3-4 2-1: window agent project_access placement 백필.
+
+AC3-4 뷰가 에이전트 role/can_manage를 project_access(placement)서 읽는다(런타임은 agent_project_profiles
+LEFT JOIN). 0075 §5가 기존 agent placement를 만들었으나, 0075↔AC3-1b write-sync 사이 window agent +
+write-sync에 placement 미포함이던 신규 agent는 placement 누락 가능. create write-sync(2-1)에 placement를
+추가했고, 이 마이그는 기존 누락분 소급 백필(0075 §5 동형, idempotent).
+
+조건: type='agent' active + members 존재(0082 보정분) + placement 미존재. ON CONFLICT 대신 NOT EXISTS 가드.
+orphan-safe. 추가형·가역(no-op down — 정상 placement와 구분 불가).
+
+Revision ID: 0087
+Revises: 0086
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0087"
+down_revision = "0086"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO project_access
+            (id, project_id, org_member_id, member_id, permission, role, color, can_manage_members, access_source, created_at)
+        SELECT gen_random_uuid(), tm.project_id, NULL, tm.id, 'granted', tm.role, tm.color,
+               tm.can_manage_members, 'direct', tm.created_at
+        FROM team_members tm
+        WHERE tm.type = 'agent' AND tm.is_active = true
+          AND EXISTS (SELECT 1 FROM members m WHERE m.id = tm.id)
+          AND NOT EXISTS (
+              SELECT 1 FROM project_access pa WHERE pa.project_id = tm.project_id AND pa.member_id = tm.id
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # 데이터 백필(0075 §5 동형) — 역삭제는 정상 placement와 구분 불가. no-op.
+    pass

--- a/backend/alembic/versions/0088_team_members_projection_view.py
+++ b/backend/alembic/versions/0088_team_members_projection_view.py
@@ -1,0 +1,66 @@
+"""E-MEMBER-SSOT AC3-4 2-2: team_members 물리테이블 → members 기반 projection 뷰 강등.
+
+곱연산 물리 소거. team_members를 team_members_legacy로 rename하고, members/project_access/
+agent_project_profiles 기반 VIEW로 재정의. 2-1 dual-write로 anchor가 이미 최신이라 안전. READ는 뷰로
+투명 동작(19컬럼 전 재현). write는 코드에서 anchor-only로 전환(같은 PR).
+
+뷰 멤버십(의도된 SSOT): 휴먼=project_access 보유분(grant-only 출현·access 회수 시 live 제외),
+에이전트=agent_project_profiles per-project(1:1). created_by = owner.user_id(D1: 옛 auth.user_id 동일값
+재현, FE 소유자 배지 무변경).
+
+⚠️ 가역(G5): downgrade = DROP VIEW + team_members_legacy → team_members rename 복원.
+
+Revision ID: 0088
+Revises: 0087
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0088"
+down_revision = "0087"
+branch_labels = None
+depends_on = None
+
+# team_members 19 식별/속성 컬럼 + created_at/updated_at = 21. 모델 컬럼명과 동일해야 ORM 매핑.
+_CREATE_VIEW = """
+CREATE VIEW team_members AS
+-- 휴먼: members ⋈ project_access (per-project). agent 런타임 컬럼은 NULL.
+SELECT
+    m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, NULL::text AS webhook_url, m.is_active,
+    pa.color, NULL::text AS agent_role, NULL::integer AS fakechat_port,
+    owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN project_access pa ON pa.member_id = m.id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+-- 에이전트: members ⋈ agent_project_profiles (per-project runtime) LEFT JOIN project_access (role/color).
+SELECT
+    m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, app.webhook_url, m.is_active,
+    COALESCE(pa.color, '#3385f8') AS color, app.agent_role, app.fakechat_port,
+    owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN agent_project_profiles app ON app.member_id = m.id
+LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE team_members RENAME TO team_members_legacy")
+    op.execute(_CREATE_VIEW)
+
+
+def downgrade() -> None:
+    # G5 가역: 뷰 제거 후 물리테이블 복원.
+    op.execute("DROP VIEW IF EXISTS team_members")
+    op.execute("ALTER TABLE team_members_legacy RENAME TO team_members")

--- a/backend/alembic/versions/0089_validate_project_access_member_fks.py
+++ b/backend/alembic/versions/0089_validate_project_access_member_fks.py
@@ -1,0 +1,65 @@
+"""E-MEMBER-SSOT AC3-5 ①: project_access member FK 가드된 VALIDATE.
+
+0075가 project_access의 member FK 2종을 **NOT VALID**로 추가("후속 phase에서 VALIDATE"):
+- fk_project_access_member (member_id → members.id, CASCADE)
+- fk_project_access_inherited_member (inherited_from_member_id → members.id, SET NULL)
+
+AC3-2c/2d로 휴먼/에이전트 placement·alias canonicalize가 완료돼 member_id 무결성이 갖춰진 지금
+기존 행을 검증(VALIDATE)한다. NOT VALID FK도 신규 INSERT는 검증했으므로(트랩#7/8), 이건 기존
+행 검증을 마저 켜는 **additive·비파괴** 단계.
+
+⚠️ 가드(0080/0083 패턴): 부재 referent 행이 0건일 때만 VALIDATE(있으면 NOT VALID 유지 + RAISE
+NOTICE — migrate 하드페일 방지). 제약 부재 DB(create_all auto-name 등)면 스킵(pg_constraint 가드).
+data-dependent 분기라 bad>0은 실DB-only 발현(트랩#4b) — parity에 bad>0 가드 테스트 동봉.
+
+⚠️ agent_api_keys.member_id FK는 0083서 bad=0 VALIDATE 완료 — 본 마이그 대상 아님.
+
+Revision ID: 0089
+Revises: 0088
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0089"
+down_revision = "0088"
+branch_labels = None
+depends_on = None
+
+# (제약명, 참조 컬럼) — 0075 NOT VALID FK 2종
+_FKS = [
+    ("fk_project_access_member", "member_id"),
+    ("fk_project_access_inherited_member", "inherited_from_member_id"),
+]
+
+
+def upgrade() -> None:
+    for conname, col in _FKS:
+        op.execute(
+            f"""
+            DO $$
+            DECLARE bad int;
+            BEGIN
+                IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{conname}') THEN
+                    SELECT count(*) INTO bad
+                    FROM project_access pa
+                    WHERE pa.{col} IS NOT NULL
+                      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = pa.{col});
+                    IF bad = 0 THEN
+                        ALTER TABLE project_access VALIDATE CONSTRAINT {conname};
+                        RAISE NOTICE '{conname} validated (bad=0)';
+                    ELSE
+                        RAISE NOTICE '{conname} NOT VALID 유지: members 부재 referent % 건 — 점검 후 재VALIDATE 필요', bad;
+                    END IF;
+                ELSE
+                    RAISE NOTICE '{conname} 부재 — 스킵(create_all auto-name DB 등)';
+                END IF;
+            END $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    # VALIDATE는 비파괴(제약 상태만 NOT VALID→validated). 역전 불요 — no-op.
+    pass

--- a/backend/alembic/versions/0090_drop_vestigial_v2_columns.py
+++ b/backend/alembic/versions/0090_drop_vestigial_v2_columns.py
@@ -1,0 +1,85 @@
+"""E-MEMBER-SSOT AC3-5 ⑤: vestigial *_v2 식별 컬럼 DROP.
+
+AC3-2(0077/0078/0079)가 legacy team_member.id 식별 컬럼을 canonical members.id로 옮기는 *_v2 컬럼 +
+alias 백필을 추가했으나, 최종 채택 전략은 **(A) resolver-cutover**(legacy 컬럼이 canonicalize로 canonical
+보유) — *_v2 read-cut은 미착수(app 코드 *_v2 참조 0건). 즉 *_v2는 **백필-only vestigial**.
+
+app 전수 grep 재확인(develop 0089 기준): *_v2 식별 컬럼 코드 참조 0건(모델 주석만 — 동반 갱신). 파괴적
+DROP이나 미참조 확정 → 안전. canonical 진실은 legacy 컬럼(canonicalize_member_id) 유지, 본 DROP은 미사용
+중복 컬럼/인덱스 소거(곱연산 잔재 정리). 가역: DOWN은 nullable 컬럼+인덱스 재추가(백필-only라 데이터 손실 0).
+
+⚠️ 0077 conv/events·0078 assignee·0079 participation/notif/webhook/reward/docs 전수.
+
+Revision ID: 0090
+Revises: 0089
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0090"
+down_revision = "0089"
+branch_labels = None
+depends_on = None
+
+# scalar uuid *_v2 컬럼 (table, base_col) — 0077/0078/0079 전수
+_V2_SCALAR: list[tuple[str, str]] = [
+    # 0077 conv/events
+    ("conversations", "created_by"),
+    ("conversations", "resolved_by"),
+    ("conversation_participants", "member_id"),
+    ("conversation_messages", "sender_id"),
+    ("events", "sender_id"),
+    ("events", "recipient_id"),
+    # 0078 assignee
+    ("epics", "assignee_id"),
+    ("stories", "assignee_id"),
+    ("tasks", "assignee_id"),
+    # 0079 rest
+    ("participation", "member_id"),
+    ("notification_preferences", "member_id"),
+    ("webhook_configs", "member_id"),
+    ("reward_ledger", "member_id"),
+    ("reward_ledger", "granted_by"),
+    ("docs", "created_by"),
+    ("docs", "assignee_id"),
+    ("doc_comments", "created_by"),
+    ("doc_revisions", "created_by"),
+]
+# 배열 *_v2 컬럼 (0077 mentioned_ids)
+_V2_ARRAY: list[tuple[str, str]] = [
+    ("conversation_messages", "mentioned_ids"),
+]
+# *_v2 인덱스 (index, table, v2_col) — DROP COLUMN이 자동 제거하나 명시적·가역 재생성 위해 보유
+_V2_INDEXES: list[tuple[str, str, str]] = [
+    ("ix_events_recipient_id_v2", "events", "recipient_id_v2"),
+    ("ix_conv_participants_member_id_v2", "conversation_participants", "member_id_v2"),
+    ("ix_epics_assignee_id_v2", "epics", "assignee_id_v2"),
+    ("ix_stories_assignee_id_v2", "stories", "assignee_id_v2"),
+    ("ix_tasks_assignee_id_v2", "tasks", "assignee_id_v2"),
+    ("ix_participation_member_id_v2", "participation", "member_id_v2"),
+    ("ix_notification_preferences_member_id_v2", "notification_preferences", "member_id_v2"),
+    ("ix_webhook_configs_member_id_v2", "webhook_configs", "member_id_v2"),
+    ("ix_reward_ledger_member_id_v2", "reward_ledger", "member_id_v2"),
+]
+
+
+def upgrade() -> None:
+    # 인덱스 먼저 명시 제거(컬럼 DROP이 자동 제거하나 멱등·명시), 그 뒤 컬럼 DROP
+    for idx, _table, _col in _V2_INDEXES:
+        op.execute(f"DROP INDEX IF EXISTS {idx}")
+    for table, col in _V2_SCALAR:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+    for table, col in _V2_ARRAY:
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {col}_v2")
+
+
+def downgrade() -> None:
+    # 가역: nullable 컬럼+인덱스 재추가(백필-only였으므로 데이터 손실 0 — canonical 진실은 legacy 컬럼).
+    for table, col in _V2_SCALAR:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid")
+    for table, col in _V2_ARRAY:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN IF NOT EXISTS {col}_v2 uuid[]")
+    for idx, table, v2col in _V2_INDEXES:
+        op.execute(f"CREATE INDEX IF NOT EXISTS {idx} ON {table} ({v2col})")

--- a/backend/alembic/versions/0091_dead_org_tombstone_telemetry.py
+++ b/backend/alembic/versions/0091_dead_org_tombstone_telemetry.py
@@ -1,0 +1,70 @@
+"""E-MEMBER-SSOT AC3-5 ⑥④: orphan telemetry + dead-org tombstone(soft·가역).
+
+⑥ orphan telemetry(선행): orphan-org(org_id가 organizations에 부재) members/org_members + orphan
+project_access grant(org_member 부재) + dead revoked api_key 카운트를 RAISE NOTICE로 관측(purge 전).
+
+④ dead-org tombstone(soft-delete·가역, 하드삭제 0): orphan-org members/org_members를 deleted_at=now()로
+tombstone. org 부재라 도달 경로 0(인가 불가)인 dead 신원. **하드 DELETE 안 함** → 복구 경로 = deleted_at
+NULL(downgrade가 수행). a52b4ccd(orphan-org dead agent) 포함.
+
+⚠️ project_access orphan grant은 deleted_at 컬럼이 없어 soft-delete 불가 → 본 마이그는 **telemetry만**
+(하드 purge는 tombstone soak 후 별도 결정 — 가역 우선·purge 범위 최소화). org 부재라 inert(접근 경로 0).
+
+③ team_member_id deprecated는 코드(스키마/모델 주석) 표식 — 컬럼 dual 유지(DDL 변경 없음).
+
+Revision ID: 0091
+Revises: 0090
+Create Date: 2026-06-04
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0091"
+down_revision = "0090"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        DECLARE m int; om int; pa int; ak int;
+        BEGIN
+            -- ⑥ telemetry(선행): orphan 클래스 카운트(purge 전 관측)
+            SELECT count(*) INTO m FROM members
+             WHERE org_id NOT IN (SELECT id FROM organizations) AND deleted_at IS NULL;
+            SELECT count(*) INTO om FROM org_members
+             WHERE org_id NOT IN (SELECT id FROM organizations) AND deleted_at IS NULL;
+            -- orphan grant = org_member 행 부재 OR org_member가 orphan-org(진짜 dead-org grant 클래스)
+            SELECT count(*) INTO pa FROM project_access p
+             WHERE p.org_member_id IS NOT NULL
+               AND (p.org_member_id NOT IN (SELECT id FROM org_members)
+                    OR p.org_member_id IN (SELECT id FROM org_members
+                                            WHERE org_id NOT IN (SELECT id FROM organizations)));
+            SELECT count(*) INTO ak FROM agent_api_keys
+             WHERE member_id IS NULL AND revoked_at IS NOT NULL;
+            RAISE NOTICE 'AC3-5 telemetry: orphan-org members=% org_members=% / orphan project_access(org_member 부재)=% / dead revoked api_keys=%', m, om, pa, ak;
+
+            -- ④ dead-org tombstone(soft·가역, 하드삭제 0): orphan-org members/org_members
+            -- ⚠️ 방어 가드: organizations 빈 테이블이면 `NOT IN (빈집합)=TRUE`로 전원 tombstone되는
+            --    파국 회피(현실 불가능하나 마이그 안전). organizations 비어있으면 스킵.
+            IF EXISTS (SELECT 1 FROM organizations) THEN
+                UPDATE members SET deleted_at = now()
+                 WHERE org_id NOT IN (SELECT id FROM organizations) AND deleted_at IS NULL;
+                UPDATE org_members SET deleted_at = now()
+                 WHERE org_id NOT IN (SELECT id FROM organizations) AND deleted_at IS NULL;
+            ELSE
+                RAISE NOTICE 'AC3-5 tombstone 스킵: organizations 비어있음(파국 방지 가드)';
+            END IF;
+            RAISE NOTICE 'AC3-5 tombstone: orphan-org members/org_members deleted_at 설정(하드삭제 0·복구=deleted_at NULL). project_access orphan grant=% 건은 telemetry만(하드 purge 보류)', pa;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # 가역: 본 마이그 tombstone 복구(deleted_at NULL). orphan-org 조건 동일 — 적용분만 되돌림.
+    op.execute("UPDATE members SET deleted_at = NULL WHERE org_id NOT IN (SELECT id FROM organizations)")
+    op.execute("UPDATE org_members SET deleted_at = NULL WHERE org_id NOT IN (SELECT id FROM organizations)")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -48,6 +48,11 @@ class Settings(BaseSettings):
     # 라이브 cutover는 AC3-1 — 여기선 shadow(parity 검증용), 기본 off라 실 read 경로 무변경.
     member_ssot_resolver_shadow: bool = False
 
+    # E-MEMBER-SSOT AC3-1: API key 인증을 canonical members.id로 cut하는 플래그.
+    # off(기본)=team_members 경로(레거시), on=members 경로. ⚠️ 전 에이전트 통신 생명선이라
+    # 머지 후에도 off 기본 — 실 에이전트 무중단 실증 후 단계적 on.
+    member_ssot_apikey_cut: bool = False
+
     # Polar Billing SDK
     polar_access_token: str = ""
     polar_sandbox: bool = True  # dev=True(sandbox), prod=False

--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -43,27 +43,53 @@ async def _resolve_api_key(raw_key: str, db: AsyncSession) -> AuthContext:
     if not api_key:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
-    member_result = await db.execute(
-        select(TeamMember)
-        .where(TeamMember.id == api_key.team_member_id)
-        .where(TeamMember.is_active.is_(True))
-    )
-    member = member_result.scalar_one_or_none()
-    if not member:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
-
     # fire-and-forget last_used_at 업데이트
     api_key.last_used_at = now
-
     scope: list[str] = api_key.scope or ["read", "write"]
-    org_id = str(member.org_id)
-    project_id = str(member.project_id)
+
+    # AC3-1: 신원 해소를 플래그로 cut. ⚠️ 생명선 — 0075 1:1(member.id=team_member.id)로
+    # user_id 동일 = 무중단. 기본 off(레거시), 실 에이전트 무중단 실증 후 단계 on.
+    from app.core.config import settings as _settings
+    if _settings.member_ssot_apikey_cut:
+        # anchor cut: members.id 기반. project_id는 agent_project_profiles 경유(ORDER BY 결정성).
+        from app.models.member import AgentProjectProfile, Member
+        m = (await db.execute(
+            select(Member).where(
+                Member.id == api_key.member_id,
+                Member.type == "agent",
+                Member.is_active.is_(True),
+                Member.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if not m:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
+        proj = (await db.execute(
+            select(AgentProjectProfile.project_id)
+            .where(AgentProjectProfile.member_id == m.id)
+            .order_by(AgentProjectProfile.created_at.asc())
+            .limit(1)
+        )).scalar_one_or_none()
+        member_id = m.id
+        org_id = str(m.org_id)
+        project_id = str(proj) if proj else None
+    else:
+        # 레거시: team_members 경로
+        member = (await db.execute(
+            select(TeamMember)
+            .where(TeamMember.id == api_key.team_member_id)
+            .where(TeamMember.is_active.is_(True))
+        )).scalar_one_or_none()
+        if not member:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="API key member not found")
+        member_id = member.id
+        org_id = str(member.org_id)
+        project_id = str(member.project_id)
 
     return AuthContext(
-        user_id=str(member.id),
+        user_id=str(member_id),
         email=None,
         claims={
-            "sub": str(member.id),
+            "sub": str(member_id),
             "app_metadata": {
                 "org_id": org_id,
                 "project_id": project_id,

--- a/backend/app/models/agent_run.py
+++ b/backend/app/models/agent_run.py
@@ -19,7 +19,7 @@ class AgentRun(Base):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
     )
     agent_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     deployment_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True, index=True

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -15,6 +15,9 @@ class ApiKey(Base):
     team_member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-1: canonical members.id 미러 (team_member_id와 1:1 dual-write, 0075 ID 보존).
+    # FK는 신규 agent 생성 깨짐(QA H1) 방지로 현재 무FK — AC3-1b(anchor write-sync) 후 재추가. nullable.
+    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
     key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
     key_hash: Mapped[str] = mapped_column(Text, nullable=False)
     scope: Mapped[list | None] = mapped_column(ARRAY(Text), nullable=True)

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -16,8 +16,11 @@ class ApiKey(Base):
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-1: canonical members.id 미러 (team_member_id와 1:1 dual-write, 0075 ID 보존).
-    # FK는 신규 agent 생성 깨짐(QA H1) 방지로 현재 무FK — AC3-1b(anchor write-sync) 후 재추가. nullable.
-    member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True, index=True)
+    # AC3-1b(0080): anchor write-sync로 신규 agent members 선행 보장 → FK 재추가(QA H1 해소).
+    # ondelete SET NULL(미러 — 실삭제는 team_member_id CASCADE가 처리). nullable.
+    member_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("members.id", ondelete="SET NULL"), nullable=True, index=True
+    )
     key_prefix: Mapped[str] = mapped_column(Text, nullable=False)
     key_hash: Mapped[str] = mapped_column(Text, nullable=False)
     scope: Mapped[list | None] = mapped_column(ARRAY(Text), nullable=True)

--- a/backend/app/models/api_key.py
+++ b/backend/app/models/api_key.py
@@ -12,6 +12,9 @@ class ApiKey(Base):
     __tablename__ = "agent_api_keys"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    # E-MEMBER-SSOT AC3-5 ③: team_member_id DEPRECATED — canonical 식별자는 member_id(members.id 미러).
+    # dual 유지(레거시 호환). ⚠️ FK는 0088 rename로 team_members_legacy를 가리킴(team_members는 뷰);
+    # 모델 선언("team_members.id")은 stale-drift(런타임 무관, DB 제약이 권위).
     team_member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
     )

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -23,10 +23,10 @@ class Doc(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("docs.id", ondelete="SET NULL"), nullable=True, index=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     slug: Mapped[str] = mapped_column(Text, nullable=False)
@@ -65,7 +65,7 @@ class DocComment(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -84,7 +84,7 @@ class DocRevision(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False, default="")
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/file_lock.py
+++ b/backend/app/models/file_lock.py
@@ -19,7 +19,7 @@ class FileLock(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     story_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/models/hitl_config.py
+++ b/backend/app/models/hitl_config.py
@@ -70,7 +70,7 @@ class MemberGateOverride(Base):
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     gate_type: Mapped[str] = mapped_column(String(50), nullable=False)
     disposition: Mapped[str] = mapped_column(String(20), nullable=False)

--- a/backend/app/models/invitation.py
+++ b/backend/app/models/invitation.py
@@ -18,7 +18,7 @@ class Invitation(Base):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
     )
     invited_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     email: Mapped[str] = mapped_column(Text, nullable=False)
     role: Mapped[str] = mapped_column(Text, nullable=False, default="member")

--- a/backend/app/models/meeting.py
+++ b/backend/app/models/meeting.py
@@ -17,7 +17,7 @@ class Meeting(Base, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     meeting_type: Mapped[str] = mapped_column(Text, nullable=False, default="general")

--- a/backend/app/models/participation.py
+++ b/backend/app/models/participation.py
@@ -30,7 +30,7 @@ class Participation(Base, OrgScopedMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/models/participation.py
+++ b/backend/app/models/participation.py
@@ -30,8 +30,9 @@ class Participation(Base, OrgScopedMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     role_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("participation_role.id", ondelete="CASCADE"), nullable=False

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -148,7 +148,7 @@ class StoryComment(Base, OrgScopedMixin):
     )
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -169,7 +169,7 @@ class StoryActivity(Base, OrgScopedMixin):
     old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -49,8 +49,10 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="active")
@@ -85,8 +87,10 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     sprint_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     meeting_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("meetings.id", ondelete="SET NULL"), nullable=True
@@ -120,8 +124,10 @@ class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     story_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
+    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(String(20), nullable=False, default="todo")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -50,7 +50,8 @@ class Epic(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
@@ -88,7 +89,8 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )
@@ -125,7 +127,8 @@ class Task(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
         UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False, index=True
     )
     # E-MEMBER-SSOT AC3-2: team_members FK 완화 — grant-only 휴먼(org_member.id) 할당 500 해소
-    # (migration 0078). canonical 식별자는 assignee_id_v2. 컬럼·nullable 유지.
+    # (0078). canonical은 legacy 컬럼이 canonicalize_member_id로 보유((A) resolver-cutover);
+    # 백필-only vestigial assignee_id_v2는 0090서 DROP. 컬럼·nullable 유지.
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )

--- a/backend/app/models/policy_document.py
+++ b/backend/app/models/policy_document.py
@@ -27,7 +27,7 @@ class PolicyDocument(Base, OrgScopedMixin):
     legacy_sprint_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     legacy_epic_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/retro.py
+++ b/backend/app/models/retro.py
@@ -23,7 +23,7 @@ class RetroSession(Base, OrgScopedMixin, TimestampMixin):
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
     )
     created_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     phase: Mapped[str] = mapped_column(Text, nullable=False, default="collect")
@@ -40,7 +40,7 @@ class RetroItem(Base):
         UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
     )
     author_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     category: Mapped[str] = mapped_column(Text, nullable=False)
     text: Mapped[str] = mapped_column(Text, nullable=False)
@@ -61,7 +61,7 @@ class RetroVote(Base):
         UUID(as_uuid=True), ForeignKey("retro_items.id", ondelete="CASCADE"), nullable=False, index=True
     )
     voter_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False
+        UUID(as_uuid=True), nullable=False
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -78,7 +78,7 @@ class RetroAction(Base):
         UUID(as_uuid=True), ForeignKey("retro_sessions.id", ondelete="CASCADE"), nullable=False, index=True
     )
     assignee_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     title: Mapped[str] = mapped_column(Text, nullable=False)
     status: Mapped[str] = mapped_column(Text, nullable=False, default="open")

--- a/backend/app/models/reward.py
+++ b/backend/app/models/reward.py
@@ -16,11 +16,12 @@ class RewardLedger(Base, OrgScopedMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical=*_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     granted_by: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
+        UUID(as_uuid=True), nullable=True
     )
     amount: Mapped[float] = mapped_column(Numeric(12, 2), nullable=False)
     currency: Mapped[str] = mapped_column(Text, nullable=False, default="TJSB")

--- a/backend/app/models/reward.py
+++ b/backend/app/models/reward.py
@@ -16,7 +16,7 @@ class RewardLedger(Base, OrgScopedMixin):
     project_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical=*_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only 리워드 수령/지급 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2/granted_by_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/models/webhook_config.py
+++ b/backend/app/models/webhook_config.py
@@ -15,8 +15,9 @@ class WebhookConfig(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
     member_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="CASCADE"), nullable=False, index=True
+        UUID(as_uuid=True), nullable=False, index=True
     )
     project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True

--- a/backend/app/models/webhook_config.py
+++ b/backend/app/models/webhook_config.py
@@ -15,7 +15,7 @@ class WebhookConfig(Base):
     org_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
     )
-    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical=member_id_v2.
+    # E-MEMBER-SSOT AC3-2: team_members FK 완화(grant-only write 500 해소, 0079). canonical은 canonicalize_member_id(legacy 컬럼) 보유((A)); vestigial member_id_v2는 0090 DROP.
     member_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), nullable=False, index=True
     )

--- a/backend/app/repositories/api_key.py
+++ b/backend/app/repositories/api_key.py
@@ -48,6 +48,7 @@ class ApiKeyRepository:
             expires_at = datetime.now(timezone.utc) + timedelta(days=90)
         key = ApiKey(
             team_member_id=team_member_id,
+            member_id=team_member_id,  # AC3-1 dual-write: agent member.id = team_member.id (1:1)
             key_prefix=prefix,
             key_hash=key_hash,
             scope=scope,

--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -2,12 +2,43 @@ import uuid
 from datetime import date
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.standup import StandupEntry, StandupFeedback
-from app.models.team import TeamMember
 from app.repositories.base import BaseRepository
+
+# AC3-3: missing 산정 — "effective 휴먼 project access"를 canonical members.id로 열거(team_members
+# 열거 대체). has_project_access 3-branch(owner/admin org-wide ∪ project_access grant ∪ 레거시 휴먼
+# team_member→alias)와 정합. submitted는 alias 정규화로 마이그 전/후 모두 canonical 대조.
+_MISSING_SQL = text(
+    """
+    WITH roster AS (
+        -- 1) owner/admin org-wide 휴먼 (canonical = org_member.id)
+        SELECT om.id AS cid
+        FROM org_members om
+        WHERE om.org_id = :org AND om.deleted_at IS NULL AND om.role IN ('owner','admin')
+        UNION
+        -- 2) project_access grant (휴먼: member_id = org_member.id)
+        SELECT pa.member_id AS cid
+        FROM project_access pa
+        JOIN org_members om2 ON om2.id = pa.member_id AND om2.deleted_at IS NULL
+        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.member_id IS NOT NULL
+        UNION
+        -- 3) 레거시 휴먼 team_member → canonical(alias)
+        SELECT a.member_id AS cid
+        FROM team_members tm
+        JOIN member_identity_aliases a ON a.alias_id = tm.id
+        WHERE tm.project_id = :proj AND tm.type = 'human' AND tm.is_active = true
+    ), submitted AS (
+        SELECT DISTINCT COALESCE(a.member_id, se.author_id) AS cid
+        FROM standup_entries se
+        LEFT JOIN member_identity_aliases a ON a.alias_id = se.author_id
+        WHERE se.org_id = :org AND se.project_id = :proj AND se.date = :date
+    )
+    SELECT r.cid FROM roster r WHERE r.cid NOT IN (SELECT cid FROM submitted)
+    """
+)
 
 
 class StandupEntryRepository(BaseRepository[StandupEntry]):
@@ -33,25 +64,16 @@ class StandupEntryRepository(BaseRepository[StandupEntry]):
         return await self.create(**data)
 
     async def get_missing(self, project_id: uuid.UUID, target_date: date) -> list[uuid.UUID]:
-        """해당 날짜에 스탠드업을 제출하지 않은 활성 팀 멤버 ID 목록."""
-        submitted = await self.session.execute(
-            select(StandupEntry.author_id).where(
-                self._org_filter(),
-                StandupEntry.project_id == project_id,
-                StandupEntry.date == target_date,
-            )
-        )
-        submitted_ids = {row[0] for row in submitted.all()}
+        """해당 날짜 standup 미제출 휴먼의 **canonical members.id** 목록 (AC3-3).
 
-        all_members = await self.session.execute(
-            select(TeamMember.id).where(
-                TeamMember.project_id == project_id,
-                TeamMember.is_active.is_(True),
-                TeamMember.type == "human",
-            )
+        effective 휴먼 project access(owner/admin ∪ grant ∪ 레거시 휴먼 team_member) − 제출분.
+        멀티프로젝트 휴먼이 단일 canonical 신원으로 집계돼 N-project 중복이 사라진다(48e653e9).
+        """
+        rows = await self.session.execute(
+            _MISSING_SQL,
+            {"org": self.org_id, "proj": project_id, "date": target_date},
         )
-        all_ids = {row[0] for row in all_members.all()}
-        return list(all_ids - submitted_ids)
+        return [row[0] for row in rows.all()]
 
 
 class StandupFeedbackRepository(BaseRepository[StandupFeedback]):

--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -19,11 +19,14 @@ _MISSING_SQL = text(
         FROM org_members om
         WHERE om.org_id = :org AND om.deleted_at IS NULL AND om.role IN ('owner','admin')
         UNION
-        -- 2) project_access grant (휴먼: member_id = org_member.id)
-        SELECT pa.member_id AS cid
+        -- 2) project_access grant (휴먼: canonical = org_member.id). ⚠️ 실 grant 플로우
+        --    (create_project_access)는 org_member_id만 세팅하고 member_id는 NULL로 둔다(0075 백필분만
+        --    member_id 채워짐) → member_id 키는 신규 grant-only 휴먼을 누락. org_member_id로 집계.
+        --    (에이전트 direct placement는 org_member_id NULL이라 자연 제외 — 휴먼 grant만.)
+        SELECT pa.org_member_id AS cid
         FROM project_access pa
-        JOIN org_members om2 ON om2.id = pa.member_id AND om2.deleted_at IS NULL
-        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.member_id IS NOT NULL
+        JOIN org_members om2 ON om2.id = pa.org_member_id AND om2.deleted_at IS NULL
+        WHERE pa.project_id = :proj AND pa.permission = 'granted' AND pa.org_member_id IS NOT NULL
         UNION
         -- 3) 레거시 휴먼 team_member → canonical(alias)
         SELECT a.member_id AS cid

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,16 +1,35 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import func, select
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.member import AgentProjectProfile, Member
+from app.models.project_access import ProjectAccess
 from app.models.team import TeamMember
 from app.repositories.base import BaseRepository
+
+# AC3-4 2-2: team_members가 projection 뷰로 강등됨 → write를 앵커 테이블로 라우팅(anchor-only).
+# PATCH 필드 → 앵커 매핑(0088 뷰 정의와 정합):
+#   name/avatar_url/is_active → members,  role/color/can_manage_members → project_access(per-project),
+#   agent_config/webhook_url/agent_role → agent_project_profiles.
+_MEMBERS_FIELDS = {"name", "avatar_url", "is_active"}
+_ACCESS_FIELDS = {"role", "color", "can_manage_members"}
+_PROFILE_FIELDS = {"agent_config", "webhook_url", "agent_role"}
 
 
 class TeamMemberRepository(BaseRepository[TeamMember]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(TeamMember, session, org_id)
+
+    async def get(self, id: uuid.UUID) -> TeamMember | None:  # type: ignore[override]
+        # AC3-4 2-2: team_members가 뷰 — 휴먼은 members.id=org_member.id가 project_access 다행이라 동일
+        # id로 여러 행 가능(프로젝트별). scalar_one_or_none RAISE 회피 위해 first()(에이전트는 1:1 단일행).
+        result = await self.session.execute(
+            select(TeamMember).where(self._org_filter(), TeamMember.id == id).limit(1)
+        )
+        return result.scalars().first()
 
     async def list(self, limit: int = 1000, **filters: Any) -> list[TeamMember]:  # type: ignore[override]
         q = select(TeamMember).where(self._org_filter())
@@ -19,15 +38,49 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
 
+    async def apply_anchor_update(self, member: TeamMember, data: dict[str, Any]) -> None:
+        """AC3-4 2-2: PATCH 필드를 앵커 테이블로 라우팅(anchor-only write, 레거시 team_members UPDATE 없음).
+
+        뷰가 읽는 소스에 직접 write: members(신원·is_active) / project_access(per-project role·color·권한) /
+        agent_project_profiles(에이전트 설정). JSONB(agent_config)는 ORM 컬럼 타입으로 안전 직렬화.
+        """
+        m_set = {k: v for k, v in data.items() if k in _MEMBERS_FIELDS}
+        a_set = {k: v for k, v in data.items() if k in _ACCESS_FIELDS}
+        p_set = {k: v for k, v in data.items() if k in _PROFILE_FIELDS}
+        if m_set:
+            await self.session.execute(
+                sa_update(Member)
+                .where(Member.id == member.id)
+                .values(**m_set, updated_at=func.now())
+            )
+        if a_set:
+            await self.session.execute(
+                sa_update(ProjectAccess)
+                .where(
+                    ProjectAccess.member_id == member.id,
+                    ProjectAccess.project_id == member.project_id,
+                )
+                .values(**a_set)
+            )
+        if p_set:
+            await self.session.execute(
+                sa_update(AgentProjectProfile)
+                .where(AgentProjectProfile.member_id == member.id)
+                .values(**p_set, updated_at=func.now())
+            )
+        await self.session.flush()
+
     async def deactivate(self, id: uuid.UUID) -> bool:
-        """DELETE 대신 is_active=False soft deactivate."""
+        """DELETE 대신 is_active=False soft deactivate.
+
+        AC3-4 2-2: team_members 뷰 전환 — anchor-only. members.is_active=false로 반영(에이전트
+        members.id=tm.id 1:1). 휴먼은 members.id=org_member.id라 미매치=0건(무해; 휴먼 비활성은
+        org_members 경로에서 처리). 레거시 team_members UPDATE 제거(뷰는 write 불가).
+        """
         member = await self.get(id)
         if member is None:
             return False
-        await self.update(id, is_active=False)
-        # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(에이전트 members.id=tm.id;
-        # 휴먼은 members.id=org_member.id라 미매치=0건 무해, 휴먼 비활성은 org_members 경로에서 처리).
         await self.session.execute(
-            text("UPDATE members SET is_active = false WHERE id = :id"), {"id": str(id)}
+            sa_update(Member).where(Member.id == id).values(is_active=False, updated_at=func.now())
         )
         return True

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -26,8 +26,14 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
     async def get(self, id: uuid.UUID) -> TeamMember | None:  # type: ignore[override]
         # AC3-4 2-2: team_members가 뷰 — 휴먼은 members.id=org_member.id가 project_access 다행이라 동일
         # id로 여러 행 가능(프로젝트별). scalar_one_or_none RAISE 회피 위해 first()(에이전트는 1:1 단일행).
+        # ⚠️ order_by(project_id)로 **결정적** row 선택(휴먼 multi-project 비결정성 제거 — QA 소크 안정).
+        # 휴먼 project-specific(role/color)은 team-members 단일조회/PATCH 비-플로우(=project_access 그랜트
+        # 경로로 관리); first()는 is_active/name(members 공통) 안전망 + RAISE 회피가 목적.
         result = await self.session.execute(
-            select(TeamMember).where(self._org_filter(), TeamMember.id == id).limit(1)
+            select(TeamMember)
+            .where(self._org_filter(), TeamMember.id == id)
+            .order_by(TeamMember.project_id)
+            .limit(1)
         )
         return result.scalars().first()
 

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.team import TeamMember
@@ -25,4 +25,9 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         if member is None:
             return False
         await self.update(id, is_active=False)
+        # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(에이전트 members.id=tm.id;
+        # 휴먼은 members.id=org_member.id라 미매치=0건 무해, 휴먼 비활성은 org_members 경로에서 처리).
+        await self.session.execute(
+            text("UPDATE members SET is_active = false WHERE id = :id"), {"id": str(id)}
+        )
         return True

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -32,5 +32,13 @@ async def delete_account(
         ),
         {"now": now, "uid": str(uid)},
     )
+    # AC3-4 2-1 dual-write: 뷰가 is_active/deleted_at을 members서 읽으므로 동시 반영(cutover 전 동기).
+    await session.execute(
+        text(
+            "UPDATE members SET deleted_at = :now, is_active = false, updated_at = :now"
+            " WHERE user_id = :uid::uuid"
+        ),
+        {"now": now, "uid": str(uid)},
+    )
 
     return AccountDeleteResponse(ok=True, grace_period_days=30)

--- a/backend/app/routers/account.py
+++ b/backend/app/routers/account.py
@@ -25,14 +25,7 @@ async def delete_account(
         text("UPDATE org_members SET deleted_at = :now WHERE user_id = :uid::uuid"),
         {"now": now, "uid": str(uid)},
     )
-    await session.execute(
-        text(
-            "UPDATE team_members SET deleted_at = :now, is_active = false, updated_at = :now"
-            " WHERE user_id = :uid::uuid"
-        ),
-        {"now": now, "uid": str(uid)},
-    )
-    # AC3-4 2-1 dual-write: 뷰가 is_active/deleted_at을 members서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 전환 — anchor-only. members가 is_active/deleted_at 유일 소스.
     await session.execute(
         text(
             "UPDATE members SET deleted_at = :now, is_active = false, updated_at = :now"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -52,6 +52,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.services.project_auth import has_project_access, first_accessible_project_id
 from app.dependencies.database import get_db
 from app.models.invitation import Invitation
+from app.models.member import Member
 from app.models.org_invite import OrgInvite
 from app.models.project import OrgMember
 from app.models.team import TeamMember
@@ -286,7 +287,9 @@ async def _build_app_metadata(user: User, session: AsyncSession) -> dict:
         member = result.scalar_one_or_none()
 
     if member and member.user_id is None:
-        member.user_id = user.id
+        # AC3-5 ②: team_members가 뷰(0088) — ORM mutation+flush(UPDATE view 실패) 대신 members 앵커 UPDATE.
+        # member.user_id is None은 사실상 미발현(뷰 휴먼 브랜치 user_id 채워짐); 레거시 미링크분만 보정.
+        await session.execute(update(Member).where(Member.id == member.id).values(user_id=user.id))
 
     if not member:
         # 2. 이메일로 pending 초대 조회 → 자동 수락 + org_member 생성

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -11,6 +11,7 @@ from app.dependencies.database import get_db
 from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
 from app.repositories.doc import DocRepository
+from app.services.member_resolver import canonicalize_member_id
 from app.schemas.doc import DocCreate, DocResponse, DocSummaryResponse, DocUpdate
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
@@ -77,6 +78,8 @@ async def create_doc(
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
     )
+    # AC3-2d(2): created_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    created_by = (await canonicalize_member_id(body.created_by, session)) if body.created_by else None
     repo = DocRepository(session, org_id)
     doc = await repo.create(
         project_id=body.project_id,
@@ -84,7 +87,7 @@ async def create_doc(
         slug=body.slug,
         content=body.content,
         parent_id=body.parent_id,
-        created_by=body.created_by,
+        created_by=created_by,
         icon=body.icon,
         sort_order=body.sort_order,
         doc_type=body.doc_type,
@@ -302,6 +305,7 @@ async def add_doc_comment(
     if not doc:
         raise HTTPException(status_code=404, detail="Doc not found")
     created_by = await _resolve_doc_member_id(auth, repo.org_id, db)
+    created_by = await canonicalize_member_id(created_by, db)  # AC3-2d(2): canonical 정규화
     comment = DocComment(
         doc_id=id,
         org_id=repo.org_id,

--- a/backend/app/routers/file_locks.py
+++ b/backend/app/routers/file_locks.py
@@ -102,10 +102,11 @@ async def lock_files(
     _auth=Depends(get_current_user),
 ) -> dict:
     """AC1/3: 파일 lock 등록 + 충돌 시 warning 반환."""
+    # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
     member_result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id)
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
     )
-    member = member_result.scalar_one_or_none()
+    member = member_result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
 

--- a/backend/app/routers/invitations.py
+++ b/backend/app/routers/invitations.py
@@ -59,10 +59,13 @@ async def create_invitation(
     _: None = Depends(require_admin),
     session: AsyncSession = Depends(get_db),
 ) -> InvitationResponse:
+    # AC3-2d(1b): invited_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    from app.services.member_resolver import canonicalize_member_id
+    invited_by = (await canonicalize_member_id(body.invited_by, session)) if body.invited_by else body.invited_by
     inv = await repo.create(
         email=body.email,
         role=body.role,
-        invited_by=body.invited_by,
+        invited_by=invited_by,
         project_id=body.project_id,
     )
     await session.commit()

--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -1,12 +1,14 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import or_, select, text
+from sqlalchemy import func, or_, select, text
+from sqlalchemy import update as sa_update
 from sqlalchemy.orm import joinedload
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.member import Member
 from app.models.project import OrgMember
 from app.models.team import TeamMember
 from app.models.user import User
@@ -182,13 +184,19 @@ async def update_me(
     session: AsyncSession = Depends(get_db),
     _auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id)
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
     )
-    member = result.scalar_one_or_none()
+    member = result.scalars().first()
     if member is None:
         raise HTTPException(status_code=404, detail="Member not found")
-    member.name = body.name
-    await session.flush()
-    await session.refresh(member)
-    return MeResponse.model_validate(member)
+    # AC3-5 ②: 뷰는 write 불가 — ORM mutation+flush 대신 name을 members 앵커에 UPDATE. expire 후 뷰 재조회.
+    await session.execute(
+        sa_update(Member).where(Member.id == member_id).values(name=body.name, updated_at=func.now())
+    )
+    session.expire(member)
+    refreshed = (await session.execute(
+        select(TeamMember).where(TeamMember.id == member_id).limit(1)
+    )).scalars().first()
+    return MeResponse.model_validate(refreshed or member)

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -53,6 +53,10 @@ async def create_meeting(
     )
     repo = MeetingRepository(session, body.project_id)
     data = body.model_dump(exclude={"project_id"}, exclude_none=False)
+    # AC3-2d(1b): created_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+    if data.get("created_by"):
+        from app.services.member_resolver import canonicalize_member_id
+        data["created_by"] = await canonicalize_member_id(data["created_by"], session)
     meeting = await repo.create(**{k: v for k, v in data.items() if v is not None or k in ("participants", "decisions", "action_items")})
     return MeetingResponse.model_validate(meeting)
 

--- a/backend/app/routers/notification_preferences.py
+++ b/backend/app/routers/notification_preferences.py
@@ -55,17 +55,9 @@ async def _get_member(
             raise HTTPException(status_code=400, detail="Team member not found")
         return member
 
-    # JWT 휴먼: team_member 우선 (기존 NotificationPreference.member_id 키 보존)
-    member = (await db.execute(
-        select(TeamMember).where(
-            TeamMember.user_id == uuid.UUID(auth.user_id),
-            TeamMember.org_id == org_id,
-        )
-    )).scalars().first()
-    if member is not None:
-        return member
-
-    # team_member 없음(grant-only 휴먼) → org_member 신원으로 fallback
+    # AC3-2d(2): JWT 휴먼 → canonical members.id(=org_member.id). 0086이 notification_preferences.member_id를
+    # canonical로 정규화하므로 read/write도 canonical이어야 split-brain(기존 휴먼 prefs 유실) 0.
+    # (이전엔 team_member 우선=tm.id 반환이었으나 (A) 통일로 canonical 단일화 — grant-only도 동일 경로.)
     return await resolve_member(auth, org_id, db)
 
 

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -172,18 +172,7 @@ async def delete_org_member(
     if existing.role == "owner":
         raise HTTPException(status_code=403, detail="조직 owner는 삭제할 수 없습니다")
     await _revoke_user_refresh_tokens(repo.session, existing.user_id)
-    # cascade — team_members is_active = False
-    await session.execute(
-        text(
-            """
-            UPDATE team_members
-            SET is_active = false
-            WHERE org_id = :org_id AND user_id = :user_id AND is_active = true
-            """
-        ),
-        {"org_id": str(org_id), "user_id": str(existing.user_id)},
-    )
-    # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 전환 — anchor-only. members가 is_active 유일 소스(레거시 cascade 제거).
     await session.execute(
         text(
             "UPDATE members SET is_active = false"

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -183,6 +183,14 @@ async def delete_org_member(
         ),
         {"org_id": str(org_id), "user_id": str(existing.user_id)},
     )
+    # AC3-4 2-1 dual-write: 뷰가 is_active를 members서 읽으므로 동시 반영(cutover 전 동기).
+    await session.execute(
+        text(
+            "UPDATE members SET is_active = false"
+            " WHERE org_id = :org_id AND user_id = :user_id AND is_active = true"
+        ),
+        {"org_id": str(org_id), "user_id": str(existing.user_id)},
+    )
     # S-MBR-10 AC5: project_access grant 레코드 삭제 (soft delete는 FK CASCADE 미트리거)
     await session.execute(
         text("DELETE FROM project_access WHERE org_member_id = :om_id"),

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -86,10 +86,16 @@ async def create_project_access(
     )
     if existing.scalar_one_or_none() is not None:
         raise HTTPException(status_code=409, detail="Access record already exists")
+    # AC3-2c grant write-sync: canonical member_id(=org_member.id) 세팅 — AC3-4 projection의 member_id
+    # 읽기 토대 + (A) resolver-cutover 통일. 휴먼 members 행을 선행 보장(fk_project_access_member NOT VALID이나
+    # 신규 INSERT 검증). members 보장 실패(org_member 부재) 시 member_id 미세팅(레거시 호환).
+    from app.services.agent_anchor_sync import ensure_human_member
+    member_ok = await ensure_human_member(session, body.org_member_id)
     record = ProjectAccess(
         project_id=project_id,
         org_member_id=body.org_member_id,
         permission=body.permission,
+        member_id=body.org_member_id if member_ok else None,
     )
     session.add(record)
     await session.commit()

--- a/backend/app/routers/retros.py
+++ b/backend/app/routers/retros.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.services.member_resolver import canonicalize_member_id
 from app.repositories.retro import (
     RetroActionRepository,
     RetroItemRepository,
@@ -61,7 +62,8 @@ async def create_session(
         project_id=body.project_id,
         title=body.title,
         sprint_id=body.sprint_id,
-        created_by=body.created_by,
+        # AC3-2d(1b): 작성자 식별자 canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
+        created_by=(await canonicalize_member_id(body.created_by, db)) if body.created_by else None,
     )
     return SessionListResponse.model_validate(session)
 
@@ -120,8 +122,9 @@ async def add_item(
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
     item_repo = RetroItemRepository(db)
+    author_id = (await canonicalize_member_id(body.author_id, db)) if body.author_id else None
     item = await item_repo.create(
-        session_id=id, category=body.category, text=body.text, author_id=body.author_id
+        session_id=id, category=body.category, text=body.text, author_id=author_id
     )
     return ItemResponse.model_validate(item)
 
@@ -154,6 +157,7 @@ async def vote_item(
     session = await repo.get(id)
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
+    voter_id = await canonicalize_member_id(voter_id, db)  # AC3-2d(1b): canonical 정규화
     vote_repo = RetroVoteRepository(db)
     try:
         vote = await vote_repo.vote(item_id, voter_id)
@@ -189,8 +193,9 @@ async def create_action(
     if session is None:
         raise HTTPException(status_code=404, detail="Retro session not found")
     action_repo = RetroActionRepository(db)
+    assignee_id = (await canonicalize_member_id(body.assignee_id, db)) if body.assignee_id else None
     action = await action_repo.create(
-        session_id=id, title=body.title, assignee_id=body.assignee_id
+        session_id=id, title=body.title, assignee_id=assignee_id
     )
     return ActionResponse.model_validate(action)
 

--- a/backend/app/routers/rewards.py
+++ b/backend/app/routers/rewards.py
@@ -43,12 +43,16 @@ async def grant_reward(
     body: GrantReward,
     repo: RewardRepository = Depends(_get_repo),
 ) -> RewardLedgerResponse:
+    # AC3-2d(2): member_id(수령자)·granted_by(지급자) canonical 정규화. (A) write. agent id는 no-op.
+    from app.services.member_resolver import canonicalize_member_id
+    member_id = await canonicalize_member_id(body.member_id, repo.session)
+    granted_by = (await canonicalize_member_id(body.granted_by, repo.session)) if body.granted_by else None
     entry = await repo.grant(
         project_id=body.project_id,
-        member_id=body.member_id,
+        member_id=member_id,
         amount=body.amount,
         reason=body.reason,
-        granted_by=body.granted_by,
+        granted_by=granted_by,
         reference_type=body.reference_type,
         reference_id=body.reference_id,
     )

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -8,7 +8,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
 from app.models.pm import Story
-from app.models.standup import StandupEntry
 from app.models.team import TeamMember
 from app.repositories.sprint import SprintRepository
 from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate
@@ -224,30 +223,29 @@ async def checkin_sprint(
     )
     stories = stories_result.all()
 
-    members_result = await db.execute(
-        select(TeamMember.id, TeamMember.name).where(
-            TeamMember.project_id == sprint.project_id,
-            TeamMember.is_active.is_(True),
-        )
-    )
-    members = members_result.all()
+    # AC3-3(T3, #1167 회귀 방지): standup 미제출자를 canonical members.id로 집계 — team_members vs raw
+    # author_id 직접 비교는 canonical 저장분을 못 보고 레거시 휴먼을 "제출했는데 missing"으로 오판한다.
+    # repository.get_missing(effective 휴먼 access ∪ alias 정규화)와 동일 SSOT. 이름은 members(canonical).
+    from app.models.member import Member
+    from app.repositories.standup import StandupEntryRepository
 
-    standup_result = await db.execute(
-        select(StandupEntry.author_id).where(
-            StandupEntry.project_id == sprint.project_id,
-            StandupEntry.date == checkin_date,
-        )
+    missing_ids = await StandupEntryRepository(db, repo.org_id).get_missing(
+        sprint.project_id, checkin_date
     )
-    standup_author_ids = {row.author_id for row in standup_result}
+    name_map: dict[uuid.UUID, str] = {}
+    if missing_ids:
+        name_rows = await db.execute(
+            select(Member.id, Member.name).where(Member.id.in_(missing_ids))
+        )
+        name_map = {mid: nm for mid, nm in name_rows.all()}
 
     total_stories = len(stories)
     total_points = sum(s.story_points or 0 for s in stories)
     done_points = sum(s.story_points or 0 for s in stories if s.status == "done")
     completion_pct = round((done_points / total_points) * 100) if total_points > 0 else 0
     missing_standups = [
-        {"id": str(m.id), "name": m.name}
-        for m in members
-        if m.id not in standup_author_ids
+        {"id": str(mid), "name": name_map.get(mid, str(mid))}
+        for mid in missing_ids
     ]
 
     return {

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -16,7 +16,7 @@ from app.schemas.standup import (
     StandupSelfUpdate,
     StandupUpsert,
 )
-from app.services.member_resolver import resolve_auth_member
+from app.services.member_resolver import canonicalize_member_id, resolve_member
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
 
@@ -40,7 +40,9 @@ async def list_standups(
     if project_id:
         filters["project_id"] = project_id
     if author_id:
-        filters["author_id"] = author_id
+        # AC3-3(T3, #1167 회귀 방지): 조회 필터도 canonical 정규화 — 카드가 레거시 team_member.id로
+        # 조회해도 canonical 저장분과 매칭(raw 필터면 saved-but-not-displayed 재발).
+        filters["author_id"] = await canonicalize_member_id(author_id, repo.session)
     if sprint_id:
         filters["sprint_id"] = sprint_id
     if date_filter:
@@ -56,10 +58,13 @@ async def upsert_standup(
     _auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
+    # AC3-3: 작성자 신원을 canonical members.id로 정규화(레거시 휴먼 team_member.id → alias 치환).
+    # write↔read(카드/missing) 동일 canonical 정합 — #1167 회귀(API 200≠카드표시) 방지.
+    author_id = await canonicalize_member_id(body.author_id, session)
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
-        author_id=body.author_id,
+        author_id=author_id,
         date=body.date,
         sprint_id=body.sprint_id,
         done=body.done,
@@ -77,17 +82,17 @@ async def update_standup(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
-    """PUT /api/v2/standups — 본인 스탠드업 self-save (SID:6a1e8b1d).
+    """PUT /api/v2/standups — 본인 스탠드업 self-save (SID:6a1e8b1d → AC3-3 canonical 이행).
 
-    author_id는 인증 유저(resolve_auth_member)에서 server-side 도출 — 클라 바디 author_id를
+    author_id는 인증 유저(resolve_member)에서 server-side 도출 — 클라 바디 author_id를
     받지 않아 타인 스탠드업 위조를 차단(본인만 수정). project_id는 바디 수용.
 
-    author_id는 team_member 우선(있으면 team_member.id) → 없으면 org_member.id(grant-only).
-    스탠드업 카드(`/api/team-members` 기반)가 team_member.id로 매칭하므로, team_member가 있는
-    휴먼은 team_member.id로 저장해야 저장분이 카드에 표시된다(org_member.id-always는 카드와
-    어긋나 "미작성"으로 보이던 라이브 2차 버그 해소). grant-only는 org_member.id(카드 표시는 AC3-3).
+    AC3-3: author_id = **canonical members.id**(휴먼=org_member.id, 에이전트=team_member.id).
+    #1167은 카드(`/api/team-members`, team_member.id 매칭)와 정렬하려 team_member.id로 저장하던
+    transitional 정렬이었으나, AC3-3에서 write(author/feedback)·카드 display·missing-calc를 **모두
+    canonical로 함께** 옮겨 멀티프로젝트 휴먼 단일 신원(48e653e9 해소) + saved-but-not-displayed 회귀 0.
     """
-    member = await resolve_auth_member(auth, org_id, session, project_id=body.project_id)
+    member = await resolve_member(auth, org_id, session, project_id=body.project_id)
     repo = StandupEntryRepository(session, org_id)
     entry = await repo.upsert(
         project_id=body.project_id,
@@ -170,12 +175,14 @@ async def add_feedback(
     if entry is None:
         raise HTTPException(status_code=404, detail="Standup entry not found")
 
+    # AC3-3 (트랩#9 co-write): feedback 작성자도 author_id와 동일 canonical members.id로 정규화.
+    feedback_by_id = await canonicalize_member_id(body.feedback_by_id, session)
     fb_repo = StandupFeedbackRepository(session, org_id)
     feedback = await fb_repo.create(
         project_id=body.project_id,
         sprint_id=body.sprint_id,
         standup_entry_id=id,
-        feedback_by_id=body.feedback_by_id,
+        feedback_by_id=feedback_by_id,
         review_type=body.review_type,
         feedback_text=body.feedback_text,
     )

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -13,6 +13,7 @@ from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.routers.events import publish_event
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
+from app.services.member_resolver import canonicalize_member_id
 from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
@@ -261,7 +262,7 @@ async def update_story(
                     activity_type="assignee_changed",
                     old_value=str(old_assignee_id) if old_assignee_id else None,
                     new_value=str(story.assignee_id) if story.assignee_id else None,
-                    created_by=actor_id,
+                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
                 ))
                 await db.flush()
             except Exception:
@@ -433,7 +434,7 @@ async def update_story_status(
                     activity_type="status_changed",
                     old_value=old_status,
                     new_value=story.status,
-                    created_by=actor_id,
+                    created_by=(await canonicalize_member_id(actor_id, db)),  # AC3-2d(1b) canonical
                 ))
                 await db.flush()
             except Exception:
@@ -539,6 +540,7 @@ async def add_comment(
     if not story:
         raise HTTPException(status_code=404, detail="Story not found")
     created_by = await _resolve_team_member_id(auth, repo.org_id, db)
+    created_by = await canonicalize_member_id(created_by, db)  # AC3-2d(1b): canonical 정규화
     comment = StoryComment(
         story_id=id,
         org_id=repo.org_id,

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -177,6 +177,12 @@ async def create_team_member(
         fakechat_port=fakechat_port,
     )
 
+    # E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync(members + agent_project_profiles).
+    # ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.member_id→members FK(0080) 충족 + cut-on 무중단.
+    if body.type == "agent":
+        from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+        await sync_agent_anchor_on_create(session, member, created_by)
+
     from app.services.notification_preference_defaults import insert_default_preferences
     await insert_default_preferences(session, member.id, body.type)
 

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -142,7 +142,6 @@ async def create_team_member(
             detail="Human member creation via team-members is deprecated. Use org invites (/api/v2/organizations/{id}/invites) instead.",
         )
 
-    repo = TeamMemberRepository(session, org_id)
     created_by = uuid.UUID(auth.user_id) if body.type == "agent" else None
 
     # AC1/AC2: agent 생성 시 fakechat_port 자동 할당 (project 내 중복 방지)
@@ -162,8 +161,13 @@ async def create_team_member(
             port += 1
         fakechat_port = port
 
-    member = await repo.create(
+    # AC3-4 2-2: team_members가 projection 뷰로 강등됨 → INSERT 불가. transient TeamMember(미persist)로
+    # 신원/응답을 표현하고, 실제 영속은 앵커(members + agent_project_profiles + project_access)로만 한다.
+    now = datetime.now(timezone.utc)
+    member = TeamMember(
+        id=uuid.uuid4(),
         project_id=body.project_id,
+        org_id=org_id,
         type=body.type,
         name=body.name,
         role=body.role,
@@ -175,10 +179,18 @@ async def create_team_member(
         agent_role=body.agent_role,
         created_by=created_by,
         fakechat_port=fakechat_port,
-    )
+        is_active=True,
+        can_manage_members=False,
+        last_seen_at=None,
+        active_story_id=None,
+        agent_status=None,
+        created_at=now,
+        updated_at=now,
+    )  # NOT session.add — 앵커 write-sync가 유일 영속 경로(아래)
 
-    # E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync(members + agent_project_profiles).
-    # ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.member_id→members FK(0080) 충족 + cut-on 무중단.
+    # E-MEMBER-SSOT AC3-1b/AC3-4 2-2: 신규 agent 앵커 write-sync(members + agent_project_profiles +
+    # project_access placement) = 유일 영속 경로. ⚠️ api_key 자동생성(아래)보다 선행 — agent_api_keys.
+    # member_id→members FK(0080) 충족 + cut-on 무중단.
     if body.type == "agent":
         from app.services.agent_anchor_sync import sync_agent_anchor_on_create
         await sync_agent_anchor_on_create(session, member, created_by)
@@ -282,8 +294,11 @@ async def update_team_member(
     if member.type == "agent":
         await assert_agent_owner(id, session, org_id, uuid.UUID(auth.user_id))
     data = body.model_dump(exclude_unset=True)
-    updated = await repo.update(id, **data)
-    return TeamMemberResponse.model_validate(updated)
+    # AC3-4 2-2: team_members 뷰 — 필드를 앵커 테이블로 라우팅(anchor-only). expire 후 뷰 재조회로 갱신값 반영.
+    await repo.apply_anchor_update(member, data)
+    session.expire(member)
+    updated = await repo.get(id)
+    return TeamMemberResponse.model_validate(updated or member)
 
 
 @router.patch("/{id}/heartbeat")
@@ -298,8 +313,7 @@ async def heartbeat(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     now = datetime.now(timezone.utc)
-    await repo.update(id, last_seen_at=now, agent_status="online")
-    # AC3-4 2-1 dual-write: 뷰가 presence를 agent_project_profiles서 읽으므로 동시 반영(cutover 전 동기).
+    # AC3-4 2-2: team_members 뷰 — presence는 agent_project_profiles가 유일 소스(anchor-only).
     from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, last_seen_at=now, agent_status="online")
     return {"ok": True, "last_seen_at": now.isoformat()}
@@ -327,8 +341,8 @@ async def claim_story(
         raise HTTPException(status_code=400, detail="Story not found in this project")
 
     now = datetime.now(timezone.utc)
-    await repo.update(id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
-    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
     return {"claimed": True, "story_id": str(body.story_id)}
 
@@ -344,8 +358,8 @@ async def unclaim_story(
     member = await repo.get(id)
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
-    await repo.update(id, active_story_id=None)
-    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    # AC3-4 2-2: anchor-only — agent_project_profiles가 presence 유일 소스.
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
     await sync_agent_profile_presence(session, id, active_story_id=None)
     # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
     from app.routers.file_locks import release_all_file_locks

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -299,6 +299,9 @@ async def heartbeat(
         raise HTTPException(status_code=404, detail="Team member not found")
     now = datetime.now(timezone.utc)
     await repo.update(id, last_seen_at=now, agent_status="online")
+    # AC3-4 2-1 dual-write: 뷰가 presence를 agent_project_profiles서 읽으므로 동시 반영(cutover 전 동기).
+    from app.services.agent_anchor_sync import sync_agent_profile_presence
+    await sync_agent_profile_presence(session, id, last_seen_at=now, agent_status="online")
     return {"ok": True, "last_seen_at": now.isoformat()}
 
 
@@ -325,6 +328,8 @@ async def claim_story(
 
     now = datetime.now(timezone.utc)
     await repo.update(id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
+    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    await sync_agent_profile_presence(session, id, active_story_id=body.story_id, agent_status="online", last_seen_at=now)
     return {"claimed": True, "story_id": str(body.story_id)}
 
 
@@ -340,6 +345,8 @@ async def unclaim_story(
     if member is None:
         raise HTTPException(status_code=404, detail="Team member not found")
     await repo.update(id, active_story_id=None)
+    from app.services.agent_anchor_sync import sync_agent_profile_presence  # AC3-4 2-1 dual-write
+    await sync_agent_profile_presence(session, id, active_story_id=None)
     # AC7: unclaim 시 해당 멤버의 모든 file lock 해제
     from app.routers.file_locks import release_all_file_locks
     await release_all_file_locks(session, id)

--- a/backend/app/routers/webhooks.py
+++ b/backend/app/routers/webhooks.py
@@ -48,8 +48,11 @@ async def upsert_webhook_config(
     body: UpsertWebhookConfig,
     repo: WebhookConfigRepository = Depends(_get_repo),
 ) -> WebhookConfigResponse:
+    # AC3-2d(2): member_id canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write. agent id는 no-op.
+    from app.services.member_resolver import canonicalize_member_id
+    member_id = await canonicalize_member_id(body.member_id, repo.session)
     config = await repo.upsert(
-        member_id=body.member_id,
+        member_id=member_id,
         url=body.url,
         project_id=body.project_id,
         events=body.events,

--- a/backend/app/schemas/api_key.py
+++ b/backend/app/schemas/api_key.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ApiKeyResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    team_member_id: uuid.UUID
+    # E-MEMBER-SSOT AC3-5 ③: team_member_id는 deprecated(canonical 식별자는 members.id 미러 = ApiKey.member_id).
+    # 레거시 호환 위해 컬럼·필드 dual 유지(DDL 변경 없음). 신규 소비자는 member 신원해소(resolve)를 사용.
+    team_member_id: uuid.UUID = Field(
+        deprecated=True,
+        description="DEPRECATED(AC3-5 ③): canonical 식별자는 members.id. 레거시 호환용 dual 유지.",
+    )
     key_prefix: str
     scope: list[str] | None = None
     expires_at: datetime | None = None

--- a/backend/app/services/activity_log.py
+++ b/backend/app/services/activity_log.py
@@ -5,7 +5,6 @@ import uuid
 import logging
 from typing import Literal
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity_log import ActivityLog
@@ -28,17 +27,17 @@ async def record_activity_bg(
 ) -> None:
     """BackgroundTask용 activity log 기록. 실패해도 caller에 영향 없음 (AC6)."""
     from app.core.database import async_session_factory
-    from app.models.team import TeamMember
 
     try:
         async with async_session_factory() as db:
             resolved_type: ActorType = actor_type or "human"
             if actor_type is None and actor_id is not None:
-                tm = (await db.execute(
-                    select(TeamMember).where(TeamMember.id == actor_id).limit(1)
-                )).scalar_one_or_none()
-                if tm and tm.type in ("agent", "human"):
-                    resolved_type = tm.type  # type: ignore[assignment]
+                # AC3-2d(1b): canonical 정합 — TeamMember 직접 조회는 0085 후 canonical 휴먼(≠tm.id)을 못 찾아
+                # "human" 기본 fallback만. lookup_members_by_ids(anchor)는 canonical/legacy 모두 해소.
+                from app.services.member_resolver import lookup_members_by_ids
+                m = (await lookup_members_by_ids({actor_id}, db)).get(actor_id)
+                if m and m.type in ("agent", "human"):
+                    resolved_type = m.type  # type: ignore[assignment]
 
             await ActivityLogService(db).record(
                 org_id=org_id,

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
-
-from sqlalchemy import select
 
 from app.models.member import AgentProjectProfile, Member
 from app.models.project import OrgMember
@@ -92,6 +91,26 @@ async def sync_agent_anchor_on_create(
         .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 모두 흡수
     )
 
+    # 3. project_access direct placement (AC3-4 2-1, G3): 0075 §5 에이전트 placement 동형.
+    #    AC3-4 뷰가 role/can_manage를 project_access서 읽으므로 신규 agent도 placement 필요(누락 시 뷰서
+    #    role 기본값). member_id=tm.id(canonical), org_member_id=NULL(에이전트). ON CONFLICT 멱등.
+    from app.models.project_access import ProjectAccess
+    await session.execute(
+        pg_insert(ProjectAccess.__table__)
+        .values(
+            id=uuid.uuid4(),
+            project_id=team_member.project_id,
+            org_member_id=None,
+            member_id=team_member.id,
+            permission="granted",
+            role=team_member.role,
+            color=team_member.color,
+            can_manage_members=team_member.can_manage_members,
+            access_source="direct",
+        )
+        .on_conflict_do_nothing()  # (project_id, member_id) 부분 UNIQUE 흡수(멱등)
+    )
+
     # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
     await session.flush()
 
@@ -149,3 +168,21 @@ async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -
     )
     await session.flush()
     return True
+
+
+async def sync_agent_profile_presence(session: AsyncSession, member_id: uuid.UUID, **fields) -> None:
+    """AC3-4 2-1 dual-write: 에이전트 presence를 agent_project_profiles에도 반영(team_members UPDATE와 동시).
+
+    AC3-4 뷰가 last_seen_at/active_story_id/agent_status를 agent_project_profiles서 읽으므로 cutover 전
+    동기 유지. member_id(=agent team_member.id, 1:1)로 단일 profile 행 UPDATE. 행 없으면 0건(무해).
+    cutover(2-2) 후 레거시 team_members UPDATE 제거 시 이 경로가 유일 write가 된다.
+    """
+    allowed = {"last_seen_at", "active_story_id", "agent_status"}
+    upd = {k: v for k, v in fields.items() if k in allowed}
+    if not upd:
+        return
+    await session.execute(
+        sa_update(AgentProjectProfile.__table__)
+        .where(AgentProjectProfile.__table__.c.member_id == member_id)
+        .values(**upd)
+    )

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -1,0 +1,93 @@
+"""E-MEMBER-SSOT AC3-1b: 신규 agent 앵커 write-sync.
+
+신규 agent(team_member type='agent') 생성 시 앵커 신원(members) + per-project 런타임
+(agent_project_profiles)을 함께 dual-write 한다. 0075 백필과 **동형**(members.id=team_member.id,
+owner_member_id=생성 휴먼 member, agent_project_profiles는 team_member 런타임 필드 미러).
+
+왜 foundational:
+- members 부재 → `member_ssot_apikey_cut=on`에서 _resolve_api_key가 401(생명선 차단).
+- agent_project_profiles 부재 → cut-on의 project_id=None(M1).
+- 둘 부재 → agent_api_keys.member_id→members FK 재추가(0080) 시 신규 INSERT가 referent 없어 위반(트랩#7/8).
+
+⚠️ 호출 위치: team_member 생성 직후 ~ **api_key 자동생성 이전**(FK 선행 충족). create_team_member에서 보장.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.member import AgentProjectProfile, Member
+from app.models.project import OrgMember
+
+
+async def sync_agent_anchor_on_create(
+    session: AsyncSession,
+    team_member,
+    created_by: uuid.UUID | None,
+) -> None:
+    """agent team_member의 앵커(members + agent_project_profiles)를 멱등 dual-write.
+
+    team_member.type != 'agent'이면 no-op. 멱등(ON CONFLICT DO NOTHING) — 재호출/백필 중복 안전.
+    """
+    if getattr(team_member, "type", None) != "agent":
+        return
+
+    # owner_member_id = 생성 휴먼의 member.id (= org_member.id, 0075 불변식).
+    #   휴먼 org_member이고 members 행이 실재할 때만; 그 외(agent 생성자·orphan) NULL(SET NULL 컬럼).
+    owner_member_id: uuid.UUID | None = None
+    if created_by is not None:
+        owner_member_id = (
+            await session.execute(
+                select(OrgMember.id)
+                .where(OrgMember.org_id == team_member.org_id)
+                .where(OrgMember.user_id == created_by)
+                .where(OrgMember.deleted_at.is_(None))
+            )
+        ).scalar_one_or_none()
+        if owner_member_id is not None:
+            member_exists = (
+                await session.execute(select(Member.id).where(Member.id == owner_member_id))
+            ).scalar_one_or_none()
+            if member_exists is None:
+                owner_member_id = None
+
+    # 1. members (id=team_member.id, type='agent') — 0075 에이전트 백필 동형
+    await session.execute(
+        pg_insert(Member.__table__)
+        .values(
+            id=team_member.id,
+            org_id=team_member.org_id,
+            type="agent",
+            user_id=None,
+            owner_member_id=owner_member_id,
+            name=team_member.name,
+            avatar_url=team_member.avatar_url,
+            org_role=None,
+            is_active=team_member.is_active,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+
+    # 2. agent_project_profiles (member_id=team_member.id) — 런타임/설정 미러
+    await session.execute(
+        pg_insert(AgentProjectProfile.__table__)
+        .values(
+            id=uuid.uuid4(),
+            member_id=team_member.id,
+            project_id=team_member.project_id,
+            agent_config=team_member.agent_config,
+            webhook_url=team_member.webhook_url,
+            agent_role=team_member.agent_role,
+            fakechat_port=team_member.fakechat_port,
+            last_seen_at=team_member.last_seen_at,
+            active_story_id=team_member.active_story_id,
+            agent_status=team_member.agent_status,
+        )
+        .on_conflict_do_nothing()  # (project_id, member_id) UNIQUE + (project_id, fakechat_port) 부분 UNIQUE 모두 흡수
+    )
+
+    # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
+    await session.flush()

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -19,8 +19,11 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sqlalchemy import select
+
 from app.models.member import AgentProjectProfile, Member
 from app.models.project import OrgMember
+from app.models.user import User
 
 
 async def sync_agent_anchor_on_create(
@@ -91,3 +94,58 @@ async def sync_agent_anchor_on_create(
 
     # api_key 자동생성(create_team_member)이 같은 트랜잭션에서 members FK를 즉시 보도록 flush
     await session.flush()
+
+
+async def ensure_human_member(session: AsyncSession, org_member_id: uuid.UUID) -> bool:
+    """휴먼 org_member의 앵커 members 행을 멱등 보장(AC3-2c grant write-sync).
+
+    members.id = org_member.id (0075 휴먼 불변식). 0075 백필 동형(name=users.email/display_name).
+    project_access.member_id=org_member.id를 세팅하기 전 호출 — fk_project_access_member(NOT VALID이나
+    신규 INSERT 검증)가 members 행을 요구하므로. 신규 휴먼(0075 이후)은 members 행이 없을 수 있다.
+
+    반환: members 행이 (이미 있거나) 보장되면 True, org_member 부재/삭제 **또는 orphan org**면
+    False(호출부 미세팅 — member_id NULL 레거시 호환).
+
+    ⚠️ orphan-safe(QA E1, 0084 §1 동형): members.org_id NOT NULL FK라 **org 부재 시 INSERT 불가**
+    → org 존재 확인 후만 INSERT(아니면 False). user_id는 users FK라 **orphan user면 NULL**(user.id|NULL).
+    """
+    from app.models.organization import Organization
+
+    om = (
+        await session.execute(
+            select(OrgMember).where(OrgMember.id == org_member_id, OrgMember.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if om is None:
+        return False
+
+    # org 존재 확인 — orphan org면 members.org_id FK 위반(500) 회피로 미보장(False)
+    org_exists = (
+        await session.execute(select(Organization.id).where(Organization.id == om.org_id))
+    ).scalar_one_or_none()
+    if org_exists is None:
+        return False
+
+    user = (
+        await session.execute(select(User).where(User.id == om.user_id))
+    ).scalar_one_or_none()
+    # orphan user면 user_id=NULL(members.user_id FK 위반 회피, 0084 LEFT JOIN u.id 동형)
+    user_id_val = user.id if user is not None else None
+    name = (getattr(user, "display_name", None) or getattr(user, "email", None) or str(om.user_id)) if user else str(om.user_id)
+
+    await session.execute(
+        pg_insert(Member.__table__)
+        .values(
+            id=om.id,  # 0075 불변식: 휴먼 members.id = org_member.id
+            org_id=om.org_id,
+            type="human",
+            user_id=user_id_val,
+            owner_member_id=None,
+            name=name,
+            org_role=om.role,
+            is_active=True,
+        )
+        .on_conflict_do_nothing(index_elements=["id"])
+    )
+    await session.flush()
+    return True

--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -462,3 +462,39 @@ async def filter_org_member_ids(
         )).scalars().all())
 
     return tm_ids | om_ids
+
+
+async def canonicalize_member_id(
+    member_id: uuid.UUID,
+    session: AsyncSession,
+) -> uuid.UUID:
+    """레거시 식별자를 canonical members.id로 정규화 — AC3-2/AC3-3 read-cut 방향.
+
+    레거시 휴먼 team_member.id는 member_identity_aliases로 canonical(org_member.id) 치환,
+    그 외(이미 canonical org_member.id·에이전트 team_member.id)는 그대로(orphan-safe).
+    COALESCE(alias.member_id, id) 동형.
+    """
+    aliased = (
+        await session.execute(
+            select(MemberIdentityAlias.member_id).where(MemberIdentityAlias.alias_id == member_id)
+        )
+    ).scalar_one_or_none()
+    return aliased or member_id
+
+
+async def canonicalize_member_ids(
+    member_ids: set[uuid.UUID],
+    session: AsyncSession,
+) -> dict[uuid.UUID, uuid.UUID]:
+    """배치 정규화 — {원본 id: canonical id}. alias 없으면 자기 자신(orphan-safe)."""
+    if not member_ids:
+        return {}
+    rows = (
+        await session.execute(
+            select(MemberIdentityAlias.alias_id, MemberIdentityAlias.member_id).where(
+                MemberIdentityAlias.alias_id.in_(member_ids)
+            )
+        )
+    ).all()
+    alias_map = {a: m for a, m in rows}
+    return {mid: alias_map.get(mid, mid) for mid in member_ids}

--- a/backend/scripts/audit_apikey_member_anchor.py
+++ b/backend/scripts/audit_apikey_member_anchor.py
@@ -1,0 +1,75 @@
+"""E-MEMBER-SSOT AC3-1b AC2: agent_api_keys 앵커 정합 감사 (H2).
+
+`member_ssot_apikey_cut=on`의 _resolve_api_key는 `members(id=api_key.member_id, type='agent',
+is_active, not deleted)`를 요구한다. 0076은 agent_api_keys 전 row에 member_id=team_member_id를
+dual-write 했고 0075는 type='agent' team_member만 members에 넣었으므로, **active key 중**
+(a) tm.type != 'agent' 이거나 (b) members(agent) 행이 부재이면 cut-on 시 401(생명선 차단)이 된다.
+
+이 스크립트는 그런 **위반 active key**를 나열한다.
+- 0건  → flag-on 안전 + 0080 FK VALIDATE 통과.
+- 1건+ → 처리 필요: 정당 agent면 members 보정(또는 agent_anchor_sync 재실행), human/오용 key면 무효화.
+
+env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 읽기 전용(조회만).
+실행: cd backend && DATABASE_URL=... python -m scripts.audit_apikey_member_anchor
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+from sqlalchemy import text
+
+from app.core.database import async_session_factory
+
+# active(미revoke·미만료) key 중 cut-on이 깨질 row: members(agent,active) 부재
+AUDIT_SQL = """
+SELECT ak.id            AS api_key_id,
+       ak.team_member_id,
+       ak.member_id,
+       tm.type          AS tm_type,
+       tm.is_active     AS tm_active,
+       (m.id IS NOT NULL) AS member_exists,
+       (m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL) AS member_cut_ok
+FROM agent_api_keys ak
+LEFT JOIN team_members tm ON tm.id = ak.team_member_id
+LEFT JOIN members m       ON m.id = ak.member_id
+WHERE ak.revoked_at IS NULL
+  AND (ak.expires_at IS NULL OR ak.expires_at > now())
+  AND NOT (m.id IS NOT NULL AND m.type = 'agent' AND m.is_active AND m.deleted_at IS NULL)
+ORDER BY ak.created_at
+"""
+
+# 0080 FK VALIDATE 가드와 동일 기준: member_id referent 부재(active 무관 전 row)
+FK_VIOLATION_SQL = """
+SELECT count(*) FROM agent_api_keys ak
+WHERE ak.member_id IS NOT NULL
+  AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id)
+"""
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("[FAIL] DATABASE_URL 필요", file=sys.stderr)
+        return 2
+    async with async_session_factory() as s:
+        rows = (await s.execute(text(AUDIT_SQL))).mappings().all()
+        fk_bad = (await s.execute(text(FK_VIOLATION_SQL))).scalar_one()
+
+    print(f"=== AC2 H2 감사: cut-on 위반 active key {len(rows)}건 ===")
+    for r in rows:
+        print(
+            f"  api_key={r['api_key_id']} tm={r['team_member_id']}({r['tm_type']},active={r['tm_active']}) "
+            f"member_id={r['member_id']} member_exists={r['member_exists']} cut_ok={r['member_cut_ok']}"
+        )
+    print(f"=== 0080 FK VALIDATE 위반(members 부재 referent, 전 row) {fk_bad}건 ===")
+
+    if len(rows) == 0 and fk_bad == 0:
+        print("[PASS] 위반 0건 — flag-on 안전 + 0080 FK VALIDATE 통과 예상")
+        return 0
+    print("[WARN] 위반 존재 — flag-on 전 처리 필요(정당 agent: members 보정 / human·오용: key 무효화)")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/verify_grant_only_story_assign.py
+++ b/backend/scripts/verify_grant_only_story_assign.py
@@ -1,0 +1,149 @@
+"""grant-only 휴먼 "스토리 배정" 200 라이브 검증 (E-MEMBER-SSOT AC3-2).
+
+스토리 배정 write 경로는 stories.assignee_id(FK 완화 0078) + participation.member_id(FK 완화 0079)
+**2개 컬럼**을 건드린다(update_story → _upsert_assignee_participation). 따라서 grant-only 스토리배정
+200은 0078·0079가 **둘 다** dev 적용된 뒤에만 통과한다. 0078만 적용된 상태에선 participation INSERT에서
+여전히 FK violation 500.
+
+이 스크립트는: 임시 grant-only 휴먼(User+OrgMember[member]+project_access[granted], team_member 없음)과
+임시 스토리를 만들고, 그 휴먼 JWT로 dev 백엔드 PATCH /api/v2/stories/{id}에 assignee_id=org_member.id를
+보내 **200**을 확인한 뒤, participation 행 생성까지 검증하고 전부 정리(cleanup)한다.
+
+전제(환경변수):
+  BACKEND_URL   예) https://sprintable-backend-dev-57iommnikq-du.a.run.app
+  DATABASE_URL  백엔드와 동일 (postgresql+asyncpg://...  cloud-sql-proxy 경유 가능)
+  JWT_SECRET    dev와 동일 secret (Secret Manager JWT_SECRET) — create_access_token 서명용
+  ORG_ID        대상 조직 (실 dev org)
+  PROJECT_ID    대상 프로젝트 (해당 org 소속)
+
+실행:
+  cd backend && DATABASE_URL=... JWT_SECRET=... BACKEND_URL=... ORG_ID=... PROJECT_ID=... \
+      python -m scripts.verify_grant_only_story_assign
+
+⚠️ 0079 migrate-dev 적용 후 실행할 것. (0078만 적용 시 의도적으로 500이 나며 FAIL로 표시된다.)
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+
+import httpx
+from sqlalchemy import text
+
+from app.core.database import async_session_factory
+from app.core.security import create_access_token
+from app.models.pm import Story
+from app.models.project import OrgMember
+from app.models.project_access import ProjectAccess
+from app.models.user import User
+
+
+def _env(name: str) -> str:
+    v = os.environ.get(name)
+    if not v:
+        print(f"[FAIL] 환경변수 {name} 필요", file=sys.stderr)
+        sys.exit(2)
+    return v
+
+
+async def main() -> int:
+    backend = _env("BACKEND_URL").rstrip("/")
+    org_id = uuid.UUID(_env("ORG_ID"))
+    project_id = uuid.UUID(_env("PROJECT_ID"))
+    _env("DATABASE_URL")  # async_session_factory가 settings.database_url로 이미 바인딩
+    _env("JWT_SECRET")
+
+    suffix = uuid.uuid4().hex[:10]
+    email = f"grant-only-verify-{suffix}@example.invalid"
+
+    user_id = om_id = story_id = None
+    try:
+        # ── 1. 임시 grant-only 휴먼 + 스토리 (team_member 없음) ──────────────────
+        async with async_session_factory() as s:
+            u = User(email=email, hashed_password="x" * 32, email_verified=True)
+            s.add(u)
+            await s.flush()
+            om = OrgMember(org_id=org_id, user_id=u.id, role="member")  # owner/admin 아님 = 순수 grant 의존
+            s.add(om)
+            await s.flush()
+            pa = ProjectAccess(
+                project_id=project_id,
+                org_member_id=om.id,
+                permission="granted",
+                member_id=om.id,
+                role="member",
+                access_source="direct",
+            )
+            s.add(pa)
+            story = Story(org_id=org_id, project_id=project_id, title=f"grant-only assign verify {suffix}")
+            s.add(story)
+            await s.flush()
+            user_id, om_id, story_id = u.id, om.id, story.id
+
+            # 안전망: team_member가 없어야 진짜 grant-only
+            tm = await s.execute(
+                text("SELECT 1 FROM team_members WHERE org_id=:o AND user_id=:u LIMIT 1"),
+                {"o": org_id, "u": user_id},
+            )
+            assert tm.scalar_one_or_none() is None, "임시 휴먼에 team_member가 존재 — grant-only 아님"
+            await s.commit()
+
+        print(f"[setup] user={user_id} org_member={om_id} story={story_id} (grant-only, no team_member)")
+
+        # ── 2. 그 휴먼 JWT로 스토리 배정 PATCH → 200 기대 ────────────────────────
+        token = create_access_token(
+            str(user_id),
+            email=email,
+            app_metadata={
+                "org_id": str(org_id),
+                "project_id": str(project_id),
+                "project_ids": [str(project_id)],
+                "role": "member",
+            },
+        )
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.patch(
+                f"{backend}/api/v2/stories/{story_id}",
+                json={"assignee_id": str(om_id)},
+                headers={"Authorization": f"Bearer {token}"},
+            )
+        print(f"[assign] PATCH /api/v2/stories/{story_id} assignee_id={om_id} → {resp.status_code}")
+        if resp.status_code != 200:
+            print(f"[FAIL] 기대 200, 실제 {resp.status_code}: {resp.text[:400]}")
+            return 1
+
+        # ── 3. participation 공동-write까지 확인 (member_id = org_member.id) ──────
+        async with async_session_factory() as s:
+            assignee = await s.execute(text("SELECT assignee_id FROM stories WHERE id=:i"), {"i": story_id})
+            part = await s.execute(
+                text("SELECT 1 FROM participation WHERE story_id=:s AND member_id=:m LIMIT 1"),
+                {"s": story_id, "m": om_id},
+            )
+            assignee_ok = assignee.scalar_one_or_none() == om_id
+            part_ok = part.scalar_one_or_none() is not None
+        print(f"[verify] stories.assignee_id==org_member.id: {assignee_ok} / participation 행 생성: {part_ok}")
+        if not (assignee_ok and part_ok):
+            print("[FAIL] 배정/참가 행 확인 실패")
+            return 1
+
+        print("[PASS] grant-only 휴먼 스토리 배정 200 + participation 공동-write 정상 (0078+0079 적용 확인)")
+        return 0
+    finally:
+        # ── cleanup (생성 역순) ─────────────────────────────────────────────────
+        async with async_session_factory() as s:
+            if story_id is not None:
+                await s.execute(text("DELETE FROM participation WHERE story_id=:s"), {"s": story_id})
+                await s.execute(text("DELETE FROM stories WHERE id=:i"), {"i": story_id})
+            if om_id is not None:
+                await s.execute(text("DELETE FROM project_access WHERE org_member_id=:m"), {"m": om_id})
+                await s.execute(text("DELETE FROM org_members WHERE id=:m"), {"m": om_id})
+            if user_id is not None:
+                await s.execute(text("DELETE FROM users WHERE id=:u"), {"u": user_id})
+            await s.commit()
+        print("[cleanup] 임시 데이터 정리 완료")
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/backend/scripts/verify_grant_only_story_assign.py
+++ b/backend/scripts/verify_grant_only_story_assign.py
@@ -68,13 +68,12 @@ async def main() -> int:
             om = OrgMember(org_id=org_id, user_id=u.id, role="member")  # owner/admin 아님 = 순수 grant 의존
             s.add(om)
             await s.flush()
+            # 실 grant 플로우(create_project_access)와 동형: org_member_id만 세팅, member_id는 NULL.
+            # member_id=om.id로 채우면 fk_project_access_member(members 미존재) 위반 — 실 grant은 member_id 안 씀.
             pa = ProjectAccess(
                 project_id=project_id,
                 org_member_id=om.id,
                 permission="granted",
-                member_id=om.id,
-                role="member",
-                access_source="direct",
             )
             s.add(pa)
             story = Story(org_id=org_id, project_id=project_id, title=f"grant-only assign verify {suffix}")

--- a/backend/tests/test_e_entity_cleanup_s5_human_cleanup.py
+++ b/backend/tests/test_e_entity_cleanup_s5_human_cleanup.py
@@ -63,20 +63,24 @@ def test_invitations_keeps_org_member_creation():
     assert "OrgMember" in source or "org_members" in source
 
 
-# ─── AC3: story assignee FK 정상 동작 ────────────────────────────────────────
+# ─── AC3: story/task assignee — E-MEMBER-SSOT AC3-2(0078)에서 계약 변경 ──────────
+# S5 당시: assignee_id team_members FK 유지(agent 배정).
+# AC3-2(1154dd9e, migration 0078): 그 FK가 grant-only 휴먼(org_member.id) 배정 시 실DB FK
+#   violation 500을 유발 → FK 제거. canonical 식별자는 assignee_id_v2. agent 배정은 id 값으로
+#   계속 동작(FK 강제만 해제). 따라서 team_members FK가 **없어야** 정상. [[feedback_one_sided_transition]]
 
-def test_story_assignee_fk_still_defined():
-    """Story.assignee_id FK는 team_members.id로 유지됨 (agent 배정 정상 동작)."""
+def test_story_assignee_has_no_team_members_fk():
+    """AC3-2: Story.assignee_id team_members FK 제거 — grant-only 배정 500 해소."""
     from app.models.pm import Story
-    fk_targets = [str(fk.target_fullname) for fk in Story.__table__.foreign_keys]
-    assert any("team_members" in t for t in fk_targets)
+    referred = {fk.column.table.name for fk in Story.__table__.c.assignee_id.foreign_keys}
+    assert "team_members" not in referred
 
 
-def test_task_assignee_fk_still_defined():
-    """Task.assignee_id FK는 team_members.id로 유지됨."""
+def test_task_assignee_has_no_team_members_fk():
+    """AC3-2: Task.assignee_id team_members FK 제거 — grant-only 배정 500 해소."""
     from app.models.pm import Task
-    fk_targets = [str(fk.target_fullname) for fk in Task.__table__.foreign_keys]
-    assert any("team_members" in t for t in fk_targets)
+    referred = {fk.column.table.name for fk in Task.__table__.c.assignee_id.foreign_keys}
+    assert "team_members" not in referred
 
 
 # ─── AC4: agent 영향 없음 ────────────────────────────────────────────────────

--- a/backend/tests/test_member_ssot_ac3_1b.py
+++ b/backend/tests/test_member_ssot_ac3_1b.py
@@ -1,0 +1,39 @@
+"""E-MEMBER-SSOT AC3-1b: 신규 agent anchor write-sync + agent_api_keys.member_id FK 재추가.
+
+실데이터 기능(write-sync가 members/profile 생성·FK 충족)은 test_member_ssot_parity_realdb.py(실 PG)에서.
+여기선 항상 도는 구조회귀 + 헬퍼 no-op 가드.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_apikey_member_id_has_members_fk():
+    """AC3(0080): agent_api_keys.member_id → members FK 재추가(QA H1 해소). write-sync로 referent 선행."""
+    from app.models.api_key import ApiKey
+
+    referred = {fk.column.table.name for fk in ApiKey.__table__.c.member_id.foreign_keys}
+    assert "members" in referred, "agent_api_keys.member_id의 members FK가 없음(0080 재추가 누락)"
+
+
+@pytest.mark.anyio
+async def test_sync_agent_anchor_noop_for_non_agent():
+    """type != 'agent'면 write-sync는 no-op(어떤 INSERT/flush도 안 함)."""
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    tm = MagicMock()
+    tm.type = "human"
+    await sync_agent_anchor_on_create(session, tm, created_by=uuid.uuid4())
+    session.execute.assert_not_called()
+    session.flush.assert_not_called()
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"

--- a/backend/tests/test_member_ssot_ac3_2.py
+++ b/backend/tests/test_member_ssot_ac3_2.py
@@ -1,0 +1,20 @@
+"""E-MEMBER-SSOT AC3-2: 식별 컬럼 v2 + team_members FK 완화 구조 회귀.
+
+Batch2: stories/tasks/epics assignee_id team_members FK 제거(grant-only 할당 500 해소, migration 0078).
+실데이터 백필/parity는 test_member_ssot_parity_realdb.py(실 PG) 및 격리 PG 하네스로 검증.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.parametrize("model_name", ["Epic", "Story", "Task"])
+def test_assignee_id_has_no_team_members_fk(model_name):
+    """assignee_id의 team_members FK 제거 — grant-only 휴먼(org_member.id) 할당 시 실DB FK violation
+    500이 나지 않음 (migration 0078). canonical은 assignee_id_v2."""
+    import app.models.pm as pm
+
+    model = getattr(pm, model_name)
+    col = model.__table__.c.assignee_id
+    referred = {fk.column.table.name for fk in col.foreign_keys}
+    assert "team_members" not in referred, f"{model_name}.assignee_id still has team_members FK"

--- a/backend/tests/test_member_ssot_ac3_2.py
+++ b/backend/tests/test_member_ssot_ac3_2.py
@@ -10,11 +10,37 @@ import pytest
 
 @pytest.mark.parametrize("model_name", ["Epic", "Story", "Task"])
 def test_assignee_id_has_no_team_members_fk(model_name):
-    """assignee_id의 team_members FK 제거 — grant-only 휴먼(org_member.id) 할당 시 실DB FK violation
-    500이 나지 않음 (migration 0078). canonical은 assignee_id_v2."""
+    """Batch2(0078): assignee_id team_members FK 제거 — grant-only 휴먼(org_member.id) 배정 시 실DB
+    FK violation 500이 나지 않음. canonical은 assignee_id_v2."""
     import app.models.pm as pm
 
     model = getattr(pm, model_name)
     col = model.__table__.c.assignee_id
     referred = {fk.column.table.name for fk in col.foreign_keys}
     assert "team_members" not in referred, f"{model_name}.assignee_id still has team_members FK"
+
+
+def _batch3_identity_cols():
+    from app.models.doc import Doc, DocComment, DocRevision
+    from app.models.participation import Participation
+    from app.models.reward import RewardLedger
+    from app.models.webhook_config import WebhookConfig
+
+    return [
+        (Participation, "member_id"),
+        (WebhookConfig, "member_id"),
+        (RewardLedger, "member_id"),
+        (RewardLedger, "granted_by"),
+        (Doc, "created_by"),
+        (Doc, "assignee_id"),
+        (DocComment, "created_by"),
+        (DocRevision, "created_by"),
+    ]
+
+
+@pytest.mark.parametrize("model,col", _batch3_identity_cols(), ids=lambda v: getattr(v, "__name__", v))
+def test_batch3_identity_col_has_no_team_members_fk(model, col):
+    """Batch3(0079): participation/webhook/reward/docs 식별 컬럼 team_members FK 제거 —
+    grant-only 휴먼 write 시 실DB FK violation 500 방지. canonical은 *_v2. (notif는 0073서 기제거)"""
+    referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
+    assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -41,3 +41,31 @@ def test_ac3_2d_red_col_has_no_team_members_fk(model, col):
     FK violation 500 방지. canonical 정규화는 0085 백필 + batch1b write canonicalize."""
     referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
     assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"
+
+
+# ── 배치1b: write 경로 canonicalize 소스 가드 ──────────────────────────────────────
+def test_batch1b_write_routers_canonicalize():
+    """1b: 휴먼-보유 컬럼 write 라우터가 canonicalize_member_id 적용(레거시 tm.id→canonical, (A) write).
+    agent-context(hitl/file_locks/agent_runs)·policy(no-create)는 0085 no-op이라 제외."""
+    import inspect
+
+    from app.routers import invitations, meetings, retros, stories
+
+    for mod, name in [(retros, "retros"), (invitations, "invitations"), (meetings, "meetings"), (stories, "stories")]:
+        src = inspect.getsource(mod)
+        assert "canonicalize_member_id" in src, f"{name} write canonicalize 누락"
+    # retro 4 식별 컬럼 전부 canonicalize(created_by/author_id/voter_id/assignee_id)
+    rsrc = inspect.getsource(retros)
+    assert rsrc.count("canonicalize_member_id(") >= 4, "retro 4컬럼 canonicalize 미흡"
+
+
+def test_batch1b_activity_log_uses_lookup_members():
+    """1b 노트#1: activity_log actor_type 해소가 raw TeamMember 조회 → lookup_members_by_ids(anchor)로
+    전환(0085 후 canonical 휴먼도 정확 해소; 'human' 기본 fallback 의존 제거)."""
+    import inspect
+
+    from app.services import activity_log
+
+    src = inspect.getsource(activity_log)
+    assert "lookup_members_by_ids" in src, "activity_log lookup_members 전환 누락"
+    assert "select(TeamMember)" not in src, "activity_log에 raw TeamMember 조회 잔존"

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -69,3 +69,22 @@ def test_batch1b_activity_log_uses_lookup_members():
     src = inspect.getsource(activity_log)
     assert "lookup_members_by_ids" in src, "activity_log lookup_members 전환 누락"
     assert "select(TeamMember)" not in src, "activity_log에 raw TeamMember 조회 잔존"
+
+
+# ── 배치2(🟡+notif): write canonicalize + notif_prefs canonical 소스 가드 ──────────────────────────
+def test_batch2_yellow_write_canonicalize():
+    """배치2: 🟡 write 라우터(webhook/reward/docs) + notif_prefs가 canonical 통일(canonicalize_member_id /
+    notif _get_member=resolve_member). 휴먼-context body/resolved id의 (A) write."""
+    import inspect
+
+    from app.routers import docs, notification_preferences, rewards, webhooks
+
+    for mod, name in [(webhooks, "webhooks"), (rewards, "rewards"), (docs, "docs")]:
+        assert "canonicalize_member_id" in inspect.getsource(mod), f"{name} write canonicalize 누락"
+    # reward: member_id + granted_by 둘 다
+    assert inspect.getsource(rewards).count("canonicalize_member_id(") >= 2, "reward member_id+granted_by 미흡"
+    # notif_prefs _get_member: tm-first 제거 + resolve_member(canonical) 통일
+    nsrc = inspect.getsource(notification_preferences._get_member)
+    assert "resolve_member(" in nsrc, "notif _get_member canonical 전환 누락"
+    # JWT 휴먼 tm-first lookup(TeamMember.user_id 매칭) 제거됨 — api_key 분기의 TeamMember.id만 잔존
+    assert "TeamMember.user_id" not in nsrc, "notif _get_member에 JWT-휴먼 tm-first 잔존(split-brain 위험)"

--- a/backend/tests/test_member_ssot_ac3_2d.py
+++ b/backend/tests/test_member_ssot_ac3_2d.py
@@ -1,0 +1,43 @@
+"""E-MEMBER-SSOT AC3-2d 배치1(🔴): 잔여 team_members FK 완화 구조 회귀.
+
+migration 0085가 12컬럼의 team_members FK를 완화(grant-only 휴먼 write 500 해소) + 기존 데이터 canonical
+정규화. 실데이터 정규화/백필은 test_member_ssot_parity_realdb.py(실 PG). 여기선 모델 FK 부재 구조회귀.
+write 경로 canonicalize는 batch1b(별 PR).
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def _red_cols():
+    from app.models.agent_run import AgentRun
+    from app.models.file_lock import FileLock
+    from app.models.hitl_config import MemberGateOverride
+    from app.models.invitation import Invitation
+    from app.models.meeting import Meeting
+    from app.models.policy_document import PolicyDocument
+    from app.models.pm import StoryActivity, StoryComment
+    from app.models.retro import RetroAction, RetroItem, RetroSession, RetroVote
+
+    return [
+        (RetroSession, "created_by"),
+        (RetroItem, "author_id"),
+        (RetroVote, "voter_id"),
+        (RetroAction, "assignee_id"),
+        (FileLock, "member_id"),
+        (MemberGateOverride, "member_id"),
+        (Invitation, "invited_by"),
+        (Meeting, "created_by"),
+        (PolicyDocument, "created_by"),
+        (StoryComment, "created_by"),
+        (StoryActivity, "created_by"),
+        (AgentRun, "agent_id"),
+    ]
+
+
+@pytest.mark.parametrize("model,col", _red_cols(), ids=lambda v: getattr(v, "__name__", v))
+def test_ac3_2d_red_col_has_no_team_members_fk(model, col):
+    """0085: 🔴 식별 컬럼 team_members FK 제거 — grant-only 휴먼(canonical members.id) write 시 실DB
+    FK violation 500 방지. canonical 정규화는 0085 백필 + batch1b write canonicalize."""
+    referred = {fk.column.table.name for fk in model.__table__.c[col].foreign_keys}
+    assert "team_members" not in referred, f"{model.__name__}.{col} still has team_members FK"

--- a/backend/tests/test_member_ssot_ac3_3.py
+++ b/backend/tests/test_member_ssot_ac3_3.py
@@ -1,0 +1,55 @@
+"""E-MEMBER-SSOT AC3-3: standup author/feedback canonical 이행 — 구조 + 헬퍼 가드.
+
+실데이터 기능(canonical missing 단일신원·0081 병합/정규화)은 test_member_ssot_parity_realdb.py(실 PG).
+여기선 항상 도는 구조회귀 + standups write 경로가 canonical resolver로 전환됐는지.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+def test_standups_write_uses_canonical_resolver():
+    """PUT self-save가 resolve_auth_member(team_member-first) → resolve_member(canonical)로 전환되고,
+    POST/feedback가 canonicalize_member_id로 정규화하는지(소스 가드)."""
+    import inspect
+
+    from app.routers import standups
+
+    src = inspect.getsource(standups)
+    assert "resolve_auth_member" not in src, "PUT가 아직 team_member-first(#1167 회귀 위험)"
+    assert "resolve_member(" in src, "canonical resolver 미사용"
+    assert src.count("canonicalize_member_id") >= 2, "POST author + feedback canonicalize 누락(트랩#9)"
+
+
+def test_get_missing_uses_effective_access_not_team_member_enum():
+    """missing 산정이 TeamMember 열거가 아닌 effective access(project_access/alias) 기반인지(소스 가드)."""
+    import inspect
+
+    from app.repositories import standup
+
+    src = inspect.getsource(standup)
+    assert "member_identity_aliases" in src and "project_access" in src, "effective-access 미반영"
+    assert "TeamMember.type" not in src, "여전히 team_member 열거(멀티프로젝트 중복 미해소)"
+
+
+def test_standups_read_query_param_canonicalized():
+    """T3(#1167 회귀): GET ?author_id= 필터도 canonicalize_member_id 적용 — 레거시 tm.id 조회가
+    canonical 저장분과 매칭(raw 필터면 saved-but-not-displayed)."""
+    import inspect
+
+    from app.routers import standups
+
+    src = inspect.getsource(standups.list_standups)
+    assert "canonicalize_member_id" in src, "list_standups author_id query param canonicalize 누락"
+
+
+def test_sprint_checkin_missing_is_canonical():
+    """T3(#1167 회귀): sprint checkin missing_standups가 team_members vs raw author_id 직접비교가
+    아닌 canonical(get_missing) 기반인지(소스 가드)."""
+    import inspect
+
+    from app.routers import sprints
+
+    src = inspect.getsource(sprints)
+    assert "standup_author_ids" not in src, "checkin이 여전히 raw author_id 직접 비교(레거시 휴먼 오판)"
+    assert "get_missing" in src, "checkin이 canonical get_missing 미사용"

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -245,9 +245,13 @@ async def test_agent_anchor_writesync_creates_members_and_profile():
                 "SELECT type, owner_member_id, name, is_active FROM members WHERE id=:i"), {"i": str(NEW_TM)})).first()
             prof = (await s.execute(text(
                 "SELECT project_id, agent_role, fakechat_port FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
+            # AC3-4 2-1: write-sync가 project_access placement도 생성(뷰 role/can_manage 소스)
+            pa = (await s.execute(text(
+                "SELECT project_id, role, access_source FROM project_access WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
         assert m is not None and m.type == "agent" and m.is_active is True, "members(agent) 미생성"
         assert str(m.owner_member_id) == str(OM_OWNER), f"owner_member_id=생성 휴먼 member 아님: {m.owner_member_id}"
         assert prof is not None and str(prof.project_id) == str(P1) and prof.agent_role == "dev", "agent_project_profiles 미생성/미러 불일치"
+        assert pa is not None and str(pa.project_id) == str(P1) and pa.access_source == "direct", "project_access placement 미생성(AC3-4 2-1)"
 
         # 멱등: 재호출해도 중복/에러 없음
         async with Session() as s:

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import uuid
+from datetime import date as _date
 from unittest.mock import MagicMock
 
 import pytest
@@ -297,6 +298,72 @@ async def test_apikey_insert_after_writesync_succeeds_and_absent_member_violates
                     "VALUES (gen_random_uuid(),:tm,:m,'sk_live_ba','hashba')"
                 ), {"tm": str(absent), "m": str(absent)})
                 await s.commit()
+    finally:
+        await engine.dispose()
+
+
+_SD = "2026-06-04"  # standup 테스트 날짜
+_SD_DATE = _date.fromisoformat(_SD)
+
+
+@pytest.mark.anyio
+async def test_canonicalize_member_id_alias_and_passthrough():
+    """AC3-3: 레거시 휴먼 team_member.id → canonical(org_member.id), 직접 canonical/agent는 그대로."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.member_resolver import canonicalize_member_id
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            assert await canonicalize_member_id(TM_OWNER, s) == OM_OWNER  # 레거시 휴먼 → canonical
+            assert await canonicalize_member_id(OM_MEM, s) == OM_MEM      # 이미 canonical
+            assert await canonicalize_member_id(AG1, s) == AG1            # 에이전트 passthrough
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_get_missing_canonical_single_identity():
+    """⚠️ AC3-3 핵심: missing 산정이 effective 휴먼 access를 canonical로 집계 — 레거시 team_member.id로
+    제출해도 canonical로 인식(#1167 무회귀), 멀티프로젝트 단일 신원."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.repositories.standup import StandupEntryRepository
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM standup_entries WHERE project_id=:p AND date=:d"),
+                            {"p": str(P1), "d": _SD_DATE})
+            await s.commit()
+        # roster(P1) = owner(OM_OWNER) ∪ grant(OM_MEM) ∪ 레거시 휴먼 tm(TM_OWNER→OM_OWNER) = {OWNER, MEM}
+        async with Session() as s:
+            missing = set(await StandupEntryRepository(s, ORG).get_missing(P1, _SD_DATE))
+        assert missing == {OM_OWNER, OM_MEM}, f"roster 불일치: {missing}"
+
+        # OM_MEM이 canonical로 제출 → missing에서 빠짐
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan_story_ids) "
+                "VALUES (gen_random_uuid(),:o,:p,:a,:d,'{}')"
+            ), {"o": str(ORG), "p": str(P1), "a": str(OM_MEM), "d": _SD_DATE})
+            await s.commit()
+            m2 = set(await StandupEntryRepository(s, ORG).get_missing(P1, _SD_DATE))
+        assert m2 == {OM_OWNER}, f"canonical 제출 미반영: {m2}"
+
+        # 레거시 team_member.id(TM_OWNER)로 제출해도 canonical(OM_OWNER)로 인식 → missing 비게
+        async with Session() as s:
+            await s.execute(text(
+                "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan_story_ids) "
+                "VALUES (gen_random_uuid(),:o,:p,:a,:d,'{}')"
+            ), {"o": str(ORG), "p": str(P1), "a": str(TM_OWNER), "d": _SD_DATE})
+            await s.commit()
+            m3 = set(await StandupEntryRepository(s, ORG).get_missing(P1, _SD_DATE))
+        assert m3 == set(), f"레거시 id 제출이 canonical로 인식 안 됨(#1167 회귀): {m3}"
     finally:
         await engine.dispose()
 

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -511,3 +511,83 @@ async def test_0082_guard_validate_raise_branch_bad_gt0():
             ))
             await s.commit()
         await engine.dispose()
+
+
+# ── 0083: orphan-org dead agent api_key revoke + member_id NULL + FK VALIDATE ──────────────────────
+_DO_0083 = f"""
+DO $$
+DECLARE revoked int; bad int;
+BEGIN
+    UPDATE agent_api_keys SET revoked_at = now(), member_id = NULL
+    WHERE revoked_at IS NULL AND member_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = agent_api_keys.member_id);
+    GET DIAGNOSTICS revoked = ROW_COUNT;
+    RAISE NOTICE 'orphan-org dead agent api_key revoke + member_id NULL: % 건', revoked;
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK_0080}' AND NOT convalidated) THEN
+        SELECT count(*) INTO bad FROM agent_api_keys ak
+        WHERE ak.member_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+        ELSE
+            RAISE NOTICE 'FK NOT VALID 유지 (bad=% 잔여)', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0083_revoke_orphan_org_apikey_and_validate():
+    """⚠️ AC2 마무리: 0083이 orphan-org dead agent 키(members 부재 member_id)를 revoke+member_id NULL로
+    정리하고 FK를 VALIDATE하되, **legit 키(member_id 존재)는 안 건드린다**. revoke만으론 FK 위반이 남으므로
+    member_id=NULL이 핵심(VALIDATE는 revoked 무관 전 행 검사)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    legit_key = uuid.UUID("b7000000-0000-0000-0000-0000000000d1")   # member_id=AG1(존재) — 무영향
+    orphan_key = uuid.UUID("b7000000-0000-0000-0000-0000000000d2")  # member_id=orphan — revoke 대상
+    orphan_member = uuid.UUID("b9000000-0000-0000-0000-0000000000d2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for k in (legit_key, orphan_key):
+                await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(k)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) VALUES "
+                "(:lk,:tm,:lm,'sk_live_d1','hd1',ARRAY['read','write']),"
+                "(:ok,:tm,:om,'sk_live_d2','hd2',ARRAY['read','write'])"
+            ), {"lk": str(legit_key), "ok": str(orphan_key), "tm": str(AG1), "lm": str(AG1), "om": str(orphan_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        async with Session() as s:
+            await s.execute(text(_DO_0083))
+            await s.commit()
+        async with Session() as s:
+            legit = (await s.execute(text(
+                "SELECT member_id, revoked_at IS NULL FROM agent_api_keys WHERE id=:i"), {"i": str(legit_key)})).first()
+            orphan = (await s.execute(text(
+                "SELECT member_id, revoked_at IS NULL FROM agent_api_keys WHERE id=:i"), {"i": str(orphan_key)})).first()
+            conval = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert str(legit[0]) == str(AG1) and legit[1] is True, f"legit 키 영향받음: {legit}"
+        assert orphan[0] is None and orphan[1] is False, f"orphan 키 revoke+NULL 안 됨: {orphan}"
+        assert conval is True, "orphan 정리 후에도 FK 미validate"
+    finally:
+        async with Session() as s:
+            for k in (legit_key, orphan_key):
+                await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(k)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -60,6 +60,12 @@ def _tup(r):
 async def _seed(session):
     """legacy + anchor를 일관되게 시드(0075 백필 결과 모사 — members.id=org_member/team_member.id)."""
     from sqlalchemy import text
+    # AC3-4 2-2: cutover(0088) 후 team_members는 projection 뷰 → INSERT 불가. 물리 레거시 행은
+    # team_members_legacy에 시드. 미적용 DB(pre-0088)면 team_members가 물리테이블 — 동적 선택(양립).
+    physical_tm = (await session.execute(text(
+        "SELECT CASE WHEN to_regclass('public.team_members_legacy') IS NOT NULL "
+        "THEN 'team_members_legacy' ELSE 'team_members' END"
+    ))).scalar()
     stmts = [
         # 방어: fresh `alembic upgrade head`에선 0075 DROP NOT NULL이 미지속되는 관찰(별건 flag)이 있어,
         # 에이전트 placement(org_member_id NULL) 시드를 위해 idempotent하게 nullable 보장(테스트 신뢰성).
@@ -69,7 +75,7 @@ async def _seed(session):
         f"DELETE FROM member_identity_aliases WHERE org_id='{ORG}'",
         f"DELETE FROM members WHERE org_id='{ORG}'",
         f"DELETE FROM project_access WHERE project_id IN ('{P1}','{P2}')",
-        f"DELETE FROM team_members WHERE org_id='{ORG}'",
+        f"DELETE FROM {physical_tm} WHERE org_id='{ORG}'",
         f"DELETE FROM projects WHERE org_id='{ORG}'",
         f"DELETE FROM org_members WHERE org_id='{ORG}'",
         f"DELETE FROM users WHERE id IN ('{U_OWNER}','{U_MEM}')",
@@ -79,7 +85,7 @@ async def _seed(session):
         f"('{U_OWNER}','owner@pg.test','x','Owner',true,true,0,false,0),('{U_MEM}','mem@pg.test','x','Mem',true,true,0,false,0)",
         f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_OWNER}','{ORG}','{U_OWNER}','owner'),('{OM_MEM}','{ORG}','{U_MEM}','member')",
         f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0),('{P2}','{ORG}','P2',0)",
-        f"INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) VALUES "
+        f"INSERT INTO {physical_tm} (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) VALUES "
         f"('{TM_OWNER}','{P1}','{ORG}','{U_OWNER}','human','Owner','owner','#3385f8',true,true,NULL),"
         f"('{AG1}','{P1}','{ORG}',NULL,'agent','Bot','member','#ff0000',false,true,'{U_OWNER}'),"
         f"('{AG2}','{P2}','{ORG}',NULL,'agent','Bot','reviewer','#00ff00',false,true,'{U_OWNER}')",
@@ -693,4 +699,55 @@ async def test_ensure_human_member_orphan_safe():
                 await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
                 await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
             await s.commit()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ac3_4_team_members_projection_view():
+    """AC3-4 2-2: team_members가 projection 뷰(0088)로 강등됨을 검증(migrate 0088 적용 DB 전제).
+
+    ⚠️ migrate head<0088이면 team_members가 물리테이블 → relkind!='v'이라 skip(가드).
+    검증: ① relkind='v'(뷰) ② agent(AG1) 행 = anchor 소스(role=project_access, agent_role/presence=profile)
+    ③ 에이전트는 id로 단일행(1:1) ④ deleted members 제외 ⑤ team_members_legacy 물리 잔존(가역 자산).
+    """
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            relkind = (await s.execute(text(
+                "SELECT relkind FROM pg_class WHERE relname='team_members'"
+            ))).scalar()
+        if relkind != "v":
+            pytest.skip(f"team_members relkind={relkind} — migrate 0088 미적용, AC3-4 cutover 전")
+
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            # ② AG1(agent) 행 = anchor 소스 재현: role(project_access P1=member), agent_role/port(profile=dev/9101)
+            row = (await s.execute(text(
+                "SELECT type, role, agent_role, fakechat_port FROM team_members WHERE id=:id"
+            ), {"id": str(AG1)})).first()
+            assert row is not None, "AG1 뷰 미출현"
+            assert row[0] == "agent" and row[1] == "member" and row[2] == "dev" and row[3] == 9101, f"AG1 매핑 불일치: {row}"
+            # ③ 에이전트 id 단일행(1:1)
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE id=:id"), {"id": str(AG1)})).scalar_one()
+            assert cnt == 1, f"agent 다중행: {cnt}"
+            # ④ deleted members 제외 — 임시 soft-delete 후 뷰 미출현
+            await s.execute(text("UPDATE members SET deleted_at=now() WHERE id=:id"), {"id": str(AG1)})
+            await s.commit()
+            gone = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE id=:id"), {"id": str(AG1)})).scalar_one()
+            assert gone == 0, "deleted member가 뷰에 잔존"
+            await s.execute(text("UPDATE members SET deleted_at=NULL WHERE id=:id"), {"id": str(AG1)})
+            await s.commit()
+            # ⑤ team_members_legacy 물리테이블 잔존(G5 가역 자산)
+            legacy_kind = (await s.execute(text(
+                "SELECT relkind FROM pg_class WHERE relname='team_members_legacy'"
+            ))).scalar()
+            assert legacy_kind == "r", f"team_members_legacy 물리테이블 부재: {legacy_kind}"
+    finally:
         await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -751,3 +751,66 @@ async def test_ac3_4_team_members_projection_view():
             assert legacy_kind == "r", f"team_members_legacy 물리테이블 부재: {legacy_kind}"
     finally:
         await engine.dispose()
+
+
+# ── 0089(AC3-5 ①) project_access FK 가드 VALIDATE의 bad>0 분기(트랩#4b 실DB-only) ───────────────
+_GUARD_DO_0089_MEMBER = """
+DO $$
+DECLARE bad int;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fk_project_access_member') THEN
+        SELECT count(*) INTO bad FROM project_access pa
+        WHERE pa.member_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = pa.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE project_access VALIDATE CONSTRAINT fk_project_access_member;
+            RAISE NOTICE 'fk_project_access_member validated (bad=0)';
+        ELSE
+            RAISE NOTICE 'fk_project_access_member NOT VALID 유지: members 부재 referent % 건 — 점검 후 재VALIDATE 필요', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0089_guard_validate_project_access_fk_bad_gt0():
+    """⚠️ AC3-5 ① 트랩#4b(실DB-only): 0089 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid·
+    크래시 없이 NOT VALID 유지하는지. 위반행을 FK 추가 전 INSERT(NOT VALID도 신규검증) → 가드 DO 실행.
+    CI fresh-DB는 bad=0(VALIDATE)라 RAISE 분기 미발현 — % placeholder 회귀 가드(0080 교훈 동형)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_pa = uuid.UUID("c0000000-0000-0000-0000-0000000000fa")
+    absent_member = uuid.UUID("c9000000-0000-0000-0000-0000000000fa")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM project_access WHERE id=:i"), {"i": str(bad_pa)})
+            # FK 잠시 DROP → 위반행(member_id가 members에 없음) INSERT → NOT VALID로 재추가(기존행 검증 보류)
+            await s.execute(text("ALTER TABLE project_access DROP CONSTRAINT IF EXISTS fk_project_access_member"))
+            await s.execute(text(
+                "INSERT INTO project_access (id,project_id,org_member_id,member_id,permission,access_source) "
+                "VALUES (:id,:p,NULL,:m,'granted','direct')"
+            ), {"id": str(bad_pa), "p": str(P1), "m": str(absent_member)})
+            await s.execute(text(
+                "ALTER TABLE project_access ADD CONSTRAINT fk_project_access_member "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE CASCADE NOT VALID"
+            ))
+            await s.commit()
+        # 가드 DO 실행 — bad>0 → RAISE NOTICE 분기(크래시·% 회귀 없이)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0089_MEMBER))
+            await s.commit()
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname='fk_project_access_member'"
+            ))).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM project_access WHERE id=:i"), {"i": str(bad_pa)})
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -591,3 +591,102 @@ async def test_0083_revoke_orphan_org_apikey_and_validate():
             ))
             await s.commit()
         await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ensure_human_member_creates_anchor_idempotent():
+    """AC3-2c: ensure_human_member가 members 없는 휴먼 org_member에 members 행(id=om.id·type=human·
+    name=email)을 멱등 생성 — create_project_access가 member_id=org_member.id 세팅 전 호출(FK 충족)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import ensure_human_member
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    new_user = uuid.UUID("b2000000-0000-0000-0000-0000000000e1")
+    new_om = uuid.UUID("b3000000-0000-0000-0000-0000000000e1")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # members 없는 신규 휴먼 org_member(0075 이후 생성 모사)
+            await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM users WHERE id=:i"), {"i": str(new_user)})
+            await s.execute(text(
+                "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+                "VALUES (:u,'newhuman@pg.test','x','NewHuman',true,true,0,false,0)"), {"u": str(new_user)})
+            await s.execute(text(
+                "INSERT INTO org_members (id,org_id,user_id,role) VALUES (:om,:o,:u,'member')"),
+                {"om": str(new_om), "o": str(ORG), "u": str(new_user)})
+            await s.commit()
+        async with Session() as s:
+            ok = await ensure_human_member(s, new_om)
+            await s.commit()
+            assert ok is True
+            m = (await s.execute(text(
+                "SELECT type, name, user_id FROM members WHERE id=:i"), {"i": str(new_om)})).first()
+        assert m is not None and m.type == "human", "휴먼 members 미생성"
+        assert m.name == "NewHuman" and str(m.user_id) == str(new_user)
+        # 멱등: 재호출 무에러·중복 0
+        async with Session() as s:
+            await ensure_human_member(s, new_om)
+            await s.commit()
+            cnt = (await s.execute(text("SELECT count(*) FROM members WHERE id=:i"), {"i": str(new_om)})).scalar_one()
+            assert cnt == 1
+        # org_member 부재 → False(미세팅)
+        async with Session() as s:
+            assert await ensure_human_member(s, uuid.UUID("b3000000-0000-0000-0000-0000000000ee")) is False
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(new_om)})
+            await s.execute(text("DELETE FROM users WHERE id=:i"), {"i": str(new_user)})
+            await s.commit()
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_ensure_human_member_orphan_safe():
+    """⚠️ E1(QA): ensure_human_member orphan-safe — orphan org면 False(members.org_id FK 500 회피),
+    orphan user면 user_id=NULL(members.user_id FK 회피). 0084 §1 동형(트랩#3 실DB orphan)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import ensure_human_member
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    om_orphan_org = uuid.UUID("b3000000-0000-0000-0000-0000000000f1")   # org_id가 organizations에 없음
+    om_orphan_user = uuid.UUID("b3000000-0000-0000-0000-0000000000f2")  # user_id가 users에 없음
+    orphan_user = uuid.UUID("b2000000-0000-0000-0000-0000000000f2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            for i in (om_orphan_org, om_orphan_user):
+                await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
+                await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
+            # org_members.org_id/user_id는 FK 없음 → orphan 삽입 가능(실DB 정합 모사)
+            await s.execute(text(
+                "INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+                "(:o1,'cccccccc-0000-0000-0000-0000000000cc',:u0,'member'),"  # orphan org
+                "(:o2,:org,:uo,'member')"                                      # orphan user
+            ), {"o1": str(om_orphan_org), "u0": str(U_MEM), "o2": str(om_orphan_user), "org": str(ORG), "uo": str(orphan_user)})
+            await s.commit()
+        # orphan org → False, members 미생성(500 없이)
+        async with Session() as s:
+            assert await ensure_human_member(s, om_orphan_org) is False, "orphan org인데 True"
+            await s.commit()
+            cnt = (await s.execute(text("SELECT count(*) FROM members WHERE id=:i"), {"i": str(om_orphan_org)})).scalar_one()
+            assert cnt == 0, "orphan org members 생성됨(FK 위험)"
+        # orphan user → True, members 생성·user_id NULL
+        async with Session() as s:
+            assert await ensure_human_member(s, om_orphan_user) is True
+            await s.commit()
+            row = (await s.execute(text("SELECT user_id FROM members WHERE id=:i"), {"i": str(om_orphan_user)})).first()
+            assert row is not None and row[0] is None, f"orphan user인데 user_id 비-NULL: {row}"
+    finally:
+        async with Session() as s:
+            for i in (om_orphan_org, om_orphan_user):
+                await s.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(i)})
+                await s.execute(text("DELETE FROM org_members WHERE id=:i"), {"i": str(i)})
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -203,41 +203,99 @@ async def test_apikey_resolve_parity_legacy_vs_anchor():
         await engine.dispose()
 
 
+NEW_TM = uuid.UUID("b5000000-0000-0000-0000-0000000000b9")
+NEW_APIKEY = uuid.UUID("b7000000-0000-0000-0000-0000000000b9")
+
+
+async def _make_new_agent_tm(session):
+    """members/profile/apikey 없는 신규 agent team_member 삽입(재실행 정리 포함). TeamMember ORM 반환."""
+    from sqlalchemy import select, text
+    from app.models.team import TeamMember
+    await session.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(NEW_APIKEY)})
+    await session.execute(text("DELETE FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text("DELETE FROM members WHERE id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text("DELETE FROM team_members WHERE id=:i"), {"i": str(NEW_TM)})
+    await session.execute(text(
+        "INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by,agent_role,fakechat_port) "
+        "VALUES (:id,:p,:o,NULL,'agent','NewBot','member','#fff',false,true,:cb,'dev',9199)"
+    ), {"id": str(NEW_TM), "p": str(P1), "o": str(ORG), "cb": str(U_OWNER)})
+    await session.commit()
+    return (await session.execute(select(TeamMember).where(TeamMember.id == NEW_TM))).scalar_one()
+
+
 @pytest.mark.anyio
-async def test_apikey_insert_without_member_row_no_fk_violation():
-    """⚠️ H1 회귀: agent_api_keys.member_id에 members 없는 값(신규 agent 시뮬) INSERT가 FK 위반
-    없이 성공 — dual-write가 신규 agent 생성(auto API key)을 깨지 않음(생명선·머지 안전)."""
+async def test_agent_anchor_writesync_creates_members_and_profile():
+    """⚠️ 생명선 AC3-1b AC1: 신규 agent 생성 write-sync가 members(id=tm.id·type=agent·owner=생성휴먼)
+    + agent_project_profiles(member=tm.id·런타임 미러)를 만든다 → cut-on 무중단·project_id 해소·FK 충족."""
     from sqlalchemy import text
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
 
     engine = create_async_engine(_ASYNC_URL)
     Session = async_sessionmaker(engine, expire_on_commit=False)
     try:
         async with Session() as s:
             await _seed(s)
-        # members에 없는 team_member(AG1은 members 있으니 새 tm 생성) + 그 id로 api_key dual-write
-        new_tm = uuid.UUID("b5000000-0000-0000-0000-0000000000b9")
+            tm = await _make_new_agent_tm(s)
+            await sync_agent_anchor_on_create(s, tm, created_by=U_OWNER)
+            await s.commit()
         async with Session() as s:
-            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": "b7000000-0000-0000-0000-0000000000b9"})
-            await s.execute(text("DELETE FROM team_members WHERE id=:i"), {"i": str(new_tm)})
-            await s.execute(text(
-                "INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) "
-                "VALUES (:id,:p,:o,NULL,'agent','NewBot','member','#fff',false,true,:cb)"
-            ), {"id": str(new_tm), "p": str(P1), "o": str(ORG), "cb": str(U_OWNER)})
-            # dual-write: member_id=team_member_id (members 행 없음) — FK 없으므로 성공해야
+            m = (await s.execute(text(
+                "SELECT type, owner_member_id, name, is_active FROM members WHERE id=:i"), {"i": str(NEW_TM)})).first()
+            prof = (await s.execute(text(
+                "SELECT project_id, agent_role, fakechat_port FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).first()
+        assert m is not None and m.type == "agent" and m.is_active is True, "members(agent) 미생성"
+        assert str(m.owner_member_id) == str(OM_OWNER), f"owner_member_id=생성 휴먼 member 아님: {m.owner_member_id}"
+        assert prof is not None and str(prof.project_id) == str(P1) and prof.agent_role == "dev", "agent_project_profiles 미생성/미러 불일치"
+
+        # 멱등: 재호출해도 중복/에러 없음
+        async with Session() as s:
+            from sqlalchemy import select
+            from app.models.team import TeamMember
+            tmobj = (await s.execute(select(TeamMember).where(TeamMember.id == NEW_TM))).scalar_one()
+            await sync_agent_anchor_on_create(s, tmobj, created_by=U_OWNER)
+            await s.commit()
+            prof_cnt = (await s.execute(text(
+                "SELECT count(*) FROM agent_project_profiles WHERE member_id=:i"), {"i": str(NEW_TM)})).scalar_one()
+            assert prof_cnt == 1, f"멱등 위반: profile {prof_cnt}건"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apikey_insert_after_writesync_succeeds_and_absent_member_violates_fk():
+    """⚠️ 생명선 AC3-1b AC3: 0080 FK 재추가 후 — write-sync로 members 선행 시 신규 agent api_key
+    INSERT 성공(H1을 올바른 방식으로 해소), members 부재 member_id는 FK 위반(트랩#7/8 가드)."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.services.agent_anchor_sync import sync_agent_anchor_on_create
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            tm = await _make_new_agent_tm(s)
+            await sync_agent_anchor_on_create(s, tm, created_by=U_OWNER)  # members 선행
+            await s.commit()
+        # write-sync 후 api_key INSERT(member_id=tm.id) → FK 충족 성공
+        async with Session() as s:
             await s.execute(text(
                 "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
                 "VALUES (:id,:tm,:m,'sk_live_b9','hashb9',ARRAY['read','write'])"
-            ), {"id": "b7000000-0000-0000-0000-0000000000b9", "tm": str(new_tm), "m": str(new_tm)})
+            ), {"id": str(NEW_APIKEY), "tm": str(NEW_TM), "m": str(NEW_TM)})
             await s.commit()
-        # 검증: 삽입됨 + member_id가 members에 없음(FK 미적용 확인)
+            cnt = (await s.execute(text("SELECT count(*) FROM agent_api_keys WHERE id=:i"), {"i": str(NEW_APIKEY)})).scalar_one()
+            assert cnt == 1, "write-sync 후 api_key INSERT 실패(H1 회귀)"
+        # members 부재 member_id → FK 위반(0080 재추가 입증)
+        absent = uuid.UUID("b5000000-0000-0000-0000-0000000000ba")
         async with Session() as s:
-            cnt = (await s.execute(text(
-                "SELECT count(*) FROM agent_api_keys WHERE id='b7000000-0000-0000-0000-0000000000b9'"
-            ))).scalar_one()
-            assert cnt == 1
-            orphan = (await s.execute(text(
-                "SELECT count(*) FROM members WHERE id=:i"), {"i": str(new_tm)})).scalar_one()
-            assert orphan == 0  # members 없음에도 INSERT 성공 = FK 없음
+            with pytest.raises(IntegrityError):
+                await s.execute(text(
+                    "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash) "
+                    "VALUES (gen_random_uuid(),:tm,:m,'sk_live_ba','hashba')"
+                ), {"tm": str(absent), "m": str(absent)})
+                await s.commit()
     finally:
         await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -40,6 +40,8 @@ TM_OWNER = uuid.UUID("b5000000-0000-0000-0000-000000000001")  # 레거시 휴먼
 AG1 = uuid.UUID("b5000000-0000-0000-0000-0000000000a1")       # 멀티프로젝트 agent — proj1
 AG2 = uuid.UUID("b5000000-0000-0000-0000-0000000000a2")       # 멀티프로젝트 agent — proj2
 ORPHAN = uuid.UUID("bf000000-0000-0000-0000-000000000000")
+APIKEY_ID = uuid.UUID("b7000000-0000-0000-0000-000000000001")
+APIKEY_RAW = "sk_live_" + "0" * 64
 
 
 def _auth(uid, api_key=False):
@@ -97,6 +99,14 @@ async def _seed(session):
     ]
     for s in stmts:
         await session.execute(text(s))
+    # AC3-1: agent API key (team_member_id=member_id=AG1, 1:1) — dual-write 상태 모사
+    from app.core.security import hash_token
+    await session.execute(text(
+        "DELETE FROM agent_api_keys WHERE id=:id"), {"id": str(APIKEY_ID)})
+    await session.execute(text(
+        "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+        "VALUES (:id,:tm,:m,:pfx,:h,ARRAY['read','write'])"
+    ), {"id": str(APIKEY_ID), "tm": str(AG1), "m": str(AG1), "pfx": "sk_live_0", "h": hash_token(APIKEY_RAW)})
     await session.commit()
 
 
@@ -159,4 +169,75 @@ async def test_lookup_members_parity_identity_and_canonicalization():
         assert anchor[TM_OWNER].id == OM_OWNER
     finally:
         mr.settings.member_ssot_resolver_shadow = False
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apikey_resolve_parity_legacy_vs_anchor():
+    """⚠️ 생명선: _resolve_api_key가 flag off(team_member) vs on(member)에서 **동일 AuthContext**
+    (user_id·org_id·project_id·scope·api_key_id) — API key 인증 신원 무중단 입증."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.core import config as _cfg
+    from app.dependencies.auth import _resolve_api_key
+    from app.services import member_resolver as mr
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        _cfg.settings.member_ssot_apikey_cut = False
+        async with Session() as s:
+            legacy = await _resolve_api_key(APIKEY_RAW, s)
+        _cfg.settings.member_ssot_apikey_cut = True
+        async with Session() as s:
+            anchor = await _resolve_api_key(APIKEY_RAW, s)
+
+        assert legacy.user_id == anchor.user_id, f"user_id 불일치(무중단 위반): {legacy.user_id} vs {anchor.user_id}"
+        assert legacy.org_id == anchor.org_id
+        assert legacy.claims["app_metadata"] == anchor.claims["app_metadata"], \
+            f"app_metadata 불일치: {legacy.claims['app_metadata']} vs {anchor.claims['app_metadata']}"
+    finally:
+        _cfg.settings.member_ssot_apikey_cut = False
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_apikey_insert_without_member_row_no_fk_violation():
+    """⚠️ H1 회귀: agent_api_keys.member_id에 members 없는 값(신규 agent 시뮬) INSERT가 FK 위반
+    없이 성공 — dual-write가 신규 agent 생성(auto API key)을 깨지 않음(생명선·머지 안전)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+        # members에 없는 team_member(AG1은 members 있으니 새 tm 생성) + 그 id로 api_key dual-write
+        new_tm = uuid.UUID("b5000000-0000-0000-0000-0000000000b9")
+        async with Session() as s:
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": "b7000000-0000-0000-0000-0000000000b9"})
+            await s.execute(text("DELETE FROM team_members WHERE id=:i"), {"i": str(new_tm)})
+            await s.execute(text(
+                "INSERT INTO team_members (id,project_id,org_id,user_id,type,name,role,color,can_manage_members,is_active,created_by) "
+                "VALUES (:id,:p,:o,NULL,'agent','NewBot','member','#fff',false,true,:cb)"
+            ), {"id": str(new_tm), "p": str(P1), "o": str(ORG), "cb": str(U_OWNER)})
+            # dual-write: member_id=team_member_id (members 행 없음) — FK 없으므로 성공해야
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+                "VALUES (:id,:tm,:m,'sk_live_b9','hashb9',ARRAY['read','write'])"
+            ), {"id": "b7000000-0000-0000-0000-0000000000b9", "tm": str(new_tm), "m": str(new_tm)})
+            await s.commit()
+        # 검증: 삽입됨 + member_id가 members에 없음(FK 미적용 확인)
+        async with Session() as s:
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM agent_api_keys WHERE id='b7000000-0000-0000-0000-0000000000b9'"
+            ))).scalar_one()
+            assert cnt == 1
+            orphan = (await s.execute(text(
+                "SELECT count(*) FROM members WHERE id=:i"), {"i": str(new_tm)})).scalar_one()
+            assert orphan == 0  # members 없음에도 INSERT 성공 = FK 없음
+    finally:
         await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -441,3 +441,73 @@ async def test_0080_guard_validate_raise_branch_bad_gt0():
             ))
             await s.commit()
         await engine.dispose()
+
+
+# ── 0082 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기 syntax 검증(트랩#4 실DB-only) ──────────────────
+_GUARD_DO_0082 = f"""
+DO $$
+DECLARE bad int;
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_constraint WHERE conname = '{_FK_0080}' AND NOT convalidated) THEN
+        SELECT count(*) INTO bad FROM agent_api_keys ak
+        WHERE ak.member_id IS NOT NULL
+          AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+        IF bad = 0 THEN
+            ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+        ELSE
+            RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 (window 보정 후에도 잔여 — 점검 필요)', bad;
+        END IF;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0082_guard_validate_raise_branch_bad_gt0():
+    """⚠️ 트랩#4(실DB-only): 0082 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid해야 한다.
+    0082 백필은 team_members 기반이라 team_member 없는 orphan api_key member_id는 보정 못 함 → bad>0
+    잔여 시 RAISE 분기를 탄다(0080과 동일 % 회귀 가드, IF EXISTS NOT convalidated 래퍼 포함). 위반행을
+    FK 추가 전 INSERT(NOT VALID도 신규검증) → FK NOT VALID → 가드 DO 크래시 없이 NOT VALID 유지하는지."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_key = uuid.UUID("b7000000-0000-0000-0000-0000000000c2")
+    # member_id가 members에도 없고 team_member.id도 아닌 orphan — 0082 백필(members.id=team_member.id 기반)
+    # 으로도 생성 불가 → bad>0 잔여. team_member_id는 실존 AG1(agent_api_keys.team_member_id FK 충족).
+    orphan_member = uuid.UUID("b9000000-0000-0000-0000-0000000000c2")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+                "VALUES (:id,:tm,:m,'sk_live_c2','hashc2',ARRAY['read','write'])"
+            ), {"id": str(bad_key), "tm": str(AG1), "m": str(orphan_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        # 0082 가드 DO 실행 — bad>0 → RAISE NOTICE 분기. SyntaxError 없이 통과해야(% 회귀 가드)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0082))
+            await s.commit()
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -299,3 +299,73 @@ async def test_apikey_insert_after_writesync_succeeds_and_absent_member_violates
                 await s.commit()
     finally:
         await engine.dispose()
+
+
+# ── 0080 hotfix: 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기 syntax 검증(트랩#4 실DB-only) ──────────
+_FK_0080 = "fk_agent_api_keys_member_id_members"
+_GUARD_DO_0080 = f"""
+DO $$
+DECLARE bad int;
+BEGIN
+    SELECT count(*) INTO bad FROM agent_api_keys ak
+    WHERE ak.member_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM members m WHERE m.id = ak.member_id);
+    IF bad = 0 THEN
+        ALTER TABLE agent_api_keys VALIDATE CONSTRAINT {_FK_0080};
+    ELSE
+        RAISE NOTICE 'agent_api_keys.member_id FK NOT VALID 유지: members 부재 row % 건 — AC2 감사·보정 후 재VALIDATE 필요', bad;
+    END IF;
+END $$;
+"""
+
+
+@pytest.mark.anyio
+async def test_0080_guard_validate_raise_branch_bad_gt0():
+    """⚠️ 트랩#4(실DB-only): 0080 가드 VALIDATE의 bad>0(RAISE NOTICE) 분기가 syntax-valid해야 한다.
+    CI fresh-DB는 bad=0(VALIDATE 분기)라 RAISE 분기 미발현 — members 부재 active key가 실재하는 dev에서만
+    터졌던 `too many parameters for RAISE`(%% vs % 회귀) 가드. 위반행을 FK 추가 전 INSERT(NOT VALID도
+    신규검증) → FK NOT VALID → 가드 DO 실행이 크래시 없이 NOT VALID 유지하는지."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    bad_key = uuid.UUID("b7000000-0000-0000-0000-0000000000c0")
+    absent_member = uuid.UUID("b9000000-0000-0000-0000-0000000000c0")
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            for fk in (_FK_0080, "agent_api_keys_member_id_fkey"):
+                await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {fk}"))
+            # FK 부재 상태에서 위반행 INSERT(member_id가 members에 없음) — bad>0 모사
+            await s.execute(text(
+                "INSERT INTO agent_api_keys (id,team_member_id,member_id,key_prefix,key_hash,scope) "
+                "VALUES (:id,:tm,:m,'sk_live_c0','hashc0',ARRAY['read','write'])"
+            ), {"id": str(bad_key), "tm": str(AG1), "m": str(absent_member)})
+            await s.execute(text(
+                f"ALTER TABLE agent_api_keys ADD CONSTRAINT {_FK_0080} "
+                f"FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        # 가드 DO 실행 — bad>0 → RAISE NOTICE 분기. SyntaxError 없이 통과해야(%% 회귀 가드)
+        async with Session() as s:
+            await s.execute(text(_GUARD_DO_0080))
+            await s.commit()
+        # FK는 NOT VALID 유지(가드가 VALIDATE 안 함)
+        async with Session() as s:
+            convalidated = (await s.execute(text(
+                "SELECT convalidated FROM pg_constraint WHERE conname=:n"), {"n": _FK_0080})).scalar_one()
+        assert convalidated is False, "bad>0인데 FK가 VALIDATE됨(가드 오작동)"
+    finally:
+        async with Session() as s:
+            await s.execute(text("DELETE FROM agent_api_keys WHERE id=:i"), {"i": str(bad_key)})
+            await s.execute(text(f"ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS {_FK_0080}"))
+            # 모델 baseline FK 복원(NOT VALID — 검증 실패 없이 재실행/타테스트 오염 방지)
+            await s.execute(text("ALTER TABLE agent_api_keys DROP CONSTRAINT IF EXISTS agent_api_keys_member_id_fkey"))
+            await s.execute(text(
+                "ALTER TABLE agent_api_keys ADD CONSTRAINT agent_api_keys_member_id_fkey "
+                "FOREIGN KEY (member_id) REFERENCES members(id) ON DELETE SET NULL NOT VALID"
+            ))
+            await s.commit()
+        await engine.dispose()

--- a/backend/tests/test_member_ssot_parity_realdb.py
+++ b/backend/tests/test_member_ssot_parity_realdb.py
@@ -339,8 +339,13 @@ async def test_get_missing_canonical_single_identity():
             await _seed(s)
             await s.execute(text("DELETE FROM standup_entries WHERE project_id=:p AND date=:d"),
                             {"p": str(P1), "d": _SD_DATE})
+            # ⚠️ 실 grant 플로우 모사: create_project_access는 member_id를 NULL로 둔다(org_member_id만).
+            # branch2가 member_id 키면 OM_MEM 누락(신규 grant-only 휴먼 미표시) → org_member_id 키여야 함.
+            await s.execute(text(
+                "UPDATE project_access SET member_id=NULL WHERE project_id=:p AND org_member_id=:m"),
+                {"p": str(P1), "m": str(OM_MEM)})
             await s.commit()
-        # roster(P1) = owner(OM_OWNER) ∪ grant(OM_MEM) ∪ 레거시 휴먼 tm(TM_OWNER→OM_OWNER) = {OWNER, MEM}
+        # roster(P1) = owner(OM_OWNER) ∪ grant(OM_MEM, member_id=NULL) ∪ 레거시 휴먼 tm(TM_OWNER→OM_OWNER)
         async with Session() as s:
             missing = set(await StandupEntryRepository(s, ORG).get_missing(P1, _SD_DATE))
         assert missing == {OM_OWNER, OM_MEM}, f"roster 불일치: {missing}"

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -238,10 +238,11 @@ async def test_soft_delete_200():
             # call 1: router get(id) for existing check
             # call 2: revoke refresh tokens (UPDATE)
             # call 3: cascade UPDATE team_members is_active=false
-            # call 4: S-MBR-10 AC5 DELETE project_access
-            # call 5: soft_delete internal get(id)
-            # call 6: soft_delete UPDATE deleted_at
-            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 5) else None
+            # call 4: AC3-4 2-1 dual-write UPDATE members is_active=false (NEW)
+            # call 5: S-MBR-10 AC5 DELETE project_access
+            # call 6: soft_delete internal get(id)
+            # call 7: soft_delete UPDATE deleted_at
+            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 6) else None
             result.scalars.return_value.all.return_value = []
             return result
 

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -237,12 +237,11 @@ async def test_soft_delete_200():
             result = MagicMock()
             # call 1: router get(id) for existing check
             # call 2: revoke refresh tokens (UPDATE)
-            # call 3: cascade UPDATE team_members is_active=false
-            # call 4: AC3-4 2-1 dual-write UPDATE members is_active=false (NEW)
-            # call 5: S-MBR-10 AC5 DELETE project_access
-            # call 6: soft_delete internal get(id)
-            # call 7: soft_delete UPDATE deleted_at
-            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 6) else None
+            # call 3: AC3-4 2-2 anchor-only UPDATE members is_active=false (레거시 team_members UPDATE 제거)
+            # call 4: S-MBR-10 AC5 DELETE project_access
+            # call 5: soft_delete internal get(id)
+            # call 6: soft_delete UPDATE deleted_at
+            result.scalar_one_or_none.return_value = _mock_member() if call_count in (1, 5) else None
             result.scalars.return_value.all.return_value = []
             return result
 

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -151,7 +151,7 @@ async def test_heartbeat_404_if_not_found():
     client, session, app = await _heartbeat_client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:

--- a/backend/tests/test_s38.py
+++ b/backend/tests/test_s38.py
@@ -126,7 +126,8 @@ async def test_account_delete_updates_org_and_team_members():
         async with client as c:
             await c.post("/api/v2/account/delete")
 
-        assert session.execute.call_count == 2
+        # AC3-4 2-1 dual-write: org_members + team_members + **members**(anchor) UPDATE = 3
+        assert session.execute.call_count == 3
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_s38.py
+++ b/backend/tests/test_s38.py
@@ -126,8 +126,8 @@ async def test_account_delete_updates_org_and_team_members():
         async with client as c:
             await c.post("/api/v2/account/delete")
 
-        # AC3-4 2-1 dual-write: org_members + team_members + **members**(anchor) UPDATE = 3
-        assert session.execute.call_count == 3
+        # AC3-4 2-2 anchor-only: org_members + **members**(anchor) UPDATE = 2 (레거시 team_members UPDATE 제거)
+        assert session.execute.call_count == 2
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_standups.py
+++ b/backend/tests/test_standups.py
@@ -256,7 +256,7 @@ async def test_update_standup_self_save_no_author_id_200():
         entry = _mock_entry()
         entry.author_id = derived_member_id
 
-        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:
@@ -288,7 +288,7 @@ async def test_update_standup_ignores_client_author_id():
         entry = _mock_entry()
         entry.author_id = derived
 
-        with patch("app.routers.standups.resolve_auth_member", new=AsyncMock(return_value=member)), \
+        with patch("app.routers.standups.resolve_member", new=AsyncMock(return_value=member)), \
              patch("app.repositories.standup.StandupEntryRepository.upsert", new_callable=AsyncMock) as mock_upsert:
             mock_upsert.return_value = entry
             async with client as c:

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -142,7 +142,8 @@ async def test_get_team_member_200():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_member()
+        # AC3-4 2-2: repo.get은 뷰 multi-row 방어로 scalars().first() 사용
+        mock_result.scalars.return_value.first.return_value = _mock_member()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:
@@ -159,7 +160,7 @@ async def test_get_team_member_404():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:
@@ -177,8 +178,10 @@ async def test_update_team_member_200():
         updated = _mock_member()
         updated.color = "#ff0000"
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = updated
+        # AC3-4 2-2: PATCH = repo.get(scalars().first()) → apply_anchor_update → expire → repo.get
+        mock_result.scalars.return_value.first.return_value = updated
         session.execute = AsyncMock(return_value=mock_result)
+        session.expire = MagicMock()  # sync 메서드(AsyncMock 코루틴 경고 회피)
 
         async with client as c:
             resp = await c.patch(f"/api/v2/team-members/{MEMBER_ID}", json={"color": "#ff0000"})
@@ -227,7 +230,7 @@ async def test_deactivate_not_found_404():
     client, session, app = await _client()
     try:
         mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = None
+        mock_result.scalars.return_value.first.return_value = None  # AC3-4 2-2: deactivate→get→scalars().first()
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:


### PR DESCRIPTION
공유 dev/prod DB에 0084~0091(team_members→뷰 포함) 이미 라이브 → prod 구 코드(fd10df2d) team_members write가 뷰-write 500 잠재위험. AC3-x 코드(anchor-write 호환) 승격으로 해소. flags-off(write/뷰 호환은 무조건부, flag flip은 별도 선생님 타이밍). 선생님 GO(2026-06-04). 22커밋: AC2-x 잔여~AC3-5 #1196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)