### PR TITLE
fix(authz): 0d68ad20 — grant/admin 휴먼 project-scoped 403 제거 (SSOT 리졸버 정합)

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -270,9 +270,12 @@ async def _resolve_doc_member_id(auth: AuthContext, org_id: uuid.UUID, db: Async
         .limit(1)
     )
     member = result.scalar_one_or_none()
-    if not member:
-        raise HTTPException(status_code=403, detail="Team member not found for current user")
-    return member.id
+    if member:
+        return member.id
+    # 0d68ad20: grant-only/admin 휴먼(team_member 행 없음)도 org 멤버면 403 금지 — SSOT canonical
+    # member id(org_member.id)로 폴백. 비-멤버는 resolve_member가 400.
+    from app.services.member_resolver import resolve_member
+    return (await resolve_member(auth, org_id, db)).id
 
 
 # ─── Comments ─────────────────────────────────────────────────────────────────

--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -25,10 +25,11 @@ async def _resolve_member_id(
     db: AsyncSession,
     project_id: uuid.UUID | None = None,
 ) -> uuid.UUID:
-    """JWT auth → team_member_id 반환. project_id 있으면 해당 project member 정확히 지정.
+    """JWT auth → canonical member_id 반환. project_id 있으면 해당 project member 정확히 지정.
 
-    multi-project 사용자에서 project_id 없으면 임의 member 반환 위험 있음.
-    list/unread-count는 project_id query param으로 필터링 권장.
+    0d68ad20: team_member 행만 요구하면 grant-only/admin 휴먼(team_member 없음)이 `/api/projects`엔
+    보이는 프로젝트에서 403 — has_project_access SSOT와 인가 불일치. team_member 곱연산 의존을 버리고
+    SSOT 리졸버(resolve_member)로 canonical id 해소. 미인가는 resolve_member가 403/400.
     """
     user_id = uuid.UUID(str(auth.user_id))
     filters = [
@@ -41,9 +42,13 @@ async def _resolve_member_id(
         select(TeamMember.id).where(*filters).limit(1)
     )
     member_id = result.scalar_one_or_none()
-    if member_id is None:
-        raise HTTPException(status_code=403, detail="Team member not found")
-    return member_id
+    if member_id is not None:
+        return member_id
+    # team_member 행 없음 — SSOT 리졸버로 해소(team_member 곱연산 의존 제거). 휴먼=has_project_access
+    # 후 canonical org_member.id, 에이전트=team_member.id. 미인가면 resolve_member가 403/400.
+    # events는 recipient(canonical id)-addressed라 grant-only 휴먼은 자연히 0건(빈 결과).
+    from app.services.member_resolver import resolve_member
+    return (await resolve_member(auth, org_id, db, project_id=project_id)).id
 
 
 # ─── Pydantic schemas ─────────────────────────────────────────────────────────

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -613,9 +613,13 @@ async def _resolve_team_member_id(auth: AuthContext, org_id: uuid.UUID, db: Asyn
         .limit(1)
     )
     member = result.scalar_one_or_none()
-    if not member:
-        raise HTTPException(status_code=403, detail="Team member not found for current user")
-    return member.id
+    if member:
+        return member.id
+    # 0d68ad20: grant-only/admin 휴먼(team_member 행 없음)도 org 멤버면 403 금지 — SSOT canonical
+    # member id(org_member.id)로 폴백(conversations/notification_preferences와 동일 패턴). 비-멤버는
+    # resolve_member가 400.
+    from app.services.member_resolver import resolve_member
+    return (await resolve_member(auth, org_id, db)).id
 
 
 @router.post("/{id}/comments", response_model=CommentResponse, status_code=201)

--- a/backend/tests/test_0d68_grant_member_resolution.py
+++ b/backend/tests/test_0d68_grant_member_resolution.py
@@ -1,0 +1,102 @@
+"""0d68ad20: grant-only/admin 휴먼(team_member 행 없음) project-scoped 인가 불일치 fix.
+
+근본: project-scoped 엔드포인트가 team_member 행만 요구(403) — `/api/projects`(has_project_access
+SSOT 3-branch)엔 보이는 프로젝트가 알림/코멘트에선 403. fix: team_member 없어도 grant/admin이면 403 금지.
+- event_notifications._resolve_member_id: has_project_access면 None(빈 결과)·없으면 403.
+- stories._resolve_team_member_id / docs._resolve_doc_member_id: resolve_member SSOT 폴백(org_member.id).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+ORG = uuid.uuid4()
+USER = uuid.uuid4()
+PROJ = uuid.uuid4()
+OM_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth():
+    a = MagicMock()
+    a.user_id = str(USER)
+    a.claims = {"app_metadata": {}}
+    return a
+
+
+def _no_team_member_db():
+    db = AsyncMock()
+    res = MagicMock(); res.scalar_one_or_none.return_value = None  # team_member 없음
+    db.execute = AsyncMock(return_value=res)
+    return db
+
+
+# ─── event_notifications._resolve_member_id ──────────────────────────────────
+
+@pytest.mark.anyio
+async def test_event_notif_grant_only_uses_ssot_resolver():
+    """team_member 없으면 resolve_member(SSOT)로 canonical org_member.id 해소(403 금지)."""
+    from app.routers import event_notifications as en
+
+    db = _no_team_member_db()
+    rm = MagicMock(); rm.id = OM_ID
+    with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=rm)):
+        mid = await en._resolve_member_id(_auth(), ORG, db, project_id=PROJ)
+    assert mid == OM_ID  # canonical id (None 아님 — team_member 곱연산 의존 제거)
+
+
+@pytest.mark.anyio
+async def test_event_notif_no_access_still_403():
+    """team_member 없고 접근권도 없으면 resolve_member가 403(미인가 보호 유지)."""
+    from app.routers import event_notifications as en
+
+    db = _no_team_member_db()
+    raiser = AsyncMock(side_effect=HTTPException(status_code=403, detail="No access to this project"))
+    with patch("app.services.member_resolver.resolve_member", new=raiser):
+        with pytest.raises(HTTPException) as ei:
+            await en._resolve_member_id(_auth(), ORG, db, project_id=PROJ)
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_event_notif_team_member_path_unchanged():
+    """team_member 있으면 그 id 반환(기존 동작)."""
+    from app.routers import event_notifications as en
+
+    db = AsyncMock()
+    res = MagicMock(); res.scalar_one_or_none.return_value = OM_ID
+    db.execute = AsyncMock(return_value=res)
+    mid = await en._resolve_member_id(_auth(), ORG, db, project_id=PROJ)
+    assert mid == OM_ID
+
+
+# ─── stories / docs: resolve_member 폴백 ─────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_stories_resolve_falls_back_to_org_member():
+    """team_member 없으면 resolve_member(SSOT)로 org_member.id 폴백(403 금지)."""
+    from app.routers import stories
+
+    db = _no_team_member_db()
+    rm = MagicMock(); rm.id = OM_ID
+    with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=rm)):
+        mid = await stories._resolve_team_member_id(_auth(), ORG, db)
+    assert mid == OM_ID
+
+
+@pytest.mark.anyio
+async def test_docs_resolve_falls_back_to_org_member():
+    from app.routers import docs
+
+    db = _no_team_member_db()
+    rm = MagicMock(); rm.id = OM_ID
+    with patch("app.services.member_resolver.resolve_member", new=AsyncMock(return_value=rm)):
+        mid = await docs._resolve_doc_member_id(_auth(), ORG, db)
+    assert mid == OM_ID


### PR DESCRIPTION
## 0d68ad20 (critical) — 선생님 prod 재검 발견

iamyoonjae = Moonklabs **admin** + 장사왕 project **grant**(project_access) 보유·team_member 행 없음 → `GET /api/v2/event-notifications/unread-count?project_id=…` **403 "Team member not found"**. 같은 project_id가 `GET /api/projects`엔 정상 노출. **인가 불일치.**

### 재현 (dev latest-dev·실데이터)
sellerking(admin)·Test Org 2 프로젝트 `a4f76f42`·team_member None → `_resolve_member_id` → **HTTP 403 확인**.

### 근본
- `/api/projects` = `accessible_project_ids_in_org` = **has_project_access SSOT 3-branch**(team_member ∪ grant ∪ owner/admin) → 보임.
- project-scoped 엔드포인트 = **team_member 행만** 요구 → grant/admin은 403.

### fix — team_member 곱연산 의존 폐기, SSOT 리졸버 사용 (선생님 설계)
`member_resolver.resolve_member`: 휴먼=`has_project_access` 후 **canonical org_member.id**, 에이전트=team_member.id, 미인가 403/400.
- **event_notifications**`._resolve_member_id`: team_member 없으면 `resolve_member().id` (초안의 None/has_access 떡칠 폐기 — 선생님 지적 반영). events는 canonical-addressed라 grant-only 휴먼은 자연히 0건.
- **stories**`._resolve_team_member_id` / **docs**`._resolve_doc_member_id`: `resolve_member` 폴백.

### sweep 결과
- 수정: event_notifications(4콜) · stories:604(3콜) · docs.
- **이미 SSOT 폴백 보유(무변경):** notifications(JWT=user_id 직접) · notification_preferences(resolve_member) · conversations(resolve_member 폴백).
- file_locks: 명시 member_id path-param 패턴(현재유저 해소 아님) — 별개.

### 연계
이 403 cascade가 0746 switch-org "스위칭 안됨"의 유력 근본(장사왕 진입 시 project-scoped 호출 줄줄이 403 → 앱 깨짐). 이 fix가 함께 해소 기대.

### 테스트 (5 신규 + 라우터 회귀 62 pass)
grant→canonical·미인가 403·team_member 경로 유지·stories/docs 폴백.

머지+dev 배포 후 repro 재실행(403→canonical id) 라이브 재검 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)