### PR TITLE
feat(E-ONBOARDING S4): 초대 실메일 — 무음 실패 가시화 (Resend live)

### DIFF
--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -8,23 +8,27 @@ from email.mime.text import MIMEText
 logger = logging.getLogger(__name__)
 
 
-def send_email(to: str, subject: str, html_body: str) -> None:
+def send_email(to: str, subject: str, html_body: str) -> bool:
     """이메일 발송.
 
     우선순위: RESEND_API_KEY → EMAIL_SMTP_HOST → 콘솔 출력 fallback.
-    실패 시 예외를 re-raise — 호출자가 오류 처리 책임.
+    반환: **True = Resend/SMTP로 실제 발송됨. False = provider 미설정 → 콘솔 fallback(실발송 아님)**.
+    provider 발송 실패 시 예외를 re-raise — 호출자가 오류 처리 책임.
+    (E-ONBOARDING S4: False/예외를 호출자가 '미발송'으로 surface해 무음 성공을 차단.)
     """
     resend_key = os.getenv("RESEND_API_KEY", "")
     if resend_key:
         _send_via_resend(to=to, subject=subject, html_body=html_body, api_key=resend_key)
-        return
+        return True
 
     smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
     if smtp_host:
         _send_via_smtp(to=to, subject=subject, html_body=html_body, smtp_host=smtp_host)
-        return
+        return True
 
-    logger.info("[EMAIL FALLBACK] To: %s | Subject: %s\n%s", to, subject, html_body)
+    # provider 미설정 — 콘솔 fallback은 실제 발송이 아니다. 호출자가 '미발송'으로 처리해야 함.
+    logger.warning("[EMAIL FALLBACK] provider 미설정 — 실발송 아님. To: %s | Subject: %s", to, subject)
+    return False
 
 
 def _send_via_resend(*, to: str, subject: str, html_body: str, api_key: str) -> None:

--- a/backend/app/services/org_invite_email.py
+++ b/backend/app/services/org_invite_email.py
@@ -77,11 +77,16 @@ def send_invite_email(
     )
 
     try:
-        send_email(
+        delivered = send_email(
             to=to,
             subject=f"[Sprintable] {org_name} 조직에 초대됐습니다",
             html_body=html_body,
         )
+        if not delivered:
+            # E-ONBOARDING S4: provider 미설정 → 콘솔 fallback은 실발송 아님.
+            # error로 surface해 email_sent_at=null + 경고가 UI에 노출되도록(무음 거짓 성공 차단).
+            logger.warning("Invite email NOT delivered (provider unconfigured) to %s", to)
+            return "email provider not configured — invite email was not delivered"
         return None
     except Exception as exc:  # noqa: BLE001
         logger.exception("Failed to send invite email to %s", to)

--- a/backend/tests/test_e_onboarding_s4_invite_email.py
+++ b/backend/tests/test_e_onboarding_s4_invite_email.py
@@ -1,0 +1,49 @@
+"""E-ONBOARDING S4: 초대 실메일 발송 — 무음 실패 가시화.
+
+핵심: provider 미설정(콘솔 fallback)이나 Resend 실패를 '발송완료'로 무음 처리하지 않고,
+send_invite_email이 error를 반환 → 라우터가 email_sent_at=null + email_error로 surface.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.services.email import send_email
+from app.services.org_invite_email import send_invite_email
+
+
+# ── send_email: 실발송 여부를 bool로 반환 ─────────────────────────────────────
+
+def test_send_email_false_on_console_fallback():
+    """provider env 없음 → 콘솔 fallback → False(실발송 아님)."""
+    with patch.dict("os.environ", {}, clear=True):
+        assert send_email(to="a@b.com", subject="s", html_body="<p>x</p>") is False
+
+
+def test_send_email_true_on_resend():
+    """RESEND_API_KEY 있으면 Resend 발송 → True."""
+    with patch.dict("os.environ", {"RESEND_API_KEY": "re_test"}, clear=True), \
+         patch("app.services.email._send_via_resend") as mock_resend:
+        assert send_email(to="a@b.com", subject="s", html_body="<p>x</p>") is True
+        mock_resend.assert_called_once()
+
+
+# ── send_invite_email: 무음 성공 차단 ─────────────────────────────────────────
+
+def test_invite_email_warns_on_unconfigured_provider():
+    """콘솔 fallback(False) → error 문자열 반환(무음 '성공' 아님)."""
+    with patch("app.services.org_invite_email.send_email", return_value=False):
+        err = send_invite_email(to="x@y.com", org_name="Org", token="t", role="member")
+    assert err is not None and "not" in err.lower()  # surface된 경고
+
+
+def test_invite_email_none_on_real_delivery():
+    """실발송(True) → None(성공)."""
+    with patch("app.services.org_invite_email.send_email", return_value=True):
+        assert send_invite_email(to="x@y.com", org_name="Org", token="t", role="member") is None
+
+
+def test_invite_email_returns_error_on_exception():
+    """Resend 예외 → error 문자열(라우터가 email_sent_at=null로 처리)."""
+    with patch("app.services.org_invite_email.send_email", side_effect=RuntimeError("resend 500")):
+        err = send_invite_email(to="x@y.com", org_name="Org", token="t", role="member")
+    assert err is not None and "resend 500" in err

--- a/backend/tests/test_e_org_multi_s3_2_invite_email.py
+++ b/backend/tests/test_e_org_multi_s3_2_invite_email.py
@@ -89,6 +89,7 @@ def test_send_invite_email_includes_token():
 
     def _mock_send(to, subject, html_body):
         sent_bodies.append(html_body)
+        return True  # E-ONBOARDING S4: send_email True=실발송
 
     with patch("app.services.org_invite_email.send_email", side_effect=_mock_send):
         result = send_invite_email(to="x@y.com", org_name="Test", token="tok123", role="member")

--- a/backend/tests/test_s_inv_03.py
+++ b/backend/tests/test_s_inv_03.py
@@ -51,6 +51,7 @@ def test_invite_html_inviter_fallback():
 
     def mock_send(*, to, subject, html_body):
         captured["html"] = html_body
+        return True  # E-ONBOARDING S4: send_email True=실발송
 
     with patch("app.services.org_invite_email.send_email", side_effect=lambda **kw: mock_send(**kw)):
         # inviter_name 미전달
@@ -294,7 +295,7 @@ def test_send_invite_email_success():
     """send_invite_email — 이메일 발송 성공 시 None 반환."""
     from app.services.org_invite_email import send_invite_email
     with patch("app.services.org_invite_email.send_email") as mock_send:
-        mock_send.return_value = None
+        mock_send.return_value = True  # E-ONBOARDING S4: True=실발송 → 성공(None)
         result = send_invite_email(
             to="test@example.com",
             org_name="TestOrg",


### PR DESCRIPTION
## E-ONBOARDING S4 — 초대 실메일 발송 (데모 온보딩 마지막 조각)

story `01ea1662-7104-406f-b33d-ad6665377529` | epic E-ONBOARDING | BE only

이메일 인프라(RESEND_API_KEY/EMAIL_FROM·sprintable.ai 도메인 인증·dev 배선)는 **PO 완비**. 코드가 무음 성공을 더는 내지 않게.

**근본:** `send_email`의 콘솔 fallback이 예외 없이 `None` 반환 → `send_invite_email`이 '성공'으로 보고 → `email_sent_at=now()` (UI 거짓 '발송완료'). provider 미설정/실패가 무음.

### 변경
| 파일 | 변경 |
|------|------|
| `services/email.py` | `send_email` 반환 `None`→**`bool`**. True=Resend/SMTP 실발송, False=콘솔 fallback(미발송). provider 실패는 기존대로 예외 |
| `services/org_invite_email.py` | `send_invite_email`: `delivered=False`면 error 문자열 반환 → 라우터가 `email_sent_at=null`+`email_error`로 surface |
| tests | 신규 5 + 회귀 mock 3건(None=success→True=delivered) |

### AC 매핑
- ✅ live path `org_invites.py:60`→`email.py`: env 있으면 **Resend 실발송**(True), 컬럼 영속화는 기존 라우터 정합
- ✅ **무음 실패 가시화**: Resend/콘솔fallback 미발송 → `email_sent_at=null` + `email_error` 응답 → UI 경고 가능 (기존 None='success' 무음 제거)
- ✅ `email_sent_at`는 **0042에서 이미 존재** → 마이그 없음
- ✅ `invitations.py` 미수정(org_invites canonical, 정리는 follow-up)

### 검증
- `pytest`: **1523 passed**. 신규 `test_e_onboarding_s4_invite_email`(5: fallback→False/Resend→True / invite warn·none·error)
- 회귀 갱신: `test_s_inv_03`·`test_e_org_multi_s3_2`의 send_email mock(None→True)
- 잔여 14 = realdb/mcp/subprocess 인프라 사전존재, 본 변경 무관
- **실 수신**: PO가 dev 실초대로 외부메일 확인(인프라 PO 담당)

🤖 Generated with [Claude Code](https://claude.com/claude-code)