### PR TITLE
fix(infra): maxScale 10→6 — prod DB 연결고갈 인시던트 재발방지 (#1319 역방향)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,16 +46,17 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # maxScale 6: 연결고갈 인시던트(2026-06-08) 後 안전캡. 6×8=48 ≤ DB 100(churn 흡수). 7+ 금지.
+            echo "backend_max_instances=6" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 10(안전 상한·11+ 금지). 산식 10×(pool5+overflow3)=80+20 headroom ≤ DB 100.
-            # prod(L49)·cloudbuild.yaml default와 합치. durable scale↑ 전제는 2c4dcae7 PgBouncer.
-            # (이전 '3'이 substitution override로 cloudbuild.yaml default를 덮어 dev maxScale 리셋한 진짜 근본.)
-            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
+            # maxScale 6: 연결고갈 인시던트(2026-06-08) 後 안전캡. 6×8=48 ≤ DB 100(배포 churn 흡수·7+ 금지).
+            # 10은 80+20 tight → churn이 100 초과해 prod 고갈. prod(L49)·cloudbuild.yaml default와 합치.
+            # durable fix는 2c4dcae7 PgBouncer. (이전 '3' override가 default 덮던 근본.)
+            echo "backend_max_instances=6" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,12 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ maxScale 10 = 안전 상한. 산식: maxScale × (db_pool_size 5 + db_max_overflow 3) + headroom
-  #    ≤ DB max_connections(dev/prod 둘 다 100) → 10×8=80 + 20 headroom. 11+ 금지(88+ → 고갈 근접).
-  #    durable scale↑ 전제는 2c4dcae7 PgBouncer(연결 풀링으로 80 제약 해소). 그 前까지 10 캡.
+  # ⚠️ maxScale 6 = 연결고갈 인시던트(2026-06-08) 後 안전캡. 산식: maxScale × (db_pool_size 5 +
+  #    db_max_overflow 3) ≤ DB max_connections(dev/prod 100) → 6×8=48 + 52 headroom(배포 churn 흡수).
+  #    10은 80+20 tight → 배포 churn(구/신 리비전 동시 연결)이 100 초과해 prod 고갈 발생 → 6 하향.
+  #    durable fix는 2c4dcae7 PgBouncer(연결 decouple)·그게 maxScale↑ 전제. 그 前까지 6 캡(7+ 금지).
   #    (이전 '3'이 매 배포 maxScale 리셋 → 수동 fix 덮던 근본. dev/prod 공통 default.)
-  _BACKEND_MAX_INSTANCES: '10'
+  _BACKEND_MAX_INSTANCES: '6'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 
 steps:


### PR DESCRIPTION
## 인시던트 (2026-06-08)
prod DB 연결고갈 — maxScale 10 + 배포 churn(구/신 리비전 동시 연결)이 DB max_connections 100 초과 → 고갈. 오르테가군 restart + maxScale 6 수동 하향으로 해소(db:ok 6/6).

## fix
#1319의 maxScale 10(80+20 headroom·tight)을 **6으로 하향**. 3곳:
```
cloudbuild.yaml:18      _BACKEND_MAX_INSTANCES '10' → '6'
cloud-build.yml:49 prod  backend_max_instances 10 → 6
cloud-build.yml:58 dev   backend_max_instances 10 → 6
```
- 산식: maxScale 6 × (db_pool_size 5 + db_max_overflow 3) = **48 + 52 headroom(churn 흡수)** ≤ DB 100. 7+ 금지.
- prod 현 maxScale 이미 6(오르테가군 수동) — 이 변경은 **다음 배포가 10으로 reset 못하게 고정**(#1319가 default를 10으로 올렸던 것 역방향).
- ⚠️ durable fix는 **2c4dcae7 PgBouncer**(연결 decouple)·그게 maxScale↑ 전제·데모後 1순위.

## 검증
yaml valid(cloudbuild+cloud-build·max=6)·주석 산식 6×8=48 갱신. 마이그0·BE 코드 무변경(인프라 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)