### PR TITLE
feat(standup): E-STANDUP 3b6b567c — standup org-level 모델 재설계 (migration 0099)

### DIFF
--- a/backend/alembic/versions/0099_standup_org_level.py
+++ b/backend/alembic/versions/0099_standup_org_level.py
@@ -1,0 +1,226 @@
+"""E-STANDUP 3b6b567c: standup_entries org-level 재설계 (project-level → org-level).
+
+기존: app-level upsert 키 (project_id, author_id, date) — 같은 author+date 가 프로젝트마다
+별도 엔트리. (DB-level UNIQUE 는 부재 — 순수 app-level.)
+목표: (org_id, author_id, date) 단위 1엔트리. 프로젝트 surface 는 standup_entry_projects
+link 로 projection (51447ca0). write 링크 채우기는 1c2be9db(write API) 스코프.
+
+이 마이그(3b6b567c):
+1. standup_entry_projects link table 신설 + 기존 project_id 에서 backfill.
+2. preflight dedupe (0081 패턴·PARTITION (org_id,author_id,date)):
+   - feedback 를 keeper 로 reattach **先**, 잉여 entry DELETE **後** (CP2 — 순서 틀리면 FK
+     CASCADE 로 feedback 소멸).
+   - keeper = latest updated_at. done/plan/blockers 는 그룹 내 **distinct non-empty 값을
+     provenance 구분자로 MERGE**(winner 값 + 상이한 비-winner 값 append) → **내용 0 소실**
+     (PO ①·dev lossy_rows=1 실적출 → winner-only 폐기). plan_story_ids 는 그룹 union.
+   - CP4: 구분자 project name JOIN soft-deleted/NULL → project:<id> 폴백.
+   - 머지 그룹 RAISE NOTICE 로그(rollback·감사 재현).
+3. project_id DROP NOT NULL — 단, 값은 keeper origin 보존(NULL 미도입) → 기존 project-filter
+   read 무파손. 풀 projection 은 link join(51447ca0).
+4. UNIQUE(org_id, author_id, date) 추가(현재 DB-level unique 부재 → 신규).
+
+멱등: IF NOT EXISTS·ON CONFLICT DO NOTHING·dedupe 재실행 시 단일행 그룹이면 no-op.
+롤백: 구조 revert(unique index·link table drop). 데이터 MERGE 는 비가역(0081 동일 정책).
+
+Revision ID: 0099
+Revises: 0098
+Create Date: 2026-06-05
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0099"
+down_revision = "0098"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ── 0. 잠재 갭 하드닝: standup_entries.id 에 unique 보장 ────────────────────
+    # dev 실측상 standup_entries 는 PK/unique 제약이 부재(모델은 primary_key=True 이나 DB 미반영).
+    # link table FK(REFERENCES standup_entries(id)) 가 성립하려면 id 가 unique 여야 한다.
+    # 멱등(IF NOT EXISTS) — fresh DB(PK 보유)에선 중복 무해, dev(PK 부재)에선 FK 가능화.
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_entries_id ON standup_entries (id)")
+
+    # ── 1. link table + backfill ──────────────────────────────────────────────
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS standup_entry_projects (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            entry_id uuid NOT NULL REFERENCES standup_entries(id) ON DELETE CASCADE,
+            project_id uuid NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+            org_id uuid NOT NULL,
+            CONSTRAINT uq_standup_entry_project UNIQUE (entry_id, project_id)
+        )
+        """
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sep_entry_id ON standup_entry_projects(entry_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sep_project_id ON standup_entry_projects(project_id)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_sep_org_id ON standup_entry_projects(org_id)")
+    op.execute(
+        """
+        INSERT INTO standup_entry_projects (id, entry_id, project_id, org_id)
+        SELECT gen_random_uuid(), se.id, se.project_id, se.org_id
+        FROM standup_entries se
+        WHERE se.project_id IS NOT NULL
+          -- dev 실측: standup_entries 가 under-constrained(PK·FK 미enforced)라 orphan
+          -- project_id(하드삭제된 프로젝트 참조)가 존재. link table 은 FK 를 강제하므로
+          -- 존재하는 project 만 backfill (orphan 은 자연 제외 — projection 대상 아님).
+          AND EXISTS (SELECT 1 FROM projects p WHERE p.id = se.project_id)
+        ON CONFLICT (entry_id, project_id) DO NOTHING
+        """
+    )
+
+    # ── 2. preflight dedupe ───────────────────────────────────────────────────
+    # 2a. feedback reattach → keeper (DELETE 先행 금지 — CP2)
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id,
+                   row_number() OVER w AS rn,
+                   first_value(id) OVER w AS keeper
+            FROM standup_entries
+            WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)
+        )
+        UPDATE standup_feedback sf SET standup_entry_id = r.keeper
+        FROM ranked r
+        WHERE sf.standup_entry_id = r.id AND r.rn > 1
+        """
+    )
+
+    # 2b. keeper 가 그룹 내 모든 project 링크를 union 보유 (잉여행 DELETE 시 그들 링크는 CASCADE)
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id, org_id, project_id,
+                   first_value(id) OVER w AS keeper
+            FROM standup_entries
+            WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)
+        )
+        INSERT INTO standup_entry_projects (id, entry_id, project_id, org_id)
+        SELECT gen_random_uuid(), r.keeper, r.project_id, r.org_id
+        FROM ranked r
+        WHERE r.project_id IS NOT NULL
+          AND EXISTS (SELECT 1 FROM projects p WHERE p.id = r.project_id)
+        ON CONFLICT (entry_id, project_id) DO NOTHING
+        """
+    )
+
+    # 2c. 머지 그룹 로그 (DELETE 前 — rollback·감사 재현)
+    op.execute(
+        """
+        DO $$
+        DECLARE r record;
+        BEGIN
+            FOR r IN
+                SELECT org_id, author_id, date, count(*) AS c
+                FROM standup_entries
+                GROUP BY org_id, author_id, date
+                HAVING count(*) > 1
+            LOOP
+                RAISE NOTICE 'E-STANDUP 3b6b567c dedupe MERGE: org=% author=% date=% rows=%',
+                    r.org_id, r.author_id, r.date, r.c;
+            END LOOP;
+        END $$
+        """
+    )
+
+    # 2d. text MERGE (winner 값 + 상이한 비-winner non-empty 값 provenance append) + plan_story_ids union
+    #     CP4: project name NULL/soft-deleted → project:<id> 폴백 (LEFT JOIN 으로 행 자체는 확보).
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id, org_id, author_id, date,
+                   row_number() OVER w AS rn,
+                   first_value(id) OVER w AS keeper,
+                   count(*) OVER w AS cnt
+            FROM standup_entries
+            WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)
+        ),
+        keepers AS (
+            SELECT k.id, k.org_id, k.author_id, k.date, k.done, k.plan, k.blockers
+            FROM standup_entries k
+            JOIN ranked r ON r.id = k.id
+            WHERE r.rn = 1 AND r.cnt > 1
+        )
+        UPDATE standup_entries t SET
+            done = CASE WHEN sfx.done_sfx = '' THEN t.done
+                        ELSE COALESCE(t.done, '') || sfx.done_sfx END,
+            plan = CASE WHEN sfx.plan_sfx = '' THEN t.plan
+                        ELSE COALESCE(t.plan, '') || sfx.plan_sfx END,
+            blockers = CASE WHEN sfx.blk_sfx = '' THEN t.blockers
+                            ELSE COALESCE(t.blockers, '') || sfx.blk_sfx END,
+            plan_story_ids = COALESCE(sfx.psids, t.plan_story_ids)
+        FROM keepers kp
+        CROSS JOIN LATERAL (
+            SELECT
+                COALESCE((
+                    SELECT string_agg(
+                        '\n\n--- merged from project: ' ||
+                        COALESCE(NULLIF(p.name, ''), se2.project_id::text) || ' ---\n' || se2.done,
+                        '' ORDER BY se2.updated_at DESC, se2.id DESC)
+                    FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+                    WHERE se2.org_id = kp.org_id AND se2.author_id = kp.author_id AND se2.date = kp.date
+                      AND se2.id <> kp.id
+                      AND COALESCE(se2.done, '') <> '' AND COALESCE(se2.done, '') <> COALESCE(kp.done, '')
+                ), '') AS done_sfx,
+                COALESCE((
+                    SELECT string_agg(
+                        '\n\n--- merged from project: ' ||
+                        COALESCE(NULLIF(p.name, ''), se2.project_id::text) || ' ---\n' || se2.plan,
+                        '' ORDER BY se2.updated_at DESC, se2.id DESC)
+                    FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+                    WHERE se2.org_id = kp.org_id AND se2.author_id = kp.author_id AND se2.date = kp.date
+                      AND se2.id <> kp.id
+                      AND COALESCE(se2.plan, '') <> '' AND COALESCE(se2.plan, '') <> COALESCE(kp.plan, '')
+                ), '') AS plan_sfx,
+                COALESCE((
+                    SELECT string_agg(
+                        '\n\n--- merged from project: ' ||
+                        COALESCE(NULLIF(p.name, ''), se2.project_id::text) || ' ---\n' || se2.blockers,
+                        '' ORDER BY se2.updated_at DESC, se2.id DESC)
+                    FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+                    WHERE se2.org_id = kp.org_id AND se2.author_id = kp.author_id AND se2.date = kp.date
+                      AND se2.id <> kp.id
+                      AND COALESCE(se2.blockers, '') <> '' AND COALESCE(se2.blockers, '') <> COALESCE(kp.blockers, '')
+                ), '') AS blk_sfx,
+                (
+                    SELECT array_agg(DISTINCT x)
+                    FROM standup_entries se3, unnest(se3.plan_story_ids) AS x
+                    WHERE se3.org_id = kp.org_id AND se3.author_id = kp.author_id AND se3.date = kp.date
+                ) AS psids
+        ) sfx
+        WHERE t.id = kp.id
+        """
+    )
+
+    # 2e. 잉여행 DELETE (feedback reattach·링크 union·merge 완료 後)
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id,
+                   row_number() OVER (PARTITION BY org_id, author_id, date
+                                      ORDER BY updated_at DESC, id DESC) AS rn
+            FROM standup_entries
+        )
+        DELETE FROM standup_entries se USING ranked r WHERE se.id = r.id AND r.rn > 1
+        """
+    )
+
+    # ── 3. project_id nullable (값 보존 — NULL 도입 안 함) ─────────────────────
+    op.execute("ALTER TABLE standup_entries ALTER COLUMN project_id DROP NOT NULL")
+
+    # ── 4. org-level UNIQUE (현재 DB-level unique 부재 → 신규 추가) ────────────
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_org_author_date "
+        "ON standup_entries (org_id, author_id, date)"
+    )
+
+
+def downgrade() -> None:
+    # 구조 revert. 데이터 MERGE(복수 project-entry → 1 org-entry, 텍스트 병합)는 비가역
+    # (0081·0075 동일 정책 — no-op 데이터). project_id 는 NULL 도입을 안 했으나 1c2be9db
+    # org-level write 이후 NULL 이 생길 수 있어 NOT NULL 복원은 생략(안전).
+    op.execute("DROP INDEX IF EXISTS uq_standup_org_author_date")
+    op.execute("DROP TABLE IF EXISTS standup_entry_projects")

--- a/backend/app/models/standup.py
+++ b/backend/app/models/standup.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import date
 
-from sqlalchemy import Date, ForeignKey, Text
+from sqlalchemy import Date, ForeignKey, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -13,8 +13,11 @@ class StandupEntry(Base, OrgScopedMixin, TimestampMixin):
     __tablename__ = "standup_entries"
 
     id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    project_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    # E-STANDUP 3b6b567c: org-level 재설계 — 엔트리는 (org_id, author_id, date) 단위 1건.
+    # project_id 는 nullable 로 완화(레거시 origin 보존·기존 project-filter read 무파손).
+    # 프로젝트 surface 는 standup_entry_projects link 로 projection(51447ca0).
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=True, index=True
     )
     sprint_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("sprints.id", ondelete="SET NULL"), nullable=True
@@ -35,6 +38,35 @@ class StandupEntry(Base, OrgScopedMixin, TimestampMixin):
 
     feedbacks: Mapped[list["StandupFeedback"]] = relationship(
         "StandupFeedback", back_populates="entry", lazy="select"
+    )
+    projects: Mapped[list["StandupEntryProject"]] = relationship(
+        "StandupEntryProject", back_populates="entry", lazy="select",
+        cascade="all, delete-orphan",
+    )
+
+
+class StandupEntryProject(Base):
+    """E-STANDUP 3b6b567c: org-level 스탠드업 엔트리 ↔ 프로젝트 projection link.
+
+    하나의 org-level 엔트리가 복수 프로젝트 보드에 surface 되도록 명시 M:N 링크.
+    plan_story_ids-derive 대비: 스토리 계획이 빈 엔트리도 orphan 되지 않음.
+    write 시 링크 채우기는 1c2be9db(write API) 스코프, read projection 은 51447ca0.
+    """
+    __tablename__ = "standup_entry_projects"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    entry_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("standup_entries.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+
+    entry: Mapped["StandupEntry"] = relationship("StandupEntry", back_populates="projects")
+
+    __table_args__ = (
+        UniqueConstraint("entry_id", "project_id", name="uq_standup_entry_project"),
     )
 
 

--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -49,22 +49,41 @@ class StandupEntryRepository(BaseRepository[StandupEntry]):
         super().__init__(StandupEntry, session, org_id)
 
     async def upsert(self, **data: Any) -> StandupEntry:
-        """UNIQUE(project_id, author_id, date) 기반 upsert."""
+        """E-STANDUP 3b6b567c: org-level upsert — 키 **(org_id, author_id, date)**.
+
+        프로젝트별 별도 행이 아니라 author+date 당 org 1엔트리. 프로젝트 surface 는
+        standup_entry_projects link 로 projection(51447ca0). project_id(origin)는 컬럼 유지
+        하되 더 이상 identity 키가 아니다. org_id 는 self.org_id(=get_verified_org_id 검증값,
+        CP3) — 클라 바디 미수용.
+        """
         existing = await self.session.execute(
             select(StandupEntry).where(
                 self._org_filter(),
-                StandupEntry.project_id == data["project_id"],
                 StandupEntry.author_id == data["author_id"],
                 StandupEntry.date == data["date"],
             )
         )
         entry = existing.scalar_one_or_none()
         if entry is not None:
-            update_data = {k: v for k, v in data.items() if k not in ("project_id", "author_id", "date")}
+            update_data = {k: v for k, v in data.items() if k not in ("author_id", "date")}
             updated = await self.update(entry.id, **update_data)
             assert updated is not None
-            return updated
-        return await self.create(**data)
+            entry = updated
+        else:
+            entry = await self.create(**data)
+        # projection link 유지 (project_id 제공 시 멱등 보장). 빈 링크/프로젝트 미선택 등
+        # full write 링크 정책은 1c2be9db(write API) 스코프.
+        project_id = data.get("project_id")
+        if project_id is not None:
+            await self.session.execute(
+                text(
+                    "INSERT INTO standup_entry_projects (id, entry_id, project_id, org_id) "
+                    "VALUES (gen_random_uuid(), :e, :p, :o) "
+                    "ON CONFLICT (entry_id, project_id) DO NOTHING"
+                ),
+                {"e": entry.id, "p": project_id, "o": self.org_id},
+            )
+        return entry
 
     async def get_missing(self, project_id: uuid.UUID, target_date: date) -> list[uuid.UUID]:
         """해당 날짜 standup 미제출 휴먼의 **canonical members.id** 목록 (AC3-3).

--- a/backend/tests/test_standup_org_level_3b6b567c.py
+++ b/backend/tests/test_standup_org_level_3b6b567c.py
@@ -1,0 +1,231 @@
+"""E-STANDUP 3b6b567c: org-level 재설계 — upsert shim + dedupe MERGE 회귀.
+
+- shim: upsert 키 (project_id,author_id,date) → (org_id,author_id,date) 전환 검증(mock).
+- dedupe lossless: real-DB(ALEMBIC_DATABASE_URL 있을 때) — 같은 (org,author,date) 복수
+  project 엔트리(상이 plan) 시드 → dedupe SQL → 1엔트리·내용 0소실·링크 union·feedback
+  reattach·lossy_rows=0·멱등. (마이그 0099 의 2a~2e 와 동형 SQL; dev migrate 재프로브는
+  PR 본문에 별도 실증.)
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date as _date
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── shim 단위 (mock) ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_upsert_keys_on_org_author_date_not_project():
+    """org-level upsert: 기존 엔트리 조회 WHERE 에 project_id 가 빠지고 author_id+date 만."""
+    from app.repositories.standup import StandupEntryRepository
+
+    org = uuid.uuid4()
+    repo = StandupEntryRepository(MagicMock(), org)
+    repo.session = AsyncMock()
+    existing_entry = MagicMock(); existing_entry.id = uuid.uuid4()
+    sel_result = MagicMock(); sel_result.scalar_one_or_none.return_value = existing_entry
+    repo.session.execute = AsyncMock(return_value=sel_result)
+    repo.update = AsyncMock(return_value=existing_entry)
+
+    await repo.upsert(
+        project_id=uuid.uuid4(), author_id=uuid.uuid4(), date=_date(2026, 6, 5),
+        done="d", plan="p", blockers=None, plan_story_ids=[],
+    )
+
+    # 첫 execute = SELECT (org-level 조회), 마지막 execute = link INSERT
+    sel_sql = str(repo.session.execute.await_args_list[0].args[0])
+    assert "author_id" in sel_sql and "date" in sel_sql
+    assert "project_id =" not in sel_sql.replace("\n", " ")  # project_id 가 식별 키가 아님
+    link_sql = str(repo.session.execute.await_args_list[-1].args[0])
+    assert "standup_entry_projects" in link_sql  # link 유지
+
+
+@pytest.mark.anyio
+async def test_upsert_update_data_excludes_author_date_keeps_project():
+    """update_data 에서 author_id/date(키)만 제외 — project_id(origin)는 갱신 대상 유지."""
+    from app.repositories.standup import StandupEntryRepository
+
+    repo = StandupEntryRepository(MagicMock(), uuid.uuid4())
+    repo.session = AsyncMock()
+    entry = MagicMock(); entry.id = uuid.uuid4()
+    res = MagicMock(); res.scalar_one_or_none.return_value = entry
+    repo.session.execute = AsyncMock(return_value=res)
+    captured = {}
+    async def _upd(_id, **data): captured.update(data); return entry
+    repo.update = _upd
+
+    pid = uuid.uuid4()
+    await repo.upsert(project_id=pid, author_id=uuid.uuid4(), date=_date(2026, 6, 5), done="x", plan_story_ids=[])
+    assert "author_id" not in captured and "date" not in captured
+    assert captured.get("project_id") == pid
+    assert captured.get("done") == "x"
+
+
+# ── dedupe MERGE lossless (real-DB·skip-able) ─────────────────────────────────
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+# 0099 upgrade 의 2a~2e 와 동형 (PARTITION (org,author,date)). 테스트가 unique index 를 잠시
+# drop 후 dup 시드 → 이 SQL 실행 → 재생성.
+_DEDUPE_SQL = [
+    # 2a feedback reattach → keeper (先)
+    """
+    WITH ranked AS (
+        SELECT id, row_number() OVER w AS rn, first_value(id) OVER w AS keeper
+        FROM standup_entries
+        WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC))
+    UPDATE standup_feedback sf SET standup_entry_id = r.keeper
+    FROM ranked r WHERE sf.standup_entry_id = r.id AND r.rn > 1
+    """,
+    # 2b keeper link union
+    """
+    WITH ranked AS (
+        SELECT id, org_id, project_id, first_value(id) OVER w AS keeper
+        FROM standup_entries
+        WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC))
+    INSERT INTO standup_entry_projects (id, entry_id, project_id, org_id)
+    SELECT gen_random_uuid(), r.keeper, r.project_id, r.org_id FROM ranked r
+    WHERE r.project_id IS NOT NULL AND EXISTS (SELECT 1 FROM projects p WHERE p.id=r.project_id) ON CONFLICT (entry_id, project_id) DO NOTHING
+    """,
+    # 2d text MERGE + plan_story_ids union
+    """
+    WITH ranked AS (
+        SELECT id, org_id, author_id, date,
+               row_number() OVER w AS rn, first_value(id) OVER w AS keeper, count(*) OVER w AS cnt
+        FROM standup_entries
+        WINDOW w AS (PARTITION BY org_id, author_id, date ORDER BY updated_at DESC, id DESC)),
+    keepers AS (
+        SELECT k.id, k.org_id, k.author_id, k.date, k.done, k.plan, k.blockers
+        FROM standup_entries k JOIN ranked r ON r.id = k.id WHERE r.rn = 1 AND r.cnt > 1)
+    UPDATE standup_entries t SET
+        plan = CASE WHEN sfx.plan_sfx = '' THEN t.plan ELSE COALESCE(t.plan,'') || sfx.plan_sfx END,
+        plan_story_ids = COALESCE(sfx.psids, t.plan_story_ids)
+    FROM keepers kp
+    CROSS JOIN LATERAL (
+        SELECT COALESCE((
+            SELECT string_agg('\n\n--- merged from project: ' ||
+                COALESCE(NULLIF(p.name,''), se2.project_id::text) || ' ---\n' || se2.plan,
+                '' ORDER BY se2.updated_at DESC, se2.id DESC)
+            FROM standup_entries se2 LEFT JOIN projects p ON p.id = se2.project_id
+            WHERE se2.org_id=kp.org_id AND se2.author_id=kp.author_id AND se2.date=kp.date
+              AND se2.id <> kp.id AND COALESCE(se2.plan,'')<>'' AND COALESCE(se2.plan,'')<>COALESCE(kp.plan,'')
+        ), '') AS plan_sfx,
+        (SELECT array_agg(DISTINCT x) FROM standup_entries se3, unnest(se3.plan_story_ids) AS x
+         WHERE se3.org_id=kp.org_id AND se3.author_id=kp.author_id AND se3.date=kp.date) AS psids
+    ) sfx WHERE t.id = kp.id
+    """,
+    # 2e 잉여행 DELETE (後)
+    """
+    WITH ranked AS (
+        SELECT id, row_number() OVER (PARTITION BY org_id, author_id, date
+               ORDER BY updated_at DESC, id DESC) AS rn FROM standup_entries)
+    DELETE FROM standup_entries se USING ranked r WHERE se.id = r.id AND r.rn > 1
+    """,
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_dedupe_merge_lossless_and_idempotent_realdb():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    org = uuid.uuid4(); author = uuid.uuid4(); d = _date(2026, 6, 5)
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    e1, e2, e3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    fb = uuid.uuid4()
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        async with sm() as s:
+            # 격리: unique index 잠시 제거(테스트 dup 시드 허용)
+            await s.execute(text("DROP INDEX IF EXISTS uq_standup_org_author_date"))
+            for pid, nm in ((p1, "Alpha"), (p2, "Beta"), (p3, "Gamma")):
+                await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,:n,now())"),
+                                {"i": pid, "o": org, "n": nm})
+            rows = [
+                (e1, p1, "PLAN-ALPHA", "2026-06-05 10:00+00"),
+                (e2, p2, "PLAN-BETA", "2026-06-05 11:00+00"),
+                (e3, p3, "PLAN-GAMMA", "2026-06-05 12:00+00"),  # keeper(latest)
+            ]
+            for eid, pid, plan, ts in rows:
+                await s.execute(text(
+                    "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan,plan_story_ids,created_at,updated_at)"
+                    " VALUES (:i,:o,:p,:a,:d,:pl,ARRAY[]::uuid[],:t,:t)"),
+                    {"i": eid, "o": org, "p": pid, "a": author, "d": d, "pl": plan, "t": ts})
+                await s.execute(text(
+                    "INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
+                    {"e": eid, "p": pid, "o": org})
+            # feedback on 비-keeper(e1)
+            await s.execute(text(
+                "INSERT INTO standup_feedback (id,org_id,project_id,standup_entry_id,feedback_by_id,review_type,feedback_text,created_at,updated_at)"
+                " VALUES (:i,:o,:p,:se,:fb,'comment','good',now(),now())"),
+                {"i": fb, "o": org, "p": p1, "se": e1, "fb": uuid.uuid4()})
+            await s.commit()
+
+            async def run_dedupe():
+                for sql in _DEDUPE_SQL:
+                    await s.execute(text(sql))
+                await s.commit()
+
+            await run_dedupe()
+
+            # 1엔트리만 남음 = keeper(e3)
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                {"o": org, "a": author, "d": d})).scalar_one()
+            assert cnt == 1
+            keeper_plan = (await s.execute(text(
+                "SELECT plan FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                {"o": org, "a": author, "d": d})).scalar_one()
+            # 내용 0 소실 — 세 plan 전부 보존
+            assert "PLAN-GAMMA" in keeper_plan
+            assert "PLAN-ALPHA" in keeper_plan and "Alpha" in keeper_plan  # provenance
+            assert "PLAN-BETA" in keeper_plan and "Beta" in keeper_plan
+            # 링크 union = {p1,p2,p3} 가 keeper 에
+            links = set((await s.execute(text(
+                "SELECT project_id FROM standup_entry_projects WHERE entry_id IN "
+                "(SELECT id FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)"),
+                {"o": org, "a": author, "d": d})).scalars().all())
+            assert links == {p1, p2, p3}
+            # feedback reattach → keeper(e3)
+            fb_entry = (await s.execute(text("SELECT standup_entry_id FROM standup_feedback WHERE id=:i"),
+                                        {"i": fb})).scalar_one()
+            assert fb_entry == e3
+            # lossy_rows = 0 재프로브(그룹 단일행 → dup 0)
+            lossy = (await s.execute(text("""
+                WITH ranked AS (SELECT id, row_number() OVER (PARTITION BY org_id,author_id,date) rn
+                                FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d)
+                SELECT count(*) FROM ranked WHERE rn>1"""), {"o": org, "a": author, "d": d})).scalar_one()
+            assert lossy == 0
+
+            # 멱등: 재실행 무변화
+            await run_dedupe()
+            cnt2 = (await s.execute(text(
+                "SELECT count(*) FROM standup_entries WHERE org_id=:o AND author_id=:a AND date=:d"),
+                {"o": org, "a": author, "d": d})).scalar_one()
+            assert cnt2 == 1
+        # cleanup + unique index 복원
+        async with sm() as s:
+            await s.execute(text("DELETE FROM standup_feedback WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.execute(text(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_standup_org_author_date "
+                "ON standup_entries (org_id, author_id, date)"))
+            await s.commit()
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 개요 (E-STANDUP 3b6b567c · critical · foundational)
스탠드업을 **project-level → org-level** 재설계. (project_id,author_id,date) app-level upsert → **(org_id,author_id,date) 1엔트리**. 프로젝트 surface 는 `standup_entry_projects` link projection. E-STANDUP 4스토리 토대(write API `1c2be9db`·projection `51447ca0` 가 이 위에).

PO 설계리뷰 GO + 까심 CP1~4 반영. **migrate-dev dry-run 비파괴 검증 5/5 PASS**(아래).

## Projection 선택 = link table (justify)
`standup_entry_projects`(entry_id·project_id·org_id) 채택 — plan_story_ids-derive 대비:
- plan_story_ids 빈 엔트리도 **orphan 안 됨**. dedupe union 보존. projection JOIN 결정적·인덱스. 1:1 backfill.

## Migration 0099 (멱등·순서 엄수)
0. **갭 하드닝**: `uq_standup_entries_id`(dev 실측 standup_entries PK/unique **부재** → link FK 가능화).
1. link table + backfill(orphan project_id 는 `EXISTS projects` 가드 — dev FK 미enforced 대비).
2. preflight dedupe (0081 패턴·PARTITION (org,author,date)):
   - **CP2**: feedback `UPDATE standup_entry_id=keeper` **先** → 잉여 entry `DELETE` **後** (FK CASCADE 소실 방지).
   - **CP1/PO①**: keeper=latest updated_at. done/plan/blockers 는 distinct non-empty 값 **MERGE**(provenance 구분자) = **내용 0 소실**. plan_story_ids union. 머지 그룹 `RAISE NOTICE`.
   - **CP4**: 구분자 project name soft-deleted/NULL → `project:<id>` 폴백.
3. project_id `DROP NOT NULL` (값 보존·NULL 미도입 → 기존 project-filter read 무파손).
4. `UNIQUE(org_id,author_id,date)` (현재 DB-level unique 부재 → 신규).

## Shim (CP3) + model
- `StandupEntryRepository.upsert` 키 → (org_id,author_id,date), org_id=`self.org_id`(get_verified_org_id 검증·클라 미수용). write 시 link 멱등 유지(full 정책=1c2be9db).
- `StandupEntry.project_id` nullable + `StandupEntryProject` 신설.

## ★ migrate-dev dry-run (실 dev 데이터·트랜잭션 ROLLBACK·비파괴) — PASS 5/5
실 dev 에 존재한 lossy 그룹(author 81ff0947·2026-06-05·3 project rows·plan 상이)으로:
```
lossy group → 1 entry                                  OK
merged keeper.plan contains nonkeeper(제로고) content    OK   ← 내용 0 소실(PO①)
global dup_rows == 0                                   OK
global lossy_rows == 0                                 OK   ← PO 요구 조건
keeper link union >= 3 (제로고+sprintable+장사왕)         OK
DRYRUN-0099 PASS (5/5)  → ROLLED_BACK (dev unchanged)
```
사전 프로브: dev 150엔트리·lossy_rows=1 → winner-only 폐기·MERGE 채택 근거. prod=0엔트리(fresh).

## 발견·하드닝 (latent dev 스키마 갭 2종)
- standup_entries 에 **PK/unique 제약 부재**(모델 primary_key=True 이나 DB 미반영) → 마이그가 id unique 추가.
- standup_entries.project_id **orphan**(FK 미enforced·하드삭제 프로젝트 참조) → backfill EXISTS 가드.

## 테스트
- mock: upsert org-level 키 2종. real-DB(skip-able): dedupe lossless·링크 union·feedback reattach·lossy_rows=0·멱등 (CI alembic-fresh-db 잡서 실행).
- 기존 standup 테스트(test_standups·ac3_3) 무회귀 17 PASS.

## 규율
dev migrate 선행(dry-run 검증 완료)·breaking UNIQUE 는 shim 코드 동반·prod 는 코드 웨이브 後. 데이터 MERGE 비가역(0081 정책). 까심 cross-model QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)