### PR TITLE
feat(gateway·E-CHAT-CMD S3): 슬래시 커맨드 판정 classifier (중앙집중 단일 구현)

### DIFF
--- a/backend/app/services/command_classifier.py
+++ b/backend/app/services/command_classifier.py
@@ -1,0 +1,70 @@
+"""채팅 메시지 슬래시 커맨드 판정 — 중앙집중 단일 구현 (E-CHAT-CMD S3).
+
+블루프린트 `blueprint-chat-command-skill-execution` §Policy(Command 판정)·§Task 3.
+
+게이트웨이 dispatch **전**에 호출돼 "이 채팅 메시지가 슬래시 커맨드인가"를 판정한다. ⚠️ 판정
+로직은 **이 모듈 하나**에만 존재한다 — adapter/connector 별 parsing 을 추가하지 말 것(AC3).
+다운스트림(커맨드 실행/라우팅)은 `classify_command()` 결과를 소비만 한다.
+
+판정 규칙(AC1):
+- 커맨드 = 메시지 맨 앞(position 0)이 ``/`` + **ASCII 영문자** → ``^/[a-zA-Z]``.
+- 이스케이프(= 커맨드 아님, 리터럴):
+    · 선행 공백 ``" /cmd"`` — 맨 앞이 공백이라 ``^/`` 미일치.
+    · ``"//cmd"`` — ``/`` 다음이 ``/``(영문자 아님)라 미일치. 리터럴 렌더는 ``//`` → ``/``
+      (`dequote_literal`).
+- 비대상: ``/123``(숫자)·``/?``(기호)·``/한글``(비-ASCII)·``/``(단독).
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# 맨 앞 '/' + ASCII 영문자로 시작하는 토큰. 선행 공백/'/'(이스케이프)는 자연 미일치.
+# [a-zA-Z] 는 ASCII 전용이라 '/한글' 등 비-ASCII 는 매치되지 않는다.
+_COMMAND_RE = re.compile(r"^/[a-zA-Z]\S*")
+
+
+@dataclass(frozen=True)
+class CommandCandidate:
+    """커맨드 후보 metadata (AC2).
+
+    raw: 원문(전체 메시지, 무변형). normalized: 정규화(트레일링 공백 제거 — 커맨드는 선행
+    공백이 없으므로 leading 영향 없음). name: 슬래시 뒤 커맨드 이름(첫 공백 전 토큰). args:
+    이름 뒤 인자(trim, 없으면 빈 문자열).
+    """
+
+    raw: str
+    normalized: str
+    name: str
+    args: str
+
+
+def classify_command(text: str | None) -> CommandCandidate | None:
+    """채팅 메시지가 슬래시 커맨드면 CommandCandidate, 아니면 None.
+
+    중앙집중 단일 진입점 — 모든 게이트웨이 경로/어댑터가 이 함수만 호출한다.
+    """
+    if not text:
+        return None
+    if _COMMAND_RE.match(text) is None:
+        return None
+    normalized = text.strip()  # 커맨드는 선행 공백 0(매치 조건) → 트레일링만 제거됨
+    body = normalized[1:]      # 슬래시 제거
+    split = body.split(maxsplit=1)
+    name = split[0]
+    args = split[1].strip() if len(split) > 1 else ""
+    return CommandCandidate(raw=text, normalized=normalized, name=name, args=args)
+
+
+def is_command(text: str | None) -> bool:
+    """커맨드 여부만 필요할 때의 경량 술어."""
+    return bool(text) and _COMMAND_RE.match(text) is not None
+
+
+def dequote_literal(text: str) -> str:
+    """이스케이프된 리터럴 렌더링: 선행 ``//`` → ``/``(1개 제거). 선행 공백 이스케이프는
+    그대로 둔다(표시 의도 보존). 커맨드 아닌 메시지를 그대로 전달할 때 다운스트림이 사용.
+    """
+    if text.startswith("//"):
+        return text[1:]
+    return text

--- a/backend/tests/test_command_classifier.py
+++ b/backend/tests/test_command_classifier.py
@@ -1,0 +1,108 @@
+"""E-CHAT-CMD S3: 슬래시 커맨드 판정 classifier 단위테스트 (AC1/AC2/AC3 케이스 커버)."""
+import pytest
+
+from app.services.command_classifier import (
+    CommandCandidate,
+    classify_command,
+    dequote_literal,
+    is_command,
+)
+
+
+# ── AC1: 커맨드 인식 (^/[a-zA-Z]) ──────────────────────────────────────────────
+@pytest.mark.parametrize("text,name", [
+    ("/cmd", "cmd"),
+    ("/c", "c"),                 # 단일 영문자
+    ("/CMD", "CMD"),             # 대문자
+    ("/Deploy", "Deploy"),
+    ("/cmd-sub", "cmd-sub"),     # 영문자 시작 후 비공백 허용
+    ("/x123", "x123"),           # 영문자 시작이면 숫자 포함 가능
+])
+def test_recognized_as_command(text, name):
+    cand = classify_command(text)
+    assert cand is not None, f"{text!r} 은 커맨드여야"
+    assert cand.name == name
+    assert is_command(text) is True
+
+
+# ── AC1: 비대상 ────────────────────────────────────────────────────────────────
+@pytest.mark.parametrize("text", [
+    "/123",      # 숫자
+    "/?",        # 기호
+    "/!hi",      # 기호
+    "/한글",      # 비-ASCII
+    "/",         # 슬래시 단독
+    "//",        # 슬래시 둘
+    "hello",     # 슬래시 없음
+    "hello /cmd",  # 슬래시가 맨 앞 아님
+    "",          # 빈 문자열
+    "   ",       # 공백만
+])
+def test_not_a_command(text):
+    assert classify_command(text) is None, f"{text!r} 은 커맨드가 아니어야"
+    assert is_command(text) is False
+
+
+def test_none_input_is_not_command():
+    assert classify_command(None) is None
+    assert is_command(None) is False
+
+
+# ── AC1: 이스케이프(리터럴) ────────────────────────────────────────────────────
+@pytest.mark.parametrize("text", [
+    " /cmd",     # 선행 공백 → 리터럴
+    "\t/cmd",    # 선행 탭 → 리터럴
+    "  /deploy", # 선행 공백 다수
+    "//cmd",     # '//' → 리터럴
+    "//deploy now",
+])
+def test_escaped_is_literal_not_command(text):
+    assert classify_command(text) is None, f"{text!r} 은 이스케이프(리터럴)라 커맨드 아님"
+
+
+def test_dequote_literal_collapses_leading_double_slash():
+    # '//cmd' 리터럴 렌더 = '/cmd' (슬래시 1개 제거)
+    assert dequote_literal("//cmd") == "/cmd"
+    assert dequote_literal("//deploy now") == "/deploy now"
+    # 선행 공백 이스케이프는 표시 의도 보존(그대로)
+    assert dequote_literal(" /cmd") == " /cmd"
+    # 일반 메시지는 무변형
+    assert dequote_literal("hello") == "hello"
+    assert dequote_literal("/cmd") == "/cmd"
+
+
+# ── AC2: candidate metadata (원문·정규화·name·args) ────────────────────────────
+def test_metadata_raw_normalized_name_args():
+    cand = classify_command("/deploy app prod")
+    assert cand == CommandCandidate(
+        raw="/deploy app prod", normalized="/deploy app prod", name="deploy", args="app prod"
+    )
+
+
+def test_metadata_trailing_whitespace_normalized():
+    cand = classify_command("/cmd   \n")
+    assert cand is not None
+    assert cand.raw == "/cmd   \n"        # 원문 보존
+    assert cand.normalized == "/cmd"      # 트레일링 제거
+    assert cand.name == "cmd"
+    assert cand.args == ""
+
+
+def test_metadata_no_args():
+    cand = classify_command("/help")
+    assert cand is not None and cand.name == "help" and cand.args == ""
+
+
+def test_metadata_multiword_args_collapsed():
+    cand = classify_command("/say   hello   world")
+    assert cand is not None
+    assert cand.name == "say"
+    assert cand.args == "hello   world"   # 이름 뒤 인자(앞뒤 trim, 내부 보존)
+
+
+def test_candidate_is_immutable():
+    import dataclasses
+    cand = classify_command("/cmd")
+    assert cand is not None
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cand.name = "x"  # type: ignore[misc]


### PR DESCRIPTION
## E-CHAT-CMD S3 — backend gateway command 판정 classifier

블루프린트 `blueprint-chat-command-skill-execution` §Policy(Command 판정)·§Task 3. (S1 위, deps 없음)

## 변경 (신규 2파일, 기존 파일 무수정)

`app/services/command_classifier.py` — 게이트웨이 dispatch **전** 호출되는 중앙 단일 classifier.

**AC1 — 판정 규칙**
- 커맨드 = 메시지 맨 앞(pos 0) `/` + **ASCII 영문자** → `^/[a-zA-Z]`.
- 이스케이프(리터럴, 커맨드 아님):
  - 선행 공백 ` /cmd` — 맨 앞이 공백이라 `^/` 미일치
  - `//cmd` — `/` 다음이 `/`(영문자 아님)라 미일치. 리터럴 렌더는 `//`→`/` (`dequote_literal`)
- 비대상: `/123`(숫자)·`/?`(기호)·`/한글`(비-ASCII, `[a-zA-Z]`는 ASCII 전용)·`/`(단독)

**AC2 — candidate metadata**
- `CommandCandidate`(frozen): `raw`(원문)·`normalized`(트레일링 trim)·`name`(커맨드명)·`args`(인자).

**AC3 — 중앙집중 단일 구현**
- 슬래시-커맨드 parsing은 이 모듈 **하나**에만 존재(어댑터/커넥터/라우터 0건 — grep 확인). `classify_command()`/`is_command()`/`dequote_literal()` 단일 진입점. adapter별 parsing 추가 0.

## 검증 (dev 기준)

- **단위 28건**: 커맨드 인식(단/대문자·하이픈·영문자+숫자)·비대상(숫자/기호/비-ASCII/슬래시단독/슬래시없음/빈값/None)·이스케이프(선행공백/탭/다수공백/`//`)·dequote_literal·metadata(raw/normalized/name/args·트레일링 정규화·multiword args·frozen 불변)
- **회귀**: 전체 백엔드 mock suite **1709 passed**(기존 파일 무수정 — 회귀 0). 실패 3건은 MCP e2e 라이브 연결·contract 파일 부재로 본 변경 무관

## 통합 지점 (S4용 명시)

classifier는 아직 live dispatch 경로에 배선하지 않음 — 핸들러(커맨드 실행/라우팅)가 없는 단계서 배선 시 동작변경·dead path 위험. 통합 지점 = `app/routers/conversations.py` 송신 경로의 에이전트 dispatch **직전**(단일 chokepoint)에서 `classify_command()` 호출 → 커맨드 후보 metadata 부여. 커맨드-핸들링 스토리에서 wiring.

## 워크플로

develop까지(prod 배포는 에픽 완료 일괄). 마이그 없음(코드 전용). done = dev 검증. 디디 fix → PO 게이트 → 까심 QA(dev 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)