### PR TITLE
fix(authz): projects.py GET/PATCH/DELETE per-project grant 가드 — 정책B 정합 (7a03c5f1)

### DIFF
--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -10,16 +10,13 @@ from app.dependencies.database import get_db
 from app.models.project import Project
 from app.repositories.project import ProjectRepository
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
-from app.services.project_auth import accessible_project_ids_in_org
+from app.services.project_auth import (
+    accessible_project_ids_in_org,
+    has_project_access,
+    is_org_owner_or_admin,
+)
 
 router = APIRouter(prefix="/api/v2/projects", tags=["projects"])
-
-
-def _get_repo(
-    session: AsyncSession = Depends(get_db),
-    org_id: uuid.UUID = Depends(get_verified_org_id),
-) -> ProjectRepository:
-    return ProjectRepository(session, org_id)
 
 
 @router.get("", response_model=list[ProjectResponse])
@@ -77,10 +74,14 @@ async def create_project(
 @router.get("/{id}", response_model=ProjectResponse)
 async def get_project(
     id: uuid.UUID,
-    repo: ProjectRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
 ) -> ProjectResponse:
-    project = await repo.get(id)
-    if project is None:
+    # 정책B 정합: 미부여 일반 org-member 는 프로젝트 존재/메타 비노출(list_projects 가시성과 일치).
+    # grant ∪ owner/admin 만 열람 허용. 미접근은 404 로 존재 자체를 숨겨 정보노출 제거.
+    project = await ProjectRepository(session, org_id).get(id)
+    if project is None or not await has_project_access(session, uuid.UUID(auth.user_id), id, org_id):
         raise HTTPException(status_code=404, detail="Project not found")
     return ProjectResponse.model_validate(project)
 
@@ -89,8 +90,16 @@ async def get_project(
 async def update_project(
     id: uuid.UUID,
     body: ProjectUpdate,
-    repo: ProjectRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
 ) -> ProjectResponse:
+    repo = ProjectRepository(session, org_id)
+    # 편집은 부여 멤버 ∪ owner/admin 만. 미접근은 404(비노출).
+    if await repo.get(id) is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="Project not found")
     data = body.model_dump(exclude_unset=True)
     project = await repo.update(id, **data)
     if project is None:
@@ -101,8 +110,22 @@ async def update_project(
 @router.delete("/{id}", status_code=200)
 async def delete_project(
     id: uuid.UUID,
-    repo: ProjectRepository = Depends(_get_repo),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    session: AsyncSession = Depends(get_db),
 ) -> dict:
+    repo = ProjectRepository(session, org_id)
+    # 미접근 멤버에겐 존재 비노출(404).
+    if await repo.get(id) is None or not await has_project_access(
+        session, uuid.UUID(auth.user_id), id, org_id
+    ):
+        raise HTTPException(status_code=404, detail="Project not found")
+    # 삭제는 파괴적(stories/tasks cascade) — 접근권만으론 불가, org owner/admin 전용.
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(
+            status_code=403,
+            detail="프로젝트 삭제는 조직 owner/admin 권한이 필요합니다",
+        )
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Project not found")

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -62,6 +62,32 @@ async def has_project_access(
     return row.scalar_one_or_none() is not None
 
 
+async def is_org_owner_or_admin(
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> bool:
+    """user 가 해당 org 의 owner/admin 인지. 파괴적 작업(프로젝트 삭제 등) 게이트용.
+
+    grant(project_access)만으론 불가 — org-level 역할만 통과. has_project_access 의
+    owner/admin 분기와 동일 기준(team_member 봐주기 없음).
+    """
+    row = await session.execute(
+        text(
+            """
+            SELECT 1 FROM org_members
+            WHERE user_id = :user_id
+              AND org_id = :org_id
+              AND deleted_at IS NULL
+              AND role IN ('owner', 'admin')
+            LIMIT 1
+            """
+        ),
+        {"user_id": user_id, "org_id": org_id},
+    )
+    return row.scalar_one_or_none() is not None
+
+
 async def first_accessible_project_id(
     session: AsyncSession,
     user_id: uuid.UUID,

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -176,3 +176,133 @@ async def test_delete_project_200():
         assert resp.json()["ok"] is True
     finally:
         app.dependency_overrides.clear()
+
+
+# ── 7a03c5f1: per-project grant 인가 (정책B 정합) ─────────────────────────────
+# 접근 모델: GET/PATCH = has_project_access(grant ∪ owner/admin), DELETE = owner/admin 전용.
+
+def _found_session():
+    """repo.get(id) 가 프로젝트를 찾도록(존재) 하는 mock_session."""
+    session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.scalar_one_or_none.return_value = _mock_project()
+    session.execute = AsyncMock(return_value=mock_result)
+    session.delete = AsyncMock()
+    session.flush = AsyncMock()
+    return session
+
+
+async def _client_with(session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.email = "test@example.com"
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def override_db():
+        yield session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_get_project_unauthorized_404():
+    """미부여 일반 org-member → GET 차단(404, 존재 비노출)."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/projects/{PROJECT_ID}")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_project_unauthorized_404():
+    """미부여 일반 org-member → PATCH 차단(404)."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/projects/{PROJECT_ID}", json={"name": "X"})
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_project_unauthorized_404():
+    """미부여 일반 org-member → DELETE 차단(404)."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/projects/{PROJECT_ID}")
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_project_granted_member_200():
+    """부여 멤버 → GET 정상."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.get(f"/api/v2/projects/{PROJECT_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["id"] == str(PROJECT_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_update_project_granted_member_200():
+    """부여 멤버 → PATCH 정상."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/projects/{PROJECT_ID}", json={"name": "Updated Name"})
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_project_granted_member_forbidden_403():
+    """부여 멤버지만 owner/admin 아님 → DELETE 차단(403, 파괴적 작업 권한 부족)."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=True)), \
+             patch("app.routers.projects.is_org_owner_or_admin", new=AsyncMock(return_value=False)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/projects/{PROJECT_ID}")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_project_owner_admin_200():
+    """owner/admin → DELETE 정상."""
+    client, app = await _client_with(_found_session())
+    try:
+        with patch("app.routers.projects.has_project_access", new=AsyncMock(return_value=True)), \
+             patch("app.routers.projects.is_org_owner_or_admin", new=AsyncMock(return_value=True)):
+            async with client as c:
+                resp = await c.delete(f"/api/v2/projects/{PROJECT_ID}")
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 문제 (7a03c5f1 · high/security)
`get/update/delete_project` 가 org 스코프(`get_verified_org_id`)만 걸고 **per-project grant 미검증** → grant 없는 일반 org-member 가:
- **GET /projects/{id}** 200 으로 미부여 프로젝트 name/desc **정보노출** (미르코 E2E 관찰)
- **PATCH/DELETE /projects/{id}** 로 미부여 프로젝트 **수정/삭제** (write authz 갭, read 노출보다 심각)

반면 `list_projects` 는 정책B `accessible_project_ids_in_org` 필터(미부여→빈 목록) → 불일치.

## 접근 모델 (PO 결정 · canonical SSOT · team_member 봐주기 없음)
| 엔드포인트 | 가드 | 미접근 |
|---|---|---|
| GET /projects/{id} | `has_project_access`(grant ∪ owner/admin) | **404**(존재 비노출, list 가시성 일치) |
| PATCH /projects/{id} | `has_project_access` | 404 |
| DELETE /projects/{id} | **owner/admin 전용**(파괴적·cascade) | 미접근 404 / 접근권有·비-admin **403** |

## 변경
- `app/routers/projects.py`: GET/PATCH/DELETE 에 가드 추가. 미사용 `_get_repo` 제거.
- `app/services/project_auth.py`: `is_org_owner_or_admin` SSOT 헬퍼 추가(`has_project_access` owner/admin 분기와 동일 기준).
- `tests/test_projects.py`: AC 매트릭스 7종 — 미부여 GET/PATCH/DELETE→차단 / 부여 GET·PATCH 정상·DELETE 403 / owner·admin DELETE 정상.

## 테스트
- 로컬 test_projects 14 PASS + 관련 슬라이스 80 PASS. AST OK.
- 회귀: 부여 멤버·owner/admin 정상 무회귀, `list_projects` 필터 무영향.

까심군 cross-model QA 요청. (시퀀스: c6b82459 #1267 verify 완료 → 본 건 → a1580005)

🤖 Generated with [Claude Code](https://claude.com/claude-code)