### PR TITLE
feat(agent·E-CHAT-CMD S1b): team_members 뷰 runtime_type 노출 + PATCH 배선 (S2 언블록)

### DIFF
--- a/backend/alembic/versions/0106_expose_runtime_type_in_team_members_view.py
+++ b/backend/alembic/versions/0106_expose_runtime_type_in_team_members_view.py
@@ -1,0 +1,82 @@
+"""team_members projection 뷰에 members.runtime_type 노출 (E-CHAT-CMD S1b).
+
+⚠️ team_members 는 0088 projection VIEW(members ⋈ project_access / agent_project_profiles).
+0105 에서 canonical `members.runtime_type` 컬럼을 추가했으나 뷰에 미노출 → team-members GET/PATCH
+경로(에이전트 read/write 표면)서 보이지 않음. message_policy_mode(0096) 선례 동형으로 뷰를 현재
+(0105) 정의 그대로 + `m.runtime_type` 1컬럼만 더해 **재생성**(read 투명 재현, write 는 anchor
+라우팅으로 members 에 기록).
+
+순수 read 추가 — additive. 휴먼은 runtime_type NULL(미설정), 에이전트는 설정값. 다른 컬럼 불변.
+
+Revision ID: 0106
+Revises: 0105
+Create Date: 2026-06-09
+"""
+from alembic import op
+
+revision = "0106"
+down_revision = "0105"
+branch_labels = None
+depends_on = None
+
+# 0105 정의 + m.runtime_type (두 UNION 브랜치 동일 위치 — message_policy_mode 뒤).
+_VIEW_WITH_RUNTIME = """
+CREATE VIEW team_members AS
+ SELECT m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, m.is_active, pa.color,
+    NULL::text AS agent_role, NULL::integer AS fakechat_port, owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.message_policy_mode, m.runtime_type, m.created_at, m.updated_at
+   FROM members m
+     JOIN project_access pa ON pa.member_id = m.id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+ SELECT m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, m.is_active, COALESCE(pa.color, '#3385f8') AS color,
+    app.agent_role, app.fakechat_port, owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode, m.runtime_type,
+    m.created_at, m.updated_at
+   FROM members m
+     JOIN agent_project_profiles app ON app.member_id = m.id
+     LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+# 0105 원본(runtime_type 없음) — downgrade 복원용.
+_VIEW_0105 = """
+CREATE VIEW team_members AS
+ SELECT m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, m.is_active, pa.color,
+    NULL::text AS agent_role, NULL::integer AS fakechat_port, owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.message_policy_mode, m.created_at, m.updated_at
+   FROM members m
+     JOIN project_access pa ON pa.member_id = m.id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+ SELECT m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, m.is_active, COALESCE(pa.color, '#3385f8') AS color,
+    app.agent_role, app.fakechat_port, owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode,
+    m.created_at, m.updated_at
+   FROM members m
+     JOIN agent_project_profiles app ON app.member_id = m.id
+     LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_WITH_RUNTIME)
+
+
+def downgrade() -> None:
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_0105)

--- a/backend/app/models/team.py
+++ b/backend/app/models/team.py
@@ -30,6 +30,8 @@ class TeamMember(Base, OrgScopedMixin, TimestampMixin):
     message_policy_mode: Mapped[str] = mapped_column(
         Text, nullable=False, server_default="creator_only", default="creator_only"
     )
+    # E-CHAT-CMD S1b: 에이전트 런타임 종류 — canonical members.runtime_type 투영(0106 뷰). 휴먼 NULL.
+    runtime_type: Mapped[str | None] = mapped_column(Text, nullable=True)
     fakechat_port: Mapped[int | None] = mapped_column(nullable=True)
     created_by: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("users.id", ondelete="SET NULL"), nullable=True

--- a/backend/app/repositories/team_member.py
+++ b/backend/app/repositories/team_member.py
@@ -14,9 +14,10 @@ from app.repositories.base import BaseRepository
 
 # AC3-4 2-2: team_members가 projection 뷰로 강등됨 → write를 앵커 테이블로 라우팅(anchor-only).
 # PATCH 필드 → 앵커 매핑(0088 뷰 정의와 정합):
-#   name/avatar_url/is_active → members,  role/color/can_manage_members → project_access(per-project),
+#   name/avatar_url/is_active/runtime_type → members,  role/color/can_manage_members → project_access(per-project),
 #   agent_config/agent_role → agent_project_profiles.
-_MEMBERS_FIELDS = {"name", "avatar_url", "is_active"}
+# E-CHAT-CMD S1b: runtime_type 은 에이전트 단위 식별 → canonical members 에 기록(0106 뷰가 투영).
+_MEMBERS_FIELDS = {"name", "avatar_url", "is_active", "runtime_type"}
 _ACCESS_FIELDS = {"role", "color", "can_manage_members"}
 _PROFILE_FIELDS = {"agent_config", "agent_role"}
 

--- a/backend/app/schemas/team_member.py
+++ b/backend/app/schemas/team_member.py
@@ -36,6 +36,7 @@ class TeamMemberUpdate(BaseModel):
     agent_role: str | None = None
     is_active: bool | None = None
     can_manage_members: bool | None = None
+    runtime_type: str | None = None  # E-CHAT-CMD S1b: 에이전트 런타임 PATCH(anchor=members)
 
 
 class TeamMemberResponse(BaseModel):
@@ -53,6 +54,7 @@ class TeamMemberResponse(BaseModel):
     is_active: bool
     color: str
     agent_role: str | None = None
+    runtime_type: str | None = None  # E-CHAT-CMD S1b: members.runtime_type 투영(0106 뷰)
     created_by: uuid.UUID | None = None
     can_manage_members: bool = False
     created_at: datetime

--- a/backend/tests/test_runtime_type_view_exposure_472460aa.py
+++ b/backend/tests/test_runtime_type_view_exposure_472460aa.py
@@ -1,0 +1,191 @@
+"""E-CHAT-CMD S1b real-DB: team_members 뷰 runtime_type 노출 + PATCH/GET round-trip.
+
+마이그 0106 적용 DB 전제. AC: PATCH /api/v2/team-members/{id} {runtime_type} → 200 + 실저장
+(members.runtime_type) + GET 반환 + 회귀 0. message_policy_mode(0096) 선례 동형.
+
+DB env(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL) 없으면 skip — CI alembic-fresh-db 잡에서 실행.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+
+_RAW_URL = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+ORG = uuid.UUID("f1b60000-0000-0000-0000-000000000001")
+P1 = uuid.UUID("f1b60000-0000-0000-0000-0000000000a1")
+U_OWNER = uuid.UUID("f1b60000-0000-0000-0000-0000000000b1")
+OM_OWNER = uuid.UUID("f1b60000-0000-0000-0000-0000000000c1")
+M_AGENT = uuid.UUID("f1b60000-0000-0000-0000-0000000000e1")
+
+
+async def _seed(session):
+    from sqlalchemy import text
+
+    stmts = [
+        f"DELETE FROM agent_project_profiles WHERE member_id = '{M_AGENT}'",
+        f"DELETE FROM project_access WHERE project_id = '{P1}'",
+        f"DELETE FROM members WHERE org_id = '{ORG}'",
+        f"DELETE FROM projects WHERE org_id = '{ORG}'",
+        f"DELETE FROM org_members WHERE org_id = '{ORG}'",
+        f"DELETE FROM users WHERE id = '{U_OWNER}'",
+        f"DELETE FROM organizations WHERE id = '{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','F1B6','f1b6org','free')",
+        "INSERT INTO users (id,email,hashed_password,display_name,is_active,email_verified,login_fail_count,totp_enabled,totp_fail_count) "
+        f"VALUES ('{U_OWNER}','owner@f1b6.test','x','Owner',true,true,0,false,0)",
+        # auth user = org owner → assert_agent_owner 가 _is_org_admin 으로 통과
+        f"INSERT INTO org_members (id,org_id,user_id,role) VALUES ('{OM_OWNER}','{ORG}','{U_OWNER}','owner')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0)",
+        # 휴먼 anchor(owner) + 에이전트 anchor(runtime_type 초기 NULL)
+        "INSERT INTO members (id,org_id,type,user_id,name,org_role,is_active) VALUES "
+        f"('{OM_OWNER}','{ORG}','human','{U_OWNER}','Owner','owner',true)",
+        "INSERT INTO members (id,org_id,type,owner_member_id,name,is_active) VALUES "
+        f"('{M_AGENT}','{ORG}','agent','{OM_OWNER}','RuntimeBot',true)",
+        # 에이전트 뷰 출현(agent 분기 = members ⋈ agent_project_profiles)
+        f"INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port) "
+        f"VALUES (gen_random_uuid(),'{M_AGENT}','{P1}','dev',9401)",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+def _auth():
+    c = MagicMock()
+    c.user_id = str(U_OWNER)
+    c.claims = {"app_metadata": {"org_id": str(ORG)}}
+    return c
+
+
+@pytest.mark.anyio
+async def test_view_exposes_runtime_type_human_null_agent_value():
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("UPDATE members SET runtime_type='hermes' WHERE id=:i"), {"i": str(M_AGENT)})
+            await s.commit()
+        async with Session() as s:
+            agent_rt = (await s.execute(text(
+                "SELECT runtime_type FROM team_members WHERE id=:i"), {"i": str(M_AGENT)})).scalar_one()
+            human_rt = (await s.execute(text(
+                "SELECT runtime_type FROM team_members WHERE id=:i"), {"i": str(OM_OWNER)})).scalar_one_or_none()
+        assert agent_rt == "hermes", f"뷰 agent runtime_type 미노출: {agent_rt}"
+        # 휴먼은 뷰 출현 시 runtime_type NULL (미설정). project_access 없으면 휴먼 뷰행 0 — None 허용.
+        assert human_rt in (None,), f"휴먼 runtime_type NULL 아님: {human_rt}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_runtime_type_persists_and_get_returns():
+    """⚠️ AC 핵심: PATCH {runtime_type} → 200 + members 실저장 + GET 반환."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from httpx import ASGITransport, AsyncClient
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        async def override_db():
+            # 실 get_db 동형: yield 후 commit(미commit 시 PATCH write 롤백 — verify_commit_race).
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: _auth()
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                # PATCH runtime_type
+                r = await c.patch(f"/api/v2/team-members/{M_AGENT}", json={"runtime_type": "openclaw"})
+                assert r.status_code == 200, r.text
+                assert r.json()["runtime_type"] == "openclaw", f"PATCH 응답 미반영: {r.json().get('runtime_type')}"
+                # GET (project-scoped) → 반환
+                g = await c.get(f"/api/v2/team-members?project_id={P1}&type=agent")
+                assert g.status_code == 200, g.text
+                agent = next((m for m in g.json() if m["id"] == str(M_AGENT)), None)
+                assert agent is not None and agent["runtime_type"] == "openclaw", f"GET 미반환: {agent}"
+        finally:
+            app.dependency_overrides.clear()
+
+        # 실저장 확인: canonical members.runtime_type
+        async with Session() as s:
+            saved = (await s.execute(text(
+                "SELECT runtime_type FROM members WHERE id=:i"), {"i": str(M_AGENT)})).scalar_one()
+        assert saved == "openclaw", f"members.runtime_type 실저장 실패: {saved}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_patch_unrelated_field_does_not_touch_runtime_type():
+    """회귀: 다른 필드 PATCH 가 runtime_type 을 건드리지 않음(부분 갱신 격리)."""
+    from sqlalchemy import text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from httpx import ASGITransport, AsyncClient
+    from app.main import app
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+            await s.execute(text("UPDATE members SET runtime_type='grok' WHERE id=:i"), {"i": str(M_AGENT)})
+            await s.commit()
+
+        async def override_db():
+            # 실 get_db 동형: yield 후 commit(미commit 시 PATCH write 롤백 — verify_commit_race).
+            async with Session() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        app.dependency_overrides[get_db] = override_db
+        app.dependency_overrides[get_current_user] = lambda: _auth()
+        try:
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+                r = await c.patch(f"/api/v2/team-members/{M_AGENT}", json={"name": "Renamed"})
+                assert r.status_code == 200, r.text
+        finally:
+            app.dependency_overrides.clear()
+
+        async with Session() as s:
+            rt = (await s.execute(text(
+                "SELECT runtime_type FROM members WHERE id=:i"), {"i": str(M_AGENT)})).scalar_one()
+        assert rt == "grok", f"무관 PATCH 가 runtime_type 변경: {rt}"
+    finally:
+        await engine.dispose()

--- a/backend/tests/test_s2_2_passive_heartbeat.py
+++ b/backend/tests/test_s2_2_passive_heartbeat.py
@@ -36,6 +36,7 @@ def _mock_member_for_heartbeat():
     m.is_active = True
     m.color = "#3385f8"
     m.agent_role = None
+    m.runtime_type = None  # E-CHAT-CMD S1b: 신규 필드 — mock 명시(from_attributes ValidationError 방지)
     m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)

--- a/backend/tests/test_s2_3_presence_status.py
+++ b/backend/tests/test_s2_3_presence_status.py
@@ -36,6 +36,7 @@ def _mock_member(type_: str = "agent", last_seen_at=None):
     m.is_active = True
     m.color = "#3385f8"
     m.agent_role = None
+    m.runtime_type = None  # E-CHAT-CMD S1b: 신규 필드 — mock 명시(from_attributes ValidationError 방지)
     m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)

--- a/backend/tests/test_s2_4_claim_unclaim.py
+++ b/backend/tests/test_s2_4_claim_unclaim.py
@@ -38,6 +38,7 @@ def _mock_member(active_story_id=None, last_seen_at=None, type_="agent"):
     m.is_active = True
     m.color = "#3385f8"
     m.agent_role = None
+    m.runtime_type = None  # E-CHAT-CMD S1b: 신규 필드 — mock 명시(from_attributes ValidationError 방지)
     m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)

--- a/backend/tests/test_s4_1_file_conflict.py
+++ b/backend/tests/test_s4_1_file_conflict.py
@@ -125,6 +125,7 @@ def _mock_member():
     m.is_active = True
     m.color = "#3385f8"
     m.agent_role = None
+    m.runtime_type = None  # E-CHAT-CMD S1b: 신규 필드 — mock 명시(from_attributes ValidationError 방지)
     m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)

--- a/backend/tests/test_team_members.py
+++ b/backend/tests/test_team_members.py
@@ -25,6 +25,7 @@ def _mock_member(is_active: bool = True, type_: str = "human") -> MagicMock:
     m.is_active = is_active
     m.color = "#3385f8"
     m.agent_role = None
+    m.runtime_type = None  # E-CHAT-CMD S1b: 신규 필드 — mock 명시(from_attributes ValidationError 방지)
     m.created_by = None
     m.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     m.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)


### PR DESCRIPTION
## E-CHAT-CMD S1b — BE 배선 블로커 (미르코 §8 게이트 적출, S2 save/reload 언블록)

S1이 `members.runtime_type` 컬럼을 추가했으나 0088 projection 뷰(team_members)에 미노출 → 에이전트 read/write 표면(GET/PATCH `/api/v2/team-members`)서 반환·저장 불가. message_policy_mode(0096) 선례 동형으로 5곳 배선.

## 변경 (5곳)

1. **마이그 0106** — team_members 뷰 DROP+CREATE 재정의, `m.runtime_type`를 휴먼·에이전트 양 브랜치에 추가(message_policy_mode 뒤). 가역·다른 컬럼 불변.
2. **TeamMember 모델** — `runtime_type` 속성(뷰/ORM 정합·fresh-OSS create_all).
3. **TeamMemberResponse** — serializer 노출(없으면 GET 미반환).
4. **TeamMemberUpdate** — PATCH whitelist(없으면 PATCH drop).
5. **`_MEMBERS_FIELDS`** — anchor write 라우팅(PATCH→`UPDATE members SET runtime_type`).

## 검증 (dev 기준)

realdb 3건(head 마이그 DB):
- **AC 핵심**: `PATCH /api/v2/team-members/{id} {runtime_type}` → 200 + 응답 반영 + **members.runtime_type 실저장** + 별도 세션 GET 반환
- 뷰 노출: 에이전트 runtime_type 값·휴먼 NULL
- 회귀: 무관 필드 PATCH가 runtime_type 미변경(부분 갱신 격리)
- 마이그 0106: upgrade/downgrade 가역 + message_policy_mode 무회귀(뷰 재정의 손상 0)

회귀: 전체 백엔드 mock suite **1709 passed**. 신규 필드로 TeamMember MagicMock fixture 5파일에 `runtime_type=None` 명시(from_attributes ValidationError 방지 — pytest_mock_fixture 교훈). 실패 3건은 MCP e2e 라이브 연결·contract 파일 부재로 본 변경 무관.

## 워크플로

⚠️ 마이그 0106 동반 — 머지=migrate-dev 원자성. develop까지(prod 배포는 에픽 완료 일괄). done=dev 검증(PATCH/GET round-trip). 디디 fix → PO 게이트 → 까심 QA(dev 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)