### PR TITLE
[SID:E-BOARD-UX-S3] Story 상세에 Acceptance Criteria 렌더+인라인 편집

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -184,6 +184,8 @@
     "cancel": "Cancel",
     "edit": "Edit",
     "addDescription": "Add description",
+    "acceptanceCriteria": "Acceptance Criteria",
+    "addAcceptanceCriteria": "Add acceptance criteria",
     "searchSprints": "Search sprints...",
     "searchEpics": "Search epics...",
     "searchAssignees": "Search assignees...",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -184,6 +184,8 @@
     "cancel": "취소",
     "edit": "편집",
     "addDescription": "설명 추가",
+    "acceptanceCriteria": "완료 조건",
+    "addAcceptanceCriteria": "완료 조건 추가",
     "searchSprints": "스프린트 검색...",
     "searchEpics": "에픽 검색...",
     "searchAssignees": "담당자 검색...",

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -116,6 +116,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState(story.description ?? '');
   const [savingDescription, setSavingDescription] = useState(false);
+  const [editingAC, setEditingAC] = useState(false);
+  const [acDraft, setAcDraft] = useState(story.acceptance_criteria ?? '');
+  const [savingAC, setSavingAC] = useState(false);
 
   const [intent, setIntent] = useState<OutcomeIntentValue>({
     success_hypothesis: story.success_hypothesis ?? '',
@@ -168,13 +171,14 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   useEffect(() => {
     setTitleDraft(story.title);
     setDescriptionDraft(story.description ?? '');
+    setAcDraft(story.acceptance_criteria ?? '');
     setIntent({
       success_hypothesis: story.success_hypothesis ?? '',
       metric_definition: story.metric_definition ?? null,
       measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
     });
     setIntentOpen(!!story.success_hypothesis || !!story.metric_definition);
-  }, [story.id, story.title, story.description, story.success_hypothesis, story.metric_definition, story.measure_after]);
+  }, [story.id, story.title, story.description, story.acceptance_criteria, story.success_hypothesis, story.metric_definition, story.measure_after]);
 
   useEffect(() => {
     if (editingTitle) {
@@ -357,6 +361,18 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     if (updated) onStoryUpdate?.({ ...story, description: updated.description });
   };
 
+  const handleSaveAC = async () => {
+    if (acDraft === (story.acceptance_criteria ?? '')) {
+      setEditingAC(false);
+      return;
+    }
+    setSavingAC(true);
+    const updated = await patchStory({ acceptance_criteria: acDraft || null });
+    setSavingAC(false);
+    setEditingAC(false);
+    if (updated) onStoryUpdate?.({ ...story, acceptance_criteria: updated.acceptance_criteria });
+  };
+
   const handleSaveIntent = async () => {
     setSavingIntent(true);
     await patchStory({
@@ -413,12 +429,13 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       if (e.key === 'Escape') {
         if (editingTitle) { setEditingTitle(false); setTitleDraft(story.title); return; }
         if (editingDescription) { setEditingDescription(false); setDescriptionDraft(story.description ?? ''); return; }
+        if (editingAC) { setEditingAC(false); setAcDraft(story.acceptance_criteria ?? ''); return; }
         onClose();
       }
     };
     window.addEventListener('keydown', handleEsc);
     return () => window.removeEventListener('keydown', handleEsc);
-  }, [onClose, editingTitle, editingDescription, story.title, story.description]);
+  }, [onClose, editingTitle, editingDescription, editingAC, story.title, story.description, story.acceptance_criteria]);
 
   const handleSubmitComment = async () => {
     if (!commentInput.trim() || submittingComment) return;
@@ -675,6 +692,53 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
                 >
                   + {t('addDescription')}
+                </button>
+              )}
+            </div>
+
+            {/* Acceptance Criteria — Description 블록 미러 (E-BOARD-UX S3) */}
+            <div>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('acceptanceCriteria')}</span>
+                {!editingAC && (
+                  <button
+                    type="button"
+                    onClick={() => setEditingAC(true)}
+                    className="text-xs text-muted-foreground transition hover:text-foreground"
+                  >
+                    ✎ {t('edit')}
+                  </button>
+                )}
+              </div>
+              {editingAC ? (
+                <div className="mt-2 space-y-2">
+                  <textarea
+                    value={acDraft}
+                    onChange={(e) => setAcDraft(e.target.value)}
+                    placeholder="Markdown 형식으로 작성하세요..."
+                    className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    autoFocus
+                  />
+                  <div className="flex gap-2">
+                    <Button size="sm" onClick={handleSaveAC} disabled={savingAC}>
+                      {savingAC ? t('loading') : t('save')}
+                    </Button>
+                    <Button size="sm" variant="ghost" onClick={() => { setEditingAC(false); setAcDraft(story.acceptance_criteria ?? ''); }}>
+                      {t('cancel')}
+                    </Button>
+                  </div>
+                </div>
+              ) : story.acceptance_criteria ? (
+                <div className="mt-2 cursor-pointer" onClick={() => setEditingAC(true)}>
+                  <DescriptionViewer description={story.acceptance_criteria} />
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setEditingAC(true)}
+                  className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
+                >
+                  + {t('addAcceptanceCriteria')}
                 </button>
               )}
             </div>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -10,6 +10,7 @@ export interface KanbanStory {
   epic_id: string | null;
   sprint_id: string | null;
   description: string | null;
+  acceptance_criteria: string | null;
   position: number | null;
   success_hypothesis: string | null;
   metric_definition: MetricDefinition | null;


### PR DESCRIPTION
## 요약
Story 상세 패널에 **Acceptance Criteria** 섹션을 추가(렌더 + 인라인 편집). **Description 블록을 95% 미러** — 신규 디자인 0, 신규 i18n 2키만. BE 완비(`pm.py:105` 컬럼·schema response/update·PATCH allowlist) → **FE-only·마이그 0**.

스토리: E-BOARD-UX S3 (`4e3d3ecf-...`) | high / FE

## 변경 사항
- **`types.ts`**: `KanbanStory.acceptance_criteria: string | null` 추가(description 다음).
- **`story-detail-panel.tsx`**: Description 블록 **바로 아래** AC 섹션 마운트(배치 시안대로). 레이블 토큰(`text-[10px] font-mono uppercase tracking-wider`)·마크다운 뷰어(`DescriptionViewer` **재사용**)·편집 textarea(`min-h-[160px] font-mono`)·Save/Cancel·empty 점선버튼(`border-dashed hover:border-primary`) **전부 Description 동형**. `editingAC`/`acDraft`/`savingAC` + `handleSaveAC`(PATCH `/api/stories/{id}` `{acceptance_criteria}` → `onStoryUpdate`) + `story.id` useEffect 동기화 + ESC 취소 확장.
- **i18n**: `acceptanceCriteria`(완료 조건 / Acceptance Criteria) · `addAcceptanceCriteria`(완료 조건 추가 / Add acceptance criteria) — **en/ko 대칭** 신규 2키.

## 디자인 가디언 가이드 반영
- **신규 디자인 토큰·매직넘버 0** — Description 패턴·DescriptionViewer·토큰 전부 재사용.
- i18n **en/ko 대칭 필수** 준수(standup MISSING_MESSAGE 교훈) — JSON 파싱 검증 통과.

## 검증
- en/ko JSON valid ✅ / `lint` 0 errors ✅ / `build` 158/158 ✅
- **리로드 유지 확인**: 리스트(`json.data` raw)·상세(`/api/stories/{id}`) fetch 둘 다 `acceptance_criteria` 통과 → 저장 후 재로드 정상(AC4 핵심).
- AC4(섹션 마운트·저장 후 리로드 유지·빈 AC '+ add' 어포던스)는 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)