### PR TITLE
[SID:774b745a] fix(standup): 보드카드 전체표시 + 매직색 토큰화

### DIFF
--- a/apps/web/src/components/standup/standup-board-card.tsx
+++ b/apps/web/src/components/standup/standup-board-card.tsx
@@ -60,21 +60,21 @@ export function StandupBoardCard({
         {entry ? (
           <>
             <div className="space-y-1">
-              <div className="text-xs font-semibold uppercase tracking-wider text-emerald-400">{t('doneLabel')}</div>
-              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.done ? 'text-foreground/90' : 'text-muted-foreground')}>
+              <div className="text-xs font-semibold uppercase tracking-wider text-success">{t('doneLabel')}</div>
+              <p className={cn('whitespace-pre-wrap text-sm', entry.done ? 'text-foreground/90' : 'text-muted-foreground')}>
                 {entry.done || t('emptySection')}
               </p>
             </div>
             <div className="space-y-1">
-              <div className="text-xs font-semibold uppercase tracking-wider text-[color:var(--brand-soft)]">{t('planLabel')}</div>
-              <p className={cn('whitespace-pre-wrap text-sm line-clamp-3', entry.plan ? 'text-foreground/90' : 'text-muted-foreground')}>
+              <div className="text-xs font-semibold uppercase tracking-wider text-brand">{t('planLabel')}</div>
+              <p className={cn('whitespace-pre-wrap text-sm', entry.plan ? 'text-foreground/90' : 'text-muted-foreground')}>
                 {entry.plan || t('emptySection')}
               </p>
             </div>
             {entry.blockers ? (
               <div className="space-y-1">
-                <div className="text-xs font-semibold uppercase tracking-wider text-rose-300">{t('blockersLabel')}</div>
-                <p className="whitespace-pre-wrap text-sm text-foreground/90 line-clamp-3">
+                <div className="text-xs font-semibold uppercase tracking-wider text-destructive">{t('blockersLabel')}</div>
+                <p className="whitespace-pre-wrap text-sm text-foreground/90">
                   {entry.blockers}
                 </p>
               </div>


### PR DESCRIPTION
## 요약
스탠드업 보드카드의 Done/Plan/Blockers 내용이 `line-clamp-3`로 3줄 넘으면 잘려 긴 PLAN 등이 안 보이던 문제 해소 + 매직/arbitrary 라벨색 토큰화. 유나양 채팅 명세.

## 변경 (`standup-board-card.tsx`)
- **line-clamp-3 제거**(Done/Plan/Blockers 3개 내용 `<p>`) — 전체 표시·`whitespace-pre-wrap` 유지(줄바꿈 보존). 스탠드업=읽기·피드백 surface라 정보 우선.
- **매직색 토큰화**: `text-emerald-400`→`text-success` · `text-[color:var(--brand-soft)]`→`text-brand` · `text-rose-300`→`text-destructive`. 매직 hex 0.

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build`(webpack) 성공 · 잔여 매직색/clamp 0. 격리 worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)