### PR TITLE
fix(notify): Story Assign 시 Inbox 알림 중복(멀티프로젝트 멤버) dedup

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -111,6 +111,19 @@ async def dispatch_notification(
                     SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
                 )
 
+        # 졷버그 fix: team_members는 0088 이후 projection VIEW라 멤버당 **프로젝트별 1행**(동일 id)을
+        # 반환한다. dedup 없이 루프하면 멀티프로젝트 멤버에게 알림이 **프로젝트 수만큼 중복 생성**됨
+        # (Story Assign 시 Inbox 알림 3개 증상 = 담당자가 3개 프로젝트 소속). member id로 dedup해
+        # 멤버당 1 알림/이벤트만 생성. (view-cutover multi-row 트랩)
+        _seen_member_ids: set = set()
+        _deduped = []
+        for _m in members:
+            if _m.id in _seen_member_ids:
+                continue
+            _seen_member_ids.add(_m.id)
+            _deduped.append(_m)
+        members = _deduped
+
         inserted = False
         for member_row in members:
             if member_row.type == "agent":

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -238,3 +238,32 @@ async def test_mixed_settings_only_enabled_gets_notification(mock_session, org_i
     assert added.user_id == user_on
 
 
+@pytest.mark.anyio
+async def test_dispatch_dedups_multiproject_view_rows(mock_session, org_id):
+    """졷버그: team_members 뷰(0088 projection)는 멀티프로젝트 멤버를 N행(동일 id)으로 반환 →
+    dedup 없으면 알림이 프로젝트 수만큼 중복 생성됨(Story Assign 시 Inbox 3개 증상).
+    member id dedup으로 멤버당 1 알림만 생성되어야 한다."""
+    from app.services.notification_dispatch import dispatch_notification
+
+    member_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    settings = _settings_result([])
+    wh_result = MagicMock()
+    wh_result.scalars.return_value.all.return_value = []
+    # 멀티프로젝트 멤버 = 같은 (id, user_id) 3행 (3개 프로젝트 소속 재현)
+    members = _members_result([(member_id, user_id), (member_id, user_id), (member_id, user_id)])
+    mock_session.execute.side_effect = [settings, wh_result, members]
+
+    await dispatch_notification(
+        mock_session,
+        org_id=org_id,
+        event_type="story_assigned",
+        target_member_ids=[member_id],
+        title="스토리 담당자로 지정됨",
+    )
+
+    notifs = [c.args[0] for c in mock_session.add.call_args_list if isinstance(c.args[0], Notification)]
+    assert len(notifs) == 1, f"멀티프로젝트 멤버에게 알림 {len(notifs)}개 생성됨 (dedup으로 1개여야)"
+    assert notifs[0].user_id == user_id
+
+


### PR DESCRIPTION
## 버그 fix — Story Assign 시 Inbox 알림 3개 생성

story `e08baede-e34a-48fa-8e96-74dda405be14` | 선생님 리포트 · demo-visible · BE

**증상:** 단순 Story Assign만 했는데 Inbox 알림 **3개**씩 도착.

### 근본 원인 (view-cutover multi-row 트랩)
`team_members`는 0088(E-MEMBER-SSOT)에서 **projection VIEW**로 강등 — 멤버당 **프로젝트별 1행**(동일 `m.id`) 반환. `dispatch_notification`의 멤버 조회:
```python
select(TeamMember.id, TeamMember.user_id, ...).where(TeamMember.id.in_(enabled_member_ids), ...)
```
가 멀티프로젝트 멤버를 **N행**으로 받아 루프에서 알림 N개 중복 INSERT. **담당자가 3개 프로젝트 소속 → 정확히 3개**(org는 5프로젝트, 담당자는 3 소속 — dev 실측).

### Fix
`dispatch_notification`에서 `members`를 **member id로 dedup** → 멤버당 1 알림/이벤트만. distinct 멤버(서로 다른 id)는 영향 없음(중복 행만 collapse). **중앙 수정**이라 `stories`/`tasks`/`sprints`/`dispatch`/`team_members` 등 **모든 dispatch_notification 호출처의 멀티프로젝트 중복**을 동시 해소.

### 검증
- 신규 단위 `test_dispatch_dedups_multiproject_view_rows`: 동일 (id,user_id) 3행 → 알림 **1개** 단언 (무수정 시 3개로 FAIL)
- 풀 스위트 **1562 passed**. 잔여 14 = 인프라 사전존재. **마이그 없음**(merge-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
