### PR TITLE
[SID:E-BOARD-S6] 복수 Assignee FE (스택 아바타 + multi-select)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -180,6 +180,7 @@
     "assignees": "Assignees",
     "assignee": "Assignee",
     "unassigned": "Unassigned",
+    "clearAssignees": "Clear all",
     "save": "Save",
     "cancel": "Cancel",
     "edit": "Edit",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -180,6 +180,7 @@
     "assignees": "담당자",
     "assignee": "담당자",
     "unassigned": "담당자 없음",
+    "clearAssignees": "전체 해제",
     "save": "저장",
     "cancel": "취소",
     "edit": "편집",

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1151,6 +1151,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     story={activeStory}
                     epicName={activeStory.epic_id ? epicMap[activeStory.epic_id] : undefined}
                     assignee={activeStory.assignee_id ? memberMap[activeStory.assignee_id] : undefined}
+                    assignees={(activeStory.assignee_ids ?? []).flatMap((id) => memberMap[id] ? [memberMap[id]] : [])}
                     onClick={() => {}}
                   />
                 </div>

--- a/apps/web/src/components/kanban/kanban-column.tsx
+++ b/apps/web/src/components/kanban/kanban-column.tsx
@@ -299,6 +299,7 @@ export function KanbanColumn({
                   story={story}
                   epicName={story.epic_id ? epicMap[story.epic_id] : undefined}
                   assignee={story.assignee_id ? memberMap[story.assignee_id] : undefined}
+                  assignees={(story.assignee_ids ?? []).flatMap((id) => memberMap[id] ? [memberMap[id]] : [])}
                   onClick={() => onStoryClick(story)}
                   onEdit={onEditStory}
                   onChangeStatus={onChangeStatus}

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -36,6 +36,7 @@ interface StoryCardProps {
   story: KanbanStory;
   epicName?: string;
   assignee?: KanbanMember;
+  assignees?: KanbanMember[];
   onClick: () => void;
   onEdit?: (storyId: string) => void;
   onChangeStatus?: (storyId: string, newStatus: string) => void;
@@ -49,8 +50,11 @@ interface StoryCardProps {
   gates?: { id: string; gate_type: string; status: string }[];
 }
 
-export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [] }: StoryCardProps) {
+export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdit, onChangeStatus, onAssign, onDelete, projectId, onKickoff, lastExecution, blockedBy = [], labels = [], gates = [] }: StoryCardProps) {
   const t = useTranslations('board');
+  // E-BOARD S6: 복수 assignee. assignees 우선, 없으면 단일 assignee 폴백. agent 한 명이라도 있으면 agent 취급(glow).
+  const assigneeList = (assignees && assignees.length > 0) ? assignees : (assignee ? [assignee] : []);
+  const hasAgent = assigneeList.some((m) => m.type === 'agent');
   const tCage = useTranslations('cage');
   const [contextMenuOpen, setContextMenuOpen] = useState(false);
   const [statusMenuOpen, setStatusMenuOpen] = useState(false);
@@ -175,12 +179,12 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
       onClick={onClick}
       onContextMenu={handleContextMenu}
       className={`group relative cursor-pointer overflow-hidden rounded-lg p-3 transition ${
-        assignee?.type === 'agent'
+        hasAgent
           ? 'bg-gradient-to-br from-accent-claim/8 to-purple-500/4 ring-1 ring-accent-claim/30 hover:ring-accent-claim/60'
           : 'bg-background shadow-sm hover:shadow-md hover:bg-background'
       }`}
     >
-      {assignee?.type === 'agent' && (
+      {hasAgent && (
         <div className="absolute inset-0 pointer-events-none rounded-lg border border-transparent bg-gradient-to-r from-accent-claim/10 to-purple-500/10 opacity-50" />
       )}
       {epicName && story.epic_id ? (
@@ -211,18 +215,34 @@ export function StoryCard({ story, epicName, assignee, onClick, onEdit, onChange
       <p className="relative z-10 line-clamp-2 text-sm font-medium leading-5 text-foreground">{story.title}</p>
       <div className="relative z-10 mt-3 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          {assignee ? (
-            <div className={`flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ${
-              assignee.type === 'agent' 
-                ? 'border-accent-claim/30 bg-accent-claim/10 text-accent-claim'
-                : 'border-border bg-muted text-muted-foreground'
-            }`} title={assignee.name}>
-              {getInitials(assignee.name)}
+          {assigneeList.length > 0 ? (
+            <div className="flex -space-x-1.5">
+              {assigneeList.slice(0, 3).map((m) => (
+                <div
+                  key={m.id}
+                  className={`relative flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-medium ring-1 ring-background ${
+                    m.type === 'agent'
+                      ? 'border-accent-claim/30 bg-accent-claim/10 text-accent-claim'
+                      : 'border-border bg-muted text-muted-foreground'
+                  }`}
+                  title={m.name}
+                >
+                  {getInitials(m.name)}
+                  {m.type === 'agent' && (
+                    <span className="absolute -bottom-px -right-px h-[6px] w-[6px] rounded-full bg-brand-strong ring-1 ring-background" />
+                  )}
+                </div>
+              ))}
+              {assigneeList.length > 3 && (
+                <div className="flex h-6 w-6 items-center justify-center rounded-full border border-border bg-muted text-[10px] font-medium text-muted-foreground ring-1 ring-background">
+                  +{assigneeList.length - 3}
+                </div>
+              )}
             </div>
           ) : (
             <div />
           )}
-          {assignee?.type === 'agent' && (
+          {hasAgent && (
             <div className="flex items-center gap-1.5 text-[10px] font-mono text-accent-claim">
               <span className="relative flex h-1.5 w-1.5">
                 <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-accent-claim opacity-75"></span>

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -349,12 +349,28 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     if (updated) onStoryUpdate?.({ ...story, title: updated.title });
   };
 
-  const handleSaveAssignee = async (assigneeId: string | null) => {
+  // E-BOARD S6: 복수 assignee. assignee_ids 우선, 없으면 단일 assignee_id로 폴백(하위호환).
+  const currentAssigneeIds = (story.assignee_ids && story.assignee_ids.length > 0)
+    ? story.assignee_ids
+    : (story.assignee_id ? [story.assignee_id] : []);
+
+  const handleToggleAssignee = async (memberId: string) => {
+    const set = new Set(currentAssigneeIds);
+    if (set.has(memberId)) set.delete(memberId); else set.add(memberId);
+    const next = Array.from(set);
+    setSavingAssignee(true);
+    const updated = await patchStory({ assignee_ids: next });
+    setSavingAssignee(false);
+    // BE가 assignee_id(주담당)를 assignee_ids[0]로 동기화 → 응답 우선, 없으면 로컬 계산.
+    if (updated) onStoryUpdate?.({ ...story, assignee_ids: updated.assignee_ids ?? next, assignee_id: updated.assignee_id ?? next[0] ?? null });
+  };
+
+  const handleClearAssignees = async () => {
     setSavingAssignee(true);
     setEditingAssignee(false);
-    const updated = await patchStory({ assignee_id: assigneeId });
+    const updated = await patchStory({ assignee_ids: [] });
     setSavingAssignee(false);
-    if (updated) onStoryUpdate?.({ ...story, assignee_id: assigneeId });
+    if (updated) onStoryUpdate?.({ ...story, assignee_ids: [], assignee_id: null });
   };
 
   const handleSaveDescription = async () => {
@@ -636,25 +652,28 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 <div className="mt-1 flex flex-col gap-1 rounded-md border border-border bg-muted/30 p-1">
                   <button
                     type="button"
-                    onClick={() => handleSaveAssignee(null)}
+                    onClick={() => void handleClearAssignees()}
                     className="w-full rounded px-2 py-1.5 text-left text-sm text-muted-foreground hover:bg-muted"
                   >
-                    — {t('unassigned')}
+                    — {t('clearAssignees')}
                   </button>
-                  {members.filter((m, i, arr) => arr.findIndex((x) => x.id === m.id) === i).map((m) => (
-                    <button
-                      key={m.id}
-                      type="button"
-                      onClick={() => handleSaveAssignee(m.id)}
-                      className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${story.assignee_id === m.id ? 'font-medium text-foreground' : 'text-muted-foreground'}`}
-                    >
-                      <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground">
-                        {m.name.slice(0, 2).toUpperCase()}
-                      </span>
-                      {m.name}
-                      {story.assignee_id === m.id && <span className="ml-auto text-primary">✓</span>}
-                    </button>
-                  ))}
+                  {members.filter((m, i, arr) => arr.findIndex((x) => x.id === m.id) === i).map((m) => {
+                    const selected = currentAssigneeIds.includes(m.id);
+                    return (
+                      <button
+                        key={m.id}
+                        type="button"
+                        onClick={() => void handleToggleAssignee(m.id)}
+                        className={`flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted ${selected ? 'font-medium text-foreground' : 'text-muted-foreground'}`}
+                      >
+                        <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-muted text-[10px] font-medium text-foreground">
+                          {m.name.slice(0, 2).toUpperCase()}
+                        </span>
+                        {m.name}
+                        {selected && <span className="ml-auto text-primary">✓</span>}
+                      </button>
+                    );
+                  })}
                   <button
                     type="button"
                     onClick={() => setEditingAssignee(false)}
@@ -665,7 +684,11 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 </div>
               ) : (
                 <p className="mt-1 text-sm text-foreground">
-                  {savingAssignee ? t('loading') : story.assignee_id ? (memberMap[story.assignee_id]?.name ?? '—') : '—'}
+                  {savingAssignee
+                    ? t('loading')
+                    : currentAssigneeIds.length > 0
+                      ? currentAssigneeIds.map((id) => memberMap[id]?.name ?? '—').join(', ')
+                      : '—'}
                 </p>
               )}
             </div>
@@ -678,7 +701,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   entityType="story"
                   entityId={story.id}
                   projectId={projectId}
-                  currentAssigneeId={story.assignee_id}
+                  currentAssigneeId={currentAssigneeIds.length > 1 ? undefined : story.assignee_id}
                   onAssigneePatched={(aid) => onStoryUpdate?.({ ...story, assignee_id: aid })}
                 />
               </div>

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -8,6 +8,7 @@ export interface KanbanStory {
   priority: string;
   story_points: number | null;
   assignee_id: string | null;
+  assignee_ids?: string[];
   epic_id: string | null;
   sprint_id: string | null;
   description: string | null;

--- a/apps/web/src/services/story.ts
+++ b/apps/web/src/services/story.ts
@@ -90,7 +90,7 @@ export class StoryService {
   async update(id: string, input: UpdateStoryInput) {
     const ALLOWED_FIELDS: (keyof UpdateStoryInput)[] = [
       'title', 'status', 'priority', 'story_points', 'description', 'acceptance_criteria',
-      'attachments', 'epic_id', 'sprint_id', 'assignee_id', 'position',
+      'attachments', 'epic_id', 'sprint_id', 'assignee_id', 'assignee_ids', 'position',
       'success_hypothesis', 'metric_definition', 'measure_after',
     ];
     const sanitized: Record<string, unknown> = {};

--- a/packages/core-storage/src/interfaces/IStoryRepository.ts
+++ b/packages/core-storage/src/interfaces/IStoryRepository.ts
@@ -55,6 +55,7 @@ export interface UpdateStoryInput {
   epic_id?: string | null;
   sprint_id?: string | null;
   assignee_id?: string | null;
+  assignee_ids?: string[] | null;
   position?: number | null;
   success_hypothesis?: string | null;
   metric_definition?: MetricDefinition | null;

--- a/packages/shared/src/schemas/stories.ts
+++ b/packages/shared/src/schemas/stories.ts
@@ -58,6 +58,7 @@ export const updateStorySchema = z.object({
   epic_id: z.string().optional().nullable(),
   sprint_id: z.string().optional().nullable(),
   assignee_id: z.string().optional().nullable(),
+  assignee_ids: z.array(z.string()).optional().nullable(),
   position: z.number().int().optional().nullable(),
   success_hypothesis: z.string().optional().nullable(),
   metric_definition: metricDefinitionSchema.optional().nullable(),


### PR DESCRIPTION
## 요약
보드 스토리 **복수 담당자(assignee_ids)** FE. BE #1203 완료(`assignee_ids` Create/Update/Response + `assignee_id`를 `assignee_ids[0]`로 동기화) → **FE만**. 신규 디자인 토큰 0(CHP 아바타 스택 패턴 재사용).

스토리: E-BOARD S6 (`281bc297-...`) | FE

## ⚠️ S4 교훈 적용 — PATCH 게이트 3곳 (최우선)
attachments fix #1225와 동일 패턴. `assignee_ids`를 **3곳 모두** 추가(누락 시 zod strip / `"No valid fields to update"` 400):
- `packages/shared` `updateStorySchema`: `assignee_ids: z.array(z.string()).optional().nullable()`
- `apps/web/src/services/story.ts` `ALLOWED_FIELDS`: `'assignee_ids'`
- `packages/core-storage` `UpdateStoryInput`: `assignee_ids?: string[] | null`
- `KanbanStory.assignee_ids?: string[]` (assignee_id 공존·하위호환)

## UI (신규 디자인 토큰 0)
- **story-card 스택 아바타**: 단일 → 스택. 개별 `h-6 w-6`(카드 일관) · `-space-x-1.5` overlap · **max 3 + `+N`** · **agent dot 6px**(`bg-brand-strong ring-1 ring-background`) · agent accent-claim 색 · `getInitials` 재사용. (chat-list-view CHP 스택 미러)
- **agent glow 확장**: `assignee.type==='agent'` → **`hasAgent`(assignee_ids 멤버 중 하나라도 agent)** → 카드 glow + "Agent active" 배지.
- **story-detail multi-select**: assignee 드롭다운을 **토글**(클릭 add/remove·✓·복수), `unassigned`→**"전체 해제"**(`board.clearAssignees`), 저장 PATCH `{assignee_ids}`. 비편집 시 멤버명 join.
- **dispatch(EntityDispatchPanel)**: ⚠️ 복수일 때 `currentAssigneeId` 자동 프리필 **금지**(킥오프 대상 명시 1택, placeholder 유지) — 단일일 때만 프리필. silently-first-of-multi 회피.
- i18n `board.clearAssignees` en("Clear all")/ko("전체 해제") 대칭.

## 검증
- en/ko JSON valid + clearAssignees 대칭 ✅ / `lint` 0 errors ✅ / `build` 158/158(packages 재컴파일) ✅
- ⚠️ **실 PATCH 200 검증**(S4 교훈)은 머지 후 유나양 AC4 dev — 2명 배정→PATCH 200→카드 스택·상세 multi·리로드 유지·agent glow·dispatch silently-first 금지 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)