### PR TITLE
feat(E-INFRA S2): DB 커넥션 풀 right-size (prod max_connections=100)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,16 @@ class Settings(BaseSettings):
     cloud_sql_instance_dev: str = "sprintable-494803:asia-northeast3:sprintable-dev"
     cloud_sql_instance_prod: str = "sprintable-494803:asia-northeast3:sprintable-prod"
 
+    # E-INFRA S2: DB 커넥션 풀 right-size (env DB_POOL_SIZE / DB_MAX_OVERFLOW로 override).
+    # 산식: (maxScale × (pool_size + max_overflow)) + admin/migration headroom ≤ max_connections.
+    #   prod(sprintable-prod db-g1-small, max_connections=100, maxScale=10):
+    #     10 × (5 + 3) = 80  + ~20 headroom(superuser_reserved 3 + migrate-prod 잡 + 수동 admin) = 100 ✓
+    #   dev(maxScale=3): 3 × (5+3)=24 로 여유 큼 — 필요 시 env로 상향(예 10/20) 독립 right-size.
+    # ⚠️ --concurrency=80(인스턴스당 동시 HTTP 요청)과 별개: 풀은 **DB op 점유 구간만** 커넥션을 잡고
+    #    즉시 반납하므로 80 동시요청 ≠ 80 커넥션. pool+overflow 초과분은 pool_timeout 대기(실패 아님).
+    db_pool_size: int = 5
+    db_max_overflow: int = 3
+
     # JWT
     jwt_secret: str = ""
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -5,17 +5,16 @@ from sqlalchemy.orm import DeclarativeBase
 
 from app.core.config import settings
 
-# S20: DB 풀 사이징 — SSE는 대기 구간에서 커넥션 미점유 (개별 세션 패턴)
-# pool_size = 동시 쓰기 워커 수 × 2 + 여유분
-#   → 에이전트 5명 × API 요청 동시성 2 = 10 (현재 pool_size)
-# max_overflow = 트래픽 피크 버퍼 (pool_size × 2)
-#   → 30개 총 커넥션 (pool_size 10 + max_overflow 20)
-# SSE 연결 100개 기준: 각 heartbeat/backfill마다 ~0.05초 커넥션 점유 → 평균 5개 동시
-# 공식: pool_size ≥ (avg_concurrent_writes) + (avg_sse_db_ops_concurrent)
+# S20/E-INFRA S2: DB 풀 right-size — SSE는 대기 구간에서 커넥션 미점유(개별 세션 패턴).
+# 인스턴스당 최대 커넥션 = pool_size + max_overflow. 클러스터 총합 = maxScale × (pool_size+overflow).
+# ⚠️ 산식: (maxScale × (pool_size+max_overflow)) + admin/migration headroom ≤ Cloud SQL max_connections.
+#   prod(db-g1-small max_connections=100, maxScale=10): 10×(5+3)=80 + ~20 headroom = 100 ✓
+#   (이전 10/20=30/instance × 10 = 300 > 100 → 고갈 위험이라 right-size)
+# env DB_POOL_SIZE / DB_MAX_OVERFLOW로 환경별 독립 조정(config.py 산식 주석 참조).
 engine = create_async_engine(
     settings.database_url,
-    pool_size=10,
-    max_overflow=20,
+    pool_size=settings.db_pool_size,
+    max_overflow=settings.db_max_overflow,
     pool_pre_ping=True,
     echo=settings.debug,
 )

--- a/backend/tests/test_e_infra_s2_pool.py
+++ b/backend/tests/test_e_infra_s2_pool.py
@@ -1,0 +1,43 @@
+"""E-INFRA S2: DB 풀 right-size — prod max_connections=100 고갈 방지.
+
+산식: (maxScale × (pool_size + max_overflow)) + headroom ≤ max_connections.
+prod(db-g1-small): max_connections=100, maxScale=10 → pool+overflow ≤ 8/instance.
+"""
+from app.core.config import Settings
+
+PROD_MAX_CONNECTIONS = 100
+PROD_MAX_SCALE = 10
+HEADROOM = 20  # superuser_reserved(3) + migrate-prod 잡 + 수동 admin
+
+
+def _clear_pool_env(monkeypatch):
+    monkeypatch.delenv("DB_POOL_SIZE", raising=False)
+    monkeypatch.delenv("DB_MAX_OVERFLOW", raising=False)
+
+
+def test_default_pool_fits_prod_max_connections(monkeypatch):
+    _clear_pool_env(monkeypatch)
+    s = Settings()
+    per_instance = s.db_pool_size + s.db_max_overflow
+    cluster_total = PROD_MAX_SCALE * per_instance + HEADROOM
+    assert cluster_total <= PROD_MAX_CONNECTIONS, (
+        f"prod 풀 고갈 위험: {PROD_MAX_SCALE}×{per_instance}+{HEADROOM}={cluster_total} > {PROD_MAX_CONNECTIONS}"
+    )
+    assert per_instance <= 8, f"인스턴스당 {per_instance} > 8 (maxScale 10 기준 초과)"
+
+
+def test_pool_env_configurable(monkeypatch):
+    # dev는 maxScale 3이라 여유 큼 — env로 상향 가능
+    monkeypatch.setenv("DB_POOL_SIZE", "10")
+    monkeypatch.setenv("DB_MAX_OVERFLOW", "20")
+    s = Settings()
+    assert s.db_pool_size == 10
+    assert s.db_max_overflow == 20
+
+
+def test_engine_uses_settings_pool():
+    from app.core import database
+    from app.core.config import settings
+    # 엔진 풀이 settings 값을 반영 (하드코딩 아님)
+    assert database.engine.pool.size() == settings.db_pool_size
+    assert database.engine.pool._max_overflow == settings.db_max_overflow


### PR DESCRIPTION
## E-INFRA S2 — DB 커넥션 풀 right-size

story `b6afa43b-7c1c-44c4-a3a1-a63bcbe4800c` | epic E-INFRA-SCALE | BE only

커트오버로 prod tier 확정 → unblock. **prod=sprintable-prod db-g1-small `max_connections=100`**(실측), maxScale=10. 현 풀 하드코딩 10/20=30/instance → **10×30=300 > 100 → 고갈 위험**.

### 변경
| 파일 | 변경 |
|------|------|
| `config.py` | `db_pool_size`(5)/`db_max_overflow`(3) 신규 settings + env `DB_POOL_SIZE`/`DB_MAX_OVERFLOW` override + **산식 주석** |
| `database.py` | 하드코딩 10/20 → `settings.db_pool_size`/`db_max_overflow` |

### 산식
`(maxScale × (pool_size + max_overflow)) + admin/migration headroom ≤ max_connections`
- **prod**: 10 × (5+3) = 80 + ~20 headroom(superuser_reserved 3 + migrate-prod 잡 + 수동 admin) = **100 ✓**
- **dev**(maxScale 3): 3×8=24 여유 큼 — 필요 시 env로 상향(독립 right-size)

### AC 매핑
- ✅ (max-instances × (pool+overflow)) + headroom ≤ **100**(AC 숫자 정정 반영: prod=100, not 200)
- ✅ env/settings-configurable(dev/prod 독립)
- ✅ `--concurrency=80` vs 풀 문서화(80 동시 HTTP 요청 ≠ 80 커넥션 — 풀은 DB op 점유 구간만, 초과분은 pool_timeout 대기·실패 아님)
- ✅ 마이그 없음

### ⚠️ 배포 갭 (PO 확인 필요)
이 fix는 **새 코드**. 현 prod는 **c3ee9edc(0095 데모 이미지)로 하드코딩 10/20** → maxScale 10에서 300 잠재 > 100. **prod가 S2 코드로 재배포되기 전까진 고갈 위험 잔존**(데모 저부하면 인스턴스 소수만 떠 실위험 낮음).
- **interim 완화(코드배포 X·가역)**: prod maxScale **10→3** 하면 3×30=90<100 안전. 원하면 즉시 적용 가능.
- **장기**: prod 재배포 시 이 fix(5/3) 반영 → maxScale 10 안전.

### 검증
- `pytest`: **1565 passed**. 신규 `test_e_infra_s2_pool`(3): prod 산식 ≤100·env override·엔진이 settings 반영
- 잔여 14 = 인프라 사전존재

🤖 Generated with [Claude Code](https://claude.com/claude-code)