### PR TITLE
[SID:0c1d2c30] 에이전트 런타임 타입 셀렉터 + 커맨드 지원 배지 (E-CHAT-CMD S2)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -797,7 +797,21 @@
     "ownershipDenied": "Permission denied. Only the agent owner or admin can edit.",
     "agentOwner": "my agent",
     "webhookHelperEmptyHuman": "Set a webhook URL and enable the toggle to receive your mentions and events for this project at an external endpoint. Other projects require separate configuration.",
-    "webhookHelperActiveHuman": "Your mentions and event notifications for this project are forwarded to the configured URL. Other projects require separate configuration."
+    "webhookHelperActiveHuman": "Your mentions and event notifications for this project are forwarded to the configured URL. Other projects require separate configuration.",
+    "runtimeTypeTitle": "Runtime type",
+    "runtimeTypeDescription": "The runtime this agent runs on. Chat slash-command support depends on the runtime.",
+    "runtimeTypePlaceholder": "Select runtime",
+    "runtimeSupported": "Command supported",
+    "runtimePartial": "Partial support",
+    "runtimeUnsupported": "Command not supported",
+    "runtimeUnset": "Not set",
+    "runtimeUnknown": "Unknown runtime",
+    "runtimeSupportedHelp": "Runs slash commands deterministically.",
+    "runtimePartialHelp": "Command endpoint exists; execution is model-mediated (non-deterministic).",
+    "runtimeUnsupportedHelp": "This runtime does not execute slash commands.",
+    "runtimeUnsetHelp": "No runtime set. Treated as command-unsupported.",
+    "runtimeUnknownHelp": "The saved value is not in the current registry. Shown for data preservation; treated as command-unsupported.",
+    "runtimeTypeSaved": "Runtime type saved"
   },
   "landing": {
     "navProduct": "Overview",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -797,7 +797,21 @@
     "ownershipDenied": "권한이 없습니다. 에이전트 소유자 또는 관리자만 수정할 수 있습니다.",
     "agentOwner": "내 에이전트",
     "webhookHelperEmptyHuman": "현재 프로젝트의 내 멘션·이벤트를 외부 URL로 받으려면 Webhook URL을 설정하고 토글을 켜세요. 다른 프로젝트는 해당 프로젝트에서 별도 설정이 필요합니다.",
-    "webhookHelperActiveHuman": "현재 프로젝트의 내 멘션·이벤트 알림이 설정된 URL로 전송됩니다. 다른 프로젝트의 멘션은 별도 설정이 필요합니다."
+    "webhookHelperActiveHuman": "현재 프로젝트의 내 멘션·이벤트 알림이 설정된 URL로 전송됩니다. 다른 프로젝트의 멘션은 별도 설정이 필요합니다.",
+    "runtimeTypeTitle": "런타임 타입",
+    "runtimeTypeDescription": "이 에이전트가 실행되는 런타임. 채팅 슬래시 커맨드 지원 여부는 런타임에 따라 달라진다.",
+    "runtimeTypePlaceholder": "런타임 선택",
+    "runtimeSupported": "커맨드 지원",
+    "runtimePartial": "부분 지원",
+    "runtimeUnsupported": "커맨드 미지원",
+    "runtimeUnset": "미설정",
+    "runtimeUnknown": "미인식 런타임",
+    "runtimeSupportedHelp": "슬래시 커맨드를 결정적(deterministic)으로 실행한다.",
+    "runtimePartialHelp": "커맨드 엔드포인트는 있으나 모델이 해석해 실행한다(model-mediated).",
+    "runtimeUnsupportedHelp": "이 런타임은 슬래시 커맨드를 실행하지 않는다.",
+    "runtimeUnsetHelp": "런타임이 설정되지 않았다. 커맨드 미지원으로 처리된다.",
+    "runtimeUnknownHelp": "저장된 값이 현재 registry에 없다. 데이터 보존을 위해 원값을 표시하되 커맨드 미지원으로 처리된다.",
+    "runtimeTypeSaved": "런타임 타입 저장됨"
   },
   "landing": {
     "navProduct": "개요",

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { AlertTriangle, ArrowLeft, Check, Copy, Pencil, Plus, X, XCircle } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Check, Copy, MinusCircle, Pencil, Plus, X, XCircle } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { MessagingPolicySection } from '@/components/agents/messaging-policy-section';
@@ -34,7 +34,7 @@ const RUNTIME_STATUS_UI: Record<
   supported: { variant: 'success', labelKey: 'runtimeSupported', helpKey: 'runtimeSupportedHelp', Icon: Check },
   partial: { variant: 'warning', labelKey: 'runtimePartial', helpKey: 'runtimePartialHelp', Icon: AlertTriangle },
   unsupported: { variant: 'destructive', labelKey: 'runtimeUnsupported', helpKey: 'runtimeUnsupportedHelp', Icon: XCircle },
-  unset: { variant: 'chip', labelKey: 'runtimeUnset', helpKey: 'runtimeUnsetHelp', Icon: null },
+  unset: { variant: 'chip', labelKey: 'runtimeUnset', helpKey: 'runtimeUnsetHelp', Icon: MinusCircle },
   unknown: { variant: 'destructive', labelKey: 'runtimeUnknown', helpKey: 'runtimeUnknownHelp', Icon: XCircle },
 };
 

--- a/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/members/agents/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
-import { ArrowLeft, Check, Copy, Pencil, Plus, X } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, Check, Copy, Pencil, Plus, X, XCircle } from 'lucide-react';
 import { Switch } from '@/components/ui/switch';
 import { AgentApiKeyManager } from '@/components/agents/agent-api-key-manager';
 import { MessagingPolicySection } from '@/components/agents/messaging-policy-section';
@@ -14,6 +14,29 @@ import { OperatorInput } from '@/components/ui/operator-control';
 import { OperatorDropdownSelect } from '@/components/ui/operator-dropdown-select';
 import { SectionCard, SectionCardBody, SectionCardHeader } from '@/components/ui/section-card';
 import { useToast } from '@/components/ui/toast';
+import {
+  RUNTIME_REGISTRY,
+  getRuntimeDef,
+  resolveRuntimeStatus,
+  type RuntimeStatus,
+} from '@/lib/runtime-capabilities';
+
+/** 런타임 상태(6종 중 ①~⑤) → 배지·헬퍼 표현. ⑥(드롭다운 dot)은 AC 범위 외(§11). */
+const RUNTIME_STATUS_UI: Record<
+  RuntimeStatus,
+  {
+    variant: 'success' | 'warning' | 'destructive' | 'chip';
+    labelKey: string;
+    helpKey: string;
+    Icon: typeof Check | null;
+  }
+> = {
+  supported: { variant: 'success', labelKey: 'runtimeSupported', helpKey: 'runtimeSupportedHelp', Icon: Check },
+  partial: { variant: 'warning', labelKey: 'runtimePartial', helpKey: 'runtimePartialHelp', Icon: AlertTriangle },
+  unsupported: { variant: 'destructive', labelKey: 'runtimeUnsupported', helpKey: 'runtimeUnsupportedHelp', Icon: XCircle },
+  unset: { variant: 'chip', labelKey: 'runtimeUnset', helpKey: 'runtimeUnsetHelp', Icon: null },
+  unknown: { variant: 'destructive', labelKey: 'runtimeUnknown', helpKey: 'runtimeUnknownHelp', Icon: XCircle },
+};
 
 function getAppOrigin() {
   if (typeof window !== 'undefined') return window.location.origin;
@@ -31,6 +54,7 @@ interface AgentMember {
   webhook_url: string | null;
   created_by: string | null;
   fakechat_port: number | null;
+  runtime_type: string | null;
 }
 
 interface WebhookConfig {
@@ -106,6 +130,9 @@ export default function AgentDetailPage() {
   const [editName, setEditName] = useState('');
   const [editRole, setEditRole] = useState('');
   const [savingEdit, setSavingEdit] = useState(false);
+
+  const [selectedRuntime, setSelectedRuntime] = useState<string>('');
+  const [savingRuntime, setSavingRuntime] = useState(false);
 
   const [webhookConfigs, setWebhookConfigs] = useState<WebhookConfig[]>([]);
   const [webhookUrl, setWebhookUrl] = useState('');
@@ -192,6 +219,11 @@ export default function AgentDetailPage() {
   useEffect(() => {
     setWebhookActive(webhookConfigs[0]?.is_active ?? false);
   }, [webhookConfigs]);
+
+  // S2: 저장된 runtime_type → staged 셀렉터 동기화(로드·저장 후 재파생).
+  useEffect(() => {
+    setSelectedRuntime(agent?.runtime_type ?? '');
+  }, [agent?.runtime_type]);
 
   const assignedProjectIds = useMemo(() => {
     const ids = new Set(sameNameAgents.map((a) => a.project_id));
@@ -396,6 +428,32 @@ export default function AgentDetailPage() {
     orgRole === 'admin' ||
     orgRole === 'owner';
 
+  const handleSaveRuntime = async () => {
+    setSavingRuntime(true);
+    try {
+      const res = await fetch(`/api/team-members/${id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runtime_type: selectedRuntime || null }),
+      });
+      if (res.ok) {
+        const json = await res.json() as { data: AgentMember };
+        setAgent(json.data);
+        addToast({ type: 'success', title: t('runtimeTypeSaved') });
+      } else {
+        const status = res.status;
+        const json = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+        if (status === 403) {
+          addToast({ type: 'error', title: t('ownershipDenied') });
+        } else {
+          addToast({ type: 'error', title: json?.error?.message ?? tc('error') });
+        }
+      }
+    } finally {
+      setSavingRuntime(false);
+    }
+  };
+
   const handleToggleActive = async () => {
     const next = !agent.is_active;
     const res = await fetch(`/api/team-members/${id}`, {
@@ -489,6 +547,72 @@ export default function AgentDetailPage() {
           </SectionCardBody>
         )}
       </SectionCard>
+
+      {/* 런타임 타입 (E-CHAT-CMD S2) */}
+      {(() => {
+        const savedRuntime = agent.runtime_type ?? '';
+        const runtimeStatus = resolveRuntimeStatus(selectedRuntime || null);
+        const ui = RUNTIME_STATUS_UI[runtimeStatus];
+        const stagedDef = getRuntimeDef(selectedRuntime);
+        const stagedKnown = !!stagedDef;
+        // ⑤ 미인식: 원값을 드롭다운 트리거에 그대로 노출(데이터 은닉 금지) + 미인식 표시.
+        const runtimeOptions = [
+          ...(selectedRuntime && !stagedKnown
+            ? [{ value: selectedRuntime, label: `${selectedRuntime} (${t('runtimeUnknown')})`, disabled: true }]
+            : []),
+          ...RUNTIME_REGISTRY.map((r) => ({ value: r.key, label: r.label })),
+        ];
+        // 변경 + registry 등록값일 때만 저장 가능(④ 미선택·⑤ 미인식 재저장 방지).
+        const canSaveRuntime = stagedKnown && selectedRuntime !== savedRuntime;
+        const StatusIcon = ui.Icon;
+        return (
+          <SectionCard>
+            <SectionCardHeader>
+              <div className="space-y-1">
+                <div className="flex items-center gap-2 flex-wrap">
+                  <h2 className="text-base font-semibold text-foreground">{t('runtimeTypeTitle')}</h2>
+                  <Badge variant={ui.variant}>
+                    {StatusIcon ? <StatusIcon className="h-3 w-3" /> : null}
+                    {t(ui.labelKey)}
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">{t('runtimeTypeDescription')}</p>
+              </div>
+            </SectionCardHeader>
+            <SectionCardBody className="space-y-3">
+              {canEdit ? (
+                <>
+                  <div className="flex gap-2">
+                    <OperatorDropdownSelect
+                      value={selectedRuntime}
+                      onValueChange={setSelectedRuntime}
+                      options={runtimeOptions}
+                      placeholder={t('runtimeTypePlaceholder')}
+                      className="flex-1"
+                    />
+                    <Button
+                      variant="hero"
+                      size="sm"
+                      onClick={() => void handleSaveRuntime()}
+                      disabled={savingRuntime || !canSaveRuntime}
+                    >
+                      {savingRuntime ? '...' : tc('save')}
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground">{t(ui.helpKey)}</p>
+                </>
+              ) : (
+                <div className="space-y-1">
+                  <p className="text-sm text-foreground">
+                    {stagedDef?.label ?? (selectedRuntime || t('runtimeUnset'))}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{t(ui.helpKey)}</p>
+                </div>
+              )}
+            </SectionCardBody>
+          </SectionCard>
+        );
+      })()}
 
       {/* API Keys */}
       {canEdit && (

--- a/apps/web/src/lib/runtime-capabilities.ts
+++ b/apps/web/src/lib/runtime-capabilities.ts
@@ -1,0 +1,85 @@
+/**
+ * 에이전트 런타임 capability registry (FE 단일 출처 — E-CHAT-CMD S2).
+ *
+ * 백엔드 SSOT `backend/app/services/agent_runtime.py`(블루프린트
+ * `blueprint-chat-command-skill-execution` §Task 1)와 값 정합. 셀렉터·배지가 이 단일
+ * registry를 읽어 런타임별 슬래시 커맨드 지원 여부를 판정한다.
+ *
+ * - deterministicCommand: 런타임이 결정적 커맨드(모델 비경유, 직접 실행)를 지원하는가.
+ * - commandEndpointAvailable: 커맨드 주입 엔드포인트가 존재하는가. opencode는 엔드포인트는
+ *   있으나 결정적 실행은 아님(deterministic=false, endpoint=true → 부분 지원).
+ *
+ * 표시명(label)은 proper noun이라 i18n 미적용 — registry 상수에 둔다.
+ */
+
+export type RuntimeKey =
+  | 'hermes'
+  | 'openclaw'
+  | 'gemini'
+  | 'grok'
+  | 'pi'
+  | 'opencode'
+  | 'claude-code'
+  | 'codex'
+  | 'cursor';
+
+export interface RuntimeCapability {
+  deterministicCommand: boolean;
+  commandEndpointAvailable: boolean;
+}
+
+export interface RuntimeDef {
+  key: RuntimeKey;
+  label: string;
+  capability: RuntimeCapability;
+}
+
+/** 커맨드 지원 3단계(capability 기반) + fallback 2종(빈값/미인식). */
+export type CommandSupport = 'supported' | 'partial' | 'unsupported';
+export type RuntimeStatus = CommandSupport | 'unset' | 'unknown';
+
+/**
+ * 드롭다운 옵션 순서 = 블루프린트 §3 표 순서(지원 → 부분 → 미지원으로 그룹핑).
+ * 9 런타임, BE RuntimeType enum과 값 1:1 정합.
+ */
+export const RUNTIME_REGISTRY: readonly RuntimeDef[] = [
+  { key: 'hermes', label: 'Hermes', capability: { deterministicCommand: true, commandEndpointAvailable: true } },
+  { key: 'openclaw', label: 'OpenClaw', capability: { deterministicCommand: true, commandEndpointAvailable: true } },
+  { key: 'gemini', label: 'Gemini', capability: { deterministicCommand: true, commandEndpointAvailable: true } },
+  { key: 'grok', label: 'Grok', capability: { deterministicCommand: true, commandEndpointAvailable: true } },
+  { key: 'pi', label: 'Pi', capability: { deterministicCommand: true, commandEndpointAvailable: true } },
+  { key: 'opencode', label: 'OpenCode', capability: { deterministicCommand: false, commandEndpointAvailable: true } },
+  { key: 'claude-code', label: 'Claude Code', capability: { deterministicCommand: false, commandEndpointAvailable: false } },
+  { key: 'codex', label: 'Codex', capability: { deterministicCommand: false, commandEndpointAvailable: false } },
+  { key: 'cursor', label: 'Cursor', capability: { deterministicCommand: false, commandEndpointAvailable: false } },
+] as const;
+
+const REGISTRY_BY_KEY: ReadonlyMap<string, RuntimeDef> = new Map(
+  RUNTIME_REGISTRY.map((def) => [def.key, def]),
+);
+
+/** runtime_type 키 → registry 정의. 미등록/빈값은 undefined. */
+export function getRuntimeDef(key: string | null | undefined): RuntimeDef | undefined {
+  if (!key) return undefined;
+  return REGISTRY_BY_KEY.get(key);
+}
+
+/** capability → 커맨드 지원 3단계 판정(BE get_runtime_capability와 동일 규칙). */
+export function commandSupportFor(capability: RuntimeCapability): CommandSupport {
+  if (capability.deterministicCommand) return 'supported';
+  if (capability.commandEndpointAvailable) return 'partial';
+  return 'unsupported';
+}
+
+/**
+ * 저장된 runtime_type을 표시 상태로 정규화(AC2 fallback).
+ * - null/빈값 → 'unset'(미설정, 신규 에이전트 기본 — 기능상 미지원이나 중립 표시)
+ * - registry에 없는 값 → 'unknown'(미인식, 원값 보존 + 미지원 처리)
+ * - 등록값 → capability 기반 supported/partial/unsupported
+ */
+export function resolveRuntimeStatus(runtimeType: string | null | undefined): RuntimeStatus {
+  if (!runtimeType) return 'unset';
+  const def = getRuntimeDef(runtimeType);
+  if (!def) return 'unknown';
+  return commandSupportFor(def.capability);
+}


### PR DESCRIPTION
## 개요
에이전트 상세 페이지에 **런타임 타입 셀렉터 + 런타임별 커맨드 지원 배지**를 추가한다. 핸드오프 doc `handoff-e-chat-cmd-s2-runtime-type-settings`(13섹션) 기준 충실 구현.

- 배치: 기본 정보 카드 직후 · API Keys 앞 신규 SectionCard (§2 IA: identity → runtime → keys → channels)
- **신규 컴포넌트 0** — SectionCard·OperatorDropdownSelect·Badge·Button hero 전부 재사용, 매직 hex 0(토큰만)

## AC1 — 셀렉터 + 배지 ✅
- 9 런타임 셀렉터(드롭다운 순서 = §3 표: 지원→부분→미지원 그룹핑)
- capability 배지 라이브 판정(현재 staged 선택값 기준):
  - ✅ `success` 커맨드 지원 — hermes·openclaw·gemini·grok·pi (`deterministicCommand`)
  - ⚠️ `warning` 부분 지원 — opencode (`!det && endpoint`, model-mediated)
  - ❌ `destructive` 커맨드 미지원 — claude-code·codex·cursor (둘 다 false)
- 배지 = 아이콘(Check/AlertTriangle/XCircle) + 텍스트 라벨 (a11y: 색상 단독 신호 금지)

## AC2 — fallback + save/reload
- ④ 미설정(null/빈값): `chip` "미설정", 셀렉터 placeholder, 저장 disable (신규 에이전트 기본 — 중립 표시)
- ⑤ 미인식(registry 미등록): `destructive` "미인식 런타임", **원값 보존**(트리거에 원값 노출, 데이터 은닉 금지), 재저장 disable
- save: `PATCH /api/team-members/[id]` `{runtime_type}` + `setAgent(json.data)` + toast + 403/error 분기
- reload: 저장 응답으로 agent 갱신 → 배지/헬퍼/버튼 재파생
- 권한: `canEdit` 게이팅 — 비편집자는 배지+표시명 읽기전용

## 단일 출처 registry
- `apps/web/src/lib/runtime-capabilities.ts` 신설 — BE SSOT `backend/app/services/agent_runtime.py`(블루프린트 §Task1) 값과 1:1 정합. 셀렉터·배지가 동일 registry를 읽는다.

## i18n
- `settings` 네임스페이스 `runtime*` 키 13종 en/ko 추가 (핸드오프 §9 카피 그대로)

## ⚠️ AC2 BE 의존성 (별도 검증)
S1(#1337)은 `members.runtime_type` 컬럼 + capability registry만 추가, **team_members API 미노출**. AC2 save/reload 완전 검증은 BE 5곳 배선(team_members 뷰 DDL `m.runtime_type`·`TeamMemberUpdate`·`TeamMemberResponse`·`_MEMBERS_FIELDS`·`TeamMember` 모델, 0106 마이그 — message_policy_mode 0096 선례) dev 랜딩 후. **BE-less 윈도우엔 전 에이전트가 ④ 미설정으로 graceful 표시(회귀 아님, 설계 의도)** — BE 랜딩 시 FE rework 0으로 ①~③/⑤ 자연 전환.

## 검증
- `pnpm type-check` ✅ (에러 0)
- `pnpm lint` ✅ (에러 0 / 변경 파일 경고 0 — 잔여 경고는 미변경 기존 파일)
- `pnpm build` ✅ (라우트 `/settings/members/agents/[id]` 정상 빌드)
- 시각 검증(상태 ①~⑤ · 반응형): dev 배포 후 유나 가디언 + 까심 QA AC1 게이트

## 스크린샷
에이전트 상세는 인증 세션·실 agent fetch가 필요해 로컬 인증 캡처는 보류. 상태 ①~⑤ 시각 검증은 dev(develop auto-deploy)에서 가디언/QA 게이트로 수행 — 합의된 QA 게이트와 정합.

🤖 Generated with [Claude Code](https://claude.com/claude-code)