### PR TITLE
feat(db): DB_PGBOUNCER flag — transaction-mode statement_cache 비활성+pool 축소 (PgBouncer ④·default off)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -25,6 +25,14 @@ class Settings(BaseSettings):
     db_pool_size: int = 5
     db_max_overflow: int = 3
 
+    # PgBouncer ④: 사이드카(localhost:6432·pool_mode=transaction) 경유 여부(env DB_PGBOUNCER).
+    # off(기본): 직접 Cloud SQL — 현 동작 100% 유지(사이드카 없어도 다운 X).
+    # on: statement_cache 비활성(pooled conn 간 prepared statement reuse 깨짐 방지) +
+    #     app-side pool 최소화(PgBouncer default_pool_size가 실 풀 역할).
+    db_pgbouncer: bool = False
+    db_pgbouncer_pool_size: int = 2  # flag on 時 app-side pool(PgBouncer가 실 풀)
+    db_pgbouncer_max_overflow: int = 1
+
     # JWT
     jwt_secret: str = ""
 

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -11,17 +11,30 @@ from app.core.config import settings
 #   prod(db-g1-small max_connections=100, maxScale=10): 10×(5+3)=80 + ~20 headroom = 100 ✓
 #   (이전 10/20=30/instance × 10 = 300 > 100 → 고갈 위험이라 right-size)
 # env DB_POOL_SIZE / DB_MAX_OVERFLOW로 환경별 독립 조정(config.py 산식 주석 참조).
-engine = create_async_engine(
-    settings.database_url,
-    pool_size=settings.db_pool_size,
-    max_overflow=settings.db_max_overflow,
-    pool_pre_ping=True,
-    echo=settings.debug,
-    # ⚠️ statement_cache_size=0(#1314·2c4dcae7 ②)는 PgBouncer transaction-mode 전제였으나
-    # PgBouncer ③④ 미배포 상태(직접 Cloud SQL + SQLAlchemy pool=커넥션 재사용)에서는 prepared
-    # statement 캐시 비활성이 매 쿼리 re-prepare 오버헤드 = net-negative(429 포화 기여) → revert로
-    # 캐시 재활성. PgBouncer 랜딩(2c4dcae7 ③④) 시 transaction-mode 호환 위해 재적용 필요(랜딩 PR에서).
-)
+def _build_engine_kwargs() -> dict:
+    """create_async_engine 인자를 DB_PGBOUNCER flag로 분기.
+
+    헬퍼로 추출한 이유: engine은 import-time 단일 생성이라 테스트에서 flag별 재생성이
+    어렵다. 분기 로직만 함수로 떼어내 settings 토글 → 인자 검증을 단위 테스트로 커버한다.
+
+    off(기본·직접 Cloud SQL): pool_size=5/overflow=3 + prepared statement 캐시 on(#1330·
+      re-prepare 오버헤드 회피·429 포화 기여 revert). connect_args 비움.
+    on(DB_PGBOUNCER=true·PgBouncer transaction-mode 경유): app-side pool 최소(2/1·PgBouncer
+      default_pool_size가 실 풀) + statement_cache_size=0(pooled conn 간 prepared statement
+      reuse 깨짐 방지·#1314 재적용). host는 DATABASE_URL — 사이드카 배포 時 시크릿이
+      localhost:6432(③ cloudbuild 리비전과 atomic).
+    """
+    pgb = settings.db_pgbouncer
+    return {
+        "pool_size": settings.db_pgbouncer_pool_size if pgb else settings.db_pool_size,
+        "max_overflow": settings.db_pgbouncer_max_overflow if pgb else settings.db_max_overflow,
+        "pool_pre_ping": True,
+        "echo": settings.debug,
+        "connect_args": {"statement_cache_size": 0} if pgb else {},
+    }
+
+
+engine = create_async_engine(settings.database_url, **_build_engine_kwargs())
 
 async_session_factory = async_sessionmaker(
     engine,

--- a/backend/tests/test_pgbouncer_config.py
+++ b/backend/tests/test_pgbouncer_config.py
@@ -1,0 +1,54 @@
+"""PgBouncer ④: DB_PGBOUNCER flag 분기 검증.
+
+engine은 import-time 단일 생성이라 flag별 재생성이 어렵다 → 분기 로직을
+database._build_engine_kwargs()로 추출해 settings 토글 → 인자 검증으로 커버한다.
+
+- off(기본): pool_size=5/overflow=3 + connect_args 비움(statement_cache_size 없음)
+- on:        pool_size=2/overflow=1 + connect_args={"statement_cache_size": 0}
+"""
+from __future__ import annotations
+
+from app.core.config import Settings
+from app.core.database import _build_engine_kwargs
+from app.core import database
+
+
+def test_settings_defaults_flag_off():
+    s = Settings()
+    assert s.db_pgbouncer is False
+    assert s.db_pgbouncer_pool_size == 2
+    assert s.db_pgbouncer_max_overflow == 1
+    assert s.db_pool_size == 5
+    assert s.db_max_overflow == 3
+
+
+def test_settings_flag_on_via_env(monkeypatch):
+    monkeypatch.setenv("DB_PGBOUNCER", "true")
+    s = Settings()
+    assert s.db_pgbouncer is True
+
+
+def test_build_engine_kwargs_flag_off(monkeypatch):
+    monkeypatch.setattr(database.settings, "db_pgbouncer", False)
+    kw = _build_engine_kwargs()
+    assert kw["pool_size"] == database.settings.db_pool_size
+    assert kw["max_overflow"] == database.settings.db_max_overflow
+    assert kw["pool_pre_ping"] is True
+    # off: 캐시 on(#1330 revert) — statement_cache_size 미지정
+    assert kw["connect_args"] == {}
+    assert "statement_cache_size" not in kw["connect_args"]
+
+
+def test_build_engine_kwargs_flag_on(monkeypatch):
+    monkeypatch.setattr(database.settings, "db_pgbouncer", True)
+    kw = _build_engine_kwargs()
+    assert kw["pool_size"] == database.settings.db_pgbouncer_pool_size
+    assert kw["max_overflow"] == database.settings.db_pgbouncer_max_overflow
+    assert kw["pool_pre_ping"] is True
+    # on: transaction-mode 호환 — prepared statement 캐시 비활성(#1314 재적용)
+    assert kw["connect_args"] == {"statement_cache_size": 0}
+
+
+def test_imported_engine_uses_default_off():
+    """import-time 생성된 engine은 flag off(기본) 풀 크기 그대로."""
+    assert database.engine.pool.size() == database.settings.db_pool_size


### PR DESCRIPTION
## PgBouncer ④ — BE config (env flag)

PgBouncer 사이드카(localhost:6432·pool_mode=transaction)와 함께 활성화될 BE config를 env flag `DB_PGBOUNCER`(default **False**)로 추가.

### 동작
- **flag off(기본)**: 현 동작 100% 유지(pool 5/3 + prepared statement 캐시 on). 사이드카 없어도 다운 X → 머지만으로 안전.
- **flag on**: transaction-mode 호환 — `statement_cache_size=0`(pooled conn 간 prepared statement reuse 깨짐 방지·#1314 재적용) + app-side pool 축소(2/1·PgBouncer default_pool_size가 실 풀). host는 `DATABASE_URL`(사이드카 배포 時 시크릿이 localhost:6432).

### atomic 짝
- ③ cloudbuild(오르테가군) 사이드카 리비전과 atomic.
- #1330(캐시 revert) ↔ 본 PR(on 時 재적용)의 짝.
- dev 먼저 → prod 승인-first.

### 변경
- `config.py`: `db_pgbouncer`/`db_pgbouncer_pool_size`/`db_pgbouncer_max_overflow` 필드(env override 가능).
- `database.py`: `_build_engine_kwargs()` 헬퍼로 flag 분기 추출(import-time engine 테스트 한계 우회). #1330 주석 → 분기 주석으로 교체.
- `tests/test_pgbouncer_config.py`: settings default + flag on/off 분기 인자 검증.

### 검증 (전부 PASS)
- py_compile(config.py·database.py) OK
- engine import(off): pgb False·pool 5
- flag on sim: `DB_PGBOUNCER=true` → True·2
- pytest `-k "config or database or pgbouncer"`: 44 passed·회귀 0
- ruff: All checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)