### PR TITLE
feat(security): 첨부 인가 엔드포인트 — public 버킷 → auth-gated 서빙 (a54ddc16 BE)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -30,7 +30,7 @@ async def lifespan(app: FastAPI):
             pass
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, invitations, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -134,6 +134,7 @@ app.include_router(retros.router)
 app.include_router(entities.router)
 app.include_router(event_notifications.router)
 app.include_router(notifications.router)
+app.include_router(attachments.router)
 app.include_router(notification_preferences.router)
 app.include_router(analytics.router)
 app.include_router(invitations.router)

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -1,0 +1,83 @@
+"""a54ddc16: 첨부 인가 엔드포인트 — 서명URL 발급 전 SSOT 권한 게이트.
+
+버킷 public(allUsers) 제거 후, Next 서명 라우트(/api/attachments/sign)가 V4 signed URL 발급
+**전에** 이 엔드포인트로 요청자 권한을 확인한다. message 첨부 → conversation 참가자, story 첨부
+→ has_project_access. + path 가 그 리소스 소속인지 검증(cross-resource path 추측 차단).
+team_member 봐주기 없음(resolve_member·has_project_access SSOT 재사용).
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.models.conversation import ConversationParticipant
+from app.models.pm import Story
+from app.services.member_resolver import resolve_member
+from app.services.project_auth import has_project_access
+
+router = APIRouter(prefix="/api/v2/attachments", tags=["attachments"])
+
+
+@router.get("/authorize")
+async def authorize_attachment(
+    path: str = Query(..., description="GCS object path (또는 stored attachment url 의 path 부분)"),
+    conversation_id: uuid.UUID | None = Query(default=None),
+    story_id: uuid.UUID | None = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """GET /api/v2/attachments/authorize — 첨부 접근 인가(200) / 거부(403).
+
+    정확히 하나의 리소스(conversation_id XOR story_id)를 받아 ① 요청자의 그 리소스 접근권과
+    ② path 가 그 리소스의 첨부인지를 검증한다.
+    """
+    if (conversation_id is None) == (story_id is None):
+        raise HTTPException(status_code=400, detail="exactly one of conversation_id or story_id required")
+    if not path:
+        raise HTTPException(status_code=400, detail="path required")
+
+    if conversation_id is not None:
+        # message 첨부 → conversation 참가자(canonical member). team_member 봐주기 없음.
+        member = await resolve_member(auth, org_id, db, project_id=None)
+        is_participant = (await db.execute(
+            select(ConversationParticipant.id).where(
+                ConversationParticipant.conversation_id == conversation_id,
+                ConversationParticipant.member_id == member.id,
+            )
+        )).scalar_one_or_none()
+        if is_participant is None:
+            raise HTTPException(status_code=403, detail="Not a participant of this conversation")
+        # path 가 이 conversation 의 메시지 첨부에 실제 존재하는지(추측 차단)
+        belongs = (await db.execute(
+            text(
+                "SELECT EXISTS ("
+                " SELECT 1 FROM conversation_messages m,"
+                " jsonb_array_elements(coalesce(m.attachments, '[]'::jsonb)) att"
+                " WHERE m.conversation_id = :cid AND strpos(att->>'url', :path) > 0)"
+            ),
+            {"cid": conversation_id, "path": path},
+        )).scalar()
+        if not belongs:
+            raise HTTPException(status_code=403, detail="Attachment does not belong to this conversation")
+    else:
+        row = (await db.execute(
+            select(Story.project_id, Story.attachments).where(
+                Story.id == story_id,
+                Story.org_id == org_id,
+                Story.deleted_at.is_(None),
+            )
+        )).first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="Story not found")
+        project_id, attachments = row
+        if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
+            raise HTTPException(status_code=403, detail="No access to this project")
+        belongs = any(path in (a.get("url") or "") for a in (attachments or []))
+        if not belongs:
+            raise HTTPException(status_code=403, detail="Attachment does not belong to this story")
+
+    return {"authorized": True}

--- a/backend/app/routers/attachments.py
+++ b/backend/app/routers/attachments.py
@@ -2,9 +2,16 @@
 
 버킷 public(allUsers) 제거 후, Next 서명 라우트(/api/attachments/sign)가 V4 signed URL 발급
 **전에** 이 엔드포인트로 요청자 권한을 확인한다. message 첨부 → conversation 참가자, story 첨부
-→ has_project_access. + path 가 그 리소스 소속인지 검증(cross-resource path 추측 차단).
-team_member 봐주기 없음(resolve_member·has_project_access SSOT 재사용).
+→ has_project_access. team_member 봐주기 없음(resolve_member·has_project_access SSOT 재사용).
+
+보안(까심 P1): path 소속 검증은 **substring 금지·정확 매치**.
+- ① 구조적 스코프: 업로드 경로가 `chat/<proj>/<conv_id>/<file>` / `story/<proj>/<story_id>/<file>`
+  로 resource 에 스코프되므로, 요청 path 의 segment 에 해당 resource id 가 있어야 한다
+  (metadata 에 임의 URL 을 심어도 victim path 는 victim 의 id 를 가지므로 차단).
+- ② stored 첨부와 **canonical object path 정확 일치**(우리 버킷 prefix 만 인정·== 비교).
+요청 path 는 bare object path(스킴 없음)여야 한다. ⚠️ Next sign 라우트도 동일 추출 규칙을 쓸 것.
 """
+import os
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -20,10 +27,28 @@ from app.services.project_auth import has_project_access
 
 router = APIRouter(prefix="/api/v2/attachments", tags=["attachments"])
 
+_BUCKET = os.environ.get("GCS_MEMO_ATTACHMENTS_BUCKET", "sprintable-memo-attachments")
+_PUBLIC_PREFIX = f"https://storage.googleapis.com/{_BUCKET}/"
+
+
+def _canonical_object_path(stored_url: str) -> str | None:
+    """stored attachment url → canonical GCS object path. 우리 버킷 외/비정상이면 None.
+
+    신규 = bare object path 그대로. legacy = `https://storage.googleapis.com/{bucket}/{path}`.
+    다른 도메인/스킴 URL 은 None(유효 객체 아님) → 임의-URL 삽입 차단.
+    """
+    if not stored_url:
+        return None
+    if stored_url.startswith(_PUBLIC_PREFIX):
+        return stored_url[len(_PUBLIC_PREFIX):]
+    if "://" in stored_url:
+        return None  # 외부 도메인 등 → 우리 객체 아님
+    return stored_url  # 이미 bare object path
+
 
 @router.get("/authorize")
 async def authorize_attachment(
-    path: str = Query(..., description="GCS object path (또는 stored attachment url 의 path 부분)"),
+    path: str = Query(..., description="GCS object path (bare·스킴 없음)"),
     conversation_id: uuid.UUID | None = Query(default=None),
     story_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
@@ -32,16 +57,21 @@ async def authorize_attachment(
 ) -> dict:
     """GET /api/v2/attachments/authorize — 첨부 접근 인가(200) / 거부(403).
 
-    정확히 하나의 리소스(conversation_id XOR story_id)를 받아 ① 요청자의 그 리소스 접근권과
-    ② path 가 그 리소스의 첨부인지를 검증한다.
+    정확히 하나의 리소스(conversation_id XOR story_id)·요청자 접근권·path 소속(구조+정확매치).
     """
     if (conversation_id is None) == (story_id is None):
         raise HTTPException(status_code=400, detail="exactly one of conversation_id or story_id required")
-    if not path:
-        raise HTTPException(status_code=400, detail="path required")
+    if not path or "://" in path:
+        raise HTTPException(status_code=400, detail="path must be a bare object path")
+
+    segments = path.split("/")
+    legacy_url = _PUBLIC_PREFIX + path  # legacy stored 형태
 
     if conversation_id is not None:
-        # message 첨부 → conversation 참가자(canonical member). team_member 봐주기 없음.
+        # ① 구조적 스코프: chat/<proj>/<conv_id>/<file> — conv id 가 path segment 여야
+        if not (path.startswith("chat/") and str(conversation_id) in segments):
+            raise HTTPException(status_code=403, detail="Attachment path not scoped to this conversation")
+        # 권한: conversation 참가자(canonical member). team_member 봐주기 없음.
         member = await resolve_member(auth, org_id, db, project_id=None)
         is_participant = (await db.execute(
             select(ConversationParticipant.id).where(
@@ -51,19 +81,22 @@ async def authorize_attachment(
         )).scalar_one_or_none()
         if is_participant is None:
             raise HTTPException(status_code=403, detail="Not a participant of this conversation")
-        # path 가 이 conversation 의 메시지 첨부에 실제 존재하는지(추측 차단)
+        # ② 정확 매치: stored url == bare path(신규) OR == legacy 전체 URL. substring 금지.
         belongs = (await db.execute(
             text(
                 "SELECT EXISTS ("
                 " SELECT 1 FROM conversation_messages m,"
                 " jsonb_array_elements(coalesce(m.attachments, '[]'::jsonb)) att"
-                " WHERE m.conversation_id = :cid AND strpos(att->>'url', :path) > 0)"
+                " WHERE m.conversation_id = :cid AND att->>'url' IN (:path, :legacy))"
             ),
-            {"cid": conversation_id, "path": path},
+            {"cid": conversation_id, "path": path, "legacy": legacy_url},
         )).scalar()
         if not belongs:
             raise HTTPException(status_code=403, detail="Attachment does not belong to this conversation")
     else:
+        # ① 구조적 스코프: story/<proj>/<story_id>/<file>
+        if not (path.startswith("story/") and str(story_id) in segments):
+            raise HTTPException(status_code=403, detail="Attachment path not scoped to this story")
         row = (await db.execute(
             select(Story.project_id, Story.attachments).where(
                 Story.id == story_id,
@@ -76,7 +109,11 @@ async def authorize_attachment(
         project_id, attachments = row
         if not await has_project_access(db, uuid.UUID(auth.user_id), project_id, org_id):
             raise HTTPException(status_code=403, detail="No access to this project")
-        belongs = any(path in (a.get("url") or "") for a in (attachments or []))
+        # ② 정확 매치: canonical object path == 요청 path
+        belongs = any(
+            _canonical_object_path(a.get("url") or "") == path
+            for a in (attachments or [])
+        )
         if not belongs:
             raise HTTPException(status_code=403, detail="Attachment does not belong to this story")
 

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -1,0 +1,172 @@
+"""a54ddc16: GET /api/v2/attachments/authorize — 첨부 서명 전 SSOT 인가 게이트.
+
+message→ConversationParticipant·story→has_project_access·path 소속 검증·team_member 봐주기 0.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+ORG_ID = uuid.uuid4()
+CONV_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+MEMBER_ID = uuid.uuid4()
+PATH = "chat/2026/06/obj-abc.png"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client(session):
+    from app.main import app
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    async def _db():
+        yield session
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return ORG_ID
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    from httpx import ASGITransport, AsyncClient
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+def _scalar(v):
+    r = MagicMock(); r.scalar_one_or_none.return_value = v; r.scalar.return_value = v
+    return r
+
+
+def _member():
+    m = MagicMock(); m.id = MEMBER_ID; return m
+
+
+@pytest.mark.anyio
+async def test_authorize_400_both_resources():
+    session = AsyncMock()
+    client, app = await _client(session)
+    try:
+        async with client as c:
+            r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}&story_id={STORY_ID}")
+        assert r.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_400_neither_resource():
+    session = AsyncMock()
+    client, app = await _client(session)
+    try:
+        async with client as c:
+            r = await c.get(f"/api/v2/attachments/authorize?path={PATH}")
+        assert r.status_code == 400
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_participant_and_belongs_200():
+    session = AsyncMock()
+    # execute: participant select(scalar_one_or_none=id) → belongs(scalar=True)
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 200
+        assert r.json()["authorized"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_not_participant_403():
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(None)])  # 참가자 아님
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_path_not_belongs_403():
+    session = AsyncMock()
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(False)])  # 참가자지만 path 미소속
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+def _story_row(attachments):
+    r = MagicMock()
+    r.first.return_value = (PROJECT_ID, attachments)
+    return r
+
+
+@pytest.mark.anyio
+async def test_authorize_story_access_and_belongs_200():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_story_row([{"url": f"https://x/{PATH}"}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_story_no_access_403():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_story_row([{"url": f"https://x/{PATH}"}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=False):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_story_path_not_belongs_403():
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_story_row([{"url": "https://x/other-obj.png"}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
+            async with client as c:
+                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
+        assert r.status_code == 403
+    finally:
+        app.dependency_overrides.clear()

--- a/backend/tests/test_attachment_authorize_a54ddc16.py
+++ b/backend/tests/test_attachment_authorize_a54ddc16.py
@@ -1,6 +1,7 @@
 """a54ddc16: GET /api/v2/attachments/authorize — 첨부 서명 전 SSOT 인가 게이트.
 
-message→ConversationParticipant·story→has_project_access·path 소속 검증·team_member 봐주기 0.
+message→ConversationParticipant·story→has_project_access·team_member 봐주기 0.
+path 소속 = ① 구조적 스코프(resource id in path) ② canonical object-path 정확 매치(substring 금지·P1).
 """
 from __future__ import annotations
 
@@ -14,7 +15,9 @@ CONV_ID = uuid.uuid4()
 STORY_ID = uuid.uuid4()
 PROJECT_ID = uuid.uuid4()
 MEMBER_ID = uuid.uuid4()
-PATH = "chat/2026/06/obj-abc.png"
+# 업로드 경로 구조: chat/<proj>/<conv>/<file> · story/<proj>/<story>/<file>
+CONV_PATH = f"chat/{PROJECT_ID}/{CONV_ID}/u1-abc.png"
+STORY_PATH = f"story/{PROJECT_ID}/{STORY_ID}/u1-abc.png"
 
 
 @pytest.fixture
@@ -56,25 +59,33 @@ def _member():
     m = MagicMock(); m.id = MEMBER_ID; return m
 
 
+def _story_row(attachments):
+    r = MagicMock()
+    r.first.return_value = (PROJECT_ID, attachments)
+    return r
+
+
+async def _get(client, qs):
+    async with client as c:
+        return await c.get(f"/api/v2/attachments/authorize?{qs}")
+
+
 @pytest.mark.anyio
 async def test_authorize_400_both_resources():
-    session = AsyncMock()
-    client, app = await _client(session)
+    client, app = await _client(AsyncMock())
     try:
-        async with client as c:
-            r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}&story_id={STORY_ID}")
+        r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}&story_id={STORY_ID}")
         assert r.status_code == 400
     finally:
         app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
-async def test_authorize_400_neither_resource():
-    session = AsyncMock()
-    client, app = await _client(session)
+async def test_authorize_400_path_with_scheme():
+    """요청 path 가 bare 가 아니면(스킴 포함) 400 — 임의 URL 주입 차단."""
+    client, app = await _client(AsyncMock())
     try:
-        async with client as c:
-            r = await c.get(f"/api/v2/attachments/authorize?path={PATH}")
+        r = await _get(client, f"path=https://evil/x&conversation_id={CONV_ID}")
         assert r.status_code == 400
     finally:
         app.dependency_overrides.clear()
@@ -83,15 +94,28 @@ async def test_authorize_400_neither_resource():
 @pytest.mark.anyio
 async def test_authorize_conversation_participant_and_belongs_200():
     session = AsyncMock()
-    # execute: participant select(scalar_one_or_none=id) → belongs(scalar=True)
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(True)])  # participant, belongs
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
-        assert r.status_code == 200
-        assert r.json()["authorized"] is True
+            r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
+        assert r.status_code == 200 and r.json()["authorized"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_conversation_path_not_scoped_403():
+    """구조적 스코프 위반(다른 conv id 의 path)은 권한쿼리 전에 403 — cross-resource 차단."""
+    session = AsyncMock()
+    session.execute = AsyncMock()  # 호출되면 안 됨
+    other_conv = uuid.uuid4()
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
+            r = await _get(client, f"path=chat/{PROJECT_ID}/{other_conv}/u-victim.png&conversation_id={CONV_ID}")
+        assert r.status_code == 403
+        session.execute.assert_not_awaited()  # 스코프 게이트서 차단
     finally:
         app.dependency_overrides.clear()
 
@@ -99,47 +123,69 @@ async def test_authorize_conversation_participant_and_belongs_200():
 @pytest.mark.anyio
 async def test_authorize_conversation_not_participant_403():
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(None)])  # 참가자 아님
+    session.execute = AsyncMock(side_effect=[_scalar(None)])  # 비참가
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
+            r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
         assert r.status_code == 403
     finally:
         app.dependency_overrides.clear()
 
 
 @pytest.mark.anyio
-async def test_authorize_conversation_path_not_belongs_403():
+async def test_authorize_conversation_belong_exact_miss_403():
+    """구조 스코프 통과·참가자지만 stored 와 정확 일치 안 하면 403(substring 아님)."""
     session = AsyncMock()
-    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(False)])  # 참가자지만 path 미소속
+    session.execute = AsyncMock(side_effect=[_scalar(uuid.uuid4()), _scalar(False)])
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.resolve_member", new_callable=AsyncMock, return_value=_member()):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&conversation_id={CONV_ID}")
+            r = await _get(client, f"path={CONV_PATH}&conversation_id={CONV_ID}")
         assert r.status_code == 403
     finally:
         app.dependency_overrides.clear()
-
-
-def _story_row(attachments):
-    r = MagicMock()
-    r.first.return_value = (PROJECT_ID, attachments)
-    return r
 
 
 @pytest.mark.anyio
 async def test_authorize_story_access_and_belongs_200():
     session = AsyncMock()
-    session.execute = AsyncMock(return_value=_story_row([{"url": f"https://x/{PATH}"}]))
+    session.execute = AsyncMock(return_value=_story_row([{"url": STORY_PATH}]))  # bare path 저장
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
+            r = await _get(client, f"path={STORY_PATH}&story_id={STORY_ID}")
         assert r.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_story_legacy_url_exact_match_200():
+    """legacy stored(full public URL)도 canonical 추출 후 정확 매치 → 200."""
+    session = AsyncMock()
+    legacy = f"https://storage.googleapis.com/sprintable-memo-attachments/{STORY_PATH}"
+    session.execute = AsyncMock(return_value=_story_row([{"url": legacy}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
+            r = await _get(client, f"path={STORY_PATH}&story_id={STORY_ID}")
+        assert r.status_code == 200
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_authorize_story_substring_attack_403():
+    """🔴 P1: 악성 외부 URL 에 victim path 를 substring 으로 심어도 canonical 추출서 None → 403."""
+    session = AsyncMock()
+    malicious = f"https://malicious.example.com/{STORY_PATH}"  # victim path substring
+    session.execute = AsyncMock(return_value=_story_row([{"url": malicious}]))
+    client, app = await _client(session)
+    try:
+        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
+            r = await _get(client, f"path={STORY_PATH}&story_id={STORY_ID}")
+        assert r.status_code == 403  # substring 매치 안 됨(exact + 우리 버킷 prefix만)
     finally:
         app.dependency_overrides.clear()
 
@@ -147,26 +193,11 @@ async def test_authorize_story_access_and_belongs_200():
 @pytest.mark.anyio
 async def test_authorize_story_no_access_403():
     session = AsyncMock()
-    session.execute = AsyncMock(return_value=_story_row([{"url": f"https://x/{PATH}"}]))
+    session.execute = AsyncMock(return_value=_story_row([{"url": STORY_PATH}]))
     client, app = await _client(session)
     try:
         with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=False):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
-        assert r.status_code == 403
-    finally:
-        app.dependency_overrides.clear()
-
-
-@pytest.mark.anyio
-async def test_authorize_story_path_not_belongs_403():
-    session = AsyncMock()
-    session.execute = AsyncMock(return_value=_story_row([{"url": "https://x/other-obj.png"}]))
-    client, app = await _client(session)
-    try:
-        with patch("app.routers.attachments.has_project_access", new_callable=AsyncMock, return_value=True):
-            async with client as c:
-                r = await c.get(f"/api/v2/attachments/authorize?path={PATH}&story_id={STORY_ID}")
+            r = await _get(client, f"path={STORY_PATH}&story_id={STORY_ID}")
         assert r.status_code == 403
     finally:
         app.dependency_overrides.clear()


### PR DESCRIPTION
## 🔴 보안 이슈
버킷 `sprintable-memo-attachments` IAM = `allUsers:roles/storage.objectViewer`(전체 공개 읽기). `uploadToGcs` → 직접 public URL 저장 → FE 직접 렌더. **URL 만 알면 누구나(비로그인 포함) 첨부 접근·권한 체크 0.** GA 전 차단(high).

## PO 설계 (A·서명URL·서명=Next·인가=BE SSOT)
BE(FastAPI)엔 GCS 클라이언트 없음(서명 불가)·Next 앱은 서명 creds 보유 → **서명은 Next, 인가는 BE**. 이 PR = **BE 인가 엔드포인트.**

## 엔드포인트
`GET /api/v2/attachments/authorize?path=&conversation_id=|story_id=` → `200 {authorized:true}` / `403`
- **message 첨부** → conversation 참가자(`ConversationParticipant`·`resolve_member` canonical). **story 첨부** → `has_project_access`(project_auth SSOT). ⚠️ **team_member 봐주기 없음.**
- **path 소속 검증**(cross-resource path 추측 차단): conversation 은 `jsonb_array_elements`+`strpos`, story 는 attachments 매칭.
- 정확히 하나의 리소스(conversation_id XOR story_id)·path 필수(400).

## 🔗 미르코 핸드오프 (Next 서명 라우트 `/api/attachments/sign`)
1. stored 값서 path 추출(신규=object path·legacy=public URL서 추출).
2. `GET /api/v2/attachments/authorize?path=<path>&conversation_id=<id>`(또는 story_id) 세션토큰으로 호출.
3. 200 이면 `@/lib/gcs` 에 `getSignedUrl`(V4·단기 만료) 추가해 발급 → signed URL 반환. 403 이면 거부.
4. 렌더를 sign 라우트 경유로 전환.

## ⚠️ 시퀀싱 (오르테가/인프라)
버킷 `allUsers` IAM 해제는 **sign 라우트 배포 後**(그 전엔 legacy public URL 이 살아있어야 렌더 안 깨짐). ③ 마이그(FE 정규화·백필 불요) + ④ IAM 타이밍 확정 핑 부탁.

## 테스트
400(both/neither)·conversation(참가+belong 200·비참가 403·belong아님 403)·story(access+belong 200·no-access 403·belong아님 403). 로컬 8 PASS. 마이그0·gcloud 무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)