### PR TITLE
[SID:e371dc09] 채팅 command-blocked hint bubble 렌더 (E-CHAT-CMD S5)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2306,6 +2306,9 @@
     "hypothesisSection": "Outcome Hypothesis"
   },
   "chats": {
+    "commandBlockedLead": "{agentName} doesn't run chat slash-commands directly.",
+    "commandBlockedAlt": "Try natural language instead — e.g. \"use the {command} skill to …\"",
+    "commandBlockedSettings": "View runtime settings",
     "attachmentDenied": "You don't have access",
     "attachmentReload": "Reload attachment",
     "title": "Chats",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2306,6 +2306,9 @@
     "hypothesisSection": "효과 가설"
   },
   "chats": {
+    "commandBlockedLead": "{agentName} 에이전트는 채팅 슬래시 커맨드를 직접 실행하지 않습니다.",
+    "commandBlockedAlt": "대신 자연어로 요청해 보세요 — 예: \"{command} 스킬로 …\"",
+    "commandBlockedSettings": "런타임 설정 보기",
     "attachmentDenied": "접근 권한이 없습니다",
     "attachmentReload": "첨부를 다시 불러오기",
     "title": "채팅",

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, RefreshCw } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { ChatBubble } from './chat-bubble';
+import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ChatInput } from './chat-input';
 import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
@@ -44,6 +45,9 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string | null>(null);
   const [showNewIndicator, setShowNewIndicator] = useState(false);
+  // S5: 미지원 런타임 커맨드 차단 hint — 트리거 메시지 id에 keyed된 ephemeral state.
+  // POST 응답 command_gate.blocked에서만 적재(persist 안 함·reload 시 소멸).
+  const [commandHints, setCommandHints] = useState<Record<string, BlockedHint[]>>({});
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
   const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
@@ -255,7 +259,14 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
       return;
     }
     const payload = (raw.data ?? raw) as Record<string, unknown>;
-    addMessage(normalizeToMessage(payload));
+    const sent = normalizeToMessage(payload);
+    addMessage(sent);
+    // S5: 미지원 런타임 차단 hint를 트리거 메시지에 keyed로 적재(차단 발생 시에만 키 존재).
+    const gate = raw.command_gate as { blocked?: BlockedHint[] } | undefined;
+    const blocked = gate?.blocked;
+    if (blocked?.length) {
+      setCommandHints((prev) => ({ ...prev, [sent.id]: blocked }));
+    }
   }, [threadId, addMessage, apiPrefix, pathname, router]);
 
   // chat-attach: 파일을 GCS에 업로드(서버사이드)하고 첨부 메타를 반환 — 유령경로(/api/chats/.../upload) 폐기.
@@ -419,14 +430,19 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
                       const prev = group.messages[idx - 1];
                       const isGrouped = Boolean(prev && prev.created_by === msg.created_by);
                       return (
-                        <ChatBubble
-                          key={msg.id}
-                          message={msg}
-                          isMine={msg.created_by === currentTeamMemberId}
-                          isGrouped={isGrouped}
-                          onOpenThread={openThread}
-                          onDelete={handleDeleteMessage}
-                        />
+                        <Fragment key={msg.id}>
+                          <ChatBubble
+                            message={msg}
+                            isMine={msg.created_by === currentTeamMemberId}
+                            isGrouped={isGrouped}
+                            onOpenThread={openThread}
+                            onDelete={handleDeleteMessage}
+                          />
+                          {/* S5: 트리거 메시지 직후 차단 hint notice(차단 에이전트별 1건) */}
+                          {commandHints[msg.id]?.map((h) => (
+                            <CommandHintNotice key={h.agent_id} hint={h} />
+                          ))}
+                        </Fragment>
                       );
                     })}
                   </div>

--- a/apps/web/src/components/chat/command-hint-notice.tsx
+++ b/apps/web/src/components/chat/command-hint-notice.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight, Info } from 'lucide-react';
+import { useTranslations } from 'next-intl';
+
+/**
+ * S4 capability gate가 발신자 응답(`command_gate.blocked[]`)으로 돌려주는 차단 hint 1건.
+ * BE는 facts(agent_name·command·runtime_type)만 제공 — 자연어 대안 카피는 FE가 i18n으로 구성.
+ */
+export interface BlockedHint {
+  agent_id: string;
+  agent_name: string;
+  runtime_type: string | null;
+  command: string;
+  reason: string;
+}
+
+/**
+ * 미지원 런타임 에이전트에 슬래시 커맨드를 보냈을 때 timeline에 렌더되는 가이드 카드.
+ * 참여자 버블(아바타+말풍선)과 구별되는 inset 시스템 notice — info 톤(에러 아닌 친절한 리디렉션).
+ */
+export function CommandHintNotice({ hint }: { hint: BlockedHint }) {
+  const t = useTranslations('chats');
+  return (
+    <div className="mx-2 flex items-start gap-2.5 rounded-xl border border-info-border bg-info-tint px-3.5 py-2.5">
+      <Info className="mt-0.5 h-[18px] w-[18px] shrink-0 text-info" aria-hidden />
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm text-foreground">
+          {t('commandBlockedLead', { agentName: hint.agent_name })}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {t('commandBlockedAlt', { command: hint.command })}
+        </p>
+        <Link
+          href={`/settings/members/agents/${hint.agent_id}`}
+          className="inline-flex items-center gap-1 rounded text-xs font-medium text-info underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {t('commandBlockedSettings')}
+          <ArrowRight className="h-3.5 w-3.5" aria-hidden />
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 개요
미지원 런타임 에이전트에게 채팅에서 슬래시 커맨드(`/cmd`)를 보내면, S4 백엔드가 발신자 응답에 차단 hint를 반환한다. **S5 = FE가 그 hint를 chat timeline에 가이드 notice로 렌더** + 자연어 skill 대안 + 런타임 설정 이동 affordance. 핸드오프 doc `handoff-e-chat-cmd-s5-command-hint` 충실 구현.

## 데이터 계약 (S4 — triple-verified, BE 무변경)
`POST .../messages` 응답 **top-level** `command_gate.blocked[]` (`forked` 형제, message metadata 아님):
```
command_gate: { blocked: [ { agent_id, agent_name, runtime_type, command, reason:"unsupported_runtime" } ] }
```
- 차단 발생 시에만 키 존재. BE는 facts만 제공 — 자연어 대안 카피는 FE가 i18n으로 구성.

## 렌더 모델 (핵심)
- **hint = POST 응답 필드(persisted 메시지 아님)** → **트리거 메시지 id에 keyed된 ephemeral client state**로 적재
- ⚠️ **synthetic ChatMessage 주입 안 함** (persist/SSE/ordering 오염 회피)
- **sender-only · ephemeral** — reload/네비게이션 시 소멸 (just-in-time 가이드, 설계 의도)

## 구현
- `CommandHintNotice` **신규 컴포넌트 1** (`components/chat/command-hint-notice.tsx`) — 참여자 버블과 구별되는 inset 시스템 가이드 카드
  - **톤: `info`** (에러 아닌 친절한 리디렉션) — info-tint/border/text 토큰 + Info 아이콘. **destructive 빨강 금지**
  - 매직 hex 0, Info 아이콘 + 텍스트 라벨 (색상 단독 신호 금지 a11y), settings `<Link>`(키보드 포커스)
- `chat-view.tsx`: `BlockedHint` 타입 + `commandHints` ephemeral state(msg.id keyed) + handleSend에서 `raw.command_gate.blocked` 적재 + 렌더 루프에서 트리거 메시지 직후 notice 렌더(Fragment)
- **멀티에이전트**: `blocked[]` N건 → 차단 에이전트별 1 notice
- i18n 3키 `chats` en/ko: `commandBlockedLead`/`Alt`/`Settings` — particle-safe(`{agentName} 에이전트는` 고정 조사)

## 검증
- `pnpm type-check` ✅ (에러 0)
- `pnpm lint` ✅ (에러 0 / 변경 파일 경고 0)
- `pnpm build` ✅
- 시각/동작 검증(info 톤·자연어 대안·settings 링크·멀티에이전트 N건·ephemeral): dev 배포 후 유나 가디언 + 까심 QA

## 스크린샷
인증 채팅 세션 + 미지원 런타임 에이전트 대화가 필요해 로컬 캡처는 보류 — 시각/동작 검증은 dev(develop auto-deploy)에서 가디언/QA 게이트로 수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)