### PR TITLE
[SID:f44e2644] fix(onboarding): llms.txt URL 랜딩 canonical 직지정

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -12,7 +12,9 @@ function getAppOrigin() {
   return process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.sprintable.ai';
 }
 const MCP_SERVER_URL = () => `${getAppOrigin()}/api/v2/mcp`;
-const LLMS_PROMPT = () => `Read this document and complete onboarding: ${getAppOrigin()}/llms.txt`;
+// f44e2644: 온보딩 문서는 랜딩 canonical(sprintable.ai/llms.txt) 직지정. app.sprintable.ai/llms.txt는
+// host-스코프 CF 301이 prod에서 미발동(앱 자체 사본 서빙·onboarding-guide 링크 깨짐)이라 직지정이 안전.
+const LLMS_PROMPT = () => `Read this document and complete onboarding: https://sprintable.ai/llms.txt`;
 const AGENT_ROLES = ['developer', 'designer', 'pm', 'qa', 'devops'];
 
 function buildMcpConfig(apiKey: string) {

--- a/apps/web/src/components/agents/agent-api-key-manager.tsx
+++ b/apps/web/src/components/agents/agent-api-key-manager.tsx
@@ -44,7 +44,8 @@ export function AgentApiKeyManager({ agentId, agentName, onNewKey }: AgentApiKey
   const [revokeConfirmDialog, setRevokeConfirmDialog] = useState(false);
   const { addToast } = useToast();
 
-  const LLMS_URL = 'https://app.sprintable.ai/llms.txt';
+  // f44e2644: 랜딩 canonical 직지정(app.sprintable.ai CF 301 prod 미발동·앱 사본 onboarding-guide 깨짐).
+  const LLMS_URL = 'https://sprintable.ai/llms.txt';
 
   const buildOnboardingMessage = (apiKey: string) =>
     `아래의 정보를 읽고 온보딩하기 바람.\nsprintable agent name : ${agentName}\nsprintable agent api key : ${apiKey}\n${LLMS_URL}`;

--- a/apps/web/src/components/settings/agent-api-keys-section.tsx
+++ b/apps/web/src/components/settings/agent-api-keys-section.tsx
@@ -12,7 +12,8 @@ function getAppOrigin() {
 }
 
 const MCP_SERVER_URL = () => `${getAppOrigin()}/api/v2/mcp`;
-const LLMS_PROMPT = () => `Read this document and complete onboarding: ${getAppOrigin()}/llms.txt`;
+// f44e2644: 온보딩 문서는 랜딩 canonical(sprintable.ai/llms.txt) 직지정(app.sprintable.ai CF 301 prod 미발동).
+const LLMS_PROMPT = () => `Read this document and complete onboarding: https://sprintable.ai/llms.txt`;
 
 interface AgentMember {
   id: string;


### PR DESCRIPTION
## 요약
온보딩 프롬프트/키 발급 화면의 `llms.txt` URL이 **app.sprintable.ai**(getAppOrigin) 또는 하드코딩 app.sprintable.ai를 가리켜, prod에서 host-스코프 CF 301이 미발동(앱 자체 사본 서빙·`onboarding-guide.txt` 링크가 307→login으로 깨짐) → 온보딩 동선 깨짐(데모 visible). **랜딩 canonical `sprintable.ai/llms.txt` 직지정**으로 교체.

## 변경 (FE 3곳)
- `onboarding-form.tsx:15` · `agent-api-keys-section.tsx:15`: `${getAppOrigin()}/llms.txt` → `https://sprintable.ai/llms.txt`. (`getAppOrigin`은 `MCP_SERVER_URL`서 유지 — MCP 엔드포인트는 앱 origin이 맞음.)
- `agent-api-key-manager.tsx:47`: 하드코딩 `https://app.sprintable.ai/llms.txt` → `https://sprintable.ai/llms.txt`.

## 배경
- 45a5a006의 host-스코프 301(app.sprintable.ai→랜딩)이 prod CF 프록시 Host 재작성으로 미발동(별도 follow-up). 그 사이 온보딩 URL은 canonical 직지정이 안전·robust.

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build` 성공 · 잔여 `app.sprintable.ai/llms` 참조 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)