### PR TITLE
[SID:E-SETTINGS-S3] fix: /agents/workflow thin guard (404 not-found 일관성)

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/workflow/page.tsx
+++ b/apps/web/src/app/(authenticated)/agents/workflow/page.tsx
@@ -1,0 +1,8 @@
+import { notFound } from 'next/navigation';
+
+// E-SETTINGS S3: 죽은 /agents/workflow 차단. page.tsx 삭제 시 (authenticated) layout 밖 루트 404가
+// 잡혀 사이드바 없는 기본 404가 나옴 → S5 /meetings 처럼 thin guard 유지해야
+// (authenticated)/not-found.tsx(사이드바 유지·한글·대시보드 CTA)가 일관 적용된다.
+export default function Page() {
+  notFound();
+}


### PR DESCRIPTION
## 요약
S3(#1229) AC4 blocker fix-forward. `/agents/workflow/page.tsx` **삭제** → `(authenticated)` layout 밖 **루트 기본 404**(사이드바 없음·영문)로 빠져 #1228 `not-found.tsx`(사이드바 유지·한글·대시보드 CTA)와 불일치.

스토리: E-SETTINGS S3 (`388b3137-...`)

## 근본 원인
Next.js App Router: route **삭제** 시 그 경로가 `(authenticated)` 세그먼트를 거치는 매칭 route가 없어 **세그먼트 `not-found.tsx`가 안 잡히고 루트 기본 404**가 뜸. S5 `/meetings`는 page.tsx를 **유지 + `notFound()`** 했기에 `(authenticated)/not-found.tsx`가 잡힘(S5 AC4 확인).

## 수정
- `agents/workflow/page.tsx`를 **삭제 대신 S5 동일 server thin guard**(`notFound()`)로 복원 → `(authenticated)/not-found.tsx` 일관 404(사이드바 유지·한글·"대시보드로" CTA).
- orphan `agent-workflow-editor.tsx`/`.test.tsx` 제거 + href CTA 2곳 제거는 **#1229 그대로 유지**(이번 PR 변경 없음).

## 검증
- `lint` 0 errors ✅ / `build` 158/158(`/agents/workflow` route thin guard 복귀) ✅
- AC4 재검증(/agents/workflow→(authenticated) not-found UI·사이드바 유지·대시보드 CTA)는 머지 후 유나양 Puppeteer.

> 교훈: route 차단은 page.tsx **삭제가 아니라 `notFound()` thin guard 유지**해야 세그먼트 not-found가 잡힌다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)