### PR TITLE
[SID:E-ONB-S5] FINAL: 온보딩 org 생성 직후 refresh (project 401 근본 해소)

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -107,6 +107,10 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     }
 
     setOrgId(json.data.id);
+    // E-ONB S5 FINAL(까심 진단): org 생성 시 org_member가 최초 생성됨 → 즉시 토큰 refresh로
+    // 새 JWT에 org_id(BE auth Path4 org_member fallback) 반영. 이래야 다음 단계 project 생성의
+    // getAuthContext(/api/v2/me)가 통과한다(미refresh 시 fresh JWT엔 team_member 없어 me null → 401).
+    await fetch('/api/auth/refresh', { method: 'POST' }).catch(() => null);
     setStep('project');
     setLoading(false);
   };
@@ -124,11 +128,10 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
     setLoading(true);
     setError('');
 
+    // E-ONB S5 FINAL: org 생성 직후 refresh(handleCreateOrg)로 JWT에 org_id 반영됨 → X-Org-Id 불요(제거).
     const res = await fetch('/api/projects', {
       method: 'POST',
-      // E-ONB S5: 신규 register JWT는 app_metadata 비어(org_id 없음) → BE get_verified_org_id 401.
-      // 방금 생성한 org.id를 X-Org-Id로 보내면 BE가 membership fallback 검증(proxyToFastapi가 x-org-id forward).
-      headers: { 'Content-Type': 'application/json', 'X-Org-Id': orgId },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ org_id: orgId, name: projectName.trim(), description: projectDesc.trim() || null }),
     });
     const json = await res.json();


### PR DESCRIPTION
## 요약
#1237(머지됨) 후속 FINAL fix. #1237의 ① X-Org-Id가 **dev에서 미작동** — 까심 진단: project route `getAuthContext`의 `fastapiCall('/api/v2/me')`가 fresh register JWT(team_member 없음)로 `null` → **X-Org-Id forward 전에** route 401. 타이밍 문제.

스토리: E-ONB S5 (온보딩 E2E)

## FINAL fix (근본·확실)
**org 생성 직후(project 생성 전)** `POST /api/auth/refresh` — `org_member`가 org 생성 시 최초 생기므로 refresh로 새 JWT에 `org_id`(BE auth Path4 `org_member` fallback) 반영 → 이후 `/api/v2/me`·project 생성 통과.
- `handleCreateOrg`에서 `setOrgId` 직후 refresh (타이밍 핵심: project 후가 아닌 **org 후**).
- **죽은 X-Org-Id 헤더 제거**(까심 confirmed 미작동 — getAuthContext 단계에서 막힘).
- `finishToDashboard` refresh(#1237 ②)는 dashboard 진입 토큰 freshness용으로 유지(belt-suspenders).

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅ / develop 대비 **+6/-3 clean delta**
- AC4(fresh register→org→**refresh→project 200**→완료→dashboard·앱전반 보드/스토리)는 머지 후 유나양 재검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)