### PR TITLE
[SID:7f8066a3] fix(dispatch): 실패 사유 구분 + 비-비즈니스 카피 교체

### DIFF
--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -81,12 +81,20 @@ export function EntityDispatchPanel({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ entity_type: entityType, entity_id: entityId, project_id: projectId }),
       });
-      if (!dispatchRes.ok) throw new Error('dispatch failed');
-      const dispatchData = await dispatchRes.json() as { dispatched?: boolean };
-      if (!dispatchData.dispatched) throw new Error('dispatch not executed — assignee missing');
-      addToast({ type: 'success', title: 'Dispatch 완료' });
+      // 7f8066a3: 실패 사유 구분(reason 매트릭스) — 서버 오류 vs 담당자 미지정을 분리 안내한다.
+      if (!dispatchRes.ok) {
+        addToast({ type: 'error', title: '전달에 실패했습니다', body: '전달 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요.' });
+        return;
+      }
+      const dispatchData = await dispatchRes.json().catch(() => ({})) as { dispatched?: boolean };
+      if (!dispatchData.dispatched) {
+        // 담당자가 지정되지 않아 전달 대상이 없는 경우 — 오류가 아니라 안내로 처리한다.
+        addToast({ type: 'error', title: '담당자가 지정되지 않았습니다', body: '담당자를 지정한 뒤 다시 전달해 주세요.' });
+        return;
+      }
+      addToast({ type: 'success', title: '전달했습니다' });
     } catch {
-      addToast({ type: 'error', title: 'Dispatch 실패. 다시 시도하겠는.' });
+      addToast({ type: 'error', title: '전달에 실패했습니다', body: '일시적인 문제로 전달하지 못했습니다. 잠시 후 다시 시도해 주세요.' });
     } finally {
       setDispatching(false);
     }

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -88,8 +88,8 @@ export function EntityDispatchPanel({
       }
       const dispatchData = await dispatchRes.json().catch(() => ({})) as { dispatched?: boolean };
       if (!dispatchData.dispatched) {
-        // 담당자가 지정되지 않아 전달 대상이 없는 경우 — 오류가 아니라 안내로 처리한다.
-        addToast({ type: 'error', title: '담당자가 지정되지 않았습니다', body: '담당자를 지정한 뒤 다시 전달해 주세요.' });
+        // 담당자가 지정되지 않아 전달 대상이 없는 경우 — 오류가 아니라 안내(info)로 처리한다.
+        addToast({ type: 'info', title: '담당자가 지정되지 않았습니다', body: '담당자를 지정한 뒤 다시 전달해 주세요.' });
         return;
       }
       addToast({ type: 'success', title: '전달했습니다' });


### PR DESCRIPTION
## 요약
`EntityDispatchPanel`(docs/epics dispatch) 전달 실패 시 **모든 경우를 "Dispatch 실패. 다시 시도하겠는." 단일 토스트**로 처리하던 것을 **사유별 reason 매트릭스**로 분리하고, **agent-tone/비-비즈니스 카피를 비즈니스 톤으로 교체**.

## 변경 (FE·1파일·1컴포넌트)
`apps/web/src/components/dispatch/entity-dispatch-panel.tsx` `handleDispatch`:
| 사유 | 기존 | 변경(비즈니스 톤) |
|------|------|------|
| 서버 오류(dispatchRes !ok) | "Dispatch 실패. 다시 시도하겠는." | "전달에 실패했습니다 / 전달 중 문제가 발생했습니다. 잠시 후 다시 시도해 주세요." |
| 담당자 미지정(dispatched=false) | 동일 토스트(오류) | "담당자가 지정되지 않았습니다 / 담당자를 지정한 뒤 다시 전달해 주세요." (오류 아닌 안내) |
| 네트워크/예외 | "Dispatch 실패. 다시 시도하겠는." | "전달에 실패했습니다 / 일시적인 문제로 전달하지 못했습니다…" |
| 성공 | "Dispatch 완료" | "전달했습니다" |

## 규율 정합
- **agent-tone 제거**: "…다시 시도하겠는."(~하겠는) → ~습니다/~세요 비즈니스 톤([[feedback-ui-text-agent-tone]]).
- 잔여 스캔: dispatch 영역 "Dispatch 실패"·"다시 시도하겠는" 0건.

## 범위/의존
- **FE 사유 매트릭스 + 카피**만(이 PR). BE 멤버 룩업(grant-only/polymorphic assignee → `dispatched:false` 오탐 해소·case b)은 `dispatch.py`(디디·`resolve_member_identity`)에서 별도 — 이미 develop 반영분.
- 버튼 라벨 "Dispatch" i18n/구분은 **f5ae74e4(crit·다음 스토리)** 스코프라 미터치(1스토리 1PR).

## 검증
- `pnpm exec eslint` 0 · `tsc --noEmit` 0 · `pnpm build`(webpack) 성공. 격리 worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)