### PR TITLE
feat(E-MCP S3): 로컬 MCP 부팅 시 허용 toolset만 노출

### DIFF
--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -6,8 +6,22 @@ import sys
 
 from .api_client import SprintableApiError, client
 from .config import settings
-from .server import mcp
+from .server import filter_tools_by_scope, mcp
 from .sse_bridge import start_sse_bridge
+
+
+async def _setup() -> list[str] | None:
+    """auth context resolve + E-MCP S3 toolset 매니페스트 scope 조회.
+
+    auth 실패는 raise(상위에서 exit). 매니페스트 실패는 None 반환(레거시 비파괴셋으로 degrade, crash X).
+    """
+    await client.resolve_auth_context()
+    try:
+        manifest = await client.get("/api/v2/mcp/manifest")
+        return manifest.get("scope")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: MCP manifest fetch 실패 ({exc}) — 레거시 비파괴셋으로 degrade", file=sys.stderr)
+        return None
 
 
 def main() -> None:
@@ -20,7 +34,7 @@ def main() -> None:
 
     client.configure(settings.sprintable_api_url, settings.agent_api_key)
     try:
-        asyncio.run(client.resolve_auth_context())
+        _scope = asyncio.run(_setup())
     except SprintableApiError as exc:
         if exc.status == 401:
             print("Error: Invalid API Key — AGENT_API_KEY를 확인하는.", file=sys.stderr)
@@ -30,6 +44,11 @@ def main() -> None:
     except Exception as exc:
         print(f"Error: auth context resolve failed: {exc}", file=sys.stderr)
         sys.exit(1)
+
+    # E-MCP S3: 허용 toolset만 노출 (S2 wrapper의 call-time 차단은 유지·defense-in-depth)
+    n_hidden = filter_tools_by_scope(_scope)
+    if n_hidden:
+        print(f"MCP toolset: {n_hidden} tools hidden by key scope", file=sys.stderr)
 
     asyncio.run(_run())
 

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -486,3 +486,27 @@ _TOOL_DEFS: list[tuple] = [
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:
     mcp.tool()(_flat(_name, _doc, _cls, _fn))
+
+
+# ── E-MCP S3: 부팅 시 허용 toolset만 노출 (schema/list 컨텍스트 절감) ─────────────
+# S2의 call-time wrapper(호출 차단)는 그대로 유지 — S3는 list/schema에서 허용 밖 도구를 숨겨
+# 컨텍스트를 절감하는 UX 레이어(defense-in-depth). 규칙은 동일하게 is_tool_allowed(SSOT) 공유.
+def disallowed_tools(scope: list[str] | None) -> list[str]:
+    """주어진 scope에서 허용되지 않는 등록 도구명 목록 (순수 — mcp 미변경)."""
+    return [name for name, _doc, _cls, _fn in _TOOL_DEFS if not is_tool_allowed(name, scope)]
+
+
+def filter_tools_by_scope(scope: list[str] | None) -> int:
+    """허용 밖 도구를 MCP 레지스트리에서 제거(부팅 시 1회). 제거 수 반환.
+
+    scope=None(매니페스트 fetch 실패/미바인딩) → 레거시 비파괴셋(destructive만 숨김)로 graceful degrade.
+    _ALWAYS_ALLOWED(ping 등)는 is_tool_allowed가 항상 True라 보존.
+    """
+    removed = 0
+    for name in disallowed_tools(scope):
+        try:
+            mcp.remove_tool(name)
+            removed += 1
+        except Exception:
+            logger.debug("remove_tool skipped for %s (not registered)", name)
+    return removed

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -1,0 +1,52 @@
+"""E-MCP S3: 로컬 MCP 부팅 시 허용 toolset만 노출 (S2 매니페스트 기반 boot 필터).
+
+S2 wrapper(call-time 차단)는 유지, S3는 list/schema에서 허용 밖 도구 제거(컨텍스트 절감).
+매니페스트 fetch 실패 시 None → 레거시 비파괴셋으로 degrade(crash 금지).
+"""
+import sprintable_mcp.server as server
+
+
+def test_disallowed_tools_explicit_group():
+    d = server.disallowed_tools(["stories"])
+    assert "sprintable_add_task" in d        # tasks 그룹 미허용 → 제거 대상
+    assert "sprintable_add_story" not in d    # stories 허용 → 노출
+    assert "sprintable_send_chat_message" in d  # chat 미허용
+
+
+def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
+    d = server.disallowed_tools(["read", "write"])
+    assert "sprintable_add_story" not in d     # 비파괴 → 노출
+    assert "sprintable_delete_story" in d       # destructive → 숨김(grant 없음)
+    assert "sprintable_give_reward" in d
+
+
+def test_disallowed_tools_none_fallback_equals_legacy():
+    """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
+    d = server.disallowed_tools(None)
+    assert "sprintable_add_story" not in d
+    assert "sprintable_delete_story" in d
+
+
+def test_ping_never_in_disallowed():
+    # ping은 _TOOL_DEFS 밖 항상-노출 도구 → 어떤 scope에서도 제거 대상 아님
+    for scope in (["stories"], None, [], ["read"]):
+        assert "sprintable_ping" not in server.disallowed_tools(scope)
+        assert "ping" not in server.disallowed_tools(scope)
+
+
+def test_filter_tools_by_scope_removes_disallowed(monkeypatch):
+    removed: list[str] = []
+    monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
+    n = server.filter_tools_by_scope(["stories"])
+    assert n == len(removed) > 0
+    assert "sprintable_add_task" in removed       # 제거됨
+    assert "sprintable_add_story" not in removed   # 보존
+    assert "sprintable_ping" not in removed        # 항상 노출
+
+
+def test_filter_fallback_none_hides_only_destructive(monkeypatch):
+    removed: list[str] = []
+    monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
+    server.filter_tools_by_scope(None)  # degrade
+    assert "sprintable_delete_story" in removed     # destructive 숨김
+    assert "sprintable_add_story" not in removed     # 비파괴 보존


### PR DESCRIPTION
## E-MCP S3 — 로컬 MCP 부팅 시 허용 toolset만 노출

story `8242faf3-ea15-4a9d-9c93-f7e03ec000fa` | epic E-MCP-RIGHT | BE only · deps S2(#1218✓)

S2(백엔드)가 enforcement SSOT(진짜 차단), **S3는 로컬 UX/컨텍스트 절감** — 허용 밖 도구 schema를 list에 안 올림. non-demo-blocking.

### 변경
| 파일 | 변경 |
|------|------|
| `sprintable_mcp/__main__.py` | `_setup()`: auth context + S2 매니페스트 fetch → scope. 부팅 시 `filter_tools_by_scope(scope)` |
| `sprintable_mcp/server.py` | `disallowed_tools(scope)`(순수) + `filter_tools_by_scope(scope)`: 허용 밖 도구 `mcp.remove_tool`로 제거(부팅 1회). 규칙은 S2 `is_tool_allowed`(SSOT) 공유 |
| tests | 신규 단위 6 |

### AC 매핑
- ✅ 부팅 시 매니페스트(S2 `GET /api/v2/mcp/manifest`) fetch → 허용 toolset만 노출(`_TOOL_DEFS` 그룹 매핑)
- ✅ 미허용 툴 schema 미노출(list 부재 = 컨텍스트 절감)
- ✅ **폴백**: 매니페스트 fetch 실패 → `scope=None` → 레거시 비파괴셋(destructive만 숨김) graceful degrade, **crash 금지**
- ✅ stdio 유지(HTTP/원격 전환 0)
- ✅ S2 `_ALWAYS_ALLOWED`(ping)·legacy 폴백과 정합(미바인딩 키 안 깨짐)

### 설계 노트
- **import-time 등록 유지 + 부팅 필터**: 다수 테스트가 `sprintable_mcp.server`를 import하므로 등록을 import-time에 두고(회귀 0), 부팅 시 `remove_tool`로 허용 밖만 제거.
- **이중 방어**: S2 wrapper(call-time 호출 차단) 유지 + S3(list/schema hide) → defense-in-depth. 둘 다 동일 `is_tool_allowed`.

### 검증
- `pytest`: **1549 passed**. 신규 `test_e_mcp_s3_boot_filter`(6): 명시그룹 필터·legacy/None 폴백·ping 항상노출·`remove_tool` 타겟팅
- 잔여 14 = realdb/mcp-e2e/subprocess 인프라 사전존재, 본 변경 무관

🤖 Generated with [Claude Code](https://claude.com/claude-code)