### PR TITLE
[SID:05fa365f] fix(invite): 수락 화면 프로젝트 행 "외 N개" 카운트 클리핑 해소

### DIFF
--- a/apps/web/src/app/invite/accept/invite-accept-client.tsx
+++ b/apps/web/src/app/invite/accept/invite-accept-client.tsx
@@ -17,12 +17,13 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
   const [accepting, setAccepting] = useState(false);
   const [result, setResult] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
 
-  // 정책B surface②: 부여될 프로젝트 — 3개 초과 시 앞 3개 + "외 N개"(박스 과밀 방지)
-  const projectText = projects.length === 0
+  // 정책B surface②: 부여될 프로젝트 — 3개 초과 시 앞 3개 이름 + "외 N개" 배지.
+  // 이름만 truncate하고 카운트 배지는 shrink-0로 분리해 max-w-sm 박스에서도 "외 N개"가 잘리지 않게 한다.
+  const projectNames = projects.length === 0
     ? null
-    : projects.length > 3
-      ? `${projects.slice(0, 3).map((p) => p.name).join(', ')} ${t('acceptProjectsMore', { count: projects.length - 3 })}`
-      : projects.map((p) => p.name).join(', ');
+    : projects.slice(0, 3).map((p) => p.name).join(', ');
+  const moreCount = projects.length > 3 ? projects.length - 3 : 0;
+  const projectTitle = projects.map((p) => p.name).join(', ');
 
   const handleAccept = async () => {
     if (accepting) return;
@@ -63,10 +64,15 @@ export function InviteAcceptClient({ token, orgName, role, email, projects }: In
           </div>
           <div className="mt-2 flex items-center justify-between gap-4 text-sm">
             <span className="shrink-0 text-muted-foreground">{t('acceptProjectsRow')}</span>
-            {projectText === null ? (
+            {projectNames === null ? (
               <span className="text-muted-foreground">{t('acceptProjectsNone')}</span>
             ) : (
-              <span className="truncate text-right font-medium text-foreground/85" title={projectText}>{projectText}</span>
+              <span className="flex min-w-0 items-center justify-end gap-1 text-right font-medium text-foreground/85" title={projectTitle}>
+                <span className="truncate">{projectNames}</span>
+                {moreCount > 0 && (
+                  <span className="shrink-0 text-muted-foreground">{t('acceptProjectsMore', { count: moreCount })}</span>
+                )}
+              </span>
             )}
           </div>
         </div>


### PR DESCRIPTION
## 변경 사항
정책B surface② 초대 수락 화면(`invite-accept-client.tsx`)의 **프로젝트 행** 표시 버그 수정.

부여 프로젝트가 3개를 초과하면 `"이름1, 이름2, 이름3 외 N개"` 문자열 **전체**가 하나의 `truncate` span에 들어가, `max-w-sm`(384px) 박스에서 문자열 **끝**의 `외 N개` 카운트가 통째로 잘려 사라졌다. 사용자는 미표시 프로젝트가 몇 개 더 있는지 알 수 없었다.

**수정**: 이름 목록과 카운트 배지를 분리.
- 이름 목록 → `truncate` (길면 ellipsis)
- `외 N개` 배지 → `shrink-0` (항상 노출)
- flex 부모 → `min-w-0` (ellipsis가 박스를 넘치지 않게)
- `title` 속성은 전체 프로젝트명 유지 (hover 시 전체 확인)

## 스크린샷
### Before (dev, 5개 부여 케이스)
프로젝트 행: `sprintable, 장사왕, B2B Sales G...` — `B2B Sales GTM 외 2개`의 **`외 2개`가 완전히 클리핑**됨. (dev `sprintable-frontend-dev` 재현 확인)

### After
이름만 truncate되고 `외 2개` 배지는 항상 노출. → **dev 머지 후 디자인 가디언(유나) 픽셀 1패스에서 시각 확인 예정** (E2E 가디언 동석 패스와 합산).

## 검증
- `pnpm exec eslint` → 0 warnings/errors
- `pnpm exec tsc --noEmit` → 0 errors
- 격리 git worktree에서 작업 (공유 체크아웃 동시 조작 회피)

## 연관
- `05fa365f` 정책B surface②의 비차단 잔여 nit (유나 핸드오프 플래그)
- 동일 스토리 #1265 grant→access E2E 재검 PASS 결과와 합산해 `05fa365f` done 클로즈 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)