### PR TITLE
feat(standup): org-level write API — project_id 생략 + author 접근 프로젝트 auto-link (1c2be9db)

### DIFF
--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -85,6 +85,29 @@ class StandupEntryRepository(BaseRepository[StandupEntry]):
             )
         return entry
 
+    async def resync_project_links(self, entry_id: uuid.UUID, project_ids: list[uuid.UUID]) -> None:
+        """1c2be9db: org-level write — entry 의 projection 링크를 project_ids 로 **full overwrite**.
+
+        DELETE(entry_id) 후 INSERT — author 접근 프로젝트(accessible) 동기화 경로 전용
+        (CP2-B). target 에 없는 기존 링크는 삭제(접근 변동 반영·stale 0). project_ids 는
+        accessible_project_ids_in_org(canonical helper) 결과여야 한다(존재하는 project 만 — FK 안전).
+        legacy project_id 명시 write 는 이 메서드를 호출하지 않고 upsert 의 additive(ON CONFLICT
+        DO NOTHING·미삭제) 만 사용한다.
+        """
+        await self.session.execute(
+            text("DELETE FROM standup_entry_projects WHERE entry_id = :e"),
+            {"e": entry_id},
+        )
+        for pid in project_ids:
+            await self.session.execute(
+                text(
+                    "INSERT INTO standup_entry_projects (id, entry_id, project_id, org_id) "
+                    "VALUES (gen_random_uuid(), :e, :p, :o) "
+                    "ON CONFLICT (entry_id, project_id) DO NOTHING"
+                ),
+                {"e": entry_id, "p": pid, "o": self.org_id},
+            )
+
     async def get_missing(self, project_id: uuid.UUID, target_date: date) -> list[uuid.UUID]:
         """해당 날짜 standup 미제출 휴먼의 **canonical members.id** 목록 (AC3-3).
 

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -17,8 +17,27 @@ from app.schemas.standup import (
     StandupUpsert,
 )
 from app.services.member_resolver import canonicalize_member_id, resolve_member
+from app.services.project_auth import accessible_project_ids_in_org
 
 router = APIRouter(prefix="/api/v2/standups", tags=["standups"])
+
+
+async def _sync_org_level_links(
+    repo: StandupEntryRepository,
+    session: AsyncSession,
+    entry: StandupEntry,
+    project_id: uuid.UUID | None,
+    user_id: str,
+    org_id: uuid.UUID,
+) -> None:
+    """1c2be9db: org-level write(project_id 없음) → entry 링크 = author 접근 프로젝트로 full
+    overwrite. canonical `accessible_project_ids_in_org`(has_project_access/정책B 동일 SSOT)
+    재사용 — team_member 쿼리 자작 금지(CP2-A). legacy(project_id 명시)는 upsert 의 additive
+    링크만 사용하고 여기 호출 안 함(DELETE 없음·CP2-B)."""
+    if project_id is not None:
+        return
+    accessible = await accessible_project_ids_in_org(session, uuid.UUID(user_id), org_id)
+    await repo.resync_project_links(entry.id, accessible)
 
 
 def _get_repo(
@@ -55,7 +74,7 @@ async def list_standups(
 async def upsert_standup(
     body: StandupUpsert,
     session: AsyncSession = Depends(get_db),
-    _auth: AuthContext = Depends(get_current_user),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> StandupEntryResponse:
     # AC3-3: 작성자 신원을 canonical members.id로 정규화(레거시 휴먼 team_member.id → alias 치환).
@@ -72,6 +91,8 @@ async def upsert_standup(
         blockers=body.blockers,
         plan_story_ids=body.plan_story_ids,
     )
+    # 1c2be9db: org-level write(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
+    await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
     return StandupEntryResponse.model_validate(entry)
 
 
@@ -104,6 +125,8 @@ async def update_standup(
         blockers=body.blockers,
         plan_story_ids=body.plan_story_ids,
     )
+    # 1c2be9db: org-level self-save(project_id 없음) → author 접근 프로젝트로 링크 full overwrite.
+    await _sync_org_level_links(repo, session, entry, body.project_id, auth.user_id, org_id)
     return StandupEntryResponse.model_validate(entry)
 
 

--- a/backend/app/schemas/standup.py
+++ b/backend/app/schemas/standup.py
@@ -7,7 +7,9 @@ REVIEW_TYPES = ("comment", "approve", "request_changes")
 
 
 class StandupUpsert(BaseModel):
-    project_id: uuid.UUID
+    # 1c2be9db: org-level write — project_id 생략 가능. 생략 시 entry 링크 = author 접근
+    # 프로젝트 자동(accessible_project_ids_in_org). 명시 시 그 프로젝트 additive 링크(legacy).
+    project_id: uuid.UUID | None = None
     org_id: uuid.UUID | None = None
     author_id: uuid.UUID
     date: date
@@ -22,9 +24,9 @@ class StandupSelfUpdate(BaseModel):
     """self-save(PUT) 전용 — author_id는 서버가 인증 유저(resolve_member)에서 도출.
 
     클라 바디 author_id를 받지 않아 타인 스탠드업 위조를 차단(SID:6a1e8b1d).
-    project_id는 바디 수용. (extra 필드는 pydantic 기본 무시 — 클라 author_id 전송돼도 무시됨)
+    project_id는 바디 수용(생략 가능 — 1c2be9db org-level). (extra 필드는 pydantic 기본 무시)
     """
-    project_id: uuid.UUID
+    project_id: uuid.UUID | None = None
     date: date
     sprint_id: uuid.UUID | None = None
     done: str | None = None
@@ -37,7 +39,7 @@ class StandupEntryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     id: uuid.UUID
-    project_id: uuid.UUID
+    project_id: uuid.UUID | None = None  # 1c2be9db: org-level 엔트리는 origin project_id 가 NULL 일 수 있음
     org_id: uuid.UUID
     sprint_id: uuid.UUID | None = None
     author_id: uuid.UUID

--- a/backend/sprintable_mcp/tools/standup.py
+++ b/backend/sprintable_mcp/tools/standup.py
@@ -79,8 +79,13 @@ async def get_standup(args: GetStandupInput) -> list[TextContent]:
 
 
 async def save_standup(args: SaveStandupInput) -> list[TextContent]:
-    """스탠드업 저장/업데이트."""
-    body: dict = {"author_id": args.author_id, "date": args.date, "project_id": client.project_id}
+    """스탠드업 저장/업데이트.
+
+    1c2be9db: org-level 기본 — client.project_id 를 강제 주입하지 않는다(이전엔 project-level
+    행을 강제). project_id 생략 → BE 가 org-level 엔트리 1건으로 upsert 하고 작성자 접근
+    프로젝트로 자동 링크(projection). (org_id/author_id 는 BE 가 canonical 처리.)
+    """
+    body: dict = {"author_id": args.author_id, "date": args.date}
     for field in ("done", "plan", "blockers"):
         val = getattr(args, field)
         if val is not None:

--- a/backend/tests/test_standup_org_write_1c2be9db.py
+++ b/backend/tests/test_standup_org_write_1c2be9db.py
@@ -1,0 +1,169 @@
+"""E-STANDUP 1c2be9db: org-level write API — project_id 생략 + author 접근 프로젝트 auto-link.
+
+- 스키마: project_id Optional.
+- 핸들러: org-level write(project_id 없음) → 링크 = accessible_project_ids_in_org full overwrite
+  (canonical helper 재사용·CP2-A). legacy(project_id 명시) → resync 미호출·additive(CP2-B).
+- real-DB: 2프로젝트 접근 유저 1 save → entry 1 + 링크 2(CP2-C).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date as _date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_schema_project_id_optional():
+    from app.schemas.standup import StandupSelfUpdate, StandupUpsert
+
+    # project_id 생략해도 검증 통과(org-level)
+    u = StandupUpsert(author_id=uuid.uuid4(), date=_date(2026, 6, 5))
+    assert u.project_id is None
+    s = StandupSelfUpdate(date=_date(2026, 6, 5))
+    assert s.project_id is None
+
+
+async def _client(uid: uuid.UUID, org_id: uuid.UUID):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uid)
+    ctx.claims = {"app_metadata": {"org_id": str(org_id)}}
+
+    async def _db():
+        yield AsyncMock()
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return org_id
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+def _entry(org_id, project_id=None):
+    e = MagicMock()
+    e.id = uuid.uuid4(); e.org_id = org_id; e.project_id = project_id
+    e.sprint_id = None; e.author_id = uuid.uuid4(); e.date = _date(2026, 6, 5)
+    e.done = "d"; e.plan = "p"; e.blockers = None; e.plan_story_ids = []
+    e.created_at = e.updated_at = __import__("datetime").datetime(2026, 6, 5)
+    return e
+
+
+@pytest.mark.anyio
+async def test_org_level_post_resyncs_to_accessible_projects():
+    """project_id 없는 POST → resync_project_links(accessible) 호출(full overwrite·CP2-A)."""
+    uid, org = uuid.uuid4(), uuid.uuid4()
+    p1, p2 = uuid.uuid4(), uuid.uuid4()
+    client, app = await _client(uid, org)
+    resync = AsyncMock()
+    try:
+        with patch("app.routers.standups.canonicalize_member_id", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("app.routers.standups.accessible_project_ids_in_org", new=AsyncMock(return_value=[p1, p2])), \
+             patch("app.repositories.standup.StandupEntryRepository.upsert", new=AsyncMock(return_value=_entry(org))), \
+             patch("app.repositories.standup.StandupEntryRepository.resync_project_links", new=resync):
+            async with client as c:
+                resp = await c.post("/api/v2/standups", json={
+                    "author_id": str(uuid.uuid4()), "date": "2026-06-05", "plan": "p",
+                })
+        assert resp.status_code == 201
+        # resync 가 accessible [p1,p2] 로 호출
+        resync.assert_awaited_once()
+        assert list(resync.await_args.args[1]) == [p1, p2]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_legacy_post_with_project_id_no_resync():
+    """project_id 명시 POST(legacy) → resync 미호출(additive only·DELETE 없음·CP2-B)."""
+    uid, org = uuid.uuid4(), uuid.uuid4()
+    client, app = await _client(uid, org)
+    resync = AsyncMock()
+    accessible = AsyncMock(return_value=[])
+    try:
+        with patch("app.routers.standups.canonicalize_member_id", new=AsyncMock(return_value=uuid.uuid4())), \
+             patch("app.routers.standups.accessible_project_ids_in_org", new=accessible), \
+             patch("app.repositories.standup.StandupEntryRepository.upsert", new=AsyncMock(return_value=_entry(org, uuid.uuid4()))), \
+             patch("app.repositories.standup.StandupEntryRepository.resync_project_links", new=resync):
+            async with client as c:
+                resp = await c.post("/api/v2/standups", json={
+                    "author_id": str(uuid.uuid4()), "date": "2026-06-05",
+                    "project_id": str(uuid.uuid4()), "plan": "p",
+                })
+        assert resp.status_code == 201
+        resync.assert_not_awaited()       # org-level 분기 미진입 → DELETE 없음
+        accessible.assert_not_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── real-DB: 2프로젝트 1 save → entry 1 + 링크 2 (CP2-C) ───────────────────────
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_resync_links_full_overwrite_realdb():
+    """resync_project_links: DELETE 후 INSERT — 링크를 target 으로 full overwrite·멱등."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.repositories.standup import StandupEntryRepository
+
+    org = uuid.uuid4(); author = uuid.uuid4()
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    eid = uuid.uuid4()
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        async with sm() as s:
+            for pid in (p1, p2, p3):
+                await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,'P',now())"),
+                                {"i": pid, "o": org})
+            await s.execute(text(
+                "INSERT INTO standup_entries (id,org_id,author_id,date,plan_story_ids,created_at,updated_at)"
+                " VALUES (:i,:o,:a,:d,ARRAY[]::uuid[],now(),now())"),
+                {"i": eid, "o": org, "a": author, "d": _date(2026, 6, 5)})
+            await s.commit()
+
+            repo = StandupEntryRepository(s, org)
+            # 1) [p1,p2] 로 set
+            await repo.resync_project_links(eid, [p1, p2]); await s.commit()
+            got = set((await s.execute(text(
+                "SELECT project_id FROM standup_entry_projects WHERE entry_id=:e"), {"e": eid})).scalars().all())
+            assert got == {p1, p2}
+            # 2) [p2,p3] 로 re-sync(full overwrite — p1 삭제·p3 추가)
+            await repo.resync_project_links(eid, [p2, p3]); await s.commit()
+            got2 = set((await s.execute(text(
+                "SELECT project_id FROM standup_entry_projects WHERE entry_id=:e"), {"e": eid})).scalars().all())
+            assert got2 == {p2, p3}
+            # 3) 멱등 — 같은 set 재실행 무변화
+            await repo.resync_project_links(eid, [p2, p3]); await s.commit()
+            got3 = set((await s.execute(text(
+                "SELECT project_id FROM standup_entry_projects WHERE entry_id=:e"), {"e": eid})).scalars().all())
+            assert got3 == {p2, p3}
+        async with sm() as s:
+            await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.commit()
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 개요 (E-STANDUP 1c2be9db)
3b6b567c org-level 모델 위에 **write API 를 org-level 화**. PO 설계리뷰 GO(auto-link 승인)·까심 CP1/CP2 반영.

## 링크 population 규칙 (PO 승인)
write 경로별 **단일 규칙**:
- **org-level write(project_id 없음):** entry projection 링크 = `accessible_project_ids_in_org(auth.user_id, org)` 로 **full overwrite**(re-sync = DELETE entry + INSERT accessible). **canonical helper 재사용**(has_project_access/list_projects 정책B 동일 SSOT·team_member 쿼리 자작 0 — **CP2-A**).
- **legacy project_id 명시 write:** upsert 의 additive(`ON CONFLICT DO NOTHING`)만·**DELETE 없음**(back-compat — **CP2-B**).
- non-accessible 기존 링크 pruning = 접근 불가 보드 미surface(올바른 정책·CP1).

## 변경
- 스키마: `StandupUpsert`/`StandupSelfUpdate`/`StandupEntryResponse`.project_id → **Optional**.
- 핸들러(POST/PUT): org-level 분기에서만 `resync_project_links(accessible)`. author=auth(self-save).
- repo: `resync_project_links(entry_id, project_ids)` — DELETE 후 INSERT full overwrite.
- MCP `save_standup`: `client.project_id` 강제 제거 → org-level 기본.

## 설계 근거 (PO 승인)
auto-link: AC pixel(같은 유저·2프로젝트·1 save→**양쪽 뷰** surface)·zero-friction(FE 멀티셀렉트 불요)·org-level 모델 의미(그 사람 하루=전 작업)·SSOT 재사용. over-surface(N뷰)는 모델 의도(write once·전 관련뷰 visible). edge: accessible 0→org-only 엔트리.

## 테스트
- org-level POST→`resync_project_links([p1,p2])` 호출(**CP2-A**) · legacy POST→resync 미호출·DELETE 없음(**CP2-B**) · 스키마 optional · real-DB resync full overwrite(2→3 프로젝트 pruning)+멱등(**CP2-C** resync 코어). 기존 standup(test_standups·ac3_3) 무회귀 18 PASS.
- 머지+dev 배포 후 함수형 verify(2프로젝트 유저 org-level save→entry 1+링크 2+양쪽 projection) 예정.

## ⚠️ FE 동반 (별도)
`standup/page.tsx handleSave` 가 project_id 미전송(org-level) 해야 pixel 완성. BE 는 back-compat(legacy project_id 수용)이라 **독립 머지 가능**. FE 변경은 미르코군 coordination.

까심 cross-model QA(CP1/CP2 체크리스트). 51447ca0(projection read)이 이 링크 위에 올라감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)