### PR TITLE
feat(E-MSG-POLICY S3 BE): 에이전트 메시징 정책 관리 endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -150,6 +150,7 @@ app.include_router(mcp.router)  # E-MCP S2: toolset 매니페스트
 app.include_router(project_settings.router)
 app.include_router(webhooks.router)
 app.include_router(api_keys.router)
+app.include_router(agent_message_policy.router)  # E-MSG-POLICY S3: 메시징 정책 관리
 app.include_router(agent_runs.router)
 app.include_router(agent_inbox.router)
 app.include_router(policy_documents.router)

--- a/backend/app/routers/agent_message_policy.py
+++ b/backend/app/routers/agent_message_policy.py
@@ -1,0 +1,138 @@
+"""E-MSG-POLICY S3 (BE): 에이전트 메시징 정책 관리 endpoints.
+
+agent별 mode(creator_only/org_wide/list) 조회·변경 + allow_list 멤버 add/remove.
+admin/owner-only(assert_agent_owner)·org-scoped. S1 enforcement가 즉시 반영(다음 conversation-create부터).
+mode는 canonical `members`에 저장(team_members는 0088 projection 뷰라 직접 UPDATE 불가).
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, field_validator
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.dependencies.ownership import assert_agent_owner
+from app.models.member import Member
+from app.models.team import AgentMessageAllowlist
+from app.services.member_resolver import resolve_member_identity
+
+router = APIRouter(prefix="/api/v2", tags=["agent-message-policy"])
+
+_VALID_MODES = ("creator_only", "org_wide", "list")
+
+
+class MessagePolicyResponse(BaseModel):
+    agent_id: uuid.UUID
+    mode: str
+    allowlist: list[uuid.UUID]
+
+
+class UpdateModeRequest(BaseModel):
+    mode: str
+
+    @field_validator("mode")
+    @classmethod
+    def _valid_mode(cls, v: str) -> str:
+        if v not in _VALID_MODES:
+            raise ValueError(f"mode must be one of {list(_VALID_MODES)}")
+        return v
+
+
+class AllowlistAddRequest(BaseModel):
+    member_id: uuid.UUID
+
+
+async def _allowlist_ids(session: AsyncSession, agent_id: uuid.UUID) -> list[uuid.UUID]:
+    rows = (await session.execute(
+        select(AgentMessageAllowlist.allowed_id).where(
+            AgentMessageAllowlist.agent_member_id == agent_id
+        )
+    )).scalars().all()
+    return list(rows)
+
+
+@router.get("/agents/{agent_id}/message-policy", response_model=MessagePolicyResponse)
+async def get_message_policy(
+    agent_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessagePolicyResponse:
+    agent = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    return MessagePolicyResponse(
+        agent_id=agent_id,
+        mode=getattr(agent, "message_policy_mode", None) or "creator_only",
+        allowlist=await _allowlist_ids(session, agent_id),
+    )
+
+
+@router.put("/agents/{agent_id}/message-policy", response_model=MessagePolicyResponse)
+async def update_message_policy(
+    agent_id: uuid.UUID,
+    body: UpdateModeRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessagePolicyResponse:
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    # team_members는 뷰 → canonical members.id에 UPDATE (뷰가 투영).
+    await session.execute(
+        update(Member).where(Member.id == agent_id).values(message_policy_mode=body.mode)
+    )
+    await session.commit()
+    return MessagePolicyResponse(
+        agent_id=agent_id, mode=body.mode, allowlist=await _allowlist_ids(session, agent_id)
+    )
+
+
+@router.post("/agents/{agent_id}/message-policy/allowlist", status_code=201,
+             response_model=MessagePolicyResponse)
+async def add_allowlist_member(
+    agent_id: uuid.UUID,
+    body: AllowlistAddRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessagePolicyResponse:
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    # 대상이 같은 org의 멤버인지 검증(grant-only 휴먼 포함).
+    target = await resolve_member_identity(body.member_id, org_id, session)
+    if target is None:
+        raise HTTPException(status_code=404, detail="Member not found in org")
+    await session.execute(
+        pg_insert(AgentMessageAllowlist)
+        .values(id=uuid.uuid4(), agent_member_id=agent_id, allowed_id=body.member_id, org_id=org_id)
+        .on_conflict_do_nothing(constraint="uq_agent_message_allowlist_pair")  # 멱등
+    )
+    await session.commit()
+    return MessagePolicyResponse(
+        agent_id=agent_id,
+        mode="",  # GET으로 확인; add 응답은 allowlist 갱신 확인용
+        allowlist=await _allowlist_ids(session, agent_id),
+    )
+
+
+@router.delete("/agents/{agent_id}/message-policy/allowlist/{member_id}",
+               response_model=MessagePolicyResponse)
+async def remove_allowlist_member(
+    agent_id: uuid.UUID,
+    member_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> MessagePolicyResponse:
+    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    await session.execute(
+        sa_delete(AgentMessageAllowlist).where(
+            AgentMessageAllowlist.agent_member_id == agent_id,
+            AgentMessageAllowlist.allowed_id == member_id,
+        )
+    )
+    await session.commit()
+    return MessagePolicyResponse(
+        agent_id=agent_id, mode="", allowlist=await _allowlist_ids(session, agent_id)
+    )

--- a/backend/app/routers/agent_message_policy.py
+++ b/backend/app/routers/agent_message_policy.py
@@ -98,7 +98,7 @@ async def add_allowlist_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> MessagePolicyResponse:
-    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    agent = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     # 대상이 같은 org의 멤버인지 검증(grant-only 휴먼 포함).
     target = await resolve_member_identity(body.member_id, org_id, session)
     if target is None:
@@ -111,7 +111,7 @@ async def add_allowlist_member(
     await session.commit()
     return MessagePolicyResponse(
         agent_id=agent_id,
-        mode="",  # GET으로 확인; add 응답은 allowlist 갱신 확인용
+        mode=getattr(agent, "message_policy_mode", None) or "creator_only",
         allowlist=await _allowlist_ids(session, agent_id),
     )
 
@@ -125,7 +125,7 @@ async def remove_allowlist_member(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> MessagePolicyResponse:
-    await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
+    agent = await assert_agent_owner(agent_id, session, org_id, uuid.UUID(auth.user_id))
     await session.execute(
         sa_delete(AgentMessageAllowlist).where(
             AgentMessageAllowlist.agent_member_id == agent_id,
@@ -134,5 +134,7 @@ async def remove_allowlist_member(
     )
     await session.commit()
     return MessagePolicyResponse(
-        agent_id=agent_id, mode="", allowlist=await _allowlist_ids(session, agent_id)
+        agent_id=agent_id,
+        mode=getattr(agent, "message_policy_mode", None) or "creator_only",
+        allowlist=await _allowlist_ids(session, agent_id),
     )

--- a/backend/tests/test_e_msg_policy_s3_management.py
+++ b/backend/tests/test_e_msg_policy_s3_management.py
@@ -8,7 +8,12 @@ _P = "app.routers.agent_message_policy"
 
 
 def _owner(monkeypatch, agent=None):
-    monkeypatch.setattr(f"{_P}.assert_agent_owner", AsyncMock(return_value=agent or MagicMock()))
+    # default mock agent carries a valid message_policy_mode — POST/DELETE allowlist responses
+    # now echo it (B1 fix), and a bare MagicMock attr would not be a valid mode literal.
+    monkeypatch.setattr(
+        f"{_P}.assert_agent_owner",
+        AsyncMock(return_value=agent or MagicMock(message_policy_mode="creator_only")),
+    )
 
 
 def _allowlist_result(ids):

--- a/backend/tests/test_e_msg_policy_s3_management.py
+++ b/backend/tests/test_e_msg_policy_s3_management.py
@@ -1,0 +1,83 @@
+"""E-MSG-POLICY S3 (BE): 메시징 정책 관리 endpoints — GET/PUT mode + POST/DELETE allowlist."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_P = "app.routers.agent_message_policy"
+
+
+def _owner(monkeypatch, agent=None):
+    monkeypatch.setattr(f"{_P}.assert_agent_owner", AsyncMock(return_value=agent or MagicMock()))
+
+
+def _allowlist_result(ids):
+    res = MagicMock()
+    res.scalars.return_value.all.return_value = list(ids)
+    return res
+
+
+@pytest.mark.anyio
+async def test_get_message_policy(test_client, mock_session, monkeypatch):
+    agent = MagicMock(); agent.message_policy_mode = "list"
+    _owner(monkeypatch, agent)
+    ids = [uuid.uuid4(), uuid.uuid4()]
+    mock_session.execute = AsyncMock(return_value=_allowlist_result(ids))
+    resp = await test_client.get(f"/api/v2/agents/{uuid.uuid4()}/message-policy")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["mode"] == "list"
+    assert len(body["allowlist"]) == 2
+
+
+@pytest.mark.anyio
+async def test_put_mode_valid(test_client, mock_session, monkeypatch):
+    _owner(monkeypatch)
+    mock_session.execute = AsyncMock(return_value=_allowlist_result([]))
+    mock_session.commit = AsyncMock()
+    resp = await test_client.put(f"/api/v2/agents/{uuid.uuid4()}/message-policy", json={"mode": "org_wide"})
+    assert resp.status_code == 200
+    assert resp.json()["mode"] == "org_wide"
+
+
+@pytest.mark.anyio
+async def test_put_mode_invalid_422(test_client, monkeypatch):
+    _owner(monkeypatch)
+    resp = await test_client.put(f"/api/v2/agents/{uuid.uuid4()}/message-policy", json={"mode": "bogus"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.anyio
+async def test_add_allowlist_member(test_client, mock_session, monkeypatch):
+    member_id = uuid.uuid4()
+    _owner(monkeypatch)
+    monkeypatch.setattr(f"{_P}.resolve_member_identity", AsyncMock(return_value=MagicMock()))
+    mock_session.execute = AsyncMock(return_value=_allowlist_result([member_id]))
+    mock_session.commit = AsyncMock()
+    resp = await test_client.post(
+        f"/api/v2/agents/{uuid.uuid4()}/message-policy/allowlist", json={"member_id": str(member_id)}
+    )
+    assert resp.status_code == 201
+    assert str(member_id) in str(resp.json()["allowlist"])
+
+
+@pytest.mark.anyio
+async def test_add_allowlist_member_not_in_org_404(test_client, mock_session, monkeypatch):
+    _owner(monkeypatch)
+    monkeypatch.setattr(f"{_P}.resolve_member_identity", AsyncMock(return_value=None))
+    resp = await test_client.post(
+        f"/api/v2/agents/{uuid.uuid4()}/message-policy/allowlist", json={"member_id": str(uuid.uuid4())}
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_delete_allowlist_member(test_client, mock_session, monkeypatch):
+    _owner(monkeypatch)
+    mock_session.execute = AsyncMock(return_value=_allowlist_result([]))
+    mock_session.commit = AsyncMock()
+    resp = await test_client.delete(
+        f"/api/v2/agents/{uuid.uuid4()}/message-policy/allowlist/{uuid.uuid4()}"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["allowlist"] == []


### PR DESCRIPTION
## E-MSG-POLICY S3 (BE 부분) — 메시징 정책 관리 API

story `930b7cf6-541b-4590-8982-b107141d59f5` | epic E-MSG-POLICY | **BE 부분**(FE 설정 패널은 유나/미르코) · deps S1

agent별 mode + allow_list를 admin이 관리하는 endpoints. FE 설정 패널의 BE 계약.

### 엔드포인트 (`app/routers/agent_message_policy.py`)
| method | path | 동작 |
|--------|------|------|
| GET | `/api/v2/agents/{id}/message-policy` | `{mode, allowlist}` 조회 |
| PUT | `/api/v2/agents/{id}/message-policy` | `{mode}` 변경(creator_only/org_wide/list 검증·422) |
| POST | `/api/v2/agents/{id}/message-policy/allowlist` | `{member_id}` 추가(멱등·org 멤버 검증·404) |
| DELETE | `.../allowlist/{member_id}` | 제거 |

- 전부 **`assert_agent_owner`(owner/admin)·org-scoped**.
- mode는 **canonical `members`에 UPDATE**(team_members는 0088 projection 뷰라 직접 UPDATE 불가 — view-cutover 정합).
- 변경 즉시 **S1 enforcement 반영**(다음 conversation-create부터 mode/allowlist 적용).
- allow_list add는 **멱등**(`on_conflict_do_nothing`, S2와 동일 unique pair).

### 검증
- 신규 단위 **6**(GET·PUT valid/invalid 422·allowlist add/not-found 404/delete) + 풀 스위트 **1583 passed**
- 마이그 없음(S1 테이블 재사용)

### 참고
S3의 FE(`settings/.../agents/[id]` Messaging policy 섹션·member-picker·creator locked)는 유나/미르코. 이 PR이 그 BE 계약을 제공.

🤖 Generated with [Claude Code](https://claude.com/claude-code)