### PR TITLE
feat(E-INFRA S5): /agent/stream per-key 동시 스트림 제한 (tier-aware)

### DIFF
--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -23,6 +23,7 @@ from app.core.database import async_session_factory
 from app.dependencies.database import get_db
 from app.models.agent_gateway import AgentEventCursor, AgentGatewaySession
 from app.models.event import Event
+from app.models.organization import Organization
 from app.models.team import TeamMember
 from app.routers.events import _agent_connections, _event_to_payload
 
@@ -38,6 +39,19 @@ _BACKFILL_LIMIT: int = int(os.getenv("AGENT_GATEWAY_BACKFILL_LIMIT", "100"))
 #   legacy /events/stream은 폐기 수순이라 카운터 통합 시 잘못된 상호 제약이 생긴다. → 분리 유지.
 _MAX_AGENT_SSE_CONNECTIONS: int = int(os.getenv("MAX_AGENT_SSE_CONNECTIONS", "100"))
 _agent_sse_connection_count: int = 0
+
+# E-INFRA S5: per-API-key(=agent) 동시 스트림 제한 (tier-aware, abuse/fair-use).
+# 한 키가 무제한 스트림을 열어 메모리/큐를 독점하는 것 방지. per-key 카운트 = _agent_connections[agent_id] size.
+# ⚠️ tier 출처: agent 키는 sk_live_(ApiKey 모델)라 dependencies/rate_limit._resolve_tier
+#   (pk_live_/ProjectApiKey 전용)에 안 맞는다. agent의 올바른 tier 출처는 **org.plan**(free/team/pro)
+#   이므로 그것으로 tier 해소(TIER_LIMITS 패턴·429+Retry-After 응답 shape 재사용).
+_AGENT_STREAM_TIER_LIMITS: dict[str, int] = {
+    "free": int(os.getenv("AGENT_STREAM_LIMIT_FREE", "3")),
+    "team": int(os.getenv("AGENT_STREAM_LIMIT_TEAM", "15")),
+    "pro": int(os.getenv("AGENT_STREAM_LIMIT_PRO", "30")),
+}
+_AGENT_STREAM_DEFAULT_LIMIT: int = int(os.getenv("AGENT_STREAM_LIMIT_DEFAULT", "3"))
+_AGENT_STREAM_RETRY_AFTER: int = int(os.getenv("AGENT_STREAM_RETRY_AFTER", "5"))
 
 # âââ wake_agent: commit í í ìë¦¼ ââââââââââââââââââââââââââââââââââââââââââââ
 
@@ -163,6 +177,11 @@ async def agent_stream(
         if tm is None:
             raise HTTPException(status_code=404, detail="Agent not found")
 
+        # E-INFRA S5: tier(=org.plan) 해소 — per-key 동시 스트림 cap 산정용 (free<paid)
+        org_plan = (await db.execute(
+            select(Organization.plan).where(Organization.id == tm.org_id)
+        )).scalar_one_or_none() or "free"
+
         # acked_seq DB ì¡°í
         cursor = (await db.execute(
             select(AgentEventCursor).where(AgentEventCursor.agent_id == agent_id)
@@ -190,6 +209,21 @@ async def agent_stream(
 
     start_seq = max(acked_seq, header_seq)
     agent_id_str = str(agent_id)
+
+    # E-INFRA S5: per-key(agent) 동시 스트림 제한 (tier-aware) — 초과 시 429 + Retry-After.
+    # per-key 카운트 = _agent_connections[agent_id] (현재 동시 스트림 수). 새 연결은 아직 미등록 상태이므로
+    # >= limit 이면 이번 연결이 (limit+1)번째 → 거부. global cap(503)보다 먼저 검사(키 단위 quota가 우선 신호).
+    _per_key_limit = _AGENT_STREAM_TIER_LIMITS.get(org_plan, _AGENT_STREAM_DEFAULT_LIMIT)
+    if len(_agent_connections[agent_id_str]) >= _per_key_limit:
+        raise HTTPException(
+            status_code=429,
+            detail={
+                "code": "AGENT_STREAM_LIMITED",
+                "message": f"Concurrent agent stream limit ({_per_key_limit}) reached for this key",
+                "retry_after": _AGENT_STREAM_RETRY_AFTER,
+            },
+            headers={"Retry-After": str(_AGENT_STREAM_RETRY_AFTER)},
+        )
 
     # E-INFRA S4: 전역 agent stream 연결 cap — 초과 시 503 (legacy events.py:234-237 미러).
     # 증가 직후 진입하는 generate()의 finally에서 반드시 decrement (disconnect/GeneratorExit 누수 방지).

--- a/backend/tests/test_e_infra_s4_agent_stream_cap.py
+++ b/backend/tests/test_e_infra_s4_agent_stream_cap.py
@@ -32,8 +32,9 @@ def _patch_db_and_auth(monkeypatch, agent_id):
     db.commit = AsyncMock()
     tm = MagicMock()
     res_agent = MagicMock(); res_agent.scalar_one_or_none.return_value = tm
+    res_plan = MagicMock(); res_plan.scalar_one_or_none.return_value = "free"  # E-INFRA S5: org.plan 조회
     res_cursor = MagicMock(); res_cursor.scalar_one_or_none.return_value = None
-    db.execute = AsyncMock(side_effect=[res_agent, res_cursor])
+    db.execute = AsyncMock(side_effect=[res_agent, res_plan, res_cursor])
 
     class _Ctx:
         async def __aenter__(self):

--- a/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
+++ b/backend/tests/test_e_infra_s5_agent_stream_rate_limit.py
@@ -1,0 +1,93 @@
+"""E-INFRA S5: /agent/stream per-API-key(=agent) 동시 스트림 제한 (tier-aware).
+
+한 키가 무제한 스트림을 열어 메모리/큐 독점하는 abuse 방지. per-key 카운트 = _agent_connections[agent_id].
+tier(=org.plan) free < paid. 초과 → 429 + Retry-After. 다른 키는 무관.
+"""
+import asyncio
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
+
+from app.routers import agent_gateway as ag
+from app.dependencies.auth import AuthContext
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _patch(monkeypatch, agent_id, org_plan="free"):
+    db = AsyncMock(); db.add = MagicMock(); db.commit = AsyncMock()
+    tm = MagicMock(); tm.org_id = uuid.uuid4()
+    res_agent = MagicMock(); res_agent.scalar_one_or_none.return_value = tm
+    res_plan = MagicMock(); res_plan.scalar_one_or_none.return_value = org_plan
+    res_cursor = MagicMock(); res_cursor.scalar_one_or_none.return_value = None
+    db.execute = AsyncMock(side_effect=[res_agent, res_plan, res_cursor])
+
+    class _Ctx:
+        async def __aenter__(self):
+            return db
+        async def __aexit__(self, *a):
+            return False
+
+    monkeypatch.setattr(ag, "async_session_factory", lambda: _Ctx())
+    monkeypatch.setattr(ag, "_agent_sse_connection_count", 0)  # global cap 여유
+    req = MagicMock(); req.headers = {}
+    auth = AuthContext(user_id=str(agent_id), email=None,
+                       claims={"app_metadata": {"api_key_id": "k"}}, org_id=None)
+    return req, auth, str(agent_id)
+
+
+def _fill(agent_id_str, n):
+    for _ in range(n):
+        ag._agent_connections[agent_id_str].add(asyncio.Queue())
+
+
+def test_tier_limits_free_lower_than_paid():
+    assert ag._AGENT_STREAM_TIER_LIMITS["free"] < ag._AGENT_STREAM_TIER_LIMITS["team"]
+    assert ag._AGENT_STREAM_TIER_LIMITS["free"] < ag._AGENT_STREAM_TIER_LIMITS["pro"]
+
+
+@pytest.mark.anyio
+async def test_same_key_over_limit_returns_429(monkeypatch):
+    aid = uuid.uuid4()
+    req, auth, aid_str = _patch(monkeypatch, aid, org_plan="free")
+    limit = ag._AGENT_STREAM_TIER_LIMITS["free"]
+    _fill(aid_str, limit)  # 한도만큼 기존 스트림 → 다음 연결은 초과
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await ag.agent_stream(req, auth=auth)
+        assert exc.value.status_code == 429
+        assert exc.value.headers.get("Retry-After") is not None
+    finally:
+        ag._agent_connections.pop(aid_str, None)
+
+
+@pytest.mark.anyio
+async def test_different_key_independent(monkeypatch):
+    a_str = str(uuid.uuid4())
+    _fill(a_str, ag._AGENT_STREAM_TIER_LIMITS["free"])  # agent A 한도 도달
+    b = uuid.uuid4()
+    req, auth, b_str = _patch(monkeypatch, b, org_plan="free")  # agent B는 빈 상태
+    try:
+        resp = await ag.agent_stream(req, auth=auth)
+        assert isinstance(resp, StreamingResponse)  # B는 A와 무관하게 허용
+    finally:
+        ag._agent_connections.pop(a_str, None)
+        ag._agent_connections.pop(b_str, None)
+
+
+@pytest.mark.anyio
+async def test_tier_aware_paid_allows_more(monkeypatch):
+    aid = uuid.uuid4()
+    req, auth, aid_str = _patch(monkeypatch, aid, org_plan="pro")
+    _fill(aid_str, ag._AGENT_STREAM_TIER_LIMITS["free"])  # free 한도(3)만큼 — pro는 한도 더 높음
+    try:
+        resp = await ag.agent_stream(req, auth=auth)  # pro라 허용(free였으면 429)
+        assert isinstance(resp, StreamingResponse)
+    finally:
+        ag._agent_connections.pop(aid_str, None)


### PR DESCRIPTION
## E-INFRA S5 — /agent/stream per-API-key rate limit

story `0b4c14d0-9e9d-4000-8162-66c377dd4715` | epic E-INFRA-SCALE | BE only · deps S4(충족)

**문제:** S4(전역 cap) 위에, 단일 키가 abusive하게 스트림을 무제한 열어 fair-use/메모리를 독점 — per-key 제한 부재.

### 변경 (`app/routers/agent_gateway.py`)
- **per-agent 동시 스트림 cap**: `len(_agent_connections[agent_id]) >= per_tier_limit` → **429 + Retry-After**. global cap(S4 503)보다 **먼저** 검사(키 단위 quota가 더 actionable한 신호).
- **tier-aware**: `_AGENT_STREAM_TIER_LIMITS`(free=3·team=15·pro=30, env `AGENT_STREAM_LIMIT_*`). free가 낮음.

### AC 매핑
- ✅ per-key(api_key_id별=agent별) 동시 스트림 제한, per-key 카운트 = `_agent_connections[agent_id]` size, 초과→429+retry hint
- ✅ tier-aware(free vs paid), free 낮은 cap
- ✅ 테스트: 같은 키 N+1→429, 다른 키 무관
- ✅ 마이그 없음

### ⚠️ AC 괴리 1건 (PO 확인) — `_resolve_tier` 재사용 불가
AC는 `dependencies/rate_limit._resolve_tier` 재사용을 명시했으나, 그건 **`pk_live_`/ProjectApiKey 전용**. agent stream 키는 **`sk_live_`/ApiKey 모델**이라 _resolve_tier에 안 맞음(다른 키 타입). → agent의 **올바른 tier 출처 = `org.plan`(free/team/pro)** 으로 해소. `TIER_LIMITS` 패턴 + 429/Retry-After 응답 shape는 그대로 재사용, 신규 limiter 빌드 없음. (sliding-window open-rate는 메모리-abuse엔 concurrent가 핵심이라 이번 범위 외; 필요 시 기존 RateLimiter로 후속 가능.)

### 검증
- `pytest`: **1533 passed**. 신규 `test_e_infra_s5_...`(4: same-key 초과→429 / 다른 key 무관 / paid 더 허용 / free<paid)
- S4 테스트 mock에 org.plan 조회(3rd execute) 추가(엔드포인트 변경 반영)
- 잔여 14 = realdb/mcp/subprocess 인프라 사전존재, 본 변경 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)