### PR TITLE
fix(auth): register 응답에 email_delivered 플래그 — 인증메일 발송실패 가시화 (bacefe2c 건1)

### DIFF
--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -500,8 +500,10 @@ async def register(
     await _store_refresh_token(session, user, tokens["refresh_token"], refresh_exp)
 
     # 이메일 인증 발송 — 실패해도 가입은 완료하되 **반드시 가시화**(silent swallow 금지).
-    # send_email은 bool 반환(True=Resend/SMTP 실발송, False=콘솔 폴백=미발송). 둘 다 로깅해
-    # "201인데 인증메일 안 옴" 디버깅이 가능하게 한다(데모 signup 치명 경로).
+    # send_email은 bool 반환(True=Resend/SMTP 실발송, False=콘솔 폴백=미발송). delivered를 응답
+    # email_delivered로 노출(silent swallow 금지) — FE가 "201인데 인증메일 안 옴"을 감지·안내 가능
+    # (bacefe2c: console-fallback 환경서 verify메일 안 와 stuck 되는 데모 signup 치명 경로 방어).
+    delivered = False
     try:
         verification_token = create_email_verification_token(str(user.id))
         app_url = os.getenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
@@ -527,7 +529,7 @@ async def register(
             user.id, user.email,
         )
 
-    return _ok(tokens, 201)
+    return _ok({**tokens, "email_delivered": delivered}, 201)
 
 
 # ─── POST /api/v2/auth/token ──────────────────────────────────────────────────

--- a/backend/tests/test_register_email_delivered.py
+++ b/backend/tests/test_register_email_delivered.py
@@ -1,0 +1,87 @@
+"""bacefe2c 건1: register 201 응답에 email_delivered 플래그 노출 — 인증메일 발송실패 가시화.
+
+register는 이메일 발송이 콘솔 폴백(미발송)이어도 201을 반환한다. 과거엔 logger.warning만 남기고
+응답엔 아무 신호가 없어 FE가 "201인데 인증메일 안 옴"을 감지할 수 없었다(데모 signup 치명 경로).
+이제 응답 data.email_delivered(bool)로 노출 — True=실발송, False=콘솔 폴백/미발송.
+"""
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _client():
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    # 신규 가입 경로: _get_user_by_email/_build_app_metadata 조회 모두 None → 빈 메타데이터.
+    mock_result.scalar_one_or_none.return_value = None
+    mock_result.scalars.return_value.all.return_value = []
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+    mock_session.flush = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session.add = MagicMock()
+
+    async def override_db():
+        yield mock_session
+
+    async def override_auth():
+        ctx = MagicMock()
+        ctx.user_id = str(uuid.uuid4())
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), mock_session, app
+
+
+def _payload():
+    # 충돌 방지용 유니크 이메일 — 가입 성공(201) 경로.
+    return {
+        "email": f"new-{uuid.uuid4().hex}@example.com",
+        "password": "TestPass1!",
+        "display_name": "Test User",
+        "tos_accepted": True,
+    }
+
+
+@pytest.mark.anyio
+async def test_register_email_delivered_true(monkeypatch):
+    """send_email True(실발송) → 201 + data.email_delivered is True."""
+    # register 내부 `from app.services.email import send_email` → patch 대상은 원본 모듈 심볼.
+    monkeypatch.setattr("app.services.email.send_email", lambda **kwargs: True)
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_payload())
+        assert resp.status_code == 201
+        assert resp.json()["data"]["email_delivered"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_register_email_delivered_false(monkeypatch):
+    """send_email False(콘솔 폴백·미발송) → 201 + data.email_delivered is False.
+
+    silent swallow가 아니라 플래그로 미발송이 명시 노출됨을 확인(FE 감지·안내 가능).
+    """
+    monkeypatch.setattr("app.services.email.send_email", lambda **kwargs: False)
+    client, session, app = await _client()
+    try:
+        async with client as c:
+            resp = await c.post("/api/v2/auth/register", json=_payload())
+        assert resp.status_code == 201
+        assert resp.json()["data"]["email_delivered"] is False
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 근본 원인
register(`POST /api/v2/auth/register`)는 이메일 인증 발송이 실패하거나 콘솔 폴백(미발송)이어도 201을 반환한다. 그런데 결과를 `logger.warning`으로만 남기고 응답에는 아무 신호가 없어, FE는 "201 성공인데 인증메일이 안 옴" 상황을 감지·안내할 수 없었다. RESEND_API_KEY/EMAIL_FROM 미설정 환경(데모 등)에서 가입자가 verify 메일을 못 받고 stuck 되는 signup 치명 경로다.

## 수정
- register 핸들러에서 `send_email`의 bool 반환값(`delivered`)을 201 응답 data의 `email_delivered`로 노출.
  - `True` = Resend/SMTP 실발송
  - `False` = 콘솔 폴백 / 미발송 (silent swallow가 아니라 플래그로 명시)
- `delivered = False` 초기화를 try 이전에 두어 console-fallback / 예외 경로에서도 응답 플래그가 안전하게 `False`로 노출되도록 방어.
- FE는 이 플래그로 "메일이 발송되지 않았으니 재발송하거나 관리자에게 문의" 안내를 띄울 수 있다.

## 테스트
신규 `backend/tests/test_register_email_delivered.py` (2 케이스, 기존 TOS/c_s1 register 셋업 패턴 차용):
- `test_register_email_delivered_true`: `send_email` patch → True → 201 + `data.email_delivered is True`
- `test_register_email_delivered_false`: `send_email` patch → False(콘솔 폴백) → 201 + `data.email_delivered is False` (미발송이 플래그로 노출됨을 확인)

patch 대상: register 내부에서 `from app.services.email import send_email` 하므로 원본 모듈 심볼 `app.services.email.send_email`.

검증: py_compile OK · pytest `-k "register or email_delivered or auth_tos"` 19 passed / 2 xfailed (신규 2 포함, 회귀 0) · ruff는 auth.py가 base origin/develop과 동일한 19개 선존재 dead-import 에러뿐(내 변경 라인 신규 에러 0, 본 PR 스코프 밖) · 신규 테스트 파일 ruff clean.

## 범위 메모
- 건2(refresh) 관련은 FE 유나 별건 — 본 PR 미포함.
- dev/prod는 별도 DB이므로 dev 검증 후 prod 반영은 승인-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)