### PR TITLE
fix(project-access): GET /access 500 — org_member_id Optional (0075 에이전트 placement)

### DIFF
--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -25,7 +25,12 @@ class ProjectAccessResponse(BaseModel):
 
     id: uuid.UUID
     project_id: uuid.UUID
-    org_member_id: uuid.UUID
+    # nullable: migration 0075 가 NOT NULL 을 해제해 에이전트 direct placement(agents have no
+    # org_member)를 수용한다. 스키마가 모델(Mapped[uuid.UUID | None])을 뒤따르지 못해 에이전트
+    # 행 model_validate 시 ValidationError → GET /access 500 이던 것을 정합화한다.
+    org_member_id: uuid.UUID | None = None
+    # E-MEMBER-SSOT AC2-1 canonical 앵커 — 에이전트 행은 org_member_id 대신 member_id 로 식별.
+    member_id: uuid.UUID | None = None
     permission: str
     created_at: datetime
 

--- a/backend/tests/test_e_entity_cleanup_s3_project_access.py
+++ b/backend/tests/test_e_entity_cleanup_s3_project_access.py
@@ -137,3 +137,47 @@ def test_migration_has_downgrade():
         content = f.read()
     assert "def downgrade" in content
     assert "drop_table" in content
+
+
+# ─── access 500 fix: ProjectAccessResponse org_member_id Optional (0075 에이전트 placement) ──
+
+def test_response_accepts_null_org_member_id():
+    """에이전트 direct placement 행(org_member_id NULL·0075 NOT NULL 해제)을
+    ProjectAccessResponse 가 수용. org_member_id required 였을 때 GET /access 가 500이었다."""
+    import uuid
+    from datetime import datetime, timezone
+    from unittest.mock import MagicMock
+
+    from app.routers.project_access import ProjectAccessResponse
+
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.project_id = uuid.uuid4()
+    r.org_member_id = None  # 에이전트는 org_member 없음
+    r.member_id = uuid.uuid4()  # canonical 앵커로 식별
+    r.permission = "granted"
+    r.created_at = datetime.now(timezone.utc)
+
+    v = ProjectAccessResponse.model_validate(r)
+    assert v.org_member_id is None
+    assert v.member_id is not None
+
+
+def test_response_accepts_human_org_member_id():
+    """휴먼 행(org_member_id set) 무회귀."""
+    import uuid
+    from datetime import datetime, timezone
+    from unittest.mock import MagicMock
+
+    from app.routers.project_access import ProjectAccessResponse
+
+    r = MagicMock()
+    r.id = uuid.uuid4()
+    r.project_id = uuid.uuid4()
+    r.org_member_id = uuid.uuid4()
+    r.member_id = None
+    r.permission = "granted"
+    r.created_at = datetime.now(timezone.utc)
+
+    v = ProjectAccessResponse.model_validate(r)
+    assert v.org_member_id is not None


### PR DESCRIPTION
## 배경 (선생님 적출 P0 · pre-existing)
`GET /api/v2/projects/{id}/access` → **500**. webhook-save 와 무관(0075-era 갭).

## 근본
migration 0075 가 `project_access.org_member_id` NOT NULL 을 해제 — **에이전트 direct placement(agents have no org_member)** 행 수용. 하지만 `ProjectAccessResponse.org_member_id` 는 required(`uuid.UUID`)로 남아, 에이전트 행(org_member_id NULL) `model_validate` 시 pydantic ValidationError → list 핸들러 **전체 500**.

## fix (principled · 마이그 불요)
- `org_member_id: uuid.UUID | None = None` — 에이전트 placement NULL 을 **유효 상태**로 수용(team_member 봐주기/데이터 정리 아님). ORM 이미 nullable이라 마이그 0.
- `member_id: uuid.UUID | None = None` 추가 — 에이전트 행은 org_member_id 대신 canonical member_id 로 식별(additive optional·기존 FE 무영향·미르코 FE 렌더 활용 가능).

## 검증
- `test_e_entity_cleanup_s3_project_access.py` **14 passed** — ProjectAccessResponse 가 org_member_id NULL(에이전트) 수용 + 휴먼(set) 무회귀 단위테스트 추가
- ruff PASS

까심 QA: access 200 로드 + 에이전트 배치 행(org_member_id NULL) 표시 정상. 배포: dev verify → prod(마이그0·low-risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)