### PR TITLE
feat(infra): cloudbuild deploy-backend 3컨테이너 전환 초안 — PgBouncer 사이드카 (PgBouncer ③)

### DIFF
--- a/.github/workflows/cloud-build.yml
+++ b/.github/workflows/cloud-build.yml
@@ -49,6 +49,10 @@ jobs:
             # maxScale 10: 429 포화(2026-06-09)·6은 sat 유발. #1330 가속→연결 회전→10×8=80<DB 100 viable. PgBouncer 後 30+.
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=G-RYHFE7XM3X" >> "$GITHUB_OUTPUT"
+            # PgBouncer ③ — prod 인스턴스/시크릿(ground truth). cloudbuild.yaml dev default override 필수.
+            echo "instance_connection_name=sprintable-494803:asia-northeast3:sprintable-prod" >> "$GITHUB_OUTPUT"
+            echo "db_secret=DATABASE_URL_PROD_PGB" >> "$GITHUB_OUTPUT"
+            echo "pgb_upstream_secret=PGB_UPSTREAM_PROD" >> "$GITHUB_OUTPUT"
           else
             echo "target=dev" >> "$GITHUB_OUTPUT"
             echo "fastapi_url=https://sprintable-backend-dev-787818285179.asia-northeast3.run.app" >> "$GITHUB_OUTPUT"
@@ -57,6 +61,10 @@ jobs:
             # 10×8=80<DB 100 viable. prod(L49)·cloudbuild.yaml default와 합치. PgBouncer 랜딩 後 30+.
             echo "backend_max_instances=10" >> "$GITHUB_OUTPUT"
             echo "ga4_measurement_id=" >> "$GITHUB_OUTPUT"
+            # PgBouncer ③ — dev 인스턴스/시크릿. cloudbuild.yaml default와 합치(명시 주입).
+            echo "instance_connection_name=sprintable-494803:asia-northeast3:sprintable-dev" >> "$GITHUB_OUTPUT"
+            echo "db_secret=DATABASE_URL_DEV_PGB" >> "$GITHUB_OUTPUT"
+            echo "pgb_upstream_secret=PGB_UPSTREAM_DEV" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Submit Cloud Build
@@ -64,6 +72,6 @@ jobs:
           gcloud builds submit \
             --config=cloudbuild.yaml \
             --project="${{ secrets.GCP_PROJECT_ID }}" \
-            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}" \
+            --substitutions=COMMIT_SHA="${{ github.sha }}",_DEPLOY_ENV="${{ steps.env.outputs.target }}",_FASTAPI_URL="${{ steps.env.outputs.fastapi_url }}",_BACKEND_MIN_INSTANCES="${{ steps.env.outputs.backend_min_instances }}",_BACKEND_MAX_INSTANCES="${{ steps.env.outputs.backend_max_instances }}",_GA4_MEASUREMENT_ID="${{ steps.env.outputs.ga4_measurement_id }}",_INSTANCE_CONNECTION_NAME="${{ steps.env.outputs.instance_connection_name }}",_DB_SECRET="${{ steps.env.outputs.db_secret }}",_PGB_UPSTREAM_SECRET="${{ steps.env.outputs.pgb_upstream_secret }}" \
             --suppress-logs \
             .

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,6 +18,18 @@ substitutions:
   #    (GHA develop→dev·main→prod 자동배포가 이 default 주입 → 6이면 머지마다 429 재발 latent → 10.)
   _BACKEND_MAX_INSTANCES: '10'
   _GA4_MEASUREMENT_ID: ""  # dev 기본값 빈 문자열 — prod 트리거에서 G-RYHFE7XM3X 주입
+  # ─── PgBouncer ③ 멀티컨테이너 사이드카 substitution (dev 기본값) ──────────────
+  # ⚠️ 아래는 오르테가 dev 격리(sprintable-backend-dev-pgbtest) 검증값. prod는 GHA
+  #    cloud-build.yml에서 _DEV → prod 시크릿/인스턴스로 override 필요(PO export 대조 後).
+  _INSTANCE_CONNECTION_NAME: sprintable-494803:asia-northeast3:sprintable-dev
+  _DB_SECRET: DATABASE_URL_DEV_PGB            # backend DATABASE_URL → localhost:6432
+  _PGB_UPSTREAM_SECRET: PGB_UPSTREAM_DEV       # pgbouncer upstream → localhost:5432
+  _GITHUB_CLIENT_ID_SECRET: GITHUB_CLIENT_ID_DEV
+  _GITHUB_CLIENT_SECRET_SECRET: GITHUB_CLIENT_SECRET_DEV
+  _APP_URL: https://dev-app.sprintable.ai
+  # 사이드카 이미지(필요 시 AR 미러로 교체 가능)
+  _PGBOUNCER_IMAGE: edoburu/pgbouncer:latest
+  _CLOUD_SQL_PROXY_IMAGE: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1
 
 steps:
   # ─── Frontend (Next.js standalone) ────────────────────────────────────────
@@ -91,18 +103,32 @@ steps:
       - --quiet
     waitFor: [push-frontend]
 
+  # PgBouncer ③: 멀티컨테이너(backend+pgbouncer+cloud-sql-proxy) — knative Service YAML
+  #   replace 방식. 단일 `gcloud run deploy --image`로는 3컨테이너 per-container 시크릿/
+  #   container-dependencies 기동순서를 표현하기 난해해 services replace YAML을 채택.
+  #   placeholder는 cloudbuild substitution + envsubst로 주입.
   - id: deploy-backend
     name: gcr.io/google.com/cloudsdktool/cloud-sdk
-    entrypoint: gcloud
+    entrypoint: bash
     args:
-      - run
-      - deploy
-      - sprintable-backend-${_DEPLOY_ENV}
-      - --image=${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
-      - --region=${_AR_REGION}
-      - --min-instances=${_BACKEND_MIN_INSTANCES}
-      - --max-instances=${_BACKEND_MAX_INSTANCES}
-      - --quiet
+      - -c
+      - |
+        set -euo pipefail
+        # envsubst(gettext-base)는 cloud-sdk 이미지에 보통 포함되나, 변종 대비 가드.
+        command -v envsubst >/dev/null 2>&1 || (apt-get update -qq && apt-get install -y -qq gettext-base) >&2
+        export PROJECT_ID="${PROJECT_ID}" COMMIT_SHA="${COMMIT_SHA}"
+        export _AR_REGION="${_AR_REGION}" _AR_REPO="${_AR_REPO}" _DEPLOY_ENV="${_DEPLOY_ENV}"
+        export _BACKEND_MIN_INSTANCES="${_BACKEND_MIN_INSTANCES}" _BACKEND_MAX_INSTANCES="${_BACKEND_MAX_INSTANCES}"
+        export _INSTANCE_CONNECTION_NAME="${_INSTANCE_CONNECTION_NAME}"
+        export _DB_SECRET="${_DB_SECRET}" _PGB_UPSTREAM_SECRET="${_PGB_UPSTREAM_SECRET}"
+        export _GITHUB_CLIENT_ID_SECRET="${_GITHUB_CLIENT_ID_SECRET}" _GITHUB_CLIENT_SECRET_SECRET="${_GITHUB_CLIENT_SECRET_SECRET}"
+        export _APP_URL="${_APP_URL}"
+        export _PGBOUNCER_IMAGE="${_PGBOUNCER_IMAGE}" _CLOUD_SQL_PROXY_IMAGE="${_CLOUD_SQL_PROXY_IMAGE}"
+        envsubst < service-backend.yaml > /workspace/service-backend.rendered.yaml
+        echo "─── rendered service-backend.yaml ───" >&2
+        cat /workspace/service-backend.rendered.yaml >&2
+        gcloud run services replace /workspace/service-backend.rendered.yaml \
+          --region="${_AR_REGION}" --quiet
     waitFor: [push-backend]
 
 options:

--- a/service-backend.yaml
+++ b/service-backend.yaml
@@ -1,0 +1,176 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# PgBouncer ③ — Cloud Run 멀티컨테이너(사이드카) backend Service spec (초안)
+#
+# 토폴로지: backend(8000·ingress) → pgbouncer(6432) → cloud-sql-proxy(5432)
+#   - container-dependencies 어노테이션으로 기동 순서 강제(proxy→pgbouncer→backend)
+#   - 기존 cloudsql-instances 어노테이션 제거(명시 cloud-sql-proxy 사이드카로 대체)
+#   - backend의 DATABASE_URL 시크릿은 localhost:6432(PgBouncer)을 가리켜야 함
+#   - pgbouncer의 DATABASE_URL(upstream) 시크릿은 localhost:5432(proxy)을 가리켜야 함
+#
+# 주입 placeholder(cloudbuild step에서 envsubst):
+#   ${COMMIT_SHA}              — 배포 이미지 태그
+#   ${_AR_REGION} ${PROJECT_ID} ${_AR_REPO}
+#   ${_DEPLOY_ENV}            — dev / prod (서비스명 suffix)
+#   ${_BACKEND_MIN_INSTANCES} ${_BACKEND_MAX_INSTANCES}
+#   ${_INSTANCE_CONNECTION_NAME} — Cloud SQL 인스턴스 연결명 (proxy --private-ip 인자)
+#   ${_DB_SECRET}            — backend DATABASE_URL 시크릿명 (localhost:6432 가리킴)
+#   ${_PGB_UPSTREAM_SECRET}  — pgbouncer upstream 시크릿명 (localhost:5432 가리킴)
+#   ${_GITHUB_CLIENT_ID_SECRET} ${_GITHUB_CLIENT_SECRET_SECRET} — env별 GitHub OAuth 시크릿명
+#   ${_PGBOUNCER_IMAGE} ${_CLOUD_SQL_PROXY_IMAGE} — 사이드카 이미지(AR 미러 가능)
+#
+# ⚠️ 본 파일은 오르테가(PO) dev 격리 검증(sprintable-backend-dev-pgbtest) export를
+#    ground truth로 대조한 골격 초안이다. 머지 前 PO export와 최종 대조 필요.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: sprintable-backend-${_DEPLOY_ENV}
+  labels:
+    cloud.googleapis.com/location: ${_AR_REGION}
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: '${_BACKEND_MIN_INSTANCES}'
+        autoscaling.knative.dev/maxScale: '${_BACKEND_MAX_INSTANCES}'
+        run.googleapis.com/startup-cpu-boost: 'true'
+        run.googleapis.com/vpc-access-egress: private-ranges-only
+        run.googleapis.com/network-interfaces: '[{"network":"default","subnetwork":"default"}]'
+        # 기동 순서: cloud-sql-proxy → pgbouncer → backend
+        run.googleapis.com/container-dependencies: '{"backend":["pgbouncer"],"pgbouncer":["cloud-sql-proxy"]}'
+    spec:
+      containerConcurrency: 80
+      timeoutSeconds: 3600
+      serviceAccountName: cloudrun-runtime-${_DEPLOY_ENV}@${PROJECT_ID}.iam.gserviceaccount.com
+      containers:
+        # ─── 1) backend (primary·ingress 8000) ───────────────────────────────
+        - name: backend
+          image: ${_AR_REGION}-docker.pkg.dev/${PROJECT_ID}/${_AR_REPO}/backend:${COMMIT_SHA}
+          ports:
+            - name: http1
+              containerPort: 8000
+          env:
+            # DATABASE_URL → localhost:6432 (PgBouncer). 시크릿값이 6432를 가리켜야 함.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${_DB_SECRET}
+                  key: latest
+            - name: DB_PGBOUNCER
+              value: 'true'
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: JWT_SECRET
+                  key: latest
+            - name: SUPABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: NEXT_PUBLIC_SUPABASE_URL
+                  key: latest
+            - name: SUPABASE_SERVICE_ROLE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: SUPABASE_SERVICE_ROLE_KEY
+                  key: latest
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: GOOGLE_CLIENT_ID
+                  key: latest
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: GOOGLE_CLIENT_SECRET
+                  key: latest
+            - name: GITHUB_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: ${_GITHUB_CLIENT_ID_SECRET}
+                  key: latest
+            - name: GITHUB_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: ${_GITHUB_CLIENT_SECRET_SECRET}
+                  key: latest
+            - name: EVENTBUS_ENABLED
+              value: 'true'
+            - name: APP_URL
+              value: ${_APP_URL}
+            - name: MEMBER_SSOT_RESOLVER_SHADOW
+              value: 'true'
+            - name: MEMBER_SSOT_APIKEY_CUT
+              value: 'true'
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: RESEND_API_KEY
+                  key: latest
+            - name: EMAIL_FROM
+              valueFrom:
+                secretKeyRef:
+                  name: EMAIL_FROM
+                  key: latest
+          resources:
+            limits:
+              cpu: '1'
+              memory: 512Mi
+          startupProbe:
+            tcpSocket:
+              port: 8000
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+
+        # ─── 2) pgbouncer (transaction-mode·6432) ────────────────────────────
+        - name: pgbouncer
+          image: ${_PGBOUNCER_IMAGE}
+          env:
+            # upstream(DATABASE_URL) → localhost:5432 (cloud-sql-proxy). 시크릿값이 5432를 가리켜야 함.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: ${_PGB_UPSTREAM_SECRET}
+                  key: latest
+            - name: POOL_MODE
+              value: transaction
+            - name: DEFAULT_POOL_SIZE
+              value: '25'
+            - name: MAX_CLIENT_CONN
+              value: '1000'
+            - name: MIN_POOL_SIZE
+              value: '5'
+            - name: LISTEN_PORT
+              value: '6432'
+          resources:
+            limits:
+              cpu: '1'
+              memory: 256Mi
+          startupProbe:
+            tcpSocket:
+              port: 6432
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+
+        # ─── 3) cloud-sql-proxy (5432) ───────────────────────────────────────
+        - name: cloud-sql-proxy
+          image: ${_CLOUD_SQL_PROXY_IMAGE}
+          args:
+            - --address=0.0.0.0
+            - --port=5432
+            - --private-ip
+            - ${_INSTANCE_CONNECTION_NAME}
+          resources:
+            limits:
+              cpu: '1'
+              memory: 256Mi
+          startupProbe:
+            tcpSocket:
+              port: 5432
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 10
+  traffic:
+    - latestRevision: true
+      percent: 100

--- a/service-backend.yaml
+++ b/service-backend.yaml
@@ -132,6 +132,9 @@ spec:
                 secretKeyRef:
                   name: ${_PGB_UPSTREAM_SECRET}
                   key: latest
+            # PG15 SCRAM 인증 필수 — 없으면 pgbouncer가 Cloud SQL(PG15) 인증 실패 → 컨테이너 기동/배포 실패.
+            - name: AUTH_TYPE
+              value: scram-sha-256
             - name: POOL_MODE
               value: transaction
             - name: DEFAULT_POOL_SIZE


### PR DESCRIPTION
## 개요

`cloudbuild.yaml`의 `deploy-backend` 단계를 단일 컨테이너(`gcloud run deploy --image`)에서 **3컨테이너 멀티컨테이너(사이드카)** 토폴로지로 전환하는 **초안(draft)** PR입니다.

> ⚠️ **본 PR은 prod 라이브 인프라를 다루는 골격 초안입니다.** 무검증 syntax 위험이 있어, 오르테가(PO)께서 dev 격리 서비스(`sprintable-backend-dev-pgbtest`)로 동일 토폴로지를 실배포 검증 중입니다. 그 검증된 `gcloud run services describe ... --format export` YAML이 ground truth이며, **머지 前 PO export와 최종 대조**가 필요합니다. (구조는 현재 라이브 pgbtest export를 기준으로 잡았습니다.)

## 토폴로지

Cloud Run 멀티컨테이너(사이드카), 기동 순서 강제:

```
cloud-sql-proxy(5432) → pgbouncer(6432) → backend(8000·ingress)
```

- **backend** (primary·ingress): `backend:${COMMIT_SHA}` · port 8000 · `DB_PGBOUNCER=true` · `DATABASE_URL` 시크릿 → localhost:6432(PgBouncer) 가리킴
- **pgbouncer**: `edoburu/pgbouncer` · `POOL_MODE=transaction` · `DEFAULT_POOL_SIZE=25` · `MAX_CLIENT_CONN=1000` · `MIN_POOL_SIZE=5` · listen 6432 · upstream(`DATABASE_URL`) 시크릿 → localhost:5432(proxy) 가리킴
- **cloud-sql-proxy**: `gcr.io/cloud-sql-connectors/cloud-sql-proxy` · args `--address=0.0.0.0 --port=5432 --private-ip <INSTANCE_CONNECTION_NAME>` · listen 5432
- `run.googleapis.com/container-dependencies: {"backend":["pgbouncer"],"pgbouncer":["cloud-sql-proxy"]}` 어노테이션으로 기동 순서 강제
- 기존 `run.googleapis.com/cloudsql-instances` 어노테이션 **제거** → 명시적 cloud-sql-proxy 사이드카로 대체
- VPC `network-interfaces` + `vpc-access-egress: private-ranges-only` 보존(private-ip 연결)

## 채택 방식: services replace YAML (방식 a)

`service-backend.yaml`(knative Service spec) 신규 + `deploy-backend` step을 `gcloud run services replace`로 전환했습니다.

**이유:**
- `gcloud run deploy`는 `--container`/`--depends-on` 멀티컨테이너 플래그를 지원하나, **3컨테이너 각각의 per-container 시크릿(`secretKeyRef`) + 기동순서(`container-dependencies`)**를 플래그로 표현하면 args 블록이 비대해지고 리뷰/감사가 어렵습니다.
- PO의 검증 서비스(`sprintable-backend-dev-pgbtest`)가 이미 동일한 knative 멀티컨테이너 형태로 존재 → **services replace YAML이 PO export와 1:1 대조 가능**(머지 게이트가 명확).
- 선언적 YAML이 라이브 인프라 변경의 audit/diff에 유리.

`${COMMIT_SHA}`·`${_DEPLOY_ENV}` 등은 cloudbuild substitution + `envsubst`로 주입합니다(`deploy-backend` step에서 `envsubst < service-backend.yaml | gcloud run services replace`). envsubst 미존재 변종 대비 `gettext-base` 설치 가드 포함.

## Placeholder (PO dev export로 정확값 채울 항목)

cloudbuild substitution 기본값은 **dev 검증값**으로 채웠고, prod는 GHA `cloud-build.yml`에서 override 필요합니다:

| substitution | dev 기본값(검증) | prod (PO 확인 필요) |
|---|---|---|
| `_INSTANCE_CONNECTION_NAME` | `sprintable-494803:asia-northeast3:sprintable-dev` | prod 인스턴스명 |
| `_DB_SECRET` (backend→6432) | `DATABASE_URL_DEV_PGB` | prod PgB 시크릿명 |
| `_PGB_UPSTREAM_SECRET` (pgb→5432) | `PGB_UPSTREAM_DEV` | prod upstream 시크릿명 |
| `_GITHUB_CLIENT_ID_SECRET` | `GITHUB_CLIENT_ID_DEV` | prod GitHub 시크릿 |
| `_GITHUB_CLIENT_SECRET_SECRET` | `GITHUB_CLIENT_SECRET_DEV` | prod GitHub 시크릿 |
| `_APP_URL` | `https://dev-app.sprintable.ai` | prod APP_URL |
| `_PGBOUNCER_IMAGE` | `edoburu/pgbouncer:latest` | AR 미러 검토 |
| `_CLOUD_SQL_PROXY_IMAGE` | `gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.14.1` | (동일) |

> **`_DB_SECRET` / `_PGB_UPSTREAM_SECRET` 시크릿값 자체**(연결 문자열이 각각 localhost:6432 / localhost:5432를 가리키는지)는 코드가 아닌 Secret Manager 측 값이므로 PO export·시크릿 확인 필요.

## 검증 (가능 범위)

- `cloudbuild.yaml` YAML valid ✓ (`yaml.safe_load`)
- `service-backend.yaml` raw(placeholder) YAML valid ✓
- `envsubst` 렌더 결과 YAML valid ✓ — containers `[backend, pgbouncer, cloud-sql-proxy]`, container-dependencies 어노테이션·proxy args·secretKeyRef 주입 정상, 잔여 `${...}` 0건
- 렌더 결과가 PO 라이브 `sprintable-backend-dev-pgbtest` export 토폴로지와 구조 일치 확인
- ⚠️ **실 배포 검증 불가** — PO dev 격리(`pgbtest`)가 ground truth. 본 PR은 구조 초안.

## multi-container syntax 중 PO 검증값 필요 항목

- prod 시크릿명/인스턴스 연결명(위 표) — dev override 매핑
- `_DB_SECRET`·`_PGB_UPSTREAM_SECRET` **시크릿 내부 연결 문자열**이 localhost:6432 / localhost:5432를 정확히 가리키는지
- pgbouncer/cloud-sql-proxy 이미지의 AR 미러 채택 여부

## 머지 전제

prod 라이브 고위험 → **dev 먼저 적용 → prod는 PO 승인-first**. 머지 前 PO dev export 최종 대조 필수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)