### PR TITLE
feat(E-FILE S1): 채팅 첨부 BE — /messages attachments 수신·저장·직렬화

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -132,6 +132,8 @@ def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember 
         "last_reply_at": msg.last_reply_at.isoformat() if msg.last_reply_at else None,
         "content": msg.content,
         "mentioned_ids": [str(m) for m in (msg.mentioned_ids or [])],
+        # E-FILE S1: 첨부 직렬화 (SSE + GET messages 공통). list 아니면 [](레거시/None/mock 안전).
+        "attachments": msg.attachments if isinstance(msg.attachments, list) else [],
         "sender": {
             "id": str(sender.id),
             "name": sender.name,
@@ -324,10 +326,55 @@ class CreateConversationRequest(BaseModel):
     project_id: uuid.UUID
 
 
+# E-FILE S1: 채팅 첨부. GCS 기록은 FE-proxy(uploadToGcs)가 처리하고 BE는 URL+메타만 저장.
+_MAX_ATTACHMENTS = 10
+_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
+
+
+class MessageAttachment(BaseModel):
+    url: str           # FE-proxy가 GCS에 업로드한 객체 URL (https)
+    name: str          # 원본 파일명
+    content_type: str  # MIME
+    size: int          # 바이트
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str) -> str:
+        v = v.strip()
+        if not v.startswith("https://"):
+            raise ValueError("attachment url must be an https:// URL")
+        return v
+
+    @field_validator("name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("size")
+    @classmethod
+    def _validate_size(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("size must be >= 0")
+        if v > _MAX_ATTACHMENT_SIZE:
+            raise ValueError(f"attachment too large (max {_MAX_ATTACHMENT_SIZE} bytes)")
+        return v
+
+
 class SendMessageRequest(BaseModel):
     content: str
     mentioned_ids: list[uuid.UUID] = []
     thread_id: uuid.UUID | None = None
+    attachments: list[MessageAttachment] = []
+
+    @field_validator("attachments")
+    @classmethod
+    def _limit_attachments(cls, v: list[MessageAttachment]) -> list[MessageAttachment]:
+        if len(v) > _MAX_ATTACHMENTS:
+            raise ValueError(f"too many attachments (max {_MAX_ATTACHMENTS})")
+        return v
 
 
 class UpdateStatusRequest(BaseModel):
@@ -746,6 +793,8 @@ async def send_message(
         content=body.content,
         mentioned_ids=valid_mentioned_ids,
         thread_id=body.thread_id,
+        # E-FILE S1: 첨부 메타(URL+name+content_type+size)를 0093 attachments JSONB에 저장
+        attachments=[a.model_dump() for a in body.attachments],
     )
     db.add(msg)
 

--- a/backend/tests/test_efile_s1_chat_attach.py
+++ b/backend/tests/test_efile_s1_chat_attach.py
@@ -1,0 +1,77 @@
+"""E-FILE S1: 채팅 첨부 BE — payload 검증 + _msg_payload 직렬화.
+
+GCS 업로드는 FE-proxy 담당. BE는 URL+메타 수신·저장·직렬화만 (경량).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
+
+from app.routers.conversations import (
+    MessageAttachment,
+    SendMessageRequest,
+    _msg_payload,
+    _MAX_ATTACHMENTS,
+)
+
+_GOOD = {"url": "https://storage.googleapis.com/bucket/a.png", "name": "a.png",
+         "content_type": "image/png", "size": 1024}
+
+
+# ── payload 계약 ──────────────────────────────────────────────────────────────
+
+def test_attachment_accepts_valid():
+    a = MessageAttachment(**_GOOD)
+    assert a.url.startswith("https://") and a.name == "a.png" and a.size == 1024
+
+
+def test_attachment_rejects_non_https():
+    with pytest.raises(ValidationError):
+        MessageAttachment(**{**_GOOD, "url": "http://insecure/a.png"})
+
+
+def test_attachment_rejects_empty_name_or_type():
+    with pytest.raises(ValidationError):
+        MessageAttachment(**{**_GOOD, "name": "  "})
+    with pytest.raises(ValidationError):
+        MessageAttachment(**{**_GOOD, "content_type": ""})
+
+
+def test_attachment_rejects_negative_or_oversized():
+    with pytest.raises(ValidationError):
+        MessageAttachment(**{**_GOOD, "size": -1})
+    with pytest.raises(ValidationError):
+        MessageAttachment(**{**_GOOD, "size": 200 * 1024 * 1024})
+
+
+def test_send_message_request_defaults_and_limit():
+    assert SendMessageRequest(content="hi").attachments == []
+    # 최대 개수 초과 거부
+    with pytest.raises(ValidationError):
+        SendMessageRequest(content="hi", attachments=[_GOOD] * (_MAX_ATTACHMENTS + 1))
+
+
+# ── 직렬화 (_msg_payload) ─────────────────────────────────────────────────────
+
+def _fake_msg(attachments):
+    return SimpleNamespace(
+        id=uuid.uuid4(), conversation_id=uuid.uuid4(), thread_id=None,
+        reply_count=0, last_reply_at=None, content="hi", mentioned_ids=[],
+        attachments=attachments, created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_msg_payload_includes_attachments():
+    atts = [_GOOD]
+    payload = _msg_payload(_fake_msg(atts), sender=None)
+    assert payload["attachments"] == atts
+
+
+def test_msg_payload_non_list_attachments_safe():
+    # None/레거시/mock → [] (KeyError·shape 깨짐 방지)
+    assert _msg_payload(_fake_msg(None), sender=None)["attachments"] == []
+    assert _msg_payload(_fake_msg(object()), sender=None)["attachments"] == []


### PR DESCRIPTION
## E-FILE S1 — 채팅 첨부 백엔드 (chat-attach)

story `66b3e19c-0d1e-4708-967e-16286134532d` | epic E-FILE-ATTACH | BE only

GCS 업로드는 **FE-proxy**(Next 라우트 서버사이드 `uploadToGcs`) 전담. BE는 URL+메타 수신·저장·직렬화만(경량, BE 부하 분산). **마이그 없음** — 0093 `conversation_messages.attachments` JSONB 재사용 → deploy-before-migrate 무관.

### 변경 (`app/routers/conversations.py`)
- `MessageAttachment` 스키마: `{url, name, content_type, size}` + 검증(url `https://` 필수, name/content_type 비어있으면 거부, size 0~100MB)
- `SendMessageRequest.attachments: list[MessageAttachment]`(기본 `[]`, 최대 10)
- `send_message`가 `attachments`를 `ConversationMessage.attachments`(0093)에 저장
- `_msg_payload`에 `attachments` 직렬화 → `GET /messages` + SSE `conversation.message_created` 동일 shape. `isinstance(list)` 가드로 레거시/None/mock 안전.

### AC 매핑
- ✅ `/api/v2/conversations` 메시지 생성이 attachments(`{url,name,content_type,size}` 리스트) 수신 → 0093 컬럼 저장
- ✅ `_msg_payload` attachments 직렬화 → SSE + GET messages 포함
- ✅ participant/org/cross-org 체크는 기존 `send_message` 경로 그대로(신규 우회 없음)
- ✅ multipart/GCS는 FE-proxy — BE는 URL 수신만
- ✅ 계약(FE payload shape) thread `728c0e6b`에 게시 → 미르코군 Next 라우트 병렬 진행

### 검증
- `pytest`: **1503 passed**(conversations 39 + 신규 `test_efile_s1_chat_attach` 7 포함), 16 skipped, 8 xfailed
- 잔여 14 실패 = realdb/mcp/subprocess 인프라 의존(로컬 live DB·서버 없음) 사전존재 — `asyncpg.connect`/`McpError`/subprocess `FileNotFoundError`, 본 변경 무관, CI 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)