### PR TITLE
[SID:03428448] fix(chat): 멀티라인 메시지 단일 줄바꿈 보존 (remark-breaks)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,6 +58,7 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "shadcn": "^4.1.2",
     "shiki": "^4.1.0",

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useRef, useState } from 'react';
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import { Bot, MessageSquare, Terminal, User } from 'lucide-react';
 import { useTranslations } from 'next-intl';
 import type { ChatMessage } from '@/hooks/use-chat-sse';
@@ -53,7 +54,7 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
 
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={[remarkGfm, remarkBreaks]}
       urlTransform={(url) =>
         url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
+      remark-breaks:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -4318,6 +4321,9 @@ packages:
   mdast-util-mdxjs-esm@2.0.1:
     resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
+  mdast-util-newline-to-break@2.0.0:
+    resolution: {integrity: sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==}
+
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
 
@@ -4964,6 +4970,9 @@ packages:
 
   rehype-sanitize@6.0.0:
     resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  remark-breaks@4.0.0:
+    resolution: {integrity: sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -10051,6 +10060,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mdast-util-newline-to-break@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-find-and-replace: 3.0.2
+
   mdast-util-phrasing@4.1.0:
     dependencies:
       '@types/mdast': 4.0.4
@@ -10944,6 +10958,12 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
+
+  remark-breaks@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-newline-to-break: 2.0.0
+      unified: 11.0.5
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
## 문제
채팅 `ChatMarkdown`이 `remarkPlugins={[remarkGfm]}`만 사용 → 단일 `\n`이 markdown 표준대로 collapse. 산티아고 `/status` 같은 멀티라인+bold 결과가 한 줄로 뭉침.

## 수정
- `chat-bubble.tsx` `ChatMarkdown`: `remarkPlugins={[remarkGfm, remarkBreaks]}` — 단일 `\n` → `<br>` (Discord/Slack/GitHub comment 동형, 유저가 친 줄바꿈 보존)
- `remark-breaks ^4.0.0` 의존 추가 (remark-gfm ^4와 동일 메이저·pnpm-lock 갱신)

## 무회귀 근거
- **plain-text 브랜치**(`!hasMarkdown && !hasMention`)는 이미 `whitespace-pre-wrap`로 `\n` 보존 → 영향 없음(원래 collapse는 markdown 경로만)
- **command 버블**(S8 `isCommand`)은 별도 `<code>` 렌더 → ChatMarkdown 미경유 → 무영향
- 리터럴 dequote·bold·list·link·mention·코드블록 렌더 무영향(remark-breaks는 single-`\n`→`<br>`만 추가)

## 스코프
`embed-card.tsx`도 동일 `remarkGfm`-only(엔티티 카드 description/AC/objective)지만 **다른 surface**(채팅 메시지 아님)이고 기존 엔티티 렌더 회귀 surface라 본 PR 제외. break 통일 원하면 동일 1줄 추가로 후속(PO 판단).

## 검증
- `pnpm type-check` ✅ (에러 0)
- `pnpm lint` ✅ (chat-bubble 경고 0)
- `pnpm build` ✅

## 스크린샷
인증 채팅 세션 필요해 로컬 캡처 보류 — 멀티라인(/status) 줄바꿈 픽셀은 dev에서 가디언/QA. 데모 직결로 E-CHAT-CMD prod 프로모션에 동반 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)