### PR TITLE
feat(E-MSG-POLICY S1): agent DM 인가 3모드 + allowlist enforcement

### DIFF
--- a/backend/alembic/versions/0096_agent_message_policy.py
+++ b/backend/alembic/versions/0096_agent_message_policy.py
@@ -1,0 +1,55 @@
+"""agent message policy mode + allowlist
+
+E-MSG-POLICY S1: 공용 에이전트 메시징 정책. team_members에 message_policy_mode
+(creator_only default | org_wide | list) 추가 + agent_message_allowlist 테이블 신설.
+
+additive(컬럼 NOT NULL + server_default 'creator_only' → 기존 에이전트 백필=현행 동작 불변,
+신규 테이블)라 공유 dev/prod DB에서 breaking 아님. 기존 코드는 새 컬럼/테이블 미참조.
+
+⚠️ 스키마 추가 — deploy-before-migrate 주의. 머지 직후 윈도우0 pre-apply(migrate-dev 잡 선행).
+
+Revision ID: 0096
+Revises: 0095
+Create Date: 2026-06-04
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0096"
+down_revision = "0095"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1) agent DM 정책 모드 (기존 행 = creator_only 백필 → 동작 불변)
+    op.add_column(
+        "team_members",
+        sa.Column(
+            "message_policy_mode",
+            sa.Text(),
+            nullable=False,
+            server_default="creator_only",
+        ),
+    )
+    # 2) list 모드 허용 대상
+    op.create_table(
+        "agent_message_allowlist",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("agent_member_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("allowed_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.UniqueConstraint("agent_member_id", "allowed_id", name="uq_agent_message_allowlist_pair"),
+    )
+    op.create_index(
+        "ix_agent_message_allowlist_agent", "agent_message_allowlist", ["agent_member_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_message_allowlist_agent", table_name="agent_message_allowlist")
+    op.drop_table("agent_message_allowlist")
+    op.drop_column("team_members", "message_policy_mode")

--- a/backend/alembic/versions/0096_agent_message_policy.py
+++ b/backend/alembic/versions/0096_agent_message_policy.py
@@ -1,12 +1,15 @@
-"""agent message policy mode + allowlist
+"""agent message policy mode + allowlist (members col + team_members view recreate)
 
-E-MSG-POLICY S1: 공용 에이전트 메시징 정책. team_members에 message_policy_mode
-(creator_only default | org_wide | list) 추가 + agent_message_allowlist 테이블 신설.
+E-MSG-POLICY S1: 공용 에이전트 메시징 정책. mode(creator_only default|org_wide|list) + allowlist.
 
-additive(컬럼 NOT NULL + server_default 'creator_only' → 기존 에이전트 백필=현행 동작 불변,
-신규 테이블)라 공유 dev/prod DB에서 breaking 아님. 기존 코드는 새 컬럼/테이블 미참조.
+⚠️ team_members는 0088(E-MEMBER-SSOT)에서 **projection VIEW로 강등**됨(members ⋈ project_access/
+agent_project_profiles). 따라서 컬럼은 canonical `members` 테이블에 추가하고, team_members 뷰를
+0088 정의 그대로 + `message_policy_mode` 1컬럼만 더해 **재생성**한다(read 투명 재현).
 
-⚠️ 스키마 추가 — deploy-before-migrate 주의. 머지 직후 윈도우0 pre-apply(migrate-dev 잡 선행).
+additive: members 컬럼 NOT NULL + server_default 'creator_only'(기존 에이전트 백필=현행 동작 불변).
+agent_message_allowlist는 실 테이블 신설. 기존 코드는 새 컬럼/테이블 미참조.
+
+⚠️ 스키마 추가 + core 뷰 재생성 — deploy-before-migrate 주의. 머지 전 window-0 pre-apply.
 
 Revision ID: 0096
 Revises: 0095
@@ -21,19 +24,76 @@ down_revision = "0095"
 branch_labels = None
 depends_on = None
 
+# 0088 정의 + message_policy_mode (두 UNION 브랜치 동일 위치, can_manage_members 뒤).
+_VIEW_WITH_MODE = """
+CREATE VIEW team_members AS
+SELECT
+    m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, NULL::text AS webhook_url, m.is_active,
+    pa.color, NULL::text AS agent_role, NULL::integer AS fakechat_port,
+    owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.message_policy_mode, m.created_at, m.updated_at
+FROM members m
+JOIN project_access pa ON pa.member_id = m.id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+SELECT
+    m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, app.webhook_url, m.is_active,
+    COALESCE(pa.color, '#3385f8') AS color, app.agent_role, app.fakechat_port,
+    owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode,
+    m.created_at, m.updated_at
+FROM members m
+JOIN agent_project_profiles app ON app.member_id = m.id
+LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+# 0088 원본(message_policy_mode 없음) — downgrade 복원용.
+_VIEW_0088 = """
+CREATE VIEW team_members AS
+SELECT
+    m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, NULL::text AS webhook_url, m.is_active,
+    pa.color, NULL::text AS agent_role, NULL::integer AS fakechat_port,
+    owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN project_access pa ON pa.member_id = m.id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+SELECT
+    m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, app.webhook_url, m.is_active,
+    COALESCE(pa.color, '#3385f8') AS color, app.agent_role, app.fakechat_port,
+    owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.created_at, m.updated_at
+FROM members m
+JOIN agent_project_profiles app ON app.member_id = m.id
+LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+LEFT JOIN members owner ON owner.id = m.owner_member_id
+WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
 
 def upgrade() -> None:
-    # 1) agent DM 정책 모드 (기존 행 = creator_only 백필 → 동작 불변)
+    # 1) canonical members에 정책 모드 (기존 행 백필 creator_only → 동작 불변)
     op.add_column(
-        "team_members",
-        sa.Column(
-            "message_policy_mode",
-            sa.Text(),
-            nullable=False,
-            server_default="creator_only",
-        ),
+        "members",
+        sa.Column("message_policy_mode", sa.Text(), nullable=False, server_default="creator_only"),
     )
-    # 2) list 모드 허용 대상
+    # 2) team_members projection 뷰 재생성 (0088 + message_policy_mode)
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_WITH_MODE)
+    # 3) list 모드 허용 대상 (실 테이블)
     op.create_table(
         "agent_message_allowlist",
         sa.Column("id", UUID(as_uuid=True), primary_key=True),
@@ -52,4 +112,6 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_agent_message_allowlist_agent", table_name="agent_message_allowlist")
     op.drop_table("agent_message_allowlist")
-    op.drop_column("team_members", "message_policy_mode")
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_0088)
+    op.drop_column("members", "message_policy_mode")

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -44,6 +44,11 @@ class Member(Base):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     avatar_url: Mapped[str | None] = mapped_column(Text, nullable=True)
     org_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # E-MSG-POLICY S1: agent DM 인가 모드(creator_only default|org_wide|list). 에이전트 단위 정책 —
+    # canonical 위치(team_members 뷰가 m.message_policy_mode로 투영). 휴먼은 무의미(default 유지).
+    message_policy_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="creator_only", default="creator_only"
+    )
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, DateTime, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -26,6 +26,11 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     color: Mapped[str] = mapped_column(Text, nullable=False, default="#3385f8")
     agent_role: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # E-MSG-POLICY S1: agent DM 인가 모드 — creator_only(default·기존 동작) | org_wide | list.
+    # 휴먼↔에이전트만 게이팅, agent↔agent는 enforcement에서 항상 skip(팀 comms 불변).
+    message_policy_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="creator_only", default="creator_only"
+    )
     fakechat_port: Mapped[int | None] = mapped_column(nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True
@@ -41,6 +46,23 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     can_manage_members: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     project: Mapped["Project"] = relationship("Project", back_populates="team_members")
+
+
+class AgentMessageAllowlist(Base, OrgScopedMixin, TimestampMixin):
+    """E-MSG-POLICY S1: list 모드 agent의 메시지 허용 대상.
+
+    (agent_member_id, allowed_id) unique. allowed_id = 허용 휴먼의 member_id(team_member/org_member).
+    list 모드에서 이 목록(+creator) 외 휴먼이 agent와 대화 시도하면 403.
+    """
+    __tablename__ = "agent_message_allowlist"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    agent_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    allowed_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("agent_member_id", "allowed_id", name="uq_agent_message_allowlist_pair"),
+    )
 
 
 from app.models.project import Project  # noqa: E402, F401 — resolve forward ref

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -18,7 +18,7 @@ from app.dependencies.database import get_db
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
 from app.models.project import OrgMember
-from app.models.team import TeamMember
+from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
 from app.services.event_seq import assign_recipient_seq
@@ -64,33 +64,57 @@ async def _enforce_agent_creator_policy(
     agent_ids = {a.id for a in agent_tms}
     non_agent_ids = all_ids - agent_ids
     if not non_agent_ids:
-        return  # 에이전트↔에이전트 → creator 무관 허용
+        return  # ⭐ 에이전트↔에이전트 → 게이팅 skip (팀 comms 불변·핵심 안전조건, E-MSG-POLICY S1 불변)
 
-    # 참가자 집합의 user_id 수집 (sender + 나머지 non-agent participants)
-    human_user_ids: set[uuid.UUID] = set()
+    # 휴먼 참가자 (member_id, user_id) 수집 — mode별 인가에 둘 다 필요
+    humans: list[tuple[uuid.UUID, uuid.UUID | None]] = []
     sender_user_id = getattr(sender, "user_id", None)
-    if sender_user_id is not None and sender.id in non_agent_ids:
-        human_user_ids.add(sender_user_id)
+    if sender.id in non_agent_ids:
+        humans.append((sender.id, sender_user_id))
 
     remaining_ids = non_agent_ids - {sender.id}
     if remaining_ids:
-        # TeamMember에서 user_id 조회
+        # TeamMember 조회
         tm_humans = (await db.execute(
             select(TeamMember).where(TeamMember.id.in_(remaining_ids))
         )).scalars().all()
-        human_user_ids.update(tm.user_id for tm in tm_humans if tm.user_id)
+        humans.extend((tm.id, tm.user_id) for tm in tm_humans)
 
-        # OrgMember에서 user_id 조회 (grant-only 휴먼)
+        # OrgMember 조회 (grant-only 휴먼)
         tm_found_ids = {tm.id for tm in tm_humans}
         om_ids = remaining_ids - tm_found_ids
         if om_ids:
             oms = (await db.execute(
                 select(OrgMember).where(OrgMember.id.in_(om_ids))
             )).scalars().all()
-            human_user_ids.update(om.user_id for om in oms if om.user_id)
+            humans.extend((om.id, om.user_id) for om in oms)
 
-    # 각 에이전트의 created_by가 참가자 user_id 집합에 있는지 확인
+    human_user_ids: set[uuid.UUID] = {u for _, u in humans if u}
+
+    # E-MSG-POLICY S1: 각 에이전트의 message_policy_mode 별 인가
     for agent_tm in agent_tms:
+        mode = getattr(agent_tm, "message_policy_mode", None) or "creator_only"
+
+        if mode == "org_wide":
+            continue  # org 내 휴먼 전부 허용 (참가자는 이미 org-scoped) → 통과
+
+        if mode == "list":
+            allowed_ids = set((await db.execute(
+                select(AgentMessageAllowlist.allowed_id).where(
+                    AgentMessageAllowlist.agent_member_id == agent_tm.id
+                )
+            )).scalars().all())
+            for member_id, user_id in humans:
+                # creator는 모드 무관 항상 허용 (자기 에이전트 접근)
+                is_creator = user_id is not None and user_id == agent_tm.created_by
+                if member_id not in allowed_ids and not is_creator:
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Member is not in this agent's message allowlist",
+                    )
+            continue
+
+        # creator_only (default·기존 동작): 에이전트 creator가 참가자여야
         if agent_tm.created_by is None:
             raise HTTPException(status_code=403, detail="Agent has no creator — conversation not allowed")
         if agent_tm.created_by not in human_user_ids:
@@ -651,6 +675,14 @@ async def add_participant(
     target = await resolve_member_identity(body.member_id, org_id, db)
     if target is None:
         raise HTTPException(status_code=404, detail="Member not found")
+
+    # E-MSG-POLICY S1: 참가자 추가도 동일 정책 게이트 (back-door 차단).
+    # 기존 참가자 ∪ 신규 대상으로 각 에이전트 정책 재검증 (list 모드 비허용 휴먼 추가 시 403 등).
+    _existing_ids = (await db.execute(
+        select(ConversationParticipant.member_id)
+        .where(ConversationParticipant.conversation_id == conversation_id)
+    )).scalars().all()
+    await _enforce_agent_creator_policy(sender, list(set(_existing_ids) | {body.member_id}), db)
 
     # DM → 기존 DM 유지, 기존 참여자 + 신규 참여자로 그룹 conversation fork
     if conv.type == "dm":

--- a/backend/tests/test_e_msg_policy_s1.py
+++ b/backend/tests/test_e_msg_policy_s1.py
@@ -1,0 +1,136 @@
+"""E-MSG-POLICY S1: agent DM 인가 모드(creator_only/org_wide/list) enforcement.
+
+⭐ 핵심 안전조건: agent↔agent는 어떤 모드에서도 게이팅 skip (팀 comms 불변).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.conversations import _enforce_agent_creator_policy
+from app.services.member_resolver import ResolvedMember
+
+ORG_ID = uuid.uuid4()
+
+
+def _human_sender(member_id: uuid.UUID, user_id: uuid.UUID) -> ResolvedMember:
+    return ResolvedMember(id=member_id, user_id=user_id, name="u", type="human",
+                          role="member", org_id=ORG_ID)
+
+
+def _agent(agent_id: uuid.UUID, mode: str, created_by: uuid.UUID | None) -> MagicMock:
+    a = MagicMock()
+    a.id = agent_id
+    a.type = "agent"
+    a.created_by = created_by
+    a.message_policy_mode = mode
+    return a
+
+
+def _result(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── ⭐ agent↔agent skip — 모드 무관 (팀 comms 불변) ────────────────────────────
+
+@pytest.mark.anyio
+async def test_agent_to_agent_skip_even_with_list_mode():
+    """두 에이전트 대화 — 한쪽이 list 모드여도 게이팅 skip(403 없음)."""
+    a1, a2 = uuid.uuid4(), uuid.uuid4()
+    sender_agent = _agent(a1, "list", None)
+    other_agent = _agent(a2, "list", None)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([sender_agent, other_agent]))
+    await _enforce_agent_creator_policy(sender_agent, [a2], session)  # 예외 없음 = skip
+
+
+# ── creator_only (default·기존 동작) ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_creator_only_creator_present_ok():
+    creator_uid = uuid.uuid4()
+    sender = _human_sender(uuid.uuid4(), creator_uid)  # sender가 creator
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "creator_only", creator_uid)
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([agent]))
+    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과
+
+
+@pytest.mark.anyio
+async def test_creator_only_creator_absent_403():
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())  # creator 아님
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "creator_only", uuid.uuid4())  # 다른 creator
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([agent]))
+    with pytest.raises(HTTPException) as exc:
+        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    assert exc.value.status_code == 403
+
+
+# ── org_wide — org 내 휴먼 전부 허용 ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_org_wide_allows_non_creator():
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())  # creator 아님
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "org_wide", uuid.uuid4())
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([agent]))
+    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과 (creator 무관)
+
+
+# ── list — allowlist(+creator) 외 403 ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_list_mode_allowlisted_ok():
+    sender_mid = uuid.uuid4()
+    sender = _human_sender(sender_mid, uuid.uuid4())  # creator 아님이지만 allowlist에 있음
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "list", uuid.uuid4())
+    session = AsyncMock()
+    # 1) agents, 2) allowlist(allowed_id = sender_mid 포함)
+    session.execute = AsyncMock(side_effect=[_result([agent]), _result([sender_mid])])
+    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과
+
+
+@pytest.mark.anyio
+async def test_list_mode_not_allowlisted_403():
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())  # allowlist 밖 + creator 아님
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "list", uuid.uuid4())
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_result([agent]), _result([])])  # allowlist 빈
+    with pytest.raises(HTTPException) as exc:
+        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_list_mode_creator_always_allowed():
+    """list 모드라도 creator는 allowlist 없이 항상 허용."""
+    creator_uid = uuid.uuid4()
+    sender = _human_sender(uuid.uuid4(), creator_uid)  # sender = creator
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "list", creator_uid)
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_result([agent]), _result([])])  # allowlist 빈
+    await _enforce_agent_creator_policy(sender, [agent_id], session)  # creator라 통과
+
+
+@pytest.mark.anyio
+async def test_no_participants_skip():
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())
+    session = AsyncMock()
+    await _enforce_agent_creator_policy(sender, [], session)  # 빈 참가자 → skip (쿼리 없음)


### PR DESCRIPTION
## E-MSG-POLICY S1 — allow_list 모델 + DM 인가 enforcement

story `3228890f-edbb-4c5d-b506-8fecfafdd843` | epic E-MSG-POLICY | BE only · deps none · **critical**

공용 에이전트(제리 등) 메시징 정책 기반. 하드코딩 creator-only → 설정 가능 **3모드**(creator_only/org_wide/list).

### 변경
| 파일 | 변경 |
|------|------|
| `alembic/0096` | **additive 마이그**: `team_members.message_policy_mode` TEXT NOT NULL DEFAULT `creator_only`(백필=현행) + `agent_message_allowlist` 테이블(agent_member_id, allowed_id, unique pair, org_scoped) |
| `app/models/team.py` | `message_policy_mode` 컬럼 + `AgentMessageAllowlist` 모델 |
| `app/routers/conversations.py` | `_enforce_agent_creator_policy` **mode-aware** + `add_participant` 동일 게이트 |

### AC 매핑
- ✅ 마이그(additive): mode enum(creator_only default/org_wide/list) + allowlist 테이블, 백필 creator_only(**동작 불변**)
- ✅ `_enforce_agent_creator_policy` mode-aware: creator_only=현행 / org_wide=org 휴먼 / list=allowlist(+creator) 외 403
- ✅ `add_participant` 동일 게이트(back-door 차단 — 기존 참가자 ∪ 신규 대상 재검증)
- ✅ ⭐ **agent↔agent는 모든 모드에서 skip** — 핵심 안전조건(팀 comms 불변). 회귀 테스트(`test_agent_to_agent_skip_even_with_list_mode`)
- ✅ 테스트: 각 모드 allow+403, agent↔agent skip, 기존 creator-policy 회귀

### 검증
- `pytest`: **1561 passed**. 신규 `test_e_msg_policy_s1`(8) + 기존 `test_member_ssot_phase0` creator-policy 회귀 통과(mock fall-through→creator_only)
- 잔여 14 = realdb/mcp-e2e/subprocess 인프라 사전존재, 본 변경 무관

### ⚠️ 배포 주의 — window-0 pre-apply 필수
마이그가 **`team_members`에 컬럼 추가** → 모델 SELECT가 모든 곳에서 `message_policy_mode`를 읽음. deploy-before-migrate 시 **전 team_members 쿼리 500**(#1202 인시던트보다 광범위). → **머지 전 window-0 pre-apply**(branch 이미지 빌드→migrate-dev 잡 선행 실행→revert). 내가 직후 수행 + thread 보고.

### 범위(S1)
- enforcement 인프라(모델+마이그+게이팅). **mode/allowlist 변경(관리 endpoint/UI)은 후속(S2)** — enforcement는 read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)