### PR TITLE
fix(sprints): omit empty team_size/capacity to avoid zod null rejection

### DIFF
--- a/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
+++ b/apps/web/src/app/(authenticated)/sprints/sprints-client.tsx
@@ -101,8 +101,9 @@ function CreateDialog({ projectId, onCreated, onClose }: CreateDialogProps) {
     try {
       const payload = {
         goal: goal.trim() || null,
-        capacity: capacity ? Number(capacity) : null,
-        team_size: teamSize ? Number(teamSize) : null,
+        // 미입력 시 null 대신 필드 omit — BFF createSprintSchema가 number().optional()이라 null은 거부하고 undefined(omit)는 통과한다.
+        ...(capacity ? { capacity: Number(capacity) } : {}),
+        ...(teamSize ? { team_size: Number(teamSize) } : {}),
         success_hypothesis: intent.success_hypothesis.trim() || null,
         metric_definition: intent.metric_definition,
         measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,


### PR DESCRIPTION
## 문제 (데모-크리티컬)
`/sprints` → '새 스프린트'에서 이름+날짜만 입력하고 생성하면 VALIDATION_ERROR('스프린트 생성에 실패했습니다'). 폼이 `team_size`/`capacity` 미입력 시 `null`로 전송하는데, 공유 `createSprintSchema`가 두 필드를 `z.number().optional()`로 검증 → `null`은 거부·`undefined`(omit)는 통과.

## Fix
`sprints-client.tsx` 생성 payload에서 `team_size`/`capacity`를 미입력 시 **omit**(conditional spread). 미입력=불특정이라 기본값 강제보다 omit이 의미 명확. zod·BE 무변경(이미 optional)·데모-safe. **diff 1파일·+3/-2**(fresh origin/develop 베이스·마이그/standup/auth 미포함).

## Test
- 이름+날짜만 → 201
- 인원/용량 입력 → 201 (회귀 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)