### PR TITLE
[SID:77679f3f] chore(standup): orphan meetingNotes i18n 키 제거 (meeting/standup 분리 마무리)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1080,7 +1080,6 @@
     "previousDay": "Previous day",
     "nextDay": "Next day",
     "today": "Today",
-    "meetingNotes": "Meeting notes",
     "editEntry": "Edit",
     "notWrittenYet": "Not written yet",
     "feedbackCount": "{count} feedback",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1080,7 +1080,6 @@
     "previousDay": "어제",
     "nextDay": "내일",
     "today": "오늘",
-    "meetingNotes": "회의록",
     "editEntry": "편집",
     "notWrittenYet": "아직 작성하지 않음",
     "feedbackCount": "피드백 {count}개",


### PR DESCRIPTION
## 요약
**meeting-vs-standup 개념 분리(77679f3f)** 마무리. 전수 검증 결과 분리는 이미 완결돼 있고, **유일 잔재 = orphan i18n 키**였음:
- 데이터/라우트 분리: meeting 별도 테이블·`/meetings`·`/meetings/new`·`/meetings/[id]` 전부 `notFound()` 404 thin guard(E-SETTINGS-S5).
- standup top-bar의 dead link `<Link href={\`/meetings/new?standup_date=\${date}\`}>{t('meetingNotes')}</Link>`는 **E-SETTINGS-S5(#1228·4ae1d5d0)서 이미 제거**(git -S 확인). PO·가디언이 기억한 링크는 S5가 흡수.
- 그때 i18n 키 `standup.meetingNotes`만 **orphan**으로 남음(코드 사용처 0).

## 변경
- `messages/ko.json`·`en.json`: standup 네임스페이스 `meetingNotes`("회의록"/"Meeting notes") 키 제거(ko/en 대칭). **코드 변경 0**(이미 링크 없음) → standup 영역 meeting 잔재 0.

## 검증
- `jq` valid · `meetingNotes` 사용처 0(grep) · `pnpm build` 성공(next-intl 타입 메시지 OK). 격리 worktree.
- ∴ 77679f3f = orphan 키 정리로 done(분리 완결).

🤖 Generated with [Claude Code](https://claude.com/claude-code)