### PR TITLE
feat(db): asyncpg statement_cache_size=0 — PgBouncer transaction-mode prereq (2c4dcae7 ②)

### DIFF
--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -17,6 +17,10 @@ engine = create_async_engine(
     max_overflow=settings.db_max_overflow,
     pool_pre_ping=True,
     echo=settings.debug,
+    # 2c4dcae7 ②: asyncpg prepared statement 캐시 비활성. PgBouncer transaction-mode 의
+    # 필수 전제(pooled conn 간 prepared stmt reuse 깨짐 방지). PgBouncer 도입 前에도 안전한
+    # additive 설정(asyncpg 자체 동작·성능 영향 미미). ③④ 인프라(PgBouncer 실배포)의 prereq.
+    connect_args={"statement_cache_size": 0},
 )
 
 async_session_factory = async_sessionmaker(


### PR DESCRIPTION
## 2c4dcae7 ② BE (설계 PO APPROVE·② 선행 GO)
PgBouncer transaction-mode 의 필수 전제. `create_async_engine` 에 `connect_args={"statement_cache_size": 0}` 추가 — asyncpg prepared statement 캐시 비활성(pooled conn 간 prepared stmt reuse 깨짐 방지).

- **additive·PgBouncer 무관 안전**: PgBouncer 도입 前에도 정상(asyncpg 자체 동작·성능 영향 미미·기존 pool/pre_ping/echo 무변경). 그래서 ③④ 인프라 前 선행 PR.
- **③④ 인프라(DevOps·별도)**: PgBouncer 실배포(sidecar vs managed·pool_mode=transaction)·DATABASE_URL_PROD→endpoint·load smoke(pg_stat_activity). ⚠️prod=별도 안전윈도+선생님 승인(최고위험·DB 커넥션 레이어).
- **pool right-size guardrail**: 현 config(db_pool_size=5·max_overflow=3·prod maxScale 10 → 80+20 headroom ≤ max_connections 100) 이미 충족 — 변경 불요.

## 검증
- py_compile·**engine import OK(connect_args 적용)**·회귀 pytest 10 passed·ruff PASS

데모 안전분(prereq·additive)이라 dev 검증→prod batch 포함 가능. PgBouncer 실배포(③④)는 heavier 인프라로 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)