### PR TITLE
[SID:ORGLESS-GUARD] org-less onboarding guard + rewards loading finally (🔴 prod)

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -37,7 +37,13 @@ export default async function AuthenticatedLayout({
   // 401(인증 만료)만 /login 리다이렉트, 다른 에러(500 등)는 children 렌더링 유지
   if (!meRes || meRes.status === 401) redirect('/login');
 
+  // 🔴 org 없는 유저(신규 OAuth 가입자 등 — team_member 미생성 시 /me 404) → 온보딩으로.
+  // auth/callback이 is_new_user 무관 /inbox 리다이렉트하는 결함을 layout에서 OAuth+email/pw 공통 커버
+  // (org-less가 깨진 페이지 도달 자체 차단). /onboarding은 (authenticated) 밖이라 루프 없음.
+  if (meRes.status === 404) redirect('/onboarding');
+
   const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
+  if (meRes.ok && !me?.org_id) redirect('/onboarding');
   const memberships: { projectId: string; projectName: string }[] =
     membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
   const projectMemberships = memberships.length > 0

--- a/apps/web/src/app/(authenticated)/rewards/page.tsx
+++ b/apps/web/src/app/(authenticated)/rewards/page.tsx
@@ -51,8 +51,10 @@ export default function RewardsPage() {
         if (lbRes.ok && !cancelled) { const j = await lbRes.json(); setLeaderboard(j.data ?? []); }
         if (ledgerRes.ok && !cancelled) { const j = await ledgerRes.json(); setLedger(j.data ?? []); }
         if (membersRes.ok && !cancelled) { const j = await membersRes.json(); setMembers(j.data ?? []); }
-      } catch { /* silent */ }
-      if (!cancelled) setLoading(false);
+      } catch { /* silent */ } finally {
+        // 실패/예외 무관 loading 해소 (#1242 settings 패턴) — 무한 스켈레톤 방지.
+        if (!cancelled) setLoading(false);
+      }
     }
     void load();
     return () => { cancelled = true; };


### PR DESCRIPTION
## 요약
🔴 선생님 prod 막힘 긴급(오르테가군 요청·까심군 근본원인). 작은 fix 2건.

## ① `(authenticated)/layout.tsx` — org-less guard
**근본**: `auth/callback/route.ts`가 `is_new_user` 무관 무조건 `/inbox` 리다이렉트 → OAuth 신규 유저가 온보딩 없이 orphan(org 없는 채 깨진 페이지 도달). BE `/api/v2/me`는 team_member 없으면 **404**(me.py:89).
**fix**: layout에서 `meRes.status === 404` → `/onboarding`, `meRes.ok && !me?.org_id` → `/onboarding`. (401→`/login`, 500→children 기존 유지.) **OAuth+email/pw 모든 진입 경로 공통 커버**, org-less가 깨진 페이지 도달 자체 차단. `/onboarding`은 `(authenticated)` 밖이라 redirect 루프 없음.

## ② `rewards/page.tsx` — loading finally
`load()`의 `setLoading(false)`를 `try/catch` 뒤 → **`finally`**로 이동(#1242 settings 패턴 동일). 실패/예외 무관 loading 해소(무한 스켈레톤 방지).

## 검증
- `lint` 0 errors ✅ / `build` 158/158 ✅
- AC4(OAuth 신규 가입→org 없는 채 앱 진입→/onboarding redirect / rewards loading 해소)는 머지·배포 후 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)