### PR TITLE
prod: presence 본체 (P1 online/offline + P2 working/typing + snappy)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2309,6 +2309,12 @@
     "hypothesisSection": "Outcome Hypothesis"
   },
   "chats": {
+    "isTyping": "{name} is typing",
+    "othersTyping": "{name} and {count} others are typing",
+    "presenceOnline": "Online",
+    "presenceIdle": "Idle",
+    "presenceOffline": "Offline",
+    "presenceWorking": "Working",
     "commandBlockedLead": "{agentName} ({runtime}) doesn't run chat slash-commands directly.",
     "runtimeUnsetLabel": "No runtime set",
     "commandBlockedAlt": "Try natural language instead — e.g. \"use the {command} skill to …\"",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2309,6 +2309,12 @@
     "hypothesisSection": "효과 가설"
   },
   "chats": {
+    "isTyping": "{name} 님이 입력 중",
+    "othersTyping": "{name} 외 {count}명 입력 중",
+    "presenceOnline": "온라인",
+    "presenceIdle": "자리비움",
+    "presenceOffline": "오프라인",
+    "presenceWorking": "작업 중",
     "commandBlockedLead": "{agentName} ({runtime}) 에이전트는 채팅 슬래시 커맨드를 직접 실행하지 않습니다.",
     "runtimeUnsetLabel": "런타임 미설정",
     "commandBlockedAlt": "대신 자연어로 요청해 보세요 — 예: \"{command} 스킬로 …\"",

--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { ChevronLeft, UserPlus } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChatView } from '@/components/chat/chat-view';
+import type { PresenceStatus } from '@/components/chat/presence-dot';
 import { AddParticipantModal } from '@/components/chat/add-participant-modal';
 import { useDashboardContext } from '../../../dashboard/dashboard-shell';
 
@@ -52,6 +53,31 @@ export default function ConversationPage() {
       if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [] });
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
+
+  // 1aeecdde P2: 에이전트 presence_status(연결축 dot) 폴링 — P1 진실값. 15s 갱신(시간 기반 상태).
+  const [presenceById, setPresenceById] = useState<Record<string, PresenceStatus>>({});
+  const fetchPresence = useCallback(async () => {
+    try {
+      const res = await fetch('/api/team-members?type=agent');
+      if (!res.ok) return;
+      const json = await res.json() as { data?: Array<{ id: string; presence_status?: string | null }> };
+      const map: Record<string, PresenceStatus> = {};
+      for (const m of json.data ?? []) {
+        if (m.presence_status === 'online' || m.presence_status === 'idle' || m.presence_status === 'offline') {
+          map[m.id] = m.presence_status;
+        }
+      }
+      setPresenceById(map);
+    } catch { /* non-critical */ }
+  }, []);
+
+  // 마운트 1회 fetch(단일행·기존 fetchMeta 패턴 동형) + 15s 폴링(시간 기반 presence 갱신).
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { void fetchPresence(); }, [fetchPresence]);
+  useEffect(() => {
+    const interval = setInterval(() => { void fetchPresence(); }, 15000);
+    return () => clearInterval(interval);
+  }, [fetchPresence]);
 
   // eslint-disable-next-line react-hooks/set-state-in-effect
   useEffect(() => { void fetchMeta(); }, [fetchMeta]);
@@ -126,6 +152,7 @@ export default function ConversationPage() {
           apiPrefix="/api/conversations"
           backRoute="/chats"
           commandTargets={commandTargets}
+          presenceById={presenceById}
         />
       </div>
 

--- a/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/working/route.ts
@@ -1,0 +1,12 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// 1aeecdde P2: GET /api/v2/conversations/{id}/working 프록시 — 지금 답장 생성 중(working) member 목록.
+// 디디 P2 BE(#1353 chat_presence·in-memory ephemeral) 폴링. FE는 이 결과로 "...is typing"/working ring 렌더.
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ conversation_id: string }> },
+): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}/working`);
+}

--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -13,6 +13,7 @@ import { getFileIcon } from '@/lib/file-icon';
 import { AttachmentImage } from './attachment-image';
 import { AttachmentFile } from './attachment-file';
 import { MessageContextMenu } from './message-context-menu';
+import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from './presence-dot';
 
 interface ChatBubbleProps {
   message: ChatMessage;
@@ -20,6 +21,9 @@ interface ChatBubbleProps {
   isGrouped?: boolean;
   onOpenThread?: (message: ChatMessage) => void;
   onDelete?: (messageId: string) => void;
+  // 1aeecdde P2: 2축 presence — 연결(dot) + 활동(working ring). 에이전트 sender만 적용.
+  presenceStatus?: PresenceStatus | null;
+  isWorking?: boolean;
 }
 
 interface ContextMenuState {
@@ -91,7 +95,7 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
 
 const LONG_PRESS_MS = 500;
 
-export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete }: ChatBubbleProps) {
+export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, onDelete, presenceStatus, isWorking = false }: ChatBubbleProps) {
   const t = useTranslations('chats');
   const isAgent = message.sender_type === 'agent';
   // S8: 슬래시 커맨드는 전용 버블(brand·mono·⌘). 리터럴(`//`)은 dequote된 일반 텍스트.
@@ -166,18 +170,23 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
         onTouchEnd={handleTouchEnd}
         onTouchMove={handleTouchMove}
       >
-        {/* Avatar — hidden when grouped */}
+        {/* Avatar — hidden when grouped. 1aeecdde P2: agent에 연결 dot + working ring(2축). */}
         {isGrouped ? (
           <div className="w-7 flex-shrink-0" />
         ) : (
-          <div className={`flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full text-xs font-medium ${
-            isAgent
-              ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
-              : isMine
-                ? 'bg-primary/20 text-primary'
-                : 'bg-muted text-muted-foreground'
-          }`}>
-            {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+          <div className="relative h-7 w-7 flex-shrink-0">
+            <div className={`flex h-full w-full items-center justify-center rounded-full text-xs font-medium ${
+              isAgent
+                ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300'
+                : isMine
+                  ? 'bg-primary/20 text-primary'
+                  : 'bg-muted text-muted-foreground'
+            } ${isAgent && isWorking ? WORKING_RING_CLASS : ''}`}>
+              {isAgent ? <Bot className="h-3.5 w-3.5" /> : <User className="h-3.5 w-3.5" />}
+            </div>
+            {isAgent && presenceStatus ? (
+              <PresenceDot status={presenceStatus} className="absolute -bottom-0.5 -right-0.5" />
+            ) : null}
           </div>
         )}
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -3,7 +3,9 @@
 import { Fragment, useCallback, useEffect, useRef, useState } from 'react';
 import { ChevronLeft, RefreshCw } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { ChatBubble } from './chat-bubble';
+import type { PresenceStatus } from './presence-dot';
 import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
@@ -20,6 +22,8 @@ interface ChatViewProps {
   backRoute?: string | null;
   // S8 #2: pre-send capability 경고 대상(에이전트 participant runtime). 빈 배열이면 경고 미표시(graceful).
   commandTargets?: CommandTarget[];
+  // 1aeecdde P2: 에이전트 member_id → presence_status(연결축 dot). 없으면 dot 미표시(graceful).
+  presenceById?: Record<string, PresenceStatus>;
 }
 
 interface MessageGroup {
@@ -38,9 +42,10 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos', commandTargets }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos', commandTargets, presenceById }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const t = useTranslations('chats');
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -50,6 +55,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   // S5: 미지원 런타임 커맨드 차단 hint — 트리거 메시지 id에 keyed된 ephemeral state.
   // POST 응답 command_gate.blocked에서만 적재(persist 안 함·reload 시 소멸).
   const [commandHints, setCommandHints] = useState<Record<string, BlockedHint[]>>({});
+  // 1aeecdde P2: 답장 생성 중 에이전트 typing — 디디 #1353 GET /working 폴링(BE 45s TTL) 결과.
+  const [typingAgents, setTypingAgents] = useState<{ id: string; name: string }[]>([]);
   // CB-S9: 스레드 패널 상태
   const [activeThread, setActiveThread] = useState<ChatMessage | null>(null);
   const [threadIncoming, setThreadIncoming] = useState<ChatMessage | null>(null);
@@ -127,7 +134,13 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     }
   }, [loading, scrollToBottom]);
 
+  // 1aeecdde P2: 에이전트 typing 즉시 해제(답장 메시지 도착 시·다음 폴링 전 갭 제거).
+  const clearTyping = useCallback((agentId: string) => {
+    setTypingAgents((prev) => (prev.some((a) => a.id === agentId) ? prev.filter((a) => a.id !== agentId) : prev));
+  }, []);
+
   const addMessage = useCallback((msg: ChatMessage) => {
+    clearTyping(msg.created_by); // 답장 도착 → 해당 에이전트 typing 즉시 해제(AC1)
     const nearBottom = isNearBottom();
     setMessages((prev) => {
       if (prev.some((m) => m.id === msg.id)) return prev;
@@ -139,7 +152,7 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     } else {
       setShowNewIndicator(true);
     }
-  }, [isNearBottom]);
+  }, [isNearBottom, clearTyping]);
 
   const handleNewMessage = useCallback((msg: ChatMessage) => {
     if (msg.memo_id !== threadId) return;
@@ -177,6 +190,27 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
   const handleReconnect = useCallback(() => {
     fetchMessages();
   }, [fetchMessages]);
+
+  // 1aeecdde P2: working 폴링(디디 #1353 GET /working·in-memory 45s TTL) → typingAgents.
+  // 이름=commandTargets(없으면 미표시 graceful). poll이 BE working 셋 그대로 반영(클라 TTL 불요).
+  const fetchWorking = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/conversations/${threadId}/working`);
+      if (!res.ok) return;
+      const json = await res.json() as { data?: Array<{ member_id: string }> };
+      const next = (json.data ?? [])
+        .map((w) => ({ id: w.member_id, name: (commandTargets ?? []).find((tg) => tg.agentId === w.member_id)?.agentName }))
+        .filter((a): a is { id: string; name: string } => !!a.name);
+      setTypingAgents(next);
+    } catch { /* non-critical */ }
+  }, [threadId, commandTargets]);
+
+  // 마운트 1회 + 5s 폴링(생성구간 typing 갱신·PO: 연결 dot 15s보다 민감하게).
+  useEffect(() => { void fetchWorking(); }, [fetchWorking]);
+  useEffect(() => {
+    const interval = setInterval(() => { void fetchWorking(); }, 5000);
+    return () => clearInterval(interval);
+  }, [fetchWorking]);
 
   useChatSse({
     currentTeamMemberId,
@@ -439,6 +473,8 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
                             isGrouped={isGrouped}
                             onOpenThread={openThread}
                             onDelete={handleDeleteMessage}
+                            presenceStatus={presenceById?.[msg.created_by]}
+                            isWorking={typingAgents.some((a) => a.id === msg.created_by)}
                           />
                           {/* S5: 트리거 메시지 직후 차단 hint notice(차단 에이전트별 1건) */}
                           {commandHints[msg.id]?.map((h) => (
@@ -465,6 +501,22 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
               >
                 ↓ 새 메시지
               </button>
+            </div>
+          )}
+
+          {/* 1aeecdde P2: "...is typing" — 메시지 리스트 아래·composer 위·답장 생성 중·완료 시 사라짐(aria-live) */}
+          {typingAgents.length > 0 && (
+            <div className="flex flex-shrink-0 items-center gap-2 px-4 py-1.5 text-xs text-muted-foreground" aria-live="polite">
+              <span className="flex items-center gap-0.5" aria-hidden>
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce" />
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:150ms]" />
+                <span className="size-1.5 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:300ms]" />
+              </span>
+              <span>
+                {typingAgents.length === 1
+                  ? t('isTyping', { name: typingAgents[0]?.name ?? '' })
+                  : t('othersTyping', { name: typingAgents[0]?.name ?? '', count: typingAgents.length - 1 })}
+              </span>
             </div>
           )}
 

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -205,10 +205,10 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
     } catch { /* non-critical */ }
   }, [threadId, commandTargets]);
 
-  // 마운트 1회 + 5s 폴링(생성구간 typing 갱신·PO: 연결 dot 15s보다 민감하게).
+  // 마운트 1회 + 1.5s 폴링(typing snappiness·선생님 피드백 "빠릿빠릿"·연결 dot 15s보다 훨씬 민감).
   useEffect(() => { void fetchWorking(); }, [fetchWorking]);
   useEffect(() => {
-    const interval = setInterval(() => { void fetchWorking(); }, 5000);
+    const interval = setInterval(() => { void fetchWorking(); }, 1500);
     return () => clearInterval(interval);
   }, [fetchWorking]);
 

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
+/**
+ * 1aeecdde P2 — 에이전트 presence 2축 시각(설계 `handoff-presence-working-typing`).
+ * - 연결 축(P1 `presence_status` 진실): offline/idle/online → avatar 우하단 dot.
+ * - 활동 축(P2): working(답장 생성 중) → avatar에 working pulse ring(아래 WORKING_RING_CLASS).
+ *   **dot 색을 바꾸지 않고 ring을 덧댄다**(AC2 — 축 합침 금지·'online인데 idle vs 일하는 중' 구분).
+ * 휴먼은 presence_status null → dot 미표시.
+ */
+export type PresenceStatus = 'online' | 'idle' | 'offline';
+
+const DOT_CLASS: Record<PresenceStatus, string> = {
+  online: 'bg-success',
+  idle: 'bg-warning',
+  offline: 'bg-muted-foreground/40',
+};
+
+const STATUS_LABEL_KEY: Record<PresenceStatus, string> = {
+  online: 'presenceOnline',
+  idle: 'presenceIdle',
+  offline: 'presenceOffline',
+};
+
+/**
+ * 활동 축 — working 시 avatar 래퍼에 덧대는 ring(brand pulse). dot과 별개(축 합침 금지).
+ * prefers-reduced-motion 시 정적 ring(모션 0).
+ */
+export const WORKING_RING_CLASS = 'ring-2 ring-brand ring-offset-1 ring-offset-card motion-safe:animate-pulse';
+
+/** 연결 축 dot(avatar 우하단). status null/undefined(휴먼·미상)면 미표시. */
+export function PresenceDot({
+  status,
+  className = '',
+}: {
+  status: PresenceStatus | null | undefined;
+  className?: string;
+}) {
+  const t = useTranslations('chats');
+  if (!status) return null;
+  return (
+    <span
+      role="img"
+      aria-label={t(STATUS_LABEL_KEY[status])}
+      className={`inline-block size-2.5 rounded-full border-2 border-card ${DOT_CLASS[status]} ${className}`}
+    />
+  );
+}

--- a/apps/web/src/hooks/use-chat-sse.ts
+++ b/apps/web/src/hooks/use-chat-sse.ts
@@ -151,6 +151,7 @@ export function useChatSse({ currentTeamMemberId, onNewMessage, onReplyCreated, 
           onConversationMessageRef.current?.(payload);
         } catch { /* ignore parse errors */ }
       });
+
     }
 
     connect();

--- a/backend/app/routers/agent_gateway.py
+++ b/backend/app/routers/agent_gateway.py
@@ -8,14 +8,15 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlalchemy import select, text, update
+from sqlalchemy import delete, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_current_user_streaming
@@ -27,10 +28,87 @@ from app.models.organization import Organization
 from app.models.team import TeamMember
 from app.routers.events import _agent_connections, _event_to_payload
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/api/v2/agent", tags=["agent-gateway"])
 
 _SSE_HEARTBEAT: float = float(os.getenv("SSE_HEARTBEAT_TIMEOUT", "30"))
 _BACKFILL_LIMIT: int = int(os.getenv("AGENT_GATEWAY_BACKFILL_LIMIT", "100"))
+
+# 49fed0a1 P1: presence를 실제 SSE 연결에 배선 — online/offline 진실화.
+# SSE dial-out 에이전트(Hermes 등)는 MCP heartbeat를 호출하지 않으므로 연결 lifecycle에서
+# presence(last_seen_at/agent_status)를 직접 갱신해야 "연결 중 online·끊으면 offline"이 진실해진다.
+# - 연결 유지 중 최소 갱신 주기(초). wake 빈발로 timeout heartbeat가 안 떠도 last_seen이 stale되지 않게
+#   매 loop iteration에서 경과 체크 후 throttle write(에이전트당 최대 1회/주기).
+_PRESENCE_TICK_INTERVAL: float = _SSE_HEARTBEAT
+# - AgentGatewaySession이 "활성"으로 간주되는 last_seen 무갱신 허용 시간(초). 주기 갱신(_PRESENCE_TICK_INTERVAL)
+#   대비 여유(3×)를 둬 정상 연결이 잠깐 느려도 stale 오판하지 않게. 인스턴스 크래시로 finally 미실행된
+#   좀비 세션은 이 TTL 밖이 되어 disconnect cleanup의 "잔여 활성 세션" 판정에서 제외된다(멀티인스턴스 정합).
+_SESSION_FRESH_TTL: float = _SSE_HEARTBEAT * 3
+
+
+async def _mark_agent_online(agent_id: uuid.UUID, session_id: uuid.UUID) -> None:
+    """49fed0a1 AC1/AC2: SSE 연결 중 presence online 갱신.
+
+    AgentGatewaySession.last_seen_at(연결 추적·멀티인스턴스 queryable) + 프로필 presence
+    (last_seen_at/agent_status — team_members 뷰가 agent_project_profiles서 읽음)를 함께 NOW로 갱신.
+    long-lived 스트림은 get_db 커넥션을 idle-hold 하면 안 되므로 독립 세션 사용. best-effort
+    (presence 갱신 실패가 스트림을 끊지 않도록 예외 삼킴·로깅).
+    """
+    now = datetime.now(timezone.utc)
+    try:
+        async with async_session_factory() as db:
+            await db.execute(
+                update(AgentGatewaySession)
+                .where(AgentGatewaySession.id == session_id)
+                .values(last_seen_at=now)
+            )
+            from app.services.agent_anchor_sync import sync_agent_profile_presence
+            await sync_agent_profile_presence(
+                db, agent_id, last_seen_at=now, agent_status="online"
+            )
+            await db.commit()
+    except Exception:
+        logger.warning("presence online tick failed agent=%s", agent_id, exc_info=True)
+
+
+async def _mark_agent_disconnected(agent_id: uuid.UUID, session_id: uuid.UUID) -> None:
+    """49fed0a1 AC2/AC3: SSE 연결 종료 cleanup — 연결-도출 offline 강등.
+
+    이 세션 행 삭제 후, 같은 에이전트의 **다른 활성(last_seen TTL 이내) 세션**이 없으면 presence를
+    offline로 강등. 같은 API Key의 멀티세션(멀티인스턴스 Cloud Run)은 한 presence 그룹이므로
+    **마지막 연결이 끊길 때만** offline (AC2). last_seen_at=None → presence_status 즉시 offline
+    (schema 단락). MCP heartbeat·재연결 시 online 복귀(self-heal). finally 호출이라 예외 비전파.
+    """
+    now = datetime.now(timezone.utc)
+    fresh_cutoff = now - timedelta(seconds=_SESSION_FRESH_TTL)
+    try:
+        async with async_session_factory() as db:
+            # 이 세션 + 같은 에이전트의 좀비 세션(크래시로 finally 미실행 → last_seen stale) 정리.
+            # 멀티인스턴스서 테이블 무한증식 방지 + 아래 "잔여 활성" 판정을 신뢰 가능하게.
+            await db.execute(
+                delete(AgentGatewaySession).where(
+                    (AgentGatewaySession.id == session_id)
+                    | (
+                        (AgentGatewaySession.agent_id == agent_id)
+                        & (AgentGatewaySession.last_seen_at < fresh_cutoff)
+                    )
+                )
+            )
+            remaining = (await db.execute(
+                select(AgentGatewaySession.id).where(
+                    AgentGatewaySession.agent_id == agent_id,
+                    AgentGatewaySession.last_seen_at >= fresh_cutoff,
+                ).limit(1)
+            )).scalar_one_or_none()
+            if remaining is None:
+                from app.services.agent_anchor_sync import sync_agent_profile_presence
+                await sync_agent_profile_presence(
+                    db, agent_id, last_seen_at=None, agent_status="offline"
+                )
+            await db.commit()
+    except Exception:
+        logger.warning("presence disconnect cleanup failed agent=%s", agent_id, exc_info=True)
 
 # E-INFRA S4: /agent/stream 전역 연결 cap (legacy /events/stream S20 미러).
 # 무제한 agent stream 연결이 인스턴스 메모리/큐(=connection당 Queue maxsize=200)를 고갈시키는 것 방지.
@@ -189,14 +267,8 @@ async def agent_stream(
         acked_seq: int = cursor.acked_seq if cursor else 0
 
         # ì¸ì ë±ë¡
-        session_rec = AgentGatewaySession(
-            id=uuid.uuid4(),
-            agent_id=agent_id,
-            connected_at=datetime.now(timezone.utc),
-            last_seen_at=datetime.now(timezone.utc),
-        )
-        db.add(session_rec)
-        await db.commit()
+        # 49fed0a1: 세션 등록 + presence online은 cap 체크 통과 후 generate() 내부에서 수행
+        # (거부된 429/503 연결이 세션 행/presence를 남기지 않도록 — setup/teardown을 스트림 lifecycle에 대칭).
 
     # Last-Event-ID í¤ë íì± (gateway_seq)
     last_event_id_hdr = request.headers.get("Last-Event-ID") or request.headers.get("last-event-id")
@@ -244,7 +316,26 @@ async def agent_stream(
         - acked_seqë í´ë¼ì´ì¸í¸ POST /ack ë¡ë§ ì ì§ â ìë²ê° ìë ì ì§ ì í¨.
         - í´ë¼ì´ì¸í¸ë seq ê¸°ë° dedup(ê°ì seq ë ë² ë°ìë í ë² ì²ë¦¬) íì.
         """
+        session_id = uuid.uuid4()
+        _presence_wired = False
         try:
+            # 49fed0a1 AC1: cap 통과 후 세션 등록 + presence online. SSE dial-out 에이전트는 MCP
+            # heartbeat를 호출하지 않아 이 배선이 없으면 붙어 일해도 offline(거짓)이었다. 독립 세션 사용
+            # (long-lived 스트림이 get_db 커넥션을 idle-hold 하지 않도록).
+            async with async_session_factory() as _pdb:
+                _pdb.add(AgentGatewaySession(
+                    id=session_id,
+                    agent_id=agent_id,
+                    connected_at=datetime.now(timezone.utc),
+                    last_seen_at=datetime.now(timezone.utc),
+                ))
+                from app.services.agent_anchor_sync import sync_agent_profile_presence
+                await sync_agent_profile_presence(
+                    _pdb, agent_id, last_seen_at=datetime.now(timezone.utc), agent_status="online"
+                )
+                await _pdb.commit()
+            _presence_wired = True
+
             yield "event: heartbeat\ndata: {}\n\n"
 
             # ì´ê¸° ë°±í â acked_seq(=start_seq)ë¶í° ì¬ì¤ìº
@@ -261,7 +352,15 @@ async def agent_stream(
                     backfill_floor = gseq
 
             # ì¤ìê° â wake ì í¸ â acked_seqë¶í° DB ì¬ì¤ìº
+            # 49fed0a1 AC1: 연결 유지 중 presence를 주기적으로 online 갱신. wake가 잦으면 timeout
+            # heartbeat가 안 떠도(매번 wait_for가 일찍 반환) last_seen이 stale → 거짓 offline 되므로,
+            # 매 iteration 경과를 체크해 _PRESENCE_TICK_INTERVAL마다 throttle write(busy/idle 무관 갱신 보장).
+            last_presence_tick = datetime.now(timezone.utc)
             while not await request.is_disconnected():
+                _now = datetime.now(timezone.utc)
+                if (_now - last_presence_tick).total_seconds() >= _PRESENCE_TICK_INTERVAL:
+                    await _mark_agent_online(agent_id, session_id)
+                    last_presence_tick = _now
                 try:
                     signal = await asyncio.wait_for(queue.get(), timeout=_SSE_HEARTBEAT)
                     if signal.get("__wake__"):
@@ -301,6 +400,10 @@ async def agent_stream(
             _agent_connections[agent_id_str].discard(queue)
             if not _agent_connections[agent_id_str]:
                 _agent_connections.pop(agent_id_str, None)
+            # 49fed0a1 AC2/AC3: 연결 종료 → 세션 행 삭제 + 마지막 세션이면 presence offline 강등.
+            # (presence 배선 성공한 연결만 — 세션 미생성 시 타 세션 presence 오염 방지.)
+            if _presence_wired:
+                await _mark_agent_disconnected(agent_id, session_id)
 
     return StreamingResponse(
         generate(),

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -22,6 +22,7 @@ from app.models.team import AgentMessageAllowlist, TeamMember
 from app.models.agent_deployment import AgentAuditLog
 from app.models.webhook_config import WebhookConfig
 from app.routers.events import _push_to_agent, publish_event
+from app.services import chat_presence
 from app.services.agent_runtime import supports_deterministic_command
 from app.services.command_classifier import classify_command
 from app.services.event_seq import assign_recipient_seq
@@ -287,6 +288,10 @@ async def _dispatch_conversation_event(
         )
         db.add(event)
         events_to_push.append((str(pid), event))
+        # 1aeecdde P2: agent recipient 에게 메시지가 dispatch = 답장 생성 시작 → working emit.
+        # 그 agent 가 reply 를 보내면 send_message 에서 clear, 안 보내면 TTL 자동 소멸(ephemeral).
+        if m_type == "agent":
+            chat_presence.set_working(str(conversation.id), str(pid))
 
     # flush로 event.id 확보
     await db.flush()
@@ -860,6 +865,45 @@ async def list_messages(
     return {"data": data, "meta": {"next_cursor": next_cursor, "has_more": has_more}}
 
 
+@router.get("/{conversation_id}/working")
+async def list_working_members(
+    conversation_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """1aeecdde P2: GET /api/v2/conversations/{id}/working — 지금 답장 생성 중인 member 목록.
+
+    presence(online) 와 **별도 축**(working/typing). FE 는 이 결과로 "...is typing"/working dot 을
+    online dot 과 분리 표시(AC2). ephemeral·TTL 기반(미reply 시 자동 소멸). participant 만 조회 가능.
+    응답: {"data": [{"member_id", "state", "updated_at"}]}.
+    """
+    conv_project_id = (await db.execute(
+        select(Conversation.project_id).where(
+            Conversation.id == conversation_id, Conversation.org_id == org_id
+        )
+    )).scalar_one_or_none()
+    if conv_project_id is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv_project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    # 본인은 제외 — 내가 typing 중인 건 내 UI에 안 띄움(memo presence.py 동형).
+    items = [
+        e for e in chat_presence.list_working(str(conversation_id))
+        if e["member_id"] != str(sender.id)
+    ]
+    return {"data": items}
+
+
 @router.post("/{conversation_id}/participants", status_code=201)
 async def add_participant(
     conversation_id: uuid.UUID,
@@ -975,6 +1019,11 @@ async def send_message(
     )).scalar_one_or_none()
     if participant is None:
         raise HTTPException(status_code=403, detail="Not a participant")
+
+    # 1aeecdde P2: sender 가 이 conversation 에 메시지를 보냄 = 답장 생성 종료 → working clear.
+    # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.
+    # 휴먼 sender 면 set 된 적 없어 no-op(무해). agent reply 면 즉시 "...typing" 해제.
+    chat_presence.clear_working(str(conversation_id), str(sender.id))
 
     # cross-org 차단: mentioned_ids를 현재 org 소속 member로 일괄 필터링 (QA B1).
     # E-MEMBER-SSOT Phase 0: 저장·DM포크·group 멘션 발송 모든 경로에 org 필터를 한 번 적용.

--- a/backend/app/services/chat_presence.py
+++ b/backend/app/services/chat_presence.py
@@ -1,0 +1,76 @@
+"""1aeecdde P2: 채팅 working/typing 인디케이터 — 답장 생성구간 ephemeral 신호.
+
+memo `presence.py`(viewing/typing) 동형 — in-memory·TTL 기반 ephemeral 저장소. presence P1
+(online/offline = 연결 축)과 **별도 축**(working = 작업 축). 같은 dot에 합치지 말 것(AC2):
+- online: SSE 연결 여부(team_members.presence_status·DB 도출)
+- working: 지금 답장을 생성 중인지(이 모듈·in-memory ephemeral)
+
+emit 훅(BE):
+- set_working: 메시지가 agent participant 에게 dispatch 될 때(=이벤트 수신점). 답장 생성 시작.
+- clear_working: 그 agent 가 conversation 에 메시지를 보낼 때(=reply POST). 생성 종료.
+- 둘 다 안 와도 _TTL_SEC 후 자동 소멸(에이전트가 답장 안 하기로 한 경우 등 — ephemeral 안전망).
+
+⚠️ 멀티인스턴스 한계: presence.py 와 동일하게 인스턴스-로컬 in-memory. 같은 인스턴스가 emit·GET
+을 처리해야 보인다. 크로스-인스턴스 실시간(Cloud Run 다인스턴스)은 pubsub/SSE 브로드캐스트가
+필요하며 FE 전송 설계(유나/미르코)와 함께 후속(P3)으로 다룬다. 본 P2 는 spec 의 'presence.py
+동형 in-memory poll' 계약을 따른다.
+"""
+from __future__ import annotations
+
+import time
+from dataclasses import asdict, dataclass, field
+
+# 답장 생성 구간 ephemeral TTL(초). presence.py(45s) 동형. 생성이 더 길면 인디케이터가 일찍
+# 사라질 수 있고(refresh 없음), 답장을 안 하면 최대 이 시간만큼 잔존한다 — ephemeral 안전망.
+_TTL_SEC = 45
+
+VALID_STATES = ("working", "typing")
+
+
+@dataclass
+class WorkingEntry:
+    member_id: str
+    state: str  # "working" | "typing"
+    updated_at: float = field(default_factory=time.time)
+
+
+# conversation_id(str) → {member_id(str): WorkingEntry}
+_working_store: dict[str, dict[str, WorkingEntry]] = {}
+
+
+def _evict_expired(conversation_id: str) -> None:
+    now = time.time()
+    store = _working_store.get(conversation_id, {})
+    expired = [mid for mid, e in store.items() if now - e.updated_at > _TTL_SEC]
+    for mid in expired:
+        store.pop(mid, None)
+    if not store:
+        _working_store.pop(conversation_id, None)
+
+
+def set_working(conversation_id: str, member_id: str, state: str = "working") -> None:
+    """답장 생성 시작 — member 를 conversation 의 working 집합에 등록(TTL 갱신)."""
+    if state not in VALID_STATES:
+        state = "working"
+    _working_store.setdefault(conversation_id, {})[member_id] = WorkingEntry(
+        member_id=member_id, state=state
+    )
+
+
+def clear_working(conversation_id: str, member_id: str) -> None:
+    """답장 생성 종료(reply POST) — member 의 working 신호 제거. 없으면 무해(no-op)."""
+    store = _working_store.get(conversation_id)
+    if store is None:
+        return
+    store.pop(member_id, None)
+    if not store:
+        _working_store.pop(conversation_id, None)
+
+
+def list_working(conversation_id: str) -> list[dict]:
+    """conversation 에서 현재 working/typing 중인 member 목록(만료분 제외)."""
+    _evict_expired(conversation_id)
+    return [
+        {**asdict(e)}
+        for e in _working_store.get(conversation_id, {}).values()
+    ]

--- a/backend/tests/test_agent_gateway.py
+++ b/backend/tests/test_agent_gateway.py
@@ -330,3 +330,106 @@ def test_dispatch_mention_events_uses_sorted_mention_targets():
     assert 'sorted(mention_targets)' in src, (
         'deadlock fix reverted: sorted(mention_targets) missing in _dispatch_mention_events'
     )
+
+
+# ── 49fed0a1: presence를 실제 SSE 연결에 배선 ──────────────────────────────────
+
+import contextlib
+from datetime import datetime, timedelta, timezone
+
+from app.routers.agent_gateway import (
+    _mark_agent_online,
+    _mark_agent_disconnected,
+    _SESSION_FRESH_TTL,
+)
+
+
+def _patch_session_factory(execute_results=None):
+    """async_session_factory() 를 mock async context manager 로 대체.
+
+    execute_results: db.execute 가 호출 순서대로 반환할 result mock 리스트.
+    반환: (patch context manager target 용 callable, db mock).
+    """
+    db = MagicMock()
+    results = list(execute_results or [])
+
+    async def _execute(*a, **k):
+        return results.pop(0) if results else MagicMock()
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.commit = AsyncMock()
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    return _factory, db
+
+
+@pytest.mark.anyio
+async def test_mark_agent_online_touches_session_and_presence():
+    """연결 중 tick: AgentGatewaySession.last_seen + presence(online) 갱신 후 commit."""
+    factory, db = _patch_session_factory()
+    sid = uuid.uuid4()
+    with patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync:
+        await _mark_agent_online(AGENT_ID, sid)
+    # AgentGatewaySession UPDATE 1회 실행
+    assert db.execute.await_count == 1
+    # presence online 갱신
+    mock_sync.assert_awaited_once()
+    _, kwargs = mock_sync.await_args
+    assert kwargs["agent_status"] == "online"
+    assert kwargs["last_seen_at"] is not None
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_mark_agent_online_swallows_errors():
+    """presence 갱신 실패가 스트림을 끊지 않도록 예외 삼킴(best-effort)."""
+    def _boom():
+        raise RuntimeError("db down")
+    with patch("app.routers.agent_gateway.async_session_factory", side_effect=_boom):
+        # 예외 전파되면 테스트 실패
+        await _mark_agent_online(AGENT_ID, uuid.uuid4())
+
+
+@pytest.mark.anyio
+async def test_mark_agent_disconnected_demotes_offline_when_no_remaining():
+    """마지막 세션 종료: 세션 삭제 후 잔여 활성 세션 없으면 presence offline 강등."""
+    no_remaining = MagicMock()
+    no_remaining.scalar_one_or_none.return_value = None  # 잔여 fresh 세션 없음
+    # execute 순서: [DELETE 결과(미사용), SELECT remaining 결과]
+    factory, db = _patch_session_factory([MagicMock(), no_remaining])
+    with patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync:
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
+    mock_sync.assert_awaited_once()
+    _, kwargs = mock_sync.await_args
+    assert kwargs["agent_status"] == "offline"
+    assert kwargs["last_seen_at"] is None  # last_seen=None → presence_status 즉시 offline
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_mark_agent_disconnected_keeps_online_when_other_session_active():
+    """같은 API Key 멀티세션(AC2): 다른 활성 세션 잔존 시 offline 강등 안 함."""
+    remaining = MagicMock()
+    remaining.scalar_one_or_none.return_value = uuid.uuid4()  # 다른 fresh 세션 존재
+    factory, db = _patch_session_factory([MagicMock(), remaining])
+    with patch("app.routers.agent_gateway.async_session_factory", factory), \
+         patch("app.services.agent_anchor_sync.sync_agent_profile_presence", new=AsyncMock()) as mock_sync:
+        await _mark_agent_disconnected(AGENT_ID, uuid.uuid4())
+    mock_sync.assert_not_awaited()  # 강등 없음
+    db.commit.assert_awaited_once()
+
+
+def test_presence_tick_interval_below_online_threshold():
+    """tick 주기 < online 임계(5분) — 연결 유지 중 last_seen이 online 윈도우 안에 머무름 보장."""
+    from app.schemas.team_member import _ONLINE_THRESHOLD
+    from app.routers.agent_gateway import _PRESENCE_TICK_INTERVAL
+    assert _PRESENCE_TICK_INTERVAL < _ONLINE_THRESHOLD.total_seconds()
+    # 세션 fresh TTL 도 online 임계 미만이어야 disconnect 판정이 stale 세션을 활성으로 오판 안 함
+    assert _SESSION_FRESH_TTL < _ONLINE_THRESHOLD.total_seconds()

--- a/backend/tests/test_chat_presence.py
+++ b/backend/tests/test_chat_presence.py
@@ -1,0 +1,91 @@
+"""1aeecdde P2: 채팅 working/typing ephemeral 신호(chat_presence) 단위 테스트.
+
+AC1: 답장 생성구간 working emit·TTL 자동 소멸. AC2: presence(online)와 별도 축.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+
+import pytest
+
+from app.services import chat_presence
+
+
+@pytest.fixture(autouse=True)
+def _clear_store():
+    """각 테스트 격리 — 모듈 전역 store 초기화."""
+    chat_presence._working_store.clear()
+    yield
+    chat_presence._working_store.clear()
+
+
+def test_set_then_list_returns_member():
+    conv = str(uuid.uuid4())
+    mid = str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    items = chat_presence.list_working(conv)
+    assert len(items) == 1
+    assert items[0]["member_id"] == mid
+    assert items[0]["state"] == "working"
+
+
+def test_clear_removes_member():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    chat_presence.clear_working(conv, mid)
+    assert chat_presence.list_working(conv) == []
+
+
+def test_clear_missing_is_noop():
+    """answer 없이 clear(휴먼 sender 등) — 예외 없이 no-op."""
+    chat_presence.clear_working(str(uuid.uuid4()), str(uuid.uuid4()))  # 예외 없어야 함
+
+
+def test_invalid_state_falls_back_to_working():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid, state="bogus")
+    assert chat_presence.list_working(conv)[0]["state"] == "working"
+
+
+def test_typing_state_preserved():
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid, state="typing")
+    assert chat_presence.list_working(conv)[0]["state"] == "typing"
+
+
+def test_ttl_eviction():
+    """TTL 초과 entry 는 list 시 제거(ephemeral 자동 소멸 — 미reply 안전망)."""
+    conv, mid = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, mid)
+    # updated_at 을 TTL 이전으로 backdate
+    chat_presence._working_store[conv][mid].updated_at = time.time() - chat_presence._TTL_SEC - 1
+    assert chat_presence.list_working(conv) == []
+    # 전부 만료되면 conversation 키도 정리
+    assert conv not in chat_presence._working_store
+
+
+def test_multiple_members_independent():
+    conv = str(uuid.uuid4())
+    a, b = str(uuid.uuid4()), str(uuid.uuid4())
+    chat_presence.set_working(conv, a)
+    chat_presence.set_working(conv, b, state="typing")
+    chat_presence.clear_working(conv, a)
+    items = chat_presence.list_working(conv)
+    assert len(items) == 1 and items[0]["member_id"] == b
+
+
+def test_set_emit_hook_wired_in_dispatch():
+    """_dispatch_conversation_event 가 agent recipient 에 set_working 호출하는지 소스 가드."""
+    import inspect
+    from app.routers.conversations import _dispatch_conversation_event
+    src = inspect.getsource(_dispatch_conversation_event)
+    assert "chat_presence.set_working" in src
+
+
+def test_clear_emit_hook_wired_in_send_message():
+    """send_message 가 clear_working 호출하는지 소스 가드(원본 conversation_id 기준)."""
+    import inspect
+    from app.routers.conversations import send_message
+    src = inspect.getsource(send_message)
+    assert "chat_presence.clear_working" in src


### PR DESCRIPTION
presence 본체 prod 프로모션(선생님 '본체 먼저' 승인). #1352(P1 SSE 연결배선)·#1353(P2 BE working emit)·#1354(P2 FE 2축 폴링)·#1355(snappy 1.5s). dev 라이브 검증 PASS(presence 진실화·2축·snappy 1754ms·모바일)·다층 게이트. FE+BE·마이그0. 확장(팀 패널)은 dev 진행 중.

🤖 Generated with [Claude Code](https://claude.com/claude-code)