### PR TITLE
fix(team-members): org-level 조회 member DISTINCT — standup-dup 근본

### DIFF
--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -41,6 +41,12 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
         q = select(TeamMember).where(self._org_filter())
         for attr, val in filters.items():
             q = q.where(getattr(TeamMember, attr) == val)
+        # standup-dup 근본 fix: team_members 는 0088 projection 뷰(members ⋈ project_access /
+        # ⋈ agent_project_profiles)라 멀티프로젝트 멤버가 per-project N행이 된다. org-level
+        # (project_id 미필터) 조회는 멤버 중복 → member(id) 기준 DISTINCT ON 으로 1행만 반환
+        # (org-level 계약 = unique 멤버). project_id 필터 시엔 project당 1행이라 dedup 불요(무회귀).
+        if "project_id" not in filters:
+            q = q.distinct(TeamMember.id).order_by(TeamMember.id)
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
 

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -272,3 +272,36 @@ async def test_apply_anchor_update_agent_webhook_url_kept():
 
     # 에이전트 → p_set 유지 → AgentProjectProfile UPDATE execute 1회
     assert session.execute.await_count == 1
+
+
+# ─── standup-dup fix: org-level team_members DISTINCT ON(id) dedup ──────────────
+
+@pytest.mark.anyio
+async def test_list_org_level_distinct_on_id():
+    """team_members 뷰(0088 projection·members⋈project_access)는 멀티프로젝트 멤버가
+    per-project N행 → org-level(project_id 미필터)은 DISTINCT ON(id)로 멤버 1행만(unique)."""
+    from sqlalchemy.dialects import postgresql
+
+    from app.repositories.team_member import TeamMemberRepository
+
+    captured = []
+
+    async def cap(q, *args, **kwargs):
+        captured.append(q)
+        r = MagicMock()
+        r.scalars.return_value.all.return_value = []
+        return r
+
+    session = AsyncMock()
+    session.execute = cap
+    repo = TeamMemberRepository(session, ORG_ID)
+
+    # org-level: project_id 미필터 → DISTINCT ON 적용(멤버 dedup)
+    await repo.list()
+    org_sql = str(captured[-1].compile(dialect=postgresql.dialect()))
+    assert "DISTINCT ON" in org_sql
+
+    # project-scoped: project당 1행이라 dedup 불요(무회귀)
+    await repo.list(project_id=PROJECT_ID)
+    proj_sql = str(captured[-1].compile(dialect=postgresql.dialect()))
+    assert "DISTINCT ON" not in proj_sql


### PR DESCRIPTION
## 배경 (선생님 적출 P0 · standup-dup BE root)
스탠드업 프로젝트 뷰 멤버당 2+ 카드 중복. 오르테가 admin fetch 실측: `/api/team-members?project_id=` → dup 0(클린) / `/api/team-members`(org-level·필터없음) → **31·unique20·dup11**.

## 근본
team_members 는 0088 에서 **projection 뷰**로 강등(`members ⋈ project_access` / `⋈ agent_project_profiles`). 멀티프로젝트 멤버 = per-project N행. org-level(project_id 미필터)이 그 N행 그대로 반환 → standup org-level 멤버 목록 중복. (standups entry 는 무결 — (author,date) 중복 0·EXISTS·멱등·canonical.)

## 변경
`TeamMemberRepository.list`: project_id 미필터(org-level)일 때 `DISTINCT ON (id)`로 unique 멤버 1행. project_id 필터 시 무회귀(project당 1행). org-level 계약 = unique 멤버(다른 consumer 보호).

미르코 FE #1308(`Array.from(new Map(id→m).values())`)은 guard, **본 BE fix 가 root**.

## 검증
- `test_team_members.py` **11 passed** — org-level DISTINCT ON 적용 / project-scoped 미적용 분기 단위테스트 추가
- ruff PASS

머지+dev배포 後 BE-side verify: org-level GET unique·project-scoped 무회귀. prod 별도 윈도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)