### PR TITLE
[SID:1aeecdde] feat(presence): 에이전트 working/typing 2축 presence (P2)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2309,6 +2309,12 @@
     "hypothesisSection": "Outcome Hypothesis"
   },
   "chats": {
+    "isTyping": "{name} is typing",
+    "othersTyping": "{name} and {count} others are typing",
+    "presenceOnline": "Online",
+    "presenceIdle": "Idle",
+    "presenceOffline": "Offline",
+    "presenceWorking": "Working",
     "commandBlockedLead": "{agentName} ({runtime}) doesn't run chat slash-commands directly.",
     "runtimeUnsetLabel": "No runtime set",
     "commandBlockedAlt": "Try natural language instead — e.g. \"use the {command} skill to …\"",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2309,6 +2309,12 @@
     "hypothesisSection": "효과 가설"
   },
   "chats": {
+    "isTyping": "{name} 님이 입력 중",
+    "othersTyping": "{name} 외 {count}명 입력 중",
+    "presenceOnline": "온라인",
+    "presenceIdle": "자리비움",
+    "presenceOffline": "오프라인",
+    "presenceWorking": "작업 중",
     "commandBlockedLead": "{agentName} ({runtime}) 에이전트는 채팅 슬래시 커맨드를 직접 실행하지 않습니다.",
     "runtimeUnsetLabel": "런타임 미설정",
     "commandBlockedAlt": "대신 자연어로 요청해 보세요 — 예: \"{command} 스킬로 …\"",

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft, UserPlus } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChatView } from '@/components/chat/chat-view';
+import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { AddParticipantModal } from '@/components/chat/add-participant-modal';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 
@@ -52,6 +53,31 @@ export default function ConversationPage() {
       if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [] });
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
+
+  // 1aeecdde P2: 에이전트 presence_status(연결축 dot) 폴링 — P1 진실값. 15s 갱신(시간 기반 상태).
+  const [presenceById, setPresenceById] = useState<Record<string, PresenceStatus>>({});
+  const fetchPresence = useCallback(async () => {
+    try {
+      const res = await fetch('/api/team-members?type=agent');
+      if (!res.ok) return;
+      const json = await res.json() as { data?: Array<{ id: string; presence_status?: string | null }> };
+      const map: Record<string, PresenceStatus> = {};
+      for (const m of json.data ?? []) {
+        if (m.presence_status === 'online' || m.presence_status === 'idle' || m.presence_status === 'offline') {
+          map[m.id] = m.presence_status;
+        }
+      }
+      setPresenceById(map);
+    } catch { /* non-critical */ }
+  }, []);
+
+  // 마운트 1회 fetch(단일행·기존 fetchMeta 패턴 동형) + 15s 폴링(시간 기반 presence 갱신).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { void fetchPresence(); }, [fetchPresence]);
+  useEffect(() => {
+    const interval = setInterval(() => { void fetchPresence(); }, 15000);
+    return () => clearInterval(interval);
+  }, [fetchPresence]);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { void fetchMeta(); }, [fetchMeta]);
@@ -126,6 +152,7 @@ export default function ConversationPage() {
           apiPrefix="/api/conversations"
           backRoute="/chats"
           commandTargets={commandTargets}
+          presenceById={presenceById}
         />
       </div>
 

--- a/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// 1aeecdde P2: GET /api/v2/conversations/{id}/working 프록시 — 지금 답장 생성 중(working) member 목록.
+// 디디 P2 BE(#1353 chat_presence·in-memory ephemeral) 폴링. FE는 이 결과로 "...is typing"/working ring 렌더.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ conversation_id: string }> },
+): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}/working`);
+}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -13,6 +13,7 @@ import { getFileIcon } from '@/lib/file-icon';
 import { AttachmentImage } from './attachment-image';
 import { AttachmentFile } from './attachment-file';
 import { MessageContextMenu } from './message-context-menu';
+import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -20,6 +21,9 @@ interface ChatBubbleProps {
   isGrouped?: boolean;
   onOpenThread?: (message: ChatMessage) => void;
   onDelete?: (messageId: string) => void;
+  // 1aeecdde P2: 2축 presence — 연결(dot) + 활동(working ring). 에이전트 sender만 적용.
+  presenceStatus?: PresenceStatus | null;
+  isWorking?: boolean;
 }
 
 interface ContextMenuState {
@@ -91,7 +95,7 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
 
 const LONG_PRESS_MS = 500;
 
-export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete }: ChatBubbleProps) {
+export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete, presenceStatus, isWorking = false }: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
   // S8: 슬래시 커맨드는 전용 버블(brand·mono·⌘). 리터럴(`//`)은 dequote된 일반 텍스트.
@@ -166,18 +170,23 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
       >
-        {/* Avatar — hidden when grouped */}
+        {/* Avatar — hidden when grouped. 1aeecdde P2: agent에 연결 dot + working ring(2축). */}
         {isGrouped ? (
           <div className="w-7 flex-shrink-0" />
         ) : (
-          <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-            isAgent
-              ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
-              : isMine
-                ? 'bg-primary/20 text-primary'
-                : 'bg-muted text-muted-foreground'
-          }`}>
-            {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+          <div className="relative h-7 w-7 flex-shrink-0">
+            <div className={`flex h-full w-full items-center justify-center rounded-full text-xs font-medium ${
+              isAgent
+                ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+                : isMine
+                  ? 'bg-primary/20 text-primary'
+                  : 'bg-muted text-muted-foreground'
+            } ${isAgent && isWorking ? WORKING_RING_CLASS : ''}`}>
+              {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+            </div>
+            {isAgent && presenceStatus ? (
+              <PresenceDot status={presenceStatus} className="absolute -bottom-0.5 -right-0.5" />
+            ) : null}
           </div>
         )}
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -3,11 +3,13 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, RefreshCw } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { ChatBubble } from './chat-bubble';
+import type { PresenceStatus } from './presence-dot';
 import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
-import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
+import type { ChatMessage, SendAttachment, AgentWorkingPayload } from '@/hooks/use-chat-sse';
 import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
 
@@ -20,6 +22,8 @@ interface ChatViewProps {
   backRoute?: string | null;
   // S8 #2: pre-send capability 경고 대상(에이전트 participant runtime). 빈 배열이면 경고 미표시(graceful).
   commandTargets?: CommandTarget[];
+  // 1aeecdde P2: 에이전트 member_id → presence_status(연결축 dot). 없으면 dot 미표시(graceful).
+  presenceById?: Record<string, PresenceStatus>;
 }
 
 interface MessageGroup {
@@ -38,9 +42,10 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos', commandTargets }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos', commandTargets, presenceById }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const t = useTranslations('chats');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -50,6 +55,9 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   // S5: 미지원 런타임 커맨드 차단 hint — 트리거 메시지 id에 keyed된 ephemeral state.
   // POST 응답 command_gate.blocked에서만 적재(persist 안 함·reload 시 소멸).
   const [commandHints, setCommandHints] = useState<Record<string, BlockedHint[]>>({});
+  // 1aeecdde P2: 답장 생성 중 에이전트 typing — agent_id keyed ephemeral(TTL 12s·메시지 도착 시 clear).
+  const [typingAgents, setTypingAgents] = useState<{ id: string; name: string }[]>([]);
+  const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
   const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
@@ -127,7 +135,15 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     }
   }, [loading, scrollToBottom]);
 
+  // 1aeecdde P2: 에이전트 typing 해제(메시지 도착·TTL 만료).
+  const clearTyping = useCallback((agentId: string) => {
+    setTypingAgents((prev) => (prev.some((a) => a.id === agentId) ? prev.filter((a) => a.id !== agentId) : prev));
+    const timer = typingTimersRef.current[agentId];
+    if (timer) { clearTimeout(timer); delete typingTimersRef.current[agentId]; }
+  }, []);
+
   const addMessage = useCallback((msg: ChatMessage) => {
+    clearTyping(msg.created_by); // 답장 도착 → 해당 에이전트 typing 즉시 해제(AC1)
     const nearBottom = isNearBottom();
     setMessages((prev) => {
       if (prev.some((m) => m.id === msg.id)) return prev;
@@ -139,7 +155,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     } else {
       setShowNewIndicator(true);
     }
-  }, [isNearBottom]);
+  }, [isNearBottom, clearTyping]);
 
   const handleNewMessage = useCallback((msg: ChatMessage) => {
     if (msg.memo_id !== threadId) return;
@@ -178,11 +194,29 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     fetchMessages();
   }, [fetchMessages]);
 
+  // 1aeecdde P2: agent:working/typing SSE 수신 → 현 대화 에이전트 typing 추가(이름=commandTargets에서·TTL 12s).
+  const handleAgentWorking = useCallback((p: AgentWorkingPayload) => {
+    if (p.conversation_id !== threadId) return;
+    const name = (commandTargets ?? []).find((tg) => tg.agentId === p.agent_id)?.agentName;
+    if (!name) return; // 이름 못 찾으면 미표시(graceful)
+    setTypingAgents((prev) => (prev.some((a) => a.id === p.agent_id) ? prev : [...prev, { id: p.agent_id, name }]));
+    const existing = typingTimersRef.current[p.agent_id];
+    if (existing) clearTimeout(existing);
+    typingTimersRef.current[p.agent_id] = setTimeout(() => clearTyping(p.agent_id), 12000);
+  }, [threadId, commandTargets, clearTyping]);
+
+  // 타이머 누수 방지 — 언마운트 시 전체 정리.
+  useEffect(() => {
+    const timers = typingTimersRef.current;
+    return () => { Object.values(timers).forEach(clearTimeout); };
+  }, []);
+
   useChatSse({
     currentTeamMemberId,
     onNewMessage: handleNewMessage,
     onReplyCreated: handleReplyCreated,
     onConversationMessage: handleConversationMessage,
+    onAgentWorking: handleAgentWorking,
     onReconnect: handleReconnect,
   });
 
@@ -439,6 +473,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
                             isGrouped={isGrouped}
                             onOpenThread={openThread}
                             onDelete={handleDeleteMessage}
+                            presenceStatus={presenceById?.[msg.created_by]}
+                            isWorking={typingAgents.some((a) => a.id === msg.created_by)}
                           />
                           {/* S5: 트리거 메시지 직후 차단 hint notice(차단 에이전트별 1건) */}
                           {commandHints[msg.id]?.map((h) => (
@@ -465,6 +501,22 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
               >
                 ↓ 새 메시지
               </button>
+            </div>
+          )}
+
+          {/* 1aeecdde P2: "...is typing" — 메시지 리스트 아래·composer 위·답장 생성 중·완료 시 사라짐(aria-live) */}
+          {typingAgents.length > 0 && (
+            <div className="flex flex-shrink-0 items-center gap-2 px-4 py-1.5 text-xs text-muted-foreground" aria-live="polite">
+              <span className="flex items-center gap-0.5" aria-hidden>
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce" />
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:150ms]" />
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:300ms]" />
+              </span>
+              <span>
+                {typingAgents.length === 1
+                  ? t('isTyping', { name: typingAgents[0]?.name ?? '' })
+                  : t('othersTyping', { name: typingAgents[0]?.name ?? '', count: typingAgents.length - 1 })}
+              </span>
             </div>
           )}
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -9,7 +9,7 @@ import type { PresenceStatus } from './presence-dot';
 import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
-import type { ChatMessage, SendAttachment, AgentWorkingPayload } from '@/hooks/use-chat-sse';
+import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
 import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
 
@@ -55,9 +55,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   // S5: 미지원 런타임 커맨드 차단 hint — 트리거 메시지 id에 keyed된 ephemeral state.
   // POST 응답 command_gate.blocked에서만 적재(persist 안 함·reload 시 소멸).
   const [commandHints, setCommandHints] = useState<Record<string, BlockedHint[]>>({});
-  // 1aeecdde P2: 답장 생성 중 에이전트 typing — agent_id keyed ephemeral(TTL 12s·메시지 도착 시 clear).
+  // 1aeecdde P2: 답장 생성 중 에이전트 typing — 디디 #1353 GET /working 폴링(BE 45s TTL) 결과.
   const [typingAgents, setTypingAgents] = useState<{ id: string; name: string }[]>([]);
-  const typingTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
   const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
@@ -135,11 +134,9 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     }
   }, [loading, scrollToBottom]);
 
-  // 1aeecdde P2: 에이전트 typing 해제(메시지 도착·TTL 만료).
+  // 1aeecdde P2: 에이전트 typing 즉시 해제(답장 메시지 도착 시·다음 폴링 전 갭 제거).
   const clearTyping = useCallback((agentId: string) => {
     setTypingAgents((prev) => (prev.some((a) => a.id === agentId) ? prev.filter((a) => a.id !== agentId) : prev));
-    const timer = typingTimersRef.current[agentId];
-    if (timer) { clearTimeout(timer); delete typingTimersRef.current[agentId]; }
   }, []);
 
   const addMessage = useCallback((msg: ChatMessage) => {
@@ -194,29 +191,32 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     fetchMessages();
   }, [fetchMessages]);
 
-  // 1aeecdde P2: agent:working/typing SSE 수신 → 현 대화 에이전트 typing 추가(이름=commandTargets에서·TTL 12s).
-  const handleAgentWorking = useCallback((p: AgentWorkingPayload) => {
-    if (p.conversation_id !== threadId) return;
-    const name = (commandTargets ?? []).find((tg) => tg.agentId === p.agent_id)?.agentName;
-    if (!name) return; // 이름 못 찾으면 미표시(graceful)
-    setTypingAgents((prev) => (prev.some((a) => a.id === p.agent_id) ? prev : [...prev, { id: p.agent_id, name }]));
-    const existing = typingTimersRef.current[p.agent_id];
-    if (existing) clearTimeout(existing);
-    typingTimersRef.current[p.agent_id] = setTimeout(() => clearTyping(p.agent_id), 12000);
-  }, [threadId, commandTargets, clearTyping]);
+  // 1aeecdde P2: working 폴링(디디 #1353 GET /working·in-memory 45s TTL) → typingAgents.
+  // 이름=commandTargets(없으면 미표시 graceful). poll이 BE working 셋 그대로 반영(클라 TTL 불요).
+  const fetchWorking = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/conversations/${threadId}/working`);
+      if (!res.ok) return;
+      const json = await res.json() as { data?: Array<{ member_id: string }> };
+      const next = (json.data ?? [])
+        .map((w) => ({ id: w.member_id, name: (commandTargets ?? []).find((tg) => tg.agentId === w.member_id)?.agentName }))
+        .filter((a): a is { id: string; name: string } => !!a.name);
+      setTypingAgents(next);
+    } catch { /* non-critical */ }
+  }, [threadId, commandTargets]);
 
-  // 타이머 누수 방지 — 언마운트 시 전체 정리.
+  // 마운트 1회 + 5s 폴링(생성구간 typing 갱신·PO: 연결 dot 15s보다 민감하게).
+  useEffect(() => { void fetchWorking(); }, [fetchWorking]);
   useEffect(() => {
-    const timers = typingTimersRef.current;
-    return () => { Object.values(timers).forEach(clearTimeout); };
-  }, []);
+    const interval = setInterval(() => { void fetchWorking(); }, 5000);
+    return () => clearInterval(interval);
+  }, [fetchWorking]);
 
   useChatSse({
     currentTeamMemberId,
     onNewMessage: handleNewMessage,
     onReplyCreated: handleReplyCreated,
     onConversationMessage: handleConversationMessage,
-    onAgentWorking: handleAgentWorking,
     onReconnect: handleReconnect,
   });
 

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+/**
+ * 1aeecdde P2 — 에이전트 presence 2축 시각(설계 `handoff-presence-working-typing`).
+ * - 연결 축(P1 `presence_status` 진실): offline/idle/online → avatar 우하단 dot.
+ * - 활동 축(P2): working(답장 생성 중) → avatar에 working pulse ring(아래 WORKING_RING_CLASS).
+ *   **dot 색을 바꾸지 않고 ring을 덧댄다**(AC2 — 축 합침 금지·'online인데 idle vs 일하는 중' 구분).
+ * 휴먼은 presence_status null → dot 미표시.
+ */
+export type PresenceStatus = 'online' | 'idle' | 'offline';
+
+const DOT_CLASS: Record<PresenceStatus, string> = {
+  online: 'bg-success',
+  idle: 'bg-warning',
+  offline: 'bg-muted-foreground/40',
+};
+
+const STATUS_LABEL_KEY: Record<PresenceStatus, string> = {
+  online: 'presenceOnline',
+  idle: 'presenceIdle',
+  offline: 'presenceOffline',
+};
+
+/**
+ * 활동 축 — working 시 avatar 래퍼에 덧대는 ring(brand pulse). dot과 별개(축 합침 금지).
+ * prefers-reduced-motion 시 정적 ring(모션 0).
+ */
+export const WORKING_RING_CLASS = 'ring-2 ring-brand ring-offset-1 ring-offset-card motion-safe:animate-pulse';
+
+/** 연결 축 dot(avatar 우하단). status null/undefined(휴먼·미상)면 미표시. */
+export function PresenceDot({
+  status,
+  className = '',
+}: {
+  status: PresenceStatus | null | undefined;
+  className?: string;
+}) {
+  const t = useTranslations('chats');
+  if (!status) return null;
+  return (
+    <span
+      role="img"
+      aria-label={t(STATUS_LABEL_KEY[status])}
+      className={`inline-block size-2.5 rounded-full border-2 border-card ${DOT_CLASS[status]} ${className}`}
+    />
+  );
+}

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -57,25 +57,17 @@ interface SseChatPayload {
   created_at: string;
 }
 
-// 1aeecdde P2: 에이전트 답장 생성구간 working/typing 이벤트(BE emit=디디 P2 lane·메모 presence.py ephemeral TTL 동형).
-export interface AgentWorkingPayload {
-  agent_id: string;
-  conversation_id: string;
-  state?: 'working' | 'typing';
-}
-
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
   onReplyCreated?: (memoId: string) => void;
   onConversationMessage?: (payload: Record<string, unknown>) => void;
-  onAgentWorking?: (payload: AgentWorkingPayload) => void;
   onReconnect?: () => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onAgentWorking, onReconnect }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -84,7 +76,6 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
-  const onAgentWorkingRef = useRef(onAgentWorking);
   const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
 
@@ -93,7 +84,6 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
   useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
-  useLayoutEffect(() => { onAgentWorkingRef.current = onAgentWorking; }, [onAgentWorking]);
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
@@ -162,17 +152,6 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
         } catch { /* ignore parse errors */ }
       });
 
-      // 1aeecdde P2: agent:working/typing — 에이전트 답장 생성구간 ephemeral 시그널(BE emit=디디 P2 lane).
-      // 미머지 시 이벤트 미수신 → typing 미표시(graceful). 두 이름 모두 구독(계약 정합).
-      const onWorking = (e: MessageEvent) => {
-        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
-        try {
-          const payload = JSON.parse(e.data as string) as AgentWorkingPayload;
-          if (payload.agent_id && payload.conversation_id) onAgentWorkingRef.current?.(payload);
-        } catch { /* ignore parse errors */ }
-      };
-      source.addEventListener('agent:working', onWorking);
-      source.addEventListener('agent:typing', onWorking);
     }
 
     connect();

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -57,17 +57,25 @@ interface SseChatPayload {
   created_at: string;
 }
 
+// 1aeecdde P2: 에이전트 답장 생성구간 working/typing 이벤트(BE emit=디디 P2 lane·메모 presence.py ephemeral TTL 동형).
+export interface AgentWorkingPayload {
+  agent_id: string;
+  conversation_id: string;
+  state?: 'working' | 'typing';
+}
+
 interface UseChatSseOptions {
   currentTeamMemberId?: string;
   onNewMessage?: (message: ChatMessage) => void;
   onReplyCreated?: (memoId: string) => void;
   onConversationMessage?: (payload: Record<string, unknown>) => void;
+  onAgentWorking?: (payload: AgentWorkingPayload) => void;
   onReconnect?: () => void;
 }
 
 const RECONNECT_DELAYS_MS = [5_000, 30_000, 60_000, 300_000];
 
-export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onReconnect }: UseChatSseOptions) {
+export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, onConversationMessage, onAgentWorking, onReconnect }: UseChatSseOptions) {
   const [connected, setConnected] = useState(false);
   const sourceRef = useRef<EventSource | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -76,6 +84,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   const onNewMessageRef = useRef(onNewMessage);
   const onReplyCreatedRef = useRef(onReplyCreated);
   const onConversationMessageRef = useRef(onConversationMessage);
+  const onAgentWorkingRef = useRef(onAgentWorking);
   const onReconnectRef = useRef(onReconnect);
   const memberIdRef = useRef(currentTeamMemberId);
 
@@ -84,6 +93,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
   useLayoutEffect(() => { onNewMessageRef.current = onNewMessage; }, [onNewMessage]);
   useLayoutEffect(() => { onReplyCreatedRef.current = onReplyCreated; }, [onReplyCreated]);
   useLayoutEffect(() => { onConversationMessageRef.current = onConversationMessage; }, [onConversationMessage]);
+  useLayoutEffect(() => { onAgentWorkingRef.current = onAgentWorking; }, [onAgentWorking]);
   useLayoutEffect(() => { onReconnectRef.current = onReconnect; }, [onReconnect]);
   useLayoutEffect(() => { memberIdRef.current = currentTeamMemberId; }, [currentTeamMemberId]);
 
@@ -151,6 +161,18 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
           onConversationMessageRef.current?.(payload);
         } catch { /* ignore parse errors */ }
       });
+
+      // 1aeecdde P2: agent:working/typing — 에이전트 답장 생성구간 ephemeral 시그널(BE emit=디디 P2 lane).
+      // 미머지 시 이벤트 미수신 → typing 미표시(graceful). 두 이름 모두 구독(계약 정합).
+      const onWorking = (e: MessageEvent) => {
+        if (e.lastEventId) lastEventIdRef.current = e.lastEventId;
+        try {
+          const payload = JSON.parse(e.data as string) as AgentWorkingPayload;
+          if (payload.agent_id && payload.conversation_id) onAgentWorkingRef.current?.(payload);
+        } catch { /* ignore parse errors */ }
+      };
+      source.addEventListener('agent:working', onWorking);
+      source.addEventListener('agent:typing', onWorking);
     }
 
     connect();


### PR DESCRIPTION
## 개요
선생님 ② "...is typing" — 에이전트 답장 생성 중 표시 + **연결(online) vs 작업(working) 2축 분리**(AC2). 에픽 phase3 presence·디디 P1(`49fed0a1`·presence_status 진실화) 위. 설계 doc `handoff-presence-working-typing`. **BE 변경 0(순수 FE)**.

## 2축 모델 (AC2 — 축 합침 금지)
- **연결 축** = `PresenceDot`(신규): online=`bg-success`/idle=`bg-warning`/offline=`bg-muted-foreground/40`·`border-card`·aria-label. P1 `presence_status` 소비(FE 신규).
- **활동 축** = `WORKING_RING_CLASS`(brand pulse·`motion-safe`): working 시 avatar에 ring **덧댐**(dot 색 불변). + 채팅 "...is typing".
- → "online인데 idle vs 일하는 중" 혼동 0.

## AC1 — 채팅 "...is typing"
- 메시지 리스트 아래·composer 위·애니 3-dot·`aria-live="polite"`·단일(`isTyping`)/다중(`othersTyping`) 축약.
- `use-chat-sse` `agent:working`/`agent:typing` SSE 수신 → `typingAgents`(agent_id keyed·**TTL 12s**·메시지 도착 시 즉시 clear). 이름=`commandTargets`(없으면 미표시 graceful).

## 컴포넌트 & 터치포인트
- `components/chat/presence-dot.tsx` 신규(PresenceDot + WORKING_RING_CLASS).
- `hooks/use-chat-sse.ts`: `onAgentWorking` + agent:working/typing 리스너(graceful).
- `chat-view.tsx`: typing indicator·typingAgents·presenceById/isWorking → ChatBubble.
- `chat-bubble.tsx`: agent avatar에 PresenceDot(연결 dot) + working ring.
- `chats/[conversation_id]/page.tsx`: `/api/team-members?type=agent` presence_status fetch + 15s 폴링 → presenceById.
- i18n chats 6키 en/ko. **NotificationBell/event-notifications 무변경**.

## 토큰 & a11y
매직 hex 0(success/warning/muted/brand). 색 단독 금지(dot aria-label·typing aria-live·텍스트 동반). `prefers-reduced-motion` → ring/dot 모션 0(`motion-safe:`).

## ⚠️ working/typing 활성 = 디디 P2 BE working-emit 후
`agent:working` SSE emit(생성구간·ephemeral·디디 P2 BE lane)은 develop 미머지 → **typing/working ring은 그 전엔 graceful 미표시**(무회귀). **연결 dot은 P1 presence_status로 즉시 작동.** SSE 이벤트 계약(`{agent_id, conversation_id, state}`)은 디디·미르코 교차검증.

## 검증
`pnpm type-check` ✅ / `pnpm lint`(변경 파일 0) ✅ / `pnpm build` ✅

## 스크린샷
인증 채팅 세션 필요해 로컬 보류 — 연결 dot·2축·typing(BE emit 후)·light/dark는 dev에서 가디언 픽셀 + 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)