### PR TITLE
feat(E-ONBOARDING S2): /me 실명+email — display_name SSOT + email 노출

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -67,7 +67,8 @@ async def get_me(
             if org_member:
                 user_result = await session.execute(select(User).where(User.id == uid))
                 user = user_result.scalar_one_or_none()
-                name = user.email if user else str(uid)
+                # E-ONBOARDING S2: display_name 우선, 없을 때만 email (기존 무조건 email → 실명 반영)
+                name = (user.display_name or user.email) if user else str(uid)
                 try:
                     proj_id = uuid.UUID(project_id_str) if project_id_str else org_member.org_id
                 except (ValueError, AttributeError):
@@ -78,6 +79,7 @@ async def get_me(
                     project_id=proj_id,
                     user_id=uid,
                     name=name,
+                    email=user.email if user else None,
                     type="human",
                     role=org_member.role,
                     is_active=True,
@@ -96,6 +98,7 @@ async def get_me(
         user = user_result.scalar_one_or_none()
         if user:
             data.has_password = bool(user.hashed_password)
+            data.email = user.email  # E-ONBOARDING S2: User.email 노출
 
     # S-MBR-03: org owner/admin → effective role 상속. /me role이 JWT role과 일치하도록.
     if not is_api_key and member.user_id:

--- a/backend/app/routers/org_members.py
+++ b/backend/app/routers/org_members.py
@@ -42,14 +42,20 @@ async def list_org_members(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[OrgMemberResponse]:
     """org_members + users JOIN — email 포함 응답."""
+    # E-ONBOARDING S2: 실명 노출 — canonical Member.name → User.display_name → email 순.
+    # members는 (org_id, user_id) 활성 휴먼으로 LEFT JOIN (없으면 display_name/email 폴백).
     result = await session.execute(
         text(
             """
             SELECT om.id, om.org_id, om.user_id, om.role,
                    om.created_at, om.deleted_at,
-                   u.email
+                   u.email,
+                   COALESCE(m.name, u.display_name, u.email) AS name
             FROM org_members om
             LEFT JOIN users u ON u.id = om.user_id
+            LEFT JOIN members m
+                   ON m.org_id = om.org_id AND m.user_id = om.user_id
+                  AND m.type = 'human' AND m.deleted_at IS NULL
             WHERE om.org_id = :org_id AND om.deleted_at IS NULL
             ORDER BY om.created_at
             """
@@ -65,6 +71,7 @@ async def list_org_members(
             created_at=row.created_at,
             deleted_at=row.deleted_at,
             email=row.email,
+            name=row.name,
         )
         for row in result
     ]

--- a/backend/app/schemas/me.py
+++ b/backend/app/schemas/me.py
@@ -14,6 +14,7 @@ class MeResponse(BaseModel):
     project_id: uuid.UUID
     user_id: uuid.UUID | None = None
     name: str
+    email: str | None = None  # E-ONBOARDING S2: User.email 노출
     type: str
     role: str
     is_active: bool

--- a/backend/app/schemas/org_member.py
+++ b/backend/app/schemas/org_member.py
@@ -26,3 +26,4 @@ class OrgMemberResponse(BaseModel):
     created_at: datetime
     deleted_at: datetime | None = None
     email: str | None = None
+    name: str | None = None  # E-ONBOARDING S2: 실명(canonical Member.name → display_name → email)

--- a/backend/tests/test_auth_10_backend.py
+++ b/backend/tests/test_auth_10_backend.py
@@ -157,12 +157,14 @@ async def test_get_me_has_password_true():
         member.type = "human"
         member.role = "member"
         member.is_active = True
+        member.email = "user@example.com"  # E-ONBOARDING S2: MeResponse.email
         member.project_name = None
         member.has_password = None
         member.project = project
 
         user_mock = MagicMock()
         user_mock.id = uid
+        user_mock.email = "user@example.com"  # E-ONBOARDING S2: data.email = user.email
         user_mock.hashed_password = hash_password("Pass1!")
 
         async def override_auth():
@@ -214,12 +216,14 @@ async def test_get_me_has_password_false():
         member.type = "human"
         member.role = "member"
         member.is_active = True
+        member.email = "user@example.com"  # E-ONBOARDING S2: MeResponse.email
         member.project_name = None
         member.has_password = None
         member.project = project
 
         user_mock = MagicMock()
         user_mock.id = uid
+        user_mock.email = "user@example.com"  # E-ONBOARDING S2: data.email = user.email
         user_mock.hashed_password = ""
 
         async def override_auth():

--- a/backend/tests/test_auth_11.py
+++ b/backend/tests/test_auth_11.py
@@ -91,6 +91,7 @@ def _make_member(role: str = "member") -> MagicMock:
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.deleted_at = None
     m.email = None
+    m.name = "Test Member"  # E-ONBOARDING S2: OrgMemberResponse.name
     return m
 
 

--- a/backend/tests/test_e_onboarding_s2_me_realname.py
+++ b/backend/tests/test_e_onboarding_s2_me_realname.py
@@ -1,0 +1,86 @@
+"""E-ONBOARDING S2: /me 실명+email — 스키마 노출 + org-member fallback name 우선순위.
+
+데모 centerpiece: 초대 멤버가 가입해도 이름이 '-'/email로 뜨지 않고 실명(display_name) 반영.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.dependencies.auth import AuthContext
+from app.routers.me import get_me
+from app.schemas.me import MeResponse
+from app.schemas.org_member import OrgMemberResponse
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 스키마 노출 ───────────────────────────────────────────────────────────────
+
+def test_me_response_exposes_email():
+    assert "email" in MeResponse.model_fields
+
+
+def test_org_member_response_exposes_name():
+    assert "name" in OrgMemberResponse.model_fields
+
+
+# ── org-member fallback: display_name 우선, email은 폴백 ──────────────────────
+
+def _fallback_session(user):
+    """member 없음 → org_member 존재 → user 조회 순서로 execute side_effect 구성."""
+    org_member = MagicMock()
+    org_member.id = uuid.uuid4()
+    org_member.org_id = uuid.uuid4()
+    org_member.role = "member"
+
+    member_result = MagicMock()
+    member_result.scalars.return_value.first.return_value = None  # TeamMember 없음
+    om_result = MagicMock()
+    om_result.scalar_one_or_none.return_value = org_member
+    user_result = MagicMock()
+    user_result.scalar_one_or_none.return_value = user
+
+    s = AsyncMock()
+    s.execute = AsyncMock(side_effect=[member_result, om_result, user_result])
+    return s, org_member
+
+
+def _auth(org_id):
+    return AuthContext(
+        user_id=str(uuid.uuid4()),
+        email="invited@example.com",
+        claims={"app_metadata": {"org_id": str(org_id)}},
+        org_id=str(org_id),
+    )
+
+
+@pytest.mark.anyio
+async def test_fallback_prefers_display_name():
+    user = MagicMock()
+    user.display_name = "초대된 실명"
+    user.email = "invited@example.com"
+    user.hashed_password = "x"
+    org_id = uuid.uuid4()
+    session, _ = _fallback_session(user)
+    res = await get_me(member_id=None, session=session, auth=_auth(org_id))
+    assert res.name == "초대된 실명"  # display_name 우선
+    assert res.email == "invited@example.com"  # email 노출
+
+
+@pytest.mark.anyio
+async def test_fallback_uses_email_when_no_display_name():
+    user = MagicMock()
+    user.display_name = None
+    user.email = "invited@example.com"
+    user.hashed_password = "x"
+    org_id = uuid.uuid4()
+    session, _ = _fallback_session(user)
+    res = await get_me(member_id=None, session=session, auth=_auth(org_id))
+    assert res.name == "invited@example.com"  # display_name 없으면 email 폴백
+    assert res.email == "invited@example.com"

--- a/backend/tests/test_org_members.py
+++ b/backend/tests/test_org_members.py
@@ -21,6 +21,7 @@ def _mock_member(role: str = "member", user_id: uuid.UUID | None = None) -> Magi
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.deleted_at = None
     m.email = None  # OrgMemberResponse.email: str | None
+    m.name = "Test Member"  # E-ONBOARDING S2: OrgMemberResponse.name
     return m
 
 
@@ -67,6 +68,7 @@ async def test_list_org_members_200():
         mock_row.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
         mock_row.deleted_at = None
         mock_row.email = "test@example.com"
+        mock_row.name = "Test Member"  # E-ONBOARDING S2: COALESCE(member.name, display_name, email)
 
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([mock_row]))

--- a/backend/tests/test_s31.py
+++ b/backend/tests/test_s31.py
@@ -44,6 +44,7 @@ def _mock_member() -> MagicMock:
     m.project_name = None
     m.project = None
     m.name = "Alice"
+    m.email = "alice@example.com"  # E-ONBOARDING S2: MeResponse.email
     m.type = "human"
     m.role = "admin"
     m.is_active = True
@@ -224,6 +225,8 @@ def _mock_result(member):
     """scalars().first() 패턴 mock 생성."""
     r = MagicMock()
     r.scalars.return_value.first.return_value = member
+    # E-ONBOARDING S2: get_me의 User 조회(scalar_one_or_none)도 member 모킹 → email/has_password 일관
+    r.scalar_one_or_none.return_value = member
     return r
 
 

--- a/backend/tests/test_s_mbr_03.py
+++ b/backend/tests/test_s_mbr_03.py
@@ -138,6 +138,7 @@ async def test_get_me_org_admin_role_override():
     mock_member.user_id = user_id
     mock_member.type = "human"
     mock_member.name = "test"
+    mock_member.email = "test@example.com"  # E-ONBOARDING S2: MeResponse.email
     mock_member.role = "member"  # project level: member
     mock_member.is_active = True
     mock_member.project_name = None  # MeResponse 직렬화 필수
@@ -188,6 +189,7 @@ async def test_get_me_project_role_higher_preserved():
     mock_member.user_id = user_id
     mock_member.type = "human"
     mock_member.name = "test"
+    mock_member.email = "test@example.com"  # E-ONBOARDING S2: MeResponse.email
     mock_member.role = "admin"  # project level: admin (높음)
     mock_member.is_active = True
     mock_member.project_name = None


### PR DESCRIPTION
## E-ONBOARDING S2 — /me 실명+email (데모 centerpiece)

story `cd7c4368-2e80-4733-a79a-6261930a0b2d` | epic E-ONBOARDING | BE only

화 데모(SaaS 온보딩) 첫인상 — 초대 멤버가 가입해도 이름이 `-`/email로 뜨던 문제 해소. **마이그 없음**(필드 노출만) → deploy-before-migrate 무관.

### 변경
| 파일 | 변경 |
|------|------|
| `schemas/me.py` | `MeResponse.email` 추가 |
| `routers/me.py` | GET /me가 `User.email`로 email 채움(**TeamMember 경로 + org-member fallback 둘 다**). fallback name: `display_name` 우선, email은 null일 때만(기존 무조건 `user.email` → 고침) |
| `schemas/org_member.py` | `OrgMemberResponse.name` 추가 |
| `routers/org_members.py` | org-members 리스트 name = `COALESCE(Member.name, display_name, email)` (members LEFT JOIN: 활성 휴먼 `(org_id,user_id)`) |
| tests | from_attributes+mock 5개 파일 갱신 + 신규 단위 4건 |

### AC 매핑
- ✅ `MeResponse`에 email 추가; GET /me가 User.email로 채움(TeamMember + org-member fallback 둘 다)
- ✅ org-member fallback name = `User.display_name` 우선, email은 null일 때만
- ✅ `OrgMemberResponse`/org-members 리스트가 display_name/canonical `Member.name`으로 실명 반환
- ✅ **회귀(AC4)**: MeResponse/MemberResponse 필드 추가로 깨진 from_attributes+mock 테스트 갱신, 전체 스위트 green
- ✅ 마이그 없음

### 검증
- `pytest`: **1500 passed**, 16 skipped, 8 xfailed
- 회귀 갱신: `test_s31`·`test_s_mbr_03`·`test_org_members`·`test_auth_10_backend`·`test_auth_11` + 신규 `test_e_onboarding_s2_me_realname`(4)
- 잔여 14 실패 = realdb/mcp/subprocess 인프라 의존 사전존재(`asyncpg.connect`/`McpError`/subprocess `FileNotFoundError`), 본 변경 무관, CI 통과

### FE 연계
my-profile email 표시 · org-members `split('@')` 제거는 E-ONBOARDING S1-FE/S3(미르코), UI 검증 E2E(S5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)