### PR TITLE
feat(E-MSG-POLICY S2): agent 키 생성 시 creator 자동 allow_list 등록

### DIFF
--- a/backend/app/routers/api_keys.py
+++ b/backend/app/routers/api_keys.py
@@ -26,11 +26,15 @@ async def rotate_api_key(
     body: RotateApiKeyRequest,
     _auth: AuthContext = Depends(get_current_user),
     repo: ApiKeyRepository = Depends(_get_repo),
+    session: AsyncSession = Depends(get_db),
 ) -> ApiKeyCreatedResponse:
     result = await repo.rotate(body.api_key_id)
     if result is None:
         raise HTTPException(status_code=404, detail="API key not found")
     new_key, plaintext = result
+    # E-MSG-POLICY S2: rotate 시에도 creator allow_list entry 보장(멱등 — 기존 entry 보존, 중복 없음).
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+    await ensure_creator_allowlisted(session, new_key.team_member_id)
     data = ApiKeyResponse.model_validate(new_key)
     return ApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
 
@@ -63,6 +67,9 @@ async def create_agent_api_key(
         scope=body.scope,
         expires_at=body.expires_at,
     )
+    # E-MSG-POLICY S2: creator를 agent allow_list에 자동 등록(멱등).
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+    await ensure_creator_allowlisted(session, agent_id)
     data = ApiKeyResponse.model_validate(key)
     return ApiKeyCreatedResponse(**data.model_dump(), api_key=plaintext)
 

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -245,6 +245,9 @@ async def create_team_member(
         from app.repositories.api_key import ApiKeyRepository
         api_key_repo = ApiKeyRepository(session)
         _api_key_obj, api_key_plaintext = await api_key_repo.create(team_member_id=member.id)
+        # E-MSG-POLICY S2: creator를 agent allow_list에 자동 등록(같은 트랜잭션·멱등).
+        from app.services.agent_message_policy import ensure_creator_allowlisted
+        await ensure_creator_allowlisted(session, member.id)
 
     # AC3: agent 응답에 fakechat_port + mcp_config 포함
     response = TeamMemberResponse.model_validate(member).model_dump()

--- a/backend/app/services/agent_message_policy.py
+++ b/backend/app/services/agent_message_policy.py
@@ -1,0 +1,43 @@
+"""E-MSG-POLICY S2: agent API 키 생성 시 creator를 agent_message_allowlist에 자동 등록.
+
+creator는 list 모드에서도 항상 DM 가능해야 한다(S1 enforcement의 is_creator가 user_id로 이미 보장하나,
+allowlist에 **명시 entry**를 둬 SSOT/관리 UI(S3)에 creator가 노출되게 한다).
+
+allowed_id = agent의 owner_member_id(= 생성 휴먼의 member.id, agent_anchor_sync가 created_by→org_member.id로
+세팅). enforcement가 참가자 member_id와 매칭하는 값과 동일 도메인이라 정합.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.member import Member
+from app.models.team import AgentMessageAllowlist
+
+
+async def ensure_creator_allowlisted(session: AsyncSession, agent_member_id: uuid.UUID) -> bool:
+    """agent의 creator(owner)를 agent_message_allowlist에 멱등 등록. 등록(or 이미 존재) 시 True.
+
+    - owner_member_id 없으면(=creator 미상) skip(False). is_creator(user_id)가 enforcement는 커버.
+    - unique(agent_member_id, allowed_id)로 멱등 — 키 재생성/rotate 시 중복 없음, 기존 entry 보존.
+    """
+    row = (await session.execute(
+        select(Member.owner_member_id, Member.org_id).where(Member.id == agent_member_id)
+    )).first()
+    if row is None or row.owner_member_id is None:
+        return False
+    owner_member_id, org_id = row.owner_member_id, row.org_id
+    await session.execute(
+        pg_insert(AgentMessageAllowlist)
+        .values(
+            id=uuid.uuid4(),
+            agent_member_id=agent_member_id,
+            allowed_id=owner_member_id,
+            org_id=org_id,
+        )
+        .on_conflict_do_nothing(constraint="uq_agent_message_allowlist_pair")
+    )
+    return True

--- a/backend/tests/test_e_msg_policy_s2_creator_allowlist.py
+++ b/backend/tests/test_e_msg_policy_s2_creator_allowlist.py
@@ -1,0 +1,67 @@
+"""E-MSG-POLICY S2: agent 키 생성 시 creator 자동 allow_list 등록.
+
+ensure_creator_allowlisted: agent의 owner_member_id(creator)를 agent_message_allowlist에 멱등 등록.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_inserts_creator_with_on_conflict():
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+    agent_id, owner_id, org_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    row = MagicMock(); row.owner_member_id = owner_id; row.org_id = org_id
+    select_res = MagicMock(); select_res.first.return_value = row
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[select_res, MagicMock()])
+
+    result = await ensure_creator_allowlisted(session, agent_id)
+
+    assert result is True
+    assert session.execute.call_count == 2  # SELECT member + INSERT
+    insert_sql = str(session.execute.call_args_list[1].args[0]).lower()
+    assert "agent_message_allowlist" in insert_sql
+    assert "on conflict" in insert_sql and "do nothing" in insert_sql  # 멱등(중복 방지)
+
+
+@pytest.mark.anyio
+async def test_skips_when_no_owner():
+    """owner_member_id None(creator 미상) → insert 안 함(False). is_creator가 enforcement 커버."""
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+    row = MagicMock(); row.owner_member_id = None; row.org_id = uuid.uuid4()
+    select_res = MagicMock(); select_res.first.return_value = row
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[select_res])
+
+    result = await ensure_creator_allowlisted(session, uuid.uuid4())
+
+    assert result is False
+    assert session.execute.call_count == 1  # SELECT만, INSERT 없음
+
+
+@pytest.mark.anyio
+async def test_skips_when_agent_not_found():
+    from app.services.agent_message_policy import ensure_creator_allowlisted
+    select_res = MagicMock(); select_res.first.return_value = None
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[select_res])
+
+    assert await ensure_creator_allowlisted(session, uuid.uuid4()) is False
+    assert session.execute.call_count == 1
+
+
+def test_wired_into_all_agent_key_paths():
+    """team_members(agent create) + api_keys(manual create·rotate) 3경로 모두 호출 wiring 확인."""
+    import inspect
+    import app.routers.team_members as tm
+    import app.routers.api_keys as ak
+    tm_src = inspect.getsource(tm)
+    ak_src = inspect.getsource(ak)
+    assert "ensure_creator_allowlisted" in tm_src, "team_members agent-create 미연결"
+    # api_keys: 수동 생성 + rotate 2곳
+    assert ak_src.count("ensure_creator_allowlisted") >= 2, "api_keys create/rotate 미연결"

--- a/backend/tests/test_s35.py
+++ b/backend/tests/test_s35.py
@@ -66,6 +66,7 @@ async def test_create_api_key_201():
     client, session, app = await _client()
     try:
         with patch("app.routers.api_keys.assert_agent_owner", new_callable=AsyncMock), \
+             patch("app.services.agent_message_policy.ensure_creator_allowlisted", new_callable=AsyncMock), \
              patch("app.repositories.api_key.ApiKeyRepository.create", new_callable=AsyncMock) as mock_create:
             mock_create.return_value = (_mock_key(), PLAINTEXT)
 
@@ -122,7 +123,8 @@ async def test_rotate_key_201():
         new_key.id = uuid.uuid4()
         new_plaintext = _PREFIX_MARKER + "n" * 64
 
-        with patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
+        with patch("app.services.agent_message_policy.ensure_creator_allowlisted", new_callable=AsyncMock), \
+             patch("app.repositories.api_key.ApiKeyRepository.rotate", new_callable=AsyncMock) as mock_rotate:
             mock_rotate.return_value = (new_key, new_plaintext)
 
             async with client as c:


### PR DESCRIPTION
## E-MSG-POLICY S2 — creator 자동 allow_list 등록

story `afd4ce39-1b42-4cc7-b42f-797d787255f0` | epic E-MSG-POLICY | BE only · deps S1

creator가 **list 모드에서도 항상 DM 가능**하도록 allow_list에 명시 등록. (S1의 `is_creator`(user_id)가 enforcement는 이미 보장하나, **SSOT/관리 UI(S3)에 creator를 노출**하려면 명시 entry 필요.)

### 변경
| 파일 | 변경 |
|------|------|
| `app/services/agent_message_policy.py` (신규) | `ensure_creator_allowlisted(session, agent_member_id)` — agent의 `owner_member_id`(=생성 휴먼 member.id)를 `agent_message_allowlist`에 **멱등** 등록(`on_conflict_do_nothing`·unique pair). owner 없으면 skip |
| `app/routers/team_members.py` | agent create 시 호출(같은 트랜잭션) |
| `app/routers/api_keys.py` | 수동 키 생성(`POST /agents/{id}/api-keys`) + rotate 시 호출 |

### AC 매핑
- ✅ agent create 시 creator를 allow_list에 같은 트랜잭션 등록
- ✅ **멱등**: 재생성/rotate 중복 없음(unique pair), rotate가 기존 entry 안 지움(INSERT-only)
- ✅ 모드 무관(list 전환해도 creator 유지·entry는 모드 변경과 독립)
- ✅ allowed_id=member_id 도메인이 S1 enforcement(참가자 member_id 매칭)와 정합
- ✅ 테스트: 신규 단위 4(insert+on_conflict·owner 없으면 skip·agent 없으면 skip·**3경로 wiring**)

### ⚠️ AC 괴리 (PO 확인)
AC가 "project-scoped key path(`open_api_keys.py`)"도 언급했으나, **`ProjectApiKey`는 agent 미연결**(project_id + created_by만, team_member/agent 참조 없음) → **agent allow_list 대상이 없음**. 대신 **실제 agent-key 경로**(`api_keys.py`의 수동 생성 + rotate)를 커버 — 이게 AC 의도("creator가 그 agent를 항상 DM")에 부합. project key는 휴먼 프로젝트 접근용이라 agent messaging 무관.

### 검증
- `pytest`: **1575 passed**. S1 회귀 통과 + `test_s35`(키 엔드포인트) mock 갱신(ensure no-op patch)
- 마이그 없음(S1이 `agent_message_allowlist` 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)