### PR TITLE
fix(auth): 온보딩 에이전트 키 scope를 list(ALL_GROUPS) 명시 — 툴그룹 모델 일관 (8d02d5e8)

### DIFF
--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -242,8 +242,14 @@ async def create_team_member(
     api_key_plaintext: str | None = None
     if body.type == "agent":
         from app.repositories.api_key import ApiKeyRepository
+        from app.services.mcp_toolset import ALL_GROUPS
         api_key_repo = ApiKeyRepository(session)
-        _api_key_obj, api_key_plaintext = await api_key_repo.create(team_member_id=member.id)
+        # 8d02d5e8: 온보딩 에이전트 키도 명시적 툴그룹 scope(전 비파괴 그룹) 부여 — 고급 Tool-permissions
+        # UI와 동일 모델로 통일. scope=None(레거시 read/write fallback) 대신 list(ALL_GROUPS) 명시.
+        # 동작 동일(resolve_policy None=전체)이나 모델 일관·레거시 표기 제거.
+        _api_key_obj, api_key_plaintext = await api_key_repo.create(
+            team_member_id=member.id, scope=list(ALL_GROUPS)
+        )
         # E-MSG-POLICY S2: creator를 agent allow_list에 자동 등록(같은 트랜잭션·멱등).
         from app.services.agent_message_policy import ensure_creator_allowlisted
         await ensure_creator_allowlisted(session, member.id)

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -132,6 +132,9 @@ async def test_create_team_member_201():
 
         assert resp.status_code == 201
         assert resp.json()["name"] == "TestBot"
+        # 8d02d5e8: 온보딩 에이전트 키 scope = list(ALL_GROUPS) 명시(레거시 None 아님·툴그룹 모델 일관)
+        from app.services.mcp_toolset import ALL_GROUPS
+        assert mock_api_key.call_args.kwargs.get("scope") == list(ALL_GROUPS)
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 근본
온보딩/에이전트 생성 시 API key가 scope 미전달(team_members.py:255 `create(team_member_id=member.id)`)→ scope=None → 런타임 레거시 read/write fallback. 고급 Tool-permissions UI(툴그룹 모델)와 불일치.

## fix (오르테가군 GO=A)
team_members.py 키 생성에 `scope=list(ALL_GROUPS)` 명시(admin 제외 전 비파괴 그룹). 툴그룹 모델 통일.
- 동작 동일(resolve_policy(None)=전체)이나 명시적·모델 일관·레거시 표기 제거.
- ALL_GROUPS 16: chat·stories·tasks·sprints·docs·epics·standup·retro·meetings·notifications·webhooks·audit·agent_runs·analytics·rewards·core.

## 경로 정리 (디디·까심 cross-validation)
- ① 온보딩 None → **이 PR: ALL_GROUPS 명시**
- ② settings/agents simple `['read','write']` 레거시 → follow-up 3ef0872b(FE·데모後)
- ③ agent-api-key-manager(고급) = selectedScopes(툴그룹) → 이미 정상

## 검증
py_compile·pytest 10 passed(scope=list(ALL_GROUPS) assert 추가)·ruff PASS. 마이그0. dev→prod 승인-first(dev/prod 별도 DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)