### PR TITLE
fix(invite): 정책B 자동수락 경로 project_access grant 누락 (05fa365f core AC) — SSOT 수렴

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -233,7 +233,14 @@ async def _auto_accept_invitation(session: AsyncSession, user: User, invite_toke
         select(Invitation).where(Invitation.token == invite_token)
     )
     inv = result.scalar_one_or_none()
-    if inv is None or inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
+    if inv is None:
+        # 05fa365f: 토큰이 구 Invitation이 아니면 OrgInvite(org_invites·project_ids 보유)일 수 있음.
+        # canonical accept로 위임 → org_member 생성 + 선택 프로젝트 project_access(granted) 부여.
+        # (signup invite_token 경로가 OrgInvite를 전혀 수락 안 하던 갭 — grant 0행 근본.)
+        from app.repositories.org_invite import OrgInviteRepository
+        await OrgInviteRepository(session).accept(invite_token, user.id, user.email)
+        return
+    if inv.status != "pending" or inv.expires_at < datetime.now(timezone.utc):
         return
     if inv.email.lower() != user.email.lower():
         return
@@ -396,15 +403,12 @@ async def _build_app_metadata(
         )
         org_inv = org_inv_result.scalar_one_or_none()
         if org_inv:
-            from sqlalchemy.dialects.postgresql import insert as pg_insert
-            await session.execute(
-                pg_insert(OrgMember)
-                .values(org_id=org_inv.organization_id, user_id=user.id, role=org_inv.role)
-                .on_conflict_do_nothing(constraint="uq_org_members_org_user")
-            )
-            org_inv.status = "accepted"
-            org_inv.accepted_at = now
-            await session.flush()
+            # 05fa365f SSOT: 자동수락(login fallback)도 **canonical accept**로 위임 — org_member 생성 +
+            # 선택 프로젝트 project_access(granted) 부여 + status=accepted를 한 경로로(명시 accept·signup과
+            # 동일). 인라인 복제 제거 → 3경로(명시·signup·login-fallback) divergence 방지. (이전엔 org_member
+            # +status만 하고 grant 스킵 → invitee grant 0행 → /api/projects=[].)
+            from app.repositories.org_invite import OrgInviteRepository
+            await OrgInviteRepository(session).accept(org_inv.token, user.id, user.email)
             return {
                 "org_id": str(org_inv.organization_id),
                 "project_id": "",

--- a/backend/tests/test_bug_invite_org_invite_auto_accept.py
+++ b/backend/tests/test_bug_invite_org_invite_auto_accept.py
@@ -33,12 +33,13 @@ def test_build_app_metadata_handles_org_invite():
 
 
 def test_build_app_metadata_org_invite_auto_accept_returns_org_id():
-    """OrgInvite 자동수락 경로가 org_id를 반환함."""
+    """OrgInvite 자동수락 경로가 org_id 반환 + canonical accept(SSOT)로 위임."""
     from app.routers.auth import _build_app_metadata
     source = inspect.getsource(_build_app_metadata)
     # org_inv.organization_id → 반환 dict의 org_id
     assert "org_inv.organization_id" in source
-    assert "org_inv.status" in source
+    # 05fa365f SSOT: org_member+grant+status를 canonical accept(token)로 위임(인라인 status set 제거)
+    assert "OrgInviteRepository(session).accept(org_inv.token" in source
 
 
 # ─── 동작 검증 ────────────────────────────────────────────────────────────────
@@ -63,39 +64,29 @@ async def test_build_app_metadata_auto_accepts_org_invite():
     mock_org_inv.organization_id = org_id
     mock_org_inv.role = "member"
     mock_org_inv.status = "pending"
+    mock_org_inv.token = "org-inv-token"
     mock_org_inv.expires_at = now + timedelta(days=3)
     mock_org_inv.accepted_at = None
 
     session = AsyncMock()
 
-    # execute call 순서 (last_project_id=None → 첫 번째 경로 skip):
-    # 1. team_member fallback 조회 → None
-    # 2. Invitation lookup → None
-    # 3. OrgInvite lookup → mock_org_inv
-    # 4. pg_insert(OrgMember)
-    no_member = MagicMock()
-    no_member.scalar_one_or_none.return_value = None
-    no_inv = MagicMock()
-    no_inv.scalar_one_or_none.return_value = None
-    org_inv_result = MagicMock()
-    org_inv_result.scalar_one_or_none.return_value = mock_org_inv
-    insert_result = MagicMock()
-
-    session.execute = AsyncMock(side_effect=[
-        no_member,       # 1. team_member fallback
-        no_inv,          # 2. Invitation lookup
-        org_inv_result,  # 3. OrgInvite lookup
-        insert_result,   # 4. pg_insert(OrgMember)
-    ])
+    # execute 순서: 1.team_member fallback→None  2.Invitation lookup→None  3.OrgInvite lookup→mock_org_inv
+    # (이후 org_member+grant+status는 canonical accept로 위임 → patch)
+    no_member = MagicMock(); no_member.scalar_one_or_none.return_value = None
+    no_inv = MagicMock(); no_inv.scalar_one_or_none.return_value = None
+    org_inv_result = MagicMock(); org_inv_result.scalar_one_or_none.return_value = mock_org_inv
+    session.execute = AsyncMock(side_effect=[no_member, no_inv, org_inv_result])
     session.flush = AsyncMock()
 
-    result = await _build_app_metadata(mock_user, session)
+    # 05fa365f SSOT: 자동수락이 canonical accept(token)로 위임됨 — accept이 org_member+project_access
+    # grant+status 처리(자체 테스트 별도). 여기선 위임 호출 + 반환 dict 검증.
+    accept_mock = AsyncMock(return_value={"ok": True, "org_id": str(org_id), "role": "member"})
+    with patch("app.repositories.org_invite.OrgInviteRepository.accept", new=accept_mock):
+        result = await _build_app_metadata(mock_user, session)
 
     assert result.get("org_id") == str(org_id)
     assert result.get("role") == "member"
-    assert mock_org_inv.status == "accepted"
-    assert mock_org_inv.accepted_at is not None
-    session.flush.assert_awaited()
+    accept_mock.assert_awaited_once_with("org-inv-token", user_id, mock_user.email)
 
 
 @pytest.mark.anyio
@@ -143,3 +134,21 @@ async def test_build_app_metadata_skips_org_invite_when_invitation_found():
     assert mock_inv.status == "accepted"
     # OrgInvite 조회는 호출되지 않아야 함 (execute 3회: team_member, invitation, insert)
     assert session.execute.call_count == 3
+
+
+# ─── 05fa365f: signup invite_token 경로도 OrgInvite 위임(grant) ──────────────
+
+@pytest.mark.anyio
+async def test_auto_accept_invitation_delegates_orginvite_token():
+    """signup _auto_accept_invitation: 토큰이 구 Invitation 아니면 OrgInvite canonical accept로 위임
+    (org_member + project_access grant). 이전엔 Invitation 미존재 시 즉시 return → grant 0행."""
+    from app.routers.auth import _auto_accept_invitation
+
+    user = MagicMock(); user.id = uuid.uuid4(); user.email = "invitee@example.com"
+    # Invitation lookup → None (OrgInvite 토큰)
+    no_inv = MagicMock(); no_inv.scalar_one_or_none.return_value = None
+    session = AsyncMock(); session.execute = AsyncMock(return_value=no_inv)
+    accept_mock = AsyncMock(return_value={"ok": True})
+    with patch("app.repositories.org_invite.OrgInviteRepository.accept", new=accept_mock):
+        await _auto_accept_invitation(session, user, "org-inv-token")
+    accept_mock.assert_awaited_once_with("org-inv-token", user.id, user.email)


### PR DESCRIPTION
## 05fa365f core AC FAIL — invitee가 부여 프로젝트 접근 불가

미르코 정책B E2E + 함수형 repro(실 dev 데이터: accepted org_invite·project_ids 보유인데 **invitee project_access 0행**)로 확정. surface①은 project_ids 정상 전송·invite 자동수락됨, 근데 grant가 가시성 미반영(`/api/projects`=[]·org 스위처 0).

### 근본 — `_grant_invite_project_access` 미호출 경로 2곳
- **Path 1** signup invite_token (`_auto_accept_invitation`): 구 `Invitation` 모델만 조회 → OrgInvite 토큰이면 `scalar_one_or_none()=None` → 즉시 return → **org_member·grant 모두 0**.
- **Path 2** login email-fallback (`_build_app_metadata` 2b): org_member+status만 하고 **grant 스킵**.

(명시 accept[수락버튼·#1253]엔 grant 있었으나 위 2 auto-accept 경로 누락.)

### fix — SSOT 수렴 (PO 지시: 인라인 복제 금지)
명시 accept의 grant 로직을 복제하지 않고 **canonical `OrgInviteRepository.accept`로 수렴** → 3경로(명시버튼·signup·login-fallback)가 동일 accept(org_member + project_access grant + status) 사용 → 향후 divergence 0.
- Path 1: Invitation 미존재 시 `accept(token, user.id, email)` 위임.
- Path 2: 인라인 org_member/grant/status 제거 → `accept(org_inv.token, ...)` 위임.

### 테스트 (auth/invite 291 pass)
- 자동수락 accept 위임 검증(Path1/Path2)·Invitation 우선 무회귀·정책B grant/list 회귀.
- BE-only·마이그 없음. 머지 후 dev verify(invitee 자동수락→project_access 행 생성·`/api/projects` 부여 프로젝트 노출).

🤖 Generated with [Claude Code](https://claude.com/claude-code)