### PR TITLE
[SID:1c2be9db][SID:51447ca0] feat(standup): org-level write + 프로젝트 뷰 projection FE

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -987,6 +987,18 @@
     "primaryCta": "Open board"
   },
   "standup": {
+    "orgLevelTitle": "Today's standup",
+    "orgLevelDesc": "Write once a day and it's shared across every project you can access.",
+    "orgWriteBanner": "Organization-level entry — write once and it automatically appears in every project you have access to. No project selection needed.",
+    "oncePerDay": "1 person · 1 day · 1 entry",
+    "planStoriesOptional": "Today's planned stories (optional)",
+    "planStoriesProjectionHint": "Which projects this appears in is decided automatically by your access, independent of this selection.",
+    "projectionViewDesc": "Shows organization standups from members with access to this project.",
+    "projectionBanner": "This view collects organization-level standups projected onto this project. You don't write here — write in ‘Today's standup’ (once per organization).",
+    "sourceOrgLevel": "Org-level entry · submitted",
+    "relatedPlan": "Related plan",
+    "missingOrgStandup": "No organization standup yet",
+    "missingOrgHint": "Based on a single organization-level entry. Once written, it shows as submitted across every project you can access.",
     "title": "Daily Standup",
     "cancel": "Cancel",
     "surfaceDescription": "Update your standup and review the team state on one operator surface.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -987,6 +987,18 @@
     "primaryCta": "보드 열기"
   },
   "standup": {
+    "orgLevelTitle": "오늘의 스탠드업",
+    "orgLevelDesc": "하루 한 번 작성하면 접근한 모든 프로젝트에 공유됩니다.",
+    "orgWriteBanner": "조직 레벨 작성 — 한 번 작성하면 접근 권한이 있는 프로젝트에 자동으로 표시됩니다. 프로젝트 선택은 필요 없습니다.",
+    "oncePerDay": "1인 · 1일 · 1엔트리",
+    "planStoriesOptional": "오늘 계획 스토리 (선택)",
+    "planStoriesProjectionHint": "표시 대상 프로젝트는 접근 권한으로 자동 결정되며, 이 선택과는 무관합니다.",
+    "projectionViewDesc": "접근 권한이 있는 멤버들의 조직 스탠드업을 표시합니다.",
+    "projectionBanner": "조직 레벨 작성을 이 프로젝트 기준으로 모아 보는 화면입니다. 여기서는 작성하지 않으며, 작성은 ‘오늘의 스탠드업’(조직 1회)에서 합니다.",
+    "sourceOrgLevel": "조직 레벨 작성 · 제출됨",
+    "relatedPlan": "관련 계획",
+    "missingOrgStandup": "조직 스탠드업 미작성",
+    "missingOrgHint": "조직 1회 작성 기준입니다. 작성하면 접근한 모든 프로젝트에서 제출됨으로 표시됩니다.",
     "title": "데일리 스탠드업",
     "cancel": "취소",
     "surfaceDescription": "오늘 기준 내 스탠드업과 팀 상태를 같은 표면에서 정리합니다.",

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -102,6 +103,8 @@ export default function StandupPage() {
   const [entries, setEntries] = useState<StandupEntryRow[]>([]);
   const [members, setMembers] = useState<StandupMemberRow[]>([]);
   const [feedback, setFeedback] = useState<StandupFeedbackRow[]>([]);
+  // S3(51447ca0): Missing = org 기준(get_missing projection) — 조직 1회 미작성 멤버
+  const [missingMembers, setMissingMembers] = useState<{ id: string; name: string }[]>([]);
   const [activeSprint, setActiveSprint] = useState<StandupSprintSummary | null>(null);
   const [stories, setStories] = useState<StandupStorySummary[]>([]);
   const [done, setDone] = useState('');
@@ -179,6 +182,7 @@ export default function StandupPage() {
           setEntries([]);
           setMembers([]);
           setFeedback([]);
+          setMissingMembers([]);
           setActiveSprint(null);
           setStories([]);
           setLoadError(null);
@@ -195,11 +199,12 @@ export default function StandupPage() {
       }
 
       try {
-        const [entriesRes, membersRes, sprintsRes, feedbackRes] = await Promise.all([
+        const [entriesRes, membersRes, sprintsRes, feedbackRes, missingRes] = await Promise.all([
           fetch(`/api/standup?project_id=${projectId}&date=${date}`),
           fetch(`/api/team-members?project_id=${projectId}`),
           fetch(`/api/sprints?project_id=${projectId}&status=active`),
           fetch(`/api/standup/feedback?project_id=${projectId}&date=${date}`),
+          fetch(`/api/standup/missing?project_id=${projectId}&date=${date}`),
         ]);
 
         const [entriesData, membersData, sprintsData, feedbackData] = await Promise.all([
@@ -208,6 +213,10 @@ export default function StandupPage() {
           readJsonDataOrThrow<StandupSprintSummary[]>(sprintsRes, 'sprints'),
           readJsonDataOrThrow<StandupFeedbackRow[]>(feedbackRes, 'standup feedback'),
         ]);
+
+        // S3: Missing = org 기준(projection get_missing). 실패해도 본 화면은 막지 않음.
+        const missingJson = await missingRes.json().catch(() => null) as { data?: { missing?: { id: string; name: string }[] } } | null;
+        const missingList = missingRes.ok ? (missingJson?.data?.missing ?? []) : [];
 
         const sprint = sprintsData.find((item) => item.status === 'active') ?? sprintsData[0] ?? null;
         let storySummaries: StandupStorySummary[] = [];
@@ -246,6 +255,7 @@ export default function StandupPage() {
         setEntries(entriesData);
         setMembers(membersData);
         setFeedback(feedbackData);
+        setMissingMembers(missingList);
         setActiveSprint(sprint);
         setStories(storySummaries);
         setStoriesNextCursor(nextStoriesCursor);
@@ -285,15 +295,15 @@ export default function StandupPage() {
       : summaryBadges;
 
   async function handleSave() {
-    if (!projectId) return;
     setSaving(true);
     setSaveError(null);
     try {
+      // S2(1c2be9db): org-level write — project_id 생략 시 BE가 author 접근 프로젝트로 auto-link.
+      // 하루 한 번 작성하면 접근한 모든 프로젝트 뷰에 projection 된다(재타이핑 제거).
       const response = await fetch('/api/standup', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          project_id: projectId,
           date,
           done,
           plan,
@@ -500,6 +510,13 @@ export default function StandupPage() {
                 ) : null}
               </div>
 
+              {/* S3(51447ca0): 프로젝트 뷰 = 접근-기반 projection(read-only). 작성은 org-level. */}
+              {!loading ? (
+                <Alert variant="default">
+                  <AlertDescription className="text-xs">{t('projectionBanner')}</AlertDescription>
+                </Alert>
+              ) : null}
+
               {/* 사람 섹션 */}
               {loading ? (
                 <section className="space-y-3">
@@ -528,9 +545,19 @@ export default function StandupPage() {
                         return (
                           <div key={member.id} className="col-span-full rounded-xl border border-brand/40 bg-card p-4 shadow-sm space-y-4">
                             <div className="flex flex-wrap items-center justify-between gap-2">
-                              <h3 className="text-sm font-semibold text-foreground">{t('selfEditTitle')}</h3>
-                              <Button variant="ghost" size="sm" onClick={() => setEditingSelf(false)}>{t('cancel')}</Button>
+                              <div className="space-y-0.5">
+                                <h3 className="text-sm font-semibold text-foreground">{t('orgLevelTitle')}</h3>
+                                <p className="text-xs text-muted-foreground">{t('orgLevelDesc')}</p>
+                              </div>
+                              <div className="flex items-center gap-2">
+                                <Badge variant="outline">{t('oncePerDay')}</Badge>
+                                <Button variant="ghost" size="sm" onClick={() => setEditingSelf(false)}>{t('cancel')}</Button>
+                              </div>
                             </div>
+                            {/* S2(1c2be9db): org-level write 안내 — 프로젝트 선택 불요·접근 프로젝트 자동 표시 */}
+                            <Alert variant="info">
+                              <AlertDescription className="text-xs">{t('orgWriteBanner')}</AlertDescription>
+                            </Alert>
 
                             <div className="grid gap-4 md:grid-cols-3">
                               <div>
@@ -564,9 +591,11 @@ export default function StandupPage() {
 
                             <div className="space-y-3 rounded-xl border border-border/70 bg-muted/10 p-3">
                               <div className="flex flex-wrap items-center justify-between gap-2">
-                                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t('linkedStories')}</p>
+                                <p className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">{t('planStoriesOptional')}</p>
                                 <Badge variant="outline">{t('linkedStoryCount', { count: planStoryIds.length })}</Badge>
                               </div>
+                              {/* projection은 접근권 기준 자동 — plan_story_ids와 무관(디커플 명시) */}
+                              <p className="text-xs text-muted-foreground">{t('planStoriesProjectionHint')}</p>
                               {storyPickerStories.length > 0 ? (
                                 <div className="max-h-40 space-y-1.5 overflow-y-auto">
                                   {storyPickerStories.map((story) => {
@@ -655,6 +684,24 @@ export default function StandupPage() {
                         />
                       );
                     })}
+                  </div>
+                </section>
+              ) : null}
+
+              {/* S3(51447ca0): Missing — org 1회 작성 기준 미작성 멤버(프로젝트별 아님) */}
+              {!loading && missingMembers.length > 0 ? (
+                <section className="space-y-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <h2 className="text-sm font-semibold text-foreground">{t('missingOrgStandup')}</h2>
+                    <Badge variant="outline">{t('memberCount', { count: missingMembers.length })}</Badge>
+                  </div>
+                  <div className="rounded-xl border border-dashed border-border bg-muted/40 p-4">
+                    <div className="flex flex-wrap gap-1.5">
+                      {missingMembers.map((m) => (
+                        <Badge key={m.id} variant="outline">{m.name}</Badge>
+                      ))}
+                    </div>
+                    <p className="mt-2 text-xs text-muted-foreground">{t('missingOrgHint')}</p>
                   </div>
                 </section>
               ) : null}

--- a/apps/web/src/components/standup/standup-board-card.tsx
+++ b/apps/web/src/components/standup/standup-board-card.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Clock } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -78,6 +79,11 @@ export function StandupBoardCard({
                 </p>
               </div>
             ) : null}
+            {/* S3(51447ca0): org-level 작성을 프로젝트 뷰에 projection — 출처 표시 */}
+            <p className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" aria-hidden />
+              {t('sourceOrgLevel')}
+            </p>
           </>
         ) : (
           <p className="text-sm text-muted-foreground">{t('notWrittenYet')}</p>


### PR DESCRIPTION
## 요약
E-STANDUP S2/S3. standup을 **프로젝트별 write → org-level 1회 write + 프로젝트 뷰 = 접근-기반 projection(read-only)**. 멀티프로젝트 멤버 재타이핑 제거. 유나양 디자인 핸드오프(doc `e-standup-org-level-handoff`) 기준. **가디언 시각 1패스 요청.**

BE ready(둘 다 develop 머지): #1274(S2 write·project_id 생략→author 접근 프로젝트 auto-link) + #1276(S3 projection·GET ?project_id= link-join).

## AC 매핑
| AC | 구현 |
|----|------|
| S2 org-level write WITHOUT project_id | `handleSave` body에서 `project_id` 생략 → BE auto-link |
| S2 1유저·2프로젝트·1save → single 엔트리 양 뷰 | org-level write·접근 프로젝트 auto-projection |
| S3 GET ?project_id= = projection(link join) | 프로젝트 뷰 = #1276 서버필터·read-only |
| S3 Missing = org-submitted-once | Missing 카드 = `/api/standup/missing`(org 기준) |

## 변경 (FE-only)
- **`standup/page.tsx`**:
  - `handleSave` → org-level(project_id 생략).
  - 자기작성 폼: "오늘의 스탠드업" 헤더 + **info 배너**(접근 프로젝트 자동표시·선택 불요) + "1인1일1엔트리" 배지 + plan_story_ids **projection 무관 hint**(디커플).
  - **projection read-only 배너**(default/muted) — "여기서는 작성 안 함·작성은 오늘의 스탠드업".
  - **Missing 카드 신설**(dashed muted·org 기준·미작성 멤버) — 기존 Missing UI 부재분.
- **`standup-board-card.tsx`**: entry에 "◷ 조직 레벨 작성·제출됨" **출처 라벨**(Clock·muted).
- **`messages/{ko,en}.json`**: `standup` 신규 12키(en/ko 대칭).

## 토큰/i18n
- 토큰 신규 0(`info`/`muted`/`brand` 시맨틱 재사용)·**매직 hex 0**.
- i18n 12키 대칭(orgLevelTitle·orgWriteBanner·oncePerDay·planStoriesProjectionHint·projectionBanner·sourceOrgLevel·missingOrgStandup 등).

## ⚠️ 결정/deviation (가디언 확인)
- **페이지는 project-scoped 유지**(projection 뷰가 프로젝트 컨텍스트 필요). write는 org-level化(project_id 생략)지만, 현재는 프로젝트 진입 상태에서 작성 폼 노출. doc "프로젝트 선택 prompt 완전 제거(프로젝트 무관 단독 write 진입)"는 부분 반영 — 완전 분리(standalone org write 진입점)는 follow-up 제안. 가디언/PO 방향 확인 요청.
- services/standup.ts(Supabase 클라)는 page 미사용 레거시 경로라 미터치(실 write=`/api/standup`→BE #1274 프록시).

## 검증
- `pnpm exec eslint` 0 · `tsc --noEmit` 0 · `pnpm build`(webpack) 성공 · i18n parity.
- ⏳ 시각 라이브 = 유나양 가디언 1패스(머지+dev 배포 후) + 내 functional 와이어(org 1회 write→접근 전 프로젝트 surface·Missing org기준). 격리 worktree 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)