### PR TITLE
[SID:1aeecdde] fix(presence): typing 폴링 5s→1.5s snappiness (선생님 피드백)

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -205,10 +205,10 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     } catch { /* non-critical */ }
   }, [threadId, commandTargets]);
 
-  // 마운트 1회 + 5s 폴링(생성구간 typing 갱신·PO: 연결 dot 15s보다 민감하게).
+  // 마운트 1회 + 1.5s 폴링(typing snappiness·선생님 피드백 "빠릿빠릿"·연결 dot 15s보다 훨씬 민감).
   useEffect(() => { void fetchWorking(); }, [fetchWorking]);
   useEffect(() => {
-    const interval = setInterval(() => { void fetchWorking(); }, 5000);
+    const interval = setInterval(() => { void fetchWorking(); }, 1500);
     return () => clearInterval(interval);
   }, [fetchWorking]);
 


### PR DESCRIPTION
## 선생님 usability 피드백
"is typing이 안 빠릿빠릿" — working 폴링 5s 간격이라 typing 표시까지 최대 5s lag.

## 수정 (1줄)
`chat-view.tsx` working `setInterval` **5000 → 1500**(~1.5s) — typing이 생성 시작 후 ~1.5s 내 표시. **CLEAR는 메시지 도착 시 즉시(clearTyping) 유지** → appear 1.5s + clear 즉시 = snappy.

## 범위/판정 (유나 가디언 endorse)
- **dot 폴링 15s 유지** — 연결상태(online/idle/offline)는 시간 기반(5/30분 임계)이라 1.5s 불요(불필요 request 회피). typing만 민감하니 분리.
- request 약간↑이나 `GET /working`는 in-memory 경량 → 부하 미미.
- 진짜 real-time(SSE-push)은 **P3**(doc §5).
- 2축 시각·clearTyping·proxy 등 무변경. presence prod 프로모션 묶음.

## 검증
`pnpm type-check` ✅ / `pnpm build` ✅

## 라이브 픽셀
dev 배포 후 유나 가디언 "빠릿빠릿"(1.5s 체감) 라이브 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)