### PR TITLE
fix(sprint): duration 을 날짜에서 산출 (BE) — 기간 14d 오표기 해소 (8a2bbda2)

### DIFF
--- a/backend/app/repositories/analytics.py
+++ b/backend/app/repositories/analytics.py
@@ -283,7 +283,9 @@ class AnalyticsRepository:
         done_pts = sum((r[0] or 0) for r in stories if r[1] == "done")
         remaining = total_pts - done_pts
 
-        duration = sprint.duration or 14
+        # 8a2bbda2: stored duration(default 14·날짜 무관) 대신 날짜에서 산출(dates 단일진실)
+        from app.schemas.sprint import compute_sprint_duration
+        duration = compute_sprint_duration(sprint.start_date, sprint.end_date, sprint.duration) or 14
         start_date = sprint.start_date
 
         ideal_line = []
@@ -306,7 +308,8 @@ class AnalyticsRepository:
             "sprint": {
                 "id": sprint.id, "title": sprint.title, "status": sprint.status,
                 "start_date": sprint.start_date, "end_date": sprint.end_date,
-                "duration": sprint.duration, "velocity": sprint.velocity,
+                "duration": compute_sprint_duration(sprint.start_date, sprint.end_date, sprint.duration),
+                "velocity": sprint.velocity,
             },
             "total_points": total_pts,
             "done_points": done_pts,

--- a/backend/app/routers/sprints.py
+++ b/backend/app/routers/sprints.py
@@ -10,7 +10,7 @@ from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.sprint import SprintRepository
-from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate
+from app.schemas.sprint import KickoffBody, SprintCreate, SprintResponse, SprintUpdate, compute_sprint_duration
 from app.services.notification_dispatch import dispatch_notification
 
 router = APIRouter(prefix="/api/v2/sprints", tags=["sprints"])
@@ -46,6 +46,8 @@ async def create_sprint(
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> SprintResponse:
     repo = SprintRepository(session, org_id)
+    # 8a2bbda2: 날짜에서 duration 산출 저장(dates 단일진실·신규 정합). 날짜 없으면 model default(14).
+    _dur = compute_sprint_duration(body.start_date, body.end_date)
     sprint = await repo.create(
         project_id=body.project_id,
         title=body.title,
@@ -57,6 +59,7 @@ async def create_sprint(
         success_hypothesis=body.success_hypothesis,
         metric_definition=body.metric_definition,
         measure_after=body.measure_after,
+        **({"duration": _dur} if _dur is not None else {}),
     )
     return SprintResponse.model_validate(sprint)
 
@@ -79,6 +82,15 @@ async def update_sprint(
     repo: SprintRepository = Depends(_get_repo),
 ) -> SprintResponse:
     data = body.model_dump(exclude_unset=True)
+    # 8a2bbda2: 날짜가 갱신되면 duration 을 (병합된) 날짜에서 재산출 저장(dates 단일진실).
+    if "start_date" in data or "end_date" in data:
+        existing = await repo.get(id)
+        if existing is not None:
+            eff_start = data.get("start_date", existing.start_date)
+            eff_end = data.get("end_date", existing.end_date)
+            _dur = compute_sprint_duration(eff_start, eff_end)
+            if _dur is not None:
+                data["duration"] = _dur
     sprint = await repo.update(id, **data)
     if sprint is None:
         raise HTTPException(status_code=404, detail="Sprint not found")

--- a/backend/app/schemas/sprint.py
+++ b/backend/app/schemas/sprint.py
@@ -2,8 +2,24 @@ import uuid
 from datetime import date, datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 from app.schemas.story import _validate_metric_definition
+
+
+def compute_sprint_duration(
+    start_date: date | None,
+    end_date: date | None,
+    fallback: int | None = None,
+) -> int | None:
+    """8a2bbda2: 스프린트 기간(일)은 start_date/end_date 가 단일진실.
+
+    `(end_date - start_date).days + 1`(inclusive — 6/1~6/5 = 5d·기본 14d = 6/1~6/14 와 정합).
+    양 날짜가 모두 있고 end >= start 일 때만 산출, 아니면 fallback(stored duration). stored
+    `duration` 컬럼은 날짜와 무관(default 14)하게 오염될 수 있어 display/analytics 는 이 계산을 쓴다.
+    """
+    if start_date is not None and end_date is not None and end_date >= start_date:
+        return (end_date - start_date).days + 1
+    return fallback
 
 
 class SprintBase(BaseModel):
@@ -69,6 +85,17 @@ class SprintResponse(SprintBase):
     outcome_result: dict[str, Any] | None = None
     created_at: datetime
     updated_at: datetime
+
+    @model_validator(mode="after")
+    def _derive_duration_from_dates(self) -> "SprintResponse":
+        """8a2bbda2: 날짜가 있으면 duration 을 날짜에서 파생(stored 14 오염 무시).
+
+        기존 스프린트(stored=14)도 API 응답이 날짜 기준 정합값을 반환 → 백필 불요.
+        """
+        derived = compute_sprint_duration(self.start_date, self.end_date, self.duration)
+        if derived is not None:
+            self.duration = derived
+        return self
 
 
 class KickoffBody(BaseModel):

--- a/backend/tests/test_sprint_duration_8a2bbda2.py
+++ b/backend/tests/test_sprint_duration_8a2bbda2.py
@@ -1,0 +1,52 @@
+"""8a2bbda2: Sprint duration 을 start/end 날짜에서 산출(stored 14 오염 무시).
+
+6/1~6/5 → 5d (이전 14d 오표기). dates 단일진실 — SprintResponse·analytics·create/update 일치.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timezone
+
+from app.schemas.sprint import SprintResponse, compute_sprint_duration
+
+
+def test_compute_duration_inclusive():
+    assert compute_sprint_duration(date(2026, 6, 1), date(2026, 6, 5)) == 5   # 6/1~6/5 = 5d
+    assert compute_sprint_duration(date(2026, 6, 1), date(2026, 6, 14)) == 14  # 기본 2주와 정합
+    assert compute_sprint_duration(date(2026, 6, 1), date(2026, 6, 1)) == 1    # 당일
+
+
+def test_compute_duration_fallback_when_dates_missing():
+    assert compute_sprint_duration(None, date(2026, 6, 5), fallback=14) == 14
+    assert compute_sprint_duration(date(2026, 6, 1), None, fallback=14) == 14
+    assert compute_sprint_duration(None, None, fallback=7) == 7
+    assert compute_sprint_duration(None, None) is None
+
+
+def test_compute_duration_end_before_start_fallback():
+    # end < start → 음수 방지·fallback
+    assert compute_sprint_duration(date(2026, 6, 5), date(2026, 6, 1), fallback=14) == 14
+
+
+def _resp_payload(**over):
+    base = dict(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(),
+        title="S", status="active", duration=14,
+        start_date=date(2026, 6, 1), end_date=date(2026, 6, 5),
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+    base.update(over)
+    return base
+
+
+def test_sprint_response_derives_duration_from_dates():
+    """stored duration=14 라도 날짜(6/1~6/5)면 응답 duration=5 (기존 sprint 백필 불요)."""
+    r = SprintResponse.model_validate(_resp_payload())
+    assert r.duration == 5
+
+
+def test_sprint_response_uses_stored_when_no_dates():
+    """날짜 없으면 stored duration 유지(파생 불가)."""
+    r = SprintResponse.model_validate(_resp_payload(start_date=None, end_date=None, duration=10))
+    assert r.duration == 10


### PR DESCRIPTION
## 배경 (8a2bbda2 BE — 미르코 FE #1284 의 BE 보완)
Sprints 에서 6/1~6/5(5일) 스프린트가 "14d"로 표기. FE 표시는 #1284(`sprintDurationDays`·미르코)가 날짜 계산으로 해소. 이 PR 은 **BE 측 analytics + create/update + API 응답** 정합(dates 단일진실).

## 근본
`Sprint.duration`(stored·default 14)이 start/end 와 무관. `create_sprint` 가 날짜에서 산출 안 함 → stored 14 그대로 → display + **analytics(burndown ideal-line·sprint summary)** 가 stored 14 를 읽어 오염.

## 수정 (dates 단일진실·마이그0·백필 불요·PO 승인)
- `compute_sprint_duration(start, end, fallback)` = `(end - start).days + 1` (inclusive·6/1~6/5 = **5d**·기본 14d = 6/1~6/14 정합). 양 날짜 있고 end>=start 일 때만 산출.
- **SprintResponse**: `model_validator(after)` 로 날짜에서 duration 파생 → **기존 스프린트(stored=14)도 API 응답 정합값**(백필 불요).
- **analytics.py**: burndown duration + sprint summary 를 stored 대신 날짜 산출로 교체.
- **create/update_sprint**: 날짜에서 duration 산출 저장(update 는 병합 날짜로 재산출).
- stored `duration` 은 vestigial fallback(날짜 없을 때만).

## 테스트
compute(inclusive 6/1~6/5=5·6/1~6/14=14·당일=1 / fallback / end<start) · SprintResponse 파생(stored14+날짜→5) · 날짜없음 stored 유지. 기존 sprints 무회귀. 로컬 47 PASS. 마이그0·gcloud 무관.

라이브 verify(생성→duration 정합 응답) 는 머지+배포 후. (FE 표시는 #1284.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)