### PR TITLE
[SID:E-SETTINGS-S4] GNB Agents Deployments 탭 숨김 — Performance 단독

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1907,6 +1907,7 @@
     "workflowVersionAddedRules": "+{count}",
     "workflowVersionRemovedRules": "-{count}",
     "workflowVersionChangedRules": "~{count}",
+    "title": "Agents",
     "tabDeployments": "Deployments",
     "tabPerformance": "Performance",
     "autoBadge": "Auto",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1907,6 +1907,7 @@
     "workflowVersionAddedRules": "추가 {count}",
     "workflowVersionRemovedRules": "삭제 {count}",
     "workflowVersionChangedRules": "변경 {count}",
+    "title": "에이전트",
     "tabDeployments": "배포",
     "tabPerformance": "퍼포먼스",
     "autoBadge": "Auto",

--- a/apps/web/src/app/(authenticated)/agents/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/page.tsx
@@ -1,5 +1,5 @@
 import { AgentsPageTabs } from '@/components/agents/agents-page-tabs';
 
 export default async function AgentsPage() {
-  return <AgentsPageTabs deployments={[]} />;
+  return <AgentsPageTabs />;
 }

--- a/apps/web/src/components/agents/agents-page-tabs.tsx
+++ b/apps/web/src/components/agents/agents-page-tabs.tsx
@@ -1,84 +1,18 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import Link from 'next/link';
-import { Rocket } from 'lucide-react';
-import { buttonVariants } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
-import { AgentsDashboard, type AgentDeploymentCard } from '@/components/agents/agents-dashboard';
 import { AgentPerformancePanel } from '@/components/agents/agent-performance-panel';
 
-type Tab = 'deployments' | 'performance';
-
-interface AgentsPageTabsProps {
-  deployments: AgentDeploymentCard[];
-}
-
-export function AgentsPageTabs({ deployments }: AgentsPageTabsProps) {
+// E-SETTINGS S4: Deployments 탭(죽은 managed-deploy surface) 영구 숨김 — Performance 단독.
+// 2탭→1탭이라 토글 UI 제거(단일 토글 어색), deploy wizard CTA 미렌더. 라우트 무변경.
+// AgentsDashboard 컴포넌트·/agents/deploy route는 보존(reversible).
+export function AgentsPageTabs() {
   const t = useTranslations('agents');
-  const [activeTab, setActiveTab] = useState<Tab>('deployments');
-  const [canManageMembers, setCanManageMembers] = useState(false);
-
-  useEffect(() => {
-    async function loadMe() {
-      try {
-        const res = await fetch('/api/me');
-        if (!res.ok) return;
-        const json = await res.json() as { data?: { role?: string; type?: string } };
-        const role = json.data?.role ?? 'member';
-        const type = json.data?.type ?? 'human';
-        setCanManageMembers(
-          (role === 'owner' || role === 'admin') && type === 'human',
-        );
-      } catch {
-        // silently skip — default false (deny)
-      }
-    }
-    void loadMe();
-  }, []);
-
   return (
     <>
-      <TopBarSlot
-        title={
-          <div className="flex items-center gap-1 rounded-lg border border-border bg-muted/30 p-0.5">
-            <button
-              onClick={() => setActiveTab('deployments')}
-              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-                activeTab === 'deployments'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {t('tabDeployments')}
-            </button>
-            <button
-              onClick={() => setActiveTab('performance')}
-              className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
-                activeTab === 'performance'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {t('tabPerformance')}
-            </button>
-          </div>
-        }
-        actions={
-          activeTab === 'deployments' && canManageMembers ? (
-            <Link href="/agents/deploy" className={buttonVariants({ variant: 'outline', size: 'sm' })}>
-              <Rocket className="mr-1.5 size-3.5" />
-              {t('openWizard')}
-            </Link>
-          ) : null
-        }
-      />
-      {activeTab === 'deployments' ? (
-        <AgentsDashboard deployments={deployments} hideTopBar canManageMembers={canManageMembers} />
-      ) : (
-        <AgentPerformancePanel />
-      )}
+      <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+      <AgentPerformancePanel />
     </>
   );
 }


### PR DESCRIPTION
## 요약
GNB `/agents`의 **Deployments 탭 영구 숨김** → Performance 단독. 죽은 managed-deploy surface(부모가 이미 `deployments={[]}` 빈 배열 전달)의 데모 IA 정리. **라우트 변경 X·마이그 0·FE-only**.

스토리: E-SETTINGS S4 (`e3053e2c-...`) | high / FE

## 변경 사항
- **`agents-page-tabs.tsx`**: 2탭 토글(deployments/performance) UI **통째 제거** — 1탭 단일 토글은 어색(왜 토글?)이라 토글 없애고 `AgentPerformancePanel` **직접 렌더**(E-SETTINGS S2 단일토글/빈헤더 회피 교훈). deploy wizard **CTA 미렌더**(deployments 전용).
- **TopBar title**: `AgentPerformancePanel`에 자체 페이지 헤더 없음 확인 → **"Agents" 페이지 타이틀**(`agents.title` 신규 i18n en/ko 대칭). Dual Header 회피.
- `deployments` prop 제거 + 부모 `agents/page.tsx` → `<AgentsPageTabs />`.
- **`AgentsDashboard` 컴포넌트·`/agents/deploy` route 보존**(reversible — import만 제거).
- 서브라우트(`/agents/deploy|runs`) 차단은 follow-up(스코프 밖). 신규 디자인 토큰 0.

## 검증
- en/ko JSON valid + `agents.title` 대칭(Agents/에이전트) ✅ / `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(/agents 로드·Deployments 탭/CTA 사라짐·Performance 유일·단일 토글 없음·라우트 무변경)는 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)