### PR TITLE
[SID:standup-dup] fix(standup): org-level 멤버 중복 카드 제거 (id dedup·선생님 버그)

### DIFF
--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -254,7 +254,11 @@ export default function StandupPage() {
         if (cancelled) return;
 
         setEntries(entriesData);
-        setMembers(membersData);
+        // team_members 뷰는 휴먼=members⋈project_access(per-project 행)이라 org-level fetch(project_id 생략·
+        // d9847ef0)는 멀티프로젝트 멤버를 같은 id로 N행 반환한다. standup은 org-level이므로 id 기준 dedup
+        // (멤버 1회만) — 중복 카드 + React key 중복 방지. (선생님 standup 중복 렌더 버그.)
+        const uniqueMembers = Array.from(new Map(membersData.map((m) => [m.id, m])).values());
+        setMembers(uniqueMembers);
         setFeedback(feedbackData);
         setMissingMembers(missingList);
         setActiveSprint(sprint);


### PR DESCRIPTION
## 요약
**선생님 적출**: 스탠드업 뷰가 멤버를 **2+회 중복 렌더**(멤버당 카드 2장+). 근본 = `team_members` 뷰(0088)가 휴먼=`members ⋈ project_access`(per-project 행)·에이전트=`members ⋈ agent_project_profiles`라, **d9847ef0의 org-level fetch(`/api/team-members` project_id 생략)가 멀티프로젝트 멤버를 같은 `m.id`로 N행 반환** → `members` 배열 중복 → `filter`→`map` 중복 카드 + React key(member.id) 중복.

## 변경
- fetch 후 `membersData`를 **`id` 기준 dedup**(`Array.from(new Map(m.id→m).values())`) → standup(org-level)은 멤버 1회만 렌더. 중복 카드 + key 중복 해소.
- **스토리 selector**(`storyPickerStories`=`stories` 파생·project-scoped): **무결·정상 동작** 확인(변경 0). `humanMembersSorted.map`/`agentMembers.map`도 각 1회·로직 정상(중복은 배열 데이터가 원인).

## 검증
- `eslint` 0 · `tsc` 0 · `pnpm build` 성공 · diff-cached node_modules 0. 격리 worktree.
- (BE team-members가 per-project 행을 주는 건 뷰 설계상 정상 — org-level 소비자[standup]가 dedup. 디디군 BE dup 추적과 별개로 FE org-level dedup이 정공.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)