### PR TITLE
[SID:silent-catch] fix: silent error swallow 일괄 정리 (finding별 live/dead 검증)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -492,6 +492,7 @@
     "notification_channel_email": "Email",
     "notification_coming_soon": "Coming soon",
     "notificationSaveError": "Failed to save notification settings.",
+    "billingPortalError": "Couldn't open the billing portal. Please try again shortly.",
     "dangerZone": "Danger Zone",
     "deleteAccount": "Delete Account",
     "deleteAccountDesc": "After deleting your account, all personal data will be anonymized after a 30-day grace period. Your content will be preserved.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -492,6 +492,7 @@
     "notification_channel_email": "이메일",
     "notification_coming_soon": "준비 중",
     "notificationSaveError": "알림 설정 저장에 실패했습니다.",
+    "billingPortalError": "결제 포털을 열지 못했습니다. 잠시 후 다시 시도해 주세요.",
     "dangerZone": "위험 구역",
     "deleteAccount": "계정 삭제",
     "deleteAccountDesc": "계정을 삭제하면 30일 유예 기간 후 모든 개인정보가 익명화됩니다. 작성한 콘텐츠는 유지됩니다.",

--- a/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
+++ b/apps/web/src/app/(authenticated)/docs/docs-shell-client.tsx
@@ -156,7 +156,7 @@ export function DocsShellClient({ projectId }: DocsShellClientProps) {
         .then((data: { data?: Array<{ id: string; title: string; slug: string; snippet?: string }> } | null) => {
           setSearchResults(data?.data ?? []);
         })
-        .catch(() => { setSearchResults([]); })
+        .catch((err) => { console.error('문서 검색 실패', err); setSearchResults([]); })
         .finally(() => { setSearchLoading(false); });
     }, 300);
 

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -773,17 +773,8 @@ export function EpicsClient({ projectId, orgId }: EpicsClientProps) {
     await fetchEpics(epicsNextCursor);
   }, [epicsHasMore, epicsNextCursor, epicsLoadingMore, fetchEpics]);
 
-  const _fetchEpicDetail = useCallback(async (id: string) => {
-    try {
-      const res = await fetch(`/api/epics/${id}`);
-      if (!res.ok) throw new Error('Failed to fetch epic');
-      const { data } = await res.json() as { data: Epic };
-      setSelectedEpic(data);
-      setEpics((prev) => prev.map((e) => (e.id === id ? { ...e, stories: data.stories } : e)));
-    } catch {
-      // noop
-    }
-  }, []);
+  // (silent-catch sweep) `_fetchEpicDetail`(dead·호출처 0·handleSelectEpic이 /epics/[id]
+  // 딥링크로 대체)는 제거했다 — 실행되지 않던 silent catch였으므로 toast가 아니라 dead code 삭제.
 
   const handleSelectEpic = useCallback((epic: Epic) => {
     // AC5: 모든 디바이스에서 /epics/[id] 딥링크로 이동

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -472,21 +472,21 @@ export default function SettingsPage() {
       }
     }
 
-    void loadContext().catch(() => {});
+    void loadContext().catch((err) => { console.error('설정 컨텍스트 로드 실패', err); });
 
-    void refreshProjects().catch(() => {});
+    void refreshProjects().catch((err) => { console.error('프로젝트 목록 로드 실패', err); });
 
-    void refreshInvitations().catch(() => {});
+    void refreshInvitations().catch((err) => { console.error('초대 목록 로드 실패', err); });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentProjectId, orgId]);
 
   useEffect(() => {
     if (!memberProjectId) return;
-    void refreshMemberData(memberProjectId).catch(() => {});
+    void refreshMemberData(memberProjectId).catch((err) => { console.error('멤버 데이터 로드 실패', err); });
   }, [memberProjectId]);
 
   useEffect(() => {
-    void refreshOrgAgents().catch(() => {});
+    void refreshOrgAgents().catch((err) => { console.error('조직 에이전트 로드 실패', err); });
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -648,7 +648,7 @@ export default function SettingsPage() {
     setNewProjectDescription('');
     setProjectActionMessage({ type: 'success', text: t('projectCreated', { name: project.name }) });
 
-    await refreshProjects().catch(() => {});
+    await refreshProjects().catch((err) => { console.error('프로젝트 생성 후 목록 갱신 실패', err); });
     router.refresh();
     setCreatingProject(false);
   };
@@ -1494,9 +1494,13 @@ export default function SettingsPage() {
                         if (res.ok) {
                           const json = await res.json() as { data: { portalUrl: string } };
                           window.open(json.data.portalUrl, '_blank');
+                        } else {
+                          addToast({ type: 'error', title: t('billingPortalError') });
                         }
-                      } catch {
-                        // noop
+                      } catch (err) {
+                        // 사용자 액션(결제 포털)인데 조용히 실패하면 버튼이 무반응처럼 보인다 — 안내.
+                        console.error('결제 포털 열기 실패', err);
+                        addToast({ type: 'error', title: t('billingPortalError') });
                       }
                     }}
                   >

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -107,7 +107,7 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
       .then((data: { data?: TeamMember[] } | null) => {
         if (data?.data) setMembers(data.data);
       })
-      .catch(() => {});
+      .catch((err) => { console.error('활동 로그용 팀원 목록 로드 실패', err); });
   }, [projectId]);
 
   const buildParams = useCallback(


### PR DESCRIPTION
## 요약
선생님 **"에러 조용히 무시" 직격** + 까심 2차 스윕. 각 finding을 `git grep`으로 **live/dead 검증 後** 처리(무지성 toast 금지·디디 교차검증 룰).

## finding별 처리
| 위치 | live/dead | 처리 |
|--|--|--|
| `epics-client.tsx` `_fetchEpicDetail` | **dead**(호출처 0·`/epics/[id]` 딥링크 대체) | **dead code 제거**(실행 안 되던 silent catch) |
| `activity-log-view.tsx:110`(팀원 enrichment) | live·background | `console.error` |
| `docs-shell-client.tsx:159`(debounced 검색) | live·debounced | `console.error`(+`setSearchResults([])` 유지) |
| `settings/page.tsx` init ×5 + 생성後 refresh | live·background | `console.error` |
| `settings/page.tsx` 결제 포털 버튼 | live·**user action** | `console.error` + **toast**(`settings.billingPortalError`) |

## 원칙
- **live=핸들링**(user action→toast / background·enrichment·debounced→console.error) · **dead=제거**. 무지성 toast 금지([[reference-pr-review-tooling]] 정신).
- 결제 포털만 toast: 버튼이 무반응처럼 보이는 **유일 user-facing silent failure**. 나머지는 background라 console.error(spam/infra-bloat 회피). 가디언 카피 4종 중 background용은 미적용(promotion 원하면 추가).
- i18n `settings.billingPortalError` 신규(비즈니스톤·en/ko 대칭).

## 검증
- 4파일 빈 catch/noop **0** · `eslint` 0 error · `tsc` 0 · `pnpm build` 성공 · i18n parity. (settings 25 warning은 pre-existing·내 변경 0 추가.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)