### PR TITLE
feat(mcp): toolset-catalog 엔드포인트 — 툴 권한 picker 데이터 SSOT (2da32fbf)

### DIFF
--- a/backend/app/routers/mcp.py
+++ b/backend/app/routers/mcp.py
@@ -5,10 +5,22 @@
 """
 from fastapi import APIRouter, Depends, HTTPException
 
-from app.dependencies.auth import AuthContext, get_current_user
-from app.services.mcp_toolset import is_tool_allowed, resolve_policy
+from app.dependencies.auth import AuthContext, get_current_user, require_admin
+from app.services.mcp_toolset import build_toolset_catalog, is_tool_allowed, resolve_policy
 
 router = APIRouter(prefix="/api/v2/mcp", tags=["mcp"])
+
+
+@router.get("/toolset-catalog")
+async def get_toolset_catalog(_: AuthContext = Depends(require_admin)) -> dict:
+    """E-MCP-RIGHT S1 (2da32fbf): 툴 권한 picker 선택지 SSOT.
+
+    전체 toolset 그룹 + 그룹별 멤버 툴 + core/destructive 플래그 + order. 관리자 전용
+    (API 키 권한 picker). manifest(키별 허용 정책)와 별개 — 이건 **선택지 카탈로그**.
+    응답 = bare {groups:[...]}; FE route 가 v2 엔벨로프(apiSuccess→{data:{groups}}) 래핑하므로
+    BE 는 래핑하지 않는다(이중 래핑 방지). 계약 SSOT = FE `lib/toolset-catalog.ts`.
+    """
+    return build_toolset_catalog()
 
 
 @router.get("/manifest")

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -36,9 +36,13 @@ _GROUP_KEYWORDS: list[tuple[str, tuple[str, ...]]] = [
 
 _CORE = "core"  # ping/notifications-check 등 기본 — 항상 허용
 
-# 명시 비-그룹 핵심 도구(항상 허용)
+# 명시 비-그룹 핵심 도구(항상 허용 = picker 의 core 잠금 그룹).
+# 2da32fbf(toolset-catalog): 키워드 미매칭으로 tool_group()=='core' 로 떨어지는 read-only 유틸
+# (workflow_guide·team_members·poll_events)을 여기 포함 — picker 가 core(always-on)로 표시하는데
+# enforcement 가 explicit scope 에서 거부하던 비정합 해소. 모두 비파괴 read 라 always-allow 안전.
 _ALWAYS_ALLOWED: frozenset[str] = frozenset({
     "ping", "sprintable_ping", "sprintable_my_dashboard", "sprintable_check_notifications",
+    "sprintable_get_workflow_guide", "sprintable_list_team_members", "sprintable_poll_events",
 })
 
 # scope 토큰: 그룹명 외에 read/write(레거시·전체 비파괴 의미), admin/destructive(파괴적 허용)
@@ -138,3 +142,82 @@ def resolve_manifest(scope: list[str] | None, all_tool_names: list[str]) -> dict
         "destructive_allowed": bool(tokens & _DESTRUCTIVE_SCOPES),
         "scope": sorted(tokens),
     }
+
+
+# ── E-MCP-RIGHT S1 (2da32fbf): toolset 카탈로그 (picker 데이터 SSOT) ───────────────
+# 전체 MCP 도구 이름 — sprintable_mcp `_TOOL_DEFS`(@mcp.tool 등록분)와 정합 유지.
+# ⚠️ backend 는 sprintable_mcp 를 import 하지 않으므로(디탱글) 이 목록이 backend-owned SSOT.
+#    도구 추가/삭제 시 여기 동기화(테스트가 그룹 커버리지·core/admin 정합 검증).
+ALL_TOOL_NAMES: tuple[str, ...] = (
+    "sprintable_ping",
+    "sprintable_activate_sprint", "sprintable_add_epic", "sprintable_add_retro_action",
+    "sprintable_add_retro_item", "sprintable_add_story", "sprintable_add_task",
+    "sprintable_assign_story_to_sprint", "sprintable_change_retro_phase",
+    "sprintable_check_notifications", "sprintable_checkin_sprint", "sprintable_claim_story",
+    "sprintable_close_sprint", "sprintable_create_conversation", "sprintable_create_doc",
+    "sprintable_create_meeting", "sprintable_create_retro_session", "sprintable_create_sprint",
+    "sprintable_delete_doc", "sprintable_delete_epic", "sprintable_delete_meeting",
+    "sprintable_delete_sprint", "sprintable_delete_story", "sprintable_delete_task",
+    "sprintable_delete_webhook_config", "sprintable_emit_event", "sprintable_export_retro",
+    "sprintable_get_agent_stats", "sprintable_get_blocked_stories", "sprintable_get_doc",
+    "sprintable_get_epic_progress", "sprintable_get_leaderboard_v2", "sprintable_get_meeting",
+    "sprintable_get_member_workload", "sprintable_get_overdue_tasks", "sprintable_get_project_health",
+    "sprintable_get_project_overview", "sprintable_get_recent_activity",
+    "sprintable_get_retro_session_by_sprint", "sprintable_get_sprint_velocity_history",
+    "sprintable_get_standup", "sprintable_get_task", "sprintable_get_unassigned_stories",
+    "sprintable_get_velocity", "sprintable_get_wallet", "sprintable_get_workflow_guide",
+    "sprintable_give_reward", "sprintable_list_audit_logs", "sprintable_list_backlog",
+    "sprintable_list_chat_messages", "sprintable_list_docs", "sprintable_list_epics",
+    "sprintable_list_meetings", "sprintable_list_my_tasks", "sprintable_list_retro_sessions",
+    "sprintable_list_sprints", "sprintable_list_standup_entries", "sprintable_list_stories",
+    "sprintable_list_tasks", "sprintable_list_team_members", "sprintable_list_webhook_configs",
+    "sprintable_lock_files", "sprintable_mark_all_notifications_read",
+    "sprintable_mark_notification_read", "sprintable_my_dashboard", "sprintable_poll_events",
+    "sprintable_save_standup", "sprintable_search_docs", "sprintable_search_stories",
+    "sprintable_send_chat_message", "sprintable_sprint_summary", "sprintable_standup_history",
+    "sprintable_standup_missing", "sprintable_trigger_ai_summary",
+    "sprintable_unassign_story_from_sprint", "sprintable_unclaim_story", "sprintable_unlock_files",
+    "sprintable_update_doc", "sprintable_update_epic", "sprintable_update_meeting",
+    "sprintable_update_retro_action_status", "sprintable_update_run_status",
+    "sprintable_update_sprint", "sprintable_update_story", "sprintable_update_story_status",
+    "sprintable_update_task", "sprintable_update_task_status", "sprintable_upsert_webhook_config",
+    "sprintable_vote_retro_item",
+)
+
+# picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.
+_CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
+    "stories", "tasks", "sprints", "epics", "chat", "docs", "analytics", "retro",
+    "standup", "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs",
+)
+
+
+def build_toolset_catalog() -> dict:
+    """toolset-catalog 응답(picker SSOT). 그룹별 멤버 툴 + core/destructive 플래그 + order.
+
+    계약(FE `lib/toolset-catalog.ts`): {groups: [{key, tools[], is_core, is_destructive, order}]}.
+    - key = enforcement 그룹 토큰(scope 저장값·불변). label/description 은 FE i18n(BE 미제공).
+    - tools = tool_group() SSOT 매핑(항상허용=core 로 통합, 그룹별서 제외).
+    - is_core = core(항상허용 잠금 그룹). is_destructive = admin(위험 작업 격리·opt-in).
+    - 순서: core → 비파괴 15그룹(_CATALOG_DISPLAY_ORDER) → admin(파괴적) 마지막.
+    """
+    always = {t for t in _ALWAYS_ALLOWED if t.startswith("sprintable_")}
+    buckets: dict[str, list[str]] = {}
+    for t in ALL_TOOL_NAMES:
+        if t in always:
+            continue
+        buckets.setdefault(tool_group(t), []).append(t)
+
+    groups: list[dict] = [{
+        "key": _CORE, "tools": sorted(always),
+        "is_core": True, "is_destructive": False, "order": 0,
+    }]
+    for i, g in enumerate(_CATALOG_DISPLAY_ORDER, start=1):
+        groups.append({
+            "key": g, "tools": sorted(buckets.get(g, [])),
+            "is_core": False, "is_destructive": False, "order": i,
+        })
+    groups.append({
+        "key": "admin", "tools": sorted(buckets.get("admin", [])),
+        "is_core": False, "is_destructive": True, "order": len(_CATALOG_DISPLAY_ORDER) + 1,
+    })
+    return {"groups": groups}

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -1,0 +1,143 @@
+"""E-MCP-RIGHT S1 (2da32fbf): toolset-catalog 엔드포인트 + builder 회귀.
+
+계약(FE `lib/toolset-catalog.ts`): {groups:[{key, tools[], is_core, is_destructive, order}]}.
+검증: 그룹키 SSOT 정합·core/admin 플래그·tool 커버리지(무손실/무중복)·매핑·admin 게이트.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.services.mcp_toolset import (
+    ALL_GROUPS,
+    ALL_TOOL_NAMES,
+    build_toolset_catalog,
+    tool_group,
+)
+
+_CONTRACT_FIELDS = {"key", "tools", "is_core", "is_destructive", "order"}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_catalog_structure_and_contract_fields():
+    cat = build_toolset_catalog()
+    assert set(cat.keys()) == {"groups"}
+    groups = cat["groups"]
+    # core + 15 비파괴 + admin = 17
+    assert len(groups) == 17
+    for g in groups:
+        assert set(g.keys()) == _CONTRACT_FIELDS, f"{g['key']} 필드 계약 불일치"
+        assert isinstance(g["key"], str) and g["key"]
+        assert isinstance(g["tools"], list) and all(isinstance(t, str) for t in g["tools"])
+        assert isinstance(g["is_core"], bool) and isinstance(g["is_destructive"], bool)
+        assert isinstance(g["order"], int)
+        assert g["tools"], f"{g['key']} 빈 그룹 — 모든 그룹은 멤버 보유"
+    # order = 배열 순서와 일치(0..16 단조)
+    assert [g["order"] for g in groups] == list(range(17))
+
+
+def test_core_first_admin_last_flags():
+    groups = build_toolset_catalog()["groups"]
+    assert groups[0]["key"] == "core" and groups[0]["is_core"] and not groups[0]["is_destructive"]
+    assert groups[-1]["key"] == "admin" and groups[-1]["is_destructive"] and not groups[-1]["is_core"]
+    # is_core 는 core 만, is_destructive 는 admin 만
+    assert [g["key"] for g in groups if g["is_core"]] == ["core"]
+    assert [g["key"] for g in groups if g["is_destructive"]] == ["admin"]
+
+
+def test_group_keys_match_mcp_toolset_ssot():
+    keys = [g["key"] for g in build_toolset_catalog()["groups"]]
+    # core + admin + ALL_GROUPS 비-core = 전체
+    assert "core" in keys and "admin" in keys
+    non_core_admin = {k for k in keys if k not in ("core", "admin")}
+    assert non_core_admin == {g for g in ALL_GROUPS if g != "core"}  # 15 비파괴 그룹
+
+
+def test_every_tool_covered_exactly_once():
+    groups = build_toolset_catalog()["groups"]
+    flat = [t for g in groups for t in g["tools"]]
+    # 무중복
+    assert len(flat) == len(set(flat)), "그룹 간 tool 중복"
+    # 무손실 — ALL_TOOL_NAMES 전량 커버(core 통합 always-allowed 포함)
+    assert set(flat) == set(ALL_TOOL_NAMES)
+
+
+def test_tool_group_mapping_examples():
+    by_tool = {t: g["key"] for g in build_toolset_catalog()["groups"] for t in g["tools"]}
+    # 도메인 destructive 는 도메인 그룹(admin 아님)
+    assert by_tool["sprintable_delete_story"] == "stories"
+    assert by_tool["sprintable_give_reward"] == "rewards"
+    assert by_tool["sprintable_delete_sprint"] == "sprints"
+    # admin 그룹 = lock/unlock/emit_event/trigger_ai
+    assert by_tool["sprintable_lock_files"] == "admin"
+    assert by_tool["sprintable_emit_event"] == "admin"
+    # always-allowed(+orphan)는 core 로 통합(키워드 그룹서 제외)
+    assert by_tool["sprintable_my_dashboard"] == "core"
+    assert by_tool["sprintable_check_notifications"] == "core"
+    assert by_tool["sprintable_get_workflow_guide"] == "core"
+    assert by_tool["sprintable_list_team_members"] == "core"
+    assert by_tool["sprintable_poll_events"] == "core"
+    # 정상 그룹 매핑 sanity
+    assert by_tool["sprintable_add_story"] == "stories"
+    assert by_tool["sprintable_get_velocity"] == "analytics"
+
+
+# ── 엔드포인트 admin 게이트 ────────────────────────────────────────────────────
+
+async def _client(role: str):
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(uuid.uuid4()), "role": role}}
+
+    async def _auth():
+        return ctx
+
+    app.dependency_overrides[get_current_user] = _auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_endpoint_admin_200_bare_groups():
+    client, app = await _client("admin")
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/mcp/toolset-catalog")
+        assert resp.status_code == 200
+        body = resp.json()
+        # BE 는 bare {groups} (FE route 가 v2 엔벨로프 래핑 — 이중래핑 방지)
+        assert "groups" in body and isinstance(body["groups"], list)
+        assert {g["key"] for g in body["groups"]} >= {"core", "stories", "admin"}
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_endpoint_owner_200():
+    client, app = await _client("owner")
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/mcp/toolset-catalog")
+        assert resp.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_endpoint_non_admin_403():
+    client, app = await _client("member")
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/mcp/toolset-catalog")
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 개요 (E-MCP-RIGHT S1 · 2da32fbf)
FE 툴 권한 picker(**#1272** 미르코·유나)가 그룹 선택지를 받는 **카탈로그 엔드포인트**. 계약 SSOT = FE `apps/web/src/lib/toolset-catalog.ts`(`ToolsetGroup`/`ToolsetCatalog`).

## 엔드포인트
`GET /api/v2/mcp/toolset-catalog` — **관리자 전용**(`require_admin`·owner/admin). manifest(키별 허용 정책)와 별개 = **선택지 카탈로그**.

응답 = **bare** `{groups:[{key, tools[], is_core, is_destructive, order}]}`:
- ⚠️ FE route.ts 가 `apiSuccess(_r.json())`→`{data:{groups}}` 래핑하므로 BE 는 미래핑(**이중래핑 방지**). `fetchToolsetCatalog`가 `data` 언랩.
- `key` = enforcement 그룹 토큰(불변·scope 저장값). `label/description` 은 FE i18n(BE 미제공).
- `tools` = `tool_group()` SSOT 매핑. `is_core`=core(잠금), `is_destructive`=admin(위험 격리).
- 순서: core → 비파괴 15 → admin. `order` 필드 + 배열 순서 일치.

## 그룹 구성 (17 = core + 15 + admin)
- core(6·always-on 잠금): ping·my_dashboard·check_notifications + **유틸 3종(아래)**.
- 비파괴 15: stories·tasks·sprints·epics·chat·docs·analytics·retro·standup·meetings·notifications·webhooks·rewards·audit·agent_runs.
- admin(is_destructive·opt-in): emit_event·lock_files·trigger_ai_summary·unlock_files.
- (도메인 destructive 는 도메인 그룹: delete_story→stories·give_reward→rewards·delete_sprint→sprints. 별도 destructive scope 게이팅은 enforcement 책임.)

## ⚠️ 부수 정합 수정 (_ALWAYS_ALLOWED)
키워드 미매칭으로 `tool_group()=='core'` 로 떨어지는 read-only 유틸 **3종**(`get_workflow_guide`·`list_team_members`·`poll_events`)을 `_ALWAYS_ALLOWED` 에 추가. picker 가 core(always-on)로 표시하는데 enforcement 가 explicit scope 에서 **거부**하던 비정합 해소. 전부 비파괴 read 라 always-allow 안전. (없으면 카탈로그서 누락되거나 "always-on 거짓말" 발생.)

## tools SSOT
`ALL_TOOL_NAMES`(89) = backend-owned(sprintable_mcp `_TOOL_DEFS` 정합·디탱글로 backend 미import). e2e `test_tools_list_89_tools` 기대치와 정합.

## 테스트
계약 필드 5개·core/admin 플래그(is_core=core만·is_destructive=admin만)·그룹키 mcp_toolset SSOT 정합·tool 커버리지(**무손실/무중복** = ALL_TOOL_NAMES 전량)·매핑 예시·admin 게이트(admin/owner 200·member 403). 기존 mcp/toolset 127 PASS(e2e 2건은 라이브 서버 필요·환경적).

#1272 FE 타입과 계약 일치. 까심 cross-model QA. (#1272·이 PR 독립 머지 가능 — picker 는 스텁 폴백 동작.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)