### PR TITLE
[SID:onboarding-p0] 온보딩 step4 에이전트 api key 422 fix

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -205,7 +205,7 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
         role: agentRole,
       }),
     });
-    const memberJson = await memberRes.json() as { data?: { id: string }; error?: { message?: string } };
+    const memberJson = await memberRes.json() as { data?: { id: string; api_key?: string }; error?: { message?: string } };
     if (!memberRes.ok) {
       setError(memberJson?.error?.message ?? 'Failed to create agent');
       setLoading(false);
@@ -219,10 +219,10 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
       return;
     }
 
-    const keyRes = await fetch(`/api/agents/${agentId}/api-key`, { method: 'POST' });
-    const keyJson = await keyRes.json() as { data?: { api_key: string } };
-    if (keyRes.ok && keyJson.data?.api_key) {
-      setNewApiKey(keyJson.data.api_key);
+    // 에이전트 생성 응답에 이미 plaintext api_key가 포함됨(BE team_members.py: type=agent 생성 시 항상 발급).
+    // 별도 발급 호출(POST /api/agents/{id}/api-key)은 BE가 body 필수라 빈 본문 시 422 → 응답 키를 그대로 사용.
+    if (memberJson.data?.api_key) {
+      setNewApiKey(memberJson.data.api_key);
     }
 
     setStep('connect');


### PR DESCRIPTION
## 🔴 데모-크리티컬 P0
온보딩 step4 'AI 에이전트 추가'에서 api key 발급이 **매번 422** → 다음 진행 막힘.

## 근본원인
`onboarding-form.tsx` `handleCreateAgent`가 `POST /api/team-members`(type=agent) 응답에 **이미 담긴 plaintext `api_key`**(BE `team_members.py` — type=agent 생성 시 항상 발급)를 무시하고, `agentId`로 **빈 본문 2차 호출** `POST /api/agents/{id}/api-key` 수행. 이 BE 엔드포인트(`api_keys.py`)는 `CreateApiKeyRequest` body 필수 → 빈 본문에 **422**.

## fix (BE 변경 0)
- 2차 호출 제거 + 생성 응답의 `api_key` 그대로 사용.
- BE는 `type=agent` 생성 시 항상 api key 발급(`api_key_plaintext`)하므로 응답 `api_key` 보장.
- 부수효과: 불필요한 2번째 키 생성 시도 제거(생성 경로 1키만 발급).

## 검증
- `pnpm --filter web lint` → **0 errors**
- `pnpm --filter web build` → **Compiled successfully, 158 routes**
- diff: 1 file (2차 fetch 블록 제거 + 응답 타입에 `api_key?` 추가)

## done-gate (dev)
- [ ] dev 온보딩 step4: 에이전트 생성 → **api key 정상 발급**(422 없음) → connect 단계 진행
- [ ] 발급된 api_key가 MCP config에 정상 표기

🤖 Generated with [Claude Code](https://claude.com/claude-code)