### PR TITLE
[SID:1aeecdde] feat(chat): emit working/typing presence during agent reply generation (P2 BE)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -22,6 +22,7 @@ from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.agent_deployment import AgentAuditLog
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
+from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
@@ -287,6 +288,10 @@ async def _dispatch_conversation_event(
         )
         db.add(event)
         events_to_push.append((str(pid), event))
+        # 1aeecdde P2: agent recipient 에게 메시지가 dispatch = 답장 생성 시작 → working emit.
+        # 그 agent 가 reply 를 보내면 send_message 에서 clear, 안 보내면 TTL 자동 소멸(ephemeral).
+        if m_type == "agent":
+            chat_presence.set_working(str(conversation.id), str(pid))
 
     # flush로 event.id 확보
     await db.flush()
@@ -860,6 +865,45 @@ async def list_messages(
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
 
 
+@router.get("/{conversation_id}/working")
+async def list_working_members(
+    conversation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """1aeecdde P2: GET /api/v2/conversations/{id}/working — 지금 답장 생성 중인 member 목록.
+
+    presence(online) 와 **별도 축**(working/typing). FE 는 이 결과로 "...is typing"/working dot 을
+    online dot 과 분리 표시(AC2). ephemeral·TTL 기반(미reply 시 자동 소멸). participant 만 조회 가능.
+    응답: {"data": [{"member_id", "state", "updated_at"}]}.
+    """
+    conv_project_id = (await db.execute(
+        select(Conversation.project_id).where(
+            Conversation.id == conversation_id, Conversation.org_id == org_id
+        )
+    )).scalar_one_or_none()
+    if conv_project_id is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    # 본인은 제외 — 내가 typing 중인 건 내 UI에 안 띄움(memo presence.py 동형).
+    items = [
+        e for e in chat_presence.list_working(str(conversation_id))
+        if e["member_id"] != str(sender.id)
+    ]
+    return {"data": items}
+
+
 @router.post("/{conversation_id}/participants", status_code=201)
 async def add_participant(
     conversation_id: uuid.UUID,
@@ -975,6 +1019,11 @@ async def send_message(
     )).scalar_one_or_none()
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
+
+    # 1aeecdde P2: sender 가 이 conversation 에 메시지를 보냄 = 답장 생성 종료 → working clear.
+    # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.
+    # 휴먼 sender 면 set 된 적 없어 no-op(무해). agent reply 면 즉시 "...typing" 해제.
+    chat_presence.clear_working(str(conversation_id), str(sender.id))
 
     # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
     # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.

--- a/backend/app/services/chat_presence.py
+++ b/backend/app/services/chat_presence.py
@@ -1,0 +1,76 @@
+"""1aeecdde P2: 채팅 working/typing 인디케이터 — 답장 생성구간 ephemeral 신호.
+
+memo `presence.py`(viewing/typing) 동형 — in-memory·TTL 기반 ephemeral 저장소. presence P1
+(online/offline = 연결 축)과 **별도 축**(working = 작업 축). 같은 dot에 합치지 말 것(AC2):
+- online: SSE 연결 여부(team_members.presence_status·DB 도출)
+- working: 지금 답장을 생성 중인지(이 모듈·in-memory ephemeral)
+
+emit 훅(BE):
+- set_working: 메시지가 agent participant 에게 dispatch 될 때(=이벤트 수신점). 답장 생성 시작.
+- clear_working: 그 agent 가 conversation 에 메시지를 보낼 때(=reply POST). 생성 종료.
+- 둘 다 안 와도 _TTL_SEC 후 자동 소멸(에이전트가 답장 안 하기로 한 경우 등 — ephemeral 안전망).
+
+⚠️ 멀티인스턴스 한계: presence.py 와 동일하게 인스턴스-로컬 in-memory. 같은 인스턴스가 emit·GET
+을 처리해야 보인다. 크로스-인스턴스 실시간(Cloud Run 다인스턴스)은 pubsub/SSE 브로드캐스트가
+필요하며 FE 전송 설계(유나/미르코)와 함께 후속(P3)으로 다룬다. 본 P2 는 spec 의 'presence.py
+동형 in-memory poll' 계약을 따른다.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+
+# 답장 생성 구간 ephemeral TTL(초). presence.py(45s) 동형. 생성이 더 길면 인디케이터가 일찍
+# 사라질 수 있고(refresh 없음), 답장을 안 하면 최대 이 시간만큼 잔존한다 — ephemeral 안전망.
+_TTL_SEC = 45
+
+VALID_STATES = ("working", "typing")
+
+
+@dataclass
+class WorkingEntry:
+    member_id: str
+    state: str  # "working" | "typing"
+    updated_at: float = field(default_factory=time.time)
+
+
+# conversation_id(str) → {member_id(str): WorkingEntry}
+_working_store: dict[str, dict[str, WorkingEntry]] = {}
+
+
+def _evict_expired(conversation_id: str) -> None:
+    now = time.time()
+    store = _working_store.get(conversation_id, {})
+    expired = [mid for mid, e in store.items() if now - e.updated_at > _TTL_SEC]
+    for mid in expired:
+        store.pop(mid, None)
+    if not store:
+        _working_store.pop(conversation_id, None)
+
+
+def set_working(conversation_id: str, member_id: str, state: str = "working") -> None:
+    """답장 생성 시작 — member 를 conversation 의 working 집합에 등록(TTL 갱신)."""
+    if state not in VALID_STATES:
+        state = "working"
+    _working_store.setdefault(conversation_id, {})[member_id] = WorkingEntry(
+        member_id=member_id, state=state
+    )
+
+
+def clear_working(conversation_id: str, member_id: str) -> None:
+    """답장 생성 종료(reply POST) — member 의 working 신호 제거. 없으면 무해(no-op)."""
+    store = _working_store.get(conversation_id)
+    if store is None:
+        return
+    store.pop(member_id, None)
+    if not store:
+        _working_store.pop(conversation_id, None)
+
+
+def list_working(conversation_id: str) -> list[dict]:
+    """conversation 에서 현재 working/typing 중인 member 목록(만료분 제외)."""
+    _evict_expired(conversation_id)
+    return [
+        {**asdict(e)}
+        for e in _working_store.get(conversation_id, {}).values()
+    ]

--- a/backend/tests/test_chat_presence.py
+++ b/backend/tests/test_chat_presence.py
@@ -1,0 +1,91 @@
+"""1aeecdde P2: 채팅 working/typing ephemeral 신호(chat_presence) 단위 테스트.
+
+AC1: 답장 생성구간 working emit·TTL 자동 소멸. AC2: presence(online)와 별도 축.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from app.services import chat_presence
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    """각 테스트 격리 — 모듈 전역 store 초기화."""
+    chat_presence._working_store.clear()
+    yield
+    chat_presence._working_store.clear()
+
+
+def test_set_then_list_returns_member():
+    conv = str(uuid.uuid4())
+    mid = str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    items = chat_presence.list_working(conv)
+    assert len(items) == 1
+    assert items[0]["member_id"] == mid
+    assert items[0]["state"] == "working"
+
+
+def test_clear_removes_member():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    chat_presence.clear_working(conv, mid)
+    assert chat_presence.list_working(conv) == []
+
+
+def test_clear_missing_is_noop():
+    """answer 없이 clear(휴먼 sender 등) — 예외 없이 no-op."""
+    chat_presence.clear_working(str(uuid.uuid4()), str(uuid.uuid4()))  # 예외 없어야 함
+
+
+def test_invalid_state_falls_back_to_working():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid, state="bogus")
+    assert chat_presence.list_working(conv)[0]["state"] == "working"
+
+
+def test_typing_state_preserved():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid, state="typing")
+    assert chat_presence.list_working(conv)[0]["state"] == "typing"
+
+
+def test_ttl_eviction():
+    """TTL 초과 entry 는 list 시 제거(ephemeral 자동 소멸 — 미reply 안전망)."""
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    # updated_at 을 TTL 이전으로 backdate
+    chat_presence._working_store[conv][mid].updated_at = time.time() - chat_presence._TTL_SEC - 1
+    assert chat_presence.list_working(conv) == []
+    # 전부 만료되면 conversation 키도 정리
+    assert conv not in chat_presence._working_store
+
+
+def test_multiple_members_independent():
+    conv = str(uuid.uuid4())
+    a, b = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, a)
+    chat_presence.set_working(conv, b, state="typing")
+    chat_presence.clear_working(conv, a)
+    items = chat_presence.list_working(conv)
+    assert len(items) == 1 and items[0]["member_id"] == b
+
+
+def test_set_emit_hook_wired_in_dispatch():
+    """_dispatch_conversation_event 가 agent recipient 에 set_working 호출하는지 소스 가드."""
+    import inspect
+    from app.routers.conversations import _dispatch_conversation_event
+    src = inspect.getsource(_dispatch_conversation_event)
+    assert "chat_presence.set_working" in src
+
+
+def test_clear_emit_hook_wired_in_send_message():
+    """send_message 가 clear_working 호출하는지 소스 가드(원본 conversation_id 기준)."""
+    import inspect
+    from app.routers.conversations import send_message
+    src = inspect.getsource(send_message)
+    assert "chat_presence.clear_working" in src


### PR DESCRIPTION
## Story
`1aeecdde` [BE/FE] working/typing 인디케이터 — 답장 생성구간 emit (P2). presence P1(online/offline) 위에 얹는 **별도 축**. 본 PR은 **BE emit** 파트(FE 채팅 표시는 유나/미르코 병행).

## Design — working(작업) 축 ≠ online(연결) 축 (AC2)
- **online**: SSE 연결 여부 → `team_members.presence_status`(P1·DB 도출)
- **working**: 지금 답장을 생성 중인지 → 본 PR(ephemeral·in-memory)

memo `presence.py`(viewing/typing) 동형 — in-memory·TTL ephemeral 저장소.

## Change
- `app/services/chat_presence.py` (신규): conversation-scoped in-memory store·TTL 45s(presence.py 동형). `set_working`/`clear_working`/`list_working`.
- **emit 훅 (BE)**:
  - `set_working`: 메시지가 **agent recipient에게 dispatch**될 때(`_dispatch_conversation_event` = 이벤트 수신점) → 답장 생성 시작.
  - `clear_working`: 그 agent가 conversation에 **메시지를 보낼 때**(`send_message` = reply POST·fork 전 원본 conversation_id) → 생성 종료.
  - 답장 안 하면 **TTL 자동 소멸**(에이전트가 답 안 하기로 한 경우 ephemeral 안전망).
- `GET /api/v2/conversations/{id}/working` (신규·participant 한정): 현재 working/typing member 목록(본인 제외).

## FE 계약 (유나/미르코 정합 요청)
- 응답: `{"data": [{"member_id", "state": "working"|"typing", "updated_at"}]}`
- 폴링 GET(presence.py 동형). FE는 conversation 열람 중 N초 폴링 → "...is typing"/working dot을 **online dot과 분리** 표시(AC2).
- **멀티인스턴스 한계**: presence.py와 동일 인스턴스-로컬 in-memory(emit·GET 같은 인스턴스 처리 필요). Cloud Run 다인스턴스 실시간 정합은 pubsub/SSE 브로드캐스트 필요 → FE 전송 설계와 함께 **후속(P3)**. 본 P2는 spec의 'presence.py 동형 in-memory poll' 계약 준수.
- TTL 45s: 생성이 더 길면 인디케이터 일찍 사라질 수 있음(refresh 없음) → P3에서 connector heartbeat로 정밀화 가능.
- **emit 시작 휴리스틱**: dispatch-to-agent(=수신) 기준(BE는 '실제 생성 중'을 직접 못 봄). 멀티-agent 채널서 답 안 하는 agent의 false-positive는 TTL-bound. 1:1 DM/@mention(주 유스케이스)은 정확.

## Tests
`backend/tests/test_chat_presence.py` 9건: set/clear/list·TTL eviction·invalid-state fallback·multi-member 독립·emit 훅 소스 가드. 전체 백엔드 **1725 passed**(pre-existing e2e_dev 네트워크 실패 2건 무관). 마이그레이션 없음(in-memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)