### PR TITLE
[SID:71798d24] fix(sprints): handleAssignStory/Unassign silent catch → console.error

### DIFF
--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -404,12 +404,15 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sprint_id: selected?.id ?? null }),
       });
-      if (!res.ok) return;
+      if (!res.ok) { console.error('스토리 스프린트 배정 실패', res.status); return; }
       if (selected) {
         setSprintStories((prev) => [...prev, { ...story, sprint_id: selected.id }]);
         setBacklogStories((prev) => prev.filter((s) => s.id !== story.id));
       }
-    } catch { /* noop */ }
+    } catch (err) {
+      // 71798d24: 에러를 조용히 무시하지 않는다(background 액션 — console.error).
+      console.error('스토리 스프린트 배정 실패', err);
+    }
   };
 
   const handleUnassignStory = async (story: Story) => {
@@ -419,10 +422,13 @@ export function SprintsClient({ projectId }: SprintsClientProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ sprint_id: null }),
       });
-      if (!res.ok) return;
+      if (!res.ok) { console.error('스토리 스프린트 해제 실패', res.status); return; }
       setSprintStories((prev) => prev.filter((s) => s.id !== story.id));
       setBacklogStories((prev) => [...prev, { ...story, sprint_id: null }]);
-    } catch { /* noop */ }
+    } catch (err) {
+      // 71798d24: 에러를 조용히 무시하지 않는다(background 액션 — console.error).
+      console.error('스토리 스프린트 해제 실패', err);
+    }
   };
 
   if (loading) {


### PR DESCRIPTION
## 요약
sprints-client `handleAssignStory`/`handleUnassignStory`가 `catch { /* noop */ }` + `if (!res.ok) return`(silent)으로 스프린트 배정/해제 에러를 조용히 무시하던 것을 `console.error`로(선생님 "에러 조용히 무시" 직격·#1295 패턴·background 액션이라 toast 불요).

## 변경
- `handleAssignStory`/`handleUnassignStory`: `catch { /* noop */ }` → `catch (err) { console.error(...) }`.
- 동반: `if (!res.ok) return` → `console.error(status)` 후 return(같은 silent-swallow 클래스·완주 정신).

## 검증
- `eslint` 0 · `tsc` 0. 격리 worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)