### PR TITLE
feat(agent·E-CHAT-CMD S1): member.runtime_type + 런타임 capability registry (BE 토대)

### DIFF
--- a/backend/alembic/versions/0105_add_runtime_type_to_members.py
+++ b/backend/alembic/versions/0105_add_runtime_type_to_members.py
@@ -1,0 +1,36 @@
+"""members.runtime_type 컬럼 추가 — 에이전트 런타임 식별 (E-CHAT-CMD S1 토대).
+
+에이전트(member.type='agent')의 런타임 종류(opencode·openclaw·hermes·gemini·grok·cursor·codex·
+pi·claude-code). nullable — 휴먼/미설정은 NULL(= capability lookup 에서 미지원 처리). 9 enum 은
+앱 레이어(RuntimeType)에서 강제(코드 컨벤션 = 네이티브 PG enum 미사용·신규 런타임 확장 용이).
+컬럼 추가는 의존 뷰 team_members 무영향(뷰는 명시 컬럼만 SELECT).
+
+Revision ID: 0105
+Revises: 0104
+Create Date: 2026-06-09
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0105"
+down_revision = "0104"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("members")}
+    if "runtime_type" not in cols:
+        op.add_column("members", sa.Column("runtime_type", sa.Text, nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("members")}
+    if "runtime_type" in cols:
+        op.drop_column("members", "runtime_type")

--- a/backend/app/models/member.py
+++ b/backend/app/models/member.py
@@ -49,6 +49,10 @@ class Member(Base):
     message_policy_mode: Mapped[str] = mapped_column(
         Text, nullable=False, server_default="creator_only", default="creator_only"
     )
+    # E-CHAT-CMD S1: 에이전트 런타임 종류(RuntimeType 9종). 에이전트 단위 식별 — capability
+    # registry(app.services.agent_runtime) lookup 키. 휴먼/미설정은 NULL(= 커맨드 미지원).
+    # 9 enum 은 앱 레이어에서 강제(네이티브 PG enum 미사용 — 신규 런타임 확장 용이).
+    runtime_type: Mapped[str | None] = mapped_column(Text, nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True, server_default="true")
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/services/agent_runtime.py
+++ b/backend/app/services/agent_runtime.py
@@ -1,0 +1,88 @@
+"""에이전트 런타임 capability registry (E-CHAT-CMD S1 토대).
+
+블루프린트 `blueprint-chat-command-skill-execution` §Task 1 / 리서치 매트릭스
+`research-chat-command-skill-execution-across-runtimes`.
+
+런타임별 "결정적(deterministic) 커맨드" 실행 가능 여부의 정적 레지스트리. 채팅 명령 →
+에이전트 커맨드/스킬 실행 경로(S3 classifier·S9 allowlist 등)가 이 단일 SSOT 를 참조한다.
+
+- **deterministic_command**: 런타임이 결정적 커맨드(모델 비경유, 직접 실행)를 지원하는가.
+- **command_endpoint_available**: 커맨드 주입 엔드포인트가 존재하는가. opencode 는 엔드포인트는
+  있으나 결정적 실행은 아님(deterministic_command=False, endpoint=True).
+- **skill**: 스킬 실행 방식 — 전 런타임 `model-mediated`(결정적 스킬 실행 없음).
+
+근거 매트릭스(리서치):
+  hermes·openclaw·gemini·grok·pi  → deterministic_command=True  (endpoint 당연 available)
+  opencode                        → deterministic_command=False, command_endpoint_available=True
+  claude-code·codex·cursor        → deterministic_command=False, command_endpoint_available=False
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+SKILL_MODEL_MEDIATED = "model-mediated"
+
+
+class RuntimeType(str, Enum):
+    """member.runtime_type 의 허용 9종(앱 레이어 강제)."""
+
+    OPENCODE = "opencode"
+    OPENCLAW = "openclaw"
+    HERMES = "hermes"
+    GEMINI = "gemini"
+    GROK = "grok"
+    CURSOR = "cursor"
+    CODEX = "codex"
+    PI = "pi"
+    CLAUDE_CODE = "claude-code"
+
+
+@dataclass(frozen=True)
+class RuntimeCapability:
+    """런타임의 커맨드/스킬 실행 capability."""
+
+    deterministic_command: bool
+    command_endpoint_available: bool
+    skill: str = SKILL_MODEL_MEDIATED
+
+
+# 미지원(빈값/unknown runtime) 기본값 — 보수적: 결정적 커맨드·엔드포인트 모두 없음.
+UNSUPPORTED_CAPABILITY = RuntimeCapability(
+    deterministic_command=False, command_endpoint_available=False
+)
+
+_CAPABILITY_REGISTRY: dict[RuntimeType, RuntimeCapability] = {
+    # 결정적 커맨드 지원 — 엔드포인트 당연 available
+    RuntimeType.HERMES: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
+    RuntimeType.OPENCLAW: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
+    RuntimeType.GEMINI: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
+    RuntimeType.GROK: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
+    RuntimeType.PI: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
+    # 엔드포인트는 있으나 결정적 실행 아님
+    RuntimeType.OPENCODE: RuntimeCapability(deterministic_command=False, command_endpoint_available=True),
+    # 커맨드 엔드포인트 자체 없음 — 스킬은 model-mediated 만
+    RuntimeType.CLAUDE_CODE: RuntimeCapability(deterministic_command=False, command_endpoint_available=False),
+    RuntimeType.CODEX: RuntimeCapability(deterministic_command=False, command_endpoint_available=False),
+    RuntimeType.CURSOR: RuntimeCapability(deterministic_command=False, command_endpoint_available=False),
+}
+
+
+def get_runtime_capability(runtime_type: str | RuntimeType | None) -> RuntimeCapability:
+    """runtime_type → capability. 빈값/unknown 은 UNSUPPORTED_CAPABILITY(미지원).
+
+    member.runtime_type(nullable Text)를 직접 넘겨도 안전 — None/빈문자열/미등록 문자열 모두
+    보수적으로 미지원 처리(AC3). 알 수 없는 런타임을 '지원'으로 오판하지 않는다.
+    """
+    if not runtime_type:
+        return UNSUPPORTED_CAPABILITY
+    try:
+        rt = RuntimeType(runtime_type)
+    except ValueError:
+        return UNSUPPORTED_CAPABILITY
+    return _CAPABILITY_REGISTRY[rt]
+
+
+def supports_deterministic_command(runtime_type: str | RuntimeType | None) -> bool:
+    """편의 헬퍼: 결정적 커맨드 지원 여부(S3 classifier 등 진입점에서 사용)."""
+    return get_runtime_capability(runtime_type).deterministic_command

--- a/backend/tests/test_agent_runtime_capability.py
+++ b/backend/tests/test_agent_runtime_capability.py
@@ -1,0 +1,84 @@
+"""E-CHAT-CMD S1 AC2/AC3: 런타임 capability registry + lookup 단위 테스트.
+
+근거 매트릭스(리서치): deterministic_command —
+  hermes·openclaw·gemini·grok·pi = True / opencode·claude-code·codex·cursor = False.
+  command_endpoint_available — opencode 만 True(among non-deterministic).
+  skill — 전 런타임 model-mediated.
+"""
+from app.services.agent_runtime import (
+    SKILL_MODEL_MEDIATED,
+    UNSUPPORTED_CAPABILITY,
+    RuntimeType,
+    get_runtime_capability,
+    supports_deterministic_command,
+)
+
+
+def test_runtime_type_has_exactly_nine_enum_values():
+    expected = {
+        "opencode", "openclaw", "hermes", "gemini", "grok",
+        "cursor", "codex", "pi", "claude-code",
+    }
+    assert {r.value for r in RuntimeType} == expected
+    assert len(RuntimeType) == 9
+
+
+def test_deterministic_command_matrix():
+    """결정적 커맨드 지원 매트릭스 — 리서치 근거 그대로."""
+    supported = {"hermes", "openclaw", "gemini", "grok", "pi"}
+    unsupported = {"opencode", "claude-code", "codex", "cursor"}
+    for rt in supported:
+        assert get_runtime_capability(rt).deterministic_command is True, f"{rt} 결정적 커맨드 True 여야"
+    for rt in unsupported:
+        assert get_runtime_capability(rt).deterministic_command is False, f"{rt} 결정적 커맨드 False 여야"
+
+
+def test_opencode_endpoint_available_but_not_deterministic():
+    """opencode: 엔드포인트는 있으나 결정적 실행 아님(특수 케이스)."""
+    cap = get_runtime_capability("opencode")
+    assert cap.deterministic_command is False
+    assert cap.command_endpoint_available is True
+
+
+def test_command_endpoint_availability_matrix():
+    # 결정적 지원 런타임 + opencode = 엔드포인트 available
+    for rt in ("hermes", "openclaw", "gemini", "grok", "pi", "opencode"):
+        assert get_runtime_capability(rt).command_endpoint_available is True, f"{rt} endpoint available 여야"
+    # claude-code·codex·cursor = 엔드포인트 없음
+    for rt in ("claude-code", "codex", "cursor"):
+        assert get_runtime_capability(rt).command_endpoint_available is False, f"{rt} endpoint 없어야"
+
+
+def test_skill_is_model_mediated_for_all_runtimes():
+    for rt in RuntimeType:
+        assert get_runtime_capability(rt).skill == SKILL_MODEL_MEDIATED
+
+
+def test_lookup_accepts_enum_and_str_equivalently():
+    assert get_runtime_capability(RuntimeType.HERMES) == get_runtime_capability("hermes")
+
+
+def test_empty_and_unknown_are_unsupported():
+    """AC3: 빈값/None/미등록 문자열 = 보수적 미지원."""
+    for bad in (None, "", "  ".strip(), "unknown", "gpt-5", "CLAUDE-CODE"):
+        cap = get_runtime_capability(bad)
+        assert cap == UNSUPPORTED_CAPABILITY, f"{bad!r} 은 미지원이어야"
+        assert cap.deterministic_command is False
+        assert cap.command_endpoint_available is False
+
+
+def test_supports_deterministic_command_helper():
+    assert supports_deterministic_command("hermes") is True
+    assert supports_deterministic_command("opencode") is False
+    assert supports_deterministic_command(None) is False
+    assert supports_deterministic_command("nope") is False
+
+
+def test_capability_is_immutable():
+    """frozen dataclass — 레지스트리 항목 변조 불가(SSOT 무결성)."""
+    import dataclasses
+    import pytest
+
+    cap = get_runtime_capability("hermes")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cap.deterministic_command = False  # type: ignore[misc]

--- a/backend/tests/test_member_runtime_type_realdb.py
+++ b/backend/tests/test_member_runtime_type_realdb.py
@@ -1,0 +1,119 @@
+"""E-CHAT-CMD S1 AC1 real-DB: members.runtime_type 컬럼 마이그 + 모델 roundtrip + 무회귀.
+
+마이그 0105 적용 DB 전제. (1) 컬럼 존재(nullable Text) (2) Member 모델로 agent runtime_type
+write/read (3) 휴먼/미설정 NULL (4) team_members 뷰·기존 member read 무회귀.
+
+DB env(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡에서 실행.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_RAW_URL = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+ORG = uuid.UUID("e1660000-0000-0000-0000-000000000001")
+U_HUMAN = uuid.UUID("e1660000-0000-0000-0000-0000000000b1")
+M_HUMAN = uuid.UUID("e1660000-0000-0000-0000-0000000000c1")
+M_AGENT = uuid.UUID("e1660000-0000-0000-0000-0000000000e1")
+
+
+async def _seed(session):
+    from sqlalchemy import text
+
+    stmts = [
+        f"DELETE FROM members WHERE org_id = '{ORG}'",
+        f"DELETE FROM users WHERE id = '{U_HUMAN}'",
+        f"DELETE FROM organizations WHERE id = '{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','E166','e166org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+        f"VALUES ('{U_HUMAN}','h@e166.test','x','H',true,true,0,false,0)",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+@pytest.mark.anyio
+async def test_runtime_type_column_exists_and_nullable():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            row = (await s.execute(text(
+                "SELECT data_type, is_nullable FROM information_schema.columns "
+                "WHERE table_name='members' AND column_name='runtime_type'"
+            ))).first()
+        assert row is not None, "members.runtime_type 컬럼 미존재(마이그 0105 미적용)"
+        assert row[0] == "text", f"runtime_type 타입 text 아님: {row[0]}"
+        assert row[1] == "YES", "runtime_type nullable 아님"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_member_model_runtime_type_roundtrip_and_human_null():
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.models.member import Member
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            # 에이전트: runtime_type 설정
+            s.add(Member(id=M_AGENT, org_id=ORG, type="agent", name="HermesBot",
+                         owner_member_id=None, runtime_type="hermes"))
+            # 휴먼: runtime_type 미설정(NULL)
+            s.add(Member(id=M_HUMAN, org_id=ORG, type="human", user_id=U_HUMAN, name="H"))
+            await s.commit()
+
+        async with Session() as s:
+            agent = (await s.execute(select(Member).where(Member.id == M_AGENT))).scalar_one()
+            human = (await s.execute(select(Member).where(Member.id == M_HUMAN))).scalar_one()
+        assert agent.runtime_type == "hermes", f"agent runtime_type roundtrip 실패: {agent.runtime_type}"
+        assert human.runtime_type is None, f"휴먼 runtime_type NULL 아님: {human.runtime_type}"
+
+        # capability lookup 연동(끝단 정합): hermes=결정적 지원, 휴먼(None)=미지원
+        from app.services.agent_runtime import supports_deterministic_command
+        assert supports_deterministic_command(agent.runtime_type) is True
+        assert supports_deterministic_command(human.runtime_type) is False
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_team_members_view_unaffected_by_column_add():
+    """무회귀: members 컬럼 추가가 의존 뷰 team_members 를 깨지 않음 — agent 행 정상 조회."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            # 뷰가 살아있고 SELECT 가능한지(컬럼 추가 후 뷰 무손상)
+            await s.execute(text("SELECT id, type, name FROM team_members LIMIT 1"))
+            relkind = (await s.execute(text(
+                "SELECT relkind::text FROM pg_class WHERE relname='team_members'"))).scalar()
+        # relkind 'v' = view (asyncpg char 타입은 bytes 로 올 수 있어 ::text 캐스트)
+        assert relkind == "v", f"team_members 뷰 손상: relkind={relkind!r}"
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## E-CHAT-CMD S1 — BE 토대 (나머지 8스토리 의존)

블루프린트 `blueprint-chat-command-skill-execution` §Task 1 / 리서치 `research-chat-command-skill-execution-across-runtimes` 매트릭스.

## 변경

**AC1 — `members.runtime_type` 필드 + 마이그 0105**
- 에이전트 런타임 종류(9종). 에이전트 단위 식별 속성 → `members` 테이블에 배치(message_policy_mode 선례 동형, canonical 신원 앵커).
- nullable Text — 휴먼/미설정은 NULL(= capability lookup 미지원). 9 enum 은 앱 레이어(`RuntimeType`)에서 강제(네이티브 PG enum 미사용 — 신규 런타임 확장 용이, 코드 컨벤션 정합).
- 컬럼 추가는 의존 뷰 `team_members` 무영향(뷰는 명시 컬럼만 SELECT). idempotent 가드 + 가역.

**AC2 — 정적 capability registry** (`app/services/agent_runtime.py`)
- `RuntimeType`(9 enum) + `RuntimeCapability`(frozen) + `_CAPABILITY_REGISTRY`.
- 매트릭스(리서치 근거): `deterministic_command` — hermes·openclaw·gemini·grok·pi=True / opencode=False / claude-code·codex·cursor=False. `command_endpoint_available` — opencode만 True(among non-deterministic). `skill` — 전 런타임 `model-mediated`.

**AC3 — lookup 함수**
- `get_runtime_capability(runtime_type)` — 빈값/None/unknown 문자열은 **보수적 미지원**(`UNSUPPORTED_CAPABILITY`). 알 수 없는 런타임을 '지원'으로 오판하지 않음.
- `supports_deterministic_command()` 편의 헬퍼(S3 classifier 진입점용).

## 검증 (dev 기준)

- **단위 9건**: enum 9종·deterministic 매트릭스·opencode 특수케이스·endpoint 매트릭스·skill 전부 model-mediated·enum↔str 동치·빈값/unknown 미지원·헬퍼·frozen 불변
- **realdb 3건** (head 마이그 DB): 컬럼 존재(nullable text)·Member 모델 roundtrip(휴먼 NULL)·team_members 뷰 무손상
- **마이그 가역성**: downgrade(컬럼 제거)→upgrade(재추가) 사이클 + idempotent 가드 확인
- **회귀**: 전체 백엔드 mock suite **1681 passed**(기존 member read/write 무영향). 실패 3건은 MCP e2e 라이브 연결·contract 파일 부재로 본 변경 무관

## 워크플로 (선생님 확정)

E-CHAT-CMD 전 스토리 **develop까지만** — prod 배포는 에픽 전체 완료 후 선생님 일괄. done = **dev 검증 완료**. 마이그는 머지 후 `sprintable-migrate-dev` job까지(prod migrate는 에픽 완료 일괄).

⚠️ 마이그 동반 — 머지 후 migrate-dev 실행 필수(모델↔DB 원자성). 컬럼 추가는 nullable이라 구 코드 무영향(non-breaking).

deps: 없음. 디디 fix → PO canonical 게이트 → 까심 QA(dev 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)