### PR TITLE
feat(E-ONBOARDING S1): /me PATCH 프로필 저장 422 수정 — auth 파생 + ownership

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -182,24 +182,49 @@ async def get_my_memberships(
 
 @router.patch("", response_model=MeResponse)
 async def update_me(
-    member_id: uuid.UUID = Query(...),
-    body: UpdateMe = ...,
+    body: UpdateMe,
+    member_id: uuid.UUID | None = Query(default=None),
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
 ) -> MeResponse:
+    # E-ONBOARDING S1: 타겟 member를 auth에서 파생 — client Query 강제 제거(누락 시 422 해소).
+    #   member_id를 명시해도 **본인 소유 member만** 매칭(ownership 강제 — 남의 프로필 변경 차단).
+    uid = uuid.UUID(auth.user_id)
+    is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
+
+    if member_id is not None:
+        # 명시 member_id는 호출자 본인 것일 때만 (api_key=TeamMember.id 본인, JWT=user_id 본인)
+        if is_api_key:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.id == uid)
+        else:
+            where_clause = (TeamMember.id == member_id) & (TeamMember.user_id == uid)
+    elif is_api_key:
+        where_clause = TeamMember.id == uid
+    else:
+        project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+        if project_id_str:
+            try:
+                where_clause = (TeamMember.user_id == uid) & (TeamMember.project_id == uuid.UUID(project_id_str))
+            except (ValueError, AttributeError):
+                where_clause = TeamMember.user_id == uid
+        else:
+            where_clause = TeamMember.user_id == uid
+
     # AC3-5 ②: team_members가 뷰(0088) — multi-row 안전(휴먼 multi-project) .limit(1).first().
     result = await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id).limit(1)
+        select(TeamMember).where(where_clause).limit(1)
     )
     member = result.scalars().first()
     if member is None:
+        # 본인 소유가 아니거나 미존재 — 존재 여부 누설 없이 404
         raise HTTPException(status_code=404, detail="Member not found")
+    target_id = member.id
     # AC3-5 ②: 뷰는 write 불가 — ORM mutation+flush 대신 name을 members 앵커에 UPDATE. expire 후 뷰 재조회.
     await session.execute(
-        sa_update(Member).where(Member.id == member_id).values(name=body.name, updated_at=func.now())
+        sa_update(Member).where(Member.id == target_id).values(name=body.name, updated_at=func.now())
     )
     session.expire(member)
     refreshed = (await session.execute(
-        select(TeamMember).where(TeamMember.id == member_id).limit(1)
+        select(TeamMember).where(TeamMember.id == target_id).limit(1)
     )).scalars().first()
     return MeResponse.model_validate(refreshed or member)

--- a/backend/tests/test_e_onboarding_s1_profile_422.py
+++ b/backend/tests/test_e_onboarding_s1_profile_422.py
@@ -1,0 +1,99 @@
+"""E-ONBOARDING S1: 프로필 저장 422 수정 — update_me가 auth에서 타겟 파생 + ownership.
+
+데모 headline 버그: PATCH /me {name} (member_id 쿼리 없이) → 200. 남의 member_id → 차단.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.dependencies.auth import AuthContext
+from app.routers.me import update_me
+from app.schemas.me import UpdateMe
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_tm(user_id: uuid.UUID, name: str = "Old Name") -> MagicMock:
+    m = MagicMock()
+    m.id = uuid.uuid4()
+    m.org_id = uuid.uuid4()
+    m.project_id = uuid.uuid4()
+    m.user_id = user_id
+    m.name = name
+    m.email = "u@example.com"  # MeResponse.email (S2 머지 후 존재)
+    m.type = "human"
+    m.role = "member"
+    m.is_active = True
+    m.project_name = None
+    m.project = None
+    m.has_password = None
+    m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    m.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return m
+
+
+def _tm_result(member):
+    r = MagicMock()
+    r.scalars.return_value.first.return_value = member
+    return r
+
+
+def _auth(uid: uuid.UUID, *, org_id=None, project_id=None):
+    meta = {}
+    if org_id:
+        meta["org_id"] = str(org_id)
+    if project_id:
+        meta["project_id"] = str(project_id)
+    return AuthContext(user_id=str(uid), email="u@example.com", claims={"app_metadata": meta}, org_id=str(org_id) if org_id else None)
+
+
+@pytest.mark.anyio
+async def test_patch_me_without_member_id_query_returns_200():
+    """member_id 쿼리 없이 PATCH /me {name} → auth.user_id로 파생 → 성공(422 아님)."""
+    uid = uuid.uuid4()
+    member = _mock_tm(uid)
+    session = AsyncMock()
+    session.expire = MagicMock()  # 실제 Session.expire는 동기 (AsyncMock 경고 방지)
+    # [select TM, UPDATE members, select TM refreshed]
+    session.execute = AsyncMock(side_effect=[_tm_result(member), MagicMock(), _tm_result(member)])
+
+    res = await update_me(
+        body=UpdateMe(name="New Name"),
+        member_id=None,
+        session=session,
+        auth=_auth(uid),
+    )
+    assert res.user_id == uid
+    # UPDATE members.name이 새 이름으로 호출됐는지 (2번째 execute = sa_update)
+    update_call = session.execute.await_args_list[1]
+    compiled = str(update_call.args[0])
+    assert "UPDATE members" in compiled
+
+
+@pytest.mark.anyio
+async def test_patch_me_other_member_id_is_blocked():
+    """남의 member_id를 줘도 본인 소유가 아니면 매칭 0 → 404 (ownership 강제)."""
+    uid = uuid.uuid4()
+    other_member_id = uuid.uuid4()
+    session = AsyncMock()
+    # where_clause에 user_id==uid가 AND되므로 남의 행은 안 잡힘 → first()=None
+    session.execute = AsyncMock(side_effect=[_tm_result(None)])
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        await update_me(
+            body=UpdateMe(name="Hacked"),
+            member_id=other_member_id,
+            session=session,
+            auth=_auth(uid),
+        )
+    assert exc.value.status_code == 404
+    # UPDATE까지 가지 않음 (select 1회만)
+    assert session.execute.await_count == 1


### PR DESCRIPTION
## E-ONBOARDING S1 — 프로필 저장 422 수정 (데모 headline 버그)

story `80756038-5718-4f45-a202-d8e19a12f50a` | epic E-ONBOARDING | BE part

**증상:** 셀프가입 → Settings>My Profile → 이름 편집 → 저장 시 **422**. 데모 첫 동작.
**근본:** `update_me`(me.py)가 `member_id`를 `Query(...)` 필수로 받는데 FE는 안 보냄 → 422. + authz 갭(supplied member_id로 남의 `Member.name`도 UPDATE 가능).

### 변경 (`app/routers/me.py` — `update_me`)
- `member_id`를 `Query(...)` 필수 → **`Query(default=None)`** + **auth에서 타겟 파생**(get_me와 동일 규칙: api_key=`TeamMember.id`, JWT=`TeamMember.user_id`(+project_id 분기)). `PATCH /api/v2/me {name}` 쿼리 없이 → **200**.
- **ownership 강제**: `member_id` 명시해도 where_clause에 본인(`user_id==uid` / `id==uid`) AND → 남의 것은 매칭 0 → **404**(UPDATE 도달 안 함). me.py authz 갭 차단.
- UPDATE 대상 = 파생된 member의 canonical `Member.id` (뷰 write 불가 → members 앵커 UPDATE 유지).
- 마이그 없음.

### AC 매핑
- ✅ `update_me`가 auth에서 타겟 member 파생, client Query 아님 → 쿼리 없이 200
- ✅ ownership 강제 — 다른 member_id 줘도 남의 것 patch 불가(404)
- ✅ 회귀: me PATCH 관련 테스트 green
- ✅ 마이그 없음

### 검증
- `pytest`: **1509 passed**(신규 `test_e_onboarding_s1_profile_422` 2건: no-query→200, 남의 member_id→404; me 관련 47 포함)
- 잔여 14 실패 = realdb/mcp/subprocess 인프라 의존 사전존재, 본 변경 무관
- develop(#1207 포함) 위로 rebase — 충돌 없음

### FE 연계
my-profile-section.tsx {name}만 전송·리로드 없이 렌더는 E-ONBOARDING S1-FE/S3(미르코), UI 검증 E2E(S5). BE 파생만으로 422 해소(FE는 body {name} 이미 전송).

🤖 Generated with [Claude Code](https://claude.com/claude-code)