### PR TITLE
fix(members): org/project 생성·invite 수락 시 휴먼 members 앵커 보장 — created_by NULL·assignee 누락·DM 403 공통 뿌리 (0b115f5d)

### DIFF
--- a/apps/web/src/app/onboarding/onboarding-form.tsx
+++ b/apps/web/src/app/onboarding/onboarding-form.tsx
@@ -159,23 +159,8 @@ export function OnboardingForm({ initialStep, initialOrgId }: OnboardingFormProp
 
     setProjectId(project.id);
 
-    // team_member 자동 생성 (type=human)
-    const meRes = await fetch('/api/me');
-    if (meRes.ok) {
-      const meJson = await meRes.json() as { data?: { name?: string } };
-      const memberName = meJson.data?.name ?? t('unknownUser');
-      await fetch('/api/team-members', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          org_id: orgId,
-          project_id: project.id,
-          type: 'human',
-          name: memberName,
-          role: 'admin',
-        }),
-      }).catch(() => null);
-    }
+    // 휴먼 members 앵커는 BE가 org/project 생성 시 ensure_human_member로 보장한다(#1317 휴먼판).
+    // 과거 여기서 호출하던 /api/team-members(type=human) POST는 410 Gone(데드 경로)이라 제거.
 
     await fetch('/api/current-project', {
       method: 'POST',

--- a/backend/app/repositories/org_invite.py
+++ b/backend/app/repositories/org_invite.py
@@ -210,6 +210,8 @@ class OrgInviteRepository:
                     .on_conflict_do_nothing(constraint="uq_org_members_org_user")
                 )
                 await self.session.flush()
+                # 수락자 휴먼 members 앵커 보장(#1317 휴먼판): 재수락 경로도 누락 복구
+                await self._ensure_member_anchor(invite.organization_id, user_id)
                 # 정책B: 선택 프로젝트 project_access도 멱등 보장(재수락 시 누락 복구)
                 await self._grant_invite_project_access(invite, user_id)
                 return {
@@ -238,6 +240,9 @@ class OrgInviteRepository:
         )
         await self.session.flush()
 
+        # 수락자 휴먼 members 앵커 보장(#1317 휴먼판): created_by NULL·DM 403 공통 뿌리 해소
+        await self._ensure_member_anchor(invite.organization_id, user_id)
+
         # 정책B: 초대 시 선택한 프로젝트에 project_access(granted) 부여
         await self._grant_invite_project_access(invite, user_id)
 
@@ -246,6 +251,26 @@ class OrgInviteRepository:
         await self.session.flush()
 
         return {"ok": True, "org_id": str(invite.organization_id), "role": invite.role}
+
+    async def _ensure_member_anchor(self, org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+        """수락자(휴먼)의 canonical members 앵커(type='human', id=org_member.id)를 멱등 보장.
+
+        org_member upsert 직후 그 org_member.id를 재조회해 ensure_human_member 호출.
+        앵커 부재 시 created_by NULL·assignee 누락·DM 403의 공통 뿌리가 된다(#1317 휴먼판).
+        """
+        from app.services.agent_anchor_sync import ensure_human_member
+
+        om_id = (
+            await self.session.execute(
+                select(OrgMember.id).where(
+                    OrgMember.org_id == org_id,
+                    OrgMember.user_id == user_id,
+                    OrgMember.deleted_at.is_(None),
+                ).limit(1)
+            )
+        ).scalar_one_or_none()
+        if om_id is not None:
+            await ensure_human_member(self.session, om_id)
 
     async def _grant_invite_project_access(self, invite: OrgInvite, user_id: uuid.UUID) -> None:
         """초대 시 선택한 프로젝트(invite.project_ids)에 수락 멤버의 project_access(granted) 부여.

--- a/backend/app/routers/organizations.py
+++ b/backend/app/routers/organizations.py
@@ -1,6 +1,6 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -9,6 +9,7 @@ from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
 from app.models.user import User
 from app.repositories.organization import OrganizationRepository
+from app.services.agent_anchor_sync import ensure_human_member
 from app.schemas.organization import (
     CreateOrganization,
     DeleteOrganization,
@@ -70,6 +71,20 @@ async def create_organization(
             ),
             {"org_id": str(org.id), "user_id": auth.user_id},
         )
+        # 휴먼 members 앵커 보장(#1317 휴먼판): org_member.id를 (신규/기존 무관) 재조회 후
+        # ensure_human_member 호출. ON CONFLICT DO NOTHING이라 RETURNING 불가 → SELECT로 캡처.
+        om_id = (
+            await session.execute(
+                text(
+                    "SELECT id FROM org_members"
+                    " WHERE org_id = :org_id AND user_id = :user_id"
+                    " AND deleted_at IS NULL LIMIT 1"
+                ),
+                {"org_id": str(org.id), "user_id": auth.user_id},
+            )
+        ).scalar_one_or_none()
+        if om_id is not None:
+            await ensure_human_member(session, om_id)
         await session.commit()
 
     return OrganizationResponse.model_validate(org)

--- a/backend/app/routers/projects.py
+++ b/backend/app/routers/projects.py
@@ -10,6 +10,7 @@ from app.dependencies.database import get_db
 from app.models.project import Project
 from app.repositories.project import ProjectRepository
 from app.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.services.agent_anchor_sync import ensure_human_member
 from app.services.project_auth import (
     accessible_project_ids_in_org,
     has_project_access,
@@ -65,6 +66,20 @@ async def create_project(
             ),
             {"org_id": str(org_id), "user_id": auth.user_id},
         )
+        # 생성자 휴먼 members 앵커 보장(#1317 휴먼판): org_member.id를 (신규/기존 무관) 재조회 후
+        # ensure_human_member 호출. ON CONFLICT DO NOTHING이라 RETURNING 불가 → SELECT로 캡처.
+        om_id = (
+            await session.execute(
+                text(
+                    "SELECT id FROM org_members"
+                    " WHERE org_id = :org_id AND user_id = :user_id"
+                    " AND deleted_at IS NULL LIMIT 1"
+                ),
+                {"org_id": str(org_id), "user_id": auth.user_id},
+            )
+        ).scalar_one_or_none()
+        if om_id is not None:
+            await ensure_human_member(session, om_id)
 
     await session.commit()
 

--- a/backend/tests/test_onboarding_member_anchor_0b115f5d.py
+++ b/backend/tests/test_onboarding_member_anchor_0b115f5d.py
@@ -1,0 +1,172 @@
+"""온보딩 휴먼 members 앵커 보장(0b115f5d) — 3경로 ensure_human_member 호출 회귀.
+
+근본: 휴먼 org_member는 생기나 canonical members 앵커(type='human')가 안 생겨
+created_by NULL·assignee 누락·DM 403의 공통 뿌리가 됨. org 생성·project 생성·invite 수락
+3경로가 org_member INSERT 직후 그 org_member.id로 ensure_human_member를 호출하는지 검증.
+
+mocked 세션 + ensure_human_member 패치 — 항상 도는 구조 회귀(실 PG INSERT는 parity 테스트 영역).
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _scalar_result(value):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = value
+    return r
+
+
+# ─── 경로 ①: organizations.create_organization ──────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_organization_ensures_human_member():
+    """org 생성 시 owner org_member.id로 ensure_human_member 호출(앵커 보장)."""
+    from app.routers import organizations as orgs
+
+    om_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    session = AsyncMock()
+    # email_verified user → org-create 허용, 이후 om_id SELECT 캡처
+    user = MagicMock()
+    user.email_verified = True
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(user),   # email_verified 조회
+            MagicMock(),            # org_members INSERT
+            _scalar_result(om_id),  # om_id 재조회(캡처)
+        ]
+    )
+    session.commit = AsyncMock()
+
+    repo = MagicMock()
+    org_obj = MagicMock()
+    org_obj.id = uuid.uuid4()
+    repo.create = AsyncMock(return_value=org_obj)
+
+    auth = MagicMock()
+    auth.user_id = str(user_id)
+
+    body = MagicMock()
+    body.name = "Acme"
+    body.slug = "acme"
+    body.owner_member_id = None
+
+    with patch.object(orgs, "ensure_human_member", new=AsyncMock()) as ehm, \
+            patch.object(orgs.OrganizationResponse, "model_validate", return_value=MagicMock()):
+        await orgs.create_organization(body=body, auth=auth, repo=repo, session=session)
+
+    ehm.assert_awaited_once()
+    assert ehm.await_args.args == (session, om_id)
+
+
+# ─── 경로 ②: projects.create_project ────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_create_project_ensures_human_member():
+    """project 생성 시 생성자 org_member.id로 ensure_human_member 호출(생성자 앵커 보장)."""
+    from app.routers import projects as projs
+
+    om_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            MagicMock(),            # org_members INSERT
+            _scalar_result(om_id),  # om_id 재조회(캡처)
+        ]
+    )
+    session.commit = AsyncMock()
+
+    auth = MagicMock()
+    auth.user_id = str(user_id)
+
+    body = MagicMock()
+    body.name = "Board"
+    body.description = None
+
+    project_obj = MagicMock()
+
+    fake_repo = MagicMock()
+    fake_repo.create = AsyncMock(return_value=project_obj)
+
+    with patch.object(projs, "ProjectRepository", return_value=fake_repo), \
+            patch.object(projs, "ensure_human_member", new=AsyncMock()) as ehm, \
+            patch.object(projs.ProjectResponse, "model_validate", return_value=MagicMock()):
+        await projs.create_project(body=body, session=session, auth=auth, org_id=org_id)
+
+    ehm.assert_awaited_once()
+    assert ehm.await_args.args == (session, om_id)
+
+
+# ─── 경로 ③: org_invite.OrgInviteRepository.accept ──────────────────────────
+
+
+@pytest.mark.anyio
+async def test_invite_accept_ensures_human_member():
+    """invite 수락(pending → accepted) 시 수락자 org_member.id로 ensure_human_member 호출."""
+    from datetime import datetime, timedelta, timezone
+
+    from app.repositories.org_invite import OrgInviteRepository
+
+    om_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    invite = MagicMock()
+    invite.status = "pending"
+    invite.organization_id = org_id
+    invite.role = "member"
+    invite.email = "invitee@example.com"
+    invite.expires_at = datetime.now(timezone.utc) + timedelta(days=3)
+    invite.project_ids = []  # _grant_invite_project_access no-op
+
+    session = AsyncMock()
+    session.execute = AsyncMock(
+        side_effect=[
+            _scalar_result(invite),  # accept(): invite 조회
+            MagicMock(),             # org_members upsert
+            _scalar_result(om_id),   # _ensure_member_anchor: om_id 재조회
+        ]
+    )
+    session.flush = AsyncMock()
+
+    repo = OrgInviteRepository(session)
+
+    with patch(
+        "app.services.agent_anchor_sync.ensure_human_member", new=AsyncMock()
+    ) as ehm:
+        result = await repo.accept(
+            token="tok", user_id=user_id, user_email="invitee@example.com"
+        )
+
+    assert result["ok"] is True
+    ehm.assert_awaited_once()
+    assert ehm.await_args.args == (session, om_id)
+
+
+# ─── 구조 가드: 3경로가 ensure_human_member를 import/호출 ────────────────────
+
+
+def test_three_paths_reference_ensure_human_member():
+    """org/project 라우터 + org_invite 리포가 ensure_human_member 경로를 보유."""
+    from app.routers import organizations as orgs
+    from app.routers import projects as projs
+    from app.repositories.org_invite import OrgInviteRepository
+
+    assert hasattr(orgs, "ensure_human_member")
+    assert hasattr(projs, "ensure_human_member")
+    assert hasattr(OrgInviteRepository, "_ensure_member_anchor")

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -94,7 +94,8 @@ async def test_list_projects_empty_when_no_access():
 async def test_create_project_201():
     client, session, app = await _client()
     try:
-        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create:
+        with patch("app.repositories.base.BaseRepository.create", new_callable=AsyncMock) as mock_create, \
+                patch("app.routers.projects.ensure_human_member", new_callable=AsyncMock):
             mock_create.return_value = _mock_project()
 
             async with client as c:


### PR DESCRIPTION
## 근본 (체인 교차확인 완료)

휴먼 `org_member`는 정상 생성되지만, canonical `members` 앵커(`type='human'`, `id=org_member.id`)가 **안 생긴다**. 경로 3곳 모두 `org_members` INSERT만 하고 `ensure_human_member`를 미호출:

- ① `backend/app/routers/organizations.py` `create_organization` — OSS bootstrap org_member INSERT
- ② `backend/app/routers/projects.py` `create_project` — 생성자 org_member upsert
- ③ `backend/app/repositories/org_invite.py` `OrgInvite.accept` — 수락자 org_member upsert (정상 수락 + 멱등 재수락 2경로)

앵커 부재가 `created_by NULL` · `assignee 누락` · `DM 403`의 **단일 공통 상류 뿌리**다.

## fix

각 경로에서 org_member INSERT 직후 그 `org_member.id`로 `ensure_human_member(session, om_id)` 호출(`#1317` 휴먼판·멱등·on_conflict_do_nothing·orphan-safe).

- **org/project**: 원본 INSERT가 `gen_random_uuid()` + `ON CONFLICT DO NOTHING`이라 RETURNING 불가 → INSERT 직후 `SELECT id ... WHERE org_id/user_id`로 (신규/기존 무관) org_member.id 재조회 후 호출.
- **org_invite**: `_ensure_member_anchor(org_id, user_id)` 헬퍼 신설 — org_member.id 재조회(기존 `_grant_invite_project_access`와 동형) 후 호출. 정상 수락 + 멱등 재수락 양쪽에 배치.
- **FE** `apps/web/src/app/onboarding/onboarding-form.tsx`: 죽은 `/api/team-members`(type=human) POST 블록 제거(410 Gone·`.catch` swallow). 앵커는 BE가 org/project 생성으로 보장하므로 FE POST 불필요. 정상 agent(type=agent) POST는 유지.

`#1317`/`#1321`은 증상 하류(에이전트 앵커·FE 멤버 소스). 이 PR이 **휴먼 앵커 상류 근본**이다.

## 검증 (전부 PASS)

- py_compile(변경 .py) OK
- `pytest -k "organization or project or invite or accept or anchor or member"` → **372 passed, 15 skipped**
- ruff PASS
- `pnpm --filter web type-check` PASS
- ensure_human_member 호출 3경로 grep 확인

## 배포 주의

dev/prod 별도 DB — 머지 후 dev → prod **승인-first** 순서 준수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)