### PR TITLE
[SID:E-SETTINGS-IA-S1] Settings 'AI & Agents' 탭 deprecate 숨김 (reversible)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -110,13 +110,24 @@ function isWebhookUrlAllowed(url: string): boolean {
   return /^http:\/\/(localhost|127\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+)/i.test(url);
 }
 
+// E-SETTINGS-IA: deprecate(숨김)된 settings 탭. 컴포넌트/route는 보존(reversible) —
+// 탭 트리거·콘텐츠·딥링크(?tab=)만 차단한다. 재노출 시 이 set에서 제거만 하면 IA 위치 복원.
+const HIDDEN_SETTINGS_TABS = new Set<string>(['ai']);
+const DEFAULT_SETTINGS_TAB = 'profile';
+
+// ?tab= 딥링크가 숨김 탭을 가리키면 기본 탭으로 폴백 (빈 화면 방지).
+function resolveSettingsTab(tab: string | null): string {
+  if (!tab || HIDDEN_SETTINGS_TABS.has(tab)) return DEFAULT_SETTINGS_TAB;
+  return tab;
+}
+
 export default function SettingsPage() {
   const t = useTranslations('settings');
   const tc = useTranslations('common');
   const router = useRouter();
   const searchParamsHook = useSearchParams();
   const { orgId: ctxOrgId, orgMemberships } = useDashboardContext();
-  const [activeTab, setActiveTab] = useState(() => searchParamsHook.get('tab') ?? 'profile');
+  const [activeTab, setActiveTab] = useState(() => resolveSettingsTab(searchParamsHook.get('tab')));
   const [lnbOpen, setLnbOpen] = useState(false);
   const { toasts, addToast, dismissToast } = useToast();
 
@@ -127,7 +138,7 @@ export default function SettingsPage() {
 
   useEffect(() => {
     const tab = searchParamsHook.get('tab');
-    if (tab) setActiveTab(tab);
+    if (tab) setActiveTab(resolveSettingsTab(tab));
   }, [searchParamsHook]);
 
   const [orgId, setOrgId] = useState<string | null>(null);
@@ -766,7 +777,7 @@ export default function SettingsPage() {
             </TabsTrigger>
 
             <span className="px-2 pb-1 pt-4 text-[10px] font-medium uppercase tracking-wider text-muted-foreground/70">{t('projectSettings')}</span>
-            {currentProjectId ? (
+            {currentProjectId && !HIDDEN_SETTINGS_TABS.has('ai') ? (
               <TabsTrigger value="ai">
                 <Bot className="h-4 w-4" />
                 {t('tabAiAgents')}
@@ -1007,17 +1018,21 @@ export default function SettingsPage() {
               </div>
             </TabsContent>
 
-            <TabsContent value="ai">
-              <div className="space-y-6">
-                {currentProjectId ? (
-                  <>
-                    <AiSettingsSection projectId={currentProjectId} />
-                    <McpConnectionSettings projectId={currentProjectId} />
-                    <ByomKeyManagement projectId={currentProjectId} />
-                  </>
-                ) : null}
-              </div>
-            </TabsContent>
+            {/* E-SETTINGS-IA: deprecate 숨김. activeTab은 resolveSettingsTab로 'ai' 도달 불가지만,
+                content도 gate off하여 딥링크/forceMount 어떤 경로로도 렌더 안 되게 한다. 컴포넌트는 보존. */}
+            {!HIDDEN_SETTINGS_TABS.has('ai') ? (
+              <TabsContent value="ai">
+                <div className="space-y-6">
+                  {currentProjectId ? (
+                    <>
+                      <AiSettingsSection projectId={currentProjectId} />
+                      <McpConnectionSettings projectId={currentProjectId} />
+                      <ByomKeyManagement projectId={currentProjectId} />
+                    </>
+                  ) : null}
+                </div>
+              </TabsContent>
+            ) : null}
 
             <TabsContent value="organization">
               <SectionCard>


### PR DESCRIPTION
## 요약
Settings의 **AI & Agents** 탭을 **deprecate 숨김**(reversible). 이 탭은 BYOM/MCP를 저장하지만 그 값을 읽는 **소비자 prod 진입점이 0**(test-only 죽은 코드)이라, 삭제가 아니라 숨김 처리. 컴포넌트/route는 전부 보존.

스토리: E-SETTINGS-IA S1 (`9babf0bf-...`) | high / FE | 순수 hide

## 변경 사항 (`settings/page.tsx` 단일 파일)
모듈 레벨에 단일 소스 가드 신설:
```ts
const HIDDEN_SETTINGS_TABS = new Set<string>(['ai']);
const DEFAULT_SETTINGS_TAB = 'profile';
function resolveSettingsTab(tab) { return (!tab || HIDDEN_SETTINGS_TABS.has(tab)) ? DEFAULT_SETTINGS_TAB : tab; }
```
- **AC1** — `value="ai"` TabsTrigger gate off(숨김).
- **AC2** — `value="ai"` TabsContent gate off **+** `?tab=` 딥링크가 `ai`를 가리키면 기본 탭(`profile`)으로 폴백. `activeTab`이 'ai'에 도달 불가 → **딥링크로도 unreachable**. (기존 `?tab=` 무검증 라우팅에 가드만 추가, 다른 탭 동작은 무변경)
- **AC3** — `ai-settings.tsx`/`mcp-connection-settings.tsx`/`byom-key-management.tsx`/route **삭제 안 함**(import 유지, 보존). 재노출 시 set에서 `'ai'` 제거만 하면 IA 위치 복원.
- **AC4** — `api-keys → members+agents` redirect **불가침**(미수정).

## 디자인 가디언 가이드 반영
- 순수 hide → **신규 디자인 토큰·매직넘버 0**, 시각 변경 없음.
- 탭 1개 제거 → `flex-col` TabsList 레이아웃 깨짐 없음(항목 하나 감소).
- `?tab=ai` 딥링크 → 빈 화면 아닌 **기본 탭 폴백**(가디언 권장, 기존 default 동작 재사용).
- reversible 전제(컴포넌트/route 보존) 충족.

## 검증
- `lint`: 0 errors (변경 파일 신규 경고 0, 잔여는 무관 pre-existing) ✅
- `build`: ✓ Compiled, 158/158 ✅
- AC 시각검증(탭 사라짐 + `?tab=ai` 폴백 Puppeteer)은 머지 후 유나양이 dev에서 수행(핸드오프 합의).

> 후속: S2(workflow 탭 숨김)는 동일 `HIDDEN_SETTINGS_TABS` set에 키 추가로 확장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)