### PR TITLE
[SID:45a5a006] fix(web): app.sprintable.ai 공개 LLM 문서 단일도메인 301 (llms 2종)

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -54,6 +54,12 @@ const nextConfig: NextConfig = {
     return [
       { source: '/memos', destination: '/inbox', permanent: true },
       { source: '/memos/:path*', destination: '/inbox', permanent: true },
+      // 단일 도메인 위생(45a5a006): 호스티드 app.sprintable.ai의 공개 LLM 문서는 랜딩(canonical)으로 301.
+      // host 스코프로 한정해 self-hosted/dev 인스턴스는 영향받지 않고 자체 public 파일을 계속 서빙한다
+      // (onboarding-form 등이 getAppOrigin()/llms.txt를 참조하므로 파일 자체는 유지). onboarding-guide.txt는
+      // app(한)↔랜딩(영) 내용 상이로 별도 콘텐츠 스토리에서 처리한다.
+      { source: '/llms.txt', destination: 'https://sprintable.ai/llms.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
+      { source: '/llms-full.txt', destination: 'https://sprintable.ai/llms-full.txt', statusCode: 301, has: [{ type: 'host', value: 'app.sprintable.ai' }] },
     ];
   },
   async rewrites() {


### PR DESCRIPTION
## ⏸️ BATCH-PENDING — 단독 머지/배포 금지
PO 지시 + 선생님 "배포 모아서" 정책에 따라 **단독 prod 배포하지 않고 다음 prod 배치에 편승**. 리뷰는 진행하되 머지 타이밍은 오르테가군 배치 코디에 따른다. (low/후순위)

## 변경 사항
호스티드 `app.sprintable.ai`에서 공개 LLM 문서(`llms.txt`·`llms-full.txt`)가 랜딩(`sprintable.ai`)과 이중 노출되던 중복을 단일도메인 정책으로 정리.

`next.config.ts` `redirects()`에 **host=app.sprintable.ai 스코프 301** 추가 → 랜딩 canonical로 리다이렉트. 1파일 변경.

### 핵심 설계 (의존성 분석 반영)
- **host 스코프 한정**: self-hosted/dev 인스턴스(host≠app.sprintable.ai)는 리다이렉트 미적용 → 자체 `public/llms*.txt`를 계속 200 서빙. `next.config` 무조건 redirect였으면 self-host 파괴.
- **public 파일 유지(제거 안 함)**: `onboarding-form`·`agent-api-keys`가 `getAppOrigin()/llms.txt`를 agent에게 참조시키므로 dev/self-host 서빙 필요.
- **`onboarding-guide.txt` 범위 제외**: app(구 한국어 SSE)↔랜딩(신 영어 BYOA) 내용 실질 상이 → 단순 301 시 i18n 온보딩 단절(가디언 플래그). 별도 콘텐츠 스토리로 분리(PO 결정).

## 검증 (로컬 prod 서버 Host 스푸핑)
| 요청 | 결과 |
|---|---|
| `Host: app.sprintable.ai` /llms.txt | **301 → https://sprintable.ai/llms.txt** ✅ |
| `Host: app.sprintable.ai` /llms-full.txt | **301 → https://sprintable.ai/llms-full.txt** ✅ |
| `Host: localhost` / self-host 도메인 /llms*.txt | **200** (자체 서빙 유지) ✅ |
| `Host: app.sprintable.ai` /onboarding-guide.txt | 307 (변경 없음·미터치) ✅ |

- `pnpm exec eslint` 0 · `pnpm exec tsc --noEmit` 0 · `pnpm build`(webpack) 성공
- 격리 worktree 작업

## AC 충족 (45a5a006)
- AC1 (301 리다이렉트): ✅ host-스코프 301
- AC2 (라이브 검증): prod 배치 편승 후 app.sprintable.ai/llms*.txt 301 확인 예정 (로컬 Host 스푸핑으로 선검증)
- AC3 (회귀): ✅ build/lint/tsc·self-host 200 유지·기존 라우트/미들웨어 무영향

🤖 Generated with [Claude Code](https://claude.com/claude-code)