### PR TITLE
[SID:SETTINGS-SKELETON] fix: org 설정 무한 스켈레톤 (setLoading finally)

### DIFF
--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -429,42 +429,46 @@ export default function SettingsPage() {
         setAdminChecked(true);
       }
 
-      // Get current project
-      const projectRes = await fetch('/api/current-project');
-      if (projectRes.ok) {
-        const projectJson = await projectRes.json();
-        const projectId = projectJson?.data?.project_id ?? null;
-        const orgId = projectJson?.data?.org_id ?? null;
-        setCurrentProjectId(projectId);
-        setOrgId(orgId);
+      // Get current project — current-project 실패/예외와 무관하게 loading은 finally에서 해소(무한 스켈레톤 방지).
+      // (fresh signup 직후 org_id 없는 JWT → /current-project 실패 시 setLoading(false) 미호출되던 결함)
+      try {
+        const projectRes = await fetch('/api/current-project');
+        if (projectRes.ok) {
+          const projectJson = await projectRes.json();
+          const projectId = projectJson?.data?.project_id ?? null;
+          const orgId = projectJson?.data?.org_id ?? null;
+          setCurrentProjectId(projectId);
+          setOrgId(orgId);
 
-        // org 상세 정보 로드 — list API에서 orgId로 필터 (단건 API 미구현)
-        if (orgId) {
-          const orgListRes = await fetch('/api/organizations').catch(() => null);
-          if (orgListRes?.ok) {
-            const orgListJson = await orgListRes.json() as { data?: Array<{ id: string; name: string; slug: string; plan?: string; role?: string }> };
-            const found = (orgListJson.data ?? []).find((o) => o.id === orgId);
-            if (found) {
-              setOrgInfo(found);
-              setEditOrgName(found.name);
+          // org 상세 정보 로드 — list API에서 orgId로 필터 (단건 API 미구현)
+          if (orgId) {
+            const orgListRes = await fetch('/api/organizations').catch(() => null);
+            if (orgListRes?.ok) {
+              const orgListJson = await orgListRes.json() as { data?: Array<{ id: string; name: string; slug: string; plan?: string; role?: string }> };
+              const found = (orgListJson.data ?? []).find((o) => o.id === orgId);
+              if (found) {
+                setOrgInfo(found);
+                setEditOrgName(found.name);
+              }
             }
           }
-        }
 
-        // Get notification settings
-        const settingsRes = await fetch('/api/notification-settings');
-        if (settingsRes.ok) {
-          const settingsJson = await settingsRes.json();
-          setSettings(settingsJson.data ?? []);
+          // Get notification settings
+          const settingsRes = await fetch('/api/notification-settings');
+          if (settingsRes.ok) {
+            const settingsJson = await settingsRes.json();
+            setSettings(settingsJson.data ?? []);
+          }
+
+          // Get webhook configs
+          const webhookRes = await fetch('/api/webhooks/config');
+          if (webhookRes.ok) {
+            const webhookJson = await webhookRes.json();
+            setWebhooks(webhookJson.data ?? []);
+          }
         }
+      } finally {
         setLoading(false);
-
-        // Get webhook configs
-        const webhookRes = await fetch('/api/webhooks/config');
-        if (webhookRes.ok) {
-          const webhookJson = await webhookRes.json();
-          setWebhooks(webhookJson.data ?? []);
-        }
       }
     }
 


### PR DESCRIPTION
## 요약
아버님 prod 리포트. `/settings`가 **무한 스켈레톤**(loading 안 끝남). 까심군 근본원인.

스토리: settings 무한 스켈레톤 fix

## 근본 원인
`settings/page.tsx` `loadContext`의 `setLoading(false)`가 **`if (projectRes.ok)` 블록 안**에 있어, `/api/current-project` 실패(`projectRes.ok=false`) 시 호출되지 않음 → `loading=true` 영구. **재현**: fresh signup 직후(org_id 없는 JWT → current-project 실패) + project 없는 상태.

## 수정
current-project 로드 구간을 **`try/finally`**로 감싸고 `setLoading(false)`를 **finally**로 이동 → current-project 실패/예외/성공 **무관하게 loading 해소**. 동작 로직 변경 없음(스켈레톤 종료 + 콘텐츠 렌더만).

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(fresh signup·project 없는 상태 `/settings` → 스켈레톤 종료·콘텐츠 렌더)는 머지 후 유나양 Puppeteer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)