### PR TITLE
fix(dispatch): DispatchResponse.reason 추가 — no-assignee vs 해소실패 구분 (7f8066a3 a)

### DIFF
--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -36,6 +36,9 @@ class DispatchResponse(BaseModel):
     event_id: uuid.UUID | None = None
     assignee_id: uuid.UUID | None = None
     assignee_type: str | None = None
+    # 7f8066a3: dispatched=False 사유 구분 → FE 가 no_assignee(담당자 미지정·info 안내)와
+    # unresolved_assignee(신원 해소 실패·error)를 다르게 표시. additive·null default 하위호환.
+    reason: str | None = None
 
 
 async def _fetch_entity(
@@ -89,7 +92,8 @@ async def dispatch_entity(
     if title is None:
         raise HTTPException(status_code=404, detail="Entity not found")
     if not assignee_id:
-        return DispatchResponse(dispatched=False)
+        # 7f8066a3 (a): 담당자 미지정 — 실패 아님. FE 가 "담당자 지정 필요" 안내(info).
+        return DispatchResponse(dispatched=False, reason="no_assignee")
     # entity의 실제 project_id 사용 (body.project_id 불일치 방지)
     project_id = entity_project_id or body.project_id
 
@@ -98,7 +102,8 @@ async def dispatch_entity(
     #   grant-only 휴먼/polymorphic assignee도 수용해 dispatched:False 오탐 방지 (7f8066a3).
     assignee_member = await resolve_member_identity(assignee_id, org_id, db)
     if assignee_member is None:
-        return DispatchResponse(dispatched=False, assignee_id=assignee_id)
+        # 7f8066a3 (a): 담당자 신원 해소 실패(드뭄) — 진짜 오류. FE error 토스트.
+        return DispatchResponse(dispatched=False, assignee_id=assignee_id, reason="unresolved_assignee")
 
     member_type = assignee_member.type
 
@@ -186,4 +191,5 @@ async def dispatch_entity(
         event_id=event.id,
         assignee_id=assignee_id,
         assignee_type=member_type,
+        reason="ok",
     )

--- a/backend/tests/test_dispatch_reason_7f8066a3.py
+++ b/backend/tests/test_dispatch_reason_7f8066a3.py
@@ -1,0 +1,121 @@
+"""7f8066a3 (a): DispatchResponse.reason — no_assignee / unresolved_assignee / ok 구분.
+
+FE 가 dispatched:False 를 "담당자 미지정(info 안내)"과 "신원 해소 실패(error)"로 구분해
+표시할 수 있도록 BE 가 reason 을 반환. additive·null default 하위호환.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client(mock_session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def _db():
+        yield mock_session
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return ORG_ID
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+def _body():
+    return {"entity_type": "story", "entity_id": str(uuid.uuid4()), "project_id": str(PROJECT_ID)}
+
+
+@pytest.mark.anyio
+async def test_dispatch_no_assignee_reason():
+    """assignee 미지정 → dispatched:False, reason='no_assignee' (실패 아님)."""
+    session = AsyncMock()
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.dispatch._fetch_entity", new_callable=AsyncMock) as mfetch:
+            mfetch.return_value = (None, "Story T", "desc", PROJECT_ID)  # assignee_id=None
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json=_body())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatched"] is False
+        assert data["reason"] == "no_assignee"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dispatch_unresolved_assignee_reason():
+    """assignee 있으나 신원 해소 실패 → dispatched:False, reason='unresolved_assignee'."""
+    session = AsyncMock()
+    client, app = await _client(session)
+    aid = uuid.uuid4()
+    try:
+        with patch("app.routers.dispatch._fetch_entity", new_callable=AsyncMock) as mfetch, \
+             patch("app.routers.dispatch.resolve_member_identity", new_callable=AsyncMock) as mresolve:
+            mfetch.return_value = (aid, "Story T", "desc", PROJECT_ID)
+            mresolve.return_value = None  # 해소 실패
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json=_body())
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dispatched"] is False
+        assert data["reason"] == "unresolved_assignee"
+        assert data["assignee_id"] == str(aid)
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_dispatch_success_reason_ok():
+    """정상 dispatch(human) → dispatched:True, reason='ok' (무회귀)."""
+    session = AsyncMock()
+    # sender 해소용 execute → scalar_one_or_none = sender_id
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none.return_value = uuid.uuid4()
+    session.execute = AsyncMock(return_value=exec_result)
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+    session.commit = AsyncMock()
+    client, app = await _client(session)
+    aid = uuid.uuid4()
+    member = MagicMock()
+    member.type = "human"
+    try:
+        with patch("app.routers.dispatch._fetch_entity", new_callable=AsyncMock) as mfetch, \
+             patch("app.routers.dispatch.resolve_member_identity", new_callable=AsyncMock) as mresolve, \
+             patch("app.routers.dispatch.dispatch_notification", new_callable=AsyncMock) as mnotif:
+            mfetch.return_value = (aid, "Story T", "desc", PROJECT_ID)
+            mresolve.return_value = member
+            mnotif.return_value = None
+            async with client as c:
+                resp = await c.post("/api/v2/dispatch", json=_body())
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["dispatched"] is True
+        assert data["reason"] == "ok"
+        assert data["assignee_id"] == str(aid)
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 배경 (7f8066a3 · 스코프 절감)
진짜 Dispatch 실패 주범(grant-only/polymorphic assignee 의 TeamMember-miss)은 **이미 #1164(530bcab7·AC2-2)에서 `resolve_member_identity`(TM∪OM) 도입으로 해소**. 잔여 = **(a) no-assignee UX**: 담당자 미지정과 신원 해소 실패가 둘 다 `dispatched:False` 라 FE 가 구분 못 하고 동일 "Dispatch 실패" 토스트.

## 수정 (BE·additive·마이그0·gcloud 무관)
- `DispatchResponse.reason: str | None = None` 추가(**additive·null default 하위호환**).
- 분기별 reason:
  - `no_assignee` — 담당자 미지정(실패 아님·FE info 안내)
  - `unresolved_assignee` — 신원 해소 실패(드뭄·진짜 오류·FE error)
  - `ok` — 정상 dispatch
  - entity 404 등은 기존 HTTPException 유지.

## 테스트 (까심 CP)
- no_assignee / unresolved_assignee / **ok(정상 dispatch 무회귀)** reason 각 케이스 + assignee_id 보존. 기존 dispatch 무회귀. 로컬 15 PASS.

## FE 핸드오프 (미르코·유나)
`entity-dispatch-panel.tsx` reason 소비:
| reason | UX | 톤 |
|---|---|---|
| ok / dispatched:true | "디스패치를 완료했습니다." | success |
| no_assignee | "담당자가 지정되지 않았습니다. 먼저 담당자를 지정해 주세요." | **info** |
| unresolved_assignee | "담당자 정보를 확인할 수 없습니다. 잠시 후 다시 시도해 주세요." | error |
| HTTP !ok | "디스패치 중 오류가 발생했습니다." | error |

⚠️ 기존 토스트 `"Dispatch 실패. 다시 시도하겠는."` = **비즈니스 UI 비-비즈니스 언어 위반(즉결대상)** → 위 비즈니스 카피로 교체 필수.

라이브 dispatch 성공 verify 는 gcloud 복구 배치에 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)