### PR TITLE
[SID:2505d27d] feat(presence): 팀 presence 패널 (right-rail/drawer)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2308,6 +2308,15 @@
     "teamSizeLabel": "Team Size",
     "hypothesisSection": "Outcome Hypothesis"
   },
+  "presence": {
+    "panelTitle": "Team presence",
+    "groupWorking": "Working",
+    "groupOnline": "Online",
+    "groupOffline": "Offline",
+    "working": "Generating reply",
+    "assignedStory": "On \"{title}\"",
+    "empty": "No agents to show"
+  },
   "chats": {
     "isTyping": "{name} is typing",
     "othersTyping": "{name} and {count} others are typing",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2308,6 +2308,15 @@
     "teamSizeLabel": "인원",
     "hypothesisSection": "효과 가설"
   },
+  "presence": {
+    "panelTitle": "팀 presence",
+    "groupWorking": "작업 중",
+    "groupOnline": "온라인",
+    "groupOffline": "오프라인",
+    "working": "답 생성 중",
+    "assignedStory": "\"{title}\" 담당",
+    "empty": "표시할 에이전트가 없습니다"
+  },
   "chats": {
     "isTyping": "{name} 님이 입력 중",
     "othersTyping": "{name} 외 {count}명 입력 중",

--- a/apps/web/src/app/api/team-presence/route.ts
+++ b/apps/web/src/app/api/team-presence/route.ts
@@ -1,0 +1,8 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// 2505d27d: GET /api/v2/team-presence 프록시 — org 전 에이전트 presence(연결)+working(작업) 집계.
+// 디디 #1356(team_presence.py)·폴링 GET. 팀 presence 패널이 소비. (/working 프록시 패턴 동형)
+export async function GET(request: NextRequest): Promise<Response> {
+  return proxyToFastapi(request, '/api/v2/team-presence');
+}

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -2,12 +2,17 @@
 
 import { createContext, useContext, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
+import { useTranslations } from 'next-intl';
+import { Users } from 'lucide-react';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { AppSidebar } from '@/components/nav/app-sidebar';
 import { TopBar } from '@/components/nav/top-bar';
 import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
+import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/contextual-panel-layout';
+import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
 import { RefreshProvider } from '@/contexts/refresh-context';
+import { cn } from '@/lib/utils';
 import type { OrgSwitcherItem } from '@/components/nav/unified-switcher';
 
 export interface DashboardProjectOption {
@@ -40,13 +45,48 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   const setRef = useCallback((el: HTMLDivElement | null) => {
     setScrollContainer(el);
   }, [setScrollContainer]);
+  const t = useTranslations('presence');
+  // 2505d27d: 상시 팀 presence 패널 — 2xl=inline right-rail / <2xl=drawer. storageKey로 open 영속.
+  const panel = useContextualPanelState({ storageKey: 'team-presence', defaultOpen: true });
+  const panelActive = panel.inlinePanelOpen || panel.drawerOpen;
 
   return (
     <SidebarInset className="relative flex flex-col overflow-hidden">
       <div ref={setRef} className="flex flex-1 min-h-0 flex-col overflow-y-auto">
         {showTopBar && <TopBar />}
-        {children}
+        <ContextualPanelLayout
+          renderPanel={({ mode, closePanel }) => (
+            <div className={mode === 'inline' ? '2xl:sticky 2xl:top-0 2xl:h-svh 2xl:p-2' : 'h-full'}>
+              <TeamPresencePanel active={panelActive} mode={mode} onClose={closePanel} />
+            </div>
+          )}
+          inlinePanelOpen={panel.inlinePanelOpen}
+          drawerOpen={panel.drawerOpen}
+          onDrawerOpenChange={panel.setDrawerOpen}
+          drawerAriaLabel={t('panelTitle')}
+          drawerSide="right"
+          drawerWidthClassName="w-[min(92vw,24rem)]"
+          className="min-h-0 flex-1"
+          inlineColumnsClassName="2xl:grid-cols-[minmax(0,1fr)_320px]"
+          panelClassName="2xl:col-start-2 2xl:row-start-1"
+          contentClassName="flex min-h-0 min-w-0 flex-col 2xl:col-start-1 2xl:row-start-1"
+        >
+          {children}
+        </ContextualPanelLayout>
       </div>
+
+      {/* 토글 — 우측 가장자리 탭(상시 패널 열기/닫기). inline open 시 숨김(rail 자체 가시). */}
+      <button
+        type="button"
+        onClick={panel.togglePanel}
+        aria-label={t('panelTitle')}
+        className={cn(
+          'fixed right-0 top-1/2 z-40 -translate-y-1/2 rounded-l-md border border-r-0 border-border bg-card px-1.5 py-3 text-muted-foreground shadow-sm transition-colors hover:text-foreground',
+          panel.inlinePanelOpen && '2xl:hidden',
+        )}
+      >
+        <Users className="size-4" />
+      </button>
     </SidebarInset>
   );
 }

--- a/apps/web/src/components/chat/presence-dot.tsx
+++ b/apps/web/src/components/chat/presence-dot.tsx
@@ -29,12 +29,17 @@ const STATUS_LABEL_KEY: Record<PresenceStatus, string> = {
  */
 export const WORKING_RING_CLASS = 'ring-2 ring-brand ring-offset-1 ring-offset-card motion-safe:animate-pulse';
 
-/** 연결 축 dot(avatar 우하단). status null/undefined(휴먼·미상)면 미표시. */
+// 2505d27d: 패널은 큰 영역이라 prominent하게(size-3·12px) — 채팅 dot(size-2.5·10px)보다 가시성↑(모바일 교훈).
+const SIZE_CLASS = { sm: 'size-2.5', md: 'size-3' } as const;
+
+/** 연결 축 dot(avatar 우하단). status null/undefined(휴먼·미상)면 미표시. size: sm(채팅)·md(패널). */
 export function PresenceDot({
   status,
+  size = 'sm',
   className = '',
 }: {
   status: PresenceStatus | null | undefined;
+  size?: 'sm' | 'md';
   className?: string;
 }) {
   const t = useTranslations('chats');
@@ -43,7 +48,7 @@ export function PresenceDot({
     <span
       role="img"
       aria-label={t(STATUS_LABEL_KEY[status])}
-      className={`inline-block size-2.5 rounded-full border-2 border-card ${DOT_CLASS[status]} ${className}`}
+      className={`inline-block ${SIZE_CLASS[size]} rounded-full border-2 border-card ${DOT_CLASS[status]} ${className}`}
     />
   );
 }

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { Bot, X } from 'lucide-react';
+import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
+import { GlassPanel } from '@/components/ui/glass-panel';
+import { cn } from '@/lib/utils';
+
+// 2505d27d: 디디 #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
+interface TeamPresenceItem {
+  member_id: string;
+  name: string;
+  avatar_url?: string | null;
+  agent_role?: string | null;
+  runtime_type?: string | null;
+  presence_status?: PresenceStatus | null;
+  working: boolean;
+  active_story?: { id: string; title: string; status: string } | null;
+}
+
+// ~2s 통합 폴 — working snappy(선생님 빠릿빠릿)·presence 충분. 패널 비가시 시 중단(낭비0).
+const POLL_MS = 2000;
+
+type GroupKey = 'working' | 'online' | 'offline';
+const GROUP_DOT: Record<GroupKey, string> = {
+  working: 'bg-brand',
+  online: 'bg-success',
+  offline: 'bg-muted-foreground/40',
+};
+
+function groupItems(items: TeamPresenceItem[]): { key: GroupKey; items: TeamPresenceItem[] }[] {
+  const byName = (a: TeamPresenceItem, b: TeamPresenceItem) => a.name.localeCompare(b.name);
+  const working = items.filter((i) => i.working).sort(byName);
+  // online 그룹 = working 아님 + (online | idle). idle은 dot=amber로 구분(별 그룹 안 만듦·노이즈↓).
+  const online = items.filter((i) => !i.working && (i.presence_status === 'online' || i.presence_status === 'idle')).sort(byName);
+  const offline = items.filter((i) => !i.working && (i.presence_status === 'offline' || !i.presence_status)).sort(byName);
+  return ([
+    { key: 'working', items: working },
+    { key: 'online', items: online },
+    { key: 'offline', items: offline },
+  ] as { key: GroupKey; items: TeamPresenceItem[] }[]).filter((g) => g.items.length > 0);
+}
+
+function PresenceRow({ item }: { item: TeamPresenceItem }) {
+  const t = useTranslations('presence');
+  const offline = !item.working && (item.presence_status === 'offline' || !item.presence_status);
+  const dotStatus: PresenceStatus = item.presence_status ?? 'offline';
+  const fallback = [item.agent_role, item.runtime_type].filter(Boolean).join(' · ');
+
+  return (
+    <li className={cn('flex items-center gap-2.5 rounded-lg px-2 py-1.5', offline && 'opacity-60')}>
+      <div className={cn('relative size-8 shrink-0 rounded-full', item.working && WORKING_RING_CLASS)}>
+        {item.avatar_url ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img src={item.avatar_url} alt="" className="size-8 rounded-full object-cover" />
+        ) : (
+          <span className="flex size-8 items-center justify-center rounded-full bg-warning-tint text-warning">
+            <Bot className="size-4" />
+          </span>
+        )}
+        <PresenceDot status={dotStatus} size="md" className="absolute -bottom-0.5 -right-0.5" />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className={cn('truncate text-sm font-medium', offline ? 'text-muted-foreground' : 'text-foreground')}>
+          {item.name}
+        </p>
+        <div className="truncate text-xs text-muted-foreground">
+          {item.working ? (
+            <span className="inline-flex max-w-full items-center gap-1 text-brand">
+              <span className="shrink-0">{t('working')}</span>
+              <span className="inline-flex shrink-0 gap-0.5" aria-hidden>
+                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce" />
+                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:150ms]" />
+                <span className="size-1 rounded-full bg-brand motion-safe:animate-bounce [animation-delay:300ms]" />
+              </span>
+              {item.active_story ? (
+                <span className="truncate text-muted-foreground">· {t('assignedStory', { title: item.active_story.title })}</span>
+              ) : null}
+            </span>
+          ) : item.active_story ? (
+            t('assignedStory', { title: item.active_story.title })
+          ) : (
+            fallback
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+/**
+ * 2505d27d 팀 presence 패널 본체 — 상태별 그룹(🔵working↑→🟢online→⚫offline↓)·~2s 폴(active 시만).
+ * contextual-panel-layout의 renderPanel로 inline(right-rail)/drawer 양쪽에서 렌더.
+ */
+export function TeamPresencePanel({
+  active,
+  mode = 'inline',
+  onClose,
+}: {
+  active: boolean;
+  mode?: 'inline' | 'drawer';
+  onClose?: () => void;
+}) {
+  const t = useTranslations('presence');
+  const [items, setItems] = useState<TeamPresenceItem[]>([]);
+
+  const fetchPresence = useCallback(async () => {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    try {
+      const res = await fetch('/api/team-presence');
+      if (!res.ok) return;
+      const json = (await res.json()) as TeamPresenceItem[] | { data?: TeamPresenceItem[] };
+      setItems(Array.isArray(json) ? json : (json.data ?? []));
+    } catch {
+      /* non-critical */
+    }
+  }, []);
+
+  // 패널이 active(open·가시)일 때만 폴 — 닫힘/비가시 시 중단(낭비0).
+  useEffect(() => {
+    if (!active) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchPresence();
+    const interval = setInterval(() => { void fetchPresence(); }, POLL_MS);
+    return () => clearInterval(interval);
+  }, [active, fetchPresence]);
+
+  const groups = groupItems(items);
+
+  return (
+    <GlassPanel className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl">
+      <header className="flex shrink-0 items-center justify-between border-b border-border/60 px-4 py-3">
+        <h2 className="text-sm font-semibold text-foreground">{t('panelTitle')}</h2>
+        {mode === 'drawer' && onClose ? (
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('panelTitle')}
+            className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground"
+          >
+            <X className="size-4" />
+          </button>
+        ) : null}
+      </header>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-2">
+        {groups.length === 0 ? (
+          <p className="px-4 py-6 text-center text-sm text-muted-foreground">{t('empty')}</p>
+        ) : (
+          groups.map((g) => (
+            <section key={g.key} className="px-2 py-1">
+              <div className="flex items-center gap-2 px-2 py-1">
+                <span className={cn('size-2 rounded-full', GROUP_DOT[g.key])} aria-hidden />
+                <h3 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                  {t(g.key === 'working' ? 'groupWorking' : g.key === 'online' ? 'groupOnline' : 'groupOffline')}
+                </h3>
+                <span className="ml-auto text-xs tabular-nums text-muted-foreground">{g.items.length}</span>
+              </div>
+              <ul>
+                {g.items.map((item) => (
+                  <PresenceRow key={item.member_id} item={item} />
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+      </div>
+    </GlassPanel>
+  );
+}


### PR DESCRIPTION
## 개요
선생님 블루프린트 `blueprint-presence-prominent-display`(A/B/C 승인)·presence 확장. 전 에이전트 presence를 **상시 한눈에**(채팅 밖·**페이지 아님=C**). 디디 **#1356** `GET /api/v2/team-presence` 소비.

## 구현 (설계 doc `handoff-team-presence-panel`)
- **TeamPresencePanel + PresenceRow**: 상태별 그룹 **🔵working↑ → 🟢online → ⚫offline↓**(idle=online그룹 amber dot·빈그룹 숨김·count·이름정렬). 행 = avatar(url/Bot fallback·working시 `WORKING_RING_CLASS`) + **PresenceDot size-3**(P2 재사용) + 이름 + meta(working "답 생성 중" 애니 / active_story / role·runtime) · offline dimmed.
- **폴링 ~2s 통합**(working snappy=선생님 빠릿빠릿·`active`일 때만·`document.hidden` 중단 = 낭비0).
- **FE 프록시** `/api/team-presence`(proxyToFastapi). **PresenceDot에 `size` prop**(sm 채팅·md 패널 — 모바일 가시성 교훈).
- **shell 통합**: `useContextualPanelState`(storageKey `team-presence`·defaultOpen) + `ContextualPanelLayout` — **2xl=inline right-rail 320px / <2xl=drawer(right·92vw)** · 우측 토글 탭. **페이지 라우트 없음(C).**
- i18n `presence` ns 7키 en/ko · 매직hex0 · `prefers-reduced-motion` · dot `aria-label`.

## BE 계약 (#1356·검증완료·mismatch 0)
`GET /api/v2/team-presence` → `[{member_id,name,avatar_url,agent_role,runtime_type,presence_status,working,active_story}]`. `team_presence.py` 코드 교차검증(P2 transport 교훈 적용).

## ⚠️ 가디언 라이브 픽셀 중점(전역 shell 변경)
패널이 **DashboardShell `{children}` 전역 래핑** — type-check/lint/build 그린이나 **빌드가 못 잡는 시각/높이 회귀는 라이브 픽셀 필요**:
1. **height-fill 페이지**(chat·board 등) 2xl에서 패널 open 시 레이아웃/높이 정상(content `flex min-h-0`·panel sticky h-svh).
2. **상태별 그룹·dot·working ring/"답 생성 중"·offline dimmed** × light/dark.
3. **모바일(drawer) 가시성** — PresenceDot size-3·working ring.
4. **토글 탭** 동작(2xl inline toggle / <2xl drawer)·위치 적정성(필요시 TopBar/사이드바로 이전 가능).
- **행클릭→DM은 옵션이라 MVP 제외**(non-blocking·후속).

## 검증
`pnpm type-check` ✅ / `pnpm lint`(변경 파일 0) ✅ / `pnpm build` ✅

## 스크린샷
인증 세션 필요·로컬 보류 → dev 배포 후 가디언 라이브 픽셀(desktop right-rail + mobile drawer·3그룹).

🤖 Generated with [Claude Code](https://claude.com/claude-code)