### PR TITLE
[SID:0746aab9] switch-org 200-but-no-switch — silent-swallow footgun 2건 제거

### DIFF
--- a/apps/web/src/app/(authenticated)/layout.tsx
+++ b/apps/web/src/app/(authenticated)/layout.tsx
@@ -42,8 +42,15 @@ export default async function AuthenticatedLayout({
   // (org-less가 깨진 페이지 도달 자체 차단). /onboarding은 (authenticated) 밖이라 루프 없음.
   if (meRes.status === 404) redirect('/onboarding');
 
-  const me = meRes.ok ? (await meRes.json() as MemberContext | null) : null;
-  if (meRes.ok && !me?.org_id) redirect('/onboarding');
+  // 0746aab9: /me가 403(org 전환 후 project 접근/인가 실패) 등 비-2xx면, 조용히 null 컨텍스트로
+  // 렌더하지 않고 에러 경계(error.tsx)로 넘긴다. 기존 `me = meRes.ok ? ... : null`이 403/500을
+  // 삼켜 DashboardShell이 org/project 컨텍스트 없이 깨진 화면을 무에러로 렌더하던 footgun 제거.
+  if (!meRes.ok) {
+    throw new Error(`Failed to load account context (HTTP ${meRes.status})`);
+  }
+
+  const me = (await meRes.json()) as MemberContext | null;
+  if (!me?.org_id) redirect('/onboarding');
   const memberships: { projectId: string; projectName: string }[] =
     membershipsRes?.ok ? ((await membershipsRes.json()) as { projectId: string; projectName: string }[]) : [];
   const projectMemberships = memberships.length > 0

--- a/apps/web/src/components/nav/unified-switcher.tsx
+++ b/apps/web/src/components/nav/unified-switcher.tsx
@@ -124,10 +124,13 @@ export function UnifiedSwitcher({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ org_id: nextOrgId }),
       });
-      if (res.ok) {
+      // 0746aab9: 200이어도 실제 전환 성공(data.ok) 여부를 확인하고 refresh — 단순 res.ok만 보면
+      // 200-but-실패 케이스가 성공으로 오인돼 전환 깨진 화면이 무에러로 뜬다.
+      const json = await res.json().catch(() => null) as { data?: { ok?: boolean } } | null;
+      if (res.ok && json?.data?.ok) {
         router.refresh();
       } else {
-        setLocalOrgId(prevOrgId); // API 실패 시 롤백
+        setLocalOrgId(prevOrgId); // 실패(비-2xx 또는 data.ok 아님) 시 롤백
       }
     } finally {
       setPending(false);


### PR DESCRIPTION
## 배경 (선생님 prod)
Moonklabs(=장사왕·admin·1프로젝트) org 전환 시 **switch-org 200인데 실제 전환 안 됨·무에러**. 선생님="에러가 과한 fallback에 조용히 묻힘".

## 근본 (BE·디디)
BE가 grant/admin 멤버에 **403**(0d68ad20·team_member 의존 제거→canonical resolve_member로 근본 교체 중) → 전환 후 project-scoped 호출 cascade 403. **그게 들어가면 403 자체 소멸.**

## 이 PR (FE 방어 심층화 — BE fix 후에도 남는 footgun 2건)
**1. `(authenticated)/layout.tsx` — 403 silent-swallow footgun 제거**
- 기존 `const me = meRes.ok ? ... : null` → /me가 **403은 401(`/login`)/404(`/onboarding`) 어느 분기에도 안 걸려** `me=null`로 조용히 삼킴 → `DashboardShell`이 org/project 컨텍스트 없이 **깨진 화면을 무에러 렌더**.
- → **`!meRes.ok` 시 throw** → 기존 `error.tsx` 에러 경계(`RouteErrorState`)로 graceful 처리. (401/404 분기 유지. **신규 비주얼 0**.)

**2. `unified-switcher` `switchOrg` — 응답 data 검증**
- `if(res.ok) router.refresh()`가 200만 보고 data 무검증 → 200-but-실패를 성공 오인.
- → 응답 **`data.ok` 확인** 후 refresh, 아니면 `setLocalOrgId(prevOrgId)` 롤백.

## 검증
- `pnpm --filter web lint` → **0 errors**
- `pnpm --filter web build` → **Compiled successfully, 158 routes**
- 디자인 변경 0 (error.tsx 재사용 → 유나 가디언 불요). BE 0d68ad20 근본fix와 **별개 방어**.

## 통합검증 (dev 배포 후)
- BE 403 케이스(또는 임의 비-2xx /me) → 깨진 null-컨텍스트 화면 대신 **에러 경계 렌더**. switch-org 200-but-실패 → 롤백.

🤖 Generated with [Claude Code](https://claude.com/claude-code)