### PR TITLE
[SID:a54ddc16] fix(security): 보드 스토리 첨부도 서명 라우트 경유 (B1)

### DIFF
--- a/apps/web/src/components/chat/attachment-file.tsx
+++ b/apps/web/src/components/chat/attachment-file.tsx
@@ -12,12 +12,14 @@ import { useToast } from '@/components/ui/toast';
  */
 interface AttachmentFileProps {
   storedUrl: string;
-  conversationId: string;
+  // 첨부가 속한 리소스 — conversation(채팅) 또는 story(보드). 정확히 하나.
+  conversationId?: string;
+  storyId?: string;
   label: string;
   Icon: LucideIcon;
 }
 
-export function AttachmentFile({ storedUrl, conversationId, label, Icon }: AttachmentFileProps) {
+export function AttachmentFile({ storedUrl, conversationId, storyId, label, Icon }: AttachmentFileProps) {
   const t = useTranslations('chats');
   const { addToast } = useToast();
   const [loading, setLoading] = useState(false);
@@ -26,7 +28,9 @@ export function AttachmentFile({ storedUrl, conversationId, label, Icon }: Attac
     if (loading) return;
     setLoading(true);
     try {
-      const params = new URLSearchParams({ path: storedUrl, conversation_id: conversationId });
+      const params = new URLSearchParams({ path: storedUrl });
+      if (conversationId) params.set('conversation_id', conversationId);
+      else if (storyId) params.set('story_id', storyId);
       const res = await fetch(`/api/attachments/sign?${params.toString()}`);
       if (res.status === 403) {
         addToast({ type: 'info', title: t('attachmentDenied') });
@@ -44,7 +48,7 @@ export function AttachmentFile({ storedUrl, conversationId, label, Icon }: Attac
     } finally {
       setLoading(false);
     }
-  }, [storedUrl, conversationId, loading, addToast, t]);
+  }, [storedUrl, conversationId, storyId, loading, addToast, t]);
 
   return (
     <button

--- a/apps/web/src/components/chat/attachment-image.tsx
+++ b/apps/web/src/components/chat/attachment-image.tsx
@@ -17,11 +17,13 @@ type State = 'fetching' | 'ok' | 'expired' | 'denied';
 
 interface AttachmentImageProps {
   storedUrl: string;
-  conversationId: string;
+  // 첨부가 속한 리소스 — conversation(채팅) 또는 story(보드). 정확히 하나.
+  conversationId?: string;
+  storyId?: string;
   alt: string;
 }
 
-export function AttachmentImage({ storedUrl, conversationId, alt }: AttachmentImageProps) {
+export function AttachmentImage({ storedUrl, conversationId, storyId, alt }: AttachmentImageProps) {
   const t = useTranslations('chats');
   const [state, setState] = useState<State>('fetching');
   const [signedUrl, setSignedUrl] = useState<string | null>(null);
@@ -30,7 +32,9 @@ export function AttachmentImage({ storedUrl, conversationId, alt }: AttachmentIm
   // 'fetching'은 mount 기본값 / reload 핸들러에서 설정한다(effect 내 동기 setState 회피).
   const fetchSignedUrl = useCallback(async () => {
     try {
-      const params = new URLSearchParams({ path: storedUrl, conversation_id: conversationId });
+      const params = new URLSearchParams({ path: storedUrl });
+      if (conversationId) params.set('conversation_id', conversationId);
+      else if (storyId) params.set('story_id', storyId);
       const res = await fetch(`/api/attachments/sign?${params.toString()}`);
       if (res.status === 403) {
         setState('denied');
@@ -51,7 +55,7 @@ export function AttachmentImage({ storedUrl, conversationId, alt }: AttachmentIm
     } catch {
       setState('expired');
     }
-  }, [storedUrl, conversationId]);
+  }, [storedUrl, conversationId, storyId]);
 
   useEffect(() => {
     retriedRef.current = false;

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -9,6 +9,8 @@ import { AlertTriangle, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import { getFileIcon } from '@/lib/file-icon';
+import { AttachmentImage } from '@/components/chat/attachment-image';
+import { AttachmentFile } from '@/components/chat/attachment-file';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { DependencyGraph } from './dependency-graph';
 import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
@@ -853,25 +855,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   {story.attachments.map((att, i) => {
                     const isImage = att.content_type?.startsWith('image/');
                     const Icon = getFileIcon(att.content_type);
+                    const label = att.name ?? '첨부파일';
                     return (
                       <div key={att.url ?? i} className="group relative">
-                        {isImage && att.url ? (
-                          <a href={att.url} target="_blank" rel="noopener noreferrer" className="block">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img src={att.url} alt={att.name} className="max-h-40 max-w-[240px] rounded object-contain" />
-                          </a>
-                        ) : (
-                          <a
-                            href={att.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            download
-                            className="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-xs hover:bg-muted/50"
-                          >
-                            <Icon className="size-4 flex-shrink-0 text-muted-foreground" />
-                            <span className="truncate text-foreground">{att.name}</span>
-                          </a>
-                        )}
+                        {/* a54ddc16 B1: 보드 첨부도 auth-gated 서명 라우트 경유(chat과 동일 컴포넌트·3상태). */}
+                        {att.url ? (
+                          isImage ? (
+                            <AttachmentImage storedUrl={att.url} storyId={story.id} alt={label} />
+                          ) : (
+                            <AttachmentFile storedUrl={att.url} storyId={story.id} label={label} Icon={Icon} />
+                          )
+                        ) : null}
                         <button
                           type="button"
                           onClick={() => void handleRemoveAttachment(att.url)}


### PR DESCRIPTION
## 요약
**까심 QA B1 blocker**: #1288이 chat-bubble 첨부만 sign route로 전환하고 **보드 스토리 상세(`story-detail-panel.tsx`) 첨부는 `att.url` 직접 렌더가 누락** → 버킷 private 전환 시 보드 이미지 로드 실패 + 다운로드 403. a54ddc16 게이트 완결의 마지막 누락분.

## 변경
- **`AttachmentImage`/`AttachmentFile`**: `conversationId` 단일 → **`conversationId?`/`storyId?`(정확히 하나)** 일반화. sign route에 해당 resource param 전달(BE authorize는 `conversation_id` XOR `story_id`).
- **`story-detail-panel.tsx`**: `att.url` 직접 img/download → **`AttachmentImage`/`AttachmentFile`(`storyId=story.id`)** 교체. 유나양 Part B 3상태(skeleton/ok/expired/denied·**broken img 0**) board에 자동 일관(같은 컴포넌트·디자인 추가 0).
- `chat-bubble`은 `conversationId` 전달 유지(무영향).

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build`(webpack) 성공. 격리 worktree.
- → chat + **board** 둘 다 sign route 경유 = 버킷 private 안전. #1287 dev/prod 배포 후 board 첨부도 prod gate verify에 포함.

🤖 Generated with [Claude Code](https://claude.com/claude-code)