### PR TITLE
fix(members): FE 멤버 소스를 canonical /api/members(SSOT)로 — assignee/멤버목록 휴먼 누락 (데모 HIGH 6)

### DIFF
--- a/apps/web/src/app/api/members/route.test.ts
+++ b/apps/web/src/app/api/members/route.test.ts
@@ -1,66 +1,39 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+const { proxyToFastapi } = vi.hoisted(() => ({
+  proxyToFastapi: vi.fn(),
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
-
 describe('GET /api/members', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
   });
 
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    getAuthContext.mockResolvedValue(null);
+  it('proxies to canonical /api/v2/members (SSOT)', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(JSON.stringify([]), { status: 200 }));
+
+    await GET(new Request('http://localhost/api/members?project_id=project-1'));
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.any(Request), '/api/v2/members');
+  });
+
+  it('passes through upstream error responses', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('nope', { status: 401 }));
 
     const response = await GET(new Request('http://localhost/api/members?project_id=project-1'));
 
     expect(response.status).toBe(401);
   });
 
-  it('returns 400 when project_id is missing', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/members'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns 200 with team members list', async () => {
+  it('wraps the member array in apiSuccess data envelope', async () => {
     const members = [
-      { id: 'member-alpha', name: 'Alpha Owner', type: 'human', role: 'owner', is_active: true, webhook_url: null },
+      { id: 'member-alpha', name: 'Alpha Owner', type: 'human', role: 'owner', is_active: true },
     ];
-    const db = { from: vi.fn(() => createQueryStub(members)) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+    proxyToFastapi.mockResolvedValue(new Response(JSON.stringify(members), { status: 200 }));
 
     const response = await GET(new Request('http://localhost/api/members?project_id=project-alpha'));
 

--- a/apps/web/src/app/api/members/route.ts
+++ b/apps/web/src/app/api/members/route.ts
@@ -1,23 +1,17 @@
 import { handleApiError } from '@/lib/api-error';
-import { apiSuccess, ApiErrors } from '@/lib/api-response';
-import { getAuthContext } from '@/lib/auth-helpers';
-import { createTeamMemberRepository } from '@/lib/storage/factory';
+import { apiSuccess } from '@/lib/api-response';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
 
 // GET /api/members?project_id=X
+// Canonical SSOT 멤버 소스 — FastAPI /api/v2/members 로 프록시한다.
+// (휴먼: org_members + project_access grant 모델 / 에이전트: team_members type=agent)
+// team_members 뷰 기반 /api/v2/team-members 와 달리 grant 휴먼·owner/admin 누락이 없다.
 export async function GET(request: Request) {
   try {
-    const me = await getAuthContext(request);
-    if (!me) return ApiErrors.unauthorized();
-    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
-
-    const { searchParams } = new URL(request.url);
-    const projectId = searchParams.get('project_id');
-    if (!projectId) return ApiErrors.badRequest('project_id required');
-
-    const repo = await createTeamMemberRepository();
-    const members = await repo.list({ org_id: me.org_id, project_id: projectId });
-    const active = members.filter((m) => m.is_active);
-    return apiSuccess(active);
+    const res = await proxyToFastapi(request, '/api/v2/members');
+    if (!res.ok) return res;
+    const data: unknown = await res.json();
+    return apiSuccess(data);
   } catch (err: unknown) {
     return handleApiError(err);
   }

--- a/apps/web/src/components/activity/activity-log-view.tsx
+++ b/apps/web/src/components/activity/activity-log-view.tsx
@@ -102,7 +102,7 @@ export function ActivityLogView({ projectId }: ActivityLogViewProps) {
 
   // fetch team members for actor dropdown
   useEffect(() => {
-    fetch(`/api/team-members?project_id=${projectId}`)
+    fetch(`/api/members?project_id=${projectId}`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data: { data?: TeamMember[] } | null) => {
         if (data?.data) setMembers(data.data);

--- a/apps/web/src/components/chat/add-participant-modal.tsx
+++ b/apps/web/src/components/chat/add-participant-modal.tsx
@@ -37,7 +37,7 @@ export function AddParticipantModal({
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`/api/team-members?is_active=true&project_id=${projectId}`)
+    fetch(`/api/members?is_active=true&project_id=${projectId}`)
       .then((r) => r.json())
       .then((json) => setMembers((json.data ?? []) as Member[]))
       .catch(() => {})

--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -93,7 +93,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
   useEffect(() => {
     if (mentionQuery === null) { setMentionMembers([]); return; }
     let cancelled = false;
-    fetch(`/api/team-members?is_active=true${projectId ? `&project_id=${projectId}` : ''}`)
+    fetch(`/api/members?is_active=true${projectId ? `&project_id=${projectId}` : ''}`)
       .then((r) => r.json())
       .then((json) => {
         if (cancelled) return;

--- a/apps/web/src/components/chat/new-conversation-modal.tsx
+++ b/apps/web/src/components/chat/new-conversation-modal.tsx
@@ -27,7 +27,7 @@ export function NewConversationModal({ projectId, onClose, onCreated }: NewConve
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    fetch(`/api/team-members?is_active=true&project_id=${projectId}`)
+    fetch(`/api/members?is_active=true&project_id=${projectId}`)
       .then((r) => r.json())
       .then((json) => setMembers((json.data ?? []) as Member[]))
       .catch(() => {})

--- a/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
+++ b/apps/web/src/components/dispatch/entity-dispatch-panel.tsx
@@ -56,7 +56,7 @@ export function EntityDispatchPanel({
   }, [moreOpen]);
 
   useEffect(() => {
-    fetch(`/api/team-members?project_id=${projectId}`)
+    fetch(`/api/members?project_id=${projectId}`)
       .then((r) => r.ok ? r.json() : Promise.reject())
       .then((json) => {
         const data = (json?.data ?? json) as TeamMember[];

--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -223,7 +223,7 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
         Promise.all(statuses.map((s) => fetchStoriesByStatus(s))),
         fetch(`/api/sprints${sprintParams}`),
         fetch(`/api/epics?${epicParams.toString()}`),
-        fetch(`/api/team-members${memberParams}`),
+        fetch(`/api/members${memberParams}`),
       ]);
 
       const allStories: KanbanStory[] = [];


### PR DESCRIPTION
## 근본 원인
HIGH 6 컴포넌트가 멤버 목록을 `/api/team-members`(FE) → `/api/v2/team-members`(BE·team_members 뷰) 로 가져왔다. 이 뷰는 휴먼을 `project_access` INNER JOIN으로 산출해 **owner/admin·grant 휴먼이 누락**된다. 게다가 FE `/api/members` route.ts 도 실은 `ApiTeamMemberRepository.list()` → `/api/v2/team-members` 를 호출하고 있어 canonical 이 아니었다(SSOT 아님).

결과: assignee 드롭다운·@멘션·참여자 목록 등에서 휴먼이 비어 보임 (데모-크리티컬).

## Fix
1. **FE `/api/members` route.ts → canonical `/api/v2/members` 프록시로 교체.** 기존 repo(`/api/v2/team-members` 뷰) 호출 제거. `/api/v2/members` 는 3-branch SSOT(휴먼: org_members + project_access grant + owner/admin 항상포함 / 에이전트: team_members type=agent).
2. **HIGH 6 컴포넌트 fetch 를 `/api/team-members` → `/api/members` 로 전환:**
   - `components/kanban/kanban-board.tsx` (assignee 목록)
   - `components/dispatch/entity-dispatch-panel.tsx`
   - `components/chat/chat-input.tsx` (@멘션)
   - `components/chat/add-participant-modal.tsx`
   - `components/chat/new-conversation-modal.tsx`
   - `components/activity/activity-log-view.tsx`

## STEP0 shape 검증 결과
`/api/v2/members` MemberResponse 제공 필드: `id, name, type, role, is_active`.

| 컴포넌트 | 사용 필드 | /v2/members 제공 | 처리 |
|---|---|---|---|
| kanban-board | id, name, type | ✅ 전부 | OK |
| entity-dispatch-panel | id, name, type, is_active | ✅ 전부 | OK (is_active 필터 — v2는 이미 active만 반환, no-op 안전) |
| chat-input | id, name, role | ✅ 전부 | OK |
| add-participant-modal | id, name, type | ✅ 전부 | OK |
| new-conversation-modal | id, name, type | ✅ 전부 | OK |
| activity-log-view | id, name, type | ✅ 전부 | OK (name nullable 처리됨) |

**shape 누락 0건 — 런타임 깨질 위험 없음. BE MemberResponse 보강 불요.**

## id 시맨틱 안전
`/v2/members` id = `story.assignee_id` canonical 공간 일치(휴먼 `org_member.id` · 에이전트 `team_member.id`). 사전 확인됨.

## `?type=agent` 필터 유지
agent-api-keys·workflow-template-gallery·agent-performance·settings 등 `?type=agent`/`include_inactive` 호출은 **그대로 `/api/team-members` 유지**(에이전트 전용·정상). 휴먼 포함 멤버 목록만 전환. MED 스코프(settings/rewards/standup) 미변경.

## 응답 envelope
`/v2/members` 는 raw array 반환 → route.ts 가 `apiSuccess()` 로 `{data:[...]}` 래핑(기존 callers `json.data ?? []` 호환). 미지정 query param(is_active/type)은 FastAPI 가 무시 — 안전.

## 검증
- `pnpm --filter web type-check` ✅ PASS
- `members/route.test.ts` 프록시 기반으로 갱신 — 3/3 PASS (canonical target·error passthrough·data envelope)

## 배포
dev→prod 별도 DB(effec480·dev/prod 분리). develop 머지 후 승인-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)