### PR TITLE
feat(gateway·E-CHAT-CMD S4): capability gate — 지원=pass / 미지원=skip+hint+audit

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -19,8 +19,11 @@ from app.models.conversation import Conversation, ConversationMessage, Conversat
 from app.models.event import Event
 from app.models.project import OrgMember
 from app.models.team import AgentMessageAllowlist, TeamMember
+from app.models.agent_deployment import AgentAuditLog
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
+from app.services.agent_runtime import supports_deterministic_command
+from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
 from app.services.member_resolver import (
     ResolvedMember,
@@ -342,6 +345,75 @@ async def _dispatch_mention_events(
             await assign_recipient_seq(db, event)
     return [(pid_str, {"event_id": str(event.id), "event_type": "conversation:mention", **payload})
             for pid_str, event in events_to_push]
+
+
+async def _command_capability_gate(
+    db: AsyncSession,
+    conv: Conversation,
+    msg: ConversationMessage,
+    sender: "ResolvedMember | TeamMember",
+    org_id: uuid.UUID,
+) -> tuple[set[uuid.UUID], list[dict]]:
+    """E-CHAT-CMD S4: capability gate — 슬래시 커맨드를 미지원 런타임 에이전트에 주입하지 않는다.
+
+    메시지가 command candidate(S3 classifier)면, conversation 의 에이전트 수신자 각각의
+    runtime_type 을 capability registry(S1)로 조회한다. 결정적 커맨드 미지원(또는 runtime_type
+    없음/unknown) 에이전트는 **주입 차단**(반환된 id 를 dispatch exclude 로 사용) + audit log
+    `command_blocked_unsupported_runtime` 기록 + hint 생성. 지원 에이전트는 그대로 pass-through.
+
+    비-command 메시지는 빈 결과 → 기존 경로 무영향(AC4 회귀). project_id 없는 conversation 은
+    애초에 에이전트 dispatch 가 없어 게이트 무의미 → 빈 결과.
+
+    반환: (blocked_agent_ids, hints) — hints 는 발신자에게 돌려줄 구조화 안내.
+    """
+    candidate = classify_command(msg.content)
+    if candidate is None or not conv.project_id:
+        return set(), []
+
+    rows = (await db.execute(
+        select(TeamMember.id, TeamMember.name, TeamMember.runtime_type)
+        .join(ConversationParticipant, ConversationParticipant.member_id == TeamMember.id)
+        .where(
+            ConversationParticipant.conversation_id == conv.id,
+            TeamMember.type == "agent",
+            TeamMember.id != sender.id,
+        )
+    )).all()
+
+    blocked: set[uuid.UUID] = set()
+    hints: list[dict] = []
+    for agent_id, agent_name, runtime_type in rows:
+        if supports_deterministic_command(runtime_type):
+            continue  # AC2: 지원 런타임 → pass-through(기존 dispatch)
+        # AC3/AC4: 미지원(또는 runtime_type 없음/unknown) → 차단 + audit + hint
+        blocked.add(agent_id)
+        db.add(AgentAuditLog(
+            org_id=org_id,
+            project_id=conv.project_id,
+            agent_id=agent_id,
+            event_type="command_blocked_unsupported_runtime",
+            severity="info",
+            summary=f"'/{candidate.name}' blocked — runtime '{runtime_type or 'unset'}' lacks deterministic command support",
+            payload={
+                "command": candidate.name,
+                "raw": candidate.raw,
+                "runtime_type": runtime_type,
+                "conversation_id": str(conv.id),
+                "message_id": str(msg.id),
+                "sender_id": str(sender.id),
+            },
+        ))
+        hints.append({
+            "agent_id": str(agent_id),
+            "agent_name": agent_name,
+            "runtime_type": runtime_type,
+            "command": candidate.name,
+            "reason": "unsupported_runtime",
+        })
+
+    if blocked:
+        await db.flush()
+    return blocked, hints
 
 
 async def _dispatch_discord_outbound(
@@ -987,10 +1059,14 @@ async def send_message(
     except Exception:
         logger.warning("ChannelRouter pre-check failed message_id=%s — no SSE exclusion", msg.id)
 
+    # E-CHAT-CMD S4: capability gate — 슬래시 커맨드를 미지원 런타임 에이전트에 주입 차단(+audit+hint).
+    # 비-command 면 빈 결과 → 무영향. 차단 대상은 dispatch exclude 로 합쳐 주입 0.
+    blocked_agent_ids, command_hints = await _command_capability_gate(db, conv, msg, sender, org_id)
+
     pending_sse_pushes: list[tuple[str, dict]] = []
     try:
         async with db.begin_nested():
-            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids)
+            pending_sse_pushes += await _dispatch_conversation_event(db, conv, msg, org_id, sender, exclude_ids=discord_exclude_ids | blocked_agent_ids)
     except Exception as _dispatch_err:
         # dispatch 실패를 삼키지 않고 surface — 게이트웨이 이벤트 미생성 무음 방지
         logger.error("conversation event dispatch failed conversation_id=%s", conversation_id, exc_info=True)
@@ -998,7 +1074,7 @@ async def send_message(
 
     # AC1: 멘션 대상에게 conversation:mention SSE 발송 (participant 여부 무관)
     if msg.mentioned_ids:
-        mention_targets = set(msg.mentioned_ids) - {sender.id} - discord_exclude_ids
+        mention_targets = set(msg.mentioned_ids) - {sender.id} - discord_exclude_ids - blocked_agent_ids
         if mention_targets:
             try:
                 async with db.begin_nested():
@@ -1124,6 +1200,9 @@ async def send_message(
     if fork_info:
         response["forked"] = True
         response["forked_conversation_id"] = fork_info["forked_conversation_id"]
+    # E-CHAT-CMD S4: 미지원 런타임으로 차단된 커맨드의 hint 를 발신자에게 반환(AC3 hint response).
+    if command_hints:
+        response["command_gate"] = {"blocked": command_hints}
     return response
 
 

--- a/backend/tests/test_capability_gate_ebaae2e1.py
+++ b/backend/tests/test_capability_gate_ebaae2e1.py
@@ -1,0 +1,171 @@
+"""E-CHAT-CMD S4 real-DB: capability gate — 미지원 런타임 에이전트에 커맨드 주입 차단.
+
+마이그 0106(team_members 뷰 runtime_type 노출) 적용 DB 전제. `_command_capability_gate` 직접 검증:
+- AC1: command candidate → 에이전트 수신자 runtime_type → capability lookup
+- AC2: 지원(hermes) → 차단 안 함(pass-through)
+- AC3: 미지원(claude-code) → 차단 + audit log `command_blocked_unsupported_runtime`
+- AC4: runtime_type 없음(NULL) → 미지원 처리(차단). 비-command → 무게이트(회귀)
+
+DB env 없으면 skip — CI alembic-fresh-db 잡에서 실행.
+"""
+from __future__ import annotations
+
+import os
+import types
+import uuid
+
+import pytest
+
+_RAW_URL = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = _RAW_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+    "postgresql://", "postgresql+asyncpg://"
+)
+
+pytestmark = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+ORG = uuid.UUID("a4000000-0000-0000-0000-000000000001")
+P1 = uuid.UUID("a4000000-0000-0000-0000-0000000000a1")
+CONV = uuid.UUID("a4000000-0000-0000-0000-0000000000d1")
+SENDER = uuid.UUID("a4000000-0000-0000-0000-0000000000f1")  # human sender(member)
+AG_OK = uuid.UUID("a4000000-0000-0000-0000-0000000000e1")   # hermes — 지원
+AG_NO = uuid.UUID("a4000000-0000-0000-0000-0000000000e2")   # claude-code — 미지원
+AG_NULL = uuid.UUID("a4000000-0000-0000-0000-0000000000e3")  # runtime_type NULL — 미지원
+
+
+async def _seed(session):
+    from sqlalchemy import text
+
+    stmts = [
+        f"DELETE FROM agent_audit_logs WHERE org_id='{ORG}'",
+        f"DELETE FROM conversation_participants WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversation_messages WHERE conversation_id='{CONV}'",
+        f"DELETE FROM conversations WHERE id='{CONV}'",
+        f"DELETE FROM agent_project_profiles WHERE member_id IN ('{AG_OK}','{AG_NO}','{AG_NULL}')",
+        f"DELETE FROM members WHERE org_id='{ORG}'",
+        f"DELETE FROM projects WHERE org_id='{ORG}'",
+        f"DELETE FROM organizations WHERE id='{ORG}'",
+        f"INSERT INTO organizations (id,name,slug,plan) VALUES ('{ORG}','A4','a4org','free')",
+        f"INSERT INTO projects (id,org_id,name,violation_level) VALUES ('{P1}','{ORG}','P1',0)",
+        # sender(human member) + 3 agents(members), runtime_type 차등
+        "INSERT INTO members (id,org_id,type,name,is_active) VALUES "
+        f"('{SENDER}','{ORG}','human','Sender',true),"
+        f"('{AG_OK}','{ORG}','agent','HermesBot',true),"
+        f"('{AG_NO}','{ORG}','agent','CCBot',true),"
+        f"('{AG_NULL}','{ORG}','agent','BareBot',true)",
+        f"UPDATE members SET runtime_type='hermes' WHERE id='{AG_OK}'",
+        f"UPDATE members SET runtime_type='claude-code' WHERE id='{AG_NO}'",
+        # AG_NULL: runtime_type 미설정(NULL)
+        # 에이전트 뷰 출현(members ⋈ agent_project_profiles)
+        "INSERT INTO agent_project_profiles (id,member_id,project_id,agent_role,fakechat_port) VALUES "
+        f"(gen_random_uuid(),'{AG_OK}','{P1}','dev',9501),"
+        f"(gen_random_uuid(),'{AG_NO}','{P1}','dev',9502),"
+        f"(gen_random_uuid(),'{AG_NULL}','{P1}','dev',9503)",
+        f"INSERT INTO conversations (id,project_id,org_id,type,created_by) VALUES ('{CONV}','{P1}','{ORG}','group','{SENDER}')",
+        "INSERT INTO conversation_participants (conversation_id,member_id) VALUES "
+        f"('{CONV}','{SENDER}'),('{CONV}','{AG_OK}'),('{CONV}','{AG_NO}'),('{CONV}','{AG_NULL}')",
+    ]
+    for s in stmts:
+        await session.execute(text(s))
+    await session.commit()
+
+
+def _sender():
+    return types.SimpleNamespace(id=SENDER, type="human", name="Sender")
+
+
+def _msg(content: str):
+    from app.models.conversation import ConversationMessage
+    return ConversationMessage(id=uuid.uuid4(), conversation_id=CONV, sender_id=SENDER, content=content)
+
+
+@pytest.mark.anyio
+async def test_command_gate_blocks_unsupported_and_passes_supported():
+    from sqlalchemy import select, text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.models.agent_deployment import AgentAuditLog
+    from app.models.conversation import Conversation
+    from app.routers.conversations import _command_capability_gate
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+
+        # 커맨드 메시지 "/deploy" → hermes pass, claude-code/NULL 차단
+        async with Session() as s:
+            conv = (await s.execute(select(Conversation).where(Conversation.id == CONV))).scalar_one()
+            blocked, hints = await _command_capability_gate(s, conv, _msg("/deploy now"), _sender(), ORG)
+            await s.commit()
+
+        assert blocked == {AG_NO, AG_NULL}, f"차단 집합 불일치: {blocked}"
+        assert AG_OK not in blocked, "지원 런타임(hermes)이 차단됨(AC2 위반)"
+        assert {h["agent_id"] for h in hints} == {str(AG_NO), str(AG_NULL)}
+        assert all(h["reason"] == "unsupported_runtime" and h["command"] == "deploy" for h in hints)
+
+        # AC3: audit log 2건 — command_blocked_unsupported_runtime
+        async with Session() as s:
+            rows = (await s.execute(select(AgentAuditLog).where(
+                AgentAuditLog.org_id == ORG,
+                AgentAuditLog.event_type == "command_blocked_unsupported_runtime",
+            ))).scalars().all()
+        assert len(rows) == 2, f"audit log 2건 아님: {len(rows)}"
+        assert {r.agent_id for r in rows} == {AG_NO, AG_NULL}
+        assert all(r.payload.get("command") == "deploy" for r in rows)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_non_command_message_is_not_gated():
+    """회귀(AC4): 일반(비-command) 메시지는 게이트 무영향 — 차단 0·audit 0."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.models.agent_deployment import AgentAuditLog
+    from app.models.conversation import Conversation
+    from app.routers.conversations import _command_capability_gate
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            conv = (await s.execute(select(Conversation).where(Conversation.id == CONV))).scalar_one()
+            blocked, hints = await _command_capability_gate(s, conv, _msg("배포 좀 해줘"), _sender(), ORG)
+            await s.commit()
+        assert blocked == set() and hints == [], f"비-command가 게이트됨: {blocked}"
+        async with Session() as s:
+            cnt = (await s.execute(select(AgentAuditLog).where(AgentAuditLog.org_id == ORG))).scalars().all()
+        assert len(cnt) == 0, f"비-command인데 audit 생성: {len(cnt)}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_escaped_command_is_literal_not_gated():
+    """이스케이프(`//deploy`·선행공백)는 리터럴 → 게이트 무영향(S3 classifier 정합)."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+    from app.models.conversation import Conversation
+    from app.routers.conversations import _command_capability_gate
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await _seed(s)
+        async with Session() as s:
+            conv = (await s.execute(select(Conversation).where(Conversation.id == CONV))).scalar_one()
+            for literal in ("//deploy", " /deploy"):
+                blocked, hints = await _command_capability_gate(s, conv, _msg(literal), _sender(), ORG)
+                assert blocked == set() and hints == [], f"이스케이프 {literal!r} 가 게이트됨"
+            await s.rollback()
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## E-CHAT-CMD S4 — capability gate (S1·S3 통합)

블루프린트 §Task 4·§Degradation. S1(registry)·S3(classifier)을 dispatch 경로에 묶는다.

## 변경 (마이그 없음 — 기존 0106 뷰 + agent_audit_logs 사용)

`conversations.py` 송신 경로(`send_message`)에 `_command_capability_gate` 추가:
- **AC1**: 메시지가 command candidate(`classify_command`)면 각 에이전트 수신자의 `runtime_type`(team_members 뷰=0106 노출)을 `get_runtime_capability`(S1)로 조회.
- **AC2**: 지원 런타임(`deterministic_command`) → 그대로 dispatch pass-through(런타임 실행).
- **AC3**: 미지원 → 해당 에이전트를 dispatch **exclude**(주입 0) + `AgentAuditLog('command_blocked_unsupported_runtime')` + 발신자 응답에 `command_gate.blocked` hint.
- **AC4**: `runtime_type` 없음/unknown = 미지원(차단). **회귀**: 비-command 메시지는 `classify_command`가 None → 게이트 단락(DB 작업 0, 기존 경로 무영향).

차단 집합은 conversation·mention dispatch의 기존 `exclude_ids`에 병합 — 주입 0 보장.

## 검증 (dev 기준)

realdb 3건(head 0106 DB):
- `/deploy` → hermes(지원) pass · claude-code·runtime-NULL(미지원) 차단, hint 2건, **audit log 2건**(command_blocked_unsupported_runtime·agent_id·payload.command 검증)
- 비-command("배포 좀 해줘") → 차단 0·audit 0 (AC4 회귀)
- 이스케이프(`//deploy`·` /deploy`) → 리터럴 → 무게이트(S3 classifier 정합)

회귀: 전체 백엔드 mock suite **1709 passed**(conversations.py 송신 경로 무영향). 실패 3건은 MCP e2e·contract 파일로 본 변경 무관.

## 워크플로

develop까지·마이그 없음·done=dev 검증. hint response는 현재 발신자 응답 `command_gate` 구조화 필드(FE S8 렌더 소비). 디디 fix → PO 게이트 → 까심 QA(dev 기준).

🤖 Generated with [Claude Code](https://claude.com/claude-code)