### PR TITLE
feat(E-EVENT-INJECT S3): assignment-wake — agent 배정 시 work-turn 시작

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -8,11 +8,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_project_scoped_org_id, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.event import Event
 from app.models.pm import Epic, Story, StoryActivity, StoryComment
 from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
 from app.repositories.story_assignee import StoryAssigneeRepository
+from app.routers.agent_gateway import wake_agent
 from app.routers.events import publish_event
+from app.services.event_seq import assign_recipient_seq
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
 from app.services.notification_dispatch import dispatch_notification
@@ -289,18 +292,54 @@ async def update_story(
             ))
         except Exception:
             pass
-        # E-EVENTBUS P3 S9: story_assigned → assignee에게 알림
+        # E-EVENTBUS P3 S9 / E-EVENT-INJECT S3: story_assigned 알림 + agent assignment-wake
         if story.assignee_id and story.assignee_id != old_assignee_id:
-            await dispatch_notification(
-                db,
-                org_id=org_id,
-                event_type="story_assigned",
-                target_member_ids=[story.assignee_id],
-                title=f"스토리 담당자로 지정됨: {story.title}",
-                body=None,
-                reference_type="story",
-                reference_id=story.id,
-            )
+            # assignee 멤버 타입 resolve (agent vs human)
+            assignee_type = (await db.execute(
+                select(TeamMember.type).where(TeamMember.id == story.assignee_id).limit(1)
+            )).scalar_one_or_none()
+
+            if assignee_type == "agent":
+                # E-EVENT-INJECT S3: agent에 배정만 해도 work-turn 시작.
+                # dispatch.py 미러 — content 실린 story_assigned Event + seq + commit BEFORE wake.
+                # (기존 dispatch_notification은 content 없는 dispatched라 connector가 드롭 → 깨우지 못함)
+                _detail = (story.description or "").strip()
+                _content = f"[story] {story.title}" + (f" — {_detail[:200]}" if _detail else "")
+                sa_event = Event(
+                    project_id=story.project_id,
+                    org_id=org_id,
+                    event_type="story_assigned",  # EventType enum 미존재 → literal (connector allow-list 포함)
+                    source_entity_type="story",
+                    source_entity_id=story.id,
+                    sender_id=actor_id,
+                    recipient_id=story.assignee_id,
+                    recipient_type="agent",
+                    payload={
+                        "story_id": str(story.id),
+                        "story_title": story.title,
+                        "content": _content,
+                        "event_type": "story_assigned",
+                    },
+                    status="pending",
+                )
+                db.add(sa_event)
+                await db.flush()
+                await assign_recipient_seq(db, sa_event)  # per-recipient dense seq
+                await db.commit()  # commit BEFORE wake — seq 확정, 이중전달 방지
+                if sa_event.recipient_seq is not None:
+                    wake_agent(str(story.assignee_id), sa_event.recipient_seq)
+            else:
+                # human: 기존 dispatch_notification 유지 (변경 0)
+                await dispatch_notification(
+                    db,
+                    org_id=org_id,
+                    event_type="story_assigned",
+                    target_member_ids=[story.assignee_id],
+                    title=f"스토리 담당자로 지정됨: {story.title}",
+                    body=None,
+                    reference_type="story",
+                    reference_id=story.id,
+                )
         if actor_id:
             try:
                 db.add(StoryActivity(

--- a/backend/tests/test_e_event_inject_s3_assignment_wake.py
+++ b/backend/tests/test_e_event_inject_s3_assignment_wake.py
@@ -1,0 +1,127 @@
+"""E-EVENT-INJECT S3: assignment-wake.
+
+스토리를 agent에 배정만 해도 dispatch 클릭 없이 깨워 work-turn 시작:
+agent assignee → story_assigned gateway Event(content) + seq + commit + wake_agent.
+human assignee → 기존 dispatch_notification 유지(변경0), wake 없음.
+"""
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+ASSIGNEE_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _story(assignee_id):
+    s = MagicMock()
+    s.id = STORY_ID
+    s.org_id = ORG_ID
+    s.project_id = PROJECT_ID
+    s.epic_id = None
+    s.sprint_id = None
+    s.assignee_id = assignee_id
+    s.assignee_ids = [assignee_id] if assignee_id else []
+    s.meeting_id = None
+    s.title = "Build login"
+    s.description = "OAuth + password"
+    s.status = "backlog"
+    s.priority = "medium"
+    s.story_points = None
+    s.acceptance_criteria = None
+    s.position = None
+    s.is_excluded = False
+    s.success_hypothesis = None
+    s.metric_definition = None
+    s.measure_after = None
+    s.outcome_status = "n_a"
+    s.outcome_result = None
+    s.attachments = []
+    s.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    s.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    return s
+
+
+async def _run_patch(assignee_type: str):
+    """assignee_type('agent'/'human')으로 PATCH /stories/{id} 실행 후 (wake_agent, dispatch_notification, added events) 반환."""
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from httpx import ASGITransport, AsyncClient
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID), "project_id": str(PROJECT_ID)}}
+
+    session = AsyncMock()
+    added = []
+    session.add = MagicMock(side_effect=added.append)
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = assignee_type  # TeamMember.type 조회
+    result.scalars.return_value.all.return_value = []
+    result.all.return_value = []
+    session.execute = AsyncMock(return_value=result)
+    session.commit = AsyncMock()
+    session.flush = AsyncMock()
+
+    async def _seq(db, ev):
+        ev.recipient_seq = 7  # seq 발급 시뮬
+
+    async def override_db():
+        yield session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+
+    story = _story(ASSIGNEE_ID)
+    try:
+        with patch("app.repositories.base.BaseRepository.update", new_callable=AsyncMock, return_value=story), \
+             patch("app.routers.stories.StoryRepository.get", new_callable=AsyncMock, return_value=_story(None)), \
+             patch("app.routers.stories._resolve_team_member_id", new_callable=AsyncMock, return_value=None), \
+             patch("app.routers.stories._resolve_actor_info", new_callable=AsyncMock, return_value=(None, None, None)), \
+             patch("app.routers.stories._upsert_assignee_participation", new_callable=AsyncMock), \
+             patch("app.repositories.story_assignee.StoryAssigneeRepository.set_for_story", new_callable=AsyncMock, return_value=[ASSIGNEE_ID]), \
+             patch("app.routers.stories.assign_recipient_seq", side_effect=_seq), \
+             patch("app.routers.stories.wake_agent") as mock_wake, \
+             patch("app.routers.stories.dispatch_notification", new_callable=AsyncMock) as mock_dispatch:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as c:
+                resp = await c.patch(f"/api/v2/stories/{STORY_ID}", json={"assignee_id": str(ASSIGNEE_ID)})
+            return resp, mock_wake, mock_dispatch, added
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_agent_assignee_wakes_with_story_assigned_event():
+    resp, mock_wake, mock_dispatch, added = await _run_patch("agent")
+    assert resp.status_code == 200
+    # story_assigned Event(content 포함)가 생성됐고 wake_agent 호출됨
+    sa_events = [e for e in added if getattr(e, "event_type", None) == "story_assigned"]
+    assert len(sa_events) == 1
+    ev = sa_events[0]
+    assert ev.recipient_type == "agent"
+    assert ev.payload["content"].startswith("[story] Build login")
+    mock_wake.assert_called_once()
+    mock_dispatch.assert_not_called()  # 중복전달 방지: agent는 dispatch_notification 안 탐
+
+
+@pytest.mark.anyio
+async def test_human_assignee_uses_dispatch_notification_no_wake():
+    resp, mock_wake, mock_dispatch, added = await _run_patch("human")
+    assert resp.status_code == 200
+    sa_events = [e for e in added if getattr(e, "event_type", None) == "story_assigned"]
+    assert sa_events == []  # human은 신규 gateway Event 없음
+    mock_wake.assert_not_called()
+    mock_dispatch.assert_called_once()  # 기존 경로 유지


### PR DESCRIPTION
## E-EVENT-INJECT S3 — assignment-wake

story `c373c271-8e53-460a-a23d-c3b6172b4735` | epic E-EVENT-INJECT | BE only

스토리를 agent에 **배정만 해도** dispatch 클릭 없이 깨워 work-turn 시작.

**근본:** 기존 `dispatch_notification`의 agent 경로는 content 없는 `dispatched` Event를 만들고(seq/wake 없음) → **S1 content 게이트가 드롭** → 배정해도 에이전트가 안 깨어남.

### 변경 (`app/routers/stories.py` assignee-change 블록)
assignee가 **agent로 resolve**되면 `dispatch.py:141-178` 미러:
- `story_assigned` Event(content=`[story] {title} — {desc}`·recipient_type=`agent`) 생성
- `assign_recipient_seq` → **commit BEFORE wake** → `wake_agent` (seq 확정·이중전달 방지)
- `story_assigned`는 EventType enum 미존재 → **string literal**(S2 connector allow-list에 포함)
- **휴먼 assignee는 기존 `dispatch_notification` 유지(변경0)**. agent만 dispatch_notification 스킵(중복전달 방지)

### AC 매핑
- ✅ assignee-change 블록에서 agent resolve 시 gateway Event(story_assigned·recipient agent·payload content) + seq + commit + then wake — dispatch.py 미러
- ✅ resolve + seq+commit+wake 순서 정확히 재사용(중복전달 방지)
- ✅ `story_assigned` EventType enum 미존재 → literal
- ✅ content S1 동형 → connector(allow-list에 story_assigned 포함)가 주입
- ✅ 휴먼 assignee는 dispatch_notification 유지(변경0)
- ✅ 마이그 없음

### 검증
- `pytest`: **1520 passed**. 신규 `test_e_event_inject_s3_assignment_wake`(2: agent→story_assigned+content+wake_agent·dispatch_notification 안 탐 / human→dispatch_notification·wake 없음)
- 잔여 14 = realdb/mcp/subprocess 인프라 사전존재, 본 변경 무관

이로써 E-EVENT-INJECT 3종 완성: dispatch content(S1) + allow-list(S2) + assignment-wake(S3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)