### PR TITLE
feat(invite): InvitePreview에 프로젝트 목록 노출 (05fa365f surface②)

### DIFF
--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.org_invite import OrgInvite
 from app.models.organization import Organization
-from app.models.project import OrgMember
+from app.models.project import OrgMember, Project
 
 
 @dataclass
@@ -22,6 +22,8 @@ class InvitePreview:
     status: str
     expires_at: datetime
     email: str
+    # 정책B surface②: 수락 시 부여될 프로젝트 [{id, name}] — invitee는 org 접근 전이라 FE가 못 받음.
+    projects: list[dict] = field(default_factory=list)
 
 _INVITE_EXPIRE_DAYS = 7
 
@@ -156,12 +158,32 @@ class OrgInviteRepository:
         effective_status = (
             "expired" if invite.status == "pending" and invite.expires_at < now else invite.status
         )
+        # surface②: invite.project_ids → 프로젝트 이름 해소(invite org 소속만·cross-org 방지)
+        projects: list[dict] = []
+        pids_raw = invite.project_ids or []
+        if pids_raw:
+            wanted = []
+            for p in pids_raw:
+                try:
+                    wanted.append(uuid.UUID(str(p)))
+                except (ValueError, TypeError):
+                    continue
+            if wanted:
+                rows = await self.session.execute(
+                    select(Project.id, Project.name).where(
+                        Project.id.in_(wanted),
+                        Project.org_id == invite.organization_id,
+                        Project.deleted_at.is_(None),
+                    )
+                )
+                projects = [{"id": str(pid), "name": name} for pid, name in rows.all()]
         return InvitePreview(
             org_name=org_name,
             role=invite.role,
             status=effective_status,
             expires_at=invite.expires_at,
             email=invite.email,
+            projects=projects,
         )
 
     async def accept(self, token: str, user_id: uuid.UUID, user_email: str) -> dict:

--- a/backend/app/routers/invite_accept.py
+++ b/backend/app/routers/invite_accept.py
@@ -32,6 +32,7 @@ async def get_invite_preview(
         status=preview.status,
         expires_at=preview.expires_at,
         email=preview.email,
+        projects=preview.projects,
     )
 
 

--- a/backend/app/schemas/invite_accept.py
+++ b/backend/app/schemas/invite_accept.py
@@ -5,6 +5,12 @@ from datetime import datetime
 from pydantic import BaseModel, ConfigDict
 
 
+class InvitePreviewProject(BaseModel):
+    """초대 수락 시 부여될 프로젝트 (이름 표시용)."""
+    id: str
+    name: str
+
+
 class InvitePreviewResponse(BaseModel):
     """token으로 초대 정보 공개 조회 — 미인증 사용자도 접근 가능."""
     org_name: str
@@ -12,6 +18,8 @@ class InvitePreviewResponse(BaseModel):
     status: str  # pending / accepted / expired / revoked
     expires_at: datetime
     email: str  # 초대 대상 email (마스킹은 프론트에서)
+    # 정책B surface②: 수락 시 접근권 부여될 프로젝트 목록(invitee는 org 접근 전이라 FE resolve 불가)
+    projects: list[InvitePreviewProject] = []
 
 
 class AcceptInviteRequest(BaseModel):

--- a/backend/tests/test_invite_preview_projects.py
+++ b/backend/tests/test_invite_preview_projects.py
@@ -1,0 +1,71 @@
+"""정책B surface②: InvitePreview가 invite.project_ids를 프로젝트 이름으로 해소.
+
+invitee는 org 접근 전이라 FE가 프로젝트명을 못 받음 → 수락화면 표시용으로 preview에 포함.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _invite(project_ids):
+    inv = MagicMock()
+    inv.role = "member"
+    inv.status = "pending"
+    inv.email = "x@example.com"
+    inv.expires_at = datetime.now(timezone.utc) + timedelta(days=5)
+    inv.organization_id = ORG_ID
+    inv.project_ids = project_ids
+    return inv
+
+
+@pytest.mark.anyio
+async def test_get_preview_resolves_project_names():
+    from app.repositories.org_invite import OrgInviteRepository
+
+    P = uuid.uuid4()
+    row_res = MagicMock(); row_res.first.return_value = (_invite([str(P)]), "Test Org")
+    proj_res = MagicMock(); proj_res.all.return_value = [(P, "Project Alpha")]
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[row_res, proj_res])
+
+    preview = await OrgInviteRepository(session).get_preview("tok")
+
+    assert preview.org_name == "Test Org"
+    assert preview.projects == [{"id": str(P), "name": "Project Alpha"}]
+    assert session.execute.await_count == 2  # invite 조회 + project 이름 조회
+
+
+@pytest.mark.anyio
+async def test_get_preview_empty_project_ids_no_extra_query():
+    from app.repositories.org_invite import OrgInviteRepository
+
+    row_res = MagicMock(); row_res.first.return_value = (_invite([]), "Test Org")
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[row_res])
+
+    preview = await OrgInviteRepository(session).get_preview("tok")
+
+    assert preview.projects == []
+    assert session.execute.await_count == 1  # project_ids 비면 추가 조회 0
+
+
+@pytest.mark.anyio
+async def test_get_preview_not_found_returns_none():
+    from app.repositories.org_invite import OrgInviteRepository
+
+    row_res = MagicMock(); row_res.first.return_value = None
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[row_res])
+
+    assert await OrgInviteRepository(session).get_preview("nope") is None


### PR DESCRIPTION
## 05fa365f surface② — 수락화면 프로젝트 표시 (BE 의존)

정책B에서 초대 수락화면이 "수락 시 접근권 부여될 프로젝트"를 보여주려면 프로젝트 **이름**이 필요한데, invitee는 아직 org 접근 전이라 FE가 `project_ids`를 이름으로 resolve 불가. → 미인증 공개 preview가 직접 해소해 제공.

### 변경
- `InvitePreview`(dataclass) + `InvitePreviewResponse`(schema)에 `projects: [{id, name}]` 추가 (`InvitePreviewProject` 타입).
- `get_preview`: `invite.project_ids` → `Project` 이름 조회. **invite org 소속 프로젝트만**(cross-org 방지). 빈 배열이면 추가 쿼리 0.
- `GET /api/v2/invites/{token}` 가 `projects` 반환 (미인증 유지).

### 테스트 (3 신규 + invite 회귀 17 pass)
- project_ids → 이름 해소
- 빈 project_ids → 추가 쿼리 없음
- not_found → None

미르코 surface② FE(수락화면 프로젝트 표시)가 이 필드를 소비. (#1256 surface① FE 머지/QA 후속.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)