### PR TITLE
[SID:E-BOARD-UX-S7] /epics 더보기 페이지네이션 — 마지막 에픽 중복 수정

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -732,6 +732,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const [epicsHasMore, setEpicsHasMore] = useState(false);
   const [epicsNextCursor, setEpicsNextCursor] = useState<string | null>(null);
   const [epicsLoadingMore, setEpicsLoadingMore] = useState(false);
+  const [epicsLoadMoreError, setEpicsLoadMoreError] = useState(false);
   const [statusFilter, setStatusFilter] = useState<EpicStatus | 'all'>('all');
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
@@ -741,17 +742,24 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
       const params = new URLSearchParams({ project_id: projectId, limit: '20' });
       if (cursor) params.set('cursor', cursor);
       const res = await fetch(`/api/epics?${params.toString()}`);
-      if (!res.ok) throw new Error('Failed to fetch epics');
+      if (!res.ok) throw new Error(`Failed to fetch epics: ${res.status}`);
       const { data, meta } = await res.json() as { data: Epic[]; meta?: { hasMore?: boolean; nextCursor?: string | null } };
       if (cursor) {
-        setEpics((prev) => [...prev, ...(data ?? [])]);
+        // append 시 id 기준 중복 방어 (cursor 전진 버그 재발 대비 안전망)
+        setEpics((prev) => {
+          const seen = new Set(prev.map((e) => e.id));
+          return [...prev, ...(data ?? []).filter((e) => !seen.has(e.id))];
+        });
       } else {
         setEpics(data ?? []);
       }
       setEpicsHasMore(meta?.hasMore ?? false);
       setEpicsNextCursor(meta?.nextCursor ?? null);
-    } catch {
-      // noop — show empty state
+      setEpicsLoadMoreError(false);
+    } catch (err) {
+      // AC3: silent-swallow 금지 — 최소 로깅 + (더보기 실패 시) 인라인 표시
+      console.error('[epics] 목록을 불러오지 못했습니다', err);
+      if (cursor) setEpicsLoadMoreError(true);
     } finally {
       setLoading(false);
       setEpicsLoadingMore(false);
@@ -761,6 +769,7 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
   const loadMoreEpics = useCallback(async () => {
     if (!epicsHasMore || !epicsNextCursor || epicsLoadingMore) return;
     setEpicsLoadingMore(true);
+    setEpicsLoadMoreError(false);
     await fetchEpics(epicsNextCursor);
   }, [epicsHasMore, epicsNextCursor, epicsLoadingMore, fetchEpics]);
 
@@ -874,11 +883,18 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
                 onDeleteRequest={(id) => setDeleteConfirmId(id)}
               />
             ))}
-            {epicsHasMore && (
+            {epicsLoadMoreError ? (
+              <div className="flex flex-col items-center gap-1 py-2">
+                <p className="text-xs text-destructive">에픽을 더 불러오지 못했습니다.</p>
+                <Button variant="ghost" size="sm" onClick={() => void loadMoreEpics()} disabled={epicsLoadingMore}>
+                  {epicsLoadingMore ? '로딩 중...' : '다시 시도'}
+                </Button>
+              </div>
+            ) : epicsHasMore ? (
               <Button variant="ghost" size="sm" className="w-full text-muted-foreground" onClick={() => void loadMoreEpics()} disabled={epicsLoadingMore}>
                 {epicsLoadingMore ? '로딩 중...' : '더 보기'}
               </Button>
-            )}
+            ) : null}
           </div>
         )}
       </div>

--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -4,7 +4,7 @@ import { EpicService, type CreateEpicInput } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
+import { paginateInMemory, parseCursorPageInput } from '@/lib/pagination';
 import { createEpicRepository } from '@/lib/storage/factory';
 import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
 
@@ -21,12 +21,12 @@ export async function GET(request: Request) {
     }, { defaultLimit: 50, maxLimit: 100 });
     const repo = await createEpicRepository();
     const service = new EpicService(repo);
+    // 백엔드 GET /api/v2/epics 는 cursor/limit/order_by 미지원 — 프로젝트 전체 목록을 정렬 없이 반환한다.
+    // 따라서 cursor 페이징은 여기(라우트)에서 결정적 정렬 + cursor 적용으로 수행한다.
     const epics = await service.list({
       project_id: searchParams.get('project_id') ?? undefined,
-      limit: pageInput.limit,
-      cursor: pageInput.cursor,
     });
-    const { page, meta } = buildCursorPageMeta(epics, pageInput.limit, 'created_at');
+    const { page, meta } = paginateInMemory(epics, pageInput.limit, 'created_at', pageInput.cursor);
     return apiSuccess(page, meta);
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/apps/web/src/lib/pagination.test.ts
+++ b/apps/web/src/lib/pagination.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildCursorPageMeta, parseCursorPageInput } from './pagination';
+import { buildCursorPageMeta, paginateInMemory, parseCursorPageInput } from './pagination';
 
 describe('pagination helpers', () => {
   it('clamps limit and normalizes cursor input', () => {
@@ -18,5 +18,45 @@ describe('pagination helpers', () => {
 
     expect(page).toEqual([{ created_at: '3' }, { created_at: '2' }]);
     expect(meta).toEqual({ limit: 2, hasMore: true, nextCursor: '2' });
+  });
+});
+
+describe('paginateInMemory (epics: 백엔드 정렬/cursor 미지원)', () => {
+  // 백엔드가 무작위 순서로 반환하는 상황을 모사 (created_at 동률 포함)
+  const rows = [
+    { id: 'e', created_at: '2026-01-03T00:00:00Z' },
+    { id: 'a', created_at: '2026-01-05T00:00:00Z' },
+    { id: 'c', created_at: '2026-01-04T00:00:00Z' }, // c, d 동률
+    { id: 'd', created_at: '2026-01-04T00:00:00Z' },
+    { id: 'b', created_at: '2026-01-05T00:00:00Z' }, // a, b 동률
+    { id: 'f', created_at: '2026-01-02T00:00:00Z' },
+  ];
+
+  it('첫 페이지는 created_at desc + id desc 로 결정적 정렬한다', () => {
+    const { page, meta } = paginateInMemory(rows, 2, 'created_at');
+    expect(page.map((r) => r.id)).toEqual(['b', 'a']); // 05/b, 05/a
+    expect(meta.hasMore).toBe(true);
+    expect(meta.nextCursor).toBe('2026-01-05T00:00:00Z|a');
+  });
+
+  it('cursor 전진 시 동률 항목을 중복/누락 없이 이어붙인다', () => {
+    const all: string[] = [];
+    let cursor: string | null = null;
+    // 더보기 반복 시뮬레이션
+    for (let i = 0; i < 10; i++) {
+      const { page, meta } = paginateInMemory(rows, 2, 'created_at', cursor);
+      all.push(...page.map((r) => r.id));
+      if (!meta.hasMore) break;
+      cursor = meta.nextCursor;
+    }
+    // 각 에픽이 정확히 1회, 전체가 정렬 순서대로 (AC1: 중복 0)
+    expect(all).toEqual(['b', 'a', 'd', 'c', 'e', 'f']);
+    expect(new Set(all).size).toBe(rows.length);
+  });
+
+  it('마지막 페이지는 hasMore=false, nextCursor=null', () => {
+    const { meta } = paginateInMemory(rows.slice(0, 2), 5, 'created_at');
+    expect(meta.hasMore).toBe(false);
+    expect(meta.nextCursor).toBeNull();
   });
 });

--- a/apps/web/src/lib/pagination.ts
+++ b/apps/web/src/lib/pagination.ts
@@ -46,3 +46,50 @@ export function buildCursorPageMeta<T extends object, K extends keyof T & string
     },
   };
 }
+
+/**
+ * 백엔드가 cursor/limit를 지원하지 않고 전체 목록을 정렬 없이 반환하는 경우(에픽 GET /api/v2/epics)
+ * 라우트에서 결정적으로 정렬한 뒤 cursor를 적용해 한 페이지를 잘라낸다.
+ *
+ * - 정렬: cursorField 내림차순, 동률(타이) 시 id 내림차순 — 백엔드 ORDER BY 부재로 인한
+ *   비결정적 순서/타이를 안정화한다.
+ * - cursor: `${cursorField}|${id}` 복합 키. created_at 동률에서도 중복/누락 없이 다음 페이지로 전진한다.
+ *   client는 이 값을 불투명(opaque) 문자열로 그대로 되돌려준다.
+ */
+export function paginateInMemory<T extends { id: string }, K extends keyof T & string>(
+  rows: T[] | null | undefined,
+  limit: number,
+  cursorField: K,
+  cursor?: string | null,
+): { page: T[]; meta: CursorPageMeta } {
+  const keyVal = (r: T) => String(r[cursorField] ?? '');
+  const sorted = [...(rows ?? [])].sort((a, b) => {
+    const ka = keyVal(a), kb = keyVal(b);
+    if (ka !== kb) return ka < kb ? 1 : -1;            // cursorField desc
+    return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;     // id desc 타이브레이크
+  });
+
+  let afterCursor = sorted;
+  if (cursor) {
+    const sep = cursor.indexOf('|');
+    const cKey = sep >= 0 ? cursor.slice(0, sep) : cursor;
+    const cId = sep >= 0 ? cursor.slice(sep + 1) : '';
+    afterCursor = sorted.filter((r) => {
+      const k = keyVal(r);
+      return k !== cKey ? k < cKey : r.id < cId;       // cursor 항목 "이후"만
+    });
+  }
+
+  const hasMore = afterCursor.length > limit;
+  const page = hasMore ? afterCursor.slice(0, limit) : afterCursor;
+  const tail = page.at(-1);
+
+  return {
+    page,
+    meta: {
+      limit,
+      hasMore,
+      nextCursor: hasMore && tail ? `${keyVal(tail)}|${tail.id}` : null,
+    },
+  };
+}


### PR DESCRIPTION
## 요약
`/epics` 리스트 **더보기** 클릭 시 다음 페이지가 아니라 같은 페이지가 다시 append 되어 에픽이 **중복**되던 버그를 수정. (선생님이 에픽 리스트 검토 중 직접 발견, 월요일 데모 표면)

스토리: E-BOARD-UX S7 (`16bc880f-...`) | high / FE

## 근본 원인 (코드에서 확정)
오르테가군 추정(cursor 미전진)은 정확했고, 코드 분석으로 정확한 위치를 확정:

1. **백엔드 `GET /api/v2/epics` 는 cursor/limit/`order_by` 미지원** — 프로젝트 전체 에픽을 **정렬 없이** 반환 (`BaseRepository.list` 에 ORDER BY 없음). `SupabaseEpicRepository.list` 도 limit/cursor 를 백엔드에 전달하지 않음.
2. FE 라우트의 `buildCursorPageMeta` 는 들어온 `cursor` 를 **무시**하고 항상 `slice(0, limit)` (앞에서부터) → 더보기마다 같은 페이지 재반환 → 중복 append.
3. 실데이터: 에픽 **179개**, `created_at` **동률 15건** + 무작위 순서. created_at 단독 cursor 로는 동률 경계에서 누락/중복 위험.

> 스토리들(`/api/v2/stories`)은 백엔드가 cursor/limit 를 지원(CB-S4)하는 반면 에픽 백엔드는 미지원이라, 이번 수정은 **FE 라우트 내 인메모리 페이징**으로 처리(백엔드 변경 없음, 미르코 도메인). 추후 에픽 백엔드도 stories 패턴으로 정렬하면 인메모리 페이징은 제거 가능 — 은와추쿠군과 후속 정렬 여부 협의 가능.

## 변경 사항
- **`lib/pagination.ts`**: `paginateInMemory` 추가 — `created_at` desc + `id` desc 결정적 정렬 후 복합 cursor(`created_at|id`)로 다음 페이지 전진. created_at 동률에서도 중복/누락 0. (client 는 cursor 를 불투명 문자열로 그대로 회신 → 포맷 변경 무영향)
- **`api/epics/route.ts`**: `buildCursorPageMeta` → `paginateInMemory`, 백엔드에 무시되던 limit/cursor 전달 제거.
- **`epics-client.tsx`** (AC3): `catch {}` silent-swallow 제거 → `console.error` + 더보기 실패 시 인라인 **"다시 시도"** 푸터(기존 `text-destructive` 토큰 재사용, 신규 토큰 0). append 시 id 기준 **중복 방어 안전망** 추가.
- **`pagination.test.ts`**: 동률/무작위 순서 cursor 전진 + 중복 0 검증 3건 추가.

## AC 체크
- [x] **AC1** 더보기 → 다음 페이지 append, 중복 0 (cursor 가 마지막 항목 이후로 전진). 실데이터 179개 시뮬레이션: 9페이지, **중복 0, 전수 1회 커버**.
- [x] **AC2** 마지막 페이지 시 더보기 버튼 **unmount** (기존 `{epicsHasMore && ...}` — 유나양 권장과 일치).
- [x] **AC3** silent-swallow 제거 → 로깅 + 인라인 에러/다시 시도.
- [ ] **AC4** Puppeteer 시각검증 → 유나양이 머지 후 dev 에서 직접 수행·첨부 (핸드오프 합의)

## 디자인 가디언 가이드 반영
더보기 4상태: default / loading(`disabled`+"로딩 중...", 중복클릭 방지) / last-page(unmount, 빈 푸터) / error(인라인 "에픽을 더 불러오지 못했습니다." + "다시 시도"). **신규 디자인 토큰·매직넘버 0, 기존 패턴 재사용.**

## 검증
- `vitest`: 5/5 passed — 신규 `paginateInMemory` 3개 + 기존 2개 ✅
- `lint`: 0 errors (변경 파일 경고 0, 잔여 경고는 무관 파일 기존분) ✅
- `build`: ✓ Compiled, 158/158 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
