### PR TITLE
fix(chat): DM 1-pair=1-DM enforce — dm_pair_key + partial unique + preflight dedup (179db213)

### DIFF
--- a/backend/alembic/versions/0100_dm_pair_dedup.py
+++ b/backend/alembic/versions/0100_dm_pair_dedup.py
@@ -1,0 +1,104 @@
+"""179db213: DM 1-pair=1-DM enforce — dm_pair_key + partial unique index + preflight dedup.
+
+create_conversation 이 동일 2-member pair 에 중복 DM 을 만들 수 있던 것을 막는다.
+- conversations.dm_pair_key (정렬된 member-pair `min|max`) 추가 + type='dm' 백필.
+- preflight dedup: 같은 (org,project,dm_pair_key) 다중 DM → keeper(최古 created_at) 1개로 머지
+  (잉여 DM 의 conversation_messages 를 keeper 로 repoint **先**, 잉여 conv DELETE **後** — 메시지
+  무손실. participants 는 keeper 가 동일 pair 보유·잉여는 conv DELETE 시 CASCADE).
+- partial unique index uq_conversations_dm_pair (type='dm') → 동시생성 레이스 단일 DM 보장
+  (핸들러가 IntegrityError catch → 기존 DM 반환).
+
+멱등: ADD COLUMN/INDEX IF NOT EXISTS·dedup 재실행 시 단일 그룹이면 no-op.
+롤백: index/column drop. 데이터 머지 비가역(0081/0099 동일 정책).
+
+Revision ID: 0100
+Revises: 0099
+Create Date: 2026-06-06
+"""
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0100"
+down_revision = "0099"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. dm_pair_key 컬럼 (additive nullable)
+    op.execute("ALTER TABLE conversations ADD COLUMN IF NOT EXISTS dm_pair_key text")
+
+    # 2. type='dm' 백필 — 정렬된 member-pair
+    op.execute(
+        """
+        UPDATE conversations c SET dm_pair_key = sub.pk
+        FROM (
+            SELECT cp.conversation_id AS cid,
+                   string_agg(cp.member_id::text, '|' ORDER BY cp.member_id) AS pk
+            FROM conversation_participants cp
+            GROUP BY cp.conversation_id
+        ) sub
+        WHERE c.id = sub.cid AND c.type = 'dm'
+        """
+    )
+
+    # 3. preflight dedup (CP3) — 머지 그룹 로그
+    op.execute(
+        """
+        DO $$
+        DECLARE r record;
+        BEGIN
+            FOR r IN
+                SELECT org_id, project_id, dm_pair_key, count(*) AS c
+                FROM conversations
+                WHERE type='dm' AND dm_pair_key IS NOT NULL
+                GROUP BY org_id, project_id, dm_pair_key HAVING count(*) > 1
+            LOOP
+                RAISE NOTICE '179db213 DM dedup MERGE: org=% project=% pair=% dms=%',
+                    r.org_id, r.project_id, r.dm_pair_key, r.c;
+            END LOOP;
+        END $$
+        """
+    )
+    # 3a. 잉여 DM 의 메시지를 keeper(최古) 로 repoint (DELETE 先행 금지 — CASCADE 소실 방지·CP3)
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id,
+                   row_number() OVER w AS rn,
+                   first_value(id) OVER w AS keeper
+            FROM conversations
+            WHERE type='dm' AND dm_pair_key IS NOT NULL
+            WINDOW w AS (PARTITION BY org_id, project_id, dm_pair_key ORDER BY created_at ASC, id ASC)
+        )
+        UPDATE conversation_messages m SET conversation_id = r.keeper
+        FROM ranked r WHERE m.conversation_id = r.id AND r.rn > 1
+        """
+    )
+    # 3b. 잉여 DM DELETE (participants 는 FK CASCADE — keeper 가 동일 pair 보유)
+    op.execute(
+        """
+        WITH ranked AS (
+            SELECT id,
+                   row_number() OVER (PARTITION BY org_id, project_id, dm_pair_key
+                                      ORDER BY created_at ASC, id ASC) AS rn
+            FROM conversations
+            WHERE type='dm' AND dm_pair_key IS NOT NULL
+        )
+        DELETE FROM conversations c USING ranked r WHERE c.id = r.id AND r.rn > 1
+        """
+    )
+
+    # 4. partial unique index (CP1/CP2 — type='dm' 1-pair=1-DM·레이스 가드)
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_conversations_dm_pair "
+        "ON conversations (org_id, project_id, dm_pair_key) "
+        "WHERE type = 'dm' AND dm_pair_key IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_conversations_dm_pair")
+    op.execute("ALTER TABLE conversations DROP COLUMN IF EXISTS dm_pair_key")
+    # 데이터 머지(중복 DM → 1)는 비가역(0081/0099 동일 정책).

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -18,6 +18,9 @@ class Conversation(Base, OrgScopedMixin, TimestampMixin):
     )
     type: Mapped[str] = mapped_column(Text, nullable=False, default="group")  # dm | group
     title: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # 179db213: DM 1-pair=1-DM — 정렬된 member-pair `min|max`(type='dm'만). partial unique index
+    # uq_conversations_dm_pair(org,project,dm_pair_key WHERE type='dm')로 레이스/중복 차단.
+    dm_pair_key: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("team_members.id", ondelete="SET NULL"), nullable=True
     )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -445,45 +445,49 @@ async def create_conversation(
     # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
     await _enforce_agent_creator_policy(sender, body.participant_ids, db)
 
-    # DM 중복 방지: 동일 participant pair의 dm이 이미 있으면 반환
-    if body.type == "dm" and len(body.participant_ids) == 1:
-        other_id = body.participant_ids[0]
-        existing = (await db.execute(
-            select(Conversation.id)
-            .join(ConversationParticipant, ConversationParticipant.conversation_id == Conversation.id)
-            .where(
+    # 179db213: 1-pair=1-DM enforce — resolved member set 이 정확히 2명이면 DM 으로 dedup
+    # (body.type label 무관). dm_pair_key(정렬쌍)로 기존 DM 조회→반환. ≥3명/단독은 group.
+    all_members = sorted({sender.id, *body.participant_ids})
+    is_dm = len(all_members) == 2
+    dm_pair_key = "|".join(str(m) for m in all_members) if is_dm else None
+
+    async def _find_existing_dm() -> uuid.UUID | None:
+        return (await db.execute(
+            select(Conversation.id).where(
                 Conversation.type == "dm",
                 Conversation.org_id == org_id,
                 Conversation.project_id == body.project_id,
-                ConversationParticipant.member_id == sender.id,
+                Conversation.dm_pair_key == dm_pair_key,
             )
-        )).scalars().all()
+        )).scalar_one_or_none()
 
-        for conv_id in existing:
-            other_check = (await db.execute(
-                select(ConversationParticipant.id).where(
-                    ConversationParticipant.conversation_id == conv_id,
-                    ConversationParticipant.member_id == other_id,
-                )
-            )).scalar_one_or_none()
-            if other_check:
-                return {"id": str(conv_id), "type": "dm", "existing": True}
+    if is_dm:
+        existing = await _find_existing_dm()
+        if existing is not None:
+            return {"id": str(existing), "type": "dm", "existing": True}
 
     conv = Conversation(
         project_id=body.project_id,
         org_id=org_id,
-        type=body.type,
+        type=("dm" if is_dm else body.type),
         title=body.title,
         created_by=sender.id,
+        dm_pair_key=dm_pair_key,
     )
     db.add(conv)
-    await db.flush()
-
-    all_members = list({sender.id} | set(body.participant_ids))
-    for mid in all_members:
-        db.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
-
-    await db.commit()
+    try:
+        await db.flush()
+        for mid in all_members:
+            db.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
+        await db.commit()
+    except IntegrityError:
+        # CP2: 동시 동일 pair 생성 레이스 → uq_conversations_dm_pair 위반 → 기존 DM 반환.
+        await db.rollback()
+        if is_dm:
+            existing = await _find_existing_dm()
+            if existing is not None:
+                return {"id": str(existing), "type": "dm", "existing": True}
+        raise
     await db.refresh(conv)
     return {"id": str(conv.id), "type": conv.type, "title": conv.title, "existing": False}
 

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -148,10 +148,11 @@ async def test_create_group_conversation():
         session.refresh.side_effect = _refresh
 
         async with client as c:
+            # 179db213: 2-member 는 DM 강제이므로 group 은 ≥3 member(참가자 2명+sender)
             resp = await c.post("/api/v2/conversations", json={
                 "type": "group",
                 "title": "테스트",
-                "participant_ids": [str(uuid.uuid4())],
+                "participant_ids": [str(uuid.uuid4()), str(uuid.uuid4())],
                 "project_id": str(PROJECT_ID),
             })
 
@@ -177,13 +178,12 @@ async def test_create_dm_deduplication():
         member_result = MagicMock()
         member_result.scalars.return_value.first.return_value = mock_member
 
+        # 179db213: 새 dedup — _find_existing_dm() = scalar_one_or_none(dm_pair_key 조회)
         existing_dm_result = MagicMock()
-        existing_dm_result.scalars.return_value.all.return_value = [CONV_ID]
+        existing_dm_result.scalar_one_or_none.return_value = CONV_ID
 
-        other_check_result = MagicMock()
-        other_check_result.scalar_one_or_none.return_value = uuid.uuid4()  # 있음
-
-        session.execute = AsyncMock(side_effect=[member_result, existing_dm_result, other_check_result])
+        # execute 순서: member resolve → _find_existing_dm(scalar_one_or_none)
+        session.execute = AsyncMock(side_effect=[member_result, existing_dm_result])
 
         async with client as c:
             resp = await c.post("/api/v2/conversations", json={

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -165,6 +165,41 @@ async def test_create_group_conversation():
         app.dependency_overrides.clear()
 
 
+# ─── 179db213: 1-pair=1-DM enforce ──────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_group_request_2members_coerced_to_dm():
+    """CP1: type=group 으로 2-member(참가자 1+sender) 요청해도 DM 으로 강제(1-pair=1-DM)."""
+    client, session, app = await _make_client()
+    try:
+        mock_member = _make_member()
+        member_result = MagicMock()
+        member_result.scalars.return_value.first.return_value = mock_member
+        none_result = MagicMock()
+        none_result.scalar_one_or_none.return_value = None  # 기존 DM 없음
+        # execute: member resolve → _find_existing_dm(None) → 신규 DM 생성
+        session.execute = AsyncMock(side_effect=[member_result, none_result])
+
+        async def _refresh(obj):
+            obj.id = CONV_ID
+            obj.type = "dm"   # 핸들러가 is_dm 으로 type='dm' 세팅
+            obj.title = None
+        session.refresh.side_effect = _refresh
+
+        async with client as c:
+            resp = await c.post("/api/v2/conversations", json={
+                "type": "group",   # label 은 group 이지만 2-member → DM 강제
+                "participant_ids": [str(uuid.uuid4())],
+                "project_id": str(PROJECT_ID),
+            })
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["type"] == "dm", f"2-member group → DM 강제 실패: {body}"
+        assert body["existing"] is False
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── AC4: POST /conversations — DM 중복 방지 ────────────────────────────────
 
 @pytest.mark.anyio

--- a/backend/tests/test_dm_dedup_179db213.py
+++ b/backend/tests/test_dm_dedup_179db213.py
@@ -7,8 +7,10 @@
 from __future__ import annotations
 
 import asyncio
+import asyncio
 import os
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -89,6 +91,76 @@ _DEDUP_SQL = [
          FROM conversations WHERE type='dm' AND dm_pair_key IS NOT NULL)
        DELETE FROM conversations c USING ranked r WHERE c.id=r.id AND r.rn>1""",
 ]
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_concurrent_api_create_same_pair_single_dm_realdb(monkeypatch):
+    """CP2: 핸들러 API 레벨 동시 POST(같은 pair) 2건 → 둘 다 동일 DM id·DB 단일 DM.
+
+    (dedup-check OR IntegrityError-catch 어느 경로든 중복 0 불변식. SQL 직접이 아닌 실 핸들러.)
+    """
+    from httpx import ASGITransport, AsyncClient
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    suser, om = uuid.uuid4(), uuid.uuid4()   # sender user + org_member/member id(0075 1:1)
+    other = uuid.uuid4()
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    # 에이전트 인가 불변식 skip(이 테스트 범위 외)
+    async def _noop(*a, **k):
+        return None
+    monkeypatch.setattr("app.routers.conversations._enforce_agent_creator_policy", _noop)
+    try:
+        async with sm() as s:
+            await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,'P',now())"), {"i": proj, "o": org})
+            await s.execute(text("INSERT INTO org_members (id,org_id,user_id,role,created_at) VALUES (:i,:o,:u,'owner',now())"), {"i": om, "o": org, "u": suser})
+            await s.execute(text("INSERT INTO members (id,org_id,type,user_id,name,org_role,is_active,created_at,updated_at) VALUES (:i,:o,'human',:u,'S','owner',true,now(),now())"), {"i": om, "o": org, "u": suser})
+            await s.commit()
+
+        ctx = MagicMock()
+        ctx.user_id = str(suser)
+        ctx.claims = {"app_metadata": {"org_id": str(org)}}
+
+        async def _db():
+            async with sm() as ses:
+                yield ses
+        async def _auth():
+            return ctx
+        async def _org():
+            return org
+        app.dependency_overrides[get_db] = _db
+        app.dependency_overrides[get_current_user] = _auth
+        app.dependency_overrides[get_verified_org_id] = _org
+
+        body = {"type": "dm", "participant_ids": [str(other)], "project_id": str(proj)}
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+            r1, r2 = await asyncio.gather(
+                c.post("/api/v2/conversations", json=body),
+                c.post("/api/v2/conversations", json=body),
+            )
+        assert r1.status_code == 201 and r2.status_code == 201, (r1.text, r2.text)
+        id1, id2 = r1.json()["id"], r2.json()["id"]
+        assert id1 == id2, f"동시 생성이 다른 DM 반환(중복!): {id1} vs {id2}"
+        async with sm() as s:
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM conversations WHERE org_id=:o AND type='dm'"), {"o": org})).scalar_one()
+            assert cnt == 1, f"단일 DM 불변식 위반: {cnt}"
+    finally:
+        app.dependency_overrides.clear()
+        async with sm() as s:
+            await s.execute(text("DELETE FROM conversation_participants WHERE conversation_id IN (SELECT id FROM conversations WHERE org_id=:o)"), {"o": org})
+            await s.execute(text("DELETE FROM conversations WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM members WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM org_members WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.commit()
+        await eng.dispose()
 
 
 @pytest.mark.anyio

--- a/backend/tests/test_dm_dedup_179db213.py
+++ b/backend/tests/test_dm_dedup_179db213.py
@@ -1,0 +1,136 @@
+"""179db213: DM 1-pair=1-DM dedup — dm_pair_key·partial unique·preflight·race.
+
+- CP1: 같은 pair 2번 → 동일 DM(unique 가드). CP2: 동시 생성 → 1 DM(IntegrityError·real-DB).
+- CP3: preflight dedup — 잉여 DM messages keeper repoint·메시지 무손실. CP5: 3명→group.
+- CP6: dm_pair_key = 정렬 member join '|'.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_dm_pair_key_format_sorted():
+    """CP6: dm_pair_key = 정렬된 member-id join '|' (결정적·교환법칙)."""
+    a, b = uuid.UUID("00000000-0000-0000-0000-000000000002"), uuid.UUID("00000000-0000-0000-0000-000000000001")
+    # 핸들러와 동일 규칙: sorted({sender,*participants}) → '|'.join
+    k1 = "|".join(str(m) for m in sorted({a, b}))
+    k2 = "|".join(str(m) for m in sorted({b, a}))
+    assert k1 == k2  # 순서 무관
+    assert k1 == "00000000-0000-0000-0000-000000000001|00000000-0000-0000-0000-000000000002"
+
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC = _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+
+def _key(*ids):
+    return "|".join(str(m) for m in sorted(ids))
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_unique_index_and_concurrent_race_realdb():
+    """CP1/CP2: 같은 (org,project,dm_pair_key) DM 2개 insert → unique 위반(동시성 포함 단일 보장)."""
+    from sqlalchemy import text
+    from sqlalchemy.exc import IntegrityError
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    a, b = uuid.uuid4(), uuid.uuid4()
+    pk = _key(a, b)
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        async with sm() as s:
+            await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,'P',now())"), {"i": proj, "o": org})
+            await s.commit()
+
+        async def ins():
+            async with sm() as s2:
+                await s2.execute(text(
+                    "INSERT INTO conversations (id,org_id,project_id,type,dm_pair_key,status,created_at,updated_at)"
+                    " VALUES (gen_random_uuid(),:o,:p,'dm',:k,'open',now(),now())"), {"o": org, "p": proj, "k": pk})
+                await s2.commit()
+
+        # 동시 2 insert → 하나는 IntegrityError(unique)
+        results = await asyncio.gather(ins(), ins(), return_exceptions=True)
+        errs = [r for r in results if isinstance(r, Exception)]
+        assert len(errs) == 1 and isinstance(errs[0], IntegrityError), f"race guard: {results}"
+        async with sm() as s:
+            cnt = (await s.execute(text(
+                "SELECT count(*) FROM conversations WHERE org_id=:o AND project_id=:p AND type='dm' AND dm_pair_key=:k"),
+                {"o": org, "p": proj, "k": pk})).scalar_one()
+            assert cnt == 1, f"단일 DM 보장 실패: {cnt}"
+            await s.execute(text("DELETE FROM conversations WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.commit()
+    finally:
+        await eng.dispose()
+
+
+# 0100 preflight dedup 와 동형 (unique index 잠시 drop 후 dup 시드)
+_DEDUP_SQL = [
+    """WITH ranked AS (SELECT id, row_number() OVER w AS rn, first_value(id) OVER w AS keeper
+         FROM conversations WHERE type='dm' AND dm_pair_key IS NOT NULL
+         WINDOW w AS (PARTITION BY org_id, project_id, dm_pair_key ORDER BY created_at ASC, id ASC))
+       UPDATE conversation_messages m SET conversation_id=r.keeper FROM ranked r WHERE m.conversation_id=r.id AND r.rn>1""",
+    """WITH ranked AS (SELECT id, row_number() OVER (PARTITION BY org_id,project_id,dm_pair_key ORDER BY created_at ASC, id ASC) AS rn
+         FROM conversations WHERE type='dm' AND dm_pair_key IS NOT NULL)
+       DELETE FROM conversations c USING ranked r WHERE c.id=r.id AND r.rn>1""",
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
+async def test_preflight_dedup_message_preservation_realdb():
+    """CP3: 중복 DM 2개(각 메시지 보유) → dedup → 1 DM + 메시지 전부 keeper 로 보존(무손실)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    org, proj = uuid.uuid4(), uuid.uuid4()
+    a, b = uuid.uuid4(), uuid.uuid4()
+    pk = _key(a, b)
+    c_keep, c_dup = uuid.uuid4(), uuid.uuid4()
+    eng = create_async_engine(_ASYNC)
+    sm = async_sessionmaker(eng, expire_on_commit=False)
+    try:
+        async with sm() as s:
+            await s.execute(text("DROP INDEX IF EXISTS uq_conversations_dm_pair"))  # dup 시드 허용
+            await s.execute(text("INSERT INTO projects (id,org_id,name,created_at) VALUES (:i,:o,'P',now())"), {"i": proj, "o": org})
+            # keeper(최古) + dup
+            await s.execute(text("INSERT INTO conversations (id,org_id,project_id,type,dm_pair_key,status,created_at,updated_at) VALUES (:i,:o,:p,'dm',:k,'open','2026-06-01',now())"), {"i": c_keep, "o": org, "p": proj, "k": pk})
+            await s.execute(text("INSERT INTO conversations (id,org_id,project_id,type,dm_pair_key,status,created_at,updated_at) VALUES (:i,:o,:p,'dm',:k,'open','2026-06-02',now())"), {"i": c_dup, "o": org, "p": proj, "k": pk})
+            for cid, mid in ((c_keep, a), (c_dup, a), (c_dup, b)):
+                await s.execute(text("INSERT INTO conversation_messages (id,conversation_id,sender_id,content,mentioned_ids,created_at,updated_at) VALUES (gen_random_uuid(),:c,:s,'m',ARRAY[]::uuid[],now(),now())"), {"c": cid, "s": mid})
+            await s.commit()
+            before = (await s.execute(text("SELECT count(*) FROM conversation_messages m JOIN conversations c ON c.id=m.conversation_id WHERE c.org_id=:o"), {"o": org})).scalar_one()
+            assert before == 3
+
+            for sql in _DEDUP_SQL:
+                await s.execute(text(sql))
+            await s.commit()
+
+            dm_cnt = (await s.execute(text("SELECT count(*) FROM conversations WHERE org_id=:o AND type='dm' AND dm_pair_key=:k"), {"o": org, "k": pk})).scalar_one()
+            assert dm_cnt == 1  # keeper 만
+            keeper_left = (await s.execute(text("SELECT count(*) FROM conversations WHERE id=:i"), {"i": c_keep})).scalar_one()
+            assert keeper_left == 1  # 최古가 keeper
+            after = (await s.execute(text("SELECT count(*) FROM conversation_messages WHERE conversation_id=:k"), {"k": c_keep})).scalar_one()
+            assert after == 3, f"메시지 무손실 실패: keeper {after} (3 기대)"  # CP3
+            await s.execute(text("CREATE UNIQUE INDEX IF NOT EXISTS uq_conversations_dm_pair ON conversations (org_id, project_id, dm_pair_key) WHERE type='dm' AND dm_pair_key IS NOT NULL"))
+            await s.execute(text("DELETE FROM conversation_messages WHERE conversation_id=:k"), {"k": c_keep})
+            await s.execute(text("DELETE FROM conversations WHERE org_id=:o"), {"o": org})
+            await s.execute(text("DELETE FROM projects WHERE org_id=:o"), {"o": org})
+            await s.commit()
+    finally:
+        await eng.dispose()


### PR DESCRIPTION
## 개요 (E-MSG 179db213 · high)
`create_conversation` DM dedup 게이트가 `type=="dm" AND len(participant_ids)==1` 로 협소 → 같은 pair 에 **중복 DM** 생성 가능. dev 실측: DM 9개·전부 2-member·**중복 pair 1그룹**(버그 실재). PO 설계리뷰 GO·까심 CP1~6.

## 수정
- **① dedup broaden (CP1):** resolved member set 이 정확히 2명이면 **DM 으로 dedup**(body.type label 무관·1-pair=1-DM). `dm_pair_key`(정렬쌍 `min|max`·CP6)로 기존 DM 조회 → `existing:True` 반환. ≥3명 group(무회귀·CP5).
- **② DB race 가드 (CP2 🔴):** `partial unique index uq_conversations_dm_pair(org,project,dm_pair_key WHERE type='dm')`. 동시 동일 pair → `IntegrityError` catch → 기존 DM 반환(단일 보장).
- **③ preflight dedup (CP3 🔴):** 마이그 0100 — 중복 pair DM → keeper(최古 created_at) 1개·잉여 `conversation_messages` 를 keeper 로 **repoint 先**·잉여 conv `DELETE 後`(participants CASCADE) → **메시지 무손실**.
- **④ fork 불변 (CP4):** send_message/add_participant 3번째 멤버 → 새 group(미변경).

## 마이그 0100
`dm_pair_key` 컬럼(additive) + type='dm' 백필 + preflight dedup + partial unique index. ⚠️ **머지 후 migrate-dev 잡 선행**(CB 자동배포 앞지름 금지). 멱등(IF NOT EXISTS·dedup 재실행 no-op). 롤백 구조 revert·데이터 머지 비가역(0081/0099 정책).

## 테스트 (CP1~6)
- `dm_pair_key` format(정렬·교환법칙·CP6) · **real-DB 동시성**(concurrent insert→IntegrityError·단일 DM·CP1/CP2) · **real-DB preflight dedup**(잉여 messages keeper repoint·**메시지 무손실**·CP3) · group(3명) 무회귀(CP5). 기존 conversations 테스트는 2-member→DM 전환 반영 갱신. 로컬 18 PASS.
- 머지+migrate-dev+배포 후 함수형 verify(같은 pair 2회 create→동일 id·fork→group) 예정.

까심 cross-model QA. 후속 demo-visible 큐: 48de882a(Inbox Read)·7f8066a3(Dispatch)·96af343e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)