### PR TITLE
fix(invite): same-invitee re-accept idempotent (resolves 'Invite already accepted' 409)

### DIFF
--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -168,6 +168,27 @@ class OrgInviteRepository:
         if invite is None:
             return {"ok": False, "reason": "not_found"}
         if invite.status == "accepted":
+            # Idempotent: the same invitee re-accepting (double-click / re-visit / back button)
+            # is already a member → treat as success rather than a 409 error. Only a *different*
+            # user hitting an already-consumed invite gets already_accepted.
+            if invite.email.lower() == user_email.lower():
+                # ensure membership exists (prior accept may predate a backfill) — idempotent
+                await self.session.execute(
+                    pg_insert(OrgMember)
+                    .values(
+                        org_id=invite.organization_id,
+                        user_id=user_id,
+                        role=invite.role,
+                    )
+                    .on_conflict_do_nothing(constraint="uq_org_members_org_user")
+                )
+                await self.session.flush()
+                return {
+                    "ok": True,
+                    "org_id": str(invite.organization_id),
+                    "role": invite.role,
+                    "already_member": True,
+                }
             return {"ok": False, "reason": "already_accepted"}
         if invite.status != "pending":
             return {"ok": False, "reason": "invalid_status"}

--- a/backend/tests/test_e_org_multi_s3_3_invite_accept.py
+++ b/backend/tests/test_e_org_multi_s3_3_invite_accept.py
@@ -267,3 +267,52 @@ def test_accept_checks_email_mismatch_in_source():
     source = inspect.getsource(OrgInviteRepository.accept)
     assert "email_mismatch" in source
     assert "email" in source
+
+
+# ─── 졷버그(선생님 발견): same-invitee 재수락 멱등 ──────────────────────────────
+
+def _accepted_invite(email: str = "invited@example.com") -> MagicMock:
+    inv = MagicMock()
+    inv.status = "accepted"
+    inv.email = email
+    inv.organization_id = ORG_ID
+    inv.role = "member"
+    return inv
+
+
+@pytest.mark.anyio
+async def test_accept_same_invitee_already_accepted_is_idempotent_success():
+    """같은 초대받은이가 재수락(더블클릭/재방문/back) 시 409가 아니라 멱등 성공(이미 멤버)
+    → FE가 /dashboard로 보낼 수 있다. (선생님 발견 'Invite already accepted' 버그 근본 fix)"""
+    from app.repositories.org_invite import OrgInviteRepository
+
+    sel = MagicMock()
+    sel.scalar_one_or_none.return_value = _accepted_invite("invited@example.com")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=sel)
+    session.flush = AsyncMock()
+
+    repo = OrgInviteRepository(session)
+    out = await repo.accept(token=TOKEN, user_id=USER_ID, user_email="Invited@Example.com")  # 대소문자 무관
+
+    assert out["ok"] is True
+    assert out.get("already_member") is True
+    assert out["org_id"] == str(ORG_ID)
+    assert out["role"] == "member"
+
+
+@pytest.mark.anyio
+async def test_accept_different_user_already_accepted_still_rejected():
+    """다른 유저가 이미 소비된 초대를 수락 시도 → already_accepted 유지(멱등 성공 아님)."""
+    from app.repositories.org_invite import OrgInviteRepository
+
+    sel = MagicMock()
+    sel.scalar_one_or_none.return_value = _accepted_invite("invited@example.com")
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=sel)
+
+    repo = OrgInviteRepository(session)
+    out = await repo.accept(token=TOKEN, user_id=uuid.uuid4(), user_email="someone-else@example.com")
+
+    assert out["ok"] is False
+    assert out["reason"] == "already_accepted"


### PR DESCRIPTION
## 버그 (선생님 발견·story 474edcb7·high)

초대 메일 수신 → 수락 화면 버튼 클릭 **즉시 "Invite already accepted"(409)**.

## 근본

`OrgInviteRepository.accept()`가 `invite.status == "accepted"`면 **무조건** `{ok:False, already_accepted}`(비멱등) 반환. 같은 초대받은이의 **재클릭/재방문/back/더블클릭**(FE 버튼 disable 가드 없음) 2번째 호출이 409. org_member insert 자체는 `on_conflict_do_nothing`(멱등)인데 status 체크가 막음.

## fix (BE 멱등화)

`backend/app/repositories/org_invite.py` `accept()`: `status=="accepted"` + **수락 시도자 email == 초대 email**(같은 초대받은이) → 멱등 성공(`ok:True`·`already_member`·org_member 멱등 재보장) → 라우터 200 → FE가 `/dashboard` 리디렉트(이미 멤버=성공 취급). *다른* 유저가 소비된 초대 수락 시도는 `already_accepted`(409) 유지.

**변경 없음:** 만료(410)·email불일치(403)는 기존 graceful 에러 유지(선생님 지시).

## 테스트 (12/12 pass)

`test_e_org_multi_s3_3_invite_accept.py` +2:
- `test_accept_same_invitee_already_accepted_is_idempotent_success` — 같은 email(대소문자 무관) 재수락 → ok:True·already_member.
- `test_accept_different_user_already_accepted_still_rejected` — 다른 유저 → already_accepted 유지.

## FE (선택·미르코 핸드오프)

BE 멱등으로 증상 이미 해소(2번째 호출 200). FE `invite-accept-client.tsx` 버튼 `disabled={accepting}` 가드는 선택적 방어(중복 호출 절감) — 데모 비차단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)