### PR TITLE
[SID:2505d27d] fix(presence): presence FAB 토글 + working-count 배지 (선생님 가시성)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2310,6 +2310,7 @@
   },
   "presence": {
     "panelTitle": "Team presence",
+    "fabLabelWorking": "Team presence · {count} working",
     "groupWorking": "Working",
     "groupOnline": "Online",
     "groupOffline": "Offline",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2310,6 +2310,7 @@
   },
   "presence": {
     "panelTitle": "팀 presence",
+    "fabLabelWorking": "팀 presence · {count}명 작업 중",
     "groupWorking": "작업 중",
     "groupOnline": "온라인",
     "groupOffline": "오프라인",

--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -11,6 +11,7 @@ import { TopBarProvider, useTopBar } from '@/components/nav/top-bar-context';
 import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar';
 import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/contextual-panel-layout';
 import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
+import { useTeamPresence } from '@/components/presence/use-team-presence';
 import { RefreshProvider } from '@/contexts/refresh-context';
 import { cn } from '@/lib/utils';
 import type { OrgSwitcherItem } from '@/components/nav/unified-switcher';
@@ -48,7 +49,9 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   const t = useTranslations('presence');
   // 2505d27d: 상시 팀 presence 패널 — 2xl=inline right-rail / <2xl=drawer. storageKey로 open 영속.
   const panel = useContextualPanelState({ storageKey: 'team-presence', defaultOpen: true });
-  const panelActive = panel.inlinePanelOpen || panel.drawerOpen;
+  // 폴 상향(단일 폴) — FAB working-count 배지가 패널 닫힘 상태서도 갱신돼야 하므로 상시 폴(document.hidden 가드는 hook 내).
+  const items = useTeamPresence(true);
+  const workingCount = items.filter((i) => i.working).length;
 
   return (
     <SidebarInset className="relative flex flex-col overflow-hidden">
@@ -57,7 +60,7 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
         <ContextualPanelLayout
           renderPanel={({ mode, closePanel }) => (
             <div className={mode === 'inline' ? '2xl:sticky 2xl:top-0 2xl:h-svh 2xl:p-2' : 'h-full'}>
-              <TeamPresencePanel active={panelActive} mode={mode} onClose={closePanel} />
+              <TeamPresencePanel items={items} mode={mode} onClose={closePanel} />
             </div>
           )}
           inlinePanelOpen={panel.inlinePanelOpen}
@@ -75,17 +78,27 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
         </ContextualPanelLayout>
       </div>
 
-      {/* 토글 — 우측 가장자리 탭(상시 패널 열기/닫기). inline open 시 숨김(rail 자체 가시). */}
+      {/* 2505d27d: presence FAB(선생님 안·우하단·상시·명확) — 전 width 가시·클릭→패널 토글.
+          working-count 배지=접힌 상태서도 "N 작업 중" at-a-glance. 모바일은 하단 GNB(lg:hidden) 안 가리게 bottom↑. */}
       <button
         type="button"
         onClick={panel.togglePanel}
-        aria-label={t('panelTitle')}
+        aria-label={workingCount > 0 ? t('fabLabelWorking', { count: workingCount }) : t('panelTitle')}
+        title={t('panelTitle')}
         className={cn(
-          'fixed right-0 top-1/2 z-40 -translate-y-1/2 rounded-l-md border border-r-0 border-border bg-card px-1.5 py-3 text-muted-foreground shadow-sm transition-colors hover:text-foreground',
-          panel.inlinePanelOpen && '2xl:hidden',
+          'fixed bottom-20 right-4 z-50 flex size-14 items-center justify-center rounded-full bg-brand text-brand-foreground shadow-lg transition-transform hover:scale-105 lg:bottom-6 lg:right-6',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background',
         )}
       >
-        <Users className="size-4" />
+        <Users className="size-[22px]" />
+        {workingCount > 0 ? (
+          <span
+            className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-foreground px-1 text-xs font-bold tabular-nums text-brand shadow ring-2 ring-brand"
+            aria-hidden
+          >
+            {workingCount}
+          </span>
+        ) : null}
       </button>
     </SidebarInset>
   );

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -1,26 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { Bot, X } from 'lucide-react';
 import { PresenceDot, WORKING_RING_CLASS, type PresenceStatus } from '@/components/chat/presence-dot';
 import { GlassPanel } from '@/components/ui/glass-panel';
 import { cn } from '@/lib/utils';
-
-// 2505d27d: 디디 #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
-interface TeamPresenceItem {
-  member_id: string;
-  name: string;
-  avatar_url?: string | null;
-  agent_role?: string | null;
-  runtime_type?: string | null;
-  presence_status?: PresenceStatus | null;
-  working: boolean;
-  active_story?: { id: string; title: string; status: string } | null;
-}
-
-// ~2s 통합 폴 — working snappy(선생님 빠릿빠릿)·presence 충분. 패널 비가시 시 중단(낭비0).
-const POLL_MS = 2000;
+import type { TeamPresenceItem } from './use-team-presence';
 
 type GroupKey = 'working' | 'online' | 'offline';
 const GROUP_DOT: Record<GroupKey, string> = {
@@ -91,42 +76,20 @@ function PresenceRow({ item }: { item: TeamPresenceItem }) {
 }
 
 /**
- * 2505d27d 팀 presence 패널 본체 — 상태별 그룹(🔵working↑→🟢online→⚫offline↓)·~2s 폴(active 시만).
+ * 2505d27d 팀 presence 패널 본체 — 상태별 그룹(🔵working↑→🟢online→⚫offline↓).
+ * 폴은 ScrollShell의 `useTeamPresence`에서 상향(단일 폴·FAB 배지와 공유)·items로 주입받는다.
  * contextual-panel-layout의 renderPanel로 inline(right-rail)/drawer 양쪽에서 렌더.
  */
 export function TeamPresencePanel({
-  active,
+  items,
   mode = 'inline',
   onClose,
 }: {
-  active: boolean;
+  items: TeamPresenceItem[];
   mode?: 'inline' | 'drawer';
   onClose?: () => void;
 }) {
   const t = useTranslations('presence');
-  const [items, setItems] = useState<TeamPresenceItem[]>([]);
-
-  const fetchPresence = useCallback(async () => {
-    if (typeof document !== 'undefined' && document.hidden) return;
-    try {
-      const res = await fetch('/api/team-presence');
-      if (!res.ok) return;
-      const json = (await res.json()) as TeamPresenceItem[] | { data?: TeamPresenceItem[] };
-      setItems(Array.isArray(json) ? json : (json.data ?? []));
-    } catch {
-      /* non-critical */
-    }
-  }, []);
-
-  // 패널이 active(open·가시)일 때만 폴 — 닫힘/비가시 시 중단(낭비0).
-  useEffect(() => {
-    if (!active) return;
-    // eslint-disable-next-line react-hooks/set-state-in-effect
-    void fetchPresence();
-    const interval = setInterval(() => { void fetchPresence(); }, POLL_MS);
-    return () => clearInterval(interval);
-  }, [active, fetchPresence]);
-
   const groups = groupItems(items);
 
   return (

--- a/apps/web/src/components/presence/use-team-presence.ts
+++ b/apps/web/src/components/presence/use-team-presence.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { PresenceStatus } from '@/components/chat/presence-dot';
+
+// 2505d27d: 디디 #1356 `GET /api/v2/team-presence` 응답 계약(검증 완료·mismatch 0).
+export interface TeamPresenceItem {
+  member_id: string;
+  name: string;
+  avatar_url?: string | null;
+  agent_role?: string | null;
+  runtime_type?: string | null;
+  presence_status?: PresenceStatus | null;
+  working: boolean;
+  active_story?: { id: string; title: string; status: string } | null;
+}
+
+// ~3s 절충 폴(PO) — 전 유저 상시 폴이라 request 폭증 회피 + working 충분히 snappy. 단일 폴을 FAB 배지+패널 공유(중복0).
+const POLL_MS = 3000;
+
+/**
+ * 2505d27d: 팀 presence 폴 — ScrollShell(전역)에서 1회 폴해 FAB working-count 배지 + 패널에 공급.
+ * 배지가 패널 닫힘 상태서도 "N 작업 중"을 보여야 하므로(선생님) **패널 open 무관 상시 폴**(active 시).
+ * 단 `document.hidden`(백그라운드 탭)이면 0폴(낭비 가드).
+ */
+export function useTeamPresence(active: boolean): TeamPresenceItem[] {
+  const [items, setItems] = useState<TeamPresenceItem[]>([]);
+
+  const fetchPresence = useCallback(async () => {
+    if (typeof document !== 'undefined' && document.hidden) return;
+    try {
+      const res = await fetch('/api/team-presence');
+      if (!res.ok) return;
+      const json = (await res.json()) as TeamPresenceItem[] | { data?: TeamPresenceItem[] };
+      setItems(Array.isArray(json) ? json : (json.data ?? []));
+    } catch {
+      /* non-critical */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void fetchPresence();
+    const interval = setInterval(() => { void fetchPresence(); }, POLL_MS);
+    return () => clearInterval(interval);
+  }, [active, fetchPresence]);
+
+  return items;
+}


### PR DESCRIPTION
## 선생님 UX 피드백 (dev 직접)
`<2xl`에서 패널 토글(우측 가장자리 탭)이 **"정신병 수준" 가시성**(안 보임) → 접근 죽으면 패널 "한눈에" 가치 죽음. **선생님 안 = 우하단 FAB(상시·명확).**

## 수정
- **우측 edge 탭 → 우하단 FAB**: `fixed bottom-6 right-6`(모바일 `bottom-20`=GNB[lg:hidden] 회피)·`size-14`·`rounded-full`·`bg-brand text-brand-foreground`·`shadow-lg`·`Users` 22px·hover scale·focus ring. 동적 `aria-label`(working 시 "팀 presence · N명 작업 중")·`title` tooltip. **전 width 명확 가시.**
- **working-count 배지**(FAB 우상단·"N"): 패널 **닫힘 상태서도 "N 작업 중" at-a-glance**(선생님 의도 강화). 의미 = 지금 **채팅 답 생성 중** N명(현 working 신호 한정·PO 인지·추후 working 신호 확장 시 자동 정확).
- **폴 상향(아키텍처)**: 신규 `useTeamPresence` hook(단일 폴 **~3s**·`document.hidden` pause) → ScrollShell에서 **FAB 배지 + 패널** 둘 다 공급(중복0). 패널은 `items` prop 수신(내부 폴 제거). doc §6 "닫힘 시 폴 중단"은 배지 요구로 **supersede**(닫혀도 count 갱신·PO 승인)·document.hidden 가드 유지(백그라운드 0폴).
- i18n `presence.fabLabelWorking`(en/ko)·매직hex0(brand/brand-foreground).

## ⚠️ 가디언 라이브 픽셀 + 선생님 재확인(가시성)
1. **FAB 전 width 가시**(desktop 우하단 / 모바일 GNB·composer 안 가림)·클릭→패널 토글(≥2xl rail / <2xl drawer).
2. **working-count 배지**(실 에이전트 트리거 시 "N" 표시·닫힘 상태서도).
3. light/dark·focus ring·hover.
- **선생님 직접 가시성 재확인**이 done 게이트.

## 검증
`pnpm type-check` ✅ / `pnpm lint`(변경 파일 0) ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)