### PR TITLE
fix(epics): 에픽 삭제 BE admin/owner authz 신설 + FE thin proxy + 삭제 실패 토스트 (권한 누수 차단)

### DIFF
--- a/apps/web/src/app/api/epics/[id]/route.ts
+++ b/apps/web/src/app/api/epics/[id]/route.ts
@@ -5,7 +5,6 @@ import { handleApiError } from '@/lib/api-error';
 import { apiSuccess, apiError, ApiErrors } from '@/lib/api-response';
 import { getAuthContext } from '@/lib/auth-helpers';
 import { createEpicRepository } from '@/lib/storage/factory';
-import { requireRole, ADMIN_ROLES } from '@/lib/role-guard';
 
 type RouteParams = { params: Promise<{ id: string }> };
 
@@ -53,11 +52,9 @@ export async function DELETE(request: Request, { params }: RouteParams) {
     if (!me) return ApiErrors.unauthorized();
     if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
 
-    if (me.type !== 'agent') {
-      const denied = await requireRole(undefined, me.org_id, ADMIN_ROLES, 'Epic deletion requires admin or owner role');
-      if (denied) return denied;
-    }
-
+    // authz(admin/owner) 는 BE delete_epic 가 SSOT. FE 의 requireRole 게이트는 Supabase
+    // 레거시(db=undefined) 의존으로 깨져 있었고, 제거 시 BE 게이트 부재면 권한 누수였으므로
+    // BE 에 authz 를 신설한 뒤 thin proxy 로 전환한다.
     const repo = await createEpicRepository();
     const service = new EpicService(repo);
     await service.delete(id, me.org_id);

--- a/backend/app/routers/epics.py
+++ b/backend/app/routers/epics.py
@@ -140,10 +140,30 @@ async def delete_epic(
     id: uuid.UUID,
     repo: EpicRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> dict:
+    """에픽 삭제 — admin/owner 전용 게이트.
+
+    파괴적 작업이므로 org-level owner/admin 만 허용한다. FE 의 requireRole 게이트는
+    Supabase 레거시(db=undefined) 의존으로 깨져 있었고 그게 유일한 admin/owner 가드였다.
+    삭제하면 권한 누수(org member/viewer 가 에픽 삭제)이므로 authz 를 BE SSOT 로 옮긴다.
+    admin/owner 는 org-wide 접근권이라 project 접근권을 자동 충족한다(별도 project 게이트 불요).
+    """
     from app.repositories.dependency import DependencyRepository
     from app.repositories.label import ItemLabelRepository
+    from app.services.project_auth import is_org_owner_or_admin
+
+    # 존재 검증 먼저(없으면 404) — authz 결과로 존재 여부가 새지 않도록 404 우선.
+    epic = await repo.get(id)
+    if epic is None:
+        raise HTTPException(status_code=404, detail="Epic not found")
+
+    if not await is_org_owner_or_admin(session, uuid.UUID(auth.user_id), org_id):
+        raise HTTPException(
+            status_code=403, detail="Epic deletion requires admin or owner role"
+        )
+
     ok = await repo.delete(id)
     if not ok:
         raise HTTPException(status_code=404, detail="Epic not found")

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -231,13 +231,39 @@ async def test_update_epic_200():
 
 # ── DELETE ────────────────────────────────────────────────────────────────────
 
+def _delete_execute(*, epic, is_admin: bool):
+    """delete_epic execute 시퀀스 모킹.
+
+    1) repo.get → 존재 검증(scalar_one_or_none=에픽)
+    2) is_org_owner_or_admin → owner/admin 행 유무(scalar_one_or_none)
+    3) repo.delete 내부 self.get → 다시 에픽(없으면 False→404)
+    이후 cascade(dependency/label delete)는 영향 없음.
+    """
+    state = {"n": 0}
+
+    async def _exec(stmt, *args, **kwargs):
+        state["n"] += 1
+        r = MagicMock()
+        if state["n"] == 1:
+            r.scalar_one_or_none.return_value = epic
+        elif state["n"] == 2:
+            r.scalar_one_or_none.return_value = 1 if is_admin else None
+        elif state["n"] == 3:
+            r.scalar_one_or_none.return_value = epic
+        else:
+            r.scalar_one_or_none.return_value = None
+            r.rowcount = 0
+        return r
+
+    return _exec
+
+
 @pytest.mark.anyio
-async def test_delete_epic_200():
+async def test_delete_epic_owner_admin_200():
+    """owner/admin 은 삭제 200."""
     client, session, app = await _client()
     try:
-        mock_result = MagicMock()
-        mock_result.scalar_one_or_none.return_value = _mock_epic()
-        session.execute = AsyncMock(return_value=mock_result)
+        session.execute = _delete_execute(epic=_mock_epic(), is_admin=True)
         session.delete = AsyncMock()
         session.flush = AsyncMock()
 
@@ -246,6 +272,41 @@ async def test_delete_epic_200():
 
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_epic_non_admin_403():
+    """비-admin(member/viewer) 은 삭제 403 — 권한 누수 차단."""
+    client, session, app = await _client()
+    try:
+        session.execute = _delete_execute(epic=_mock_epic(), is_admin=False)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/epics/{EPIC_ID}")
+
+        assert resp.status_code == 403
+        assert "admin or owner" in resp.json()["error"]["message"]
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_delete_epic_404_missing():
+    """존재하지 않는 에픽은 authz 이전에 404."""
+    client, session, app = await _client()
+    try:
+        session.execute = _delete_execute(epic=None, is_admin=True)
+        session.delete = AsyncMock()
+        session.flush = AsyncMock()
+
+        async with client as c:
+            resp = await c.delete(f"/api/v2/epics/{uuid.uuid4()}")
+
+        assert resp.status_code == 404
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## 근본
- **FE** `apps/web/src/app/api/epics/[id]/route.ts` DELETE 의 `requireRole(undefined, ...)` 게이트가 Supabase 레거시(`db.auth.getUser()`)에 의존하는데 `db=undefined` 라 'Cannot read undefined auth' 400 으로 깨져 있었다. 그런데 이게 **유일한 admin/owner 게이트**였다.
- **BE** `delete_epic`(`backend/app/routers/epics.py`) 은 `get_verified_org_id`(org 멤버십)만 검증할 뿐 **admin/owner role 도 project 접근권도 0** → `repo.delete` 직행. 따라서 FE 의 깨진 requireRole 을 그냥 제거하면 org member/viewer 가 에픽을 삭제할 수 있는 **권한 누수**가 된다.

## 수정
- **BE delete_epic 에 admin/owner authz 신설** (`backend/app/routers/epics.py:138`): 존재 검증(404) 우선 → `is_org_owner_or_admin(session, user_id, org_id)`(`backend/app/services/project_auth.py` 기존 헬퍼 재사용) 아니면 403 "Epic deletion requires admin or owner role". admin/owner 는 org-wide 접근권이라 project 접근권을 자동 충족한다.
- **FE route.ts DELETE → thin proxy**: 깨진 `requireRole` 블록과 미사용 `{ requireRole, ADMIN_ROLES }` import 제거. authz 는 이제 BE 가 SSOT.
- **삭제 실패 토스트**(삼킴 제거)는 이미 `epics-client.tsx` 에 반영되어 있어 유지.
- **테스트**: `delete_epic` owner/admin 200 · member/viewer 403 · 없는 에픽 404 추가.

## #1327 과 차이
`create_epic` 은 `enforce_body_context` 로 BE authz 가 **있었다**. `delete_epic` 은 authz 가 **전무**했던 게 차이.

## dev→prod
dev/prod 는 별도 DB · maxScale 6. dev 검증 후 **승인-first** 로 prod 반영.

## 검증
- `py_compile` (epics.py · project_auth.py): OK
- `pytest tests/ -k "epic or delete or authz"`: 110 passed (사전부터 깨진 `test_contract_tests_pass` subprocess 1건 제외, 회귀 0)
- `ruff check`: All checks passed
- `pnpm --filter web type-check`: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)