### PR TITLE
feat(security): BE 엔드포인트 path→group scope 서버사이드 강제 (7b63c226)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -179,8 +179,13 @@ async def _verify_org_membership(
 _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 
 
-def _check_api_key_scope(auth: AuthContext, method: str) -> None:
-    """API Key 경로일 때만 scope 체크 — JWT 사용자(웹 UI)는 미적용."""
+def _check_api_key_scope(auth: AuthContext, method: str, path: str | None = None) -> None:
+    """API Key 경로일 때만 scope 체크 — JWT 사용자(웹 UI)는 미적용.
+
+    1) coarse read/write 게이팅(기존).
+    2) 7b63c226: path→toolset group 서버사이드 강제 — 키 scope 외 그룹 엔드포인트 직접 호출 차단
+       (MCP 클라 우회 방어·진짜 boundary). always-allowed/미매핑 면제·일반키(read/write) 무회귀.
+    """
     if not auth.claims.get("app_metadata", {}).get("api_key_id"):
         return  # JWT 경로 → 스킵
     scope: list[str] = auth.claims.get("app_metadata", {}).get("scope", ["read", "write"])
@@ -190,6 +195,13 @@ def _check_api_key_scope(auth: AuthContext, method: str) -> None:
             status_code=status.HTTP_403_FORBIDDEN,
             detail=f"API Key scope '{required}' required",
         )
+    if path is not None:
+        from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
+        if not path_allowed_for_scope(path, scope):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API Key scope does not permit '{path_to_tool_group(path)}' tools",
+            )
 
 
 def require_api_scope(required_scope: str):
@@ -217,7 +229,7 @@ async def get_verified_org_id(
     API Key 경로는 HTTP method 기반 scope 자동 체크."""
     # API Key scope 체크 (request 있을 때만 — 직접 단위 테스트 호출 시 스킵)
     if request is not None:
-        _check_api_key_scope(auth, request.method)
+        _check_api_key_scope(auth, request.method, request.url.path)
 
     jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
     # X-Org-Id 헤더 우선 — org 전환 프리뷰(unified-switcher) 지원. 항상 membership 검증.
@@ -505,7 +517,7 @@ async def get_verified_org_id_streaming(
     API key + claims org_id(헤더 없음) 경로는 DB 쿼리조차 없음.
     """
     if request is not None:
-        _check_api_key_scope(auth, request.method)
+        _check_api_key_scope(auth, request.method, request.url.path)
 
     jwt_org_id = auth.claims.get("app_metadata", {}).get("org_id")
     raw = x_org_id or jwt_org_id

--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -129,6 +129,69 @@ def resolve_policy(scope: list[str] | None) -> dict:
     }
 
 
+# ── 7b63c226: BE 서버사이드 path→group scope 강제 ────────────────────────────
+# MCP 서버(client)의 is_tool_allowed/tool_group 와 **동일 그룹 소스**(ALL_GROUPS·resolve_policy)를
+# 재사용해 드리프트를 막는다. BYO 에이전트가 MCP 클라를 우회해 BE 엔드포인트를 직접 호출해도
+# 키 scope 외 그룹은 403 — 진짜 boundary.
+
+# always-allowed(core/비파괴 read) 엔드포인트 — scope 막론 허용(CP③ bypass).
+# check_notifications·poll_events·list_team_members·my_dashboard·manifest·세션/자기 self-ops.
+_ALWAYS_ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
+    "/api/v2/notifications",
+    "/api/v2/events",
+    "/api/v2/team-members",
+    "/api/v2/dashboard",
+    "/api/v2/mcp",
+    "/api/v2/me",
+    "/api/v2/auth",
+    "/api/v2/current-project",
+    "/api/v2/agent",
+)
+
+# path-prefix → toolset group(라우터 리소스 정렬). 모든 group 은 ALL_GROUPS 소속이어야 함.
+_PATH_GROUP_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("/api/v2/standups", "standup"),
+    ("/api/v2/rewards", "rewards"),
+    ("/api/v2/wallet", "rewards"),
+    ("/api/v2/leaderboard", "rewards"),
+    ("/api/v2/audit-logs", "audit"),
+    ("/api/v2/webhooks", "webhooks"),
+    ("/api/v2/conversations", "chat"),
+    ("/api/v2/meetings", "meetings"),
+    ("/api/v2/retros", "retro"),
+    ("/api/v2/stories", "stories"),
+    ("/api/v2/tasks", "tasks"),
+    ("/api/v2/sprints", "sprints"),
+    ("/api/v2/epics", "epics"),
+    ("/api/v2/docs", "docs"),
+    ("/api/v2/agent-runs", "agent_runs"),
+    ("/api/v2/analytics", "analytics"),
+)
+
+
+def path_to_tool_group(path: str) -> str | None:
+    """요청 path → toolset group. always-allowed/미매핑(core 취급)이면 None(강제 면제)."""
+    for prefix in _ALWAYS_ALLOWED_PATH_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return None
+    for prefix, group in _PATH_GROUP_PREFIXES:
+        if path == prefix or path.startswith(prefix + "/"):
+            return group
+    return None  # 미매핑 → core 취급(허용)
+
+
+def path_allowed_for_scope(path: str, scope: list[str] | None) -> bool:
+    """7b63c226: API-key 요청 path 가 scope 의 허용 그룹에 속하는지(서버사이드 boundary).
+
+    always-allowed/미매핑 → True. 매핑된 group 은 resolve_policy 의 allowed_groups 에 있어야 True.
+    레거시(read/write)·full scope → allowed_groups=전체 → 모든 그룹 True(일반키 무회귀).
+    """
+    group = path_to_tool_group(path)
+    if group is None or group not in ALL_GROUPS:
+        return True  # 면제 or 미지(ALL_GROUPS 드리프트 방어) → over-block 방지
+    return group in resolve_policy(scope)["allowed_groups"]
+
+
 def resolve_manifest(scope: list[str] | None, all_tool_names: list[str]) -> dict:
     """key scope + 전체 tool 목록 → 매니페스트(allowed/denied/groups/destructive)."""
     allowed = [t for t in all_tool_names if is_tool_allowed(t, scope)]

--- a/backend/tests/test_be_scope_enforce_7b63c226.py
+++ b/backend/tests/test_be_scope_enforce_7b63c226.py
@@ -1,0 +1,84 @@
+"""7b63c226: BE 엔드포인트 path→group 서버사이드 scope 강제 (MCP 클라 우회 차단).
+
+그룹-scoped 키가 BE 엔드포인트를 직접 호출해도 키 scope 외 그룹은 403. 일반키(read/write) 무회귀·
+always-allowed(core) 면제. 그룹 소스는 MCP tool_group 과 동일(ALL_GROUPS·resolve_policy).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.dependencies.auth import _check_api_key_scope
+from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
+
+
+def test_path_to_tool_group_resource_prefixes():
+    assert path_to_tool_group("/api/v2/standups") == "standup"
+    assert path_to_tool_group("/api/v2/standups/missing") == "standup"
+    assert path_to_tool_group("/api/v2/rewards/give") == "rewards"
+    assert path_to_tool_group("/api/v2/wallet") == "rewards"
+    assert path_to_tool_group("/api/v2/audit-logs") == "audit"
+    assert path_to_tool_group("/api/v2/webhooks/config") == "webhooks"
+    assert path_to_tool_group("/api/v2/conversations") == "chat"
+
+
+def test_path_to_tool_group_always_allowed_and_unmapped_none():
+    # always-allowed(core) → None
+    assert path_to_tool_group("/api/v2/notifications") is None
+    assert path_to_tool_group("/api/v2/dashboard") is None
+    assert path_to_tool_group("/api/v2/team-members") is None
+    assert path_to_tool_group("/api/v2/events/pending") is None
+    # 미매핑 → None(core)
+    assert path_to_tool_group("/api/v2/projects") is None
+
+
+def test_path_allowed_group_key():
+    scope = ["read", "write", "standup"]
+    assert path_allowed_for_scope("/api/v2/standups", scope) is True       # 자기 그룹
+    assert path_allowed_for_scope("/api/v2/rewards/give", scope) is False   # 타 그룹 차단
+    assert path_allowed_for_scope("/api/v2/notifications", scope) is True   # always-allowed
+
+
+def test_path_allowed_full_key_no_regression():
+    # 일반키(read/write·그룹 토큰 없음) → 전체 그룹 허용
+    for path in ("/api/v2/rewards/give", "/api/v2/standups", "/api/v2/audit-logs"):
+        assert path_allowed_for_scope(path, ["read", "write"]) is True
+        assert path_allowed_for_scope(path, []) is True  # 빈 scope = legacy 전체
+
+
+def _api_auth(scope):
+    a = MagicMock()
+    a.claims = {"app_metadata": {"api_key_id": "ak", "scope": scope}}
+    return a
+
+
+def test_check_scope_group_key_blocks_other_group():
+    # standup 그룹키 → rewards 엔드포인트 직접 호출 → 403
+    with pytest.raises(HTTPException) as exc:
+        _check_api_key_scope(_api_auth(["read", "write", "standup"]), "POST", "/api/v2/rewards/give")
+    assert exc.value.status_code == 403
+
+
+def test_check_scope_group_key_allows_own_group():
+    # standup 그룹키 → standup 엔드포인트 → 통과(예외 없음)
+    _check_api_key_scope(_api_auth(["read", "write", "standup"]), "GET", "/api/v2/standups")
+
+
+def test_check_scope_full_key_no_regression():
+    # full 키 → 모든 그룹 통과
+    _check_api_key_scope(_api_auth(["read", "write"]), "POST", "/api/v2/rewards/give")
+
+
+def test_check_scope_always_allowed_bypass():
+    # 그룹키라도 always-allowed(notifications/dashboard) → 통과
+    _check_api_key_scope(_api_auth(["read", "write", "standup"]), "GET", "/api/v2/notifications")
+    _check_api_key_scope(_api_auth(["read", "write", "standup"]), "GET", "/api/v2/dashboard")
+
+
+def test_check_scope_jwt_skipped():
+    # JWT(api_key_id 없음) → 미적용(웹 UI 무영향)
+    jwt = MagicMock()
+    jwt.claims = {"app_metadata": {"org_id": "o"}}
+    _check_api_key_scope(jwt, "POST", "/api/v2/rewards/give")  # 예외 없음


### PR DESCRIPTION
## 🔴 pre-GA 보안 (내 적출 — 0d570782 grounding)
BE 의 유일한 API-key 강제 = `_check_api_key_scope`(get_verified_org_id 경유·거의 전 엔드포인트)인데 **coarse read/write 만** 체크. per-group(standup/rewards…)은 **client-side `is_tool_allowed`(MCP 서버)뿐** → 그룹-scoped 키가 BE 엔드포인트를 **직접 호출(MCP 클라 우회)** 하면 그룹 무시·통과. **진짜 boundary = BE server-side.**

## 수정
- `mcp_toolset.path_to_tool_group(path)` + `path_allowed_for_scope(path, scope)` — **MCP `tool_group`/`resolve_policy` 와 동일 그룹 소스(ALL_GROUPS) 재사용**(드리프트 금지·CP①). path-prefix→group 맵(라우터 리소스 정렬). always-allowed(notifications/events/team-members/dashboard/mcp/self·CP③) + 미매핑 → 면제(core).
- `_check_api_key_scope` 확장: coarse 後 path→group 강제 — 키 `allowed_groups` 외 그룹 → **403**. 호출부서 `request.url.path` 전달.
- **무회귀:** read/write/full → allowed_groups=전체 → 모든 그룹 통과(일반키 영향0). JWT 스킵.

## 테스트 (까심 CP)
- `path_to_tool_group`(resource/always-allowed/unmapped) · `path_allowed`(그룹키 타그룹 차단·full 무회귀·always-allowed 면제) · `_check_api_key_scope`(**그룹키 rewards 직접호출 403**·자기그룹 통과·full 무회귀·always-allowed bypass·JWT 스킵). 로컬 9 + 광범위 auth/toolset 무회귀 PASS.
- **under-block 0(CP②):** 전 toolset 그룹 path-prefix 커버(rewards/audit/webhooks/standup/stories/tasks/sprints/epics/docs/chat/meetings/retro/agent_runs/analytics).
- **core bypass(CP③):** always-allowed read 면제.

## ⚠️ 한계(정직)
cross-cutting 엔드포인트(analytics tool via /sprints 등)는 prefix→sprints 로 over-restrict 가능(보안 안전측·leak 아님). 민감 그룹(rewards/audit/webhooks)은 전용 prefix 정밀.

머지+배포 후 라이브 verify(그룹키 rewards 직접호출→403·MCP 클라 우회 실증) 예정. 마이그0·gcloud무관.

🤖 Generated with [Claude Code](https://claude.com/claude-code)