### PR TITLE
feat(standup): projection read — GET ?project_id= 를 standup_entry_projects link join (51447ca0)

### DIFF
--- a/backend/app/repositories/standup.py
+++ b/backend/app/repositories/standup.py
@@ -1,11 +1,13 @@
+from __future__ import annotations
+
 import uuid
 from datetime import date
 from typing import Any
 
-from sqlalchemy import select, text
+from sqlalchemy import exists, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.standup import StandupEntry, StandupFeedback
+from app.models.standup import StandupEntry, StandupEntryProject, StandupFeedback
 from app.repositories.base import BaseRepository
 
 # AC3-3: missing 산정 — "effective 휴먼 project access"를 canonical members.id로 열거(team_members
@@ -34,10 +36,14 @@ _MISSING_SQL = text(
         JOIN member_identity_aliases a ON a.alias_id = tm.id
         WHERE tm.project_id = :proj AND tm.type = 'human' AND tm.is_active = true
     ), submitted AS (
+        -- 51447ca0: projection — 제출 여부는 entry.project_id 가 아니라 standup_entry_projects
+        -- link 로 판정(org-level 엔트리가 링크된 프로젝트서 submitted). "org 1번 제출=linked
+        -- 프로젝트 전부 not-missing". legacy 엔트리는 0099 백필 링크로 동일 커버.
         SELECT DISTINCT COALESCE(a.member_id, se.author_id) AS cid
         FROM standup_entries se
+        JOIN standup_entry_projects sep ON sep.entry_id = se.id
         LEFT JOIN member_identity_aliases a ON a.alias_id = se.author_id
-        WHERE se.org_id = :org AND se.project_id = :proj AND se.date = :date
+        WHERE se.org_id = :org AND sep.project_id = :proj AND se.date = :date
     )
     SELECT r.cid FROM roster r WHERE r.cid NOT IN (SELECT cid FROM submitted)
     """
@@ -47,6 +53,27 @@ _MISSING_SQL = text(
 class StandupEntryRepository(BaseRepository[StandupEntry]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(StandupEntry, session, org_id)
+
+    async def list(self, limit: int = 1000, **filters: Any) -> list[StandupEntry]:
+        """51447ca0: project_id 필터를 standup_entry_projects link join(projection)으로 해소.
+
+        org-level 엔트리(project_id NULL·링크로 surface)도 링크된 프로젝트 뷰에 나타난다.
+        EXISTS 라 double-count 없음. legacy 엔트리는 0099 백필 링크로 동일 커버(연속성).
+        project_id 외 필터(author_id·sprint_id·date)는 기존대로 컬럼 일치.
+        """
+        project_id = filters.pop("project_id", None)
+        q = select(StandupEntry).where(self._org_filter())
+        for attr, val in filters.items():
+            q = q.where(getattr(StandupEntry, attr) == val)
+        if project_id is not None:
+            q = q.where(
+                exists().where(
+                    StandupEntryProject.entry_id == StandupEntry.id,
+                    StandupEntryProject.project_id == project_id,
+                )
+            )
+        result = await self.session.execute(q.limit(limit))
+        return list(result.scalars().all())
 
     async def upsert(self, **data: Any) -> StandupEntry:
         """E-STANDUP 3b6b567c: org-level upsert — 키 **(org_id, author_id, date)**.

--- a/backend/app/routers/standups.py
+++ b/backend/app/routers/standups.py
@@ -2,12 +2,12 @@ import uuid
 from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import exists, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.standup import StandupEntry, StandupFeedback
+from app.models.standup import StandupEntry, StandupEntryProject, StandupFeedback
 from app.repositories.standup import StandupEntryRepository, StandupFeedbackRepository
 from app.schemas.standup import (
     FeedbackCreate,
@@ -161,9 +161,14 @@ async def list_feedback(
         select(StandupFeedback)
         .join(StandupEntry, StandupFeedback.standup_entry_id == StandupEntry.id)
         .where(
-            StandupFeedback.project_id == project_id,
             StandupFeedback.org_id == org_id,
             StandupEntry.date == date_filter,
+            # 51447ca0: feedback projection — 피드백 단 엔트리가 해당 프로젝트에 링크됐는지로 판정
+            # (org-level 엔트리 피드백도 링크된 프로젝트 뷰에 surface). legacy는 0099 백필 링크로 커버.
+            exists().where(
+                StandupEntryProject.entry_id == StandupEntry.id,
+                StandupEntryProject.project_id == project_id,
+            ),
         )
     )
     result = await db.execute(q)

--- a/backend/tests/test_standup_projection_51447ca0.py
+++ b/backend/tests/test_standup_projection_51447ca0.py
@@ -1,0 +1,93 @@
+"""E-STANDUP 51447ca0: projection read — GET ?project_id= 를 standup_entry_projects link join.
+
+- org-level 엔트리(project_id NULL)가 링크된 프로젝트 뷰에 surface, 미링크 프로젝트엔 미surface.
+- legacy 엔트리(project_id 보유 + 링크)도 surface(0099 백필 링크·무회귀·CP1).
+- get_missing: 링크된 org 엔트리 제출자는 missing 제외.
+- feedback projection: 엔트리 링크 기준.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date as _date
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_projection_link_join_realdb():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.repositories.standup import StandupEntryRepository
+
+    org = uuid.uuid4()
+    p1, p2, p3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    a_org = uuid.uuid4()       # org-level 작성자(canonical member id)
+    a_leg = uuid.uuid4()       # legacy 작성자
+    e_org, e_leg = uuid.uuid4(), uuid.uuid4()
+    d = _date(2026, 6, 6)
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        async with sm() as s:
+            for pid in (p1, p2, p3):
+                await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,'P',now())"),
+                                {"i": pid, "o": org})
+            # org-level 엔트리: project_id NULL, 링크 p1+p2
+            await s.execute(text(
+                "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan_story_ids,created_at,updated_at)"
+                " VALUES (:i,:o,NULL,:a,:d,ARRAY[]::uuid[],now(),now())"), {"i": e_org, "o": org, "a": a_org, "d": d})
+            for pid in (p1, p2):
+                await s.execute(text("INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
+                                {"e": e_org, "p": pid, "o": org})
+            # legacy 엔트리: project_id=p1 보유 + 링크 p1(0099 백필 동형)
+            await s.execute(text(
+                "INSERT INTO standup_entries (id,org_id,project_id,author_id,date,plan_story_ids,created_at,updated_at)"
+                " VALUES (:i,:o,:p,:a,:d,ARRAY[]::uuid[],now(),now())"), {"i": e_leg, "o": org, "p": p1, "a": a_leg, "d": d})
+            await s.execute(text("INSERT INTO standup_entry_projects (id,entry_id,project_id,org_id) VALUES (gen_random_uuid(),:e,:p,:o)"),
+                            {"e": e_leg, "p": p1, "o": org})
+            # missing roster: a_org 를 owner org_member 로(roster 포함). submitted=링크된 엔트리.
+            await s.execute(text("INSERT INTO org_members (id,org_id,user_id,role,created_at) VALUES (:i,:o,:u,'owner',now())"),
+                            {"i": a_org, "o": org, "u": uuid.uuid4()})
+            await s.commit()
+
+            repo = StandupEntryRepository(s, org)
+            # p1: org-level + legacy 둘 다
+            ids_p1 = {e.id for e in await repo.list(project_id=p1, date=d)}
+            assert ids_p1 == {e_org, e_leg}, f"p1 projection {ids_p1}"
+            # p2: org-level 만(legacy는 p1만 링크)
+            ids_p2 = {e.id for e in await repo.list(project_id=p2, date=d)}
+            assert ids_p2 == {e_org}, f"p2 projection {ids_p2}"
+            # p3: 링크 없음 → 빈
+            ids_p3 = {e.id for e in await repo.list(project_id=p3, date=d)}
+            assert ids_p3 == set(), f"p3 should be empty {ids_p3}"
+            # project_id 없는 list = 전체(org scope)
+            ids_all = {e.id for e in await repo.list(date=d)}
+            assert {e_org, e_leg} <= ids_all
+
+            # get_missing(p1): a_org 는 링크된 엔트리 제출 → missing 제외
+            missing_p1 = await repo.get_missing(p1, d)
+            assert a_org not in missing_p1, f"a_org should not be missing on p1: {missing_p1}"
+            # get_missing(p3): a_org roster(owner org-wide)지만 p3 링크 엔트리 없음 → missing 포함
+            missing_p3 = await repo.get_missing(p3, d)
+            assert a_org in missing_p3, f"a_org should be missing on p3: {missing_p3}"
+        async with sm() as s:
+            await s.execute(text("DELETE FROM standup_entry_projects WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM standup_entries WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM org_members WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.commit()
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 개요 (E-STANDUP 51447ca0 · 마지막 스토리)
1c2be9db 가 깐 projection 링크 위에 **read projection**. org-level 엔트리(project_id NULL)가 링크된 프로젝트 뷰에 surface (write once → 전 관련 뷰 visible). PO 설계리뷰 GO·까심 CP1~5. migration 0·read-only.

## projection 메커니즘 = link join (3b6b567c 채택)
AC 원문의 plan_story_ids-derive+S1tag 폐기 → `standup_entry_projects` link join(orphan 회피·결정적·1c2be9db 링크 재사용).

read 4경로의 project_id 필터를 `entry.project_id` → **link join**:
- `StandupEntryRepository.list`: project_id 필터를 `EXISTS(standup_entry_projects WHERE entry_id=se.id AND project_id=:proj)` 로 override(**double-count 0**). 그 외 필터(author/sprint/date) 불변.
- `_MISSING_SQL` submitted: `se.project_id=:proj` → `JOIN standup_entry_projects sep WHERE sep.project_id=:proj`. roster(team_member∪grant∪owner/admin·**불변**) − submitted(링크). ⟹ "org 1번 제출 = linked 프로젝트 전부 not-missing".
- `GET /history`(repo.list 재사용)·`GET /feedback`(엔트리 링크 EXISTS) 동일 projection.

## CP1 (🔴 BLOCKER·legacy 무회귀)
기존 legacy 엔트리(project_id 보유)는 **0099 백필 링크**(dev 재프로브 **149행** 실측)로 link join 에 잡혀 뷰서 **연속(소실 0)**. 신규 legacy write 도 upsert additive 링크. prod 0099 적용 완료(standup 0행→백필 no-op·신규는 write 링크).

## 테스트
- real-DB(skip-able·CI alembic-fresh-db): org-level 엔트리(링크 p1+p2)→GET project_id=p1/p2 **양쪽 surface**·미링크 p3 **제외**·**legacy 엔트리 무회귀**(p1 surface)·`get_missing` 링크 제출자 제외/미제출(p3) 포함.
- 기존 standup(test_standups·ac3_3·3b6b567c·1c2be9db) **20 PASS 무회귀**.

## 비고
- ⚠️ `list` 메서드가 클래스 본문서 builtin `list` 를 shadow → 후속 어노테이션 `list[uuid.UUID]` TypeError → `from __future__ import annotations` 로 해소.
- FE projection(프로젝트 standup 페이지 link 기반 로드)은 미르코군 영역(BE 계약 기준). 머지+dev verify(2프로젝트 GET projection 실증) 예정.

까심 cross-model QA(CP1~5). **E-STANDUP write/read 완결.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)