### PR TITLE
[SID:8a2bbda2] fix(sprints): 기간 표시 날짜 범위 계산 (duration 우회)

### DIFF
--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -11,6 +11,15 @@ import { OutcomeIntentFields, type OutcomeIntentValue, type MetricDefinition } f
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import type { OutcomeStatus } from '@/components/outcome/outcome-status-badge';
 
+// 8a2bbda2: 기간 표시는 start_date~end_date(진실)에서 계산한다. BE `duration` 필드(예 14)가
+// 날짜 범위와 불일치하는 케이스가 있어 신뢰하지 않고, inclusive 일수(end−start+1)를 직접 산출한다.
+function sprintDurationDays(startDate: string, endDate: string): number {
+  const start = Date.parse(startDate);
+  const end = Date.parse(endDate);
+  if (Number.isNaN(start) || Number.isNaN(end)) return 0;
+  return Math.max(0, Math.round((end - start) / 86_400_000) + 1);
+}
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface Sprint {
@@ -452,7 +461,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
                   </div>
                 </div>
               <p className="mt-1 text-xs text-muted-foreground">
-                {sprint.start_date} ~ {sprint.end_date} · {sprint.duration}{t('days')}
+                {sprint.start_date} ~ {sprint.end_date} · {sprintDurationDays(sprint.start_date, sprint.end_date)}{t('days')}
               </p>
               {sprint.report_doc_id ? (
                 <a
@@ -508,7 +517,7 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
           ) : null}
           <span className="flex items-center gap-1 rounded-md border border-border bg-muted/30 px-2.5 py-1 text-xs font-medium tabular-nums text-foreground">
             <span className="text-muted-foreground">📅</span>
-            {selected.duration}{t('days')}
+            {sprintDurationDays(selected.start_date, selected.end_date)}{t('days')}
           </span>
         </div>
       ) : null}


### PR DESCRIPTION
## 요약
Sprints 리스트(:455)·상세(:511)가 BE `duration` 값(예 14)을 그대로 표시했으나 날짜 범위(`start_date~end_date`·예 2026-06-01~06-05=**5일**)와 불일치. **날짜 범위가 진실**이므로 inclusive 일수(end−start+1)를 직접 계산해 표시. 유나양 채팅 명세.

## 변경 (`sprints-client.tsx`)
- 헬퍼 `sprintDurationDays(start, end)` 1개(inclusive·`Date.parse` 안전 가드) → 리스트·상세 두 곳 공통.
- `sprint.duration` 표시 우회(필드는 타입 유지·표시만 계산값).

## 범위
- BE `duration=14` 값 자체가 왜 틀린지(default 2주 sprint 등)는 **BE lane(디디·gap-as-story 회수)**. FE는 날짜 계산으로 robust 표시.

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build`(webpack) 성공. 격리 worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)