### PR TITLE
chore(infra): cloudbuild _BACKEND_MAX_INSTANCES default 3→10 (maxScale 리셋 근본)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -52,7 +52,10 @@ jobs:
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            echo "backend_max_instances=3" >> "$GITHUB_OUTPUT"
+            # maxScale 10(안전 상한·11+ 금지). 산식 10×(pool5+overflow3)=80+20 headroom ≤ DB 100.
+            # prod(L49)·cloudbuild.yaml default와 합치. durable scale↑ 전제는 2c4dcae7 PgBouncer.
+            # (이전 '3'이 substitution override로 cloudbuild.yaml default를 덮어 dev maxScale 리셋한 진짜 근본.)
+            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,11 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  _BACKEND_MAX_INSTANCES: '3'
+  # ⚠️ maxScale 10 = 안전 상한. 산식: maxScale × (db_pool_size 5 + db_max_overflow 3) + headroom
+  #    ≤ DB max_connections(dev/prod 둘 다 100) → 10×8=80 + 20 headroom. 11+ 금지(88+ → 고갈 근접).
+  #    durable scale↑ 전제는 2c4dcae7 PgBouncer(연결 풀링으로 80 제약 해소). 그 前까지 10 캡.
+  #    (이전 '3'이 매 배포 maxScale 리셋 → 수동 fix 덮던 근본. dev/prod 공통 default.)
+  _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 
 steps:


### PR DESCRIPTION
## 근본
cloudbuild.yaml:14 substitution default `_BACKEND_MAX_INSTANCES: '3'` → 매 배포가 `--max-instances=3`(99행)으로 리셋 → 수동 maxScale 10 fix를 매 dev 배포마다 덮던 근본. 트리거가 아니라 **yaml default**가 원인.

## fix
dev/prod 공통 default '3'→'10' (1줄 + 상한 주석).

## 산식 검증 (오르테가군 실측)
- dev/prod DB max_connections **둘 다 100**(dev db-f1-micro·prod db-g1-small)
- maxScale 10 × (db_pool_size 5 + db_max_overflow 3) = **80 + 20 headroom ≤ 100** ✅ (OK·tight)
- ⚠️ **10 = 안전 상한·11+ 금지**(88+ → 100 고갈 근접·migrate잡/SSE consumer 감안)
- durable scale↑ 전제는 **2c4dcae7 PgBouncer**(연결 풀링으로 80 제약 자체 해소)

## prod
yaml default 10이라 prod 수동배포도 자동 10('prod 시 =10 필수'와 합치). 저우선 인프라 hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)