### PR TITLE
fix(notifications): 단일 읽음 처리 엔드포인트 추가 — Inbox 읽음처리 400 해소 (48de882a)

### DIFF
--- a/backend/app/repositories/notification.py
+++ b/backend/app/repositories/notification.py
@@ -47,6 +47,26 @@ class NotificationRepository(BaseRepository[Notification]):
             .values(is_read=True)
         )
 
+    async def mark_read(self, notification_id: uuid.UUID, user_id: uuid.UUID) -> Notification | None:
+        """단일 알림 읽음 처리 — 소유자 본인(user_id) 것만. 없으면 None(404 용)."""
+        await self.session.execute(
+            update(Notification)
+            .where(
+                Notification.org_id == self.org_id,
+                Notification.id == notification_id,
+                Notification.user_id == user_id,
+            )
+            .values(is_read=True)
+        )
+        result = await self.session.execute(
+            select(Notification).where(
+                Notification.org_id == self.org_id,
+                Notification.id == notification_id,
+                Notification.user_id == user_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
 
 class NotificationSettingRepository:
     def __init__(self, session: AsyncSession) -> None:

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -95,6 +95,26 @@ async def mark_all_read(
     return {"ok": True}
 
 
+@router.patch("/notifications/{id}/read", response_model=NotificationResponse, status_code=200)
+async def mark_read(
+    id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    repo: NotificationRepository = Depends(_notif_repo),
+) -> NotificationResponse:
+    """PATCH /api/v2/notifications/{id}/read — 단일 알림 읽음 처리(본인 것만).
+
+    48de882a: Inbox 클릭 시 FE(ApiNotificationRepository.markRead)가 이 경로를 호출하는데
+    BE 에 단일 read 엔드포인트가 없어(mark-all-read 만 존재) 실패하던 것을 보강. mark-all-read
+    와 동일 시스템(NotificationRepository)·user_id 소유자 스코프.
+    """
+    user_id = await _resolve_notification_user_id(auth, db)
+    notif = await repo.mark_read(id, user_id)
+    if notif is None:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return NotificationResponse.model_validate(notif)
+
+
 @router.get("/notification-settings", response_model=list[NotificationSettingResponse])
 async def get_notification_settings(
     member_id: uuid.UUID = Query(...),

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -164,6 +164,40 @@ async def test_mark_all_read_200():
 
 
 @pytest.mark.anyio
+async def test_mark_read_single_200():
+    """48de882a: PATCH /notifications/{id}/read — 단일 읽음 처리 200 + is_read=True."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.mark_read", new_callable=AsyncMock) as mock_mark:
+            mock_mark.return_value = _mock_notification(is_read=True)
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/notifications/{NOTIF_ID}/read")
+
+        assert resp.status_code == 200
+        assert resp.json()["is_read"] is True
+        assert resp.json()["id"] == str(NOTIF_ID)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_mark_read_single_404_when_not_owned():
+    """48de882a: 본인 것 아니거나 없는 알림 → 404."""
+    client, session, app = await _client()
+    try:
+        with patch("app.repositories.notification.NotificationRepository.mark_read", new_callable=AsyncMock) as mock_mark:
+            mock_mark.return_value = None
+
+            async with client as c:
+                resp = await c.patch(f"/api/v2/notifications/{NOTIF_ID}/read")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
 async def test_get_notification_settings_200():
     client, session, app = await _client()
     try:


### PR DESCRIPTION
## 증상 (2026-06-04 제보)
Inbox 항목 클릭 시 FE 가 아래를 호출하는데 실패(400):
```
PATCH https://app.sprintable.ai/api/notifications  {"id":"...","is_read":true}
```
→ FE Next route → `ApiNotificationRepository.markRead` → BE `PATCH /api/v2/notifications/{id}/read`.

## 근본 원인
BE `notifications.py`(prefix `/api/v2`·NotificationRepository 시스템)엔 `GET /notifications`·`/count`·`PATCH /mark-all-read` 는 있으나 **단일 `PATCH /notifications/{id}/read` 가 없음**. 단일 read 는 **다른 시스템**(`event_notifications.py`·`/api/v2/event-notifications/{id}/read`)에만 존재 → FE 가 부르는 경로/시스템과 불일치로 실패. (Inbox 목록은 `GET /api/v2/notifications` = NotificationRepository 라 단일 read 도 같은 시스템에 있어야 정합.)

## 수정 (BE·마이그0·gcloud 무관)
- `NotificationRepository.mark_read(notification_id, user_id)` 추가 — **소유자(user_id) 스코프** 단일 읽음·없으면 `None`(404).
- `PATCH /api/v2/notifications/{id}/read` 엔드포인트 추가 — `mark-all-read` 와 동일 시스템·`_resolve_notification_user_id` 소유자 파생·미소유/부재 404. `response_model=NotificationResponse`(FE `markRead(): Promise<Notification>` 계약 정합).

## 테스트
- 단일 read 200(is_read=True 반환·id 일치)·미소유/부재 404. 기존 notifications **11 PASS 무회귀**(mark-all-read·count·list 라우트 순서 무충돌). 로컬 13 PASS.

까심 cross-model QA. 후속 큐: 7f8066a3(Dispatch)·96af343e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)