### PR TITLE
docs(agent·E-CHAT-CMD S7): OpenCode MVP wiring 결정 — unsupported hint + Phase2 후보 기록

### DIFF
--- a/backend/app/services/agent_runtime.py
+++ b/backend/app/services/agent_runtime.py
@@ -59,7 +59,14 @@ _CAPABILITY_REGISTRY: dict[RuntimeType, RuntimeCapability] = {
     RuntimeType.GEMINI: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
     RuntimeType.GROK: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
     RuntimeType.PI: RuntimeCapability(deterministic_command=True, command_endpoint_available=True),
-    # 엔드포인트는 있으나 결정적 실행 아님
+    # E-CHAT-CMD S7 — OpenCode wiring 결정(블루프린트 §Task 7):
+    #   **MVP = unsupported hint**(deterministic_command=False). opencode 는 전용 커맨드
+    #   엔드포인트(`POST /session/:id/command`)가 존재하나(command_endpoint_available=True),
+    #   MVP 단순성을 위해 dedicated adapter 를 배선하지 않고 다른 비-결정적 런타임과 동일하게
+    #   capability gate(S4)가 차단+hint 처리한다. → 사용자에게 "이 런타임은 결정적 커맨드 미지원,
+    #   일반 메시지로 요청" 안내. ⚠️ **Phase2 후보**: command_endpoint_available=True 가 표식 —
+    #   향후 dedicated command endpoint adapter 를 배선하면 opencode 만 deterministic_command=True
+    #   로 승격 가능(다른 endpoint-없는 런타임과 구분되는 유일 케이스). 그때까지 기본값 유지.
     RuntimeType.OPENCODE: RuntimeCapability(deterministic_command=False, command_endpoint_available=True),
     # 커맨드 엔드포인트 자체 없음 — 스킬은 model-mediated 만
     RuntimeType.CLAUDE_CODE: RuntimeCapability(deterministic_command=False, command_endpoint_available=False),

--- a/backend/tests/test_agent_runtime_capability.py
+++ b/backend/tests/test_agent_runtime_capability.py
@@ -82,3 +82,25 @@ def test_capability_is_immutable():
     cap = get_runtime_capability("hermes")
     with pytest.raises(dataclasses.FrozenInstanceError):
         cap.deterministic_command = False  # type: ignore[misc]
+
+
+def test_s7_opencode_mvp_unsupported_hint_decision():
+    """E-CHAT-CMD S7 — OpenCode wiring 결정 계약 잠금(블루프린트 §Task 7).
+
+    MVP: opencode = unsupported hint(deterministic_command=False) → capability gate(S4) 차단.
+    Phase2 후보 표식: command_endpoint_available=True(전용 command endpoint 존재).
+    opencode 는 'endpoint 있으나 비-결정적'인 **유일** 런타임(Phase2 승격 단일 후보).
+    """
+    cap = get_runtime_capability("opencode")
+    # MVP: 결정적 커맨드 미지원 → S4 게이트가 차단+hint
+    assert cap.deterministic_command is False
+    assert supports_deterministic_command("opencode") is False
+    # Phase2 표식: 전용 command endpoint 존재
+    assert cap.command_endpoint_available is True
+    # opencode = 'endpoint 있음 + 비-결정적' 유일 런타임(Phase2 승격 단일 후보)
+    phase2_candidates = [
+        r.value for r in RuntimeType
+        if not get_runtime_capability(r).deterministic_command
+        and get_runtime_capability(r).command_endpoint_available
+    ]
+    assert phase2_candidates == ["opencode"], f"Phase2 후보 단일성 깨짐: {phase2_candidates}"


### PR DESCRIPTION
## E-CHAT-CMD S7 — OpenCode wiring decision (경량)

블루프린트 §Task 7. capability registry 정합 확인 + 결정 기록.

## 결정

**MVP = OpenCode unsupported hint**(기본값). opencode 는 `deterministic_command=False`라 S4 capability gate가 다른 비-결정적 런타임과 동일하게 차단+hint 처리한다 — "결정적 커맨드 미지원, 일반 메시지로 요청".

**근거**: opencode 는 전용 command endpoint(`POST /session/:id/command`)가 존재해 `command_endpoint_available=True`지만, MVP 단순성을 위해 dedicated adapter 배선은 하지 않는다.

**Phase2 후보**: opencode 는 `command_endpoint_available=True` ∧ `deterministic_command=False`인 **유일** 런타임 → 향후 dedicated command endpoint adapter 배선 시 opencode만 `deterministic_command=True`로 승격 가능한 단일 후보. 그때까지 기본값 유지.

## 변경 (동작 변경 0)

- `agent_runtime.py` opencode 엔트리에 결정 블록 주석(MVP·근거·Phase2).
- 결정 계약 잠금 테스트: opencode 현재 unsupported(`supports_deterministic_command`=False)·`command_endpoint_available`=True(Phase2 표식)·opencode가 Phase2 단일 후보.

## 검증

agent_runtime 단위 **10 passed**(신규 S7 결정 테스트 포함). registry 정합 유지(`opencode={deterministic:false, command_endpoint_available:true}`). 마이그 없음·동작 변경 없음·develop까지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)