### PR TITLE
fix(infra·P0): lifespan shutdown에 engine.dispose() 추가 — prod 연결 좀비 박멸 (S:33e0c681)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from app.core.database import engine
     from app.services.pg_pubsub import listen_loop
     task = asyncio.create_task(listen_loop())
     try:
@@ -28,6 +29,13 @@ async def lifespan(app: FastAPI):
             await task
         except asyncio.CancelledError:
             pass
+        finally:
+            # 좀비 연결 박멸(S:33e0c681): SIGTERM(Cloud Run 인스턴스 교체·스케일다운·리비전 삭제)
+            # 시 SQLAlchemy 풀의 전 DB 연결을 정상 종료. dispose 누락 시 구 인스턴스가 연결을 안
+            # 놓아 좀비 누적 → prod 100 cap 초과 → TooManyConnections(전 엔드포인트 500). lifespan
+            # shutdown 은 in-flight 요청 drain 이후 실행되므로 dispose 순서 안전(AC3). pg_pubsub
+            # raw 커넥션은 task.cancel→listen_loop finally 에서 이미 close.
+            await engine.dispose()
 
 
 from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat

--- a/backend/tests/test_lifespan_engine_dispose_33e0c681.py
+++ b/backend/tests/test_lifespan_engine_dispose_33e0c681.py
@@ -1,0 +1,115 @@
+"""S:33e0c681: 백엔드 graceful shutdown — lifespan 종료 시 engine.dispose() 호출 검증.
+
+prod 인시던트 근본: main.py lifespan 이 shutdown 에서 SQLAlchemy 엔진을 dispose 하지 않아
+Cloud Run 인스턴스 교체/스케일다운 시 풀 연결이 좀비로 남음 → 100 cap 초과 → TooManyConnections.
+fix = lifespan 종료 경로에서 `await engine.dispose()`. 본 테스트는 (1) dispose 실제 호출
+(2) 정상 startup→yield→shutdown 흐름 + pg_pubsub task 생명주기 유지 (3) pubsub task 가
+예외로 끝나도 dispose 가 반드시 실행됨(좀비 박멸 보장) 을 검증한다.
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _patch_engine(monkeypatch):
+    """app.core.database.engine 을 dispose 스파이가 달린 가짜 엔진으로 교체.
+
+    lifespan 은 호출 시점에 `from app.core.database import engine` 로 가져오므로 모듈 속성
+    교체로 충분(실 AsyncEngine setattr 제약 회피)."""
+    fake_engine = MagicMock()
+    fake_engine.dispose = AsyncMock()
+    monkeypatch.setattr("app.core.database.engine", fake_engine)
+    return fake_engine
+
+
+@pytest.mark.anyio
+async def test_lifespan_disposes_engine_on_shutdown(monkeypatch):
+    """⚠️ 핵심(AC1): shutdown 경로서 engine.dispose() 가 정확히 1회 await 된다."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+
+    started = asyncio.Event()
+
+    async def fake_listen():
+        started.set()
+        try:
+            await asyncio.Event().wait()  # cancel 까지 블록
+        except asyncio.CancelledError:
+            return
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", fake_listen)
+
+    async with lifespan(MagicMock()):
+        # startup: pubsub task 기동, 아직 dispose 안 됨(정상 흐름 유지)
+        await asyncio.wait_for(started.wait(), timeout=1)
+        fake_engine.dispose.assert_not_awaited()
+
+    # shutdown 완료 → dispose 정확히 1회
+    fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_cancels_pubsub_task_and_then_disposes(monkeypatch):
+    """AC3 회귀: pg_pubsub task 가 shutdown 에서 취소되고(좀비 raw conn 없음) dispose 가 뒤따른다."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+
+    running = asyncio.Event()
+    state = {"cancelled": False, "dispose_seen_cancelled": None}
+
+    async def fake_listen():
+        running.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            state["cancelled"] = True
+            raise
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", fake_listen)
+
+    async def record_order(*_a, **_k):
+        # dispose 시점에 pubsub 이 이미 취소됐는지 기록 → 순서(task 정리 후 dispose) 보장
+        state["dispose_seen_cancelled"] = state["cancelled"]
+
+    fake_engine.dispose.side_effect = record_order
+
+    async with lifespan(MagicMock()):
+        # task 가 실제로 기동(블록)할 때까지 대기 — cancel 이 의미를 갖도록
+        await asyncio.wait_for(running.wait(), timeout=1)
+
+    assert state["cancelled"] is True, "pg_pubsub task 가 취소되지 않음(좀비 raw conn 위험)"
+    assert state["dispose_seen_cancelled"] is True, "dispose 가 task 정리보다 먼저 실행됨(순서 위반)"
+    fake_engine.dispose.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_lifespan_disposes_even_if_pubsub_task_raises(monkeypatch):
+    """⚠️ 좀비 박멸 보장: pubsub task 가 비-Cancelled 예외로 끝나도 dispose 는 반드시 실행된다
+    (nested finally). dispose 누락이 곧 prod 연결 누수이므로 어떤 종료 경로서도 보장돼야 한다."""
+    from app.main import lifespan
+
+    fake_engine = _patch_engine(monkeypatch)
+
+    failed = asyncio.Event()
+
+    async def bad_listen():
+        failed.set()
+        raise RuntimeError("pubsub boom")
+
+    monkeypatch.setattr("app.services.pg_pubsub.listen_loop", bad_listen)
+
+    with pytest.raises(RuntimeError, match="pubsub boom"):
+        async with lifespan(MagicMock()):
+            # task 가 먼저 실행돼 예외로 종료되도록(취소가 선점하지 않게) 대기
+            await asyncio.wait_for(failed.wait(), timeout=1)
+            await asyncio.sleep(0)  # task 가 예외로 완전히 종료되게 양보
+
+    fake_engine.dispose.assert_awaited_once()


### PR DESCRIPTION
## 배경 (S:33e0c681 · P0 인프라 근본)

2026-06-09 데모-당일 prod DB `TooManyConnections` 포화 반복 → 전 DB 엔드포인트 500. PO 진단: `backend/app/main.py` lifespan이 **종료 시 `engine.dispose()`를 호출 안 함**(backend/app 전체 dispose 0건).

## 근본 원인

lifespan `finally`는 pg_pubsub 리스너 task만 취소하고 **SQLAlchemy async engine을 dispose하지 않음** → 풀의 DB 연결이 열린 채 유지. Cloud Run 인스턴스 교체·스케일다운·리비전 삭제 시 떠나는 인스턴스가 그 연결을 **좀비로 stuck** → 좀비 누적 → Cloud SQL 100 cap 초과 → 신규 연결 거부. 매 배포가 좀비를 쌓는 구조. (임시 완화 maxScale 10→6·pool 5→4·overflow 3→2 적용됨 — 본 fix는 영구 차단.)

## 변경 (단일 포인트)

lifespan 종료 경로에 **`await engine.dispose()`** 추가:
- SIGTERM 시 풀의 전 DB 연결 정상 종료 → 좀비 원천 제거 (AC1)
- 리스너 task 취소 **이후** 실행 — pg_pubsub raw asyncpg conn은 `listen_loop` finally에서 이미 close
- **nested finally**에 배치 → task await가 예외로 끝나도 dispose 무조건 실행 (좀비 박멸 보장)
- lifespan shutdown은 in-flight 요청 drain 이후 실행 → dispose 순서 안전 (AC3)

## 검증

`test_lifespan_engine_dispose_33e0c681.py` (3건, 가짜 engine spy):
1. **AC1**: shutdown에서 `engine.dispose()` 정확히 1회 await
2. **AC3**: pg_pubsub task 취소 → 그 다음 dispose (순서 보장)
3. **좀비 박멸 보장**: task가 비-Cancelled 예외로 끝나도 dispose 실행

- 신규 3건 PASS
- 전체 백엔드 mock suite **1672 passed** (실 lifespan을 띄우는 TestClient 테스트 전부 통과 = dispose 추가 회귀 0). 실패 3건은 MCP e2e 라이브 연결·contract 파일 부재로 본 변경과 무관.

## AC 매핑

- **AC1** (dispose 추가): ✅
- **AC2** (인스턴스 종료 시 연결 즉시 반납): 코드 충족 — prod 리비전 swap 후 `pg_stat_activity` 연결 0 실증은 배포 후 (⚠️ 배포는 선생님 승인 후)
- **AC3** (정상 기동·in-flight drain 후 dispose 순서): ✅ 테스트 검증
- **AC4** (선택·후속): Cloud Run 기본 grace 10s로 소규모 풀(4~8 conn) dispose 충분(sub-second). 중앙 PgBouncer 항구책은 `cloudbuild.yaml` 주석상 별도 durable fix(2c4dcae7) 예정 → 본 PR 범위 밖 후속 메모.

워크플로: 디디 verify+fix ✅ → PO 게이트 → 까심 cross-model QA → prod 배포 선생님 승인. ⚠️ done = prod 리비전 swap 시 연결 재포화 0 실증 전 금지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)