### PR TITLE
[SID:cd7c4368] Settings Members 실명 미반영 fix

### DIFF
--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -64,7 +64,7 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
       setMembers((raw.data ?? []).map((m) => ({
         id: m.id,
         user_id: m.user_id,
-        name: m.name ?? m.email?.split('@')[0] ?? m.user_id?.slice(0, 8) ?? '?',
+        name: (m.name?.trim() || null) ?? m.email?.split('@')[0] ?? m.user_id?.slice(0, 8) ?? '?',
         email: m.email ?? undefined,
         role: m.role,
         joined_at: m.created_at,

--- a/apps/web/src/components/settings/org-members-section.tsx
+++ b/apps/web/src/components/settings/org-members-section.tsx
@@ -60,11 +60,11 @@ export function OrgMembersSection({ orgId, currentRole }: OrgMembersSectionProps
       fetch(`/api/organizations/${orgId}/invites`).catch(() => null),
     ]);
     if (membersRes?.ok) {
-      const raw = await membersRes.json() as { data?: Array<{ id: string; user_id: string; email?: string | null; role: 'owner' | 'admin' | 'member'; created_at: string }> };
+      const raw = await membersRes.json() as { data?: Array<{ id: string; user_id: string; name?: string | null; email?: string | null; role: 'owner' | 'admin' | 'member'; created_at: string }> };
       setMembers((raw.data ?? []).map((m) => ({
         id: m.id,
         user_id: m.user_id,
-        name: m.email?.split('@')[0] ?? m.user_id?.slice(0, 8) ?? '?',
+        name: m.name ?? m.email?.split('@')[0] ?? m.user_id?.slice(0, 8) ?? '?',
         email: m.email ?? undefined,
         role: m.role,
         joined_at: m.created_at,


### PR DESCRIPTION
## 변경 사항
Settings › Members 멤버 목록이 멤버 **실명을 미반영**하고 `email.split('@')[0]`로 표시명을 파생하던 버그 수정.

- **근본원인**: `org-members-section.tsx`의 raw 응답 타입에 `name` 필드가 **누락**돼 있었고, line 67에서 email 로컬파트로 표시명을 파생.
- **fix**: raw 타입에 `name?: string | null` 추가 + 표시명을 응답 `name` 우선 바인딩(`m.name ?? email-prefix ?? user_id ?? '?'` — null 방어 폴백만 유지).

## BE는 정상 (변경 0)
`GET /api/v2/org-members`는 `COALESCE(m.name, u.display_name, u.email) AS name`으로 실명을 정확히 응답 중. FE 컴포넌트만 무시하고 있었음.

## 노출 경위
멤버 7인 전원 `name == email-prefix`라 가려져 있었고, `name ≠ prefix`로 바꾼 테스트로만 노출. 사이드바 계정 메뉴는 `name` 정상 반영 → 데이터는 항상 존재했음. (유나양 결함-제로 sweep 진단)

## 검증
- `pnpm --filter web lint` → **0 errors** (경고는 타 파일 pre-existing)
- `pnpm --filter web build` → **Compiled successfully, 158 routes**
- diff: 1 file, 2 insertions / 2 deletions

## AC4 (배포 후 시각검증)
- [ ] Members 목록 행이 실명(`name`) 표시 — email 로컬파트 아님
- [ ] name null 멤버는 email-prefix 폴백 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)