### PR TITLE
fix(authz): 740e3b7e — enforce_body_context를 has_project_access SSOT로 (grant/admin create 403 sweep)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -346,16 +346,36 @@ def require_project_access(
     return project_id
 
 
-def enforce_body_context(
+async def enforce_body_context(
     auth_org_id: uuid.UUID,
     body_org_id: uuid.UUID | None = None,
     body_project_id: uuid.UUID | None = None,
     auth_project_id: str | None = None,
+    *,
+    db: AsyncSession | None = None,
+    user_id: uuid.UUID | None = None,
 ) -> None:
-    """AC6/AC7: body의 org_id/project_id가 auth context와 불일치 시 403."""
+    """AC6/AC7: body의 org_id/project_id가 auth context와 일치하는지 검증.
+
+    org_id: auth org와 불일치 시 403.
+    project_id:
+      - db+user_id 전달 시(create 라우터): **has_project_access SSOT 게이트** — JWT project_id 핀과
+        무관하게 접근권(team_member ∪ grant ∪ owner/admin org-wide)만 있으면 통과. 740e3b7e:
+        grant/admin이 JWT에 안 핀된(그러나 접근 가능한) 프로젝트서 epic/task/meeting/story/doc 생성 시
+        나던 403 제거. 접근권 없으면 403 유지.
+      - db 미전달 시(레거시/단위테스트): 기존 JWT project_id 정확일치 검증으로 폴백.
+    """
     if body_org_id is not None and body_org_id != auth_org_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.org_id가 auth context와 불일치인")
-    if auth_project_id and body_project_id is not None and str(body_project_id) != str(auth_project_id):
+    if body_project_id is None:
+        return
+    if db is not None and user_id is not None:
+        from app.services.project_auth import has_project_access
+        if not await has_project_access(db, user_id, body_project_id, auth_org_id):
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="해당 프로젝트 접근권이 없는")
+        return
+    # 레거시 폴백(db 미전달): JWT project_id 핀 정확일치
+    if auth_project_id and str(body_project_id) != str(auth_project_id):
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="body.project_id가 auth context와 불일치인")
 
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -72,11 +72,13 @@ async def create_doc(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> DocResponse:
-    enforce_body_context(
+    await enforce_body_context(
         auth_org_id=org_id,
         body_org_id=body.org_id,
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+        db=session,
+        user_id=uuid.UUID(auth.user_id),
     )
     # AC3-2d(2): created_by canonical 정규화(레거시 휴먼 tm.id→members.id). (A) write.
     created_by = (await canonicalize_member_id(body.created_by, session)) if body.created_by else None

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -47,11 +47,13 @@ async def create_epic(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> EpicResponse:
-    enforce_body_context(
+    await enforce_body_context(
         auth_org_id=org_id,
         body_org_id=body.org_id,
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+        db=session,
+        user_id=uuid.UUID(auth.user_id),
     )
     repo = EpicRepository(session, org_id)
     epic = await repo.create(

--- a/backend/app/routers/meetings.py
+++ b/backend/app/routers/meetings.py
@@ -45,11 +45,13 @@ async def create_meeting(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> MeetingResponse:
-    enforce_body_context(
+    await enforce_body_context(
         auth_org_id=org_id,
         body_org_id=None,
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+        db=session,
+        user_id=uuid.UUID(auth.user_id),
     )
     repo = MeetingRepository(session, body.project_id)
     data = body.model_dump(exclude={"project_id"}, exclude_none=False)

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -148,11 +148,13 @@ async def create_story(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StoryResponse:
-    enforce_body_context(
+    await enforce_body_context(
         auth_org_id=org_id,
         body_org_id=body.org_id,
         body_project_id=body.project_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+        db=session,
+        user_id=uuid.UUID(auth.user_id),
     )
     repo = StoryRepository(session, org_id)
     # E-BOARD S5: assignee_ids 제공 시 단일 assignee_id(주담당)는 첫 요소로 동기화(미지정 시).

--- a/backend/app/routers/tasks.py
+++ b/backend/app/routers/tasks.py
@@ -46,10 +46,12 @@ async def create_task(
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> TaskResponse:
-    enforce_body_context(
+    await enforce_body_context(
         auth_org_id=org_id,
         body_org_id=body.org_id,
         auth_project_id=auth.claims.get("app_metadata", {}).get("project_id"),
+        db=session,
+        user_id=uuid.UUID(auth.user_id),
     )
     repo = TaskRepository(session, org_id)
     task = await repo.create(

--- a/backend/tests/test_740e3b7e_enforce_body_context_grant.py
+++ b/backend/tests/test_740e3b7e_enforce_body_context_grant.py
@@ -1,0 +1,84 @@
+"""740e3b7e: enforce_body_context를 has_project_access SSOT로 — grant/admin 멀티프로젝트
+create(epic/task/meeting/story/doc) 403 제거. JWT project_id 핀과 무관하게 접근권만 있으면 통과.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+ORG = uuid.uuid4()
+USER = uuid.uuid4()
+PROJ = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio
+async def test_grant_access_passes_despite_jwt_pin_mismatch():
+    """db+user_id 전달 + has_project_access TRUE → JWT project_id가 달라도 403 없음(grant/admin)."""
+    from app.dependencies.auth import enforce_body_context
+
+    db = AsyncMock()
+    with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+        # auth_project_id(JWT 핀)는 전혀 다른 프로젝트지만 통과해야
+        await enforce_body_context(
+            auth_org_id=ORG, body_org_id=ORG, body_project_id=PROJ,
+            auth_project_id=str(uuid.uuid4()), db=db, user_id=USER,
+        )
+    # 예외 없이 통과 = PASS
+
+
+@pytest.mark.anyio
+async def test_no_access_raises_403():
+    """db+user_id + has_project_access FALSE → 403."""
+    from app.dependencies.auth import enforce_body_context
+
+    db = AsyncMock()
+    with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+        with pytest.raises(HTTPException) as ei:
+            await enforce_body_context(
+                auth_org_id=ORG, body_org_id=ORG, body_project_id=PROJ,
+                auth_project_id=str(PROJ), db=db, user_id=USER,
+            )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_org_mismatch_403():
+    from app.dependencies.auth import enforce_body_context
+
+    with pytest.raises(HTTPException) as ei:
+        await enforce_body_context(
+            auth_org_id=ORG, body_org_id=uuid.uuid4(), body_project_id=None,
+        )
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_legacy_no_db_falls_back_to_jwt_pin():
+    """db 미전달(레거시/단위테스트) → 기존 JWT project_id 정확일치 폴백 유지."""
+    from app.dependencies.auth import enforce_body_context
+
+    # 일치 → OK
+    await enforce_body_context(auth_org_id=ORG, body_project_id=PROJ, auth_project_id=str(PROJ))
+    # 불일치 → 403
+    with pytest.raises(HTTPException) as ei:
+        await enforce_body_context(auth_org_id=ORG, body_project_id=PROJ, auth_project_id=str(uuid.uuid4()))
+    assert ei.value.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_no_project_id_only_org_check():
+    """body_project_id 없으면 org 체크만(예: task)."""
+    from app.dependencies.auth import enforce_body_context
+
+    db = AsyncMock()
+    # has_project_access 호출 안 되어야(project_id None)
+    with patch("app.services.project_auth.has_project_access", new=AsyncMock(side_effect=AssertionError("should not call"))):
+        await enforce_body_context(auth_org_id=ORG, body_org_id=ORG, body_project_id=None, db=db, user_id=USER)

--- a/backend/tests/test_ss1_auth_context.py
+++ b/backend/tests/test_ss1_auth_context.py
@@ -1,6 +1,6 @@
 """SS-1: auth context 강제 — AC6/AC7 mismatch 403 테스트."""
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -121,17 +121,19 @@ async def test_create_memo_org_id_mismatch_403():
 
 @pytest.mark.anyio
 async def test_create_doc_project_id_mismatch_403():
-    """AC7: docs POST — body.project_id ≠ auth.project_id → 403."""
+    """AC7(740e3b7e 후 SSOT): docs POST — 접근권 없는 프로젝트면 403.
+    (이전엔 JWT project_id 핀 불일치로 403 → 이제 has_project_access FALSE로 403. 보안 동등.)"""
     ctx = _mk_ctx(project_id=PROJECT_ID)
     client, app = await _client(ctx)
     try:
-        async with client as c:
-            resp = await c.post("/api/v2/docs", json={
-                "project_id": str(OTHER_PROJECT_ID),
-                "org_id": str(ORG_ID),
-                "title": "교차 프로젝트 doc",
-                "slug": "cross-project-doc",
-            })
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.post("/api/v2/docs", json={
+                    "project_id": str(OTHER_PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "교차 프로젝트 doc",
+                    "slug": "cross-project-doc",
+                })
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
@@ -139,16 +141,17 @@ async def test_create_doc_project_id_mismatch_403():
 
 @pytest.mark.anyio
 async def test_create_meeting_project_id_mismatch_403():
-    """AC7: meetings POST — body.project_id ≠ auth.project_id → 403."""
+    """AC7(740e3b7e 후 SSOT): meetings POST — 접근권 없는 프로젝트면 403."""
     ctx = _mk_ctx(project_id=PROJECT_ID)
     client, app = await _client(ctx)
     try:
-        async with client as c:
-            resp = await c.post("/api/v2/meetings", json={
-                "project_id": str(OTHER_PROJECT_ID),
-                "title": "교차 프로젝트 미팅",
-                "meeting_type": "general",
-            })
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.post("/api/v2/meetings", json={
+                    "project_id": str(OTHER_PROJECT_ID),
+                    "title": "교차 프로젝트 미팅",
+                    "meeting_type": "general",
+                })
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()

--- a/backend/tests/test_ss4_security_regression.py
+++ b/backend/tests/test_ss4_security_regression.py
@@ -8,7 +8,7 @@ AC5: /api/v2/auth/me 정상 응답 (유효/무효/만료/revoke 4종)
 AC6: 에이전트 MCP 도구 시나리오 회귀 없음 (create_doc, add_story, send_memo 등)
 """
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import ASGITransport, AsyncClient
@@ -210,17 +210,19 @@ async def test_org_id_omitted_stories_not_403():
 
 @pytest.mark.anyio
 async def test_project_id_mismatch_post_docs_403():
-    """AC4: body.project_id ≠ auth.project_id POST docs → 403."""
+    """AC4(740e3b7e 후 SSOT): 접근권 없는 프로젝트 POST docs → 403.
+    (JWT-pin 불일치 → has_project_access FALSE 기반 403으로 전환·보안 동등.)"""
     ctx = _mk_api_key_ctx(project_id=PROJECT_ID)
     client, _, app = await _client(ctx)
     try:
-        async with client as c:
-            resp = await c.post("/api/v2/docs", json={
-                "project_id": str(OTHER_PROJECT_ID),
-                "org_id": str(ORG_ID),
-                "title": "교차 프로젝트 doc",
-                "slug": "cross-project-doc",
-            })
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.post("/api/v2/docs", json={
+                    "project_id": str(OTHER_PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "교차 프로젝트 doc",
+                    "slug": "cross-project-doc",
+                })
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()
@@ -228,16 +230,17 @@ async def test_project_id_mismatch_post_docs_403():
 
 @pytest.mark.anyio
 async def test_project_id_mismatch_post_stories_403():
-    """AC4: body.project_id ≠ auth.project_id POST stories → 403."""
+    """AC4(740e3b7e 후 SSOT): 접근권 없는 프로젝트 POST stories → 403."""
     ctx = _mk_api_key_ctx(project_id=PROJECT_ID)
     client, _, app = await _client(ctx)
     try:
-        async with client as c:
-            resp = await c.post("/api/v2/stories", json={
-                "project_id": str(OTHER_PROJECT_ID),
-                "org_id": str(ORG_ID),
-                "title": "교차 프로젝트 스토리",
-            })
+        with patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.post("/api/v2/stories", json={
+                    "project_id": str(OTHER_PROJECT_ID),
+                    "org_id": str(ORG_ID),
+                    "title": "교차 프로젝트 스토리",
+                })
         assert resp.status_code == 403
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 740e3b7e (+ create 403 sweep) — grant/admin 멀티프로젝트 create 403

### 근본 (함수형 repro로 확정·static read 아님)
`enforce_body_context`가 `body.project_id == JWT app_metadata.project_id` **정확일치**를 요구. JWT는 single-project 핀이라 grant/admin이 **접근 가능한 다른** 프로젝트서 생성 시 **403 "body.project_id가 auth context와 불일치"**. **5개 create 라우터 공용**(epics·tasks·meetings·stories·docs) → 데모서 동형 403 다발. 이번 세션 멀티프로젝트 인가 버그(0746/0d68)와 동근본.

dev 함수형 repro:
- `EPIC_ENFORCE(mismatch)` → 403 / `(match)` → OK 확인.

### conversations(957b0096/a728501d)는 이미 fixed
함수형 repro: grant-only member(team_member=None·grant) → `conversations._resolve_member` → ResolvedMember 반환·**403 없음**. 현 코드 `_resolve_member`가 `resolve_member` 폴백 보유(스토리는 2026-06-01 OLD 코드 기술). **코드 변경 불요** → 957b0096 close-as-fixed(라이브 1회 재확인 권장)·a728501d=dup.

### fix
`enforce_body_context` async화 + `db`/`user_id` 전달 시 **`has_project_access` SSOT 게이트**(team_member ∪ grant ∪ owner/admin org-wide)로 project 검증 — JWT 핀 무관, 접근권 있으면 통과·없으면 403. db 미전달(레거시/단위테스트)은 기존 JWT-pin 폴백 유지. 5콜러(epics/tasks/meetings/stories/docs) `await` + db/user_id.

### 테스트
- 신규 5: grant 통과(JWT mismatch여도)·no-access 403·org mismatch 403·legacy 폴백·project None org-only.
- 보안회귀 4건(ss1/ss4) 'JWT mismatch→403' → 'no-access→403'(has_project_access FALSE) SSOT 의미로 갱신(보안 동등).
- 타깃 220 pass. (전체 27 fail = realdb/e2e 로컬 미연결분·CI postgres서 통과·무관.)

까심 cross-model QA. 머지 후 dev verify(grant/admin epic 생성 200·라이브). 마이그 없음·BE-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)