### PR TITLE
[SID:a54ddc16] feat(security): 첨부 auth-gated 서빙 FE — 서명 라우트 + render 3상태

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2276,6 +2276,8 @@
     "hypothesisSection": "Outcome Hypothesis"
   },
   "chats": {
+    "attachmentDenied": "You don't have access",
+    "attachmentReload": "Reload attachment",
     "title": "Chats",
     "dmSection": "Direct Messages",
     "groupSection": "Group Chats",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2276,6 +2276,8 @@
     "hypothesisSection": "효과 가설"
   },
   "chats": {
+    "attachmentDenied": "접근 권한이 없습니다",
+    "attachmentReload": "첨부를 다시 불러오기",
     "title": "채팅",
     "dmSection": "DM",
     "groupSection": "그룹 채팅",

--- a/apps/web/src/app/api/attachments/sign/route.ts
+++ b/apps/web/src/app/api/attachments/sign/route.ts
@@ -1,0 +1,63 @@
+import { getServerSession } from '@/lib/db/server';
+import { getSignedReadUrl, GCS_MEMO_ATTACHMENTS_BUCKET } from '@/lib/gcs';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { handleApiError } from '@/lib/api-error';
+
+// a54ddc16: 첨부 auth-gated 서빙. public 버킷 직링크 → 이 라우트가 BE authorize(접근권+path
+// 소속 2겹 방어) 통과 시에만 단기 만료 V4 서명 URL을 반환한다.
+//
+// GET /api/attachments/sign?path=<stored url|bare path>&conversation_id=<uuid>   (또는 story_id)
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
+const PUBLIC_PREFIX = `https://storage.googleapis.com/${GCS_MEMO_ATTACHMENTS_BUCKET}/`;
+
+// stored url → canonical bare object path. BE `_canonical_object_path` 와 동일 규칙(반드시 정합).
+// 신규 = bare path 그대로 · legacy = `https://storage.googleapis.com/{bucket}/{path}` → prefix 제거
+// · 외부 도메인/타 버킷 = null(우리 객체 아님 → 차단).
+function canonicalObjectPath(stored: string): string | null {
+  if (!stored) return null;
+  if (stored.startsWith(PUBLIC_PREFIX)) return stored.slice(PUBLIC_PREFIX.length);
+  if (stored.includes('://')) return null;
+  return stored;
+}
+
+export async function GET(request: Request) {
+  try {
+    const session = await getServerSession().catch(() => null);
+    if (!session) return ApiErrors.unauthorized();
+
+    const { searchParams } = new URL(request.url);
+    const rawPath = searchParams.get('path');
+    const conversationId = searchParams.get('conversation_id');
+    const storyId = searchParams.get('story_id');
+
+    if (!rawPath) return ApiErrors.badRequest('path is required');
+    // BE 계약: 정확히 하나의 리소스(conversation_id XOR story_id).
+    if ((conversationId === null) === (storyId === null)) {
+      return ApiErrors.badRequest('exactly one of conversation_id or story_id is required');
+    }
+
+    const objectPath = canonicalObjectPath(rawPath);
+    // bare object path(스킴 없음)만 허용 — injection 차단(BE와 동일 가드).
+    if (!objectPath || objectPath.includes('://')) return ApiErrors.badRequest('invalid attachment path');
+
+    // BE authorize — 요청자 접근권 + path 소속(구조 스코프 + canonical 정확 매치) 2겹 방어.
+    // 세션 access_token(sp_at)을 Bearer로 전달. org는 BE가 토큰서 도출.
+    const authUrl = new URL('/api/v2/attachments/authorize', FASTAPI_URL());
+    authUrl.searchParams.set('path', objectPath);
+    if (conversationId) authUrl.searchParams.set('conversation_id', conversationId);
+    if (storyId) authUrl.searchParams.set('story_id', storyId);
+
+    const authRes = await fetch(authUrl.toString(), {
+      headers: { Authorization: `Bearer ${session.access_token}` },
+      cache: 'no-store',
+    });
+    if (authRes.status === 403) return ApiErrors.forbidden('첨부 접근 권한이 없습니다');
+    if (!authRes.ok) return ApiErrors.badRequest('attachment authorization failed');
+
+    // authorize 통과 — 단기 만료 서명 URL 발급.
+    const url = await getSignedReadUrl(GCS_MEMO_ATTACHMENTS_BUCKET, objectPath);
+    return apiSuccess({ url });
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/chat/attachment-file.tsx
+++ b/apps/web/src/components/chat/attachment-file.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { LucideIcon } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+import { useToast } from '@/components/ui/toast';
+
+/**
+ * a54ddc16 — 비-이미지 첨부 다운로드를 auth-gated 서명 라우트 경유로 처리한다.
+ * 클릭 시 `/api/attachments/sign`으로 단기 서명 URL을 받아 새 탭으로 연다(public 직링크 미사용).
+ */
+interface AttachmentFileProps {
+  storedUrl: string;
+  conversationId: string;
+  label: string;
+  Icon: LucideIcon;
+}
+
+export function AttachmentFile({ storedUrl, conversationId, label, Icon }: AttachmentFileProps) {
+  const t = useTranslations('chats');
+  const { addToast } = useToast();
+  const [loading, setLoading] = useState(false);
+
+  const open = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ path: storedUrl, conversation_id: conversationId });
+      const res = await fetch(`/api/attachments/sign?${params.toString()}`);
+      if (res.status === 403) {
+        addToast({ type: 'info', title: t('attachmentDenied') });
+        return;
+      }
+      const json = (await res.json().catch(() => null)) as { data?: { url?: string } } | null;
+      const url = json?.data?.url;
+      if (!res.ok || !url) {
+        addToast({ type: 'error', title: t('attachmentReload') });
+        return;
+      }
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch {
+      addToast({ type: 'error', title: t('attachmentReload') });
+    } finally {
+      setLoading(false);
+    }
+  }, [storedUrl, conversationId, loading, addToast, t]);
+
+  return (
+    <button
+      type="button"
+      onClick={() => void open()}
+      disabled={loading}
+      className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50 disabled:opacity-60"
+    >
+      {loading ? <Loader2 className="h-4 w-4 flex-shrink-0 animate-spin text-muted-foreground" /> : <Icon className="h-4 w-4 flex-shrink-0 text-muted-foreground" />}
+      <span className="truncate text-foreground">{label}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/chat/attachment-image.tsx
+++ b/apps/web/src/components/chat/attachment-image.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Lock, RefreshCw } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * a54ddc16 — 첨부 이미지 auth-gated 렌더. public 직링크 대신 서명 라우트
+ * (`/api/attachments/sign`)로 단기 서명 URL을 받아 표시한다. 비동기 fetch라 상태 UX가 필요:
+ * - fetching: skeleton(자리 확보·레이아웃 시프트 방지)
+ * - ok: 이미지 렌더
+ * - expired: 서명 URL 만료 → 자동 재fetch 1회(투명) → 재실패 시 새로고침 안내
+ * - denied: authorize 거부(403) → Lock + 안내(중립톤·broken img 0)
+ */
+
+type State = 'fetching' | 'ok' | 'expired' | 'denied';
+
+interface AttachmentImageProps {
+  storedUrl: string;
+  conversationId: string;
+  alt: string;
+}
+
+export function AttachmentImage({ storedUrl, conversationId, alt }: AttachmentImageProps) {
+  const t = useTranslations('chats');
+  const [state, setState] = useState<State>('fetching');
+  const [signedUrl, setSignedUrl] = useState<string | null>(null);
+  const retriedRef = useRef(false);
+
+  // 'fetching'은 mount 기본값 / reload 핸들러에서 설정한다(effect 내 동기 setState 회피).
+  const fetchSignedUrl = useCallback(async () => {
+    try {
+      const params = new URLSearchParams({ path: storedUrl, conversation_id: conversationId });
+      const res = await fetch(`/api/attachments/sign?${params.toString()}`);
+      if (res.status === 403) {
+        setState('denied');
+        return;
+      }
+      if (!res.ok) {
+        setState('expired');
+        return;
+      }
+      const json = (await res.json()) as { data?: { url?: string } };
+      const url = json.data?.url;
+      if (!url) {
+        setState('expired');
+        return;
+      }
+      setSignedUrl(url);
+      setState('ok');
+    } catch {
+      setState('expired');
+    }
+  }, [storedUrl, conversationId]);
+
+  useEffect(() => {
+    retriedRef.current = false;
+    // 외부 시스템(서명 라우트) 비동기 fetch — setState는 모두 await 이후라 동기 cascading 아님.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchSignedUrl();
+  }, [fetchSignedUrl]);
+
+  // 만료된 서명 URL로 이미지 로드 실패 → 자동 재fetch 1회(투명). 재실패면 expired 안내.
+  const handleImgError = useCallback(() => {
+    if (!retriedRef.current) {
+      retriedRef.current = true;
+      void fetchSignedUrl();
+    } else {
+      setState('expired');
+    }
+  }, [fetchSignedUrl]);
+
+  const reload = useCallback(() => {
+    retriedRef.current = false;
+    setState('fetching');
+    void fetchSignedUrl();
+  }, [fetchSignedUrl]);
+
+  const frame = 'flex h-32 w-[240px] max-w-full items-center justify-center rounded bg-muted';
+
+  if (state === 'fetching') {
+    return <div className={`${frame} animate-pulse`} aria-busy="true" aria-label={alt} />;
+  }
+  if (state === 'denied') {
+    return (
+      <div className={`${frame} flex-col gap-1.5 text-muted-foreground`}>
+        <Lock className="h-4 w-4" aria-hidden />
+        <span className="text-xs">{t('attachmentDenied')}</span>
+      </div>
+    );
+  }
+  if (state === 'expired' || !signedUrl) {
+    return (
+      <div className={`${frame} flex-col gap-1.5 text-muted-foreground`}>
+        <button
+          type="button"
+          onClick={reload}
+          className="flex items-center gap-1.5 rounded px-2 py-1 text-xs hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden />
+          {t('attachmentReload')}
+        </button>
+      </div>
+    );
+  }
+  return (
+    <a href={signedUrl} target="_blank" rel="noopener noreferrer" className="block">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={signedUrl}
+        alt={alt}
+        onError={handleImgError}
+        className="max-h-40 max-w-[240px] rounded object-contain"
+      />
+    </a>
+  );
+}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -7,6 +7,8 @@ import { Bot, MessageSquare, User } from 'lucide-react';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
 import { EntityChip, getEntityHref } from '@/components/chat/embed-card';
 import { getFileIcon } from '@/lib/file-icon';
+import { AttachmentImage } from './attachment-image';
+import { AttachmentFile } from './attachment-file';
 import { MessageContextMenu } from './message-context-menu';
 
 interface ChatBubbleProps {
@@ -193,34 +195,26 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
             <ChatMarkdown content={message.content} isMine={isMine} />
           </div>
 
-          {/* Attachments — 이미지는 인라인 프리뷰, 그 외는 파일 칩 */}
+          {/* Attachments — a54ddc16: auth-gated 서명 라우트 경유(public 직링크 미사용).
+              이미지=AttachmentImage(3상태 render)·그 외=AttachmentFile(클릭 시 서명 다운로드). */}
           {message.attachments && message.attachments.length > 0 && (
             <div className="flex flex-col gap-1.5">
               {message.attachments.map((att, i) => {
                 const href = att.url;
+                if (!href) return null;
                 const label = att.name ?? att.filename ?? '첨부파일';
                 const isImage = att.content_type?.startsWith('image/');
-                if (isImage && href) {
-                  return (
-                    <a key={href ?? i} href={href} target="_blank" rel="noopener noreferrer" className="block">
-                      {/* eslint-disable-next-line @next/next/no-img-element */}
-                      <img src={href} alt={label} className="max-h-40 max-w-[240px] rounded object-contain" />
-                    </a>
-                  );
+                if (isImage) {
+                  return <AttachmentImage key={href ?? i} storedUrl={href} conversationId={message.memo_id} alt={label} />;
                 }
-                const Icon = getFileIcon(att.content_type);
                 return (
-                  <a
+                  <AttachmentFile
                     key={href ?? i}
-                    href={href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    download
-                    className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
-                  >
-                    <Icon className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-                    <span className="truncate text-foreground">{label}</span>
-                  </a>
+                    storedUrl={href}
+                    conversationId={message.memo_id}
+                    label={label}
+                    Icon={getFileIcon(att.content_type)}
+                  />
                 );
               })}
             </div>

--- a/apps/web/src/lib/gcs.ts
+++ b/apps/web/src/lib/gcs.ts
@@ -32,6 +32,26 @@ export async function uploadToGcs(
   return `https://storage.googleapis.com/${bucketName}/${filePath}`;
 }
 
+/**
+ * a54ddc16: 단기 만료 V4 read 서명 URL 생성. public 버킷 → auth-gated 서빙 전환의 일부로,
+ * authorize 통과 후에만 호출한다(서명 라우트 `/api/attachments/sign`). path 는 bare object path.
+ */
+export async function getSignedReadUrl(
+  bucketName: string,
+  objectPath: string,
+  expiresInMs = 5 * 60 * 1000,
+): Promise<string> {
+  const [url] = await getStorage()
+    .bucket(bucketName)
+    .file(objectPath)
+    .getSignedUrl({
+      version: 'v4',
+      action: 'read',
+      expires: Date.now() + expiresInMs,
+    });
+  return url;
+}
+
 export const GCS_MEMO_ATTACHMENTS_BUCKET =
   process.env['GCS_MEMO_ATTACHMENTS_BUCKET'] ?? 'sprintable-memo-attachments';
 


### PR DESCRIPTION
## 요약
첨부를 **public 버킷 직링크 → 인가 후 단기 서명 URL 서빙**으로 전환(pre-GA 보안). BE authorize(#1287·머지됨) 계약 기준 + 유나양 render spec(`c69bbff5`). **crit 보안 — 가디언 시각 + 까심 코드 QA 요청.**

## Part A — 서명 라우트 (보안 core)
- **`lib/gcs` `getSignedReadUrl` V4**(단기 만료) 신규.
- **`/api/attachments/sign?path=&conversation_id=|story_id=`**:
  1. 세션 확인 → stored url을 **canonical bare path로 정규화**(BE `_canonical_object_path`와 **동일 규칙**: 신규=bare 그대로·legacy `storage.googleapis.com/{bucket}/{path}`→prefix 제거·외부 도메인/타 버킷=차단).
  2. BE `GET /api/v2/attachments/authorize`(세션 Bearer 전달·**접근권+path 소속 2겹 방어**) 호출.
  3. 통과 시 단기 서명 URL 반환. **403→forbidden**·잘못된 path→400.

## Part B — chat-bubble render 3상태
- **`AttachmentImage`**: `fetching`(skeleton·aspect 자리확보·시프트 방지) → `ok`(img) → `expired`(서명 만료→**자동 재fetch 1회 투명**→재실패 시 RefreshCw "다시 불러오기") → `denied`(403→**Lock "접근 권한 없음"·중립톤**). **broken img 0**. 토큰 `bg-muted`/`text-muted-foreground`·매직hex0.
- **`AttachmentFile`**: 비-이미지 다운로드도 서명 라우트 경유(클릭→sign→새 탭).
- chat-bubble: `att.url` 직링크 → 컴포넌트 교체. `conversation_id=message.memo_id`.
- i18n `chats` 신규 2키 en/ko: `attachmentDenied`·`attachmentReload`.

## 보안 정합
- FE 정규화 규칙이 **BE `_canonical_object_path`와 1:1**(BE 주석 "Next sign 라우트도 동일 추출 규칙" 준수). bare path만 BE 전달·`://` 차단(injection). 인가는 전적으로 BE(2겹 방어)·FE는 서명만.
- **버킷 IAM `allUsers` 해제는 별도**(게이트 dev/prod 배포+verify 후 내가 단행) — 이 PR은 서빙 경로 전환만.

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build`(webpack·route 등록) 성공 · i18n parity. 격리 worktree.
- ⏳ **실 와이어 = #1287 dev 배포 후**(authorize 라이브) sellerking dev 채팅서 이미지 서명 렌더·만료/denied 상태·legacy 정규화 검증. 가디언 픽셀(skeleton/expired/denied·broken img 0) 합산.

🤖 Generated with [Claude Code](https://claude.com/claude-code)