### PR TITLE
feat(E-MCP S2): 키별 toolset 매니페스트 SSOT + call-time enforcement

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -146,6 +146,7 @@ app.include_router(organizations.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)
 app.include_router(me.router)
+app.include_router(mcp.router)  # E-MCP S2: toolset 매니페스트
 app.include_router(project_settings.router)
 app.include_router(webhooks.router)
 app.include_router(api_keys.router)

--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -1,0 +1,37 @@
+"""E-MCP S2: MCP toolset 매니페스트 — 키별 허용 toolset SSOT 엔드포인트.
+
+인증된 API Key의 scope를 정책 매니페스트로 반환. MCP 서버(및 BYO 에이전트 클라이언트)가
+이걸로 list 필터 + call-time enforcement(호출 차단)를 수행한다.
+"""
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.dependencies.auth import AuthContext, get_current_user
+from app.services.mcp_toolset import is_tool_allowed, resolve_policy
+
+router = APIRouter(prefix="/api/v2/mcp", tags=["mcp"])
+
+
+@router.get("/manifest")
+async def get_mcp_manifest(auth: AuthContext = Depends(get_current_user)) -> dict:
+    """현재 키의 허용 toolset 정책(scope/allowed_groups/destructive_allowed).
+
+    SSOT = ApiKey.scope. MCP 서버가 이 정책 + is_tool_allowed로 per-tool enforcement.
+    """
+    meta = auth.claims.get("app_metadata", {})
+    if not meta.get("api_key_id"):
+        raise HTTPException(status_code=403, detail="API key required for MCP manifest")
+    scope = meta.get("scope") or []
+    return resolve_policy(scope)
+
+
+@router.get("/manifest/check")
+async def check_tool_allowed(
+    tool: str,
+    auth: AuthContext = Depends(get_current_user),
+) -> dict:
+    """단일 도구 호출 허용 여부 — call-time enforcement 보조(서버측 재확인용·defense-in-depth)."""
+    meta = auth.claims.get("app_metadata", {})
+    if not meta.get("api_key_id"):
+        raise HTTPException(status_code=403, detail="API key required")
+    scope = meta.get("scope") or []
+    return {"tool": tool, "allowed": is_tool_allowed(tool, scope)}

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -1,0 +1,140 @@
+"""E-MCP S2: 키별 MCP toolset SSOT.
+
+API Key의 scope(list[str])가 허용 toolset 그룹을 보유한다(별도 마이그 없이 기존 scope 재사용).
+백엔드가 그룹 정의·허용 해소·매니페스트의 단일 진실원천(SSOT)이고, MCP 서버(및 다른 호출자)는
+이 모듈/매니페스트로 call-time enforcement(목록 숨김 + 호출 차단)를 수행한다.
+
+tool_name(`sprintable_<verb>_<domain>`) → group 은 명시 키워드 매핑으로 결정(파일 의존 X).
+destructive(delete_*/give_reward/lock 등)는 그룹과 별개로 추가 게이팅한다.
+"""
+from __future__ import annotations
+
+# ── toolset 그룹 키워드(tool 이름 부분일치, 위에서부터 우선) ──────────────────────
+# 그룹: stories/tasks/sprints/epics/chat/docs/analytics/retro/standup/meetings/
+#       notifications/webhooks/rewards/audit/agent_runs/admin/core
+_GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
+    ("rewards", ("reward", "wallet", "leaderboard")),
+    ("analytics", ("velocity", "health", "dashboard", "overview", "stats", "standup_missing",
+                   "sprint_summary", "recent_activity", "agent_stats", "blocked_stories",
+                   "unassigned_stories", "member_workload", "overdue", "epic_progress")),
+    ("agent_runs", ("agent_run", "run_status", "update_run")),
+    ("audit", ("audit",)),
+    ("webhooks", ("webhook",)),
+    ("notifications", ("notification",)),
+    ("meetings", ("meeting",)),
+    ("retro", ("retro",)),
+    ("standup", ("standup",)),
+    ("docs", ("doc", "search_docs")),
+    ("chat", ("chat", "message", "conversation")),
+    ("sprints", ("sprint",)),
+    ("epics", ("epic",)),
+    ("tasks", ("task",)),
+    ("stories", ("story", "stories", "backlog", "claim", "checkin")),
+    ("admin", ("lock", "unlock", "give_reward", "emit_event", "trigger_ai", "activate_sprint",
+               "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+]
+
+_CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
+
+# 명시 비-그룹 핵심 도구(항상 허용)
+_ALWAYS_ALLOWED: frozenset[str] = frozenset({
+    "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+})
+
+# scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
+_LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})
+_DESTRUCTIVE_SCOPES: frozenset[str] = frozenset({"admin", "destructive"})
+
+ALL_GROUPS: tuple[str, ...] = tuple(g for g, _ in _GROUP_KEYWORDS if g != "admin") + (_CORE,)
+
+
+def tool_group(tool_name: str) -> str:
+    """tool 이름 → 그룹. 매칭 없으면 'core'.
+
+    ⚠️ 모든 도구명이 'sprintable_' 접두사를 가지며 이는 'sprint'를 포함하므로, 반드시 접두사를
+    제거한 뒤 키워드 매칭한다(안 그러면 전 도구가 sprints 그룹으로 오분류).
+    """
+    n = tool_name.lower()
+    if n.startswith("sprintable_"):
+        n = n[len("sprintable_"):]
+    for group, keywords in _GROUP_KEYWORDS:
+        if any(k in n for k in keywords):
+            return group
+    return _CORE
+
+
+def is_destructive(tool_name: str) -> bool:
+    """파괴적/민감 도구 — 그룹과 별개로 추가 게이팅."""
+    n = tool_name.lower()
+    return (
+        "delete" in n
+        or "give_reward" in n
+        or n.endswith("lock_files")
+        or "unlock" in n
+        or "_delete_" in n
+        or n.startswith("sprintable_delete")
+        or "close_sprint" in n
+    )
+
+
+def is_tool_allowed(tool_name: str, scope: list[str] | None) -> bool:
+    """key의 scope로 tool 호출 허용 여부 판정 (call-time enforcement·매니페스트 공통).
+
+    규칙:
+    - 항상 허용 도구(_ALWAYS_ALLOWED)는 무조건 True.
+    - scope 미지정/레거시(read/write만) → **모든 비파괴 그룹 허용**(back-compat), destructive는 차단.
+    - scope에 그룹명 명시 → 해당 그룹만. 'admin'/'destructive' 있으면 파괴적 도구도 허용.
+    """
+    if tool_name in _ALWAYS_ALLOWED:
+        return True
+
+    tokens = {s.strip().lower() for s in (scope or []) if s and s.strip()}
+    group = tool_group(tool_name)
+    destructive = is_destructive(tool_name)
+
+    explicit_groups = tokens & set(ALL_GROUPS) | (tokens & {"admin"})
+    has_destructive_grant = bool(tokens & _DESTRUCTIVE_SCOPES)
+
+    # 그룹 허용 판정
+    if not explicit_groups:
+        # 명시 그룹 없음 → 레거시(read/write) 또는 빈 scope = 전체 비파괴 허용
+        group_ok = True
+    else:
+        group_ok = group in tokens or (group == "admin" and "admin" in tokens)
+
+    if not group_ok:
+        return False
+
+    # destructive 추가 게이팅
+    if destructive and not has_destructive_grant:
+        return False
+    return True
+
+
+def resolve_policy(scope: list[str] | None) -> dict:
+    """key scope → 정책 매니페스트(그룹 단위). 전체 tool 목록 불필요 — MCP 서버가 is_tool_allowed로
+    per-tool 적용. 백엔드는 key→scope(SSOT)와 정책만 서빙."""
+    tokens = {s.strip().lower() for s in (scope or []) if s and s.strip()}
+    explicit = tokens & set(ALL_GROUPS)
+    allowed_groups = sorted(explicit) if explicit else sorted(ALL_GROUPS)  # legacy/빈 scope = 전체 비파괴
+    return {
+        "scope": sorted(tokens),
+        "allowed_groups": allowed_groups,
+        "destructive_allowed": bool(tokens & _DESTRUCTIVE_SCOPES),
+        "all_groups": sorted(ALL_GROUPS),
+    }
+
+
+def resolve_manifest(scope: list[str] | None, all_tool_names: list[str]) -> dict:
+    """key scope + 전체 tool 목록 → 매니페스트(allowed/denied/groups/destructive)."""
+    allowed = [t for t in all_tool_names if is_tool_allowed(t, scope)]
+    denied = [t for t in all_tool_names if not is_tool_allowed(t, scope)]
+    allowed_groups = sorted({tool_group(t) for t in allowed})
+    tokens = {s.strip().lower() for s in (scope or []) if s and s.strip()}
+    return {
+        "allowed_tools": sorted(allowed),
+        "denied_tools": sorted(denied),
+        "allowed_groups": allowed_groups,
+        "destructive_allowed": bool(tokens & _DESTRUCTIVE_SCOPES),
+        "scope": sorted(tokens),
+    }

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import json
 import logging
 from typing import get_type_hints
 
@@ -17,6 +18,9 @@ from .api_client import client
 from .config import settings
 from .response import ok
 from .schemas import SprintableInput
+
+# E-MCP S2: toolset enforcement은 백엔드 SSOT(app.services.mcp_toolset)의 순수 규칙을 공유.
+from app.services.mcp_toolset import is_tool_allowed
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,
@@ -108,6 +112,35 @@ async def _heartbeat_fire_forget() -> None:
         logger.warning("heartbeat failed (ignored): %s", exc)
 
 
+# ── E-MCP S2: call-time toolset enforcement ──────────────────────────────────
+# 키의 허용 toolset(scope)을 /api/v2/mcp/manifest에서 1회 로드(캐시) 후, 매 도구 호출 시
+# is_tool_allowed로 차단(403-shape). 백엔드 ApiKey.scope가 진짜 SSOT, 여기선 defense-in-depth.
+_key_scope: list[str] | None = None
+_scope_loaded: bool = False
+
+
+async def _load_scope() -> None:
+    global _key_scope, _scope_loaded
+    if _scope_loaded:
+        return
+    _scope_loaded = True
+    try:
+        manifest = await client.get("/api/v2/mcp/manifest")
+        _key_scope = manifest.get("scope") or []
+    except Exception:
+        # 매니페스트 미가용 시 레거시 기본(비파괴 전체)로 fail-open — 백엔드가 최종 SSOT.
+        _key_scope = None
+        logger.warning("MCP toolset manifest load failed — falling back to legacy scope")
+
+
+def _denied(name: str) -> list[TextContent]:
+    return [TextContent(type="text", text=json.dumps(
+        {"error": "forbidden", "code": 403,
+         "message": f"tool '{name}' is not in this API key's allowed toolset"},
+        ensure_ascii=False,
+    ))]
+
+
 def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
     """BaseModel → flat inspect.Signature so FastMCP emits top-level params."""
     try:
@@ -133,6 +166,10 @@ def _flat(name: str, doc: str, input_cls: type[BaseModel], fn):
         )
 
     async def wrapper(**kwargs):
+        # E-MCP S2: call-time enforcement — 키 허용 밖 도구는 호출 차단(403-shape).
+        await _load_scope()
+        if not is_tool_allowed(name, _key_scope):
+            return _denied(name)
         result = await fn(input_cls(**kwargs))
         asyncio.create_task(_heartbeat_fire_forget())
         return result

--- a/backend/tests/test_e_mcp_s2_toolset.py
+++ b/backend/tests/test_e_mcp_s2_toolset.py
@@ -1,0 +1,128 @@
+"""E-MCP S2: 키별 toolset SSOT — 그룹 매핑 / is_tool_allowed / 매니페스트 / call-time enforcement."""
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.mcp_toolset import (
+    ALL_GROUPS,
+    is_destructive,
+    is_tool_allowed,
+    resolve_policy,
+    tool_group,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 그룹 매핑 (sprintable_ 접두사가 'sprint' 포함하는 함정 회피) ────────────────
+
+def test_tool_group_strips_prefix_no_sprint_false_match():
+    assert tool_group("sprintable_add_story") == "stories"
+    assert tool_group("sprintable_add_task") == "tasks"
+    assert tool_group("sprintable_send_chat_message") == "chat"
+    assert tool_group("sprintable_get_doc") == "docs"
+    assert tool_group("sprintable_get_velocity") == "analytics"
+    assert tool_group("sprintable_create_sprint") == "sprints"
+
+
+def test_destructive_detection():
+    assert is_destructive("sprintable_delete_story")
+    assert is_destructive("sprintable_give_reward")
+    assert is_destructive("sprintable_lock_files")
+    assert is_destructive("sprintable_close_sprint")
+    assert not is_destructive("sprintable_add_story")
+    assert not is_destructive("sprintable_list_stories")
+
+
+# ── is_tool_allowed: legacy / 명시 그룹 / destructive / always ─────────────────
+
+def test_legacy_scope_allows_nondestructive_blocks_destructive():
+    # read/write(레거시) → 비파괴 전체 허용, destructive 차단
+    assert is_tool_allowed("sprintable_add_story", ["read", "write"])
+    assert is_tool_allowed("sprintable_send_chat_message", ["read", "write"])
+    assert not is_tool_allowed("sprintable_delete_story", ["read", "write"])
+    assert not is_tool_allowed("sprintable_give_reward", ["read", "write"])
+
+
+def test_empty_scope_defaults_to_legacy():
+    assert is_tool_allowed("sprintable_add_story", [])
+    assert is_tool_allowed("sprintable_add_story", None)
+    assert not is_tool_allowed("sprintable_delete_story", None)
+
+
+def test_explicit_group_scopes_only_that_group():
+    assert is_tool_allowed("sprintable_add_story", ["stories"])
+    assert not is_tool_allowed("sprintable_add_task", ["stories"])  # tasks 그룹 차단
+    assert is_tool_allowed("sprintable_add_task", ["stories", "tasks"])
+
+
+def test_destructive_requires_explicit_grant():
+    assert not is_tool_allowed("sprintable_delete_story", ["stories"])  # 그룹은 OK지만 destructive 차단
+    assert is_tool_allowed("sprintable_delete_story", ["stories", "destructive"])
+    assert is_tool_allowed("sprintable_delete_story", ["stories", "admin"])
+
+
+def test_always_allowed_tools():
+    assert is_tool_allowed("sprintable_ping", ["stories"])  # 핵심 도구는 그룹 무관 허용
+    assert is_tool_allowed("ping", [])
+
+
+def test_resolve_policy():
+    p = resolve_policy(["stories", "chat"])
+    assert sorted(p["allowed_groups"]) == ["chat", "stories"]
+    assert p["destructive_allowed"] is False
+    p2 = resolve_policy(["read", "write"])  # 레거시 → 전체 비파괴 그룹
+    assert set(p2["allowed_groups"]) == set(ALL_GROUPS)
+    p3 = resolve_policy(["stories", "destructive"])
+    assert p3["destructive_allowed"] is True
+
+
+# ── 매니페스트 엔드포인트 ─────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_manifest_endpoint_returns_policy():
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user
+    from httpx import ASGITransport, AsyncClient
+
+    async def override_auth():
+        return AuthContext(
+            user_id=str(uuid.uuid4()), email=None,
+            claims={"app_metadata": {"api_key_id": "k", "scope": ["stories", "chat"]}},
+            org_id=str(uuid.uuid4()),
+        )
+
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/mcp/manifest")
+            chk = await c.get("/api/v2/mcp/manifest/check?tool=sprintable_add_task")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert sorted(body["allowed_groups"]) == ["chat", "stories"]
+        assert chk.json()["allowed"] is False  # tasks 그룹 미허용
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_manifest_requires_api_key():
+    from app.main import app
+    from app.dependencies.auth import AuthContext, get_current_user
+    from httpx import ASGITransport, AsyncClient
+
+    async def override_auth():
+        return AuthContext(user_id=str(uuid.uuid4()), email=None,
+                           claims={"app_metadata": {}}, org_id=None)  # JWT (api_key_id 없음)
+
+    app.dependency_overrides[get_current_user] = override_auth
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            resp = await c.get("/api/v2/mcp/manifest")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## E-MCP S2 — 백엔드 키별 toolset 매니페스트 + call-time enforcement

story `adde39b7-c58c-435f-8cf9-28c90c80e77f` | epic E-MCP-RIGHT | BE only · deps none

SaaS BYO 에이전트의 **권한 SSOT**. (월요일 데모는 워크스페이스 경험이라 고객 MCP 셀프셋업 비노출 → **non-demo-blocking**.) 키별 허용 toolset 부재 해소.

### 변경
| 파일 | 변경 |
|------|------|
| `app/services/mcp_toolset.py` (신규) | **SSOT 규칙**: tool→group 매핑 + destructive 감지 + `is_tool_allowed(tool, scope)` + `resolve_policy`/`resolve_manifest` |
| `app/routers/mcp.py` (신규) | `GET /api/v2/mcp/manifest`(+`/check?tool=`) — 인증 키의 허용 정책(SSOT 출처) |
| `sprintable_mcp/server.py` | `_flat` wrapper에 **call-time enforcement**: 매니페스트 scope 1회 로드 → 매 호출 `is_tool_allowed` → 허용 밖 도구 403-shape 차단 (공유 모듈 import = 규칙 단일 출처) |
| `app/main.py` | mcp 라우터 등록 |

### AC 매핑
- ✅ 키→허용 toolset 저장(기존 `ApiKey.scope` 재사용) + 매니페스트 엔드포인트
- ✅ **call-time enforcement**: 모든 MCP 툴 호출 시 허용 밖 → 차단(403-shape). 목록 숨김 아닌 **호출 차단**(defense-in-depth). SSOT = 백엔드 `ApiKey.scope` + `mcp_toolset` 규칙
- ✅ toolset 그룹 정의(stories/tasks/sprints/chat/docs/analytics/...) + destructive(delete_*/give_reward/lock/close_sprint) **별도 게이팅**(scope에 `destructive`/`admin` 필요)
- ✅ cross-org는 기존 키 스코프로 격리(로컬 단일테넌트) — 회귀 0
- ✅ **마이그 없음**(scope 재사용·back-compat: legacy read/write·빈 scope → 비파괴 전체 허용)

### 핵심 구현 노트
- ⚠️ **접두사 함정**: 모든 도구명이 `sprintable_`(= `sprint` 포함)라 키워드 매칭 전 접두사 제거 필수(안 하면 전 도구가 `sprints`로 오분류). 테스트로 회귀 고정.
- **싱글톤 멀티테넌시**: MCP 서버는 단일-키 config(로컬 단일테넌트)라 scope 1회 캐시 안전. 매니페스트 미가용 시 legacy 기본으로 fail-open(백엔드가 최종 SSOT) — 멀티-키 서버면 per-request 해소 필요(후속).
- **defense-in-depth 범위**: 이 PR은 MCP 서버 call-time 차단 + 백엔드 매니페스트(SSOT). 백엔드 REST 직접호출까지 막는 per-endpoint 강제는 후속(S3?) 여지.

### 검증
- `pytest`: **1539 passed**. 신규 `test_e_mcp_s2_toolset`(10): 그룹매핑(접두사 함정 포함)·destructive·legacy/명시/always scope·매니페스트+check+403
- 잔여 14 = realdb/mcp-e2e/subprocess 인프라 사전존재, 본 변경 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)