### PR TITLE
fix(notifications): 휴먼 개인 webhook 발송 추가 — 개인 Webhook 알림 미발송 해소 (96af343e)

### DIFF
--- a/backend/app/services/notification_dispatch.py
+++ b/backend/app/services/notification_dispatch.py
@@ -21,6 +21,77 @@ from app.models.webhook_config import WebhookConfig
 logger = logging.getLogger(__name__)
 
 
+async def _deliver_personal_webhooks(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    member_ids: list[uuid.UUID],
+    *,
+    title: str,
+    body: str | None,
+    event_type: str,
+) -> None:
+    """96af343e: 활성 개인(member-scoped) WebhookConfig 보유 휴먼에게 알림 webhook POST.
+
+    in-app Notification 과 동일 flush 타이밍(best-effort·옵션 C). global mute 멤버는 skip
+    (채널 막론 mute 우선). SSRF 검증·HMAC 서명·Discord URL 포맷·retry 는
+    dispatch_router._post_with_retry / app.core.ssrf 재사용. agent SSE 경로
+    (route_dispatch_event)는 미변경(무회귀). 개별 POST 실패는 swallow → in-app 무영향.
+    """
+    if not member_ids:
+        return
+    from app.core.ssrf import validate_webhook_url_async
+    from app.models.notification_preference import NotificationPreference
+    from app.services.dispatch_router import _post_with_retry
+
+    wh_rows = await db.execute(
+        select(WebhookConfig).where(
+            WebhookConfig.org_id == org_id,
+            WebhookConfig.member_id.in_(member_ids),
+            WebhookConfig.is_active.is_(True),
+            WebhookConfig.member_id.isnot(None),
+        )
+    )
+    configs = list(wh_rows.scalars().all())
+    if not configs:
+        return
+
+    # global mute 멤버 skip (CP②: 채널 막론 mute 우선)
+    muted_rows = await db.execute(
+        select(NotificationPreference.member_id).where(
+            NotificationPreference.member_id.in_([c.member_id for c in configs]),
+            NotificationPreference.scope_type == "global",
+            NotificationPreference.scope_id.is_(None),
+            NotificationPreference.level == "mute",
+        )
+    )
+    muted = {m for m in muted_rows.scalars().all()}
+
+    for cfg in configs:
+        if cfg.member_id in muted:
+            continue
+        # SSRF 재검증 (저장 후 DNS rebinding 방지)
+        try:
+            await validate_webhook_url_async(cfg.url)
+        except Exception:
+            logger.warning("personal webhook SSRF reject member=%s", cfg.member_id)
+            continue
+        is_discord = (
+            "discord.com/api/webhooks" in cfg.url
+            or "discordapp.com/api/webhooks" in cfg.url
+        )
+        if is_discord:
+            text = f"[{event_type}] {title}" + (f"\n{body}" if body else "")
+            payload = {"content": text}
+            secret = None  # Discord 자체 인증 방식
+        else:
+            payload = {"event": event_type, "title": title, "body": body}
+            secret = cfg.secret
+        try:
+            await _post_with_retry(cfg.url, payload, secret, str(cfg.member_id))
+        except Exception:
+            logger.warning("personal webhook POST failed (swallowed) member=%s", cfg.member_id)
+
+
 async def dispatch_notification(
     db: AsyncSession,
     *,
@@ -189,6 +260,16 @@ async def dispatch_notification(
 
         if inserted:
             await db.flush()
+
+        # 96af343e (옵션 C): 휴먼 개인 webhook 발송 — in-app Notification 과 동일 flush 타이밍
+        # best-effort. 활성 member-scoped WebhookConfig 보유 휴먼만(agent SSE 경로 무관).
+        human_member_ids = [
+            m.id for m in members
+            if m.type != "agent" and getattr(m, "user_id", None)
+        ]
+        await _deliver_personal_webhooks(
+            db, org_id, human_member_ids, title=title, body=body, event_type=event_type
+        )
 
     except Exception:
         # BUG-1 수정: 에러 삼킴 제거 → 스택 트레이스 로깅

--- a/backend/tests/test_personal_webhook_96af343e.py
+++ b/backend/tests/test_personal_webhook_96af343e.py
@@ -1,0 +1,121 @@
+"""96af343e: 휴먼 개인 webhook 발송 — _deliver_personal_webhooks.
+
+dispatch_notification 이 in-app 만 보내고 개인 WebhookConfig 로 POST 안 하던 것(2겹 근본)을
+옵션 C(flush 타이밍·best-effort)로 보강. agent SSE 경로(route_dispatch_event)는 미변경.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.notification_dispatch import _deliver_personal_webhooks
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _cfg(url="https://hooks.example.com/x", secret="s", member_id=None):
+    c = MagicMock()
+    c.member_id = member_id or uuid.uuid4()
+    c.url = url
+    c.secret = secret
+    return c
+
+
+def _scalars(values):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = values
+    return r
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_posts_for_active_config():
+    """활성 webhook 보유 휴먼 → _post_with_retry 호출 (HMAC/secret 전달)."""
+    org = uuid.uuid4()
+    cfg = _cfg(secret="sek")
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])  # configs, mute=none
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
+         patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
+        mpost.return_value = True
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body="B", event_type="story_assigned")
+    mpost.assert_awaited_once()
+    args = mpost.await_args.args
+    assert args[0] == cfg.url and args[2] == "sek"  # url, secret
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_skips_muted():
+    """global mute 멤버 → POST skip."""
+    org = uuid.uuid4()
+    cfg = _cfg()
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([cfg.member_id])])  # muted
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
+         patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+    mpost.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_discord_format_no_secret():
+    """Discord URL → {content} payload·secret None."""
+    org = uuid.uuid4()
+    cfg = _cfg(url="https://discord.com/api/webhooks/123/abc", secret="ignored")
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
+         patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="Hi", body="x", event_type="e")
+    payload, secret = mpost.await_args.args[1], mpost.await_args.args[2]
+    assert "content" in payload and secret is None
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_ssrf_reject_skips():
+    """SSRF 검증 실패 URL → POST skip (다른 건 영향 없음)."""
+    org = uuid.uuid4()
+    cfg = _cfg(url="http://169.254.169.254/x")
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost, \
+         patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock, side_effect=ValueError("blocked")):
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+    mpost.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_no_config_noop():
+    """활성 webhook 없음 → mute 조회조차 안 하고 즉시 return."""
+    org = uuid.uuid4()
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([])])  # no configs
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock) as mpost:
+        await _deliver_personal_webhooks(db, org, [uuid.uuid4()], title="T", body=None, event_type="e")
+    mpost.assert_not_awaited()
+    assert db.execute.await_count == 1  # configs 조회만
+
+
+@pytest.mark.anyio
+async def test_personal_webhook_post_failure_swallowed():
+    """_post_with_retry 예외 → swallow (호출자 무영향)."""
+    org = uuid.uuid4()
+    cfg = _cfg()
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_scalars([cfg]), _scalars([])])
+    with patch("app.services.dispatch_router._post_with_retry", new_callable=AsyncMock, side_effect=RuntimeError("boom")), \
+         patch("app.core.ssrf.validate_webhook_url_async", new_callable=AsyncMock):
+        # 예외 전파 없이 정상 반환해야 함
+        await _deliver_personal_webhooks(db, org, [cfg.member_id], title="T", body=None, event_type="e")
+
+
+@pytest.mark.anyio
+async def test_empty_member_ids_noop():
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    await _deliver_personal_webhooks(db, uuid.uuid4(), [], title="T", body=None, event_type="e")
+    db.execute.assert_not_awaited()


### PR DESCRIPTION
## 증상
Settings>Profile>Notification Channel 에 webhook(Slack/Discord/Google Chat) URL 저장해도 알림이 webhook 으로 안 옴 — Inbox(in-app)만 옴.

## 근본 (2겹·휴먼 개인 webhook 발송 경로 완전 부재)
1. `dispatch_notification` 휴먼 분기가 in-app Notification + Event INSERT 만 하고 **개인 member-scoped WebhookConfig 로 POST 를 안 함**(`webhook_member_ids` 는 agent 의 in-app skip 판정에만 사용).
2. `route_dispatch_event` 의 webhook 게이트가 `channel=="sse"`(agent 전용) → 휴먼(`in_app`)은 호출돼도 미발송. + 휴먼 Event 는 `status="delivered"` 라 라우팅서도 제외.

## 수정 (옵션 C·PO/까심 승인·additive·마이그0·gcloud 무관)
`dispatch_notification` 에 `_deliver_personal_webhooks` 추가 — 활성 member-scoped WebhookConfig 보유 **휴먼**에게 webhook POST:
- **타이밍:** in-app Notification 과 동일 **flush 타이밍**·best-effort(개별 실패 swallow → in-app 무영향).
- **mute(CP②):** global mute 멤버 skip(채널 막론 mute 우선).
- **보안/포맷:** SSRF 재검증(`validate_webhook_url_async`)·HMAC 서명·Discord URL 포맷 분기·retry → `dispatch_router._post_with_retry` / `app.core.ssrf` 재사용.
- **agent 무회귀(CP):** `route_dispatch_event` L122 SSE 게이트 **미변경** — 휴먼 전용 additive 경로.

**after_commit 훅 검토(오르테가 요청):** sync 세션 이벤트서 async POST = event-loop 스케줄링/task 수명 리스크라 **non-trivial** → 옵션 C 채택(in-app 과 durability parity·자기완결). `in-app skip`(webhook 시 in-app 생략)은 NotificationPreference 정비와 함께 **별도 PR**(스코프 분리).

## 테스트
발송(HMAC/secret 전달)·mute skip·Discord 포맷(content/secret None)·SSRF reject skip·config 없음 noop(mute 조회 안 함)·**POST 실패 swallow**·빈 입력 noop. 기존 dispatch 무회귀. 로컬 14 PASS.

라이브 webhook 수신 verify 는 gcloud 복구 배치(179db213+0100·48de882a markRead·7f8066a3 dispatch·96af343e webhook 일괄).

🤖 Generated with [Claude Code](https://claude.com/claude-code)