### PR TITLE
fix(auth): verification email 발송 실패 silent-swallow 제거 (가시화)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import secrets
 import uuid
@@ -60,6 +61,7 @@ from app.models.login_audit_log import LoginAuditLog
 from app.models.user import RefreshToken, User
 
 router = APIRouter(prefix="/api/v2/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
 
 
 async def _write_audit(
@@ -471,13 +473,15 @@ async def register(
     _, refresh_exp = create_refresh_token(str(user.id), expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS))
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
 
-    # 이메일 인증 발송 (비동기 — 실패해도 가입은 완료)
+    # 이메일 인증 발송 — 실패해도 가입은 완료하되 **반드시 가시화**(silent swallow 금지).
+    # send_email은 bool 반환(True=Resend/SMTP 실발송, False=콘솔 폴백=미발송). 둘 다 로깅해
+    # "201인데 인증메일 안 옴" 디버깅이 가능하게 한다(데모 signup 치명 경로).
     try:
         verification_token = create_email_verification_token(str(user.id))
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
         verify_link = f"{app_url}/verify-email?token={verification_token}"
         from app.services.email import send_email
-        send_email(
+        delivered = send_email(
             to=user.email,
             subject="Sprintable 이메일 인증",
             html_body=(
@@ -485,8 +489,17 @@ async def register(
                 f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
             ),
         )
+        if not delivered:
+            logger.warning(
+                "register: 인증 이메일 미발송(콘솔 폴백) user_id=%s email=%s — "
+                "RESEND_API_KEY/EMAIL_FROM 미설정 또는 발송 실패 추정",
+                user.id, user.email,
+            )
     except Exception:
-        pass  # 이메일 발송 실패는 가입에 영향 없음
+        logger.exception(
+            "register: 인증 이메일 발송 예외 user_id=%s email=%s (가입 자체는 완료)",
+            user.id, user.email,
+        )
 
     return _ok(tokens, 201)
 
@@ -1045,7 +1058,7 @@ async def resend_verification(
     app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
     verify_link = f"{app_url}/verify-email?token={verification_token}"
     from app.services.email import send_email
-    send_email(
+    delivered = send_email(
         to=user.email,
         subject="Sprintable 이메일 인증",
         html_body=(
@@ -1053,7 +1066,13 @@ async def resend_verification(
             f"<p><a href='{verify_link}'>이메일 인증하기</a></p>"
         ),
     )
-    return _ok({"message": "Verification email sent"})
+    if not delivered:
+        # 콘솔 폴백(미발송)을 "sent"로 거짓 보고하지 않는다(데모 디버깅 가시화).
+        logger.warning(
+            "resend-verification: 인증 이메일 미발송(콘솔 폴백) user_id=%s email=%s", user.id, user.email
+        )
+        return _ok({"message": "Verification email could not be delivered — check email configuration", "delivered": False})
+    return _ok({"message": "Verification email sent", "delivered": True})
 
 
 # ─── POST /api/v2/auth/switch-project ────────────────────────────────────────

--- a/backend/tests/test_register_email_silent_fail.py
+++ b/backend/tests/test_register_email_silent_fail.py
@@ -1,0 +1,59 @@
+"""② verification email silent-fail 가시화: send_email 미발송(콘솔 폴백/예외)을 삼키지 않는다.
+
+register/resend 모두 send_email의 bool 반환을 사용 — 콘솔 폴백(False)이면 "sent"로 거짓 보고하지
+않고 로깅 + 정확한 응답. (register는 가입 자체는 완료하되 실패를 로깅.)
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.anyio
+async def test_resend_verification_reports_undelivered_not_sent(
+    test_client, mock_session, auth_ctx, monkeypatch
+):
+    from app.models.user import User
+    import app.routers.auth as auth_mod
+
+    user = MagicMock(spec=User)
+    user.id = uuid.UUID(auth_ctx.user_id)
+    user.email = "test@example.com"
+    user.email_verified = False
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = user
+    mock_session.execute = AsyncMock(return_value=res)
+
+    # send_email은 함수 내부에서 import → 모듈 attr 패치로 가로챈다. False=콘솔 폴백(미발송).
+    monkeypatch.setattr("app.services.email.send_email", lambda **kw: False)
+    monkeypatch.setattr(auth_mod, "create_email_verification_token", lambda uid: "tok")
+
+    resp = await test_client.post("/api/v2/auth/resend-verification")
+    assert resp.status_code == 200
+    body = resp.json()
+    flat = str(body)
+    # 거짓 "sent"가 아니라 미발송을 정확히 반영
+    assert "could not be delivered" in flat or '"delivered": false' in flat.lower() or "delivered': False" in flat
+
+
+@pytest.mark.anyio
+async def test_resend_verification_reports_sent_when_delivered(
+    test_client, mock_session, auth_ctx, monkeypatch
+):
+    from app.models.user import User
+    import app.routers.auth as auth_mod
+
+    user = MagicMock(spec=User)
+    user.id = uuid.UUID(auth_ctx.user_id)
+    user.email = "test@example.com"
+    user.email_verified = False
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = user
+    mock_session.execute = AsyncMock(return_value=res)
+
+    monkeypatch.setattr("app.services.email.send_email", lambda **kw: True)  # 실발송
+    monkeypatch.setattr(auth_mod, "create_email_verification_token", lambda uid: "tok")
+
+    resp = await test_client.post("/api/v2/auth/resend-verification")
+    assert resp.status_code == 200
+    assert "sent" in str(resp.json())


### PR DESCRIPTION
## ② verification email silent-fail 가시화

까심 발견 · **데모 signup 치명**. register/resend의 인증 이메일 발송이 실패를 **조용히 삼킴** → "register 201인데 인증메일 안 옴"이 추적 불가(유나 E2E가 정확히 이 상황 — 인증메일 못 받아 self-verify 불가 → 수동 verify 필요했음).

### 근본
```python
# register (before)
try:
    ... send_email(...)            # bool 반환 무시
except Exception:
    pass                            # 모든 실패 silent swallow
```
- `except: pass` → Resend 실패/설정 누락 시 **무로그**.
- `send_email`의 bool 반환(True=실발송 / False=콘솔 폴백=미발송)을 **무시** → 미발송도 가입 성공으로 조용히 통과.
- resend-verification은 미발송도 **"Verification email sent"로 거짓 보고**.

### Fix
- `register`: `except: pass` → `logger.exception`(예외 surface) + `if not delivered: logger.warning`(콘솔 폴백 가시화). **가입 자체는 여전히 완료**(이메일 실패 비차단, 단 가시화).
- `resend-verification`: bool 사용 — 미발송을 `"sent"`로 거짓 보고하지 않고 로깅 + `delivered:false` 정확 응답.
- `logger` 추가.

### 검증
- 신규 단위 2(resend 미발송→정확 응답·실발송→`sent`) + 풀 스위트 **1567 passed**. 마이그 없음.

### ⚠️ 별개 finding (이 PR 범위 밖 — PO 판단)
verify-link가 `os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")` 사용인데 **dev 백엔드엔 `NEXT_PUBLIC_APP_URL` 미설정**(dev는 `APP_URL`=dev-app만 보유) → **dev verify 링크가 prod(app.sprintable.ai)를 가리킴**. dev E2E가 이메일 받아도 링크는 prod로 감. → **dev에 `NEXT_PUBLIC_APP_URL` 설정** 또는 코드를 `settings.app_url`(APP_URL)로 통일하는 follow-up 권장(환경별 정합).

### 참고 (register 영속)
PO 요청 ②-b(register 201인데 INSERT 되나)는 **false-alarm 확인**: 유나 정정 — `...107539`는 org slug timestamp 혼동, 실 register는 `...022538`(내가 verify한 것, dev DB 존재). register 영속 정상(201⟹get_db commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)