### PR TITLE
chore: 머지된 주석/docstring 비-비즈니스 언어 정화 (코드 정책)

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -111,7 +111,7 @@ async def dispatch_notification(
                     SimpleNamespace(id=om.id, user_id=om.user_id, type="human", project_id=None)
                 )
 
-        # 졷버그 fix: team_members는 0088 이후 projection VIEW라 멤버당 **프로젝트별 1행**(동일 id)을
+        # 회귀 버그 fix: team_members는 0088 이후 projection VIEW라 멤버당 **프로젝트별 1행**(동일 id)을
         # 반환한다. dedup 없이 루프하면 멀티프로젝트 멤버에게 알림이 **프로젝트 수만큼 중복 생성**됨
         # (Story Assign 시 Inbox 알림 3개 증상 = 담당자가 3개 프로젝트 소속). member id로 dedup해
         # 멤버당 1 알림/이벤트만 생성. (view-cutover multi-row 트랩)

--- a/backend/tests/test_e_org_multi_s3_3_invite_accept.py
+++ b/backend/tests/test_e_org_multi_s3_3_invite_accept.py
@@ -269,7 +269,7 @@ def test_accept_checks_email_mismatch_in_source():
     assert "email" in source
 
 
-# ─── 졷버그(선생님 발견): same-invitee 재수락 멱등 ──────────────────────────────
+# ─── 버그(선생님 발견): same-invitee 재수락 멱등 ──────────────────────────────
 
 def _accepted_invite(email: str = "invited@example.com") -> MagicMock:
     inv = MagicMock()

--- a/backend/tests/test_notification_dispatch.py
+++ b/backend/tests/test_notification_dispatch.py
@@ -240,7 +240,7 @@ async def test_mixed_settings_only_enabled_gets_notification(mock_session, org_i
 
 @pytest.mark.anyio
 async def test_dispatch_dedups_multiproject_view_rows(mock_session, org_id):
-    """졷버그: team_members 뷰(0088 projection)는 멀티프로젝트 멤버를 N행(동일 id)으로 반환 →
+    """회귀 버그: team_members 뷰(0088 projection)는 멀티프로젝트 멤버를 N행(동일 id)으로 반환 →
     dedup 없으면 알림이 프로젝트 수만큼 중복 생성됨(Story Assign 시 Inbox 3개 증상).
     member id dedup으로 멤버당 1 알림만 생성되어야 한다."""
     from app.services.notification_dispatch import dispatch_notification


### PR DESCRIPTION
## 코드베이스 비즈니스 언어 정책 정합

공식 산출물(코드·주석·test·docstring) 비-비즈니스 언어 정책에 맞춰, 과거 PR(#1233/#1252)에서 들어간 비-비즈니스 표현 3건을 비즈니스 언어("회귀 버그"/"버그")로 교체.

- `app/services/notification_dispatch.py:114` (주석)
- `tests/test_notification_dispatch.py:243` (docstring)
- `tests/test_e_org_multi_s3_3_invite_accept.py:272` (주석)

**주석/docstring만 변경 — 로직·테스트 동작 0 변경.** 레포 전체 잔여 0 확인(grep clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)