### PR TITLE
fix(webhook): webhook_config upsert를 on_conflict_do_update로 — (org,member,project) 중복키 500 해소

### DIFF
--- a/backend/app/repositories/webhook_config.py
+++ b/backend/app/repositories/webhook_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import uuid
 
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.webhook_config import WebhookConfig
@@ -45,16 +46,40 @@ class WebhookConfigRepository:
         is_active: bool = True,
         secret: str | None = None,
     ) -> WebhookConfig:
-        existing = await self.session.execute(
-            select(WebhookConfig).where(
-                WebhookConfig.org_id == self.org_id,
-                WebhookConfig.url == url,
-            )
-        )
-        config = existing.scalar_one_or_none()
+        """webhook_config upsert — conflict-key 기반.
 
-        if config is None:
-            config = WebhookConfig(
+        스키마에는 멤버 1행을 강제하는 부분 unique 인덱스 2개가 있다:
+          - idx_webhook_configs_unique:  UNIQUE(org_id, member_id, project_id) WHERE project_id IS NOT NULL
+          - idx_webhook_configs_default: UNIQUE(org_id, member_id)             WHERE project_id IS NULL
+        즉 (org, member, project) 또는 (org, member, project=NULL) 당 webhook 1행만 허용한다.
+        과거 url 기준 조회는 같은 멤버가 다른 url로 재등록하면 None→plain INSERT→부분 unique 위반→500.
+        따라서 위 두 부분 인덱스를 conflict 타깃으로 on_conflict_do_update를 수행한다(중복키 0, url/설정 갱신).
+        """
+        # 충돌(update) 시 갱신할 컬럼. 기존 url-조회 update 경로 의미 보존:
+        #   - url / is_active 는 항상 갱신
+        #   - events 는 명시(non-None) 일 때만 갱신(None → 기존 값 유지)
+        #   - secret 는 명시(non-None) 일 때만 갱신(None → 기존 값 유지)
+        set_values: dict = {
+            "url": url,
+            "is_active": is_active,
+        }
+        if events is not None:
+            set_values["events"] = events
+        if secret is not None:
+            set_values["secret"] = secret or None
+
+        if project_id is not None:
+            # idx_webhook_configs_unique (org_id, member_id, project_id) WHERE project_id IS NOT NULL
+            index_elements = ["org_id", "member_id", "project_id"]
+            index_where = WebhookConfig.project_id.isnot(None)
+        else:
+            # idx_webhook_configs_default (org_id, member_id) WHERE project_id IS NULL
+            index_elements = ["org_id", "member_id"]
+            index_where = WebhookConfig.project_id.is_(None)
+
+        stmt = (
+            pg_insert(WebhookConfig)
+            .values(
                 org_id=self.org_id,
                 member_id=member_id,
                 url=url,
@@ -62,18 +87,21 @@ class WebhookConfigRepository:
                 events=events or [],
                 is_active=is_active,
                 secret=secret or None,
+                channel="generic",
             )
-            self.session.add(config)
-        else:
-            if project_id is not None:
-                config.project_id = project_id
-            if events is not None:
-                config.events = events
-            config.is_active = is_active
-            if secret is not None:
-                config.secret = secret or None
-
+            .on_conflict_do_update(
+                index_elements=index_elements,
+                index_where=index_where,
+                set_=set_values,
+            )
+            .returning(WebhookConfig.id)
+        )
+        result = await self.session.execute(stmt)
+        config_id = result.scalar_one()
         await self.session.flush()
+
+        config = await self.get(config_id)
+        assert config is not None  # noqa: S101 — 방금 upsert한 행, 동일 org 스코프
         await self.session.refresh(config)
         return config
 

--- a/backend/tests/test_webhook_config_upsert_realdb.py
+++ b/backend/tests/test_webhook_config_upsert_realdb.py
@@ -1,0 +1,163 @@
+"""webhook_config upsert 회귀 — 부분 unique 인덱스 충돌(500) 해소 실 DB 가드.
+
+근본: WebhookConfigRepository.upsert 가 과거 url 기준 조회 → None 이면 plain INSERT 했는데,
+스키마에는 멤버 1행 강제 부분 unique 인덱스 2개가 있다:
+  - idx_webhook_configs_unique:  UNIQUE(org_id, member_id, project_id) WHERE project_id IS NOT NULL
+  - idx_webhook_configs_default: UNIQUE(org_id, member_id)             WHERE project_id IS NULL
+같은 멤버가 다른 url 로 재등록하면 url 조회 None → INSERT → 부분 unique 위반 → IntegrityError 500.
+fix(on_conflict_do_update)는 두 부분 인덱스를 충돌 타깃으로 잡아 url/설정을 갱신(중복키 0).
+
+mock 으로는 부분 unique 위반을 재현 못 한다(real PG 필요). DB env 없으면 skip — CI alembic-fresh-db.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_RAW_URL = (
+    os.environ.get("PARITY_TEST_DATABASE_URL")
+    or os.environ.get("ALEMBIC_DATABASE_URL")
+    or os.environ.get("DATABASE_URL")
+    or ""
+)
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="webhook upsert real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# 고정 UUID — 시드/검증/정리 공유
+ORG = uuid.UUID("c1000000-0000-0000-0000-000000000001")
+PROJ = uuid.UUID("c4000000-0000-0000-0000-000000000001")
+MEMBER = uuid.UUID("c5000000-0000-0000-0000-000000000001")
+
+URL_A = "https://hooks.example.com/a"
+URL_B = "https://hooks.example.com/b"
+
+
+async def _seed(session) -> None:
+    """org + project 시드(이전 실행 잔여 정리 포함). member_id 는 FK 미enforced 라 별도 시드 불필요."""
+    from sqlalchemy import text
+
+    stmts = [
+        f"DELETE FROM webhook_configs WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','WH','whorg','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{PROJ}','{ORG}','P',0)",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+async def _count(session, project_is_null: bool) -> int:
+    from sqlalchemy import text
+
+    clause = "project_id IS NULL" if project_is_null else f"project_id='{PROJ}'"
+    return (await session.execute(text(
+        f"SELECT count(*) FROM webhook_configs WHERE org_id='{ORG}' AND member_id='{MEMBER}' AND {clause}"
+    ))).scalar()
+
+
+@pytest.mark.anyio
+async def test_upsert_same_project_different_url_no_duplicate_no_500():
+    """(org,member,project) 동일·url 만 다르게 재등록 → IntegrityError 안 남·중복키 0·url 갱신."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = WebhookConfigRepository(s, ORG)
+            c1 = await repo.upsert(member_id=MEMBER, url=URL_A, project_id=PROJ, events=["e1"])
+            await s.commit()
+            assert c1.url == URL_A
+
+        # 같은 (org,member,project) 에 다른 url 재등록 — pre-fix 면 여기서 500
+        async with Session() as s:
+            repo = WebhookConfigRepository(s, ORG)
+            c2 = await repo.upsert(member_id=MEMBER, url=URL_B, project_id=PROJ, events=["e2"])
+            await s.commit()
+            assert c2.url == URL_B
+            assert c2.id == c1.id  # 같은 행 갱신(신규 INSERT 아님)
+            assert c2.events == ["e2"]
+
+        async with Session() as s:
+            assert await _count(s, project_is_null=False) == 1  # 중복키 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_project_none_different_url_no_duplicate_no_500():
+    """project_id=None(개인) 동일·url 만 다르게 재등록 → idx_..._default 충돌도 갱신(중복 폭증 0)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = WebhookConfigRepository(s, ORG)
+            c1 = await repo.upsert(member_id=MEMBER, url=URL_A, project_id=None, events=["e1"])
+            await s.commit()
+            assert c1.project_id is None
+
+        # 같은 (org,member) project=NULL 에 다른 url 재등록 — pre-fix 면 여기서 500
+        async with Session() as s:
+            repo = WebhookConfigRepository(s, ORG)
+            c2 = await repo.upsert(member_id=MEMBER, url=URL_B, project_id=None, events=None)
+            await s.commit()
+            assert c2.url == URL_B
+            assert c2.id == c1.id
+            assert c2.events == ["e1"]  # events=None → 기존 값 유지
+
+        async with Session() as s:
+            assert await _count(s, project_is_null=True) == 1  # 중복 폭증 0
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_upsert_project_and_personal_coexist():
+    """같은 멤버의 project-scoped 와 personal(NULL) webhook 은 별개 행으로 공존(부분 인덱스 분리)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.repositories.webhook_config import WebhookConfigRepository
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async with Session() as s:
+            repo = WebhookConfigRepository(s, ORG)
+            cp = await repo.upsert(member_id=MEMBER, url=URL_A, project_id=PROJ)
+            cn = await repo.upsert(member_id=MEMBER, url=URL_B, project_id=None)
+            await s.commit()
+            assert cp.id != cn.id
+
+        async with Session() as s:
+            assert await _count(s, project_is_null=False) == 1
+            assert await _count(s, project_is_null=True) == 1
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 근본
`WebhookConfigRepository.upsert`가 **url 기준**으로 existing을 조회(`WHERE org_id AND url`)한 뒤, None이면 plain INSERT 했다. 그러나 `webhook_configs`에는 멤버 1행을 강제하는 **부분 unique 인덱스 2개**가 있다(baseline/schema.sql):

- `idx_webhook_configs_unique` — `UNIQUE(org_id, member_id, project_id) WHERE project_id IS NOT NULL` (schema.sql:4272)
- `idx_webhook_configs_default` — `UNIQUE(org_id, member_id) WHERE project_id IS NULL` (schema.sql:4258)

같은 `(org, member, project)`(또는 `project=NULL`)에 **다른 url**로 재등록 시: url 조회 None → INSERT → 부분 unique 위반 → `IntegrityError` 500.

기존 코드는 NULL 경로도 무제약이 아님(별도 `idx_..._default`가 `(org,member)` WHERE project IS NULL을 강제)에도 불구하고 url 조회 방식이라 양쪽 모두 500을 냈다.

## fix
url 조회 방식을 **conflict-key 기반 `on_conflict_do_update`**로 교체:

- **project_id IS NOT NULL** 경로: `index_elements=['org_id','member_id','project_id']`, `index_where=project_id IS NOT NULL` → `idx_webhook_configs_unique` 타깃.
- **project_id IS NULL** 경로: `index_elements=['org_id','member_id']`, `index_where=project_id IS NULL` → `idx_webhook_configs_default` 타깃. (무제약 아님 — 별도 부분 인덱스 존재 확인 후 분기 처리. 중복 폭증/오삭제 없음.)
- update 시 `url`/`is_active`는 항상 갱신, `events`/`secret`은 명시(non-None)일 때만 갱신해 기존 url-조회 update 의미 보존. INSERT 경로는 `channel='generic'`(모델 Python-default를 pg_insert에 명시).
- `.returning(id)` + `get()`/`refresh()`로 객체 반환(시그니처 `-> WebhookConfig` 유지).

## 검증 (전부 PASS)
1. `py_compile` OK
2. throwaway Postgres(pgvector pg16) + `alembic upgrade head`로 실 스키마(부분 인덱스 2개 존재 확인) 구성 후:
   - 신규 실 DB 회귀 테스트 `test_webhook_config_upsert_realdb.py` 3건 PASS
   - **pre-fix 코드로 stash 후 동일 테스트 → `IntegrityError`(idx_..._default·idx_..._unique) 2건 FAIL 재현** → 진짜 회귀 가드임 입증
   - `pytest -k "webhook or upsert or s0_1"` → **57 passed, 2 xfailed** (회귀 0)
3. `ruff check` PASS

## 추가 테스트
`backend/tests/test_webhook_config_upsert_realdb.py` — DB env 없으면 skip(CI alembic-fresh-db에서 실행). (org,member,project) 다른 url 재등록·project=NULL 다른 url 재등록·project-scoped/personal 공존.

## dev→prod 승인-first
dev/prod는 별도 DB. 스키마 변경 없음(순수 쿼리 로직 fix), 부분 인덱스는 양 환경 기존 존재. maxScale 10 현행 유지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)