### PR TITLE
[SID:0746] 멀티org 프로젝트 leak fix (current-project 항상 갱신 + 0-프로젝트 EmptyState)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -88,6 +88,9 @@
   },
   "dashboard": {
     "title": "Dashboard",
+    "noProjectTitle": "No projects in this organization yet",
+    "noProjectDescription": "Create a project to start using boards and sprints.",
+    "noProjectAction": "Create a project",
     "projects": "Projects",
     "activeSprints": "Active Sprints",
     "viewAll": "View all →",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -88,6 +88,9 @@
   },
   "dashboard": {
     "title": "대시보드",
+    "noProjectTitle": "이 조직에는 아직 프로젝트가 없어요",
+    "noProjectDescription": "새 프로젝트를 만들면 보드와 스프린트를 시작할 수 있어요.",
+    "noProjectAction": "새 프로젝트 만들기",
     "projects": "프로젝트",
     "activeSprints": "활성 스프린트",
     "viewAll": "전체 보기 →",

--- a/apps/web/src/app/api/switch-org/route.ts
+++ b/apps/web/src/app/api/switch-org/route.ts
@@ -41,8 +41,14 @@ export async function POST(request: Request): Promise<Response> {
   const res = NextResponse.json({ data: { ok: true } });
   res.cookies.set(SP_AT_COOKIE, access_token, { ...cookieBase(), maxAge: 15 * 60 });
   res.cookies.set(SP_RT_COOKIE, refresh_token, { ...cookieBase(), maxAge: 30 * 24 * 60 * 60 });
+  // 0746: 전환 시 current-project 쿠키를 항상 갱신해야 stale 잔존이 없다.
+  // target org에 접근 가능 프로젝트가 있으면 그걸로 set, 없으면(미부여 멤버 등) 반드시 clear —
+  // 안 지우면 옛 org의 project_id가 남아 get_project_scoped_org_id가 옛 org로 cross-org 해소돼
+  // 다른 org 프로젝트가 노출되고 전환이 깨진다(멀티org leak).
   if (project_id) {
     res.cookies.set(CURRENT_PROJECT_COOKIE, project_id, { path: '/', sameSite: 'lax', maxAge: 60 * 60 * 24 * 365 });
+  } else {
+    res.cookies.set(CURRENT_PROJECT_COOKIE, '', { path: '/', sameSite: 'lax', maxAge: 0 });
   }
   return res;
 }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -33,6 +33,27 @@ export default async function DashboardPage() {
   const projectId = me.project_id;
   const teamMemberId = me.id;
 
+  // 0746: 전환한 org에 접근 가능한 프로젝트가 없으면(0-프로젝트 org) 옛 org 데이터 잔존/무한로딩 대신
+  // 빈상태를 일급으로 보여준다. (switch-org가 stale current-project 쿠키를 clear → projectId 없음)
+  if (!projectId) {
+    return (
+      <div className="min-h-full p-4 lg:p-6">
+        <div className="mx-auto max-w-7xl space-y-5">
+          <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
+          <EmptyState
+            title={t('noProjectTitle')}
+            description={t('noProjectDescription')}
+            action={
+              <Button asChild size="sm">
+                <Link href={`/onboarding?step=project&orgId=${me.org_id}`}>{t('noProjectAction')}</Link>
+              </Button>
+            }
+          />
+        </div>
+      </div>
+    );
+  }
+
   const agentsData = await fastapiCall<Array<{ id: string; name: string | null; is_active: boolean; type: string }>>(
     'GET', '/api/v2/members', session.access_token,
     { query: { project_id: projectId, member_type: 'agent' } },

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -221,7 +221,8 @@ export function UnifiedSwitcher({
                 <span className="truncate text-[10px] font-medium text-muted-foreground leading-tight">
                   {displayOrg}
                 </span>
-                {displayProject && (
+                {/* 0746: 전환 중에는 옛 org의 프로젝트명을 숨겨 "새 org + 옛 프로젝트" 깜빡임(leak처럼 보임)을 차단 */}
+                {!pending && displayProject && (
                   <span className="truncate text-xs font-semibold text-foreground leading-tight">
                     {displayProject}
                   </span>


### PR DESCRIPTION
## 🔴 선생님 prod 버그 (high)
2개 org 멤버(heavaa owner + MOONKLABS member)가 org 스위처로 **MOONKLABS 전환 시 heavaa의 Lingrow 프로젝트가 노출**되고 전환이 깨짐.

## 근본원인 (선생님 스샷2 + 코드 확증)
`api/switch-org/route.ts`가 BE 응답 `project_id`가 **있을 때만** `CURRENT_PROJECT_COOKIE`를 set → target org에 접근 가능 프로젝트가 없으면(미부여 멤버) **옛 org의 stale `project_id`가 잔존** → BE `get_project_scoped_org_id`가 그 project의 org(heavaa)로 **cross-org 해소** → leak.
- ✅ BE는 정상: `get_verified_org_id`는 `x_org_id or jwt_org_id` — X-Org-Id 없어도 JWT org를 신뢰. switch-org JWT도 target org를 올바로 발급. → **순수 FE stale-project 문제** (X-Org-Id 추가가 근본 아님).

## fix (유나 §5 디자인 핸드오프 `multiorg-leak-fix-ux-handoff` 기준 · BE 무변경)
- **`switch-org` route**: `CURRENT_PROJECT_COOKIE` **항상 갱신** — `project_id` 있으면 set, **없으면 clear**(maxAge 0). stale 옛-org project 잔존 0.
- **`dashboard`**: `projectId` 없는 0-프로젝트 org → 옛 org 데이터 잔존/무한로딩 대신 **EmptyState 일급** (`noProject*` i18n en/ko + "새 프로젝트 만들기" 액션).
- **`unified-switcher`**: 전환 중(`pending`) 트리거에서 **옛 프로젝트명 숨김** — "새 org + 옛 프로젝트" 깜빡임(leak처럼 보임) 하드닝.

## 랜딩규칙 (PO 확정)
전환 시 target org **첫(first_accessible) 프로젝트 자동선택**(BE switch-org) / **0건이면 clear→EmptyState**. 05fa365f(정책 B·초대 시 프로젝트 부여)와 맞물림(부여→set / 미부여→clear+EmptyState).

## 검증
- `pnpm --filter web lint` → **0 errors**
- `pnpm --filter web build` → **Compiled successfully, 158 routes**
- i18n `dashboard.noProject*` **en/ko 대칭**

## ⚠️ 통합검증 (dev 배포 후)
- **sellerking 4-org repro**: org 전환 → 각 org **프로젝트만** 노출·**leak 0** / 0-프로젝트 org → **EmptyState**(옛 org 잔존 0) / 스위칭 정상.

## 유나 §5 확인 요청 (가디언 리뷰)
- `noProject*` 3 카피(title/description/action) — §5 문구와 일치 여부 (현재 비즈니스톤 placeholder)
- 0-프로젝트 EmptyState 마운트 위치(dashboard) + 액션(onboarding project step) 적정성

🤖 Generated with [Claude Code](https://claude.com/claude-code)