### PR TITLE
[SID:03fe1663] fix(attachments): 업로드 path projectId server-side 도출 (쿠키/client 의존 제거)

### DIFF
--- a/apps/web/src/app/api/conversations/[conversation_id]/attachments/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/attachments/route.ts
@@ -6,6 +6,7 @@ import { GCS_MEMO_ATTACHMENTS_BUCKET, uploadToGcs } from '@/lib/gcs';
 
 // BE _MAX_ATTACHMENT_SIZE 정합 (conversations.py)
 const MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024; // 100MB
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 // chat-attach: 파일을 서버사이드에서 GCS로 업로드하고 메시지 첨부 메타({url,name,content_type,size})를 돌려준다.
 // 업로드된 GCS object URL은 리로드/다른 인스턴스에서도 유효(multi-instance safe) — BE 계약대로
@@ -27,7 +28,20 @@ export async function POST(
     return NextResponse.json({ error: { message: 'attachment too large (max 100MB)' } }, { status: 413 });
   }
 
-  const projectId = (formData.get('project_id') as string | null) ?? 'unknown';
+  // 03fe1663: project_id를 conversation에서 server-side 도출(클라이언트/쿠키 의존·'unknown' 폴백 제거).
+  // #1299 GET /api/v2/conversations/{id} → conversation.project_id. 인가도 BE가 강제(403/404).
+  const convRes = await fetch(new URL(`/api/v2/conversations/${conversation_id}`, FASTAPI_URL()).toString(), {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    cache: 'no-store',
+  });
+  if (!convRes.ok) {
+    return NextResponse.json({ error: { message: 'conversation not found or no access' } }, { status: convRes.status === 403 ? 403 : 404 });
+  }
+  const conv = (await convRes.json().catch(() => null)) as { project_id?: string | null } | null;
+  const projectId = conv?.project_id;
+  if (!projectId) {
+    return NextResponse.json({ error: { message: 'conversation project could not be resolved' } }, { status: 422 });
+  }
   const safeName = (file.name || 'file').replace(/[^\w.\-]+/g, '_').slice(-128) || 'file';
   const objectPath = `chat/${projectId}/${conversation_id}/${randomUUID()}-${safeName}`;
 

--- a/apps/web/src/app/api/stories/[id]/attachments/route.ts
+++ b/apps/web/src/app/api/stories/[id]/attachments/route.ts
@@ -6,6 +6,7 @@ import { GCS_MEMO_ATTACHMENTS_BUCKET, uploadToGcs } from '@/lib/gcs';
 
 // BE _MAX_ATTACHMENT_SIZE 정합 (schemas/story.py)
 const MAX_ATTACHMENT_SIZE = 100 * 1024 * 1024; // 100MB
+const FASTAPI_URL = () => process.env['NEXT_PUBLIC_FASTAPI_URL'] ?? 'http://localhost:8000';
 
 // E-FILE S4: 스토리 첨부 파일을 서버사이드에서 GCS로 업로드하고 메타({url,name,content_type,size})를 반환.
 // chat-attach 의 conversations/attachments 와 동형. 반환 메타를 호출부에서 모아
@@ -27,7 +28,20 @@ export async function POST(
     return NextResponse.json({ error: { message: 'attachment too large (max 100MB)' } }, { status: 413 });
   }
 
-  const projectId = (formData.get('project_id') as string | null) ?? 'unknown';
+  // 03fe1663: project_id를 story에서 server-side 도출(클라이언트/쿠키 의존·'unknown' 폴백 제거).
+  // GET /api/v2/stories/{id} → story.project_id. 인가도 BE가 강제(403/404).
+  const storyRes = await fetch(new URL(`/api/v2/stories/${id}`, FASTAPI_URL()).toString(), {
+    headers: { Authorization: `Bearer ${session.access_token}` },
+    cache: 'no-store',
+  });
+  if (!storyRes.ok) {
+    return NextResponse.json({ error: { message: 'story not found or no access' } }, { status: storyRes.status === 403 ? 403 : 404 });
+  }
+  const story = (await storyRes.json().catch(() => null)) as { project_id?: string | null } | null;
+  const projectId = story?.project_id;
+  if (!projectId) {
+    return NextResponse.json({ error: { message: 'story project could not be resolved' } }, { status: 422 });
+  }
   const safeName = (file.name || 'file').replace(/[^\w.\-]+/g, '_').slice(-128) || 'file';
   const objectPath = `story/${projectId}/${id}/${randomUUID()}-${safeName}`;
 

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -415,7 +415,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
       for (const file of files.slice(0, room)) {
         const fd = new FormData();
         fd.append('file', file);
-        if (projectId) fd.append('project_id', projectId);
+        // 03fe1663: project_id는 업로드 라우트가 story에서 server-side 도출(클라이언트 전달 불요).
         const res = await fetch(`/api/stories/${story.id}/attachments`, { method: 'POST', body: fd });
         if (!res.ok) throw new Error('upload failed');
         uploaded.push(await res.json() as SendAttachment);


### PR DESCRIPTION
## 요약
첨부 업로드 라우트가 attachment path의 `projectId`를 **클라이언트 FormData(미전달 시 `'unknown'`)에 의존**해 `chat/unknown/...` 경로가 생기던 것(a54ddc16 prod E2E서 발견)을, 리소스에서 **server-side 도출**로 교체. 디디 BE **#1299**와 합·BE 무변경(읽기 엔드포인트 사용).

## 변경
- **`conversations/[id]/attachments`**: #1299 `GET /api/v2/conversations/{id}`(project_id·authz)로 server-side 도출 → `chat/{project_id}/{conv}/...`. **'unknown' 폴백 제거**(미해결 시 404/403/422).
- **`stories/[id]/attachments`**: `GET /api/v2/stories/{id}` → `story/{project_id}/{story}/...`. 동일.
- **`story-detail-panel`**: 클라이언트 `project_id` FormData append 제거(라우트가 server-side 도출·client 의존 제거).
- 인가도 BE GET이 강제(403/404) — 접근 불가 리소스 업로드 차단(이중 안전).

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build` 성공 · `git diff --cached --stat` node_modules 0. 격리 worktree.
- ⏳ **#1299 dev 배포 후**: 실 업로드 path가 `chat|story/{real-project-id}/`로 생성·`unknown` 0 정합 검증(prod a54ddc16 E2E와 연계). 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)