### PR TITLE
[SID:E-FILE-S4] 보드 스토리 첨부 FE (chat-attach 미러)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -186,6 +186,8 @@
     "addDescription": "Add description",
     "acceptanceCriteria": "Acceptance Criteria",
     "addAcceptanceCriteria": "Add acceptance criteria",
+    "attachments": "Attachments",
+    "addAttachment": "Add attachment",
     "searchSprints": "Search sprints...",
     "searchEpics": "Search epics...",
     "searchAssignees": "Search assignees...",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -186,6 +186,8 @@
     "addDescription": "설명 추가",
     "acceptanceCriteria": "완료 조건",
     "addAcceptanceCriteria": "완료 조건 추가",
+    "attachments": "첨부",
+    "addAttachment": "첨부 추가",
     "searchSprints": "스프린트 검색...",
     "searchEpics": "에픽 검색...",
     "searchAssignees": "담당자 검색...",

--- a/apps/web/src/app/api/stories/[id]/attachments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/attachments/route.ts
@@ -1,0 +1,46 @@
+import { randomUUID } from 'node:crypto';
+import { type NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from '@/lib/db/server';
+import { ApiErrors } from '@/lib/api-response';
+import { GCS_MEMO_ATTACHMENTS_BUCKET, uploadToGcs } from '@/lib/gcs';
+
+// BE _MAX_ATTACHMENT_SIZE 정합 (schemas/story.py)
+const MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024; // 100MB
+
+// E-FILE S4: 스토리 첨부 파일을 서버사이드에서 GCS로 업로드하고 메타({url,name,content_type,size})를 반환.
+// chat-attach 의 conversations/attachments 와 동형. 반환 메타를 호출부에서 모아
+// PATCH /api/stories/{id} {attachments: [...전체...]} (전체 교체) 로 저장한다.
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+): Promise<Response> {
+  const session = await getServerSession();
+  if (!session?.access_token) return ApiErrors.unauthorized();
+
+  const { id } = await params;
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: { message: 'file is required' } }, { status: 400 });
+  }
+  if (file.size > MAX_ATTACHMENT_SIZE) {
+    return NextResponse.json({ error: { message: 'attachment too large (max 100MB)' } }, { status: 413 });
+  }
+
+  const projectId = (formData.get('project_id') as string | null) ?? 'unknown';
+  const safeName = (file.name || 'file').replace(/[^\w.\-]+/g, '_').slice(-128) || 'file';
+  const objectPath = `story/${projectId}/${id}/${randomUUID()}-${safeName}`;
+
+  try {
+    const url = await uploadToGcs(GCS_MEMO_ATTACHMENTS_BUCKET, objectPath, file);
+    return NextResponse.json({
+      url,
+      name: file.name || safeName,
+      content_type: file.type || 'application/octet-stream',
+      size: file.size,
+    });
+  } catch (err) {
+    console.error('[story-attach] GCS upload failed', err);
+    return NextResponse.json({ error: { message: 'upload failed' } }, { status: 502 });
+  }
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -5,8 +5,10 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
-import { AlertTriangle, GitFork, Plus, Tag, Trash2, X } from 'lucide-react';
+import { AlertTriangle, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
+import type { SendAttachment } from '@/hooks/use-chat-sse';
+import { getFileIcon } from '@/lib/file-icon';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { DependencyGraph } from './dependency-graph';
 import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
@@ -65,6 +67,9 @@ function taskTone(status: string) {
   return 'bg-background/20';
 }
 
+// BE _MAX_STORY_ATTACHMENTS 정합 (schemas/story.py)
+const STORY_ATTACHMENT_LIMIT = 10;
+
 function DescriptionViewer({ description }: { description: string }) {
   return (
     <ReactMarkdown
@@ -119,6 +124,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [editingAC, setEditingAC] = useState(false);
   const [acDraft, setAcDraft] = useState(story.acceptance_criteria ?? '');
   const [savingAC, setSavingAC] = useState(false);
+  const [uploadingAttachment, setUploadingAttachment] = useState(false);
+  const [attachError, setAttachError] = useState(false);
+  const attachInputRef = useRef<HTMLInputElement>(null);
 
   const [intent, setIntent] = useState<OutcomeIntentValue>({
     success_hypothesis: story.success_hypothesis ?? '',
@@ -371,6 +379,40 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setSavingAC(false);
     setEditingAC(false);
     if (updated) onStoryUpdate?.({ ...story, acceptance_criteria: updated.acceptance_criteria });
+  };
+
+  // E-FILE S4: 스토리 첨부 — GCS 업로드 후 PATCH {attachments} (전체 교체이므로 기존+신규 머지 필수).
+  const handleAttachFiles = async (files: File[]) => {
+    if (files.length === 0 || uploadingAttachment) return;
+    const current = story.attachments ?? [];
+    const room = STORY_ATTACHMENT_LIMIT - current.length;
+    if (room <= 0) return;
+    setUploadingAttachment(true);
+    setAttachError(false);
+    try {
+      const uploaded: SendAttachment[] = [];
+      for (const file of files.slice(0, room)) {
+        const fd = new FormData();
+        fd.append('file', file);
+        if (projectId) fd.append('project_id', projectId);
+        const res = await fetch(`/api/stories/${story.id}/attachments`, { method: 'POST', body: fd });
+        if (!res.ok) throw new Error('upload failed');
+        uploaded.push(await res.json() as SendAttachment);
+      }
+      const next = [...current, ...uploaded]; // 전체 교체: 기존 보존 + 신규 누적
+      const updated = await patchStory({ attachments: next });
+      onStoryUpdate?.({ ...story, attachments: updated?.attachments ?? next });
+    } catch {
+      setAttachError(true);
+    } finally {
+      setUploadingAttachment(false);
+    }
+  };
+
+  const handleRemoveAttachment = async (url: string) => {
+    const next = (story.attachments ?? []).filter((a) => a.url !== url); // filter → 전체 교체
+    const updated = await patchStory({ attachments: next });
+    onStoryUpdate?.({ ...story, attachments: updated?.attachments ?? next });
   };
 
   const handleSaveIntent = async () => {
@@ -740,6 +782,82 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 >
                   + {t('addAcceptanceCriteria')}
                 </button>
+              )}
+            </div>
+
+            {/* Attachments — chat-attach 자산 미러 (E-FILE S4) */}
+            <div>
+              <div className="flex items-center justify-between">
+                <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('attachments')}</span>
+                <button
+                  type="button"
+                  onClick={() => attachInputRef.current?.click()}
+                  disabled={uploadingAttachment || (story.attachments?.length ?? 0) >= STORY_ATTACHMENT_LIMIT}
+                  className="flex items-center gap-1 text-xs text-muted-foreground transition hover:text-foreground disabled:opacity-40"
+                >
+                  <Paperclip className="size-3" /> + 추가
+                </button>
+              </div>
+              <input
+                ref={attachInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                accept="image/*,.pdf,.txt,.md,.csv"
+                onChange={(e) => { void handleAttachFiles(Array.from(e.target.files ?? [])); e.target.value = ''; }}
+              />
+              {story.attachments && story.attachments.length > 0 ? (
+                <div className="mt-2 flex flex-col gap-1.5">
+                  {story.attachments.map((att, i) => {
+                    const isImage = att.content_type?.startsWith('image/');
+                    const Icon = getFileIcon(att.content_type);
+                    return (
+                      <div key={att.url ?? i} className="group relative">
+                        {isImage && att.url ? (
+                          <a href={att.url} target="_blank" rel="noopener noreferrer" className="block">
+                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                            <img src={att.url} alt={att.name} className="max-h-40 max-w-[240px] rounded object-contain" />
+                          </a>
+                        ) : (
+                          <a
+                            href={att.url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            download
+                            className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
+                          >
+                            <Icon className="size-4 flex-shrink-0 text-muted-foreground" />
+                            <span className="truncate text-foreground">{att.name}</span>
+                          </a>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => void handleRemoveAttachment(att.url)}
+                          className="absolute right-1 top-1 hidden rounded bg-destructive/20 p-0.5 text-destructive transition group-hover:block hover:bg-destructive/30"
+                          aria-label="첨부 삭제"
+                        >
+                          <X className="size-3" />
+                        </button>
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : !uploadingAttachment ? (
+                <button
+                  type="button"
+                  onClick={() => attachInputRef.current?.click()}
+                  className="mt-2 w-full rounded-md border border-dashed border-border py-3 text-sm text-muted-foreground transition hover:border-primary hover:text-primary"
+                >
+                  + {t('addAttachment')}
+                </button>
+              ) : null}
+              {uploadingAttachment && (
+                <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="size-3.5 animate-spin" /> {t('loading')}
+                </div>
+              )}
+              {attachError && (
+                <p className="mt-1 text-xs text-destructive">첨부 업로드에 실패했습니다. 다시 시도해 주세요.</p>
               )}
             </div>
 

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -1,4 +1,5 @@
 import type { MetricDefinition, OutcomeResult } from '@sprintable/core-storage';
+import type { SendAttachment } from '@/hooks/use-chat-sse';
 
 export interface KanbanStory {
   id: string;
@@ -11,6 +12,7 @@ export interface KanbanStory {
   sprint_id: string | null;
   description: string | null;
   acceptance_criteria: string | null;
+  attachments: SendAttachment[] | null;
   position: number | null;
   success_hypothesis: string | null;
   metric_definition: MetricDefinition | null;


### PR DESCRIPTION
## 요약
보드 스토리 상세 패널에 **파일/이미지 첨부** (high). **chat-attach 자산 미러** — `getFileIcon`·chat-bubble 첨부 렌더·`uploadToGcs`·`SendAttachment` 재사용, 신규 디자인 0. BE #1210 완료 → **FE-only**. S3(AC) 머지본 위에 누적(충돌 0).

스토리: E-FILE S4 (`79d9bf0a-...`) | high / FE

## 변경 사항
- **`api/stories/[id]/attachments/route.ts` 🆕**: 파일 서버사이드 `uploadToGcs`(GCS_MEMO_ATTACHMENTS_BUCKET) → `{url,name,content_type,size}`. chat-attach `conversations/attachments` 동형. 100MB 상한, path `story/{projectId}/{storyId}/{uuid}-{name}`.
- **`story-detail-panel.tsx`**: **AC 섹션 다음·Labels 이전** 첨부 섹션 마운트(배치 시안대로). 이미지 인라인 썸네일(`max-h-40 max-w-[240px]` 클릭 새 탭) / 파일 칩(`getFileIcon`+다운로드) — chat-bubble 동형. empty 점선 `+ 첨부 추가`, 업로드중 `Loader2`, hover `X` 삭제(label detach 패턴).
- **`KanbanStory.attachments: SendAttachment[] | null`** (chat `SendAttachment` 재사용).
- **i18n**: `attachments`(첨부/Attachments) · `addAttachment`(첨부 추가/Add attachment) en/ko 대칭.

## ⚠️ chat과 핵심 차이 (구현 주의)
**PATCH `attachments` = 전체 교체**(BE StoryUpdate, append 아님). 따라서:
- 추가: `[...기존, 신규]` 머지 후 PATCH
- 삭제: `기존.filter(제외)` 후 PATCH

→ 클라이언트 머지 누락 시 **기존 첨부 유실** 위험을 방지하도록 `story.attachments`를 항상 베이스로 머지.

## 디자인 가디언 가이드 반영
- **신규 디자인 토큰·매직넘버 0** — chat-attach 자산·토큰 전부 재사용. `STORY_ATTACHMENT_LIMIT=10`은 BE 계약 상수.
- i18n en/ko 대칭(standup MISSING_MESSAGE 교훈), JSON 파싱 검증.

## 검증
- en/ko JSON valid ✅ / `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(첨부→리로드 유지·GCS URL 200 서버측 curl·멀티인스턴스)는 머지 후 유나양 Puppeteer. (chat-attach서 동일 버킷 public-read 200 실증됨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)