### PR TITLE
fix(deploy): deploy_backend.sh 4결함 정리 (cutover 노출)

### DIFF
--- a/backend/scripts/deploy_backend.sh
+++ b/backend/scripts/deploy_backend.sh
@@ -51,6 +51,7 @@ case "${ENV}" in
         CPU="1"
         FRONTEND_URL="${FRONTEND_ORIGIN:-https://sprintable-frontend-dev-placeholder.run.app}"
         RUNTIME_SA="cloudrun-runtime-dev@${GCP_PROJECT}.iam.gserviceaccount.com"
+        APP_URL="${APP_URL:-https://dev-app.sprintable.ai}"  # OAuth redirect/이메일 링크용 프론트 URL
         ;;
     prod)
         SERVICE_NAME="sprintable-backend-prod"
@@ -61,6 +62,7 @@ case "${ENV}" in
         CPU="2"
         FRONTEND_URL="${FRONTEND_ORIGIN:-https://app.sprintable.ai}"
         RUNTIME_SA="cloudrun-runtime-prod@${GCP_PROJECT}.iam.gserviceaccount.com"
+        APP_URL="${APP_URL:-https://app.sprintable.ai}"
         ;;
     *)
         echo "Usage: $0 [dev|prod]" >&2; exit 1 ;;
@@ -76,10 +78,40 @@ log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$ENV] $*" >&2; }
 
 CORS_ORIGINS="http://localhost:3000,http://localhost:3108,${FRONTEND_URL}"
 
+# 추가 런타임 env (config.py 참조). 필요 시 env로 override.
+EVENTBUS_ENABLED="${EVENTBUS_ENABLED:-true}"
+MEMBER_SSOT_RESOLVER_SHADOW="${MEMBER_SSOT_RESOLVER_SHADOW:-true}"
+MEMBER_SSOT_APIKEY_CUT="${MEMBER_SSOT_APIKEY_CUT:-true}"
+# ⚠️ GitHub OAuth는 현재 _DEV 앱만 존재(prod 앱 미생성) → dev/prod 모두 _DEV 시크릿 참조.
+#   prod GitHub 앱 생성 시 GITHUB_SECRET_SUFFIX=PROD로 override.
+GITHUB_SECRET_SUFFIX="${GITHUB_SECRET_SUFFIX:-DEV}"
+
+# ── 결함③ fix: full env. Secret Manager 시크릿 (값에 콤마 없어 콤마 구분 OK). ──
+SECRETS_SPEC="DATABASE_URL=${DB_SECRET_NAME}:latest"
+SECRETS_SPEC="${SECRETS_SPEC},JWT_SECRET=JWT_SECRET:latest"
+# ⚠️ SUPABASE 시크릿은 dead(backend/app 0 functional refs·JWT_SECRET 우선) → 미주입(S1 결정 유지).
+SECRETS_SPEC="${SECRETS_SPEC},GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest"
+SECRETS_SPEC="${SECRETS_SPEC},GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest"
+SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_ID=GITHUB_CLIENT_ID_${GITHUB_SECRET_SUFFIX}:latest"
+SECRETS_SPEC="${SECRETS_SPEC},GITHUB_CLIENT_SECRET=GITHUB_CLIENT_SECRET_${GITHUB_SECRET_SUFFIX}:latest"
+SECRETS_SPEC="${SECRETS_SPEC},RESEND_API_KEY=RESEND_API_KEY:latest"
+SECRETS_SPEC="${SECRETS_SPEC},EMAIL_FROM=EMAIL_FROM:latest"
+
+# ── 결함④ fix: 평문 env. CORS_ORIGINS 값에 콤마가 있어 기본(콤마) 구분자로는 env가 쪼개진다 →
+#   gcloud 커스텀 구분자 '^@^'로 '@' 구분. NEXT_PUBLIC_APP_URL도 세팅(verify-link 환경정합·#1236 finding). ──
+ENV_VARS_SPEC="^@^APP_ENV=${ENV}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@CORS_ORIGINS=${CORS_ORIGINS}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@APP_URL=${APP_URL}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@NEXT_PUBLIC_APP_URL=${APP_URL}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@EVENTBUS_ENABLED=${EVENTBUS_ENABLED}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@MEMBER_SSOT_RESOLVER_SHADOW=${MEMBER_SSOT_RESOLVER_SHADOW}"
+ENV_VARS_SPEC="${ENV_VARS_SPEC}@MEMBER_SSOT_APIKEY_CUT=${MEMBER_SSOT_APIKEY_CUT}"
+
 log "Deploying ${SERVICE_NAME} ← ${IMAGE}"
 log "Cloud SQL: ${CLOUD_SQL_INSTANCE}"
 log "DB secret: ${DB_SECRET_NAME}"
 log "CORS origins: ${CORS_ORIGINS}"
+log "APP_URL: ${APP_URL}"
 
 # ─── DRY_RUN: gcloud 호출 없이 resolved config를 stdout으로 출력 (양 경로 검증용) ──
 if [ "${DRY_RUN}" = "1" ]; then
@@ -92,10 +124,15 @@ IMAGE=${IMAGE}
 RUNTIME_SA=${RUNTIME_SA}
 MIN_INSTANCES=${MIN_INSTANCES}
 MAX_INSTANCES=${MAX_INSTANCES}
+APP_URL=${APP_URL}
+SECRETS_SPEC=${SECRETS_SPEC}
+ENV_VARS_SPEC=${ENV_VARS_SPEC}
 EOF
     exit 0
 fi
 
+# 결함①: --startup-probe-path는 유효하지 않은 플래그 → 제거(Cloud Run 기본 TCP startup probe on --port).
+# 결함②: VPC 누락 → --network/--subnet/--vpc-egress 추가(Private-IP 경로·dev/prod 검증된 config 일치).
 gcloud run deploy "${SERVICE_NAME}" \
     --image="${IMAGE}" \
     --region="${GCP_REGION}" \
@@ -111,11 +148,11 @@ gcloud run deploy "${SERVICE_NAME}" \
     --concurrency=80 \
     --timeout=300 \
     --add-cloudsql-instances="${CLOUD_SQL_INSTANCE}" \
-    --set-env-vars="APP_ENV=${ENV},CORS_ORIGINS=${CORS_ORIGINS}" \
-    --set-secrets="\
-DATABASE_URL=${DB_SECRET_NAME}:latest,\
-JWT_SECRET=JWT_SECRET:latest" \
-    --startup-probe-path="/api/v2/health"
+    --network=default \
+    --subnet=default \
+    --vpc-egress=private-ranges-only \
+    --set-env-vars="${ENV_VARS_SPEC}" \
+    --set-secrets="${SECRETS_SPEC}"
 
 SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" \
     --region="${GCP_REGION}" \

--- a/backend/tests/test_deploy_env.py
+++ b/backend/tests/test_deploy_env.py
@@ -92,3 +92,36 @@ def test_migrate_job_dev_prod_separated():
     assert dev["CLOUD_SQL_INSTANCE"] != prod["CLOUD_SQL_INSTANCE"]
     assert dev["ALEMBIC_SECRET_NAME"] != prod["ALEMBIC_SECRET_NAME"]
     assert dev["JOB_NAME"] != prod["JOB_NAME"]
+
+
+# ── deploy_backend.sh 4결함 fix (cutover 첫 prod 실행서 노출) ────────────────────
+
+def test_deploy_full_env_secrets():
+    """결함③: full env — DATABASE_URL/JWT 외 GOOGLE/GITHUB/RESEND/EMAIL 시크릿 포함."""
+    s = _resolve(_DEPLOY, "dev")["SECRETS_SPEC"]
+    for name in ("DATABASE_URL=", "JWT_SECRET=", "GOOGLE_CLIENT_ID=", "GOOGLE_CLIENT_SECRET=",
+                 "GITHUB_CLIENT_ID=", "RESEND_API_KEY=", "EMAIL_FROM="):
+        assert name in s, f"{name} 누락 (결함③ full env 미충족)"
+
+
+def test_deploy_cors_custom_delimiter_preserves_commas():
+    """결함④: CORS_ORIGINS 값에 콤마가 있어 ^@^ 커스텀 구분자 필요(없으면 env 쪼개짐)."""
+    spec = _resolve(_DEPLOY, "dev")["ENV_VARS_SPEC"]
+    assert spec.startswith("^@^"), "커스텀 구분자(^@^) 누락 → CORS 콤마로 env 깨짐(결함④)"
+    assert "localhost:3000,http" in spec, "CORS 콤마 보존 실패"
+
+
+def test_deploy_app_url_env_specific():
+    assert _resolve(_DEPLOY, "dev")["APP_URL"] == "https://dev-app.sprintable.ai"
+    assert _resolve(_DEPLOY, "prod")["APP_URL"] == "https://app.sprintable.ai"
+
+
+def test_deploy_no_invalid_probe_flag_and_has_vpc():
+    """결함①: 무효 --startup-probe-path 제거. 결함②: VPC 플래그(Private-IP) 추가."""
+    with open(_DEPLOY) as f:
+        lines = f.readlines()
+    # 주석 멘션은 무시하고 **실제 플래그 사용**(공백 후 --로 시작)만 검사.
+    flag_usage = [ln for ln in lines if ln.strip().startswith("--startup-probe-path")]
+    assert not flag_usage, "무효 플래그 --startup-probe-path 실사용 잔존(결함①)"
+    src = "".join(lines)
+    assert "--vpc-egress" in src and "--network=default" in src, "VPC 플래그 누락(결함②)"


### PR DESCRIPTION
## deploy_backend.sh 4결함 fix

prod 커트오버를 `deploy_backend.sh`로 못 돌리고 **yaml-replace로 우회**했던 4결함 정리 → 다음 prod 배포 클린화 (non-Monday).

### 결함 → fix
| # | 결함 | fix |
|---|------|-----|
| ① | `--startup-probe-path` = **무효 플래그**(gcloud run deploy 미지원·usage 에러→배포 실패) | 제거. Cloud Run 기본 TCP startup probe(on `--port`) |
| ② | **VPC 누락**(Private-IP 경로 불가) | `--network=default --subnet=default --vpc-egress=private-ranges-only` (dev/prod 검증 config 일치) |
| ③ | **full env 미전달**(DATABASE_URL+JWT만) | GOOGLE/GITHUB/RESEND/EMAIL 시크릿(총 8) + APP_URL/NEXT_PUBLIC_APP_URL/EVENTBUS_ENABLED/MEMBER_SSOT_* env. env-specific(APP_URL·GitHub `_DEV` suffix override). **SUPABASE는 dead라 미주입**(S1 결정 유지) |
| ④ | `CORS_ORIGINS` 값에 **콤마** → 기본 콤마 구분자로 env 쪼개짐 | gcloud 커스텀 구분자 `^@^` |

### 보너스
`NEXT_PUBLIC_APP_URL=${APP_URL}` 세팅 → **#1236 finding(verify-link 환경부정합)** 해소(dev=dev-app, prod=app).

### 검증
- 신규 단위 **4**(full env 시크릿·`^@^` 구분자로 CORS 콤마 보존·env별 APP_URL·무효플래그 제거+VPC) + 기존 S1 **8** = `test_deploy_env.py` 12 passed
- `DRY_RUN=1`로 dev/prod resolved config 확인(secrets 8·env 7·APP_URL 분기)
- 풀 스위트 **1569 passed**. 마이그 없음

### ⚠️ 참고
- `EVENTBUS_ENABLED`/`MEMBER_SSOT_*`는 env override 가능(기본 true·running config 일치). config.py 주석의 "prod EVENTBUS=false"와 차이 있으면 PO 조율.
- 이 PR은 **스크립트 정리**(클린 미래 배포용). 현 running dev/prod는 무영향(이미 배포됨).

🤖 Generated with [Claude Code](https://claude.com/claude-code)