### PR TITLE
[fix] 수락 화면 org명·프로젝트 미표시 — BE-direct envelope 불일치 (surface② 후속)

### DIFF
--- a/apps/web/src/app/invite/accept/page.tsx
+++ b/apps/web/src/app/invite/accept/page.tsx
@@ -35,15 +35,19 @@ export default async function InviteAcceptPage({ searchParams }: Props) {
     );
   }
 
-  const invite = await inviteRes.json() as { data?: { org_name?: string; role?: string; email?: string; projects?: { id: string; name: string }[] } };
+  // BE-direct(/api/v2/invites/{token})는 InvitePreviewResponse를 top-level로 반환(envelope 없음).
+  // 프록시(/api/invites/{token})만 apiSuccess로 {data} 래핑하므로 양쪽 shape 모두 대응한다.
+  type InvitePreviewData = { org_name?: string; role?: string; email?: string; projects?: { id: string; name: string }[] };
+  const raw = await inviteRes.json() as InvitePreviewData & { data?: InvitePreviewData };
+  const invite = raw.data ?? raw;
 
   return (
     <InviteAcceptClient
       token={token}
-      orgName={invite.data?.org_name ?? ''}
-      role={invite.data?.role ?? 'member'}
-      email={invite.data?.email ?? ''}
-      projects={invite.data?.projects ?? []}
+      orgName={invite.org_name ?? ''}
+      role={invite.role ?? 'member'}
+      email={invite.email ?? ''}
+      projects={invite.projects ?? []}
     />
   );
 }


### PR DESCRIPTION
## 증상 (유나 dev 픽셀 FAIL)
`/invite/accept` 수락 화면에 **org명 EMPTY**("에서 초대했습니다"·박스 Organization 값 빈칸) · 역할 fallback "Member" · **프로젝트 "미지정 (조직만)"** — project_ids 5개 부여 초대인데도 안 뜸.

## 근본 (envelope 불일치)
- `page.tsx`는 **BE-direct** `${fastapiUrl}/api/v2/invites/{token}` 호출 → BE는 `InvitePreviewResponse`를 **top-level** `{org_name, role, status, expires_at, email, projects}`로 반환(envelope 없음).
- 반면 FE 프록시 `/api/invites/{token}`만 `apiSuccess(await _r.json())`로 **`{data}` 래핑**.
- `page.tsx`가 `invite.data?.org_name` 파싱 → BE-direct엔 `data` 없어 전부 undefined → org_name/role/projects **전부 fallback**.
- **org명 미표시는 surface② 이전부터의 pre-existing 잠재버그**(수락 플로우 email-gate로 시각 미검증) — surface②가 projects 추가하며 표면화.

**런타임 증거**: FE 프록시 `/api/invites/{token}` = `{data:{org_name:"뭉클랩", projects:[5]}}` (정상). page.tsx BE-direct 렌더 = 전부 EMPTY. → 프록시 wrap·BE top-level 확정.

## Fix
`raw.data ?? raw`로 **top-level/envelope 양쪽 shape 대응** 후 `invite.{org_name, role, email, projects}` 파싱.

## 검증
- `pnpm --filter web lint` 0 errors / `pnpm --filter web build` 158 routes
- 통합: dev 배포 후 수락 화면에 org명·프로젝트행(부여 5개) 정상 표시 재검(유나 + 내 puppeteer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)