### PR TITLE
fix(chat): created_by=None 에이전트 DM 403 — org owner/admin 면제 (Ohol DM 버그)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -41,6 +41,8 @@ async def _enforce_agent_creator_policy(
     sender: "ResolvedMember | TeamMember",
     participant_ids: list[uuid.UUID],
     db: AsyncSession,
+    auth: AuthContext,
+    org_id: uuid.UUID,
 ) -> None:
     """⭐ 불변식: 휴먼↔에이전트 대화 — 각 에이전트의 creator가 참가자(sender ∪ participant_ids)에 있어야.
 
@@ -91,12 +93,21 @@ async def _enforce_agent_creator_policy(
 
     human_user_ids: set[uuid.UUID] = {u for _, u in humans if u}
 
+    # P0 fix(Ohol DM 403): created_by=None 레거시 에이전트(seed/이관 전 row 등)는 creator-동석
+    # 불변식을 적용할 수 없다. sender가 org owner/admin이면 자기 org 에이전트와의 DM 을 허용한다
+    # (관리자 권한·creator 부재 시 면제). 비-admin 또는 created_by 보유 케이스는 무회귀.
+    sender_is_org_admin = await _effective_org_role(auth, org_id, db, sender) in ("owner", "admin")
+
     # E-MSG-POLICY S1: 각 에이전트의 message_policy_mode 별 인가
     for agent_tm in agent_tms:
         mode = getattr(agent_tm, "message_policy_mode", None) or "creator_only"
 
         if mode == "org_wide":
             continue  # org 내 휴먼 전부 허용 (참가자는 이미 org-scoped) → 통과
+
+        # created_by=None 에이전트 + org owner/admin sender → 게이트 면제(creator_only·list 무관·관리자 권한)
+        if agent_tm.created_by is None and sender_is_org_admin:
+            continue
 
         if mode == "list":
             allowed_ids = set((await db.execute(
@@ -460,7 +471,7 @@ async def create_conversation(
     sender = await _resolve_member(auth, org_id, db, project_id=body.project_id)
 
     # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
-    await _enforce_agent_creator_policy(sender, body.participant_ids, db)
+    await _enforce_agent_creator_policy(sender, body.participant_ids, db, auth, org_id)
 
     # 179db213: 1-pair=1-DM enforce — resolved member set 이 정확히 2명이면 DM 으로 dedup
     # (body.type label 무관). dm_pair_key(정렬쌍)로 기존 DM 조회→반환. ≥3명/단독은 group.
@@ -760,7 +771,7 @@ async def add_participant(
         select(ConversationParticipant.member_id)
         .where(ConversationParticipant.conversation_id == conversation_id)
     )).scalars().all()
-    await _enforce_agent_creator_policy(sender, list(set(_existing_ids) | {body.member_id}), db)
+    await _enforce_agent_creator_policy(sender, list(set(_existing_ids) | {body.member_id}), db, auth, org_id)
 
     # DM → 기존 DM 유지, 기존 참여자 + 신규 참여자로 그룹 conversation fork
     if conv.type == "dm":

--- a/backend/tests/test_e_msg_policy_s1.py
+++ b/backend/tests/test_e_msg_policy_s1.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -14,6 +14,13 @@ from app.routers.conversations import _enforce_agent_creator_policy
 from app.services.member_resolver import ResolvedMember
 
 ORG_ID = uuid.uuid4()
+
+
+def _make_auth() -> MagicMock:
+    ctx = MagicMock()
+    ctx.user_id = str(uuid.uuid4())
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+    return ctx
 
 
 def _human_sender(member_id: uuid.UUID, user_id: uuid.UUID) -> ResolvedMember:
@@ -51,7 +58,7 @@ async def test_agent_to_agent_skip_even_with_list_mode():
     other_agent = _agent(a2, "list", None)
     session = AsyncMock()
     session.execute = AsyncMock(return_value=_result([sender_agent, other_agent]))
-    await _enforce_agent_creator_policy(sender_agent, [a2], session)  # 예외 없음 = skip
+    await _enforce_agent_creator_policy(sender_agent, [a2], session, _make_auth(), ORG_ID)  # 예외 없음 = skip
 
 
 # ── creator_only (default·기존 동작) ──────────────────────────────────────────
@@ -64,7 +71,9 @@ async def test_creator_only_creator_present_ok():
     agent = _agent(agent_id, "creator_only", creator_uid)
     session = AsyncMock()
     session.execute = AsyncMock(return_value=_result([agent]))
-    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)  # 통과
 
 
 @pytest.mark.anyio
@@ -74,8 +83,10 @@ async def test_creator_only_creator_absent_403():
     agent = _agent(agent_id, "creator_only", uuid.uuid4())  # 다른 creator
     session = AsyncMock()
     session.execute = AsyncMock(return_value=_result([agent]))
-    with pytest.raises(HTTPException) as exc:
-        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        with pytest.raises(HTTPException) as exc:
+            await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)
     assert exc.value.status_code == 403
 
 
@@ -88,7 +99,9 @@ async def test_org_wide_allows_non_creator():
     agent = _agent(agent_id, "org_wide", uuid.uuid4())
     session = AsyncMock()
     session.execute = AsyncMock(return_value=_result([agent]))
-    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과 (creator 무관)
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)  # 통과 (creator 무관)
 
 
 # ── list — allowlist(+creator) 외 403 ────────────────────────────────────────
@@ -102,7 +115,9 @@ async def test_list_mode_allowlisted_ok():
     session = AsyncMock()
     # 1) agents, 2) allowlist(allowed_id = sender_mid 포함)
     session.execute = AsyncMock(side_effect=[_result([agent]), _result([sender_mid])])
-    await _enforce_agent_creator_policy(sender, [agent_id], session)  # 통과
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)  # 통과
 
 
 @pytest.mark.anyio
@@ -112,8 +127,10 @@ async def test_list_mode_not_allowlisted_403():
     agent = _agent(agent_id, "list", uuid.uuid4())
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[_result([agent]), _result([])])  # allowlist 빈
-    with pytest.raises(HTTPException) as exc:
-        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        with pytest.raises(HTTPException) as exc:
+            await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)
     assert exc.value.status_code == 403
 
 
@@ -126,11 +143,43 @@ async def test_list_mode_creator_always_allowed():
     agent = _agent(agent_id, "list", creator_uid)
     session = AsyncMock()
     session.execute = AsyncMock(side_effect=[_result([agent]), _result([])])  # allowlist 빈
-    await _enforce_agent_creator_policy(sender, [agent_id], session)  # creator라 통과
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)  # creator라 통과
 
 
 @pytest.mark.anyio
 async def test_no_participants_skip():
     sender = _human_sender(uuid.uuid4(), uuid.uuid4())
     session = AsyncMock()
-    await _enforce_agent_creator_policy(sender, [], session)  # 빈 참가자 → skip (쿼리 없음)
+    await _enforce_agent_creator_policy(sender, [], session, _make_auth(), ORG_ID)  # 빈 참가자 → skip (쿼리 없음)
+
+
+# ── P0 fix(Ohol DM 403): created_by=None 에이전트 + org owner/admin 면제 ──────────
+
+@pytest.mark.anyio
+async def test_created_by_none_org_admin_allowed():
+    """created_by=None 에이전트(레거시·seed) + org owner/admin sender → DM 허용(게이트 면제)."""
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())  # creator 아님
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "creator_only", None)  # creator 부재
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([agent]))
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="owner"):
+        await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)  # 예외 없음 = 허용
+
+
+@pytest.mark.anyio
+async def test_created_by_none_non_admin_403():
+    """created_by=None 에이전트 + 비-admin sender → 403(차단·기존 동작 무회귀)."""
+    sender = _human_sender(uuid.uuid4(), uuid.uuid4())  # creator 아님 + 비-admin
+    agent_id = uuid.uuid4()
+    agent = _agent(agent_id, "creator_only", None)  # creator 부재
+    session = AsyncMock()
+    session.execute = AsyncMock(return_value=_result([agent]))
+    with patch("app.routers.conversations._effective_org_role",
+               new_callable=AsyncMock, return_value="member"):
+        with pytest.raises(HTTPException) as exc:
+            await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)
+    assert exc.value.status_code == 403

--- a/backend/tests/test_member_ssot_phase0.py
+++ b/backend/tests/test_member_ssot_phase0.py
@@ -189,7 +189,7 @@ async def test_policy_skip_no_agents():
     no_agents = MagicMock(); no_agents.scalars.return_value.all.return_value = []
     session.execute = AsyncMock(return_value=no_agents)
     sender = ResolvedMember(id=ORG_MEMBER_ID, user_id=USER_ID, name="u", type="human", role="member", org_id=ORG_ID)
-    await _enforce_agent_creator_policy(sender, [uuid.uuid4()], session)  # 예외 없음
+    await _enforce_agent_creator_policy(sender, [uuid.uuid4()], session, _make_auth(), ORG_ID)  # 예외 없음
 
 
 @pytest.mark.anyio
@@ -211,7 +211,7 @@ async def test_policy_skip_agents_only():
     agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [sender_agent, agent2_tm]
     session.execute = AsyncMock(return_value=agents_result)
 
-    await _enforce_agent_creator_policy(sender_agent, [agent2_id], session)  # 403 없음
+    await _enforce_agent_creator_policy(sender_agent, [agent2_id], session, _make_auth(), ORG_ID)  # 403 없음
 
 
 @pytest.mark.anyio
@@ -238,7 +238,12 @@ async def test_policy_creator_in_participants_group():
     session.execute = AsyncMock(side_effect=[agents_result, tms_result])
 
     # creator_member_id가 participant_ids에 있음
-    await _enforce_agent_creator_policy(sender, [agent_id, creator_member_id], session)  # 예외 없음
+    with patch(
+        "app.routers.conversations._effective_org_role",
+        new_callable=AsyncMock,
+        return_value="member",
+    ):
+        await _enforce_agent_creator_policy(sender, [agent_id, creator_member_id], session, _make_auth(), ORG_ID)  # 예외 없음
 
 
 @pytest.mark.anyio
@@ -262,8 +267,13 @@ async def test_policy_creator_not_in_participants_403():
     empty_oms = MagicMock(); empty_oms.scalars.return_value.all.return_value = []
     session.execute = AsyncMock(side_effect=[agents_result, empty_tms, empty_oms])
 
-    with pytest.raises(HTTPException) as exc_info:
-        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    with patch(
+        "app.routers.conversations._effective_org_role",
+        new_callable=AsyncMock,
+        return_value="member",
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)
     assert exc_info.value.status_code == 403
 
 
@@ -284,8 +294,13 @@ async def test_policy_no_creator_in_human_conversation_403():
     agents_result = MagicMock(); agents_result.scalars.return_value.all.return_value = [agent_tm]
     session.execute = AsyncMock(return_value=agents_result)
 
-    with pytest.raises(HTTPException) as exc_info:
-        await _enforce_agent_creator_policy(sender, [agent_id], session)
+    with patch(
+        "app.routers.conversations._effective_org_role",
+        new_callable=AsyncMock,
+        return_value="member",
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await _enforce_agent_creator_policy(sender, [agent_id], session, _make_auth(), ORG_ID)
     assert exc_info.value.status_code == 403
 
 


### PR DESCRIPTION
## 근본 원인
`_enforce_agent_creator_policy`의 `creator_only` 분기는 `created_by=None` 에이전트(seed·이관 전 레거시 row)에 대해 무조건 403을 던졌다. 그 결과 org owner/admin이 자기 org의 creator 미보유 에이전트와 DM을 열 수 없는 hard-403이 발생했다(Ohol DM 버그).

## 수정
- `_enforce_agent_creator_policy(sender, participant_ids, db)` → `(sender, participant_ids, db, auth, org_id)` 시그니처 확장.
- `_effective_org_role(auth, org_id, db, sender)` 로 sender의 org-effective role을 산출.
- mode loop 내에서 `agent_tm.created_by is None and sender_is_org_admin` 이면 게이트 면제(creator_only·list 모드 무관). org owner/admin은 자기 org 에이전트 DM 허용.

## 무회귀
- `created_by` 보유 에이전트: 기존 creator 동석 불변식 그대로.
- 비-admin sender: created_by=None 에이전트에 대해 기존 403 유지.
- org_wide·list·agent↔agent skip 동작 모두 보존.

## 테스트
- 직접 호출처 13건에 `auth`·`org_id` 인자 정합(phase0 5건 + s1 8건). 휴먼 대화 분기에 도달하는 케이스는 `_effective_org_role`를 "member"로 patch해 기존 creator_only/allowlist 의도 보존.
- 면제 테스트 2건 신규: `test_created_by_none_org_admin_allowed`(owner → 허용), `test_created_by_none_non_admin_403`(member → 403 차단).
- 검증 스위트 51 passed / 3 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)