### PR TITLE
feat(E-FILE S4): 보드 스토리 첨부 — stories.attachments(0095) + API

### DIFF
--- a/backend/alembic/versions/0095_add_attachments_to_stories.py
+++ b/backend/alembic/versions/0095_add_attachments_to_stories.py
@@ -1,0 +1,30 @@
+"""add attachments to stories
+
+E-FILE S4: 보드 스토리 첨부. stories에 attachments JSONB(chat 0093과 동형) 추가.
+additive(nullable + server_default '[]')라 공유 dev/prod DB에서 breaking 아님.
+
+⚠️ 스키마 추가 — deploy-before-migrate 주의. 머지 전 윈도우0 pre-apply 권장(#1203 패턴).
+
+Revision ID: 0095
+Revises: 0094
+Create Date: 2026-06-04
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0095"
+down_revision = "0094"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "stories",
+        sa.Column("attachments", JSONB, nullable=True, server_default=sa.text("'[]'")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("stories", "attachments")

--- a/backend/app/models/pm.py
+++ b/backend/app/models/pm.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy import BigInteger, Boolean, Date, DateTime, ForeignKey, Integer, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -113,6 +113,10 @@ class Story(Base, OrgScopedMixin, TimestampMixin, SoftDeleteMixin):
     # E-OUTCOME-LOOP: 채점 필드 (outcome, 채점잡 전용)
     outcome_status: Mapped[str] = mapped_column(String(20), nullable=False, server_default="n_a")
     outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # E-FILE S4: 보드 스토리 첨부 (chat과 동형 {url,name,content_type,size} list). additive.
+    attachments: Mapped[list | None] = mapped_column(
+        JSONB, nullable=True, server_default=text("'[]'"), default=list
+    )
 
     epic: Mapped[Epic | None] = relationship("Epic", back_populates="stories")
     sprint: Mapped[Sprint | None] = relationship("Sprint", back_populates="stories")

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -177,6 +177,8 @@ async def create_story(
         success_hypothesis=body.success_hypothesis,
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,
+        # E-FILE S4: 보드 스토리 첨부 (FE-proxy URL+메타) 저장
+        attachments=[a.model_dump() for a in body.attachments],
     )
     # E-BOARD S5: 복수 assignee join 기록 (단일 assignee_id와 공존)
     saved_ids = await StoryAssigneeRepository(session, org_id).set_for_story(story.id, effective_ids)

--- a/backend/app/schemas/story.py
+++ b/backend/app/schemas/story.py
@@ -47,6 +47,49 @@ STATUS_TRANSITIONS: dict[str, str] = {
 }
 
 
+# E-FILE S4: 보드 스토리 첨부. GCS 기록은 FE-proxy(uploadToGcs), BE는 URL+메타만 저장(chat 동형).
+_MAX_STORY_ATTACHMENTS = 10
+_MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB
+
+
+class StoryAttachment(BaseModel):
+    url: str           # FE-proxy가 GCS에 업로드한 객체 URL (https)
+    name: str          # 원본 파일명
+    content_type: str  # MIME
+    size: int          # 바이트
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str) -> str:
+        v = v.strip()
+        if not v.startswith("https://"):
+            raise ValueError("attachment url must be an https:// URL")
+        return v
+
+    @field_validator("name", "content_type")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("must not be empty")
+        return v
+
+    @field_validator("size")
+    @classmethod
+    def _validate_size(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError("size must be >= 0")
+        if v > _MAX_ATTACHMENT_SIZE:
+            raise ValueError(f"attachment too large (max {_MAX_ATTACHMENT_SIZE} bytes)")
+        return v
+
+
+def _limit_story_attachments(v: list) -> list:
+    if v is not None and len(v) > _MAX_STORY_ATTACHMENTS:
+        raise ValueError(f"too many attachments (max {_MAX_STORY_ATTACHMENTS})")
+    return v
+
+
 class StoryCreate(BaseModel):
     project_id: uuid.UUID
     org_id: uuid.UUID
@@ -56,6 +99,8 @@ class StoryCreate(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. 미지정(None)이면 assignee_id 단독 동작(back-compat).
     assignee_ids: list[uuid.UUID] | None = None
+    # E-FILE S4: 보드 스토리 첨부 (기본 [], 최대 10).
+    attachments: list[StoryAttachment] = []
     meeting_id: uuid.UUID | None = None
     status: str = "backlog"
     priority: str = "medium"
@@ -73,6 +118,11 @@ class StoryCreate(BaseModel):
     def validate_metric_definition(cls, v: dict | None) -> dict | None:
         return _validate_metric_definition(v)
 
+    @field_validator("attachments")
+    @classmethod
+    def _check_attachments(cls, v):
+        return _limit_story_attachments(v)
+
 
 class StoryUpdate(BaseModel):
     title: str | None = None
@@ -81,6 +131,8 @@ class StoryUpdate(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. 미지정(None)이면 join 미변경(back-compat).
     assignee_ids: list[uuid.UUID] | None = None
+    # E-FILE S4: 보드 스토리 첨부. 미지정(None)이면 변경 안 함(back-compat).
+    attachments: list[StoryAttachment] | None = None
     meeting_id: uuid.UUID | None = None
     priority: str | None = None
     story_points: int | None = None
@@ -100,6 +152,11 @@ class StoryUpdate(BaseModel):
     def validate_metric_definition(cls, v: dict | None) -> dict | None:
         return _validate_metric_definition(v)
 
+    @field_validator("attachments")
+    @classmethod
+    def _check_attachments(cls, v):
+        return _limit_story_attachments(v)
+
 
 class StoryStatusUpdate(BaseModel):
     status: str
@@ -116,8 +173,15 @@ class StoryResponse(BaseModel):
     assignee_id: uuid.UUID | None = None
     # E-BOARD S5: 복수 assignee. join 테이블 멤버. 레거시 행은 [assignee_id] 폴백.
     assignee_ids: list[uuid.UUID] = []
+    # E-FILE S4: 보드 스토리 첨부 (column 값). list 아니면 [](레거시 None/mock 안전).
+    attachments: list[dict] = []
     meeting_id: uuid.UUID | None = None
     title: str
+
+    @field_validator("attachments", mode="before")
+    @classmethod
+    def _coerce_attachments(cls, v):
+        return v if isinstance(v, list) else []
     status: str
     priority: str
     story_points: int | None = None

--- a/backend/tests/test_e_file_s4_story_attachments.py
+++ b/backend/tests/test_e_file_s4_story_attachments.py
@@ -1,0 +1,80 @@
+"""E-FILE S4: 보드 스토리 첨부 — schema/model/migration 검증.
+
+chat-attach(S1)과 동형. GCS 기록은 FE-proxy, BE는 URL+메타 저장(stories.attachments 0095).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.story import (
+    StoryAttachment,
+    StoryCreate,
+    StoryUpdate,
+    StoryResponse,
+    _MAX_STORY_ATTACHMENTS,
+)
+
+_MIGRATION = os.path.join(
+    os.path.dirname(__file__), "..", "alembic", "versions", "0095_add_attachments_to_stories.py"
+)
+_GOOD = {"url": "https://storage.googleapis.com/sprintable-memo-attachments/a.png",
+         "name": "a.png", "content_type": "image/png", "size": 2048}
+
+
+# ── payload 검증 (chat과 동형) ────────────────────────────────────────────────
+
+def test_attachment_valid_and_invalid():
+    assert StoryAttachment(**_GOOD).size == 2048
+    with pytest.raises(ValidationError):
+        StoryAttachment(**{**_GOOD, "url": "http://insecure/a"})
+    with pytest.raises(ValidationError):
+        StoryAttachment(**{**_GOOD, "name": " "})
+    with pytest.raises(ValidationError):
+        StoryAttachment(**{**_GOOD, "size": -1})
+    with pytest.raises(ValidationError):
+        StoryAttachment(**{**_GOOD, "size": 200 * 1024 * 1024})
+
+
+def test_create_update_accept_attachments_with_limit():
+    c = StoryCreate(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="t", attachments=[_GOOD])
+    assert len(c.attachments) == 1
+    assert StoryCreate(project_id=uuid.uuid4(), org_id=uuid.uuid4(), title="t").attachments == []
+    assert StoryUpdate().attachments is None  # 미지정 → 변경 안 함
+    with pytest.raises(ValidationError):
+        StoryUpdate(attachments=[_GOOD] * (_MAX_STORY_ATTACHMENTS + 1))
+
+
+# ── 직렬화 / 회귀 (column → response, None/mock 안전) ──────────────────────────
+
+def _resp(**over):
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        title="t", status="backlog", priority="medium",
+        created_at=__import__("datetime").datetime.now(),
+        updated_at=__import__("datetime").datetime.now(),
+    )
+    base.update(over)
+    return StoryResponse(**base)
+
+
+def test_response_attachments_passthrough_and_coercion():
+    assert _resp(attachments=[_GOOD]).attachments == [_GOOD]
+    assert _resp(attachments=None).attachments == []   # 레거시 None → []
+    assert _resp(attachments="garbage").attachments == []  # 비-list(mock 등) → []
+    assert _resp().attachments == []  # 기본값
+
+
+# ── migration 0095 ────────────────────────────────────────────────────────────
+
+def test_migration_0095_chains_off_0094():
+    spec = importlib.util.spec_from_file_location("rev_0095", _MIGRATION)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    assert mod.revision == "0095"
+    assert mod.down_revision == "0094"
+    assert callable(mod.upgrade) and callable(mod.downgrade)


### PR DESCRIPTION
## E-FILE S4 — 보드 스토리 첨부 (chat-attach 패턴 재사용)

story `79d9bf0a-51b9-4225-8c01-c7fbe665a060` | epic E-FILE | BE only

스토리에 첨부 저장. GCS 기록은 **FE-proxy**(Next `uploadToGcs`, chat과 동일), BE는 URL+메타만(`{url,name,content_type,size}`).

### 변경
| 파일 | 변경 |
|------|------|
| `alembic/versions/0095_...py` (신규) | rev 0095(down=0094). `stories.attachments` JSONB nullable server_default '[]'. additive·downgrade DROP |
| `models/pm.py` | `Story.attachments` 컬럼(chat 0093과 동형) |
| `schemas/story.py` | `StoryAttachment` + 검증(url https·name/type 비움 거부·size 0~100MB). Create/Update 수신(최대 10), Response 직렬화 + before-validator(비-list→[]) |
| `routers/stories.py` | create_story attachments 저장. update_story는 column이라 data 경유 자동 |
| tests | 신규 단위 4건 |

### AC 매핑
- ✅ `stories.attachments` JSONB(chat 동형) 마이그(0095, 0094 다음)
- ✅ StoryCreate/StoryUpdate attachments 수신 + StoryResponse 직렬화
- ✅ **윈도우0 pre-apply 완료**(아래) — 머지 시 board/story 500 안 남
- ✅ 회귀: StoryResponse 필드추가 → before-validator 코어션으로 from_attributes+mock 안전, **전체 스위트 green**

### ⚠️ 윈도우0 pre-apply (migrate=디디 책임, #1203 패턴)
- 브랜치 이미지 빌드 `backend:s4-preapply-9cdf8170` (Cloud Build SUCCESS)
- `sprintable-migrate-dev` pin → 실행 → **`Running upgrade 0094 -> 0095, add attachments to stories`** dev DB 적용 확인
- 잡 이미지 `latest-dev` 원복. health 200.
- → `stories.attachments` 컬럼이 코드보다 먼저 존재 → **머지 OK, deploy-before-migrate 갭 0**

### 검증
- `pytest`: **1513 passed**, 16 skipped, 8 xfailed (신규 4 + story 슬라이스 45 포함)
- 단일 head 0095, offline up/down DDL
- 잔여 14 = realdb/mcp/subprocess 인프라 사전존재, 본 변경 무관

### FE 연계
계약 chat과 동형(`{url,name,content_type,size}`), detail-panel 첨부 우선. GCS 버킷 `sprintable-memo-attachments`. 미르코 Next 라우트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)