### PR TITLE
fix(auth): 툴그룹 scope API key write 403 — Stage 1 coarse 게이팅을 레거시 scope 한정 (BYOA 1d109a96)

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -182,19 +182,25 @@ _WRITE_METHODS = frozenset({"POST", "PUT", "PATCH", "DELETE"})
 def _check_api_key_scope(auth: AuthContext, method: str, path: str | None = None) -> None:
     """API Key 경로일 때만 scope 체크 — JWT 사용자(웹 UI)는 미적용.
 
-    1) coarse read/write 게이팅(기존).
-    2) 7b63c226: path→toolset group 서버사이드 강제 — 키 scope 외 그룹 엔드포인트 직접 호출 차단
-       (MCP 클라 우회 방어·진짜 boundary). always-allowed/미매핑 면제·일반키(read/write) 무회귀.
+    1) Stage 1=레거시 scope(read/write) 한정 coarse read/write 게이팅. 툴그룹 scope 키
+       (예 ['stories'])는 'write' 토큰이 없어 coarse 게이팅이 모든 write 를 잘못 403하므로
+       (1d109a96 BYOA), 레거시 scope 를 보유한 키에만 적용한다. 툴그룹 키의 write 경계는
+       Stage 2(path) 가 강제한다.
+    2) 7b63c226: Stage 2=path→toolset group 서버사이드 강제 — 키 scope 외 그룹 엔드포인트 직접
+       호출 차단(MCP 클라 우회 방어·진짜 boundary). always-allowed/미매핑 면제·일반키 무회귀.
     """
     if not auth.claims.get("app_metadata", {}).get("api_key_id"):
         return  # JWT 경로 → 스킵
     scope: list[str] = auth.claims.get("app_metadata", {}).get("scope", ["read", "write"])
-    required = "write" if method.upper() in _WRITE_METHODS else "read"
-    if required not in scope:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"API Key scope '{required}' required",
-        )
+    from app.services.mcp_toolset import _LEGACY_SCOPES
+    # Stage 1: 레거시(read/write) scope 키에만 coarse 게이팅. 툴그룹 scope 키는 Stage 2(path)가 강제.
+    if set(scope) & _LEGACY_SCOPES:
+        required = "write" if method.upper() in _WRITE_METHODS else "read"
+        if required not in scope:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"API Key scope '{required}' required",
+            )
     if path is not None:
         from app.services.mcp_toolset import path_allowed_for_scope, path_to_tool_group
         if not path_allowed_for_scope(path, scope):

--- a/backend/tests/test_byoa_toolgroup_scope.py
+++ b/backend/tests/test_byoa_toolgroup_scope.py
@@ -1,0 +1,77 @@
+"""1d109a96: BYOA 툴그룹 scope 키 write 403 회귀 fix.
+
+근본: _check_api_key_scope Stage 1(coarse read/write 게이팅)이 툴그룹 scope 키(예 ['stories'])에
+'write' 토큰이 없다는 이유로 모든 write(POST/PUT/PATCH/DELETE)를 잘못 403했다(Isaac write 블록).
+fix: Stage 1 을 레거시(read/write) scope 보유 키에만 적용. 툴그룹 키의 write 경계는 Stage 2(path
+→toolset group 서버사이드 강제)가 담당한다. Stage 2 는 미변경.
+
+전제 매핑(mcp_toolset SSOT): '/api/v2/stories'→'stories', '/api/v2/sprints'→'sprints'.
+둘 다 ALL_GROUPS 소속이라 Stage 2 path boundary 가 실제로 강제된다.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.dependencies.auth import _check_api_key_scope
+from app.services.mcp_toolset import ALL_GROUPS, path_to_tool_group
+
+
+def _api_auth(scope):
+    """API key AuthContext mock — app_metadata.api_key_id 세팅(API 경로 분기)."""
+    a = MagicMock()
+    a.claims = {"app_metadata": {"api_key_id": "ak", "scope": scope}}
+    return a
+
+
+def test_mapping_preconditions():
+    # 테스트가 의존하는 실제 매핑(미매핑이면 Stage 2 면제라 CP2 가 안 잡힘)
+    assert path_to_tool_group("/api/v2/stories") == "stories"
+    assert path_to_tool_group("/api/v2/sprints") == "sprints"
+    assert "stories" in ALL_GROUPS
+    assert "sprints" in ALL_GROUPS
+
+
+def test_cp1_toolgroup_scope_write_allowed():
+    # CP1: scope=['stories']·POST·/api/v2/stories → 예외 없음(툴그룹 write 언블록·Isaac)
+    _check_api_key_scope(_api_auth(["stories"]), "POST", "/api/v2/stories")
+
+
+def test_cp2_toolgroup_scope_other_group_blocked():
+    # CP2: scope=['stories']·POST·/api/v2/sprints(미허용 그룹) → 403(Stage 2 path boundary)
+    with pytest.raises(HTTPException) as exc:
+        _check_api_key_scope(_api_auth(["stories"]), "POST", "/api/v2/sprints")
+    assert exc.value.status_code == 403
+
+
+def test_cp3_no_scope_key_unaffected():
+    # CP3: app_metadata 에 scope 키 부재 → 기본 ['read','write'] → 전체 허용(무영향)
+    a = MagicMock()
+    a.claims = {"app_metadata": {"api_key_id": "ak"}}  # scope 미존재
+    _check_api_key_scope(a, "POST", "/api/v2/stories")  # 예외 없음
+    _check_api_key_scope(a, "POST", "/api/v2/sprints")  # 예외 없음
+
+
+def test_cp4_read_only_legacy_write_blocked():
+    # CP4: scope=['read']·POST·임의 path → 403(read-only 보안 유지·Stage 1 레거시 적용)
+    with pytest.raises(HTTPException) as exc:
+        _check_api_key_scope(_api_auth(["read"]), "POST", "/api/v2/stories")
+    assert exc.value.status_code == 403
+
+
+def test_cp5_legacy_read_write_no_regression():
+    # CP5: scope=['read','write']·POST → 예외 없음(legacy 무회귀)
+    _check_api_key_scope(_api_auth(["read", "write"]), "POST", "/api/v2/stories")
+    _check_api_key_scope(_api_auth(["read", "write"]), "POST", "/api/v2/sprints")
+
+
+def test_read_only_legacy_get_allowed():
+    # 보강: scope=['read']·GET → 통과(read-only 키의 read 는 허용)
+    _check_api_key_scope(_api_auth(["read"]), "GET", "/api/v2/stories")
+
+
+def test_toolgroup_scope_read_allowed_own_group():
+    # 보강: scope=['stories']·GET·/api/v2/stories → 통과(자기 그룹 read)
+    _check_api_key_scope(_api_auth(["stories"]), "GET", "/api/v2/stories")


### PR DESCRIPTION
## 근본
BYOA API key의 툴그룹 scope 키(예 `['stories']`)로 write(POST/PUT/PATCH/DELETE) 호출 시 403이 났다.

`_check_api_key_scope`는 2단계 구조다:
- **Stage 1 (coarse read/write)**: `required = 'write' if write-method else 'read'; if required not in scope → 403`. 툴그룹 키엔 `'write'` 토큰이 없어 모든 write를 **잘못 403** 했다(Isaac write 블록). Stage 2 도달조차 못 함.
- **Stage 2 (path→toolgroup boundary, 7b63c226)**: `path_allowed_for_scope(path, scope)`로 path를 toolset group에 매핑해 키 scope 외 그룹을 서버사이드 차단. **이미 정확히 작동하는 진짜 boundary.**

## fix
Stage 1을 **레거시(read/write) scope를 보유한 키에만** 적용한다(`mcp_toolset._LEGACY_SCOPES` 교집합 가드). 툴그룹 scope 키의 write 경계는 Stage 2(path boundary)가 강제한다.
**Stage 2는 일절 변경하지 않았다.**

## 체크포인트 (전부 PASS)
- **CP1** `['stories']`·POST·`/api/v2/stories` → 통과(툴그룹 write 언블록·Isaac)
- **CP2** `['stories']`·POST·`/api/v2/sprints`(미허용 그룹) → 403(Stage 2 path boundary)
- **CP3** scope 키 부재(기본 `['read','write']`) → 전체 허용(무영향)
- **CP4** `['read']`·POST → 403(read-only 보안 유지·Stage 1 레거시 적용)
- **CP5** `['read','write']`·POST → 통과(legacy 무회귀)

## 무회귀
- read-only 키(`['read']`): write 차단 유지(CP4).
- legacy full 키(`['read','write']`): 기존 동작 동일(CP5). 기존 `test_be_scope_enforce_7b63c226.py` 전량 PASS.

## 검증
- py_compile OK · ruff PASS
- `pytest tests/test_byoa_toolgroup_scope.py tests/ -k "scope or api_key or auth"` → 177 passed (회귀 0)

## 배포
⚠️ 정정: dev/prod DB는 별도 인스턴스(effec480·2026-06-06). breaking 아님·마이그0이나 develop→prod 승인-first 엄수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)