### PR TITLE
[SID:d9847ef0] feat(standup): 진입점 IA — org-level 기본 + project-scoped 조건부

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1000,6 +1000,7 @@
     "planStoriesProjectionHint": "Which projects this appears in is decided automatically by your access, independent of this selection.",
     "projectionViewDesc": "Shows organization standups from members with access to this project.",
     "projectionBanner": "This view collects organization-level standups projected onto this project. You don't write here — write in ‘Today's standup’ (once per organization).",
+    "projectScopedHint": "Select a project to see sprint context.",
     "sourceOrgLevel": "Org-level entry · submitted",
     "relatedPlan": "Related plan",
     "missingOrgStandup": "No organization standup yet",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1000,6 +1000,7 @@
     "planStoriesProjectionHint": "표시 대상 프로젝트는 접근 권한으로 자동 결정되며, 이 선택과는 무관합니다.",
     "projectionViewDesc": "접근 권한이 있는 멤버들의 조직 스탠드업을 표시합니다.",
     "projectionBanner": "조직 레벨 작성을 이 프로젝트 기준으로 모아 보는 화면입니다. 여기서는 작성하지 않으며, 작성은 ‘오늘의 스탠드업’(조직 1회)에서 합니다.",
+    "projectScopedHint": "프로젝트를 선택하면 스프린트 컨텍스트가 표시됩니다.",
     "sourceOrgLevel": "조직 레벨 작성 · 제출됨",
     "relatedPlan": "관련 계획",
     "missingOrgStandup": "조직 스탠드업 미작성",

--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -96,7 +96,6 @@ function shiftDate(dateStr: string, days: number): string {
 
 export default function StandupPage() {
   const t = useTranslations('standup');
-  const shellT = useTranslations('shell');
   const { currentTeamMemberId, projectId } = useDashboardContext();
 
   const [date, setDate] = useState(() => formatSeoulDate());
@@ -177,21 +176,6 @@ export default function StandupPage() {
     let cancelled = false;
 
     async function load() {
-      if (!projectId) {
-        if (!cancelled) {
-          setEntries([]);
-          setMembers([]);
-          setFeedback([]);
-          setMissingMembers([]);
-          setActiveSprint(null);
-          setStories([]);
-          setLoadError(null);
-          setSaveError(null);
-          setLoading(false);
-        }
-        return;
-      }
-
       if (!cancelled) {
         setLoading(true);
         setLoadError(null);
@@ -199,30 +183,46 @@ export default function StandupPage() {
       }
 
       try {
-        const [entriesRes, membersRes, sprintsRes, feedbackRes, missingRes] = await Promise.all([
-          fetch(`/api/standup?project_id=${projectId}&date=${date}`),
-          fetch(`/api/team-members?project_id=${projectId}`),
-          fetch(`/api/sprints?project_id=${projectId}&status=active`),
-          fetch(`/api/standup/feedback?project_id=${projectId}&date=${date}`),
-          fetch(`/api/standup/missing?project_id=${projectId}&date=${date}`),
+        // d9847ef0: org-level(항상) — standup entries(project_id 생략→org_id scoped 전체)·members(org-level).
+        // standalone org write 진입(프로젝트 미선택)에서도 작성/조회 가능.
+        const [entriesRes, membersRes] = await Promise.all([
+          fetch(`/api/standup?date=${date}`),
+          fetch(`/api/team-members`),
         ]);
 
-        const [entriesData, membersData, sprintsData, feedbackData] = await Promise.all([
+        const [entriesData, membersData] = await Promise.all([
           readJsonDataOrThrow<StandupEntryRow[]>(entriesRes, 'standup entries'),
           readJsonDataOrThrow<StandupMemberRow[]>(membersRes, 'team members'),
-          readJsonDataOrThrow<StandupSprintSummary[]>(sprintsRes, 'sprints'),
-          readJsonDataOrThrow<StandupFeedbackRow[]>(feedbackRes, 'standup feedback'),
         ]);
 
-        // S3: Missing = org 기준(projection get_missing). 실패해도 본 화면은 막지 않음.
-        const missingJson = await missingRes.json().catch(() => null) as { data?: { missing?: { id: string; name: string }[] } } | null;
-        const missingList = missingRes.ok ? (missingJson?.data?.missing ?? []) : [];
-
-        const sprint = sprintsData.find((item) => item.status === 'active') ?? sprintsData[0] ?? null;
+        // d9847ef0: project-scoped(projectId 있을 때만) — sprints·feedback·missing·sprint stories.
+        // missing은 get_missing_standups가 project_id REQUIRED라 project context 필수(BE 무변경).
+        let feedbackData: StandupFeedbackRow[] = [];
+        let missingList: { id: string; name: string }[] = [];
+        let sprint: StandupSprintSummary | null = null;
         let storySummaries: StandupStorySummary[] = [];
         let nextStoriesCursor: string | null = null;
 
-        if (sprint) {
+        if (projectId) {
+          const [sprintsRes, feedbackRes, missingRes] = await Promise.all([
+            fetch(`/api/sprints?project_id=${projectId}&status=active`),
+            fetch(`/api/standup/feedback?project_id=${projectId}&date=${date}`),
+            fetch(`/api/standup/missing?project_id=${projectId}&date=${date}`),
+          ]);
+
+          const [sprintsData, fbData] = await Promise.all([
+            readJsonDataOrThrow<StandupSprintSummary[]>(sprintsRes, 'sprints'),
+            readJsonDataOrThrow<StandupFeedbackRow[]>(feedbackRes, 'standup feedback'),
+          ]);
+          feedbackData = fbData;
+
+          // S3: Missing = org 기준(projection get_missing). 실패해도 본 화면은 막지 않음.
+          const missingJson = await missingRes.json().catch(() => null) as { data?: { missing?: { id: string; name: string }[] } } | null;
+          missingList = missingRes.ok ? (missingJson?.data?.missing ?? []) : [];
+
+          sprint = sprintsData.find((item) => item.status === 'active') ?? sprintsData[0] ?? null;
+
+          if (sprint) {
           const storiesRes = await fetch(`/api/stories?project_id=${projectId}&sprint_id=${sprint.id}&limit=40`);
           if (!storiesRes.ok) throw new Error('Failed to load sprint stories');
           const storiesJson = await storiesRes.json().catch(() => null);
@@ -248,6 +248,7 @@ export default function StandupPage() {
             return acc;
           }, {});
           storySummaries = storyRows.map((story) => buildStorySummary(story, taskProgressByStoryId[story.id] ?? { taskCount: 0, doneTaskCount: 0 }, memberLookup));
+          }
         }
 
         if (cancelled) return;
@@ -352,16 +353,8 @@ export default function StandupPage() {
     setRefreshToken((value) => value + 1);
   }
 
-  if (!projectId) {
-    return (
-      <>
-        <TopBarSlot title={<h1 className="text-sm font-medium">{t('title')}</h1>} />
-        <div className="flex h-64 items-center justify-center p-6">
-          <EmptyState title={shellT('projectSelectPrompt')} description={shellT('projectSelectDescription')} />
-        </div>
-      </>
-    );
-  }
+  // d9847ef0: projectId 전체 차단 제거 — org-level standup은 프로젝트 미선택에도 진입/작성/조회 가능.
+  // project-scoped 섹션만 {projectId && ...}로 조건부 렌더(아래).
 
   return (
     <>
@@ -410,7 +403,8 @@ export default function StandupPage() {
 
           {!loadError ? (
             <>
-              {/* 스프린트 섹션 — 접을 수 있는 컴팩트 카드 */}
+              {/* 스프린트 섹션 — 접을 수 있는 컴팩트 카드 (d9847ef0: project-scoped — projectId 있을 때만) */}
+              {projectId ? (
               <div className="rounded-xl border border-border bg-background">
                 <button
                   type="button"
@@ -509,9 +503,14 @@ export default function StandupPage() {
                   </div>
                 ) : null}
               </div>
+              ) : (
+                <div className="rounded-xl border border-dashed border-border bg-background p-6">
+                  <EmptyState title={t('projectScopedHint')} />
+                </div>
+              )}
 
               {/* S3(51447ca0): 프로젝트 뷰 = 접근-기반 projection(read-only). 작성은 org-level. */}
-              {!loading ? (
+              {!loading && projectId ? (
                 <Alert variant="default">
                   <AlertDescription className="text-xs">{t('projectionBanner')}</AlertDescription>
                 </Alert>


### PR DESCRIPTION
## 요약
standup write는 org-level(#1278·project_id 생략)인데 진입은 `:345 if(!projectId)`로 **전체 차단**돼 standalone org write가 막히던 모순 해소. E-STANDUP-SCOPE·#1278 follow-up·유나 doc `d9847ef0-standup-entry-ia-handoff`. **같은 `/standup`·BE 무변경·데모-safe.**

## 변경 (standup/page.tsx + i18n)
- **`:345` 전체 차단 제거** → 진입 projectId 무관.
- **데이터 fetch 분리**: org-level(항상)=`/api/standup?date=`(project_id 생략→org_id scoped)+members(org-level) / project-scoped(projectId 있을 때만)=sprints·feedback·missing·sprint stories.
- **org-level 섹션 항상 렌더**: standup write("오늘의 스탠드업")·내/팀 standup projection(#1278). 멀티프로젝트 멤버가 프로젝트 미선택에도 작성/조회.
- **project-scoped 섹션 조건부**: 스프린트 카드 `{projectId ? ... : projectScopedHint 인라인}`·projection 배너 projectId 게이팅. missing은 데이터 기반(projectId 없으면 빈 데이터→미렌더).
- i18n `standup.projectScopedHint` en/ko. orphan `shellT`(게이트 전용 import) 제거.

## ⚠️ BE 계약 정정 (PO 확정)
- 빌드 중 검증: **`get_missing_standups`가 `project_id` REQUIRED**(`Query(...)`)라 missing org-level 호출 불가. doc의 "missing=org-level"은 미검증 가정 → **missing을 project-scoped 섹션으로** 확정(BE 무변경·PO+가디언 동의). `list_standups`·`team-members`는 project_id Optional(org-level ✓) 확인.

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build` 성공 · i18n parity. BE 무변경. 격리 worktree.
- 가디언 시각(org-level 항상 렌더·project-scoped 조건부·projectScopedHint 인라인·전체차단 폐기) + 까심 QA(org-level fetch·project 게이팅·missing project-scoped) 요청.

🤖 Generated with [Claude Code](https://claude.com/claude-code)