### PR TITLE
fix(deploy): deploy_frontend.sh 결함 정리 (#1238 동형)

### DIFF
--- a/backend/scripts/deploy_frontend.sh
+++ b/backend/scripts/deploy_frontend.sh
@@ -77,15 +77,13 @@ gcloud run deploy "${SERVICE_NAME}" \
     --max-instances="${MAX_INSTANCES}" \
     --concurrency=80 \
     --timeout=60 \
-    --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1" \
-    --set-env-vars="NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL}" \
+    --set-env-vars="NODE_ENV=production,NEXT_TELEMETRY_DISABLED=1,NEXT_PUBLIC_FASTAPI_URL=${FASTAPI_URL}" \
     --set-secrets="\
 NEXT_PUBLIC_SUPABASE_URL=NEXT_PUBLIC_SUPABASE_URL:latest,\
 NEXT_PUBLIC_SUPABASE_ANON_KEY=NEXT_PUBLIC_SUPABASE_ANON_KEY:latest,\
 NEXT_PUBLIC_COOKIE_DOMAIN=NEXT_PUBLIC_COOKIE_DOMAIN:latest,\
 JWT_SECRET=JWT_SECRET:latest" \
-    --startup-cpu-boost \
-    --startup-probe-path="/api/health"
+    --cpu-boost
 
 SERVICE_URL=$(gcloud run services describe "${SERVICE_NAME}" \
     --region="${GCP_REGION}" \

--- a/backend/tests/test_deploy_env.py
+++ b/backend/tests/test_deploy_env.py
@@ -10,6 +10,7 @@ import subprocess
 
 _SCRIPTS = os.path.join(os.path.dirname(__file__), "..", "scripts")
 _DEPLOY = os.path.join(_SCRIPTS, "deploy_backend.sh")
+_DEPLOY_FE = os.path.join(_SCRIPTS, "deploy_frontend.sh")
 _MIGRATE_JOB = os.path.join(_SCRIPTS, "provision_migrate_job.sh")
 
 
@@ -125,3 +126,24 @@ def test_deploy_no_invalid_probe_flag_and_has_vpc():
     assert not flag_usage, "무효 플래그 --startup-probe-path 실사용 잔존(결함①)"
     src = "".join(lines)
     assert "--vpc-egress" in src and "--network=default" in src, "VPC 플래그 누락(결함②)"
+
+
+# ── deploy_frontend.sh 결함 fix (deploy_backend.sh와 동일 패턴) ──────────────────
+
+def test_deploy_frontend_no_invalid_flags():
+    """① --startup-cpu-boost(무효) → --cpu-boost. ② --startup-probe-path(무효) 제거."""
+    with open(_DEPLOY_FE) as f:
+        lines = f.readlines()
+    used = lambda flag: [ln for ln in lines if ln.strip().startswith(flag)]
+    assert not used("--startup-cpu-boost"), "무효 플래그 --startup-cpu-boost 잔존(결함①)"
+    assert not used("--startup-probe-path"), "무효 플래그 --startup-probe-path 잔존(결함②)"
+    assert used("--cpu-boost"), "--cpu-boost 누락(--startup-cpu-boost 대체)"
+
+
+def test_deploy_frontend_single_set_env_vars():
+    """--set-env-vars 단일화(gcloud 반복 시 덮어써 NODE_ENV/NEXT_TELEMETRY 유실 위험 방지)."""
+    with open(_DEPLOY_FE) as f:
+        src = f.read()
+    assert src.count("--set-env-vars=") == 1, "--set-env-vars 중복 → env 유실 위험"
+    for kv in ("NODE_ENV=production", "NEXT_TELEMETRY_DISABLED=1", "NEXT_PUBLIC_FASTAPI_URL="):
+        assert kv in src, f"{kv} 누락"


### PR DESCRIPTION
## deploy_frontend.sh 결함 fix (#1238 deploy_backend.sh 동형)

prod 프론트 배포를 `deploy_frontend.sh`로 못 돌리고 **image swap으로 우회**했던 결함 정리 → 다음 프론트 배포 클린화 (non-demo-critical).

### 결함 → fix
| # | 결함 | fix |
|---|------|-----|
| ① | `--startup-cpu-boost` = **무효 플래그명** | `--cpu-boost`(Cloud Run GA) |
| ② | `--startup-probe-path="/api/health"` = **무효 플래그** | 제거(기본 TCP startup probe on `--port 3000`) |
| ③ (방어) | `--set-env-vars` **2회 중복** → gcloud 반복 시 뒤가 앞을 덮어써 `NODE_ENV`/`NEXT_TELEMETRY` 유실 위험 | 단일 `--set-env-vars`로 병합(3개 env, FASTAPI_URL은 콤마 없는 URL이라 안전) |

### 검증
- 신규 단위 **2**(`test_deploy_frontend_no_invalid_flags`·`test_deploy_frontend_single_set_env_vars`) + 기존 deploy 테스트 = `test_deploy_env.py` 14 passed
- 풀 스위트 **1577 passed**. 마이그 없음
- 현 running prod 무영향(이미 image swap으로 배포됨) — 이 PR은 **향후 클린 배포용**

🤖 Generated with [Claude Code](https://claude.com/claude-code)