### PR TITLE
[SID:E-ONB-S5] fix: 온보딩 project 생성 401 (X-Org-Id 헤더)

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -118,7 +118,9 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
 
     const res = await fetch('/api/projects', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      // E-ONB S5: 신규 register JWT는 app_metadata 비어(org_id 없음) → BE get_verified_org_id 401.
+      // 방금 생성한 org.id를 X-Org-Id로 보내면 BE가 membership fallback 검증(proxyToFastapi가 x-org-id forward).
+      headers: { 'Content-Type': 'application/json', 'X-Org-Id': orgId },
       body: JSON.stringify({ org_id: orgId, name: projectName.trim(), description: projectDesc.trim() || null }),
     });
     const json = await res.json();

--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -111,6 +111,14 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     setLoading(false);
   };
 
+  // E-ONB S5: 온보딩 완료 후 /dashboard 이동 전 토큰 refresh.
+  // register JWT는 app_metadata 비어(org_id 없음) — TeamMember는 project 생성 시 최초 생기므로,
+  // 그 후 refresh로 새 JWT(sp_at)에 org_id 반영해야 보드/스토리 등 앱 전반 API가 차단되지 않는다.
+  const finishToDashboard = async () => {
+    await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);
+    window.location.href = '/dashboard';
+  };
+
   const handleCreateProject = async () => {
     if (!projectName.trim() || !orgId) return;
     setLoading(true);
@@ -171,7 +179,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     }).catch(() => null);
 
     if (initialStep === 'project') {
-      window.location.href = '/dashboard';
+      await finishToDashboard();
       return;
     }
     setStep('agent');
@@ -219,7 +227,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
   };
 
   const handleFinish = () => {
-    window.location.href = '/dashboard';
+    void finishToDashboard();
   };
 
   return (


### PR DESCRIPTION
## 요약
온보딩 E2E blocker fix-forward. 신규 register 직후 step2 project 생성이 **401("Unauthorized")** — register JWT `app_metadata: {}`(org_id 없음) + org 생성 응답에 새 토큰 없음 → BE `POST /api/v2/projects`의 `get_verified_org_id`가 org_id 소스가 없어 401. (까심군 인증 계약 분석)

스토리: E-ONB S5 (온보딩 E2E)

## FE fix (BE 변경 0)
onboarding step2 project 생성 fetch에 방금 생성한 `org.id`를 **`X-Org-Id` 헤더**로 전달. BE가 `X-Org-Id` fallback으로 membership 검증.

```ts
headers: { 'Content-Type': 'application/json', 'X-Org-Id': orgId },
```

**전달 경로 확인**: client `X-Org-Id` → `/api/projects` route(`headers: request.headers` forward, :30) → `proxyToFastapi`(`x-org-id` 명시 forward, `fastapi-proxy.ts:105`) → BE `get_verified_org_id` fallback. 끝까지 확인.

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(dev E2E: project 생성 no 401 → 3/4 → 완료 → 프로필 실명/no 422 → members 실명)는 머지 후 유나양 재개.

🤖 Generated with [Claude Code](https://claude.com/claude-code)