### PR TITLE
[SID:E-SETTINGS-IA-S2] Settings 'Workflow' 탭 deprecate 숨김 (reversible)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -112,7 +112,7 @@ function isWebhookUrlAllowed(url: string): boolean {
 
 // E-SETTINGS-IA: deprecate(숨김)된 settings 탭. 컴포넌트/route는 보존(reversible) —
 // 탭 트리거·콘텐츠·딥링크(?tab=)만 차단한다. 재노출 시 이 set에서 제거만 하면 IA 위치 복원.
-const HIDDEN_SETTINGS_TABS = new Set<string>(['ai']);
+const HIDDEN_SETTINGS_TABS = new Set<string>(['ai', 'workflow']);
 const DEFAULT_SETTINGS_TAB = 'profile';
 
 // ?tab= 딥링크가 숨김 탭을 가리키면 기본 탭으로 폴백 (빈 화면 방지).
@@ -789,7 +789,7 @@ export default function SettingsPage() {
                 {t('tabMembers')}
               </TabsTrigger>
             ) : null}
-            {adminChecked && isAdmin ? (
+            {adminChecked && isAdmin && !HIDDEN_SETTINGS_TABS.has('workflow') ? (
               <TabsTrigger value="workflow">
                 <GitBranch className="h-4 w-4" />
                 {t('tabWorkflow')}
@@ -1455,7 +1455,8 @@ export default function SettingsPage() {
             </TabsContent>
             ) : null}
 
-            {adminChecked && isAdmin ? (
+            {/* E-SETTINGS-IA S2: deprecate 숨김. set 확장으로 trigger·content·딥링크(resolveSettingsTab) 일괄 차단. 컴포넌트 보존. */}
+            {adminChecked && isAdmin && !HIDDEN_SETTINGS_TABS.has('workflow') ? (
             <TabsContent value="workflow">
               <div className="space-y-6">
                 <WorkflowTriggerTypesSection />


### PR DESCRIPTION
## 요약
Settings의 **Workflow** 관리 탭을 **deprecate 숨김**(reversible). S1의 단일 가드(`HIDDEN_SETTINGS_TABS` + `resolveSettingsTab`)를 그대로 재사용해 `'workflow'` 키만 확장.

스토리: E-SETTINGS-IA S2 (`bba200e4-...`) | medium / FE | 순수 hide
**S1 머지본(develop) 위에 누적** — 충돌 0.

> ⚠️ 이 Settings 'Workflow' 탭(trigger types + template gallery + execution history, `workflow_execution_logs` 기반)은 **`/agents/workflow` 에디터(S3 죽은 route 제거)와 별개 기능**. S2는 Settings 탭만 숨김.

## 변경 사항 (`settings/page.tsx`, +3/-2 한 줄 본질)
- `HIDDEN_SETTINGS_TABS`에 `'workflow'` 추가 (set 확장).
- **AC1** — `value="workflow"` TabsTrigger 조건에 `&& !HIDDEN_SETTINGS_TABS.has('workflow')` 추가 → 숨김.
- **AC2** — `value="workflow"` TabsContent 동일 gate off. `?tab=workflow` 딥링크는 **S1 `resolveSettingsTab`가 자동으로 `'profile'` 폴백** (set에 키만 추가하면 커버됨).
- **AC3** — `WorkflowTriggerTypesSection`/`WorkflowTemplateGallerySection`/`WorkflowExecutionHistorySection` **삭제 안 함**(import·사용 유지). 재노출 시 set에서 `'workflow'` 제거만 하면 복원.

## 디자인 가디언 가이드 반영
- 신규 토큰·매직넘버 0, 시각 변경 0.
- **빈 섹션 헤더 회귀 0**: projectSettings 섹션 = ai·members·workflow였고 S1(ai)+S2(workflow) 숨김 후 **members 1탭 잔존** → "프로젝트 설정" 헤더 안 빔. (향후 members까지 숨기는 스토리 생기면 그때 섹션 헤더 조건부 렌더 필요 — 현재 불요)
- `?tab=workflow` → 빈 화면 아닌 profile 폴백.

## 검증
- `lint`: 0 errors ✅
- `build`: ✓ Compiled, 158/158 ✅
- AC 시각검증(workflow 탭 사라짐 + `?tab=workflow`→profile 폴백)은 머지 후 유나양 dev 수행(합의).

🤖 Generated with [Claude Code](https://claude.com/claude-code)