### PR TITLE
[SID:E-BOARD-S1] 스토리 상세 패널 Dispatch 버튼 마운트

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -11,6 +11,7 @@ import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/
 import { DependencyGraph } from './dependency-graph';
 import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -609,6 +610,21 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </p>
               )}
             </div>
+
+            {/* E-BOARD S1: Dispatch — assignee 인접(킥오프=assignee 선택 후 액션). EntityDispatchPanel 마운트만(신규 디자인 0). */}
+            {projectId && (
+              <div className="rounded-lg border border-border bg-muted/20 p-3">
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Dispatch</p>
+                <EntityDispatchPanel
+                  entityType="story"
+                  entityId={story.id}
+                  projectId={projectId}
+                  currentAssigneeId={story.assignee_id}
+                  onAssigneePatched={(aid) => onStoryUpdate?.({ ...story, assignee_id: aid })}
+                />
+              </div>
+            )}
+
             {story.story_points != null ? (
               <div>
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('storyPoints')}</span>


### PR DESCRIPTION
## 요약
StoryDetailPanel에 **기존 `EntityDispatchPanel` 마운트** (⚡critical, 마운트만·신규 디자인 0). 이 패널은 epics/docs에 이미 쓰이고 `entityType`에 `'story'`를 지원하며, BE `dispatch.py`도 story+wake_agent를 이미 지원 → **FE 마운트만**.

스토리: E-BOARD S1 (`94e8c334-...`) | critical / FE

## 변경 사항 (`story-detail-panel.tsx`, +import 1)
- **Assignee 섹션 바로 아래**(storyPoints 위)에 Dispatch 카드 마운트. 근거: dispatch = assignee 선택 후 실행 액션이라 assignee 인접이 UX 정합(epic/docs 동일 패턴).
- props: `entityType="story"` / `entityId={story.id}` / `projectId` / `currentAssigneeId={story.assignee_id}` / `onAssigneePatched→onStoryUpdate`.
- **`projectId` 있을 때만 조건부 렌더** — `kanban-board.tsx:1253`이 `projectId={projectId}` 전달하므로 실 마운트됨(빌드통과≠마운트 → 호출부 확인 완료).
- no-assignee: 패널 기존 `disabled` 처리 재사용(담당자 선택 전 버튼 비활성). `mobileMode` 생략(스토리 패널 풀스크린, epic 패턴).
- 컨테이너 `rounded-lg border border-border bg-muted/20 p-3` + `text-xs font-semibold uppercase tracking-wide` "Dispatch" 라벨 — epic/docs Dispatch 카드와 동일 토큰, 스토리 스크롤 밀도에 맞춰 `p-3`. **신규 토큰·매직넘버 0.**

## 검증
- `lint`: 0 errors ✅
- `build`: ✓ Compiled, 158/158 ✅
- AC4(스토리 열면 Dispatch 실표시·no-assignee disabled·선택→dispatch→토스트)는 머지 후 유나양 Puppeteer 실URL 픽셀(마운트 확인).

## ⚠️ 후속 flag (스코프 밖, 비차단)
EntityDispatchPanel **기존** 에러 토스트 `"Dispatch 실패. 다시 시도하겠는."` = product UI에 에이전트(대화체) 말투 누수 → 비즈니스 톤이어야. 기존 컴포넌트라 이 스토리 스코프 밖 → **카피 정정 별도 follow-up 후보**(마운트엔 영향 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)