### PR TITLE
[SID:f2ec5395] fix(inbox): N회 변경 카운트 칩 클리핑 해소

### DIFF
--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -449,12 +449,15 @@ export default function InboxPage() {
                             </div>
                             <div className="min-w-0 flex-1 space-y-1">
                               <div className="flex items-start justify-between gap-2">
-                                <p className={`min-w-0 flex-1 truncate text-sm ${item.hasUnread ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}>
-                                  {item.latest.title}
-                                  <span className="ml-1.5 inline-block rounded-full border border-brand/30 bg-brand/10 px-1.5 py-0.5 align-middle text-[10px] font-medium text-brand">
+                                {/* f2ec5395 fix: 카운트 칩을 truncate <p> 밖 shrink-0 형제로 — 긴 title 잘려도 칩 항상 표시(AC1 핵심) */}
+                                <div className="flex min-w-0 flex-1 items-center gap-1.5">
+                                  <p className={`min-w-0 truncate text-sm ${item.hasUnread ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}>
+                                    {item.latest.title}
+                                  </p>
+                                  <span className="shrink-0 rounded-full border border-brand/30 bg-brand/10 px-1.5 py-0.5 text-[10px] font-medium text-brand">
                                     {t('statusChangeCount', { count: item.count })}
                                   </span>
-                                </p>
+                                </div>
                                 <span className="shrink-0 text-[11px] text-muted-foreground">{formatTime(item.latest.created_at)}</span>
                               </div>
                               {item.hasUnread ? (


### PR DESCRIPTION
## RC (가디언 라이브 픽셀)
#1349 collapsed 그룹 엔트리에서 **"N회 변경" 카운트 칩이 100% 클리핑** — 칩이 title의 `<p class="truncate">` 안에 inline이라, 긴 `story_status_changed` title("스토리 상태 변경: {제목} → {상태}"는 항상 김)이 truncate되며 칩이 잘림. AC1 핵심(최신상태 + **횟수** consolidation)이 미표시되어 그룹의 존재 이유가 무력.

## 수정 (CSS 구조만)
칩을 truncate `<p>` **밖 `shrink-0` 형제**로 분리:
- `<div class="flex min-w-0 flex-1 items-center gap-1.5">` 컨테이너
- title `<p class="truncate min-w-0">` (긴 title만 truncate)
- 칩 `<span class="shrink-0 ...">` (항상 표시)
- timestamp는 기존대로 우측 shrink-0

→ 긴 title은 줄어들되 카운트 칩은 항상 보임.

## 범위
**칩 클리핑 1건만.** 나머지(접힘/펼침 이력·최신 success dot·타알림 무영향·클릭→`/board?story={id}`·light/dark)는 #1349 가디언 픽셀 PASS·무변경. BE 변경 0.

## 검증
`pnpm type-check` ✅ / `pnpm lint`(inbox 0) ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)