### PR TITLE
fix(webhook): 휴먼 webhook_url dead-path 제거 — webhook_configs 단일 경로 (webhook-save)

### DIFF
--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -53,6 +53,12 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         m_set = {k: v for k, v in data.items() if k in _MEMBERS_FIELDS}
         a_set = {k: v for k, v in data.items() if k in _ACCESS_FIELDS}
         p_set = {k: v for k, v in data.items() if k in _PROFILE_FIELDS}
+        # webhook-save fix: 휴먼 webhook_url은 canonical webhook_configs(PUT /api/webhooks/config)로
+        # 일원화한다. agent_project_profiles 는 에이전트 전용 미러라, 휴먼 webhook_url 이 여기로
+        # 오라우팅되면 0-row UPDATE(no-op) = 200인데 persist 안 되는 silent 실패였다 → 휴먼은
+        # 이 path 에서 제외(dead-path 제거). 휴먼 webhook 저장/발송은 webhook_configs 가 유일 경로.
+        if member.type != "agent":
+            p_set.pop("webhook_url", None)
         if m_set:
             await self.session.execute(
                 sa_update(Member)

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -239,3 +239,36 @@ async def test_deactivate_not_found_404():
         assert resp.status_code == 404
     finally:
         app.dependency_overrides.clear()
+
+
+# ─── webhook-save fix: apply_anchor_update 휴먼 webhook_url dead-path 제거 ──────
+
+@pytest.mark.anyio
+async def test_apply_anchor_update_human_webhook_url_dead_path_removed():
+    """휴먼 webhook_url 은 agent_project_profiles(에이전트 전용)로 오라우팅돼 0-row no-op
+    (200인데 persist X)였다 → 휴먼은 이 path 제외. webhook 저장은 webhook_configs 단일 경로."""
+    from app.repositories.team_member import TeamMemberRepository
+
+    session = AsyncMock()
+    repo = TeamMemberRepository(session, ORG_ID)
+    member = _mock_member(type_="human")
+
+    await repo.apply_anchor_update(member, {"webhook_url": "https://example.com/wh"})
+
+    # 휴먼 webhook_url 만 있는 PATCH → m_set/a_set/p_set 전부 비어 UPDATE execute 0회(dead-path 제거)
+    assert session.execute.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_apply_anchor_update_agent_webhook_url_kept():
+    """에이전트 webhook_url 은 agent_project_profiles 미러 유지(런타임·1bc9fbae ⑤ DROP 게이트)."""
+    from app.repositories.team_member import TeamMemberRepository
+
+    session = AsyncMock()
+    repo = TeamMemberRepository(session, ORG_ID)
+    member = _mock_member(type_="agent")
+
+    await repo.apply_anchor_update(member, {"webhook_url": "https://example.com/wh"})
+
+    # 에이전트 → p_set 유지 → AgentProjectProfile UPDATE execute 1회
+    assert session.execute.await_count == 1


### PR DESCRIPTION
## 배경 (선생님 적출 P0)
project settings > access 에서 휴먼 webhook URL 저장 → **200 OK인데 새로고침하면 빔**(silent persist 실패). band-aid 차단: persist 돼도 dispatch(webhook_configs read) 미연결이면 발송 안 됨.

## 근본
PATCH /team-members 의 `apply_anchor_update` 가 `webhook_url` 을 **agent_project_profiles**(에이전트 전용 미러)로 오라우팅 → **휴먼은 profile row 가 없어 0-row UPDATE(no-op)** = 200인데 persist X. 발송 read 는 전부 webhook_configs(dispatch_router 에이전트/Discord·notification_dispatch 휴먼·webhook_dispatch org)라 team_member.webhook_url/profiles 경로는 dispatch 도 미연결.

## 변경 (BE — 미르코 FE rewire 와 합)
- `apply_anchor_update`: **휴먼 webhook_url 을 제외**(dead-path 제거). 휴먼 webhook 저장·발송은 canonical `webhook_configs`(PUT /api/webhooks/config)가 유일 경로.
- 미르코 FE: 휴먼 webhook 을 PATCH /team-members 대신 PUT/GET /webhooks/config 로 rewire(별도 PR·합).
- 에이전트 webhook_url 은 agent_project_profiles 미러 유지(런타임·1bc9fbae ⑤ DROP 게이트).

## BE crux 3점 보장 (미르코 rewire 전제)
- ① PUT /config `canonicalize_member_id`(tm.id→members.id)
- ② project-scoped: `body.project_id` 그대로 저장
- ③ notification_dispatch 가 `member_id.in_() AND org AND is_active`(**project_id 무관**) 매칭 → project-scoped 휴먼 webhook 도 발송. SSRF·HMAC·Discord(content)·retry 재사용 → 실 Discord 도착.

## 검증
- `test_team_members.py` **10 passed** (apply_anchor_update 휴먼 webhook_url skip / 에이전트 유지 회귀 추가)
- ruff PASS

까심 QA: persist(webhook_configs 행) + **실 Discord 도착**. url-only(is_active=true on save)·enable Switch defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)