### PR TITLE
fix(auth): 0746 후속 — last_org_id로 refresh 0-project org leak 차단 (마이그 0098)

### DIFF
--- a/backend/alembic/versions/0098_add_last_org_id_to_users.py
+++ b/backend/alembic/versions/0098_add_last_org_id_to_users.py
@@ -1,0 +1,41 @@
+"""add last_org_id to users
+
+0746 후속(0-project org leak): refresh는 org 컨텍스트가 없어 last_project_id=null(0-project org
+전환 후)이면 cross-org fallback으로 옛 org project를 재주입한다. 서버가 현재 org를 source-of-truth로
+들고 가도록 users.last_org_id를 추가해, _build_app_metadata가 org_id 미지정 시 이 값으로 스코프한다.
+
+additive(nullable + ondelete SET NULL)라 dev/prod 양립 안전·구코드 무영향.
+⚠️ deploy-before-migrate: 머지 후 migrate 잡 선행.
+
+Revision ID: 0098
+Revises: 0097
+Create Date: 2026-06-05
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0098"
+down_revision = "0097"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("last_org_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_users_last_org_id",
+        "users",
+        "organizations",
+        ["last_org_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("fk_users_last_org_id", "users", type_="foreignkey")
+    op.drop_column("users", "last_org_id")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -30,6 +30,11 @@ class User(Base):
     last_project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("projects.id", ondelete="SET NULL"), nullable=True
     )
+    # 0746 후속: 현재 org source-of-truth. refresh가 org 컨텍스트 없을 때 _build_app_metadata가
+    # 이 값으로 스코프해 cross-org 옛 프로젝트 재주입(0-project org leak)을 차단한다.
+    last_org_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -293,8 +293,16 @@ async def _build_app_metadata(
     user: User, session: AsyncSession, org_id: uuid.UUID | None = None
 ) -> dict:
     """JWT app_metadata 구성. org_id 지정 시(switch-org 등) 프로젝트 해소를 **그 org로 스코프**해
-    cross-org 옛 프로젝트 주입을 차단한다(0746 leak fix). org_id None이면 기존 login 동작."""
+    cross-org 옛 프로젝트 주입을 차단한다(0746 leak fix).
+
+    org_id 미지정(refresh/login)이면 **user.last_org_id**(현재 org source-of-truth)로 스코프 —
+    refresh가 org 컨텍스트가 없어 0-project org 전환 후 cross-org 옛 프로젝트를 재주입하던 leak 차단.
+    last_org_id도 없으면(최초 로그인) 기존 cross-org fallback으로 home org 결정."""
     from app.models.team import TeamMember
+
+    # org_id 미지정 시 현재 org(last_org_id)로 스코프 — refresh/login이 현재 org 유지(0746 후속)
+    if org_id is None:
+        org_id = getattr(user, "last_org_id", None)
 
     # 1. last_project_id 우선 → 해당 project의 active team_member (org_id 지정 시 그 org일 때만)
     member = None
@@ -325,6 +333,8 @@ async def _build_app_metadata(
         pid = await first_accessible_project_id(session, user.id, org_id)
         if getattr(user, "last_project_id", None) != pid:
             user.last_project_id = pid  # in-org project or None — cross-org 절대 금지
+        if getattr(user, "last_org_id", None) != org_id:
+            user.last_org_id = org_id  # 현재 org 추적 — 다음 refresh가 이 org 유지
         om_role = (
             await session.execute(
                 select(OrgMember.role).where(
@@ -426,6 +436,9 @@ async def _build_app_metadata(
     # login 시 last_project_id 자동 갱신 — 다음 로그인부터 last_project_id 우선 경로 사용
     if getattr(user, "last_project_id", None) != member.project_id:
         user.last_project_id = member.project_id
+    # 현재 org 추적(0746 후속) — 다음 refresh가 org_id 없이도 이 org로 스코프
+    if getattr(user, "last_org_id", None) != member.org_id:
+        user.last_org_id = member.org_id
 
     # S-MBR-03: org owner/admin → project role 상속 (AC1/AC2)
     # org_members.role이 team_members.role보다 높으면 org role을 effective role로 사용.
@@ -1206,6 +1219,9 @@ async def switch_organization(
 
     # 대상 org의 접근 가능한 첫 project 해소 — team_member > grant > org 첫 project (grant 유저 포함)
     user.last_project_id = await first_accessible_project_id(session, user.id, body.org_id)
+    # 0746 후속: 현재 org 영속 → 이후 refresh(org 컨텍스트 없음)가 이 org로 스코프해 0-project org서도
+    # cross-org 옛 프로젝트 재주입 0 (last_project_id=None이어도 org는 유지).
+    user.last_org_id = body.org_id
 
     # 기존 refresh token 무효화
     await session.execute(

--- a/backend/tests/test_0746_last_org_id_refresh_scope.py
+++ b/backend/tests/test_0746_last_org_id_refresh_scope.py
@@ -1,0 +1,66 @@
+"""0746 후속: refresh 0-project org leak fix — _build_app_metadata가 org_id 미지정 시
+user.last_org_id로 스코프 (refresh는 org 컨텍스트가 없어 cross-org 재주입하던 구멍 차단).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_B = uuid.uuid4()   # 현재 org (0-project)
+UID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _user(last_org_id, last_project_id=None):
+    u = MagicMock()
+    u.id = UID
+    u.email = "x@example.com"
+    u.last_project_id = last_project_id
+    u.last_org_id = last_org_id
+    return u
+
+
+@pytest.mark.anyio
+async def test_refresh_scopes_to_last_org_id_no_crossorg():
+    """org_id 미지정(refresh) + last_org_id=0-project org + stale cross-org last_project_id →
+    last_org_id로 스코프 → project_id='' (옛 org 프로젝트 재주입 0)."""
+    from app.routers.auth import _build_app_metadata
+
+    user = _user(last_org_id=ORG_B, last_project_id=uuid.uuid4())  # stale cross-org project
+    q1 = MagicMock(); q1.scalar_one_or_none.return_value = None  # branch1(ORG_B 스코프) no match
+    q2 = MagicMock(); q2.scalar_one_or_none.return_value = None  # fallback(ORG_B 스코프) no match
+    om = MagicMock(); om.scalar_one_or_none.return_value = "member"
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[q1, q2, om])
+
+    with patch("app.routers.auth.first_accessible_project_id", new=AsyncMock(return_value=None)), \
+         patch("app.routers.auth._user_projects_claim", new=AsyncMock(return_value=[])):
+        md = await _build_app_metadata(user, session)  # org_id 생략 → last_org_id 사용
+
+    assert md["org_id"] == str(ORG_B)
+    assert md["project_id"] == ""          # cross-org 옛 프로젝트 주입 0
+    assert user.last_org_id == ORG_B       # 현재 org 유지(다음 refresh도 동일)
+
+
+@pytest.mark.anyio
+async def test_explicit_org_id_takes_precedence_over_last_org_id():
+    """switch가 넘긴 org_id가 last_org_id보다 우선(전환 즉시 반영)."""
+    from app.routers.auth import _build_app_metadata
+
+    ORG_C = uuid.uuid4()
+    user = _user(last_org_id=ORG_B)  # 이전 org
+    q2 = MagicMock(); q2.scalar_one_or_none.return_value = None  # fallback(ORG_C) no match
+    om = MagicMock(); om.scalar_one_or_none.return_value = "admin"
+    session = AsyncMock(); session.execute = AsyncMock(side_effect=[q2, om])
+
+    with patch("app.routers.auth.first_accessible_project_id", new=AsyncMock(return_value=None)), \
+         patch("app.routers.auth._user_projects_claim", new=AsyncMock(return_value=[])):
+        md = await _build_app_metadata(user, session, org_id=ORG_C)  # 명시 org_id
+
+    assert md["org_id"] == str(ORG_C)      # last_org_id(ORG_B) 아닌 명시 ORG_C
+    assert user.last_org_id == ORG_C       # 명시 org로 갱신

--- a/backend/tests/test_auth_fallback_fix.py
+++ b/backend/tests/test_auth_fallback_fix.py
@@ -19,6 +19,7 @@ def _make_user(last_project_id=None) -> MagicMock:
     u.email = "user@example.com"
     u.is_active = True
     u.last_project_id = last_project_id
+    u.last_org_id = None  # 0746 후속: 신규 필드 — None이어야 org_id-None(cross-org fallback) 경로 유지
     return u
 
 

--- a/backend/tests/test_bug_invite_org_invite_auto_accept.py
+++ b/backend/tests/test_bug_invite_org_invite_auto_accept.py
@@ -56,6 +56,7 @@ async def test_build_app_metadata_auto_accepts_org_invite():
     mock_user.id = user_id
     mock_user.email = "isaacshin@moonklabs.com"
     mock_user.last_project_id = None
+    mock_user.last_org_id = None  # 0746 후속: 신규 필드 — None이어야 org_id-None(invite/Path4) 경로 유지
 
     # mock OrgInvite
     mock_org_inv = MagicMock()
@@ -111,6 +112,7 @@ async def test_build_app_metadata_skips_org_invite_when_invitation_found():
     mock_user.id = user_id
     mock_user.email = "user@example.com"
     mock_user.last_project_id = None
+    mock_user.last_org_id = None  # 0746 후속: 신규 필드 — None이어야 org_id-None(invite/Path4) 경로 유지
 
     mock_inv = MagicMock()
     mock_inv.org_id = org_id


### PR DESCRIPTION
## 0746 잔여 — 0-project org refresh leak (미르코 dev 재검 발견)

0-project org(SK Leak Test) 전환 후 /me가 **뭉클랩(home)+f3e6 stale project** leak → 대시보드에 옛 org 데이터 노출(EmptyState 안 뜸).

### 근본
`refresh_token` 엔드포인트(auth.py)는 **org 컨텍스트가 0**(refresh_token만 수신) → `_build_app_metadata(user)`를 `org_id` 없이 호출. switch가 0-project org서 `last_project_id=None`을 만들어둔 상태라 → fallback이 **cross-org oldest team_member**(옛 org project) 재주입. #1255는 switch 경로만 스코프했고 refresh는 잔존. **User에 현재 org 추적 필드 부재**(last_project_id만)가 진짜 구멍 — 0-project org는 org 정보 소실.

### fix — Option A (서버 source-of-truth)
FE X-Org-Id(Option B)는 이 레포서 #1237로 이미 실패. 서버가 현재 org를 들고 간다:
- **0098** (additive): `users.last_org_id` UUID nullable·FK organizations ON DELETE SET NULL.
- `switch_organization`: `user.last_org_id = body.org_id` 영속.
- `_build_app_metadata`: `org_id` 미지정(refresh/login)이면 **`user.last_org_id`로 스코프** + 해소 시 last_org_id 갱신(short-circuit/success 양쪽). last_org_id도 없으면(최초 로그인) 기존 cross-org fallback으로 home org 결정(무변경).

### 테스트 (2 신규 + auth/invite 회귀 187 pass)
- refresh(org_id 생략) → last_org_id 스코프 → project_id='' (cross-org 재주입 0)
- 명시 org_id(switch)가 last_org_id보다 우선
- 신규 필드라 mock fixture에 `last_org_id=None` 동기(test_auth_fallback_fix/test_bug_invite)

### ⚠️ 배포 규율
- 0098 additive(nullable)·dev/prod 양립·구코드 무영향.
- **머지 후 migrate-dev 잡 선행**(CB 자동배포 앞지름 방지·#1202 deploy-before-migrate) → dev verify(sellerking SK Leak Test refresh→leak0) → prod 배치(PO·backend+migrate).
- 0746 종결 마지막 조각(switch #1255 + refresh #이PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)