### PR TITLE
fix(auth): 0-project org switch 직후 cross-org 프로젝트 re-entry 차단 (c6b82459)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -255,9 +255,15 @@ async def get_project_scoped_org_id(
     db: AsyncSession = Depends(get_db),
     request: Request = None,
 ) -> uuid.UUID:
-    """project_id query param 또는 X-Project-Id 헤더가 있을 때, 해당 project의 org_id로
-    cross-org 접근을 허용. has_project_access(team_member ∪ grant ∪ owner/admin) 기반 검증.
-    미인가 → 403. project_id가 없으면 get_verified_org_id 동작과 동일."""
+    """project_id query param 으로 project 스코프 org_id를 해소.
+
+    cross-org 접근(project 가 현재 스코프 org 와 다른 org 소속)은 **명시적으로 요청된 경우에만**
+    허용한다: X-Org-Id 헤더가 그 org 를 지정하면 get_verified_org_id 가 base_org_id 를 해당
+    org 로 멤버십 검증해 해소하므로 project_org_id 와 일치한다. 헤더 없이 들어온 cross-org
+    project_id(JWT 스코프와 불일치)는 거부한다(403).
+
+    has_project_access(team_member ∪ grant ∪ owner/admin) 로 project 멤버십 검증.
+    project_id 가 없으면 get_verified_org_id 동작과 동일."""
     base_org_id = await get_verified_org_id(
         auth=auth, x_org_id=x_org_id, x_project_id=None, db=db, request=request
     )
@@ -271,6 +277,17 @@ async def get_project_scoped_org_id(
     project_org_id = result.scalar_one_or_none()
     if not project_org_id:
         return base_org_id
+
+    # c6b82459: cross-org re-entry 차단. project 가 현재 스코프 org(base_org_id)와 다른 org
+    # 소속이면, 그 cross-org 가 X-Org-Id 헤더로 명시 요청된 경우에만 허용한다(헤더 지정 시
+    # base_org_id 가 그 org 로 해소되어 일치). 헤더 없이 들어온 stale project_id(예: 0-project
+    # org 로 switch 직후 옛 프로젝트 쿼리)는 거부하여, FE 가 옛 org 보드로 재진입하지 않고
+    # EmptyState 를 렌더하도록 한다. (#1260 refresh 경로가 못 덮은 switch 직후 즉시경로 edge.)
+    if project_org_id != base_org_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="요청한 org 스코프와 다른 org 의 프로젝트에 접근할 수 없습니다",
+        )
 
     # E-MEMBER-SSOT AC2-2: "TeamMember 존재 = 인가" 대신 has_project_access SSOT로 전환.
     # team_member(active) ∪ project_access(granted) ∪ owner/admin org-wide 3-branch이므로

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -69,6 +69,9 @@ async def test_list_docs_200():
     try:
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [_mock_doc()]
+        # project_id query → get_project_scoped_org_id 의 project→org 조회. 실제 불변식
+        # (project 는 스코프 org 소속)을 반영: 같은 org 여야 cross-org 가드(c6b82459) 통과.
+        mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:
@@ -182,6 +185,8 @@ async def test_list_docs_with_parent_id_200():
         child_doc.parent_id = DOC_ID
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [child_doc]
+        # project→org 조회가 스코프 org 와 일치하도록(c6b82459 cross-org 가드)
+        mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:

--- a/backend/tests/test_integration.py
+++ b/backend/tests/test_integration.py
@@ -52,10 +52,13 @@ async def test_tasks_list_via_conftest(test_client, mock_session):
 
 
 @pytest.mark.anyio
-async def test_docs_list_via_conftest(test_client, mock_session, project_id):
+async def test_docs_list_via_conftest(test_client, mock_session, project_id, org_id):
     """conftest fixture로 docs list 200."""
     mock_result = MagicMock()
     mock_result.scalars.return_value.all.return_value = []
+    # project_id query → get_project_scoped_org_id 의 project→org 조회. project 가 스코프
+    # org(conftest org_id) 소속이어야 cross-org 가드(c6b82459) 통과.
+    mock_result.scalar_one_or_none.return_value = org_id
     mock_session.execute = AsyncMock(return_value=mock_result)
 
     resp = await test_client.get(f"/api/v2/docs?project_id={project_id}")

--- a/backend/tests/test_member_ssot_ac2_2.py
+++ b/backend/tests/test_member_ssot_ac2_2.py
@@ -84,6 +84,66 @@ async def test_get_project_scoped_no_access_403():
     assert exc.value.status_code == 403
 
 
+# ── c6b82459: cross-org re-entry 차단 (0-project switch 직후 stale project_id) ──
+
+@pytest.mark.anyio
+async def test_get_project_scoped_cross_org_without_header_rejected():
+    """JWT org 스코프와 다른 org 의 project_id 가 X-Org-Id 헤더 없이 들어오면 403.
+
+    0-project org 로 switch 직후 옛 프로젝트 query(stale)가 옛 org 로 재진입(leak)하던
+    경로 차단. has_project_access=True 여도 cross-org 가드가 먼저 거부함을 증명.
+    """
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()      # project 가 속한 (옛) org
+    scoped_org = uuid.uuid4()       # 현재 JWT 스코프 org (switch 대상, project_org 와 다름)
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(scoped_org)}}
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    has_access = AsyncMock(return_value=True)
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=scoped_org)), \
+         patch("app.services.project_auth.has_project_access", new=has_access):
+        with pytest.raises(HTTPException) as exc:
+            await get_project_scoped_org_id(
+                project_id=project_id, auth=ctx, x_org_id=None, db=db, request=None
+            )
+    assert exc.value.status_code == 403
+    has_access.assert_not_awaited()  # cross-org 가드가 access 체크보다 먼저 차단
+
+
+@pytest.mark.anyio
+async def test_get_project_scoped_cross_org_with_matching_header_allowed():
+    """X-Org-Id 헤더로 cross-org 가 명시 요청되면(=get_verified_org_id 가 그 org 로 해소)
+    project_org 와 일치하므로 허용 — unified-switcher cross-org 프리뷰 보존."""
+    from app.dependencies.auth import get_project_scoped_org_id
+
+    project_id = uuid.uuid4()
+    project_org = uuid.uuid4()
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(uuid.uuid4())}}  # JWT 는 다른 org
+
+    db = AsyncMock()
+    proj_result = MagicMock()
+    proj_result.scalar_one_or_none.return_value = project_org
+    db.execute = AsyncMock(return_value=proj_result)
+
+    # X-Org-Id=project_org 명시 → get_verified_org_id 가 membership 검증 후 project_org 반환
+    with patch("app.dependencies.auth.get_verified_org_id", new=AsyncMock(return_value=project_org)), \
+         patch("app.services.project_auth.has_project_access", new=AsyncMock(return_value=True)):
+        result = await get_project_scoped_org_id(
+            project_id=project_id, auth=ctx, x_org_id=str(project_org), db=db, request=None
+        )
+    assert result == project_org
+
+
 # ── dispatch_entity: assignee resolve_member_identity (7f8066a3) ──────────────
 
 async def _dispatch_client(mock_session, org_id):

--- a/backend/tests/test_stories.py
+++ b/backend/tests/test_stories.py
@@ -76,6 +76,9 @@ async def test_list_stories_200():
     try:
         mock_result = MagicMock()
         mock_result.scalars.return_value.all.return_value = [_mock_story()]
+        # project_id query → get_project_scoped_org_id 의 project→org 조회. 실제 불변식
+        # (project 는 스코프 org 소속)을 반영: 같은 org 여야 cross-org 가드(c6b82459) 통과.
+        mock_result.scalar_one_or_none.return_value = ORG_ID
         session.execute = AsyncMock(return_value=mock_result)
 
         async with client as c:


### PR DESCRIPTION
## 문제 (c6b82459)
0-project org 로 **switch 직후 즉시경로**에서, 옛 프로젝트의 `project_id`(stale query)가 board 데이터 요청에 실려 들어오면 옛 org 로 재해소되어 **옛 org 의 보드가 그대로 노출**되는 cross-org leak.
- `switch_organization` 토큰·`/me` 는 정상(project_id null)이나, board 데이터(`/stories`, `/docs`)가 `?project_id=<옛>` 로 옛 org 재진입.
- `#1260` 은 refresh 경로만 커버 → switch 직후 즉시경로 edge 미커버.

## 근본
`get_project_scoped_org_id` 가 `project_id` 쿼리만으로 cross-org 접근을 허용(`has_project_access` 통과 시 옛 org 의 owner/admin 이라 통과) → JWT org 스코프를 우회.

## 수정
cross-org 접근은 **`X-Org-Id` 헤더로 명시 요청된 경우에만** 허용.
- 헤더 지정 시 `get_verified_org_id` 가 `base_org_id` 를 그 org 로 멤버십 검증해 해소 → `project_org_id` 와 일치 → 통과.
- 헤더 없이 들어온 cross-org `project_id`(JWT 스코프 불일치) → **403** → FE 가 EmptyState 렌더.
- unified-switcher 의 cross-org 프리뷰는 항상 `X-Org-Id` 동봉(`unified-switcher.tsx`) → 보존.
- blast-radius: 해당 dep 사용처는 `stories`/`docs` list 2곳뿐.

## 함수형 repro (VPC 잡, dev rev 00750)
멀티-org 테스트 유저(orgA=1프로젝트·orgB=0프로젝트) 시드 → 로그인 → switch→A → switch→B(0-proj) 측정:
- (a) switch(orgB) 토큰 `project_id=None` ✓  (b) `/me`(tokB) `project_id=None` ✓
- (c) `/stories?project_id=pA`(orgB-스코프 토큰) → **HTTP 200 = LEAK 재현** (수정 후 403 예상)
- control: `/stories?project_id=pA`(orgA 토큰) → 200 (정당, 유지)

## 테스트
- `test_get_project_scoped_cross_org_without_header_rejected`: 헤더 없는 cross-org → 403 (`has_project_access` 호출 전 가드 선차단 검증)
- `test_get_project_scoped_cross_org_with_matching_header_allowed`: `X-Org-Id` 명시 cross-org → 허용
- stories/docs list mock 의 project→org 불변식(스코프 org 일치) 보정
- 로컬: 관련 단위 테스트 73건 PASS

## 머지 후
dev 자동배포 후 repro 잡 재실행 → CHECK-C `200→403` 전환 실증 예정. 까심군 cross-model QA 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)