### PR TITLE
[SID:BOARD-COUNTER] 보드 column counter 필터 미반영 fix

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -443,6 +443,11 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
     return true;
   });
 
+  // counter fix: 필터 활성 시 column counter는 filtered(로드된) 개수, 비활성 시 백엔드 total(페이지네이션 "20+" 유지).
+  const filterActive = Boolean(
+    selectedEpicId || selectedAssigneeId || assigneeTypeFilter || selectedLabelIds.length > 0 || searchQuery,
+  );
+
   // position 기준으로 정렬
   const storiesByColumn = (columnId: string): KanbanStory[] => {
     const col = filteredStories.filter((s) => s.status === columnId);
@@ -1134,7 +1139,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     blockedByMap={blockedByMap}
                     storyLabelsMap={storyLabelsMap}
                     storyGatesMap={storyGatesMap}
-                    totalCount={columnTotals[col.id]}
+                    totalCount={filterActive ? colStories.length : columnTotals[col.id]}
                     hasMore={!!columnCursors[col.id]}
                     loadingMore={loadingMoreColumns[col.id] ?? false}
                     onLoadMore={() => handleLoadMore(col.id)}


### PR DESCRIPTION
## 요약
아버님 리포트·demo-visible 버그. 보드 column counter가 필터를 반영하지 않아 **count vs 표시된 카드 불일치**. 디자인 변경 거의 0.

스토리: `728b1559-...` | FE

## 근본 원인
`kanban-board.tsx:1137` `totalCount={columnTotals[col.id]}` = **unfiltered 백엔드 total**(API `meta.total`). 반면 카드는 `stories={colStories}`(`filteredStories` 기준·필터 적용). → 필터 활성 시 헤더 count는 전체 수, 카드는 필터된 수로 불일치.

## 수정 (하이브리드)
```ts
const filterActive = Boolean(selectedEpicId || selectedAssigneeId || assigneeTypeFilter || selectedLabelIds.length > 0 || searchQuery);
// ...
totalCount={filterActive ? colStories.length : columnTotals[col.id]}
```
- **필터 활성** → `colStories.length`(filtered·정확, 카드와 일치)
- **필터 없음** → `columnTotals[col.id]`(백엔드 total·`hasMore "20+"` 페이지네이션 유지)

## ⚠️ 알려진 한계 (QA 교차 확인 요청)
필터는 client-side(`filteredStories = stories.filter`, **로드된 stories 기준**). 필터 + 서버 페이지네이션(컬럼 >20, 다중 페이지) 조합 시 `colStories.length`는 "로드된 것 중 filtered" = **미로드분 미포함**. demo 케이스(assignee='나', ≤20, 첫 페이지)는 정확. 서버측 필터는 별도 트랙(스코프 밖).

## 검증
- `lint` 0 errors ✅ / `build` 157/157 ✅
- AC4(assignee='나' 필터→각 column count=내 스토리만·필터 전후 count↔카드 일치)는 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)