### PR TITLE
feat(E-EVENT-INJECT S1): dispatch 이벤트에 top-level content 주입

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -96,6 +96,8 @@ async def _fetch_events(
 
 def _row_to_payload(row: object) -> dict:
     """_fetch_events row â SSE payload dict."""
+    _payload = (json.loads(row.payload)  # type: ignore[attr-defined]
+               if isinstance(row.payload, str) else row.payload)
     return {
         "event_id": row.event_id,  # type: ignore[attr-defined]
         "event_type": row.event_type,  # type: ignore[attr-defined]
@@ -105,8 +107,9 @@ def _row_to_payload(row: object) -> dict:
             "id": row.source_entity_id,  # type: ignore[attr-defined]
         },
         "sender_id": row.sender_id,  # type: ignore[attr-defined]
-        "payload": (json.loads(row.payload)  # type: ignore[attr-defined]
-                   if isinstance(row.payload, str) else row.payload),
+        "payload": _payload,
+        # E-EVENT-INJECT S1: content를 SSE top-level로 노출 → connector 드롭 방지.
+        "content": (_payload or {}).get("content"),
         "created_at": row.created_at.isoformat(),  # type: ignore[attr-defined]
     }
 

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -129,12 +129,17 @@ async def dispatch_entity(
     except Exception:
         pass
 
+    # E-EVENT-INJECT S1: connector(adapter.py)가 content 없는 이벤트를 드롭(if not content: return)하므로
+    # dispatched에 top-level content를 부여 → 에이전트 work-turn으로 실제 주입.
+    _detail = (body.message or description or "").strip()
+    content = f"[{body.entity_type}] {title}" + (f" — {_detail}" if _detail else "")
     payload = {
         "entity_type": body.entity_type,
         "entity_id": str(body.entity_id),
         "title": title,
         "description": (description or "")[:500],
         "message": body.message,
+        "content": content,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/backend/app/routers/events.py
+++ b/backend/app/routers/events.py
@@ -135,6 +135,9 @@ def _event_to_payload(event: "Event") -> dict:
         "source": {"type": event.source_entity_type, "id": str(event.source_entity_id) if event.source_entity_id else None},
         "sender_id": str(event.sender_id) if event.sender_id else None,
         "payload": event.payload,
+        # E-EVENT-INJECT S1: content를 SSE top-level로 노출(conversation.message_created 미러).
+        # connector가 top-level content를 읽어 드롭 안 걸리게.
+        "content": (event.payload or {}).get("content"),
         "created_at": event.created_at.isoformat(),
     }
 

--- a/backend/tests/test_e_event_inject_s1_dispatch_content.py
+++ b/backend/tests/test_e_event_inject_s1_dispatch_content.py
@@ -1,0 +1,73 @@
+"""E-EVENT-INJECT S1: dispatch 이벤트 content 주입 — connector 드롭 방지.
+
+connector(adapter.py:189) `content = data.get("content") or payload.get("content")`;
+`if not content: return`. 따라서 dispatched에 content 부여 + SSE top-level 노출이 핵심.
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import uuid
+from types import SimpleNamespace
+
+from app.routers.events import _event_to_payload
+from app.routers.agent_gateway import _row_to_payload
+
+
+def _ev(payload):
+    return SimpleNamespace(
+        id=uuid.uuid4(), event_type="dispatched",
+        source_entity_type="story", source_entity_id=uuid.uuid4(),
+        sender_id=None, payload=payload, created_at=datetime.datetime.now(),
+    )
+
+
+def _row(payload):
+    return SimpleNamespace(
+        event_id=uuid.uuid4().hex, event_type="dispatched", recipient_seq=1,
+        source_entity_type="story", source_entity_id=str(uuid.uuid4()),
+        sender_id=None, payload=payload, created_at=datetime.datetime.now(),
+    )
+
+
+# ── SSE 직렬화: content top-level 노출 ────────────────────────────────────────
+
+def test_event_to_payload_hoists_content_top_level():
+    p = _event_to_payload(_ev({"content": "[story] Build — ship it", "title": "Build"}))
+    assert p["content"] == "[story] Build — ship it"  # top-level
+    assert p["payload"]["content"] == "[story] Build — ship it"  # payload에도 유지
+
+
+def test_event_to_payload_content_none_when_absent():
+    p = _event_to_payload(_ev({"title": "no content"}))
+    assert p["content"] is None  # 없으면 None (안전)
+
+
+def test_row_to_payload_hoists_content_dict_and_str():
+    # dict payload
+    assert _row_to_payload(_row({"content": "X"}))["content"] == "X"
+    # JSON string payload
+    assert _row_to_payload(_row(json.dumps({"content": "Y"})))["content"] == "Y"
+    # 없으면 None
+    assert _row_to_payload(_row({"title": "t"}))["content"] is None
+
+
+# ── connector 드롭 조건 시뮬레이션 (content 비어있지 않아야 주입됨) ─────────────
+
+def _connector_would_inject(sse_data: dict) -> bool:
+    payload = sse_data.get("payload") or {}
+    content = (sse_data.get("content") or payload.get("content") or "").strip()
+    return bool(content)  # adapter.py: `if not content: return` 의 역
+
+
+def test_dispatched_event_is_not_dropped():
+    # dispatch.py가 부여하는 content 형태
+    entity_type, title, detail = "story", "Fix login", "급함"
+    content = f"[{entity_type}] {title}" + (f" — {detail}" if detail else "")
+    sse = _event_to_payload(_ev({"content": content, "title": title}))
+    assert _connector_would_inject(sse) is True  # 드롭 안 됨 → work-turn 주입
+
+
+def test_contentless_event_still_dropped():
+    sse = _event_to_payload(_ev({"title": "system note"}))
+    assert _connector_would_inject(sse) is False  # content 없으면 기존대로 드롭(의도된 동작)


### PR DESCRIPTION
## E-EVENT-INJECT S1 — dispatch 이벤트 content 부여 (데모 핵심)

story `d029e9f6-57b5-469f-b89e-2e74cf5a04aa` | epic E-EVENT-INJECT | BE only

**문제:** Dispatch 버튼(미르코 E-BOARD S1) 눌러도 dispatched 이벤트에 content가 없어 connector(`adapter.py:189 if not content: return`)가 조용히 드롭 → 에이전트가 일 시작 안 함. '에이전트한테 일 시키기' wow가 안 작동.

### 변경
| 파일 | 변경 |
|------|------|
| `routers/dispatch.py` | payload에 top-level `content` = `[{entity_type}] {title} — {message or description}` |
| `routers/events.py` `_event_to_payload` | `content`를 SSE top-level로 hoist (None-safe) |
| `routers/agent_gateway.py` `_row_to_payload` | 동일 hoist (dict/JSON-str payload 모두) |
| tests | 신규 단위 5건 |

### AC 매핑
- ✅ `dispatch.py` payload에 top-level content 추가
- ✅ gateway `_event_to_payload`/`_row_to_payload`가 content를 SSE data **top-level** 노출(conversation.message_created 미러)
- ✅ connector `if not content: return` 드롭 안 걸림 → dispatched가 work-turn 주입
- ⏭️ story_assigned 동형 content는 **S3**(S1은 dispatch 우선)
- ✅ 마이그 없음

### ⚠️ connector 외부 여부 확인 (PO 질문)
`connectors/hermes-sprintable/adapter.py`는 **in-repo(서브모듈 아님)**. 이미 `content = data.get("content") or payload.get("content")`로 top-level/payload 양쪽을 읽음 → **BE content 제공만으로 S1 완성**(adapter 변경 불요). 미르코 버튼 + 디디 content 페어로 동작.

### 검증
- `pytest`: **1514 passed**(신규 5 + dispatch/event/gateway 슬라이스 포함), 16 skipped, 8 xfailed
- 잔여 14 = realdb/mcp/subprocess 인프라 사전존재, 본 변경 무관
- 신규 단위: top-level hoist(dict/str/None) + connector 드롭 시뮬(content有→주입 / content無→드롭 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)