### PR TITLE
feat(conversations): GET /api/v2/conversations/{id} 단독 메타 (03fe1663)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator
 from sqlalchemy import and_, func, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -371,6 +371,23 @@ class CreateConversationRequest(BaseModel):
     project_id: uuid.UUID
 
 
+class ConversationResponse(BaseModel):
+    """단독 conversation 메타. 03fe1663: 첨부 업로드 라우트가 path projectId를
+    클라이언트 쿠키 대신 conversation.project_id로 server-side 도출하는 데 사용."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    project_id: uuid.UUID
+    org_id: uuid.UUID
+    type: str
+    title: str | None = None
+    status: str
+    created_by: uuid.UUID | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
 # E-FILE S1: 채팅 첨부. GCS 기록은 FE-proxy(uploadToGcs)가 처리하고 BE는 URL+메타만 저장.
 _MAX_ATTACHMENTS = 10
 _MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024  # 100MB (메타 sanity 상한)
@@ -600,6 +617,40 @@ async def list_conversations(
         })
 
     return {"data": result, "total": total, "limit": limit, "offset": offset}
+
+
+@router.get("/{conversation_id}", response_model=ConversationResponse)
+async def get_conversation(
+    conversation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ConversationResponse:
+    """GET /api/v2/conversations/{id} — 단독 메타 조회(project_id 포함).
+
+    03fe1663: 첨부 업로드 라우트가 attachment path의 projectId를 클라이언트 쿠키
+    대신 conversation.project_id로 server-side 도출하도록 메타를 제공한다.
+    인가는 messages 조회와 동일 — owner/admin은 org-level, 그 외는 participant만.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=None)
+    if await _effective_org_role(auth, org_id, db, sender) not in ("owner", "admin"):
+        sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+        participant = (await db.execute(
+            select(ConversationParticipant.id).where(
+                ConversationParticipant.conversation_id == conversation_id,
+                ConversationParticipant.member_id == sender.id,
+            )
+        )).scalar_one_or_none()
+        if participant is None:
+            raise HTTPException(status_code=403, detail="Not a participant")
+
+    return ConversationResponse.model_validate(conv)
 
 
 @router.get("/{conversation_id}/messages")

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -320,6 +320,54 @@ async def test_list_messages_response_shape():
         app.dependency_overrides.clear()
 
 
+# ─── 03fe1663: GET /conversations/{id} — 단독 메타(project_id server-side 도출용) ──
+
+@pytest.mark.anyio
+async def test_get_conversation_200_returns_project_id():
+    """GET /conversations/{id} → 단독 메타(project_id 포함). owner org-level 접근."""
+    client, session, app = await _make_client()
+    try:
+        mock_member = _make_member()
+        mock_member.role = "owner"  # _effective_org_role owner → participant 체크 skip
+        mock_conv = _make_conv()
+        mock_conv.status = "open"
+        mock_conv.created_at = datetime(2026, 5, 14, tzinfo=timezone.utc)
+
+        conv_result = MagicMock()
+        conv_result.scalar_one_or_none.return_value = mock_conv
+        member_result = MagicMock()
+        member_result.scalars.return_value.first.return_value = mock_member
+
+        session.execute = AsyncMock(side_effect=[conv_result, member_result])
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/conversations/{CONV_ID}")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["id"] == str(CONV_ID)
+        assert body["project_id"] == str(PROJECT_ID)  # 업로드 path server-side 도출의 근거
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_get_conversation_404():
+    """존재하지 않는 conversation → 404."""
+    client, session, app = await _make_client()
+    try:
+        conv_result = MagicMock()
+        conv_result.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(side_effect=[conv_result])
+
+        async with client as c:
+            resp = await c.get(f"/api/v2/conversations/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+
+
 # ─── AC7: POST /conversations/{id}/messages — 전송 ──────────────────────────
 
 @pytest.mark.anyio


### PR DESCRIPTION
## 배경 (03fe1663 · E-FILE robustness)
첨부 업로드 라우트(`conversations/[id]/attachments`)가 attachment path의 `projectId`를 **클라이언트 formData(`?? 'unknown'`)** 로 받아, 쿠키 없는/API-only 요청에서 `chat/unknown/{conv}/...` 경로를 생성. UI 동선엔 쿠키 있어 데모/실사용 무영향이나 robustness상 server-side 도출이 안전(쿠키 누락·tampering 무관).

## 블로커 해소
미르코 FE가 conversation 업로드 path projectId를 server-side 도출하려는데 **conversation detail GET이 부재**(list + messages만 존재). 본 PR이 그 BE 계약을 추가.

## 변경 (BE)
- `GET /api/v2/conversations/{conversation_id}` 단독 메타 엔드포인트 추가.
- `ConversationResponse`(id/project_id/org_id/type/title/status/created_by/created_at/updated_at) inline 스키마.
- 인가: messages 조회와 **동일** — owner/admin은 org-level, 그 외는 participant만(404/403). 기존 `_resolve_member`/`_effective_org_role` 재사용.

## FE 계약 (미르코 공유)
- conversation: `GET /api/v2/conversations/{id}` → 응답 `project_id`로 업로드 path 도출
- story: 기존 `GET /api/v2/stories/{id}.project_id` 활용 (FE-only)

## 검증
- `test_conversations.py` **13 passed** (단독 GET 200·project_id 반환·404 추가)
- 내 변경분 ruff 깨끗 (기존 F401 `and_`/`ChannelRouterError`는 develop 기존·본 PR 스코프 밖)

🤖 Generated with [Claude Code](https://claude.com/claude-code)