### PR TITLE
fix(fakechat·E-CHAT-CMD S9): 이벤트 주입 allowlist 적용 — FYI-injection 보안 갭 차단

### DIFF
--- a/packages/fakechat/inject-allowlist.test.ts
+++ b/packages/fakechat/inject-allowlist.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+
+import { INJECTABLE_EVENT_TYPES, isInjectableEventType } from './inject-allowlist'
+
+// SDK connectors/sdk/sprintable_sse.py 의 INJECTABLE_EVENT_TYPES 와 동일해야 한다(언어 경계 동기화).
+const SDK_ALLOWLIST = [
+  'dispatched',
+  'story_assigned',
+  'conversation.message_created',
+  'conversation:mention',
+  'kickoff',
+  'review_request',
+  'qa_request',
+  'deploy_request',
+  'handoff',
+]
+
+describe('E-CHAT-CMD S9 — fakechat inject allowlist', () => {
+  it('allowlist 가 SDK(sprintable_sse.py) 와 정확히 동일', () => {
+    expect(new Set(INJECTABLE_EVENT_TYPES)).toEqual(new Set(SDK_ALLOWLIST))
+    expect(INJECTABLE_EVENT_TYPES.size).toBe(SDK_ALLOWLIST.length)
+  })
+
+  it('AC1: 허용 event_type 은 data 최상위에서 통과', () => {
+    for (const t of SDK_ALLOWLIST) {
+      expect(isInjectableEventType({ event_type: t }, {})).toBe(true)
+    }
+  })
+
+  it('AC1: 허용 event_type 은 payload fallback 에서도 통과', () => {
+    expect(isInjectableEventType({}, { event_type: 'conversation.message_created' })).toBe(true)
+    // data 최상위 우선 — data 가 허용이면 payload 무관하게 통과
+    expect(isInjectableEventType({ event_type: 'dispatched' }, { event_type: 'status_changed' })).toBe(true)
+  })
+
+  it('AC2: allowlist 밖 FYI event_type 은 드롭(false) — content 유무 무관', () => {
+    const fyi = ['status_changed', 'task_completed', 'agent_joined', 'sprint_closed', 'file_conflict', 'unknown_xyz']
+    for (const t of fyi) {
+      expect(isInjectableEventType({ event_type: t, content: 'x' }, {})).toBe(false)
+      expect(isInjectableEventType({}, { event_type: t, content: 'x' })).toBe(false)
+    }
+  })
+
+  it('AC2: event_type 부재/비문자열은 드롭(false)', () => {
+    expect(isInjectableEventType({}, {})).toBe(false)
+    expect(isInjectableEventType({ content: 'x' }, { content: 'y' })).toBe(false)
+    expect(isInjectableEventType({ event_type: 123 }, {})).toBe(false)
+    expect(isInjectableEventType({ event_type: null }, {})).toBe(false)
+  })
+
+  it('회귀: 정상 conversation.message_created 는 통과(무영향)', () => {
+    const data = { content: '안녕', conversation_id: 'c1', recipient_seq: 3 }
+    const payload = { event_type: 'conversation.message_created', content: '안녕' }
+    expect(isInjectableEventType(data, payload)).toBe(true)
+  })
+})

--- a/packages/fakechat/inject-allowlist.ts
+++ b/packages/fakechat/inject-allowlist.ts
@@ -1,0 +1,34 @@
+/**
+ * E-CHAT-CMD S9: fakechat 이벤트 주입 허용 event-type allowlist.
+ *
+ * SDK `connectors/sdk/sprintable_sse.py` 의 `INJECTABLE_EVENT_TYPES` 와 **동일한** 목록.
+ * 이 목록 밖의 event_type 은 content 가 실려 있어도 work-turn 으로 주입하지 않고 드롭한다
+ * (FYI poisoning 방지: status_changed/task_completed/agent_joined/sprint_closed/file_conflict 등).
+ *
+ * ⚠️ 언어 경계(Python ↔ TS)라 상수를 import 할 수 없다 — 값 변경 시 `sprintable_sse.py` 와
+ * **반드시 함께** 동기화할 것. (S9 이전에는 fakechat 만 이 게이트가 누락된 유일 갭이었다.)
+ */
+export const INJECTABLE_EVENT_TYPES: ReadonlySet<string> = new Set<string>([
+  'dispatched',
+  'story_assigned',
+  'conversation.message_created',
+  'conversation:mention',
+  'kickoff',
+  'review_request',
+  'qa_request',
+  'deploy_request',
+  'handoff',
+])
+
+/**
+ * event_type 을 data 최상위 → payload fallback 순으로 추출해 allowlist 멤버십을 판정한다.
+ * (sprintable_sse.py:156-157 동형 — content 체크 **전**에 호출.)
+ * event_type 이 없거나 문자열이 아니거나 allowlist 밖이면 false(=드롭).
+ */
+export function isInjectableEventType(
+  data: Record<string, unknown>,
+  payload: Record<string, unknown>,
+): boolean {
+  const eventType = data.event_type ?? payload.event_type
+  return typeof eventType === 'string' && INJECTABLE_EVENT_TYPES.has(eventType)
+}

--- a/packages/fakechat/server.ts
+++ b/packages/fakechat/server.ts
@@ -16,6 +16,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js'
+import { isInjectableEventType } from './inject-allowlist'
 
 const API_URL = (
   process.env.SPRINTABLE_API_URL ?? 'https://sprintable-backend-dev-57iommnikq-du.a.run.app'
@@ -203,6 +204,11 @@ async function _onEvent(evType: string, evId: string, dataStr: string): Promise<
     (typeof data.payload === 'object' && data.payload !== null
       ? data.payload
       : {}) as Record<string, unknown>
+
+  // E-CHAT-CMD S9: allowlist 밖 event_type 은 content 체크 전에 드롭(sprintable_sse.py:157 동형).
+  // fakechat 가 유일하게 이 게이트가 없어 FYI 이벤트(status_changed/file_conflict 등)가 content 만
+  // 있으면 세션에 주입되던 보안 갭을 닫는다.
+  if (!isInjectableEventType(data, payload)) return
 
   const content = ((data.content ?? payload.content ?? '') as string).trim()
   if (!content) return


### PR DESCRIPTION
## E-CHAT-CMD S9 — fakechat event-type allowlist 갭 fix (BE/Security)

리서치 적출 보안 갭: Python SDK `connectors/sdk/sprintable_sse.py:157`는 `INJECTABLE_EVENT_TYPES` allowlist 밖 event_type을 content 체크 **전** 드롭하나, **fakechat `packages/fakechat/server.ts`만 이 게이트 미적용** → FYI 이벤트(status_changed·file_conflict·agent_joined 등)가 content만 있으면 세션에 주입되던 유일 갭.

## 변경 (TS 전용·마이그 없음)

- `packages/fakechat/inject-allowlist.ts` (신규): `INJECTABLE_EVENT_TYPES`(SDK와 동일 9종) + `isInjectableEventType(data, payload)`. server.ts가 import 시 SSE 루프를 top-level 자동 시작하므로 직접 단위테스트 불가 → allowlist를 **순수 모듈**로 분리.
- `server.ts` `_onEvent`: payload 추출 후 **content 체크 전** `if (!isInjectableEventType(data, payload)) return` (sprintable_sse.py:157 동형).

**AC1**: SDK와 동일 allowlist를 fakechat ingestion path에 적용. **AC2**: unknown event type → fakechat path drop. **회귀**: conversation.message_created 등 정상 이벤트 무영향.

⚠️ 언어 경계(Python↔TS)라 상수 import 불가 — 값 변경 시 `sprintable_sse.py`와 함께 동기화(모듈 docstring·테스트에 SDK parity assert로 가드).

## 검증 (dev 기준)

vitest **6 passed**:
- allowlist = SDK(sprintable_sse.py) 정확 동일(parity)
- 허용 event_type 통과(data 최상위·payload fallback·data 우선)
- AC2: FYI/unknown(status_changed·task_completed·agent_joined·sprint_closed·file_conflict) 드롭 · event_type 부재/비문자열 드롭
- 회귀: conversation.message_created 통과

moduleResolution=bundler라 extensionless 로컬 import 안전(Bun/vitest/tsc). CI `vitest run`이 신규 테스트 picksup.

## 워크플로

develop까지(prod 배포 에픽 완료 일괄)·마이그 없음·done=dev 검증. 디디 fix → PO 게이트 → 까심 QA(dev 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)