### PR TITLE
[SID:BOARD-COUNTER] fix: 필터 시 counter "N+" 잔재 제거

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -1140,7 +1140,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
                     storyLabelsMap={storyLabelsMap}
                     storyGatesMap={storyGatesMap}
                     totalCount={filterActive ? colStories.length : columnTotals[col.id]}
-                    hasMore={!!columnCursors[col.id]}
+                    hasMore={filterActive ? false : !!columnCursors[col.id]}
                     loadingMore={loadingMoreColumns[col.id] ?? false}
                     onLoadMore={() => handleLoadMore(col.id)}
                     collapsed={col.id === 'done' ? doneCollapsed : undefined}


### PR DESCRIPTION
## 요약
counter fix(#1230)의 꼬리 정리. 필터 활성 시 `totalCount`는 filtered(정확)이나 `hasMore`가 `columnCursors` 기준 그대로라 `KanbanColumn`이 `${totalCount}+`로 렌더 → 필터 시 의미 없는 **"N+"** 잔재(유나양 AC4 follow-up 관찰).

## 수정 (1줄)
```ts
hasMore={filterActive ? false : !!columnCursors[col.id]}
```
- 필터 시 `hasMore=false` → counter **"N"**(깔끔) + "더 보기" 미표시(client 필터라 load-more 무의미).
- 무필터 시 기존 페이지네이션·"N+" 그대로.

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(필터 시 counter "N"·"+" 없음·더보기 없음)는 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)