### PR TITLE
feat(epics): GET /api/v2/epics true cursor 페이지네이션 + 전체 카운트 (569f5316)

### DIFF
--- a/apps/web/src/app/api/epics/route.ts
+++ b/apps/web/src/app/api/epics/route.ts
@@ -4,7 +4,7 @@ import { EpicService, type CreateEpicInput } from '@/services/epic';
 import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
-import { paginateInMemory, parseCursorPageInput } from '@/lib/pagination';
+import { buildCursorPageMeta, parseCursorPageInput } from '@/lib/pagination';
 import { createEpicRepository } from '@/lib/storage/factory';
 import { getEpicActorRole, hasEpicRole } from '@/lib/epic-permissions';
 
@@ -21,12 +21,14 @@ export async function GET(request: Request) {
     }, { defaultLimit: 50, maxLimit: 100 });
     const repo = await createEpicRepository();
     const service = new EpicService(repo);
-    // 백엔드 GET /api/v2/epics 는 cursor/limit/order_by 미지원 — 프로젝트 전체 목록을 정렬 없이 반환한다.
-    // 따라서 cursor 페이징은 여기(라우트)에서 결정적 정렬 + cursor 적용으로 수행한다.
+    // 569f5316: 백엔드 GET /api/v2/epics 가 cursor/limit/order_by + total(X-Total-Count)을 지원하므로
+    // in-memory 페이징(1000+ silent-truncation 유발) 대신 BE에 위임한다. over-fetch(+1)로 hasMore 판단.
     const epics = await service.list({
       project_id: searchParams.get('project_id') ?? undefined,
+      limit: pageInput.limit + 1,
+      cursor: pageInput.cursor,
     });
-    const { page, meta } = paginateInMemory(epics, pageInput.limit, 'created_at', pageInput.cursor);
+    const { page, meta } = buildCursorPageMeta(epics, pageInput.limit, 'created_at');
     return apiSuccess(page, meta);
   } catch (err: unknown) { return handleApiError(err); }
 }

--- a/backend/app/repositories/base.py
+++ b/backend/app/repositories/base.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 import uuid
+from datetime import datetime
 from typing import Any, Generic, TypeVar
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import Base
 from app.models.base import SoftDeleteMixin
 
 T = TypeVar("T", bound=Base)
+
+# cursor 페이지네이션이 안전한 단조 정렬 컬럼 화이트리스트.
+# title/priority 등 비단조 컬럼은 cursor 중복으로 누락/중복을 유발하므로 제외한다.
+_ORDERABLE_FIELDS = ("created_at", "updated_at")
 
 
 class BaseRepository(Generic[T]):
@@ -33,6 +40,53 @@ class BaseRepository(Generic[T]):
             q = q.where(getattr(self.model, attr) == val)
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
+
+    def _orderable_fields(self) -> tuple[str, ...]:
+        """cursor 페이지네이션을 허용할 정렬 컬럼. 서브클래스에서 확장 가능."""
+        return _ORDERABLE_FIELDS
+
+    async def list_paginated(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: datetime | None = None,
+        order_by: str = "created_at",
+        **filters: Any,
+    ) -> tuple[list[T], int]:
+        """true cursor 페이지네이션 + 전체 카운트.
+
+        - order_by: 단조 컬럼 화이트리스트(created_at/updated_at). 그 외는 created_at로 폴백.
+        - cursor: 직전 페이지 마지막 row의 order_by 값(datetime). desc 페이지네이션(< cursor).
+        - total: 페이지와 무관한 필터링 전체 개수(silent-truncation을 호출자가 인지하도록).
+        - limit: None이면 기존 list()와 동일하게 1000 cap. 지정 시 그만큼만 반환(over-fetch는 호출자 책임).
+        반환: (rows, total).
+        """
+        conds = [self._org_filter()]
+        if issubclass(self.model, SoftDeleteMixin):
+            conds.append(self.model.deleted_at.is_(None))  # type: ignore[attr-defined]
+        for attr, val in filters.items():
+            conds.append(getattr(self.model, attr) == val)
+
+        # 전체 카운트(페이지네이션 무관) — 1000+ 잘림을 호출자가 알 수 있게 한다.
+        count_result = await self.session.execute(
+            select(func.count()).select_from(self.model).where(*conds)
+        )
+        total = int(count_result.scalar_one() or 0)
+
+        if order_by not in self._orderable_fields():
+            order_by = "created_at"
+        order_col = getattr(self.model, order_by)
+
+        q = select(self.model).where(*conds).order_by(
+            order_col.desc(), self.model.id.desc()  # type: ignore[attr-defined]
+        )
+
+        if cursor is not None:
+            q = q.where(order_col < cursor)
+
+        q = q.limit(limit if limit is not None else 1000)
+        result = await self.session.execute(q)
+        return list(result.scalars().all()), total
 
     async def create(self, **data: Any) -> T:
         obj = self.model(org_id=self.org_id, **data)

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -1,6 +1,7 @@
 import uuid
+from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, enforce_body_context, get_current_user, get_verified_org_id
@@ -20,16 +21,43 @@ def _get_repo(
 
 @router.get("", response_model=list[EpicResponse])
 async def list_epics(
+    response: Response,
     project_id: uuid.UUID | None = Query(default=None),
     status_filter: str | None = Query(default=None, alias="status"),
+    limit: int | None = Query(default=None, ge=1, le=2000),
+    cursor: str | None = Query(default=None, description="Cursor: ISO 8601 created_at, fetch before this time"),
+    order_by: str = Query(default="created_at"),
     repo: EpicRepository = Depends(_get_repo),
 ) -> list[EpicResponse]:
+    """에픽 목록 — true cursor 페이지네이션 + 전체 카운트(X-Total-Count 헤더).
+
+    1000+ 에픽이 조용히 잘리던 문제(#1200/569f5316)를 근절: limit/cursor로 위임
+    페이지네이션하고, 페이지와 무관한 전체 개수를 X-Total-Count로 노출한다.
+    limit 미지정 시 기존 동작(최대 1000)과 호환되며, 1000+ 인 경우에도 헤더로
+    잘림 여부를 호출자가 인지할 수 있어 silent-truncation이 아니다.
+    """
     filters: dict = {}
     if project_id:
         filters["project_id"] = project_id
     if status_filter:
         filters["status"] = status_filter
-    epics = await repo.list(**filters)
+
+    cursor_dt: datetime | None = None
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except (ValueError, TypeError) as exc:
+            # 잘못된 cursor는 silent 무시 대신 400으로 명확히 거절한다.
+            raise HTTPException(
+                status_code=400, detail="invalid cursor: expected ISO 8601 datetime"
+            ) from exc
+
+    epics, total = await repo.list_paginated(
+        limit=limit, cursor=cursor_dt, order_by=order_by, **filters
+    )
+    response.headers["X-Total-Count"] = str(total)
+    if epics:
+        response.headers["X-Next-Cursor"] = epics[-1].created_at.isoformat()
     return [EpicResponse.model_validate(e) for e in epics]
 
 

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -68,19 +68,83 @@ async def _client():
 
 # ── GET list ──────────────────────────────────────────────────────────────────
 
+def _paginated_execute(total: int, rows: list):
+    """list_paginated: 1번째 execute=count(scalar_one), 2번째=list(scalars().all())."""
+    state = {"n": 0}
+
+    async def _exec(stmt, *args, **kwargs):
+        state["n"] += 1
+        r = MagicMock()
+        if state["n"] == 1:
+            r.scalar_one.return_value = total
+        else:
+            r.scalars.return_value.all.return_value = rows
+        return r
+
+    return _exec
+
+
 @pytest.mark.anyio
 async def test_list_epics_200():
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalars.return_value.all.return_value = [_mock_epic()]
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = _paginated_execute(1, [_mock_epic()])
 
         async with client as c:
             resp = await c.get("/api/v2/epics")
 
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+        # 569f5316: 전체 카운트는 항상 헤더로 노출 → silent-truncation 불가
+        assert resp.headers["X-Total-Count"] == "1"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_limit_cursor_delegated():
+    """limit/cursor 위임 + X-Total-Count/X-Next-Cursor 헤더."""
+    client, session, app = await _client()
+    try:
+        session.execute = _paginated_execute(42, [_mock_epic()])
+
+        async with client as c:
+            resp = await c.get("/api/v2/epics?limit=50&cursor=2026-05-01T00:00:00%2B00:00")
+
+        assert resp.status_code == 200
+        assert resp.headers["X-Total-Count"] == "42"
+        assert "X-Next-Cursor" in resp.headers
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_1000plus_not_silent():
+    """1000+ 시뮬: 반환 페이지보다 total이 커도 헤더로 전체 카운트 노출(silent 잘림 아님)."""
+    client, session, app = await _client()
+    try:
+        # 페이지엔 1건만, 전체는 1500건 → X-Total-Count로 호출자가 잘림을 인지
+        session.execute = _paginated_execute(1500, [_mock_epic()])
+
+        async with client as c:
+            resp = await c.get("/api/v2/epics?limit=1")
+
+        assert resp.status_code == 200
+        assert resp.headers["X-Total-Count"] == "1500"
+        assert len(resp.json()) == 1
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_invalid_cursor_400():
+    """잘못된 cursor는 silent 무시 대신 400으로 명확히 거절."""
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/epics?cursor=not-a-datetime")
+
+        assert resp.status_code == 400
     finally:
         app.dependency_overrides.clear()
 

--- a/packages/core-storage/src/interfaces/IEpicRepository.ts
+++ b/packages/core-storage/src/interfaces/IEpicRepository.ts
@@ -48,6 +48,8 @@ export interface UpdateEpicInput {
 
 export interface EpicListFilters extends PaginationOptions {
   project_id?: string;
+  /** 단조 정렬 컬럼(created_at/updated_at). BE에 위임해 true cursor 페이지네이션에 사용. */
+  order_by?: string;
 }
 
 export interface IEpicRepository {

--- a/packages/storage-api/src/SupabaseEpicRepository.ts
+++ b/packages/storage-api/src/SupabaseEpicRepository.ts
@@ -9,7 +9,16 @@ export class SupabaseEpicRepository implements IEpicRepository {
   }
 
   async list(filters: EpicListFilters): Promise<Epic[]> {
-    return fastapiCall<Epic[]>('GET', '/api/v2/epics', this.accessToken, { query: { project_id: filters.project_id } });
+    // 569f5316: limit/cursor/order_by를 BE에 위임해 1000+ silent-truncation을 근절.
+    // (이전엔 project_id만 전달 → BE 1000 cap에서 조용히 잘림.) over-fetch(+1)는 라우트가 책임.
+    return fastapiCall<Epic[]>('GET', '/api/v2/epics', this.accessToken, {
+      query: {
+        project_id: filters.project_id,
+        cursor: filters.cursor,
+        limit: filters.limit,
+        order_by: filters.order_by,
+      },
+    });
   }
 
   async getById(id: string, _scope?: RepositoryScopeContext): Promise<Epic> {


### PR DESCRIPTION
## 배경 (569f5316 · E-BOARD-UX 후속)
에픽 1000개 초과 시 1000번째 이후가 **조용히 잘리고** 전체 카운트도 노출되지 않던 문제. 선생님 "에러 조용히 무시·fallback 떡칠 즉시 적출" 결의의 스토리.

## 근본 원인 (적출)
스토리 노트의 `paginateInMemory`는 develop에 **실재**(초기 다른 브랜치 트리에서 stale로 오인). 진짜 체인:
1. FE `epics/route.ts`가 `paginateInMemory`로 in-memory 페이징.
2. `SupabaseEpicRepository.list`가 `limit/cursor`를 BE에 **안 넘기고 `project_id`만** 전달.
3. BE `BaseRepository.list(limit=1000)` cap → **1000+ silent truncation** + 전체 카운트 없음.

(같은 체인이 MCP `list_epics`에도 존재 — limit 없이 호출.)

## 변경
**BE**
- `BaseRepository.list_paginated(limit/cursor/order_by + 전체 count)` 신규. 기존 `list()` 불변(후방호환).
- `GET /api/v2/epics`: `limit`/`cursor`/`order_by` 쿼리 + `X-Total-Count`·`X-Next-Cursor` 헤더(stories `list_board` 동형).
- 잘못된 cursor는 **silent 무시 대신 400**. `limit` 미지정 시 기존 동작(1000)과 호환 + 1000+ 도 헤더로 잘림 노출 → silent-truncation 아님.
- `order_by`는 단조 컬럼 화이트리스트(`created_at`/`updated_at`)로 cursor 누락·중복 방지.

**storage-api**
- `SupabaseEpicRepository.list`가 `limit/cursor/order_by`를 BE에 위임. `EpicListFilters`에 `order_by?` 추가.

**FE**
- `epics/route.ts`가 `paginateInMemory` 대신 BE 위임 + `buildCursorPageMeta`(over-fetch +1, stories 동형).

## 검증 (3-Gate)
- BE: `test_epics.py` **10 passed**(1000+ 시뮬·invalid cursor 400·`X-Total-Count`/`X-Next-Cursor` 헤더 회귀 포함), `test_stories.py`+`test_integration.py` **60 passed**(base 공유 회귀 없음), `ruff check` PASS.
- TS: `core-storage`·`storage-api`·`web` `type-check` 전부 PASS.

## AC 매핑
- ✅ BE cursor/limit/order_by + total count 지원, FE가 `paginateInMemory` 대신 위임.
- ✅ 1000+ 잘림 silent 금지(X-Total-Count로 전체 카운트 노출).
- ✅ 회귀: 페이지네이션 단위테스트 + 1000+ 시뮬. 현행(179개) 동작 불변.

> 참고: FE의 전체 카운트 **UI 표기**는 데모 안전(179개)·미르코군 FE 도메인이라 후속. 본 PR은 BE가 카운트를 제공(X-Total-Count)하는 데까지 닫는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)