### PR TITLE
fix(infra): cloudbuild default maxScale 6→10 — GHA 자동배포 churn 차단 (429 latent 제거)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -46,17 +46,16 @@ jobs:
             echo "target=prod" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-prod-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 6: 연결고갈 인시던트(2026-06-08) 後 안전캡. 6×8=48 ≤ DB 100(churn 흡수). 7+ 금지.
-            echo "backend_max_instances=6" >> "$GITHUB_OUTPUT"
+            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 가속→연결 회전→10×8=80<DB 100 viable. PgBouncer 後 30+.
+            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
             echo "backend_min_instances=1" >> "$GITHUB_OUTPUT"
-            # maxScale 6: 연결고갈 인시던트(2026-06-08) 後 안전캡. 6×8=48 ≤ DB 100(배포 churn 흡수·7+ 금지).
-            # 10은 80+20 tight → churn이 100 초과해 prod 고갈. prod(L49)·cloudbuild.yaml default와 합치.
-            # durable fix는 2c4dcae7 PgBouncer. (이전 '3' override가 default 덮던 근본.)
-            echo "backend_max_instances=6" >> "$GITHUB_OUTPUT"
+            # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 statement_cache 가속→연결 회전→
+            # 10×8=80<DB 100 viable. prod(L49)·cloudbuild.yaml default와 합치. PgBouncer 랜딩 後 30+.
+            echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
           fi
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,12 +11,12 @@ substitutions:
   _DEPLOY_ENV: dev
   _FASTAPI_URL: https://sprintable-backend-dev-787818285179.asia-northeast3.run.app
   _BACKEND_MIN_INSTANCES: '1'
-  # ⚠️ maxScale 6 = 연결고갈 인시던트(2026-06-08) 後 안전캡. 산식: maxScale × (db_pool_size 5 +
-  #    db_max_overflow 3) ≤ DB max_connections(dev/prod 100) → 6×8=48 + 52 headroom(배포 churn 흡수).
-  #    10은 80+20 tight → 배포 churn(구/신 리비전 동시 연결)이 100 초과해 prod 고갈 발생 → 6 하향.
-  #    durable fix는 2c4dcae7 PgBouncer(연결 decouple)·그게 maxScale↑ 전제. 그 前까지 6 캡(7+ 금지).
-  #    (이전 '3'이 매 배포 maxScale 리셋 → 수동 fix 덮던 근본. dev/prod 공통 default.)
-  _BACKEND_MAX_INSTANCES: '6'
+  # ⚠️ maxScale 10 = 429 포화 인시던트(2026-06-09) 後. 6(#1325)은 부하에 인스턴스 포화→429 유발.
+  #    #1330 statement_cache revert로 쿼리 가속→연결 빠른 회전→10×8=80 < DB 100 viable(peak 여유).
+  #    수렴 history: 3(#1319前·sat)→10(#1319·churn)→6(#1325·429 sat)→10(#1330 가속·viable).
+  #    durable fix는 2c4dcae7 PgBouncer(연결 decouple·maxScale 30+)·랜딩 後 상향. 그 前까지 10.
+  #    (GHA develop→dev·main→prod 자동배포가 이 default 주입 → 6이면 머지마다 429 재발 latent → 10.)
+  _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
 
 steps:


### PR DESCRIPTION
## 문제
#1325가 default를 6으로 내렸으나 **6은 429 포화 인시던트(2026-06-09) 유발**. GHA(develop→dev·main→prod)가 머지마다 6 자동 주입 → 수동 maxScale 10과 churn·미래 prod 자동배포가 6으로 리셋해 **429 재발 latent**.

## fix
cloudbuild.yaml default + cloud-build.yml prod(L49)/dev(L58) **6→10**.
- #1330(statement_cache revert)로 쿼리 가속→연결 빠른 회전→**10×8=80 < DB 100 viable**(peak 여유). 6은 부하에 인스턴스 포화→429.
- **수렴 history**: 3(#1319前·sat)→10(#1319·churn)→6(#1325·429 sat)→**10(#1330 가속·viable)**.
- durable fix는 2c4dcae7 PgBouncer(연결 decouple·maxScale 30+)·랜딩 後 상향.

## 검증
yaml valid(max=10·prod/dev 10)·마이그0·인프라 only. dev→prod 승인-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)