### PR TITLE
fix(standup): org-level 멤버 로스터를 org_members SSOT 직접 해소 (S:166051f0)

### DIFF
--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import uuid
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -49,6 +51,40 @@ class TeamMemberRepository(BaseRepository[TeamMember]):
             q = q.distinct(TeamMember.id).order_by(TeamMember.id)
         result = await self.session.execute(q.limit(limit))
         return list(result.scalars().all())
+
+    async def list_org_human_members(
+        self, user_id: uuid.UUID | None = None
+    ) -> list[dict[str, Any]]:
+        """org-level 휴먼 로스터 = **org_members SSOT 직접 해소** (S:166051f0).
+
+        team_members 뷰(0088 = members ⋈ project_access)는 휴먼을 project_access.member_id 로
+        join 하는데, 실 grant 플로우(create_project_access)는 member_id 를 NULL 로 두므로
+        grant-only/owner 휴먼이 뷰에서 탈락한다 → org-level 스탠드업 로스터서 휴먼 0(상용 버그).
+        여기서는 **project_access/team_members 를 일절 경유하지 않고** org_members 를 권위 소스로
+        직접 열거한다. 곱연산(휴먼×프로젝트=N행) 없음 — org_member 1행/휴먼. member_id 백필 불요.
+
+        id = org_member.id = canonical 휴먼 신원(/api/me·standup author_id·_MISSING_SQL 과 동일
+        기준 → 자기 카드 편집/제출 매칭 정합). name/avatar 는 canonical members 우선, users 폴백
+        (백필 갭 안전망). 반환은 TeamMemberResponse 와 호환되는 dict.
+        """
+        sql = (
+            "SELECT om.id AS id, om.user_id AS user_id, om.role AS role, om.created_at AS created_at, "
+            "       COALESCE(m.name, u.display_name, u.email, '') AS name, m.avatar_url AS avatar_url "
+            "FROM org_members om "
+            "JOIN users u ON u.id = om.user_id "
+            "LEFT JOIN members m ON m.org_id = om.org_id AND m.user_id = om.user_id "
+            "                   AND m.type = 'human' AND m.deleted_at IS NULL "
+            "WHERE om.org_id = :org AND om.deleted_at IS NULL"
+        )
+        params: dict[str, Any] = {"org": self.org_id}
+        # asyncpg 함정 회피: ':uid IS NULL' 분기 대신 Python 조건부로 필터를 붙인다
+        # (feedback_asyncpg_text_traps — IS NULL 바인딩 AmbiguousParameterError).
+        if user_id is not None:
+            sql += " AND om.user_id = :uid"
+            params["uid"] = user_id
+        sql += " ORDER BY name"
+        rows = await self.session.execute(text(sql), params)
+        return [dict(row._mapping) for row in rows]
 
     async def apply_anchor_update(self, member: TeamMember, data: dict[str, Any]) -> None:
         """AC3-4 2-2: PATCH 필드를 앵커 테이블로 라우팅(anchor-only write, 레거시 team_members UPDATE 없음).

--- a/backend/app/routers/team_members.py
+++ b/backend/app/routers/team_members.py
@@ -56,6 +56,34 @@ def _get_repo(
     return TeamMemberRepository(session, org_id)
 
 
+# org-level 휴먼은 특정 프로젝트에 귀속되지 않는다(org_members SSOT 직접 해소). TeamMemberResponse.
+# project_id 가 required 라 nil sentinel 을 둔다 — FE 스탠드업 로스터는 id/name/type 만 읽고
+# 휴먼은 project 컬럼을 사용하지 않는다(S:166051f0). 응답 스키마(계약) 변경 0.
+_ORG_LEVEL_HUMAN_PROJECT_ID = uuid.UUID(int=0)
+
+
+def _build_org_human_response(row: dict, org_id: uuid.UUID) -> TeamMemberResponse:
+    """org_members 직접 해소 휴먼 행 → TeamMemberResponse (S:166051f0).
+
+    id = org_member.id(canonical 휴먼 신원). presence/active_story/색상 등은 휴먼 무의미 → 기본값.
+    """
+    now = row.get("created_at") or datetime.now(timezone.utc)
+    return TeamMemberResponse(
+        id=row["id"],
+        project_id=_ORG_LEVEL_HUMAN_PROJECT_ID,
+        org_id=org_id,
+        user_id=row.get("user_id"),
+        type="human",
+        name=row["name"],
+        role=row["role"],
+        avatar_url=row.get("avatar_url"),
+        is_active=True,
+        color="#3385f8",
+        created_at=now,
+        updated_at=now,
+    )
+
+
 @router.get("", response_model=list[TeamMemberResponse])
 async def list_team_members(
     project_id: uuid.UUID | None = Query(default=None),
@@ -64,10 +92,28 @@ async def list_team_members(
     user_id: uuid.UUID | None = Query(default=None),
     repo: TeamMemberRepository = Depends(_get_repo),
     session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
 ) -> list[TeamMemberResponse]:
-    filters: dict = {}
-    if project_id:
-        filters["project_id"] = project_id
+    # S:166051f0 — org-level(project_id 없음): 휴먼 = org_members SSOT **직접** 해소
+    # (team_members 뷰=members⋈project_access 비의존 → project_access.member_id NULL 인
+    # grant-only/owner 휴먼도 포함, 곱연산 0). 에이전트는 기존 뷰(type=agent) 그대로.
+    # project-scoped(project_id 지정)는 기존 뷰 경로 무변경 → 다른 consumer 무회귀(AC3).
+    if project_id is None:
+        result: list[TeamMemberResponse] = []
+        if type_filter in (None, "human"):
+            human_rows = await repo.list_org_human_members(user_id=user_id)
+            result.extend(_build_org_human_response(r, org_id) for r in human_rows)
+        if type_filter in (None, "agent"):
+            agent_filters: dict = {"type": "agent"}
+            if is_active is not None:
+                agent_filters["is_active"] = is_active
+            if user_id:
+                agent_filters["user_id"] = user_id
+            agents = await repo.list(**agent_filters)
+            result.extend(await _inject_active_stories(agents, session))
+        return result
+
+    filters: dict = {"project_id": project_id}
     if type_filter:
         filters["type"] = type_filter
     if is_active is not None:

--- a/backend/tests/test_standup_org_roster_166051f0.py
+++ b/backend/tests/test_standup_org_roster_166051f0.py
@@ -1,0 +1,172 @@
+"""S:166051f0 real-DB: org-level 스탠드업 멤버 표시를 org_members 직접 해소.
+
+상용 뭉클랩 제로고 데모-당일 버그 재현 + 픽스 입증. team_members 뷰(0088 = members ⋈
+project_access)는 휴먼을 `pa.member_id = m.id` 로 join 하는데, 실 grant 플로우는 member_id 를
+NULL 로 둔다(grant-only) → grant-only/owner/무-access 휴먼이 뷰에서 탈락 → org-level 스탠드업
+로스터서 휴먼 0. 픽스: org-level team-members 휴먼을 **org_members SSOT 직접** 해소(뷰 비의존).
+
+⚠️ SSOT 노선(선생님 2026-06-09): project_access/team_members 링크 의존·새 프로젝트 멤버 행
+생성·member_id 백필 일절 금지. 곱연산(휴먼×프로젝트=N행) 박멸. → 본 테스트는 (1) 뷰가 휴먼을
+탈락시킴(버그) (2) 픽스가 org_members 직접으로 전원 표시 (3) read 가 어떤 write 도 안 함
+(member_id 백필 0·새 행 0·곱연산 0) 를 함께 검증한다.
+
+DB env(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡에서 실행.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_RAW_URL = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+ORG = uuid.UUID("d1660000-0000-0000-0000-000000000001")
+P1 = uuid.UUID("d1660000-0000-0000-0000-0000000000a1")
+# 휴먼 3종: owner(PA 없음)·grant-only(PA member_id NULL)·무-access(org 멤버만)
+U_OWNER = uuid.UUID("d1660000-0000-0000-0000-0000000000b1")
+U_GRANT = uuid.UUID("d1660000-0000-0000-0000-0000000000b2")
+U_NOACC = uuid.UUID("d1660000-0000-0000-0000-0000000000b3")
+OM_OWNER = uuid.UUID("d1660000-0000-0000-0000-0000000000c1")
+OM_GRANT = uuid.UUID("d1660000-0000-0000-0000-0000000000c2")
+OM_NOACC = uuid.UUID("d1660000-0000-0000-0000-0000000000c3")
+AG1 = uuid.UUID("d1660000-0000-0000-0000-0000000000e1")  # 뷰에 보이는 에이전트(대조군)
+
+
+async def _seed(session):
+    from sqlalchemy import text
+
+    stmts = [
+        # 재실행 정리(의존 역순)
+        f"DELETE FROM agent_project_profiles WHERE member_id = '{AG1}'",
+        f"DELETE FROM project_access WHERE project_id = '{P1}'",
+        f"DELETE FROM members WHERE org_id = '{ORG}'",
+        f"DELETE FROM projects WHERE org_id = '{ORG}'",
+        f"DELETE FROM org_members WHERE org_id = '{ORG}'",
+        f"DELETE FROM users WHERE id IN ('{U_OWNER}','{U_GRANT}','{U_NOACC}')",
+        f"DELETE FROM organizations WHERE id = '{ORG}'",
+        # 시드
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','D166','d166org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) VALUES "
+        f"('{U_OWNER}','owner@d166.test','x','Owner Park',true,true,0,false,0),"
+        f"('{U_GRANT}','grant@d166.test','x','Grant Kim',true,true,0,false,0),"
+        f"('{U_NOACC}','noacc@d166.test','x',NULL,true,true,0,false,0)",
+        "INSERT INTO org_members (id,org_id,user_id,role) VALUES "
+        f"('{OM_OWNER}','{ORG}','{U_OWNER}','owner'),"
+        f"('{OM_GRANT}','{ORG}','{U_GRANT}','member'),"
+        f"('{OM_NOACC}','{ORG}','{U_NOACC}','member')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0)",
+        # anchor members: 휴먼 id=org_member.id. U_NOACC 는 name 컬럼이 NULL→픽스의 users 폴백(display_name/email) 검증용으로 members 미생성.
+        "INSERT INTO members (id,org_id,type,user_id,name,org_role,is_active) VALUES "
+        f"('{OM_OWNER}','{ORG}','human','{U_OWNER}','Owner Park','owner',true),"
+        f"('{OM_GRANT}','{ORG}','human','{U_GRANT}','Grant Kim','member',true),"
+        f"('{AG1}','{ORG}','agent',NULL,'BuildBot',NULL,true)",
+        # 에이전트 런타임 미러 → 뷰 agent 분기 출현
+        f"INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port) VALUES "
+        f"(gen_random_uuid(),'{AG1}','{P1}','dev',9301)",
+        # 실 grant 플로우 모사: grant-only 휴먼은 org_member_id 만, member_id NULL → 뷰 휴먼 분기서 탈락.
+        # owner/무-access 휴먼은 project_access 자체가 없음. (곱연산 박멸 = 휴먼당 PA 다행 안 만듦.)
+        "INSERT INTO project_access (id,project_id,org_member_id,member_id,permission,role,access_source) VALUES "
+        f"(gen_random_uuid(),'{P1}','{OM_GRANT}',NULL,'granted','member','direct')",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+def _auth():
+    c = MagicMock()
+    c.user_id = str(U_OWNER)
+    c.claims = {"app_metadata": {"org_id": str(ORG)}}
+    return c
+
+
+@pytest.mark.anyio
+async def test_org_level_human_roster_from_org_members_not_view():
+    """⚠️ 핵심: 뷰는 휴먼 0(버그 재현), org-level 엔드포인트는 org_members 직접으로 휴먼 전원 표시(픽스)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # (1) 버그 재현: team_members 뷰 org-level 휴먼 = 0, 에이전트 = 1
+        async with Session() as s:
+            view_humans = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE org_id=:o AND type='human'"), {"o": str(ORG)})).scalar_one()
+            view_agents = (await s.execute(text(
+                "SELECT count(*) FROM team_members WHERE org_id=:o AND type='agent'"), {"o": str(ORG)})).scalar_one()
+        assert view_humans == 0, f"뷰가 휴먼을 노출(버그 전제 깨짐): {view_humans}"
+        assert view_agents == 1, f"뷰 에이전트 출현 실패: {view_agents}"
+
+        # (2) repo 직접: org_members SSOT 해소 — 휴먼 3인 전원, id=org_member.id, name 폴백 동작
+        from app.repositories.team_member import TeamMemberRepository
+        async with Session() as s:
+            rows = await TeamMemberRepository(s, ORG).list_org_human_members()
+        by_id = {r["id"]: r for r in rows}
+        assert set(by_id) == {OM_OWNER, OM_GRANT, OM_NOACC}, f"org_members 직접 해소 휴먼 불일치: {set(by_id)}"
+        assert by_id[OM_OWNER]["name"] == "Owner Park"          # members.name 우선
+        assert by_id[OM_GRANT]["name"] == "Grant Kim"
+        assert by_id[OM_NOACC]["name"] == "noacc@d166.test"     # members 부재 → users.email 폴백
+        # 곱연산 0: 휴먼당 정확히 1행
+        assert len(rows) == 3, f"곱연산 의심(휴먼당 1행 위반): {len(rows)}"
+
+        # (3) 엔드포인트 org-level(project_id 없음): 휴먼 3 + 에이전트 1, 자기 신원 canonical 매칭
+        from httpx import ASGITransport, AsyncClient
+        from app.main import app
+        from app.dependencies.auth import get_current_user
+        from app.dependencies.database import get_db
+
+        async def override_db():
+            async with Session() as s:
+                yield s
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: _auth()
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                resp = await c.get("/api/v2/team-members")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            humans = [m for m in body if m["type"] == "human"]
+            agents = [m for m in body if m["type"] == "agent"]
+            assert {uuid.UUID(m["id"]) for m in humans} == {OM_OWNER, OM_GRANT, OM_NOACC}, f"엔드포인트 휴먼 누락: {humans}"
+            assert len(humans) == 3 and len(agents) == 1
+            # 자기 카드 편집/제출 매칭의 근거: 휴먼 id = org_member.id (= /api/me·standup author canonical)
+            owner = next(m for m in humans if uuid.UUID(m["id"]) == OM_OWNER)
+            assert uuid.UUID(owner["user_id"]) == U_OWNER and owner["role"] == "owner"
+        finally:
+            app.dependency_overrides.clear()
+
+        # (4) anti-backfill / anti-곱연산: read 가 어떤 write 도 안 함
+        async with Session() as s:
+            pa_cnt = (await s.execute(text(
+                "SELECT count(*) FROM project_access WHERE project_id=:p"), {"p": str(P1)})).scalar_one()
+            grant_member_id = (await s.execute(text(
+                "SELECT member_id FROM project_access WHERE project_id=:p AND org_member_id=:m"),
+                {"p": str(P1), "m": str(OM_GRANT)})).scalar_one()
+            om_cnt = (await s.execute(text(
+                "SELECT count(*) FROM org_members WHERE org_id=:o"), {"o": str(ORG)})).scalar_one()
+            members_cnt = (await s.execute(text(
+                "SELECT count(*) FROM members WHERE org_id=:o"), {"o": str(ORG)})).scalar_one()
+        assert pa_cnt == 1, f"project_access 행 증가(새 멤버 행 생성 금지 위반): {pa_cnt}"
+        assert grant_member_id is None, "grant-only 휴먼 member_id 백필됨(금지 위반)"
+        assert om_cnt == 3, f"org_members 변동: {om_cnt}"
+        assert members_cnt == 3, f"members 변동(백필 의심): {members_cnt}"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## 배경 (S:166051f0 · P0 데모-당일)

상용 뭉클랩 제로고(prod project `857cc336` · org `5978f530`)의 일일 회의록/스탠드업에서 **휴먼 멤버가 안 보임**. PO 실측: org-level team-members API = 에이전트만, 휴먼 0.

## 근본 원인

org-level 스탠드업 로스터(`/api/v2/team-members`, project_id 생략)가 멤버 표시를 `team_members` 뷰(0088 = `members ⋈ project_access`)로 해소. 뷰의 휴먼 분기는 `pa.member_id = m.id` 로 join하는데, 실 grant 플로우(`create_project_access`)는 `member_id`를 NULL로 두므로(`org_member_id`만 세팅) **grant-only/owner 휴먼이 뷰에서 탈락**. (missing 로스터 `_MISSING_SQL`은 `org_member_id` 기준이라 휴먼을 맞게 잡음 — 표시 경로만 어긋남.)

## 변경

org-level 휴먼을 **`org_members` 권위 소스에서 직접** 열거 — `project_access`/`team_members` 일절 비경유.

- 🔴 SSOT 노선 준수: 새 프로젝트 멤버 행 생성 0 · `member_id` 백필 0 · 곱연산(휴먼×프로젝트=N행) 0 (휴먼당 정확히 1행).
- 휴먼 `id = org_member.id` = canonical 신원 — `/api/me`·standup `author_id`·`_MISSING_SQL`과 동일 기준이라 자기 카드 편집/제출 매칭 정합 유지.
- 이름/아바타는 canonical `members` 우선, `users`(display_name→email) 폴백 — 백필 갭 안전망.
- 에이전트는 기존 뷰(type=agent) 그대로.
- **project-scoped(project_id 지정) 경로 무변경** → 다른 team_members consumer 무회귀 (AC3).
- 응답 스키마(`TeamMemberResponse`) 계약 변경 0. FE 변경 불요.

## 검증

마이그 head(0104) 적용 실 DB에서 prod 조건 재현 테스트(`test_standup_org_roster_166051f0.py`):

1. **버그 재현**: team_members 뷰 org-level 휴먼 = 0, 에이전트 = 1
2. **픽스**: org_members 직접 해소로 grant-only/owner/무-access 휴먼 전원(3인) 표시, id=org_member.id, name 폴백 동작
3. **곱연산 0**: 휴먼당 1행
4. **anti-backfill**: read가 어떤 write도 안 함 — `project_access` 행 증가 0 · grant-only `member_id` NULL 유지 · `members`/`org_members` 변동 0

- 신규 realdb 테스트 + 기존 team-members/standup 테스트 전부 PASS
- 전체 백엔드 mock suite: 1669 passed (실패 3건은 MCP e2e 라이브 연결·contract 파일 부재로 본 변경과 무관)

## AC 매핑

- **AC1** (표시가 org_members 직접): ✅
- **AC2** (라이브, 새 행/백필 0): 본 PR로 코드 충족 — prod 라이브 확인은 배포 후 (⚠️ done = prod 라이브 휴먼 표시 확인 + 선생님 승인 후)
- **AC3** (회귀 무영향): ✅ project-scoped 경로·missing/submitted 무변경

워크플로: 디디 verify+fix ✅ → PO canonical 게이트(곱연산/백필 스캔) → 까심 cross-model QA → prod 배포는 선생님 승인 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)