### PR TITLE
[SID:eb1a8f95] feat(presence): team presence aggregation API (online + global working)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -136,6 +136,7 @@ app.include_router(stories.router)
 app.include_router(projects.router)
 app.include_router(project_access.router)
 app.include_router(team_members.router)
+app.include_router(team_presence.router)
 app.include_router(org_members.router)
 app.include_router(standups.router)
 app.include_router(retros.router)

--- a/backend/app/routers/team_presence.py
+++ b/backend/app/routers/team_presence.py
@@ -1,0 +1,81 @@
+"""eb1a8f95: 팀 presence 집계 API — FE presence 패널이 소비할 단일 계약.
+
+2축을 에이전트별로 합쳐 org-level 단일 응답 제공(채팅 밖 at-a-glance 가용성 표시):
+- presence_status: online/idle/offline = 연결 축(P1 `team_members`·last_seen_at 도출 재사용)
+- working: 작업 축(P2 `chat_presence` 를 **전 conversation 횡단 집계** — 어디든 working 이면 true)
+
+선생님 B 결정: working 은 **여부만**(boolean) — for-whom(어느 conversation·누구와) 미포함.
+⚠️ working 집계는 멀티인스턴스 per-instance best-effort(`chat_presence` in-memory 한계 동일).
+마이그 불요(읽기 집계).
+
+응답 계약(FE 미르코 정합):
+  GET /api/v2/team-presence → [
+    {member_id, name, avatar_url, agent_role, runtime_type,
+     presence_status: "online"|"idle"|"offline", working: bool,
+     active_story: {id,title,status}|null}
+  ]
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_verified_org_id
+from app.dependencies.database import get_db
+from app.repositories.team_member import TeamMemberRepository
+from app.routers.team_members import _inject_active_stories
+from app.schemas.team_member import ActiveStorySummary
+from app.services import chat_presence
+
+router = APIRouter(prefix="/api/v2/team-presence", tags=["team-presence"])
+
+
+class TeamPresenceItem(BaseModel):
+    member_id: uuid.UUID
+    name: str
+    avatar_url: str | None = None
+    agent_role: str | None = None
+    runtime_type: str | None = None
+    presence_status: str | None = None  # "online" | "idle" | "offline"
+    working: bool = False  # B: 여부만 — 어느 conversation 이든 working 이면 true
+    active_story: ActiveStorySummary | None = None
+
+
+@router.get("", response_model=list[TeamPresenceItem])
+async def get_team_presence(
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> list[TeamPresenceItem]:
+    """org 전 에이전트의 presence_status(연결) + global working(작업) 집계."""
+    repo = TeamMemberRepository(session, org_id)
+    agents = await repo.list(type="agent", is_active=True)
+
+    # team_members 뷰는 멤버당 프로젝트별 행을 반환 → 멤버당 1로 dedup(presence/working 은 멤버 단위).
+    seen: set[uuid.UUID] = set()
+    unique = []
+    for a in agents:
+        if a.id in seen:
+            continue
+        seen.add(a.id)
+        unique.append(a)
+
+    # presence_status(computed) + active_story 주입은 team_members 경로 재사용(로직 중복 방지).
+    responses = await _inject_active_stories(unique, session)
+    working_ids = chat_presence.working_member_ids()
+
+    return [
+        TeamPresenceItem(
+            member_id=r.id,
+            name=r.name,
+            avatar_url=r.avatar_url,
+            agent_role=r.agent_role,
+            runtime_type=r.runtime_type,
+            presence_status=r.presence_status,
+            working=str(r.id) in working_ids,
+            active_story=r.active_story,
+        )
+        for r in responses
+    ]

--- a/backend/app/services/chat_presence.py
+++ b/backend/app/services/chat_presence.py
@@ -74,3 +74,19 @@ def list_working(conversation_id: str) -> list[dict]:
         {**asdict(e)}
         for e in _working_store.get(conversation_id, {}).values()
     ]
+
+
+def working_member_ids() -> set[str]:
+    """eb1a8f95: 전 conversation 횡단 — 현재 working 중인 member_id 집합(만료 제외).
+
+    팀 presence 집계용. 어느 conversation 이든 working 이면 포함(B 결정="여부만"·for-whom 미포함).
+    read-only(만료분은 결과에서 제외만, store 변형 없음). 멀티인스턴스 per-instance best-effort
+    (이 인스턴스가 emit 받은 working 만 — list_working 과 동일 한계).
+    """
+    now = time.time()
+    out: set[str] = set()
+    for store in list(_working_store.values()):
+        for mid, e in store.items():
+            if now - e.updated_at <= _TTL_SEC:
+                out.add(mid)
+    return out

--- a/backend/tests/test_chat_presence.py
+++ b/backend/tests/test_chat_presence.py
@@ -89,3 +89,35 @@ def test_clear_emit_hook_wired_in_send_message():
     from app.routers.conversations import send_message
     src = inspect.getsource(send_message)
     assert "chat_presence.clear_working" in src
+
+
+# ── eb1a8f95: 전 conversation 횡단 working 집계 ────────────────────────────────
+
+def test_working_member_ids_aggregates_across_conversations():
+    c1, c2 = str(uuid.uuid4()), str(uuid.uuid4())
+    a, b, c = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(c1, a)
+    chat_presence.set_working(c1, b)
+    chat_presence.set_working(c2, c)
+    ids = chat_presence.working_member_ids()
+    assert ids == {a, b, c}
+
+
+def test_working_member_ids_same_member_multiple_convs_once():
+    c1, c2 = str(uuid.uuid4()), str(uuid.uuid4())
+    a = str(uuid.uuid4())
+    chat_presence.set_working(c1, a)
+    chat_presence.set_working(c2, a)  # 같은 멤버 두 conversation에서 working
+    assert chat_presence.working_member_ids() == {a}
+
+
+def test_working_member_ids_excludes_expired():
+    c1 = str(uuid.uuid4())
+    a = str(uuid.uuid4())
+    chat_presence.set_working(c1, a)
+    chat_presence._working_store[c1][a].updated_at = time.time() - chat_presence._TTL_SEC - 1
+    assert chat_presence.working_member_ids() == set()
+
+
+def test_working_member_ids_empty():
+    assert chat_presence.working_member_ids() == set()

--- a/backend/tests/test_team_presence.py
+++ b/backend/tests/test_team_presence.py
@@ -1,0 +1,79 @@
+"""eb1a8f95: 팀 presence 집계 API — dedup + presence_status/working 매핑 단위 테스트."""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers import team_presence
+
+ORG_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _resp(member_id, name="Agent", presence="online"):
+    """_inject_active_stories 반환 형태(TeamMemberResponse 유사) mock."""
+    return SimpleNamespace(
+        id=member_id, name=name, avatar_url=None, agent_role="be",
+        runtime_type=None, presence_status=presence, active_story=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_team_presence_maps_presence_and_working():
+    a_id, b_id = uuid.uuid4(), uuid.uuid4()
+    agents = [SimpleNamespace(id=a_id), SimpleNamespace(id=b_id)]
+    responses = [_resp(a_id, "Alpha", "online"), _resp(b_id, "Beta", "idle")]
+
+    repo = MagicMock()
+    repo.list = AsyncMock(return_value=agents)
+    with patch("app.routers.team_presence.TeamMemberRepository", return_value=repo), \
+         patch("app.routers.team_presence._inject_active_stories", new=AsyncMock(return_value=responses)), \
+         patch("app.routers.team_presence.chat_presence.working_member_ids", return_value={str(a_id)}):
+        result = await team_presence.get_team_presence(session=MagicMock(), org_id=ORG_ID)
+
+    by_id = {str(r.member_id): r for r in result}
+    assert by_id[str(a_id)].presence_status == "online"
+    assert by_id[str(a_id)].working is True   # a 는 working 집합에 있음
+    assert by_id[str(b_id)].presence_status == "idle"
+    assert by_id[str(b_id)].working is False  # b 는 없음
+
+
+@pytest.mark.anyio
+async def test_team_presence_dedups_multiproject_rows():
+    """멀티프로젝트 뷰 행(같은 id 중복) → 멤버당 1로 dedup."""
+    a_id = uuid.uuid4()
+    # 같은 에이전트가 3개 프로젝트 행으로 반환
+    agents = [SimpleNamespace(id=a_id), SimpleNamespace(id=a_id), SimpleNamespace(id=a_id)]
+    captured = {}
+
+    async def _fake_inject(unique, session):
+        captured["unique_count"] = len(unique)
+        return [_resp(a_id)]
+
+    repo = MagicMock()
+    repo.list = AsyncMock(return_value=agents)
+    with patch("app.routers.team_presence.TeamMemberRepository", return_value=repo), \
+         patch("app.routers.team_presence._inject_active_stories", new=_fake_inject), \
+         patch("app.routers.team_presence.chat_presence.working_member_ids", return_value=set()):
+        result = await team_presence.get_team_presence(session=MagicMock(), org_id=ORG_ID)
+
+    assert captured["unique_count"] == 1  # dedup 후 1
+    assert len(result) == 1
+
+
+@pytest.mark.anyio
+async def test_team_presence_empty_when_no_agents():
+    repo = MagicMock()
+    repo.list = AsyncMock(return_value=[])
+    with patch("app.routers.team_presence.TeamMemberRepository", return_value=repo), \
+         patch("app.routers.team_presence._inject_active_stories", new=AsyncMock(return_value=[])), \
+         patch("app.routers.team_presence.chat_presence.working_member_ids", return_value=set()):
+        result = await team_presence.get_team_presence(session=MagicMock(), org_id=ORG_ID)
+    assert result == []


### PR DESCRIPTION
## Story
`eb1a8f95` 팀 presence 집계 API — FE presence 패널(채팅 밖 at-a-glance 가용성 표시)이 소비할 **단일 계약**. 블루프린트 `blueprint-presence-prominent-display`(선생님 A/B/C 승인) 기반.

## Design — 2축을 에이전트별로 집계
- **presence_status** (online/idle/offline): 연결 축 — P1 `team_members`(last_seen_at 도출) 재사용(`_inject_active_stories` 경로).
- **working** (boolean): 작업 축 — P2 `chat_presence`를 **전 conversation 횡단 집계**(어디든 working이면 true). **선생님 B 결정: 여부만**(for-whom·어느 conversation/누구와 미포함).

## Change
- `app/services/chat_presence.py`: `working_member_ids()` — 횡단 working member 집합(TTL 필터·read-only). P2와 동일 per-instance in-memory best-effort.
- `app/routers/team_presence.py` (신규): `GET /api/v2/team-presence`. 멀티프로젝트 `team_members` 뷰 행을 **멤버당 1로 dedup**.
- `app/main.py`: 라우터 등록.

## 응답 계약 (⭐FE 미르코 정합 — P2 SSE↔폴링 mismatch 교훈, impl 前 확인)
```json
GET /api/v2/team-presence  →
[
  {
    "member_id": "uuid",
    "name": "string",
    "avatar_url": "string|null",
    "agent_role": "string|null",
    "runtime_type": "string|null",
    "presence_status": "online" | "idle" | "offline",
    "working": true,                       // B: 여부만
    "active_story": {"id","title","status"} | null
  }
]
```
- 폴링 GET(presence.py/P2 동형). 패널은 presence_status(online dot)와 working을 **분리 표시**.
- `active_story`는 P1에서 무료로 따라오는 필드 — 패널이 "현재 작업" 표시에 쓰면 유지, 불필요하면 드롭(미르코 콜). 코어는 presence_status + working.
- **멀티인스턴스 한계**: working 집계는 per-instance best-effort(chat_presence in-memory). 크로스-인스턴스 실시간은 P3 pubsub/SSE transport와 함께.

## Tests
신규 7건: `working_member_ids` 횡단 집계/멤버 1회/TTL evict/empty + 엔드포인트 presence·working 매핑/멀티프로젝트 dedup/empty. 전체 백엔드 **1732 passed**(pre-existing e2e_dev 네트워크 2건 무관·MCP 도구 미추가라 count 불변). 마이그 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)