### PR TITLE
feat(E-FILE S2): conversation_messages.attachments 마이그(0093) + 모델 정합

### DIFF
--- a/backend/alembic/versions/0093_add_attachments_to_conversation_messages.py
+++ b/backend/alembic/versions/0093_add_attachments_to_conversation_messages.py
@@ -1,0 +1,32 @@
+"""add attachments to conversation_messages
+
+E-FILE S2: 채팅 메시지 첨부 저장용 attachments JSONB 컬럼 추가.
+additive(nullable + server_default '[]')라 공유 dev/prod DB에서 breaking 아님 —
+기존 행은 server_default로 '[]' 채워지고, 구버전 앱 코드도 attachments 미지정 INSERT 안전.
+
+story 첨부(stories 컬럼 vs story_attachments 테이블)는 E-FILE S4 모델 확정 후
+sibling rev로 별도 추가 (PO 지침).
+
+Revision ID: 0093
+Revises: 0092
+Create Date: 2026-06-04
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0093"
+down_revision = "0092"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversation_messages",
+        sa.Column("attachments", JSONB, nullable=True, server_default=sa.text("'[]'")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversation_messages", "attachments")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func
+from sqlalchemy import DateTime, ForeignKey, Text, UniqueConstraint, func, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -83,5 +83,9 @@ class ConversationMessage(Base, TimestampMixin):
     )
     review_type: Mapped[str | None] = mapped_column(Text, nullable=True)
     msg_metadata: Mapped[dict | None] = mapped_column("metadata", JSONB, nullable=True)
+    # E-FILE S2: 첨부 목록. additive(nullable + server_default '[]') — 0093 마이그와 정합.
+    attachments: Mapped[list | None] = mapped_column(
+        JSONB, nullable=True, server_default=text("'[]'"), default=list
+    )
 
     conversation: Mapped[Conversation] = relationship("Conversation", back_populates="messages")

--- a/backend/tests/test_efile_s2_attachments.py
+++ b/backend/tests/test_efile_s2_attachments.py
@@ -1,0 +1,41 @@
+"""E-FILE S2: conversation_messages.attachments 마이그(0093) + 모델 정합 검증.
+
+실 DB 적용은 sprintable-migrate-dev(asyncpg)로 별도 확인 — CI(SQLite)는 asyncpg
+런타임을 못 잡으므로 여기선 마이그 파일 계약 + 모델 컬럼 정의만 잠근다.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+
+_MIGRATION = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions",
+    "0093_add_attachments_to_conversation_messages.py",
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("rev_0093", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_migration_0093_chains_off_0092():
+    mod = _load_migration()
+    assert mod.revision == "0093"
+    assert mod.down_revision == "0092"
+    assert callable(mod.upgrade) and callable(mod.downgrade)
+
+
+def test_model_has_attachments_jsonb_additive():
+    """모델 컬럼: JSONB, nullable, server_default '[]' (additive·non-breaking)."""
+    from sqlalchemy.dialects.postgresql import JSONB
+
+    from app.models.conversation import ConversationMessage
+
+    col = ConversationMessage.__table__.c.attachments
+    assert isinstance(col.type, JSONB)
+    assert col.nullable is True
+    assert col.server_default is not None
+    assert "[]" in str(col.server_default.arg)


### PR DESCRIPTION
## E-FILE S2 — DB migration (채팅 첨부)

story `594f5d84-1831-4614-90a1-a8c415325a12` | epic E-FILE-ATTACH

채팅 메시지 첨부 저장용 `conversation_messages.attachments` JSONB 컬럼 추가.

### 변경
| 파일 | 변경 |
|------|------|
| `alembic/versions/0093_...py` (신규) | rev 0093 (down_revision=0092). `ADD COLUMN attachments JSONB DEFAULT '[]'`, downgrade `DROP COLUMN` |
| `app/models/conversation.py` | `ConversationMessage.attachments` 필드 동기화 (JSONB, nullable, server_default '[]', default=list) |
| `tests/test_efile_s2_attachments.py` (신규) | 마이그 계약(0093→0092) + 모델 컬럼 정의 잠금 |

### AC 매핑
- ✅ rev 0092 다음 0093에 `attachments` JSONB(nullable / server_default '[]') 추가 — offline DDL: `ALTER TABLE conversation_messages ADD COLUMN attachments JSONB DEFAULT '[]'`
- ✅ downgrade 정의 — `DROP COLUMN attachments`
- ⏳ **story 첨부 파트 deferred**: E-FILE S4 모델(stories 컬럼 vs story_attachments 테이블) 미결 → PO 지침대로 chat 파트 먼저, story 파트는 S4 확정 후 **sibling rev**로. (현 E-FILE-ATTACH 에픽에 S4 모델 확정 스토리 미발견)
- ⏳ dev 적용 — 머지 후 `sprintable-migrate-dev`(asyncpg)로 실 적용+확인 예정 (CI SQLite는 asyncpg 못 잡음)

### 안전성
**additive·non-breaking** — nullable + server_default '[]'. 공유 dev/prod DB에서 양립 안전(기존 행 '[]' 백필, 구버전 앱 INSERT 안전). migration-첫-배치 원칙 준수.

### 검증
- 단일 alembic head 0093 (`alembic heads`)
- offline up/down DDL 렌더 검증 (PG)
- pytest: test_conversations 10 + chat_migration/migrate_env 20(+4 xfail) + 신규 contract 2 = **전량 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)