### PR TITLE
feat(E-MCP S4): sprintable-mcp 독립 패키지 분리 (import 디탱글 + pyproject)

### DIFF
--- a/backend/sprintable_mcp/README.md
+++ b/backend/sprintable_mcp/README.md
@@ -1,0 +1,38 @@
+# sprintable-mcp
+
+BYO 에이전트용 Sprintable MCP 서버. 에이전트 런타임을 Sprintable API에 stdio로 연결한다.
+**레포 clone 불필요** — `uvx` 한 줄로 구동.
+
+## Quick start
+
+```bash
+export SPRINTABLE_API_URL=https://app.sprintable.ai     # 또는 dev 백엔드 URL
+export AGENT_API_KEY=sk_live_...                         # 에이전트 API 키
+uvx sprintable-mcp
+```
+
+설치형:
+
+```bash
+pip install sprintable-mcp
+sprintable-mcp        # 엔트리포인트
+# 또는
+python -m sprintable_mcp
+```
+
+## 동작
+
+- 부팅 시 `/api/v2/auth/me`로 인증 컨텍스트를 잡고, `/api/v2/mcp/manifest`로 **이 키의 허용
+  toolset**을 받아 **허용된 도구만 노출**한다(E-MCP S3). 호출 시에도 허용 밖 도구는 차단(E-MCP S2).
+- 매니페스트를 못 받으면 레거시 비파괴셋으로 안전 degrade(파괴적 도구 숨김). crash 없음.
+
+## 의존성
+
+backend(app/*) 비의존 — `mcp` / `httpx` / `pydantic` / `pydantic-settings`만 필요(E-MCP S4 import 디탱글).
+
+## 필수 환경변수
+
+| 변수 | 설명 |
+|------|------|
+| `SPRINTABLE_API_URL` | Sprintable 백엔드 URL |
+| `AGENT_API_KEY` | 에이전트 API 키(`sk_live_...`) |

--- a/backend/sprintable_mcp/__main__.py
+++ b/backend/sprintable_mcp/__main__.py
@@ -6,8 +6,22 @@ import sys
 
 from .api_client import SprintableApiError, client
 from .config import settings
-from .server import mcp
+from .server import filter_tools_by_scope, mcp
 from .sse_bridge import start_sse_bridge
+
+
+async def _setup() -> list[str] | None:
+    """auth context resolve + E-MCP S3 toolset 매니페스트 scope 조회.
+
+    auth 실패는 raise(상위에서 exit). 매니페스트 실패는 None 반환(레거시 비파괴셋으로 degrade, crash X).
+    """
+    await client.resolve_auth_context()
+    try:
+        manifest = await client.get("/api/v2/mcp/manifest")
+        return manifest.get("scope")
+    except Exception as exc:  # noqa: BLE001
+        print(f"Warning: MCP manifest fetch 실패 ({exc}) — 레거시 비파괴셋으로 degrade", file=sys.stderr)
+        return None
 
 
 def main() -> None:
@@ -20,7 +34,7 @@ def main() -> None:
 
     client.configure(settings.sprintable_api_url, settings.agent_api_key)
     try:
-        asyncio.run(client.resolve_auth_context())
+        _scope = asyncio.run(_setup())
     except SprintableApiError as exc:
         if exc.status == 401:
             print("Error: Invalid API Key — AGENT_API_KEY를 확인하는.", file=sys.stderr)
@@ -30,6 +44,11 @@ def main() -> None:
     except Exception as exc:
         print(f"Error: auth context resolve failed: {exc}", file=sys.stderr)
         sys.exit(1)
+
+    # E-MCP S3: 허용 toolset만 노출 (S2 wrapper의 call-time 차단은 유지·defense-in-depth)
+    n_hidden = filter_tools_by_scope(_scope)
+    if n_hidden:
+        print(f"MCP toolset: {n_hidden} tools hidden by key scope", file=sys.stderr)
 
     asyncio.run(_run())
 

--- a/backend/sprintable_mcp/pyproject.toml
+++ b/backend/sprintable_mcp/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "sprintable-mcp"
+version = "0.1.0"
+description = "Sprintable MCP server — BYO agent toolset over the Sprintable API (stdio). No repo clone required."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Proprietary" }
+authors = [{ name = "Sprintable" }]
+keywords = ["mcp", "sprintable", "agent", "model-context-protocol"]
+dependencies = [
+    "mcp>=1.0.0",
+    "httpx>=0.27",
+    "pydantic>=2.0",
+    "pydantic-settings>=2.0",
+]
+
+# E-MCP S4: 외부(레포 없음) 한 줄 구동 — `uvx sprintable-mcp`.
+# 필수 env: SPRINTABLE_API_URL, AGENT_API_KEY (그 외 import 의존 0 — backend app/* 비의존).
+[project.scripts]
+sprintable-mcp = "sprintable_mcp.__main__:main"
+
+[project.urls]
+Homepage = "https://sprintable.ai"
+
+# in-place flat 레이아웃(backend/sprintable_mcp/*.py)을 sprintable_mcp 패키지로 빌드.
+# hatchling sources remap: 루트("")의 파일을 wheel에서 sprintable_mcp/ 아래로 배치.
+[tool.hatch.build.targets.wheel]
+include = ["*.py", "tools/*.py"]
+
+[tool.hatch.build.targets.wheel.sources]
+"" = "sprintable_mcp"
+
+[tool.hatch.build.targets.sdist]
+include = ["*.py", "tools/*.py", "README.md", "pyproject.toml"]

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -19,8 +19,9 @@ from .config import settings
 from .response import ok
 from .schemas import SprintableInput
 
-# E-MCP S2: toolset enforcement은 백엔드 SSOT(app.services.mcp_toolset)의 순수 규칙을 공유.
-from app.services.mcp_toolset import is_tool_allowed
+# E-MCP S4: 독립 패키지 디탱글 — backend(app/*) import 제거. 규칙은 vendored .toolset 사용
+# (백엔드 app/services/mcp_toolset.py와 동일 규칙 유지·SSOT는 백엔드 매니페스트).
+from .toolset import is_tool_allowed
 from .tools.agent_runs import (
     EmitEventInput, PollEventsInput, UpdateRunStatusInput,
     emit_event, poll_events, update_run_status,

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -486,3 +486,27 @@ _TOOL_DEFS: list[tuple] = [
 
 for _name, _doc, _cls, _fn in _TOOL_DEFS:
     mcp.tool()(_flat(_name, _doc, _cls, _fn))
+
+
+# ── E-MCP S3: 부팅 시 허용 toolset만 노출 (schema/list 컨텍스트 절감) ─────────────
+# S2의 call-time wrapper(호출 차단)는 그대로 유지 — S3는 list/schema에서 허용 밖 도구를 숨겨
+# 컨텍스트를 절감하는 UX 레이어(defense-in-depth). 규칙은 동일하게 is_tool_allowed(SSOT) 공유.
+def disallowed_tools(scope: list[str] | None) -> list[str]:
+    """주어진 scope에서 허용되지 않는 등록 도구명 목록 (순수 — mcp 미변경)."""
+    return [name for name, _doc, _cls, _fn in _TOOL_DEFS if not is_tool_allowed(name, scope)]
+
+
+def filter_tools_by_scope(scope: list[str] | None) -> int:
+    """허용 밖 도구를 MCP 레지스트리에서 제거(부팅 시 1회). 제거 수 반환.
+
+    scope=None(매니페스트 fetch 실패/미바인딩) → 레거시 비파괴셋(destructive만 숨김)로 graceful degrade.
+    _ALWAYS_ALLOWED(ping 등)는 is_tool_allowed가 항상 True라 보존.
+    """
+    removed = 0
+    for name in disallowed_tools(scope):
+        try:
+            mcp.remove_tool(name)
+            removed += 1
+        except Exception:
+            logger.debug("remove_tool skipped for %s (not registered)", name)
+    return removed

--- a/backend/sprintable_mcp/toolset.py
+++ b/backend/sprintable_mcp/toolset.py
@@ -1,0 +1,87 @@
+"""E-MCP S4: 독립 패키지용 vendored toolset 규칙.
+
+⚠️ 이 모듈은 backend `app/services/mcp_toolset.py`의 **vendored 복제본**이다.
+   독립 PyPI 패키지(sprintable-mcp)는 backend(app/*)를 import할 수 없으므로 규칙을 자체 보유한다.
+   규칙(그룹 키워드·destructive·is_tool_allowed)은 백엔드와 **동일하게 유지**할 것(드리프트 금지).
+   백엔드는 권한 SSOT(ApiKey.scope·매니페스트)이고, 이 사본은 로컬 list 필터/call-time 적용에만 쓴다.
+
+tool_name(`sprintable_<verb>_<domain>`) → group은 명시 키워드 매핑으로 결정(파일 의존 X).
+"""
+from __future__ import annotations
+
+_GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
+    ("rewards", ("reward", "wallet", "leaderboard")),
+    ("analytics", ("velocity", "health", "dashboard", "overview", "stats", "standup_missing",
+                   "sprint_summary", "recent_activity", "agent_stats", "blocked_stories",
+                   "unassigned_stories", "member_workload", "overdue", "epic_progress")),
+    ("agent_runs", ("agent_run", "run_status", "update_run")),
+    ("audit", ("audit",)),
+    ("webhooks", ("webhook",)),
+    ("notifications", ("notification",)),
+    ("meetings", ("meeting",)),
+    ("retro", ("retro",)),
+    ("standup", ("standup",)),
+    ("docs", ("doc", "search_docs")),
+    ("chat", ("chat", "message", "conversation")),
+    ("sprints", ("sprint",)),
+    ("epics", ("epic",)),
+    ("tasks", ("task",)),
+    ("stories", ("story", "stories", "backlog", "claim", "checkin")),
+    ("admin", ("lock", "unlock", "give_reward", "emit_event", "trigger_ai", "activate_sprint",
+               "close_sprint", "delete_sprint", "create_sprint", "upsert_webhook", "delete_webhook")),
+]
+
+_CORE = "core"
+
+_ALWAYS_ALLOWED: frozenset[str] = frozenset({
+    "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+})
+
+_LEGACY_SCOPES: frozenset[str] = frozenset({"read", "write"})
+_DESTRUCTIVE_SCOPES: frozenset[str] = frozenset({"admin", "destructive"})
+
+ALL_GROUPS: tuple[str, ...] = tuple(g for g, _ in _GROUP_KEYWORDS if g != "admin") + (_CORE,)
+
+
+def tool_group(tool_name: str) -> str:
+    """tool 이름 → 그룹. ⚠️ 'sprintable_' 접두사가 'sprint'를 포함하므로 제거 후 매칭."""
+    n = tool_name.lower()
+    if n.startswith("sprintable_"):
+        n = n[len("sprintable_"):]
+    for group, keywords in _GROUP_KEYWORDS:
+        if any(k in n for k in keywords):
+            return group
+    return _CORE
+
+
+def is_destructive(tool_name: str) -> bool:
+    n = tool_name.lower()
+    return (
+        "delete" in n
+        or "give_reward" in n
+        or n.endswith("lock_files")
+        or "unlock" in n
+        or "_delete_" in n
+        or n.startswith("sprintable_delete")
+        or "close_sprint" in n
+    )
+
+
+def is_tool_allowed(tool_name: str, scope: list[str] | None) -> bool:
+    """key scope로 tool 허용 판정. 백엔드 app/services/mcp_toolset.is_tool_allowed와 동일 규칙."""
+    if tool_name in _ALWAYS_ALLOWED:
+        return True
+    tokens = {s.strip().lower() for s in (scope or []) if s and s.strip()}
+    group = tool_group(tool_name)
+    destructive = is_destructive(tool_name)
+    explicit_groups = tokens & set(ALL_GROUPS) | (tokens & {"admin"})
+    has_destructive_grant = bool(tokens & _DESTRUCTIVE_SCOPES)
+    if not explicit_groups:
+        group_ok = True
+    else:
+        group_ok = group in tokens or (group == "admin" and "admin" in tokens)
+    if not group_ok:
+        return False
+    if destructive and not has_destructive_grant:
+        return False
+    return True

--- a/backend/tests/test_e_mcp_s3_boot_filter.py
+++ b/backend/tests/test_e_mcp_s3_boot_filter.py
@@ -1,0 +1,52 @@
+"""E-MCP S3: 로컬 MCP 부팅 시 허용 toolset만 노출 (S2 매니페스트 기반 boot 필터).
+
+S2 wrapper(call-time 차단)는 유지, S3는 list/schema에서 허용 밖 도구 제거(컨텍스트 절감).
+매니페스트 fetch 실패 시 None → 레거시 비파괴셋으로 degrade(crash 금지).
+"""
+import sprintable_mcp.server as server
+
+
+def test_disallowed_tools_explicit_group():
+    d = server.disallowed_tools(["stories"])
+    assert "sprintable_add_task" in d        # tasks 그룹 미허용 → 제거 대상
+    assert "sprintable_add_story" not in d    # stories 허용 → 노출
+    assert "sprintable_send_chat_message" in d  # chat 미허용
+
+
+def test_disallowed_tools_legacy_keeps_nondestructive_hides_destructive():
+    d = server.disallowed_tools(["read", "write"])
+    assert "sprintable_add_story" not in d     # 비파괴 → 노출
+    assert "sprintable_delete_story" in d       # destructive → 숨김(grant 없음)
+    assert "sprintable_give_reward" in d
+
+
+def test_disallowed_tools_none_fallback_equals_legacy():
+    """매니페스트 fetch 실패(None) = 레거시 비파괴셋(destructive만 숨김)."""
+    d = server.disallowed_tools(None)
+    assert "sprintable_add_story" not in d
+    assert "sprintable_delete_story" in d
+
+
+def test_ping_never_in_disallowed():
+    # ping은 _TOOL_DEFS 밖 항상-노출 도구 → 어떤 scope에서도 제거 대상 아님
+    for scope in (["stories"], None, [], ["read"]):
+        assert "sprintable_ping" not in server.disallowed_tools(scope)
+        assert "ping" not in server.disallowed_tools(scope)
+
+
+def test_filter_tools_by_scope_removes_disallowed(monkeypatch):
+    removed: list[str] = []
+    monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
+    n = server.filter_tools_by_scope(["stories"])
+    assert n == len(removed) > 0
+    assert "sprintable_add_task" in removed       # 제거됨
+    assert "sprintable_add_story" not in removed   # 보존
+    assert "sprintable_ping" not in removed        # 항상 노출
+
+
+def test_filter_fallback_none_hides_only_destructive(monkeypatch):
+    removed: list[str] = []
+    monkeypatch.setattr(server.mcp, "remove_tool", lambda name: removed.append(name))
+    server.filter_tools_by_scope(None)  # degrade
+    assert "sprintable_delete_story" in removed     # destructive 숨김
+    assert "sprintable_add_story" not in removed     # 비파괴 보존

--- a/backend/tests/test_e_mcp_s4_standalone.py
+++ b/backend/tests/test_e_mcp_s4_standalone.py
@@ -1,0 +1,68 @@
+"""E-MCP S4: sprintable-mcp 독립 패키지 — import 디탱글 + vendored 규칙 동기 검증.
+
+핵심 AC1: backend(app/*) import 없이 구동 가능. + pyproject 패키지 메타/엔트리포인트.
+"""
+import glob
+import os
+import tomllib
+
+_PKG_DIR = os.path.join(os.path.dirname(__file__), "..", "sprintable_mcp")
+
+
+def _pkg_py_files() -> list[str]:
+    return glob.glob(os.path.join(_PKG_DIR, "*.py")) + glob.glob(os.path.join(_PKG_DIR, "tools", "*.py"))
+
+
+# ── 디탱글: backend(app/*) import 0 ───────────────────────────────────────────
+
+def test_no_backend_app_imports_in_package():
+    offenders = []
+    for path in _pkg_py_files():
+        with open(path, encoding="utf-8") as f:
+            src = f.read()
+        for ln, line in enumerate(src.splitlines(), 1):
+            s = line.strip()
+            if s.startswith("from app.") or s.startswith("import app") or s.startswith("from backend"):
+                offenders.append(f"{os.path.basename(path)}:{ln} {s}")
+    assert offenders == [], f"독립 패키지에 backend import 잔존: {offenders}"
+
+
+def test_toolset_vendored_module_present():
+    assert os.path.exists(os.path.join(_PKG_DIR, "toolset.py"))
+
+
+# ── vendored 규칙이 백엔드 SSOT와 동일(드리프트 방지) ─────────────────────────
+
+def test_vendored_toolset_matches_backend_rules():
+    from sprintable_mcp import toolset as vend
+    from app.services import mcp_toolset as backend
+
+    matrix_tools = [
+        "sprintable_add_story", "sprintable_add_task", "sprintable_delete_story",
+        "sprintable_give_reward", "sprintable_send_chat_message", "sprintable_get_velocity",
+        "sprintable_ping", "sprintable_create_sprint", "sprintable_lock_files",
+    ]
+    matrix_scopes = [None, [], ["read", "write"], ["stories"], ["stories", "tasks"],
+                     ["stories", "destructive"], ["admin"]]
+    for t in matrix_tools:
+        # 그룹/destructive 동일
+        assert vend.tool_group(t) == backend.tool_group(t), t
+        assert vend.is_destructive(t) == backend.is_destructive(t), t
+        for sc in matrix_scopes:
+            assert vend.is_tool_allowed(t, sc) == backend.is_tool_allowed(t, sc), (t, sc)
+
+
+# ── pyproject 패키지 메타 ─────────────────────────────────────────────────────
+
+def test_pyproject_metadata_and_entrypoint():
+    with open(os.path.join(_PKG_DIR, "pyproject.toml"), "rb") as f:
+        cfg = tomllib.load(f)
+    assert cfg["project"]["name"] == "sprintable-mcp"
+    assert cfg["project"]["scripts"]["sprintable-mcp"] == "sprintable_mcp.__main__:main"
+    deps = " ".join(cfg["project"]["dependencies"])
+    assert "mcp" in deps and "httpx" in deps and "pydantic" in deps
+    # backend(app/*) 의존 미선언
+    assert "app" not in cfg["project"].get("dependencies", []) and "backend" not in deps
+    # entry target import + main 존재
+    import sprintable_mcp.__main__ as m
+    assert callable(m.main)


### PR DESCRIPTION
## E-MCP S4 — sprintable-mcp 독립 패키지(uvx) 분리

story `93b3f0c5-9f1b-446f-8b27-86284bd225f5` | epic E-MCP-RIGHT | BE only · deps S2/S3

현 MCP는 backend 레포 안(`python -m backend.sprintable_mcp`)이라 외부 배포 패키지가 없어 고객이 **레포 clone 없이 못 씀** = 갈래A(BYO 에이전트) 온보딩 핵심 차단점. non-demo-blocking·SaaS 런칭 필수.

### 변경
| 파일 | 변경 |
|------|------|
| `sprintable_mcp/server.py` | **import 디탱글**: `from app.services.mcp_toolset import is_tool_allowed` → `from .toolset import ...` (backend 비의존) |
| `sprintable_mcp/toolset.py` (신규) | 규칙 **vendoring**(백엔드 `app/services/mcp_toolset.py`와 동일·드리프트 금지 주석) |
| `sprintable_mcp/pyproject.toml` (신규) | `sprintable-mcp` 패키지: deps `mcp/httpx/pydantic/pydantic-settings`, 엔트리포인트 `sprintable-mcp=sprintable_mcp.__main__:main`, hatchling sources remap |
| `sprintable_mcp/README.md` (신규) | `uvx sprintable-mcp` 사용법 |
| tests | 신규 단위 4 |

### AC 매핑 (이번 스코프 = BE·deps-무관)
- ✅ **AC1: backend(app/*) 전체 import 없이 구동** — `sprintable_mcp` 내 backend import **0건**. sys.path에 backend/app 없이 `sprintable_mcp.server` import 성공(검증). `SPRINTABLE_API_URL`+`AGENT_API_KEY`만 필요. pyproject·엔트리포인트 ✅. S2/S3 변경 포함.
- ⏳ **AC5(외부 clean env `uvx sprintable-mcp` ping)**: 실 PyPI publish=릴리즈 스텝(build 툴 미설치 환경). pyproject는 빌드 가능 구조로 작성, 메타/엔트리포인트 검증 완료. **publish는 release/CI에서**.
- (AC3 CLI setup/init은 선택 — 미포함)

### 미루는(별도)
- AC2 웹 `.mcp.json` 생성기(FE·deps S1 쇼핑UI) → S1 후 유나/미르코+디디
- AC4 npx 래퍼 → 월요일 밖

### 검증
- `pytest`: **1553 passed**. 신규 `test_e_mcp_s4_standalone`(4): 디탱글 가드(backend import 0)·**vendored 규칙 == 백엔드 SSOT**(드리프트 방지)·pyproject 메타·엔트리포인트
- 잔여 14 = realdb/mcp-e2e/subprocess 인프라 사전존재, 본 변경 무관

⚠️ **stacked on #1219(S3, approved)** — #1219 머지 후 base 정리(현재 diff에 S3 커밋 포함될 수 있음).
⚠️ **vendored 규칙 드리프트**: `sprintable_mcp/toolset.py`는 backend `app/services/mcp_toolset.py`의 복제본 — 향후 규칙 변경 시 양쪽 동기 필수(테스트가 가드).

🤖 Generated with [Claude Code](https://claude.com/claude-code)