### PR TITLE
fix(chat): 에이전트 created_by persist 근본 — 생성자 members 앵커 보장 (Ohol/Isaac DM 403)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -108,6 +108,10 @@ async def _enforce_agent_creator_policy(
                 # creator는 모드 무관 항상 허용 (자기 에이전트 접근)
                 is_creator = user_id is not None and user_id == agent_tm.created_by
                 if member_id not in allowed_ids and not is_creator:
+                    logger.warning(
+                        "agent creator policy 403: agent_id=%s sender_id=%s reason=allowlist_miss member_id=%s",
+                        agent_tm.id, sender.id, member_id,
+                    )
                     raise HTTPException(
                         status_code=403,
                         detail="Member is not in this agent's message allowlist",
@@ -116,8 +120,16 @@ async def _enforce_agent_creator_policy(
 
         # creator_only (default·기존 동작): 에이전트 creator가 참가자여야
         if agent_tm.created_by is None:
+            logger.warning(
+                "agent creator policy 403: agent_id=%s sender_id=%s reason=created_by_none",
+                agent_tm.id, sender.id,
+            )
             raise HTTPException(status_code=403, detail="Agent has no creator — conversation not allowed")
         if agent_tm.created_by not in human_user_ids:
+            logger.warning(
+                "agent creator policy 403: agent_id=%s sender_id=%s reason=creator_not_participant created_by=%s",
+                agent_tm.id, sender.id, agent_tm.created_by,
+            )
             raise HTTPException(status_code=403, detail="Agent's creator must be a participant in this conversation")
 
 

--- a/backend/app/services/agent_anchor_sync.py
+++ b/backend/app/services/agent_anchor_sync.py
@@ -54,7 +54,11 @@ async def sync_agent_anchor_on_create(
                 await session.execute(select(Member.id).where(Member.id == owner_member_id))
             ).scalar_one_or_none()
             if member_exists is None:
-                owner_member_id = None
+                # 생성자(members 앵커 없는 휴먼·member-SSOT 갭) 휴먼 앵커를 멱등 보장 →
+                # owner_member_id 유지(NULL 떨굼 방지) → 뷰 created_by 충족 → DM 403 근본 해소.
+                # orphan-safe: ensure_human_member가 org/om 부재 시 False → 기존대로 NULL 유지.
+                if not await ensure_human_member(session, owner_member_id):
+                    owner_member_id = None
 
     # 1. members (id=team_member.id, type='agent') — 0075 에이전트 백필 동형
     await session.execute(


### PR DESCRIPTION
## 근본 원인
에이전트 생성 시 `sync_agent_anchor_on_create`가 생성자(owner) 후보의 `Member` 앵커 행이 없으면 `owner_member_id=None`으로 떨군다. 생성자가 members 앵커 없는 휴먼(member-SSOT 갭)인 경우 `owner_member_id`가 NULL → team_members 뷰 `created_by`(=owner.user_id)가 NULL → `_enforce_agent_creator_policy`가 "Agent has no creator" 403을 반환. 봉희신(Ohol)·이삭신(Isaac)이 만든 에이전트와의 휴먼↔에이전트 DM이 차단되던 케이스.

## 변경

### ① persist 근본 — `agent_anchor_sync.py` (핵심)
`owner_member_id` 후보의 `Member` 행이 없을 때 NULL로 떨구기 전에, 같은 모듈의 기존 함수 `ensure_human_member(session, owner_member_id)`를 재사용해 생성자 휴먼 앵커를 멱등 보장한다(raw insert 미사용). 앵커 보장 성공 시 `owner_member_id` 유지 → 뷰 `created_by` 충족 → 403 해소.
- orphan-safe: `ensure_human_member`는 org/org_member 부재 시 False를 반환하므로 그 경우 기존대로 `owner_member_id=None` 유지.

### ② 백필 — 생략 (audit 소스 신뢰 불가)
기존 NULL 에이전트 복원을 위해 audit 소스를 조사한 결과:
- 유일한 후보는 `permission_audit_logs`(`action='member_added'`, `target_user_id`=생성 에이전트 id, `actor_id`=생성자). 다만 `actor_id`는 **user_id가 아니라 TeamMember.id**이고, 깨끗한 actor user_id 컬럼이 없다. `owner_member_id`(생성자 OrgMember.id)를 얻으려면 `actor_id → TeamMember.user_id → OrgMember.id` 다단 해석이 필요한데, **정확히 orphan(앵커 없는 생성자) 케이스에서 가장 취약**하다.
- 감사 행은 `actor is not None`일 때만 기록되어 일부 에이전트는 audit 부재.
- dev DB 직접 조회 자격증명이 워크트리에 없어 커버리지/신뢰도 라이브 검증 불가.
→ 스펙 가이드대로 **백필 마이그를 무리하게 만들지 않고 ①(신규 persist)만** 적용. 기존 NULL은 owner 일괄추정 절대 금지 원칙에 따라 **NULL 유지(per-case 에스컬레이트)**. 마이그(0105) 미추가 — alembic head 0104 단일 유지.

### ③ 타입정합 확인 + 403 로깅 — `conversations.py`
- **타입정합(확인만)**: team_members 뷰 `created_by = owner.user_id`(0096 뷰 4곳), 정책이 비교하는 `human_user_ids`도 user_id. 신원공간 일치 → non-issue, 코드 변경 불요.
- **#1316 owner/admin 면제 로직은 부활시키지 않음**(반려 준수). 원본 게이트(creator_only 403·allowlist 403) 그대로 유지.
- **403 로깅**: 403 raise 3곳(allowlist 미스·created_by None·creator 불참)에 raise 직전 `logger.warning`(agent_id·sender_id·reason) 추가. 시그니처 무변경.

## 검증
- py_compile: OK (변경 .py 2개)
- ruff: PASS (변경 파일 신규 오류 0건. 기존 미사용 import 2건은 base에 선존재 — 스코프 밖)
- alembic heads: 0104 단일(마이그 미추가)
- pytest: `-k "anchor or agent_create or standup or policy"` 74 passed/7 skipped, `-k "enforce or creator or dm"` 58 passed/3 skipped — 회귀 0
- 앵커 동작: `sync_agent_anchor_on_create`가 `ensure_human_member` 호출 확인

## 배포
dev 무장애 확인 후 선생님 승인 → prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)