### PR TITLE
feat(E-INFRA S1): prod Cloud SQL tier 다운사이즈 → db-g1-small

### DIFF
--- a/backend/scripts/provision_cloud_sql.sh
+++ b/backend/scripts/provision_cloud_sql.sh
@@ -91,19 +91,26 @@ create_dev() {
 
 # ─── Prod 인스턴스 생성 ───────────────────────────────────────────────────────
 create_prod() {
-    log "Creating prod instance '${INSTANCE_PROD}' (db-custom-2-7680)..."
+    # E-INFRA S1 비용 다운사이즈: db-custom-2-7680(과스펙) → db-g1-small(1.7GB).
+    # 천장 제거의 본질은 tier가 아니라 dev/prod 분리. 초기 prod엔 small로 충분하고,
+    # 실부하 증가 시 tier만 상향하면 된다.
+    #   max_connections=100 고정 — g1-small(1.7GB) 메모리 한도. ~10MB/conn 기준
+    #     150+ 는 OOM 위험(150≈1.5GB)이라 100으로 OOM-safe 고정.
+    #     (prod 백엔드 풀 right-size는 S2에서 처리)
+    #   PITR 제외 — 초기 prod 비용 절감. 일 백업(03:00)+7일 보존으로 안전판 유지.
+    #   storage 20GB — 신규 빈 인스턴스, auto-increase 켜둠(dev=10GB 대비 소폭 상향).
+    log "Creating prod instance '${INSTANCE_PROD}' (db-g1-small)..."
     gcloud sql instances create "${INSTANCE_PROD}" \
         --database-version=POSTGRES_15 \
-        --tier=db-custom-2-7680 \
+        --tier=db-g1-small \
         --region="${GCP_REGION}" \
         --network="${VPC_NETWORK}" \
         --no-assign-ip \
         --enable-google-private-path \
         --backup-start-time=03:00 \
         --retained-backups-count=7 \
-        --enable-point-in-time-recovery \
-        --retained-transaction-log-days=7 \
-        --storage-size=50 \
+        --database-flags=max_connections=100 \
+        --storage-size=20 \
         --storage-type=SSD \
         --storage-auto-increase \
         --project="${GCP_PROJECT}"


### PR DESCRIPTION
## E-INFRA S1 후속 — prod 인스턴스 tier 다운사이즈

story `effec480-c083-4d9b-96b9-6d2be0948359` | epic E-INFRA-SCALE | #1199 후속 (provision 스크립트 단독 변경)

선생님 비용 결정(다운사이즈) 반영. `provision_cloud_sql.sh` 의 `create_prod` tier 조정.

| 항목 | before | after | 근거 |
|------|--------|-------|------|
| tier | db-custom-2-7680 (7.5GB) | **db-g1-small (1.7GB)** | 천장 제거 본질은 tier 아닌 dev/prod 분리. 초기 prod 충분, 실부하 시 tier만 상향 |
| max_connections | (기본) | **100 명시** | g1-small OOM-safe. ~10MB/conn → 150+ 위험. 풀 right-size는 S2 |
| PITR | 켜짐 | **제외** | 비용 절감. 일 백업(03:00)+7일 보존 유지 |
| storage | 50GB | **20GB** | 신규 빈 인스턴스, auto-increase 유지 |

**불변:** Private IP / `--no-assign-ip` / `--enable-google-private-path` / DB·user 생성 / 백업.

### ⚠️ How=디디 판단 항목 (PO 확인 요청)
- **PITR 제외**: PO 제안대로 초기 prod 비용 절감. 일 백업+7일 보존이 안전판. 추후 필요 시 재활성화 가능.
- **storage 20GB**: PO 미지정 항목 — 다운사이즈 취지에 맞춰 우측조정(dev 10GB 대비 소폭↑). 이견 시 조정.
- **max_connections=100**: PO 권장 100-150 중 OOM-safe 하한. prod 백엔드 풀(현 10인스턴스×30)과의 산수는 S2에서 정합.

검증: `bash -n` PASS. 실제 생성은 PO가 `provision_cloud_sql.sh prod` 수동 실행 → `SHOW max_connections` 실측.

🤖 Generated with [Claude Code](https://claude.com/claude-code)