### PR TITLE
[SID:E-FILE-S4] fix: 스토리 PATCH attachments allowlist 누락 (fix-forward)

### DIFF
--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -90,7 +90,7 @@ export class StoryService {
   async update(id: string, input: UpdateStoryInput) {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
-      'epic_id', 'sprint_id', 'assignee_id', 'position',
+      'attachments', 'epic_id', 'sprint_id', 'assignee_id', 'position',
       'success_hypothesis', 'metric_definition', 'measure_after',
     ];
     const sanitized: Record<string, unknown> = {};

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -51,6 +51,7 @@ export interface UpdateStoryInput {
   story_points?: number | null;
   description?: string | null;
   acceptance_criteria?: string | null;
+  attachments?: { url: string; name: string; content_type: string; size: number }[] | null;
   epic_id?: string | null;
   sprint_id?: string | null;
   assignee_id?: string | null;

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -49,6 +49,12 @@ export const updateStorySchema = z.object({
   story_points: storySpSchema.optional().nullable(),
   description: z.string().optional().nullable(),
   acceptance_criteria: z.string().optional().nullable(),
+  attachments: z.array(z.object({
+    url: z.string(),
+    name: z.string(),
+    content_type: z.string(),
+    size: z.number(),
+  })).max(10).optional().nullable(),
   epic_id: z.string().optional().nullable(),
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),


### PR DESCRIPTION
## 요약
S4(#1222) 머지 후 AC4 검증에서 발견된 blocker 수정. 첨부 **GCS 업로드는 200**인데 **PATCH `/api/stories/{id}` `{attachments}` = 400 `"No valid fields to update"`** — attachments가 **FE 2곳**에서 필터링되어 저장 안 됨(업로드돼도 스토리에 안 붙음 → AC4 미충족).

> ③HITL 교훈: BE Pydantic schema엔 attachments가 있어 '스키마 있음'으로 보였으나, **실 PATCH 경로의 FE zod·service 게이트**가 막고 있었음('빌드·QA통과≠실동작').

## 근본 원인 (FE 게이트 2곳)
1. **`packages/shared` `updateStorySchema`**(zod): `attachments` 누락 → `z.object`가 unknown 키 strip → attachments 단독 PATCH가 빈 body.
2. **`apps/web/src/services/story.ts` `StoryService.update` ALLOWED_FIELDS**: `attachments` 누락 → `sanitized` 빈 객체 → `"No valid fields to update"` 400.

## 수정
- `updateStorySchema`: `attachments: z.array({url,name,content_type,size}).max(10).optional().nullable()` 추가.
- `ALLOWED_FIELDS`: `'attachments'` 추가.
- `core-storage` `UpdateStoryInput`: `attachments` 필드 추가(타입 정합 — ALLOWED_FIELDS keyof).
- `SupabaseStoryRepository.update`는 body 패스스루(필터 없음) 확인 → 추가 변경 불요. BE `StoryUpdate.attachments` 수용 확인.

## 회귀 안전성
- 기존 필드(acceptance_criteria 등) 무영향 — attachments 키 **추가만**, 다른 allowlist/schema 항목 불변.
- max10·{url,name,content_type,size} 형태 BE 계약 정합.

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅(packages 재컴파일로 타입 반영)
- story 테스트 6 pass. ⚠️ 1 fail `"uses admin client for agent auth"`(GET admin-client mock)은 **이 변경 전부터 pre-existing**(stash 후 동일 fail 확인)·attachments와 무관.
- AC4 재검증(첨부→PATCH 200→렌더·리로드 유지)은 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)