### PR TITLE
fix(member-ssot): resolve_member anchor org_members 폴백 — members-less org-member 400 해소 (P0)

### DIFF
--- a/backend/app/services/member_resolver.py
+++ b/backend/app/services/member_resolver.py
@@ -169,13 +169,37 @@ async def _resolve_member_anchor(
             Member.deleted_at.is_(None),
         )
     )).scalar_one_or_none()
-    if m is None:
-        raise HTTPException(status_code=400, detail="Organization member not found")
 
     user = (await session.execute(
         select(User).where(User.id == user_id)
     )).scalar_one_or_none()
     name = user.email if user else str(user_id)
+
+    if m is None:
+        # P0 핫픽스(members-sync 갭): members 앵커 행이 없는 org-member 폴백.
+        # org-create(organizations.py)·invite-accept 는 org_members 만 INSERT·members 미생성 →
+        # 0075 백필 이후 신규 org-creator/invitee 는 members 행이 없어 여기서 400 났다.
+        # **org_members 폴백**(canonical org_member.id) — 0075 ID 보존(member.id = org_member.id)
+        # 이라 anchor 가 반환할 동일 신원을 org_members 서 소싱(parity). team_member 봐주기 아님
+        # (team_member 조회 0·org_members 만). GET /me 의 org_members 폴백과 동형.
+        om = (await session.execute(
+            select(OrgMember).where(
+                OrgMember.org_id == org_id,
+                OrgMember.user_id == user_id,
+                OrgMember.deleted_at.is_(None),
+            )
+        )).scalar_one_or_none()
+        if om is None:
+            raise HTTPException(status_code=400, detail="Organization member not found")
+        return ResolvedMember(
+            id=om.id,
+            user_id=user_id,
+            name=name,
+            type="human",
+            role=om.role,
+            org_id=om.org_id,
+            project_id=project_id,
+        )
 
     return ResolvedMember(
         id=m.id,

--- a/backend/tests/test_member_ssot_resolver_shadow.py
+++ b/backend/tests/test_member_ssot_resolver_shadow.py
@@ -90,12 +90,19 @@ async def test_anchor_resolve_member_human(monkeypatch):
 
 @pytest.mark.anyio
 async def test_anchor_resolve_member_human_not_found_400(monkeypatch):
+    """P0 핫픽스 후: members **및** org_members 둘 다 없을 때만 400.
+
+    (members-less 라도 org_members 있으면 폴백으로 200 — test_resolve_member_org_members_fallback)
+    """
     import app.services.member_resolver as mr
     from fastapi import HTTPException
 
     monkeypatch.setattr(mr.settings, "member_ssot_resolver_shadow", True)
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_result(scalar=None)])  # member 없음
+    # Member None → User None → OrgMember None(폴백도 실패) → 400
+    session.execute = AsyncMock(side_effect=[
+        _result(scalar=None), _result(scalar=None), _result(scalar=None),
+    ])
     with pytest.raises(HTTPException) as exc:
         await mr.resolve_member(_auth(uuid.uuid4()), uuid.uuid4(), session, project_id=None)
     assert exc.value.status_code == 400

--- a/backend/tests/test_resolve_member_org_members_fallback.py
+++ b/backend/tests/test_resolve_member_org_members_fallback.py
@@ -1,0 +1,78 @@
+"""P0 핫픽스: _resolve_member_anchor org_members 폴백 (members-sync 갭).
+
+shadow resolver(anchor) 가 members 앵커 행 없는 org-member(org-create/invite-accept 가
+org_members 만 INSERT·members 미생성)에서 400 나던 것을 org_members 폴백으로 해소.
+- CP1: members-less → 200 + parity(id=org_member.id). CP2: members-present 무회귀.
+- CP5: org_members 폴백만(team_member 봐주기 아님).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.member_resolver import ResolvedMember, _resolve_member_anchor
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _auth(uid, api_key=False):
+    c = MagicMock()
+    c.user_id = str(uid)
+    c.claims = {"app_metadata": ({"api_key_id": "ak"} if api_key else {})}
+    return c
+
+
+def _scalar(val):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = val
+    return r
+
+
+@pytest.mark.anyio
+async def test_anchor_members_less_org_member_fallback_parity():
+    """CP1: members 행 없는 org-member → org_members 폴백·id=org_member.id(parity)·no 400."""
+    uid, org = uuid.uuid4(), uuid.uuid4()
+    om = MagicMock(); om.id = uuid.uuid4(); om.org_id = org; om.role = "owner"
+    user = MagicMock(); user.email = "u@example.com"
+    session = AsyncMock()
+    # Member select(None) → User select(user) → OrgMember select(om)
+    session.execute = AsyncMock(side_effect=[_scalar(None), _scalar(user), _scalar(om)])
+
+    res = await _resolve_member_anchor(_auth(uid), org, session, None)
+    assert isinstance(res, ResolvedMember)
+    assert res.id == om.id          # parity: id = org_member.id (= 0075 member.id)
+    assert res.user_id == uid
+    assert res.type == "human"
+    assert res.role == "owner"      # org_member.role
+    assert res.org_id == org
+
+
+@pytest.mark.anyio
+async def test_anchor_members_present_unchanged_no_fallback():
+    """CP2: members 앵커 존재 → 폴백 미진입·무회귀(OrgMember 미조회)."""
+    uid, org = uuid.uuid4(), uuid.uuid4()
+    m = MagicMock(); m.id = uuid.uuid4(); m.org_id = org; m.org_role = "admin"
+    user = MagicMock(); user.email = "u@example.com"
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(m), _scalar(user)])
+
+    res = await _resolve_member_anchor(_auth(uid), org, session, None)
+    assert res.id == m.id and res.role == "admin"
+    assert session.execute.await_count == 2   # OrgMember 폴백 미호출
+
+
+@pytest.mark.anyio
+async def test_anchor_no_member_no_org_member_400():
+    """members·org_members 둘 다 없으면 종전대로 400."""
+    uid, org = uuid.uuid4(), uuid.uuid4()
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(None), _scalar(None), _scalar(None)])
+    with pytest.raises(HTTPException) as exc:
+        await _resolve_member_anchor(_auth(uid), org, session, None)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
## 🔴 P0 데모-크리티컬
`MEMBER_SSOT_RESOLVER_SHADOW=true`(**dev·prod 둘 다 실측 확정**) → `resolve_member` = anchor(`members` 테이블 조회). 그런데 `org-create`(organizations.py:67)·`invite-accept` 는 **`org_members` 만 INSERT·`members` 미생성** → 0075 백필 이후 **신규 org-creator/invitee 전원** members 행 없어 `resolve_member` → **400 "Organization member not found"**. standup self-save(PUT) 등 resolve_member 쓰는 전 엔드포인트가 신규 유저서 깨짐.

(1c2be9db dev verify 중 발견 — 정직 보고 → P0 에스컬레이션.)

## 수정 (옵션② — PO/QA 승인)
`_resolve_member_anchor` JWT 휴먼 분기에서 `members` 앵커 행 없으면 → **`org_members` 폴백**으로 `org_member.id` 신원 해소.
- **parity:** 0075 ID 보존(`member.id = org_member.id`)이라 anchor 가 반환할 **동일 신원**을 org_members 서 소싱. role=`org_member.role`.
- **team_member 봐주기 아님(CP5):** team_member 조회 0·`org_members` 만. GET /me 의 org_members 폴백과 동형(a1580005 패턴).
- read-only·단일 변경점·백필 불요 → **기존+신규 members-less org_member 전부 즉시 커버**(옵션①은 기존 행 미해결→백필 필요).
- `members`·`org_members` 둘 다 없을 때만 종전대로 400.

## 테스트 (CP1~5)
- **CP1**: members-less → 200 + parity(id=org_member.id·role=owner). **CP2**: members-present 무회귀(OrgMember 미조회·execute 2회). 둘다없음 → 400. 기존 shadow 테스트(member None→400)를 새 동작(둘다없음→400)으로 갱신.
- **CP3**(콜러 무회귀): resolve_member 콜러 = standups·docs·stories·event_notifications·notification_preferences·conversations — 모두 members-present 시 동작 불변, members-less 시 400→200 개선(회귀 0). **CP4**: api_key/team_member 경로 무간섭(분기 위쪽). member_ssot 슬라이스 52 PASS.
- 머지+dev 배포 후 함수형 verify(members-less org-owner org-level standup self-save→200·polyfill 실증) 예정.

까심 cross-model QA. 머지 후 prod Smoke 시드 유저도 자동 해소(별도 재시드 불요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)