### PR TITLE
[SID:7363ec8a] fix(settings): AddMemberModal 재열 시 fresh state (CP4 follow-up)

### DIFF
--- a/apps/web/src/components/settings/add-member-modal.tsx
+++ b/apps/web/src/components/settings/add-member-modal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslations } from 'next-intl';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { OperatorInput } from '@/components/ui/operator-control';
@@ -39,10 +39,20 @@ export function AddMemberModal({ open, onClose, orgId, projects, defaultType = '
   const [agentProjectId, setAgentProjectId] = useState('');
 
   const reset = () => {
+    setType(defaultType);
     setEmail(''); setRole('member'); setProjectIds([]);
     setAgentName(''); setAgentProjectId(''); setError(null);
   };
   const close = () => { reset(); onClose(); };
+
+  // CP4(까심): 모달은 열릴 때마다 fresh state로 — type을 현 defaultType(활성 subtab)에 동기화 +
+  // 폼/error 초기화. close→reopen 시 직전 선택(예: 에이전트) persist 방지.
+  useEffect(() => {
+    if (!open) return;
+    setType(defaultType);
+    setEmail(''); setRole('member'); setProjectIds([]);
+    setAgentName(''); setAgentProjectId(''); setError(null);
+  }, [open, defaultType]);
   const toggleProject = (id: string) =>
     setProjectIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
 


### PR DESCRIPTION
## 요약
#1300(7363ec8a) 사후 QA **CP4**(까심): `AddMemberModal` close→reopen 시 type 토글 state가 persist(에이전트 선택→닫기→재열면 에이전트 유지·`defaultType` reset 안 됨). 모달이 **열릴 때마다 fresh state**가 되도록 수정. polish(기능 done).

## 변경
- **open-reset `useEffect`**: 모달 open 시 `type=defaultType`(현 활성 subtab)·폼(email/role/projectIds·agentName/agentProjectId)·error 초기화. → close→reopen + subtab 변경 사이에도 fresh state.
- `reset()`(close 경유)에 `setType(defaultType)` 추가.

## 검증
- `eslint` 0(경고 0) · `tsc` 0 · `git diff --cached --stat` node_modules 0. develop 기준 격리 worktree(#1300 squash 반영분 위).

🤖 Generated with [Claude Code](https://claude.com/claude-code)