### PR TITLE
feat(E-EVENT-INJECT S2): connector 주입 allow-list (recommended ONLY)

### DIFF
--- a/connectors/hermes-sprintable/adapter.py
+++ b/connectors/hermes-sprintable/adapter.py
@@ -32,6 +32,15 @@ except ImportError:
     HTTPX_AVAILABLE = False
     httpx = None  # type: ignore[assignment]
 
+# E-EVENT-INJECT S2: 주입 allow-list는 SDK(connectors/sdk/sprintable_sse.py)가 단일 출처.
+# hermes 런타임 path에 sdk가 없으면 sibling 디렉터리를 추가해 import (분기 중복 금지).
+try:
+    from sprintable_sse import INJECTABLE_EVENT_TYPES
+except ImportError:
+    import sys
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sdk"))
+    from sprintable_sse import INJECTABLE_EVENT_TYPES
+
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -186,6 +195,10 @@ class SprintableAdapter(BasePlatformAdapter):
         # event shape: content/conversation_id/sender/recipient_seq are top-level
         # in conversation.message_created; SSE id: = event_id UUID (not the seq).
         payload = data.get("payload") or {}
+        # E-EVENT-INJECT S2: recommended ONLY allow-list (content 체크 전). FYI 등은 드롭.
+        event_type = data.get("event_type") or payload.get("event_type")
+        if event_type not in INJECTABLE_EVENT_TYPES:
+            return  # not a recommended inject type (e.g. status_changed FYI)
         content = (data.get("content") or payload.get("content") or "").strip()
         if not content:
             return  # nothing to inject (e.g. dispatched/system event without text)

--- a/connectors/sdk/sprintable_sse.py
+++ b/connectors/sdk/sprintable_sse.py
@@ -41,6 +41,24 @@ STREAM_READ_TIMEOUT = 90
 DEDUP_MAX_SIZE = 1000
 DEDUP_TTL_SECONDS = 300.0
 
+# ── E-EVENT-INJECT S2: 주입 허용 event_type (중앙 상수, recommended ONLY) ──────────
+# 이 목록 밖의 event_type은 content가 실려있어도 work-turn으로 주입하지 않고 드롭한다
+# (FYI poisoning 방지: status_changed/task_completed/agent_joined/sprint_closed/file_conflict 등).
+# 워크플로 트리거(kickoff/review_request/qa_request/deploy_request/handoff)는 현재 백엔드가
+# dispatched 이벤트로 전달하나, 향후 직접 event_type emit 대비해 명시 포함.
+# ⚠️ 단일 출처 — hermes adapter.py가 이 상수를 import해서 사용(분기 중복 금지).
+INJECTABLE_EVENT_TYPES = frozenset({
+    "dispatched",
+    "story_assigned",
+    "conversation.message_created",
+    "conversation:mention",
+    "kickoff",
+    "review_request",
+    "qa_request",
+    "deploy_request",
+    "handoff",
+})
+
 
 # ── Public types ─────────────────────────────────────────────────────────────
 
@@ -134,6 +152,10 @@ class SprintableSSEClient:
         payload = data.get("payload") or {}
         if isinstance(payload, str):
             payload = {}
+        # E-EVENT-INJECT S2: recommended ONLY allow-list (content 체크 전). FYI 등은 드롭.
+        event_type = data.get("event_type") or payload.get("event_type")
+        if event_type not in INJECTABLE_EVENT_TYPES:
+            return None
         content = (data.get("content") or payload.get("content") or "").strip()
         if not content:
             return None

--- a/connectors/sdk/test_inject_allowlist.py
+++ b/connectors/sdk/test_inject_allowlist.py
@@ -1,0 +1,71 @@
+"""E-EVENT-INJECT S2: 주입 allow-list (recommended ONLY) 검증.
+
+connector가 recommended event_type만 work-turn으로 주입하고, content가 실린 FYI는 드롭함을 확인.
+SDK(sprintable_sse) 기준 — hermes adapter.py는 동일 상수(INJECTABLE_EVENT_TYPES)를 import해 동일 게이트.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from sprintable_sse import INJECTABLE_EVENT_TYPES, SprintableSSEClient  # noqa: E402
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_RECOMMENDED = (
+    "dispatched", "story_assigned", "conversation.message_created", "conversation:mention",
+    "kickoff", "review_request", "qa_request", "deploy_request", "handoff",
+)
+_FYI = (
+    "status_changed", "story_status_changed", "task_completed",
+    "agent_joined", "sprint_closed", "file_conflict",
+)
+
+
+def test_allowlist_recommended_in_fyi_out():
+    for ok in _RECOMMENDED:
+        assert ok in INJECTABLE_EVENT_TYPES, ok
+    for bad in _FYI:
+        assert bad not in INJECTABLE_EVENT_TYPES, bad
+
+
+def _data(event_type, content="[story] do the thing", **extra):
+    return json.dumps({"event_type": event_type, "content": content,
+                       "event_id": "evt-" + event_type, **extra})
+
+
+@pytest.mark.anyio
+async def test_recommended_event_injected():
+    c = SprintableSSEClient(api_key="x")
+    ctx = await c._parse_event("message", "1", _data("dispatched"))
+    assert ctx is not None  # 주입됨
+
+
+@pytest.mark.anyio
+async def test_fyi_dropped_even_with_content():
+    c = SprintableSSEClient(api_key="x")
+    # content가 실려있어도 status_changed는 allow-list 밖 → 드롭(poisoning 방지)
+    ctx = await c._parse_event("message", "2", _data("status_changed", content="moved to done"))
+    assert ctx is None
+
+
+@pytest.mark.anyio
+async def test_unknown_and_missing_type_dropped():
+    c = SprintableSSEClient(api_key="x")
+    assert await c._parse_event("message", "3", _data("task_completed")) is None
+    assert await c._parse_event("message", "4", json.dumps({"content": "no type"})) is None
+
+
+@pytest.mark.anyio
+async def test_mention_and_message_created_injected():
+    c = SprintableSSEClient(api_key="x")
+    assert await c._parse_event("message", "5", _data("conversation:mention")) is not None
+    assert await c._parse_event("message", "6", _data("conversation.message_created")) is not None


### PR DESCRIPTION
## E-EVENT-INJECT S2 — connector 주입 allow-list (선생님 결정 'recommended ONLY')

story `e993fa18-960a-4885-85e9-6e61dd490e15` | epic E-EVENT-INJECT | connector(in-repo) only

**문제:** S1으로 dispatch가 주입되게 됐으나, connector 게이트가 **content-presence 하나뿐**(allow-list 없음) → content 실린 FYI(status_changed 등)도 주입 → 데모 중 에이전트 헛 turn poisoning.

### 변경
| 파일 | 변경 |
|------|------|
| `connectors/sdk/sprintable_sse.py` | **중앙 상수** `INJECTABLE_EVENT_TYPES`(recommended ONLY) + `_parse_event` allow-list 게이트(content 체크 전) |
| `connectors/hermes-sprintable/adapter.py` | SDK 상수 import(분기 중복 금지·path fallback) + `_on_event` 동일 게이트 |
| `connectors/sdk/test_inject_allowlist.py` (신규) | 단위 5건 |

### allow-list (recommended ONLY)
`dispatched` · `story_assigned` · `conversation.message_created` · `conversation:mention` · workflow `kickoff`/`review_request`/`qa_request`/`deploy_request`/`handoff`. **그 외(FYI: status_changed/story_status_changed/task_completed/agent_joined/sprint_closed/file_conflict)는 content 있어도 드롭.**

### AC 매핑
- ✅ `adapter.py:_on_event` + `sprintable_sse.py:_parse_event`에 event_type allow-list 게이트(content 전)
- ✅ recommended ONLY — 그 외 content 있어도 skip
- ✅ 명시 비주입 드롭 단언 테스트(status_changed/task_completed/agent_joined/sprint_closed/file_conflict + unknown/no-type)
- ✅ allow-list **중앙 상수 1개**(SDK) — hermes가 import, 분기 중복 없음
- ✅ 마이그 없음

### ⚠️ 확인 필요 (PO)
1. **hermes 배포 path**: `adapter.py`가 SDK 상수를 import — hermes 런타임이 `connectors/sdk`를 path에 두면 직접 import, 아니면 sibling 디렉터리(`../sdk`) fallback. hermes가 자기 디렉터리만 번들하는 배포라면 **sdk 번들링 스텝**이 필요. 현 배포 토폴로지 확인 부탁.
2. **워크플로 슬러그**: `kickoff`/`review_request`/... 는 backend `EventType` enum이 아니라 `trigger_type_slug`. 현재 해당 work-turn은 `dispatched` event_type으로 도달(이미 허용)하므로 동작은 OK. 목록엔 전방호환 위해 명시 포함.

### 검증
- 신규 단위 **5 passed**(SDK `_parse_event`: recommended 주입 / FYI·unknown·no-type 드롭 / mention·message_created 주입). adapter.py는 `gateway` 런타임 의존이라 백엔드 venv import 불가 → 동일 상수·동일 게이트 코드 리뷰로 확인.
- **백엔드 변경 0**(connector-only) → backend 스위트 영향 없음.

(S3 assignment-wake는 후속.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)