### PR TITLE
fix(chats): agent-view 게이트 org-effective role (org owner/admin이 project-member여도 허용)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -147,6 +147,27 @@ async def _resolve_member(
     return await resolve_member(auth, org_id, db, project_id=project_id)
 
 
+async def _effective_org_role(
+    auth: AuthContext, org_id: uuid.UUID, db: AsyncSession, sender: "ResolvedMember | TeamMember"
+) -> str:
+    """sender.role에 org owner/admin 상속(S-MBR-03). team_members 뷰는 **project role만** 주므로
+    org owner/admin이 project-member로 나오는 갭(#1223 agent-view 게이트 ↔ 멤버-SSOT 뷰)을 보정 —
+    /me effective-role과 일관(버그: org owner/admin이 agent-view 403). 에이전트(API키)는 org role
+    무관이라 sender.role 그대로."""
+    if sender.role in ("owner", "admin"):
+        return sender.role
+    if bool(auth.claims.get("app_metadata", {}).get("api_key_id")):
+        return sender.role
+    om_role = (await db.execute(
+        select(OrgMember.role).where(
+            OrgMember.org_id == org_id,
+            OrgMember.user_id == uuid.UUID(auth.user_id),
+            OrgMember.deleted_at.is_(None),
+        ).limit(1)
+    )).scalar_one_or_none()
+    return om_role if om_role in ("owner", "admin") else sender.role
+
+
 def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None") -> dict:
     return {
         "id": str(msg.id),
@@ -480,8 +501,9 @@ async def list_conversations(
     """GET /api/v2/conversations — 최근 메시지 미리보기 + 참여 대화 목록."""
     sender = await _resolve_member(auth, org_id, db, project_id=project_id)
 
-    # AC5: include_agent_conversations는 owner/admin만 허용
-    if include_agent_conversations and sender.role not in ("owner", "admin"):
+    # AC5: include_agent_conversations는 owner/admin만 허용 (org-effective role — project team_member
+    # role이 낮아도 org owner/admin이면 상속·#1223↔SSOT뷰 갭 보정)
+    if include_agent_conversations and await _effective_org_role(auth, org_id, db, sender) not in ("owner", "admin"):
         raise HTTPException(status_code=403, detail="Only owner/admin can view agent conversations.")
 
     conv_ids_result = await db.execute(
@@ -600,7 +622,8 @@ async def list_messages(
     # owner/admin: org-level 조회 (project 소속 무관 접근), member: project-level 유지
     sender = await _resolve_member(auth, org_id, db, project_id=None)
 
-    if sender.role not in ("owner", "admin"):
+    # org-effective role(S-MBR-03·#1223↔SSOT뷰 갭 보정) — project role 낮아도 org owner/admin 상속
+    if await _effective_org_role(auth, org_id, db, sender) not in ("owner", "admin"):
         # project isolation 보존 — project 소속 member 재확인
         sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
         participant = (await db.execute(

--- a/backend/tests/test_chats_effective_org_role.py
+++ b/backend/tests/test_chats_effective_org_role.py
@@ -1,0 +1,73 @@
+"""chats 회귀 버그(선생님 보고): conversations agent-view 게이트가 raw project team_member role을 봐서
+org owner/admin을 거부. fix = _effective_org_role(org owner/admin 상속·#1223↔멤버-SSOT 뷰 갭 보정).
+
+project f3e6 전원 team_member role='member'(org owner/admin인데도) → 게이트 403이 근본.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ORG = uuid.uuid4()
+USER = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(api_key=False):
+    claims = {"app_metadata": {"api_key_id": "k"} if api_key else {}}
+    return SimpleNamespace(user_id=str(USER), claims=claims)
+
+
+def _om_role_db(role):
+    res = MagicMock(); res.scalar_one_or_none.return_value = role
+    db = AsyncMock(); db.execute = AsyncMock(return_value=res)
+    return db
+
+
+@pytest.mark.anyio
+async def test_org_admin_inherited_when_project_role_low():
+    """project team_member role='member'이지만 org_member role='admin' → effective 'admin'."""
+    from app.routers.conversations import _effective_org_role
+
+    sender = SimpleNamespace(role="member")  # raw project role
+    db = _om_role_db("admin")
+    assert await _effective_org_role(_auth(), ORG, db, sender) == "admin"
+
+
+@pytest.mark.anyio
+async def test_owner_fast_path_no_query():
+    """sender.role 이미 owner/admin → 즉시 반환(org 조회 안 함)."""
+    from app.routers.conversations import _effective_org_role
+
+    sender = SimpleNamespace(role="owner")
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=AssertionError("should not query"))
+    assert await _effective_org_role(_auth(), ORG, db, sender) == "owner"
+
+
+@pytest.mark.anyio
+async def test_api_key_no_org_escape():
+    """에이전트(API키)는 org role 무관 → sender.role 그대로(조회 안 함)."""
+    from app.routers.conversations import _effective_org_role
+
+    sender = SimpleNamespace(role="member")
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=AssertionError("should not query"))
+    assert await _effective_org_role(_auth(api_key=True), ORG, db, sender) == "member"
+
+
+@pytest.mark.anyio
+async def test_plain_member_stays_member():
+    """org_member도 member면 effective 'member'(상속 없음·정상 거부 유지)."""
+    from app.routers.conversations import _effective_org_role
+
+    sender = SimpleNamespace(role="member")
+    db = _om_role_db("member")
+    assert await _effective_org_role(_auth(), ORG, db, sender) == "member"


### PR DESCRIPTION
## 선생님 보고 버그 — agent chats 안 보임 (org owner/admin인데 403)

미르코 트레이스 + PO/까심 코드 합치로 근본 확정.

### 근본
`conversations.py` agent-view 게이트(#1223 `359791bc` E-MSG-POLICY S1 도입)가 `sender.role not in (owner,admin)`로 403. 근데 `sender.role` = `_resolve_member`가 반환하는 **raw project team_member role**. **project f3e6 전원 team_member role='member'**(송윤재=org **owner**·sellerking=org **admin**인데도 — team_members 뷰가 project role만 줌) → org owner/admin도 403.

= **effective-role 상속 갭**: `/me`는 effective(org admin) 주는데 agent-view는 raw project role로 거부 → 모순(S-MBR-03 org owner/admin→project 상속 미적용).

### fix
`_effective_org_role` 헬퍼 — `sender.role`이 owner/admin 아니면 **org_member.role 상속** 확인(/me effective-role과 일관). api_key 에이전트는 org role 무관 → sender.role 그대로. conversations **2게이트** 적용(agent-view·org-level conversation 조회). 동형 sweep: conversations.py 유일(까심 확인).

### 테스트 (4 신규 + conversations 회귀 25 pass)
org-admin 상속·owner fast-path·api_key no-escape·plain member 유지. BE-only·마이그 없음.

### 회귀 시점
게이트 자체는 #1223(~06-04) 도입(이 세션 무관). #1260은 last_project_id를 바꾸지 않으므로(null일 때만 org 스코프) f3e6 전원 'member' 데이터상 #1223부터 잠재한 effective-role 갭이 본질. fix는 동일 해소.