### PR TITLE
fix(me): PATCH /api/v2/me — team_member 없는 org-member 휴먼 프로필 이름 404 해소 (a1580005)

### DIFF
--- a/backend/app/routers/me.py
+++ b/backend/app/routers/me.py
@@ -215,6 +215,56 @@ async def update_me(
         select(TeamMember).where(where_clause).limit(1)
     )
     member = result.scalars().first()
+
+    if member is None and not is_api_key and member_id is None:
+        # a1580005: team_member 행이 없는 org-member(휴먼)도 프로필 이름을 갱신할 수 있게
+        # GET /me 와 동일한 org_members 폴백을 적용. 기존엔 GET 만 폴백이 있고 PATCH 는 없어
+        # "프로필 Name 변경 시 /api/me 404" 비대칭 버그가 있었다. canonical members.name 과
+        # GET 폴백 표시 소스(users.display_name)를 함께 갱신해 모든 표면 정합.
+        org_id_str = auth.claims.get("app_metadata", {}).get("org_id")
+        project_id_str = auth.claims.get("app_metadata", {}).get("project_id")
+        if org_id_str:
+            org_member = (await session.execute(
+                select(OrgMember).where(
+                    OrgMember.org_id == uuid.UUID(org_id_str),
+                    OrgMember.user_id == uid,
+                    OrgMember.deleted_at.is_(None),
+                )
+            )).scalar_one_or_none()
+            if org_member is not None:
+                # GET 폴백이 읽는 표시 소스
+                await session.execute(
+                    sa_update(User).where(User.id == uid).values(display_name=body.name)
+                )
+                # canonical members 앵커(있으면) — chat/list_members 등 정합 (best-effort, 0 rows ok)
+                await session.execute(
+                    sa_update(Member).where(
+                        Member.user_id == uid,
+                        Member.org_id == uuid.UUID(org_id_str),
+                        Member.type == "human",
+                        Member.deleted_at.is_(None),
+                    ).values(name=body.name, updated_at=func.now())
+                )
+                user = (await session.execute(
+                    select(User).where(User.id == uid)
+                )).scalar_one_or_none()
+                try:
+                    proj_id = uuid.UUID(project_id_str) if project_id_str else org_member.org_id
+                except (ValueError, AttributeError):
+                    proj_id = org_member.org_id
+                return MeResponse(
+                    id=org_member.id,
+                    org_id=org_member.org_id,
+                    project_id=proj_id,
+                    user_id=uid,
+                    name=body.name,
+                    email=user.email if user else None,
+                    type="human",
+                    role=org_member.role,
+                    is_active=True,
+                    has_password=bool(user.hashed_password) if user else None,
+                )
+
     if member is None:
         # 본인 소유가 아니거나 미존재 — 존재 여부 누설 없이 404
         raise HTTPException(status_code=404, detail="Member not found")

--- a/backend/tests/test_e_onboarding_s1_profile_422.py
+++ b/backend/tests/test_e_onboarding_s1_profile_422.py
@@ -45,6 +45,12 @@ def _tm_result(member):
     return r
 
 
+def _scalar_result(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
 def _auth(uid: uuid.UUID, *, org_id=None, project_id=None):
     meta = {}
     if org_id:
@@ -97,3 +103,67 @@ async def test_patch_me_other_member_id_is_blocked():
     assert exc.value.status_code == 404
     # UPDATE까지 가지 않음 (select 1회만)
     assert session.execute.await_count == 1
+
+
+# ── a1580005: team_member 없는 org-member(휴먼) PATCH /me 폴백 ─────────────────
+
+@pytest.mark.anyio
+async def test_patch_me_org_member_without_team_member_falls_back_200():
+    """a1580005: team_member 행이 없는 org-member(휴먼)도 PATCH /me {name} → 200.
+
+    GET /me 는 org_members 폴백이 있어 200 인데 PATCH 는 폴백이 없어 404 나던 비대칭 해소.
+    users.display_name + canonical members.name 둘 다 갱신.
+    """
+    uid = uuid.uuid4()
+    org_id = uuid.uuid4()
+    om = MagicMock()
+    om.id = uuid.uuid4()
+    om.org_id = org_id
+    om.role = "member"
+    user = MagicMock()
+    user.email = "u@example.com"
+    user.hashed_password = "x"
+    session = AsyncMock()
+    session.expire = MagicMock()
+    # [TM select=None, OrgMember select=om, UPDATE users, UPDATE members, User select=user]
+    session.execute = AsyncMock(side_effect=[
+        _tm_result(None),
+        _scalar_result(om),
+        MagicMock(),
+        MagicMock(),
+        _scalar_result(user),
+    ])
+
+    res = await update_me(
+        body=UpdateMe(name="New Name"),
+        member_id=None,
+        session=session,
+        auth=_auth(uid, org_id=org_id),
+    )
+    assert res.name == "New Name"
+    assert res.id == om.id
+    assert res.user_id == uid
+    assert res.type == "human"
+    assert res.role == "member"
+    compiled = [str(c.args[0]) for c in session.execute.await_args_list]
+    assert any("UPDATE users" in c for c in compiled)   # GET 폴백 표시 소스
+    assert any("UPDATE members" in c for c in compiled)  # canonical 앵커
+
+
+@pytest.mark.anyio
+async def test_patch_me_no_team_member_no_org_member_404():
+    """team_member·org_member 둘 다 없으면(또는 org 컨텍스트 없음) 진짜 404."""
+    uid = uuid.uuid4()
+    org_id = uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_tm_result(None), _scalar_result(None)])
+
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        await update_me(
+            body=UpdateMe(name="x"),
+            member_id=None,
+            session=session,
+            auth=_auth(uid, org_id=org_id),
+        )
+    assert exc.value.status_code == 404


### PR DESCRIPTION
## 문제 (a1580005 · low)
Settings>My Profile 에서 **프로필 Name 변경 시 `/api/me` 404 Not Found**.

근본: `PATCH /api/v2/me`(update_me)가 타겟 멤버를 **TeamMember 로만 해소** → team_member 행이 없는 org-member(휴먼)은 `member is None` → 404. 그런데 **GET /me 는 org_members 폴백이 있어 200**(이 유저들이 프로필을 보긴 함) → GET 200 / PATCH 404 **비대칭**. 프로젝트 미배속 org-member·grant-only 휴먼·신규 가입자가 이름 저장 불가.

## dev 함수형 repro
신규 유저(team_member 없음) PATCH `/api/v2/me {name}` → `404 {"error":{"code":"NOT_FOUND","message":"Member not found"}}` 실측 확인.

## 수정
GET `/me` 와 동일한 org_members 폴백을 PATCH 에 추가:
- TeamMember 미해소(JWT·member_id 미지정) 시 JWT org 의 `org_member` 해소.
- `users.display_name`(GET 폴백 표시 소스) + canonical `members.name`(있으면) 함께 갱신 → 모든 표면 정합.
- org_member 기반 `MeResponse`(name=새 이름) 반환. org_member 도 없으면 종전대로 404.
- `get_db` 성공 시 auto-commit → 별도 commit 불요.

team_member 봐주기 제거 — canonical org_member/members SSOT 로 이름 해소.

## 테스트
- `test_patch_me_org_member_without_team_member_falls_back_200`: team_member 없는 org-member PATCH→200 + UPDATE users/members 검증.
- `test_patch_me_no_team_member_no_org_member_404`: org_member 부재→404.
- 기존 422/ownership 회귀 무영향. me 슬라이스 78 PASS.

머지+dev 배포 후 함수형 verify(org-member·team_member 없는 유저 GET 200 / PATCH 200) 예정. 까심군 cross-model QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)