### PR TITLE
[SID:7519c3ea] feat(settings): webhook inline discoverability (flat 탭 폐기 + 멤버/에이전트 inline)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -710,7 +710,6 @@
     "tabMembers": "Access",
     "tabOrganization": "Organization",
     "tabOrgMembers": "People",
-    "tabWebhooks": "Webhooks",
     "tabBilling": "Billing",
     "webhookUrlInvalid": "Only HTTPS URLs or local HTTP URLs are allowed",
     "notificationChannel": "Notification Channel",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -710,7 +710,6 @@
     "tabMembers": "접근 권한",
     "tabOrganization": "조직",
     "tabOrgMembers": "조직 구성원",
-    "tabWebhooks": "웹훅",
     "tabBilling": "결제",
     "webhookUrlInvalid": "HTTPS URL 또는 로컬 HTTP URL만 허용됩니다",
     "notificationChannel": "알림 채널",

--- a/apps/web/src/app/(authenticated)/settings/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/page.tsx
@@ -5,7 +5,7 @@ import { useDashboardContext } from '@/app/dashboard/dashboard-shell';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Menu, Palette, Trash2, User, Users, X, Zap } from 'lucide-react';
+import { BarChart2, Bell, Bot, Check, CreditCard, FolderKanban, GitBranch, Menu, Palette, Trash2, User, Users, Webhook, X } from 'lucide-react';
 import { UsageDashboard } from '@/components/settings/usage-dashboard';
 import { OrgMembersSection } from '@/components/settings/org-members-section';
 import { ProjectAccessSection } from '@/components/settings/project-access-section';
@@ -52,7 +52,9 @@ interface NotificationSetting {
 
 interface WebhookConfig {
   id: string;
+  member_id: string;
   url: string;
+  is_active: boolean;
   project_id: string | null;
   projects?: { name: string };
 }
@@ -160,8 +162,6 @@ export default function SettingsPage() {
   const [webhooks, setWebhooks] = useState<WebhookConfig[]>([]);
   const [projects, setProjects] = useState<ProjectOption[]>([]);
   const [createdProjectMembership, setCreatedProjectMembership] = useState<{ projectId: string; projectName: string } | null>(null);
-  const [newWebhookUrl, setNewWebhookUrl] = useState('');
-  const [newWebhookProjectId, setNewWebhookProjectId] = useState('');
   const [newProjectName, setNewProjectName] = useState('');
   const [newProjectDescription, setNewProjectDescription] = useState('');
   const [creatingProject, setCreatingProject] = useState(false);
@@ -643,7 +643,6 @@ export default function SettingsPage() {
     });
     setInviteProjectId(project.id);
     setMemberProjectId(project.id);
-    setNewWebhookProjectId(project.id);
     setNewProjectName('');
     setNewProjectDescription('');
     setProjectActionMessage({ type: 'success', text: t('projectCreated', { name: project.name }) });
@@ -815,12 +814,7 @@ export default function SettingsPage() {
                   <FolderKanban className="h-4 w-4" />
                   {t('tabProjects')}
                 </TabsTrigger>
-                {isAdmin ? (
-                  <TabsTrigger value="webhooks">
-                    <Zap className="h-4 w-4" />
-                    {t('tabWebhooks')}
-                  </TabsTrigger>
-                ) : null}
+                {/* 7519c3ea: flat webhooks 탭 폐기 — webhook은 멤버/에이전트 관리(members)에 inline 통합. */}
               </>
             ) : null}
 
@@ -1324,6 +1318,11 @@ export default function SettingsPage() {
                         <div className="space-y-2">
                           {orgAgents.map((agent) => {
                             const projectName = projects.find((p) => p.id === agent.project_id)?.name ?? agent.project_id;
+                            // 7519c3ea: webhook discoverability — 행에 status 한눈에(편집은 detail editor 링크=이름).
+                            const agentWebhook = webhooks.find((w) => w.member_id === agent.id);
+                            const webhookStatus: 'active' | 'inactive' | 'empty' = !agentWebhook?.url
+                              ? 'empty'
+                              : !agentWebhook.is_active ? 'inactive' : 'active';
                             return (
                               <div key={agent.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-sm">
                                 <div className="min-w-0">
@@ -1332,6 +1331,10 @@ export default function SettingsPage() {
                                     <Badge variant="secondary">{t('agentMember')}</Badge>
                                     <Badge variant="outline">{agent.role}</Badge>
                                     <Badge variant="info">SSE</Badge>
+                                    <Badge variant={webhookStatus === 'active' ? 'success' : webhookStatus === 'inactive' ? 'secondary' : 'outline'} className="gap-1">
+                                      <Webhook className="size-3" aria-hidden />
+                                      {webhookStatus === 'active' ? t('webhookStatusActive') : webhookStatus === 'inactive' ? t('webhookStatusInactive') : t('webhookStatusEmpty')}
+                                    </Badge>
                                     {agent.fakechat_port ? <span className="font-mono text-[11px] text-muted-foreground">:{agent.fakechat_port}</span> : null}
                                     <span className="text-xs text-muted-foreground">{projectName}</span>
                                     {currentUserId && agent.created_by === currentUserId ? <Badge variant="outline" className="border-primary/40 text-primary text-[10px]">{t('agentOwner')}</Badge> : null}
@@ -1388,10 +1391,57 @@ export default function SettingsPage() {
               ) : (
               <div>
                 {currentProjectId ? (
-                  <ProjectAccessSection
-                    projectId={currentProjectId}
-                    currentRole={currentOrgRole}
-                  />
+                  <div className="space-y-6">
+                    <ProjectAccessSection
+                      projectId={currentProjectId}
+                      currentRole={currentOrgRole}
+                    />
+                    {/* 7519c3ea: 팀원 webhook inline — flat 탭 폐기분을 멤버별 surface(handleSaveWebhookUrl 재사용·status 한눈에). */}
+                    <SectionCard>
+                      <SectionCardHeader>
+                        <div className="space-y-1">
+                          <h2 className="text-base font-semibold text-foreground">{t('webhooks')}</h2>
+                          <p className="text-sm text-muted-foreground">{t('webhookDescription')}</p>
+                        </div>
+                      </SectionCardHeader>
+                      <SectionCardBody className="space-y-2">
+                        {projectMembers.filter((m) => m.type === 'human').map((member) => {
+                          const draft = webhookEditing[member.id] ?? member.webhook_url ?? '';
+                          const hasUrl = Boolean(member.webhook_url);
+                          const err = webhookErrors[member.id];
+                          return (
+                            <div key={member.id} className="rounded-md border border-border bg-muted/30 px-3 py-3">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{member.name}</span>
+                                <Badge variant={hasUrl ? 'success' : 'outline'} className="gap-1">
+                                  <Webhook className="size-3" aria-hidden />
+                                  {hasUrl ? t('webhookStatusActive') : t('webhookStatusEmpty')}
+                                </Badge>
+                              </div>
+                              <div className="mt-2 flex flex-wrap items-center gap-2">
+                                <OperatorInput
+                                  type="url"
+                                  value={draft}
+                                  onChange={(e) => setWebhookEditing((prev) => ({ ...prev, [member.id]: e.target.value }))}
+                                  placeholder={t('webhookUrlPlaceholder')}
+                                  className="min-w-0 flex-1 font-mono text-xs"
+                                />
+                                <Button
+                                  variant="hero"
+                                  size="sm"
+                                  onClick={() => void handleSaveWebhookUrl(member.id)}
+                                  disabled={webhookSaving === member.id}
+                                >
+                                  {webhookSaving === member.id ? '...' : tc('save')}
+                                </Button>
+                              </div>
+                              {err ? <p className="mt-1 text-xs text-destructive">{err}</p> : null}
+                            </div>
+                          );
+                        })}
+                      </SectionCardBody>
+                    </SectionCard>
+                  </div>
                 ) : (
                   <p className="text-sm text-muted-foreground">프로젝트를 선택해주세요.</p>
                 )}
@@ -1399,65 +1449,6 @@ export default function SettingsPage() {
               )}
             </TabsContent>
 
-            {adminChecked && isAdmin ? (
-            <TabsContent value="webhooks">
-              <SectionCard>
-                <SectionCardHeader>
-                  <div className="space-y-1">
-                    <h2 className="text-base font-semibold text-foreground">{t('webhooks')}</h2>
-                    <p className="text-sm text-muted-foreground">{t('webhookDescription')}</p>
-                  </div>
-                </SectionCardHeader>
-                <SectionCardBody className="space-y-4">
-                  <div className="space-y-2">
-                    {webhooks.map((webhook) => (
-                      <div key={webhook.id} className="flex items-center justify-between gap-3 rounded-md border border-border bg-muted/30 px-3 py-3 text-xs">
-                        <span className="truncate text-foreground">{webhook.url}</span>
-                        <span className="shrink-0 text-muted-foreground">{webhook.projects?.name ?? t('defaultWebhook')}</span>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px_auto]">
-                    <OperatorInput
-                      type="url"
-                      value={newWebhookUrl}
-                      onChange={(e) => setNewWebhookUrl(e.target.value)}
-                      placeholder={t('webhookUrlPlaceholder')}
-                    />
-                    <OperatorDropdownSelect
-                      value={newWebhookProjectId}
-                      onValueChange={(v) => setNewWebhookProjectId(v)}
-                      options={[
-                        { value: '', label: t('defaultWebhook') },
-                        ...projects.map((project) => ({ value: project.id, label: project.name })),
-                      ]}
-                    />
-                    <Button
-                      variant="hero"
-                      size="lg"
-                      onClick={async () => {
-                        if (!newWebhookUrl.trim()) return;
-                        await fetch('/api/webhooks/config', {
-                          method: 'PUT',
-                          headers: { 'Content-Type': 'application/json' },
-                          body: JSON.stringify({ url: newWebhookUrl.trim(), project_id: newWebhookProjectId || null }),
-                        });
-                        setNewWebhookUrl('');
-                        setNewWebhookProjectId('');
-                        const res = await fetch('/api/webhooks/config');
-                        if (res.ok) {
-                          const j = await res.json();
-                          setWebhooks(j.data ?? []);
-                        }
-                      }}
-                    >
-                      {tc('save')}
-                    </Button>
-                  </div>
-                </SectionCardBody>
-              </SectionCard>
-            </TabsContent>
-            ) : null}
 
             {/* E-SETTINGS-IA S2: deprecate 숨김. set 확장으로 trigger·content·딥링크(resolveSettingsTab) 일괄 차단. 컴포넌트 보존. */}
             {adminChecked && isAdmin && !HIDDEN_SETTINGS_TABS.has('workflow') ? (


### PR DESCRIPTION
## 요약
webhook 관리 3곳 분산 → discoverability 낮던 것을, **flat org/project 리스트 폐기 + 멤버/에이전트 관리(members 탭)에 inline 통합**. FE-only·BE 계약 무변경·데모-safe. 유나 doc `7519c3ea-webhook-inline-handoff`·**fork (A) PO 확정**.

## 변경 (settings/page.tsx + i18n)
- **flat webhooks 탭 폐기**: TabsTrigger·TabsContent(org/project flat list + add form)·state(`newWebhookUrl`/`newWebhookProjectId`)·orphan i18n(`tabWebhooks`) 제거.
- **에이전트(Agents row)**: webhook **status 배지**(active/inactive/empty·`webhooks` table `member_id` 기준) + 이름→기존 detail editor(`agents/[id]`) 링크로 편집. **중복0**(detail editor 재사용·(A) 결정).
- **휴먼(People)**: "팀원 Webhook" 섹션 — `projectMembers`(휴먼)별 inline editor(status 배지 + URL + Save). **기존 `webhookEditing`/`handleSaveWebhookUrl`/`isWebhookUrlAllowed` 인프라 재사용** → orphan이던 핸들러 surface·**SSRF URL 검증 유지**. `team_member.webhook_url` PATCH.
- `WebhookConfig` 타입에 `member_id`/`is_active` 추가(BE `WebhookConfigResponse` 정합).

## 가디언 리뷰 노트 (결정 근거)
- **(A) 비대칭 UX**: 에이전트=status 배지+detail 링크 / 휴먼=full inline editor. 근거=에이전트가 detail editor 이미 보유 → 행 복제는 중복+is_active 행데이터 로딩+위험. discoverability(status 한눈에)는 **양쪽 동일**. (PO 확정·doc "동일 UX"=discoverability 동일로 충족.)
- **WebhookInline 공통 컴포넌트 미채택**: 휴먼은 기존 `webhookEditing` 인프라가 `isWebhookUrlAllowed`(SSRF) 검증을 포함·doc "handleSaveWebhookUrl 재사용" 타겟이라 그걸 직접 렌더(신규 컴포넌트는 검증 regress). 선제 작성한 WebhookInline은 중복이라 제거.
- **휴먼 placement**: People 서브탭=`ProjectAccessSection`(org_member 접근 grants)이고 휴먼 webhook=team_member라, 접근 UI 무수정 + projectMembers 기반 "팀원 Webhook" 섹션 추가(저위험). 
- status 토큰: active=`success`·inactive=`secondary`·empty=`outline`(유나 spec). i18n 신규 0(기존 재사용).

## 검증
- `eslint` 0 error(handleSaveWebhookUrl·Zap orphan 해소·잔여 22 warning은 pre-existing invite state) · `tsc` 0 · `pnpm build` 성공 · i18n parity. 격리 worktree.
- 가디언 시각(webhook inline 렌더·status 배지·휴먼/에이전트 discoverability·flat 폐기) + 까심 QA(webhooks/config member_id 매핑·team_member.webhook_url PATCH·검증 유지) 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)