### PR TITLE
[SID:2505d27d] fix(presence): 패널 open 시 FAB 숨김 (선생님 겹침 캐치)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -60,7 +60,10 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
         <ContextualPanelLayout
           renderPanel={({ mode, closePanel }) => (
             <div className={mode === 'inline' ? '2xl:sticky 2xl:top-0 2xl:h-svh 2xl:p-2' : 'h-full'}>
-              <TeamPresencePanel items={items} mode={mode} onClose={closePanel} />
+              <TeamPresencePanel
+                items={items}
+                onClose={mode === 'inline' ? () => panel.setInlinePanelOpen(false) : closePanel}
+              />
             </div>
           )}
           inlinePanelOpen={panel.inlinePanelOpen}
@@ -78,11 +81,13 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
         </ContextualPanelLayout>
       </div>
 
-      {/* 2505d27d: presence FAB(선생님 안·우하단·상시·명확) — 전 width 가시·클릭→패널 토글.
-          working-count 배지=접힌 상태서도 "N 작업 중" at-a-glance. 모바일은 하단 GNB(lg:hidden) 안 가리게 bottom↑. */}
+      {/* 2505d27d: presence FAB(선생님 안·우하단) — **패널 닫힘일 때만 렌더**(열림 시 redundant/겹침=선생님 캐치).
+          패널은 자체 X로 닫음 → FAB 재등장. working-count 배지=닫힘서도 "N 작업 중". 모바일 GNB(lg:hidden) 회피 bottom↑.
+          ⚠️ 폴(useTeamPresence)은 렌더와 무관하게 유지 — 배지 count 최신성 보존(폴≠렌더). */}
+      {!panel.inlinePanelOpen && !panel.drawerOpen ? (
       <button
         type="button"
-        onClick={panel.togglePanel}
+        onClick={panel.openPanel}
         aria-label={workingCount > 0 ? t('fabLabelWorking', { count: workingCount }) : t('panelTitle')}
         title={t('panelTitle')}
         className={cn(
@@ -100,6 +105,7 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
           </span>
         ) : null}
       </button>
+      ) : null}
     </SidebarInset>
   );
 }

--- a/apps/web/src/components/presence/team-presence-panel.tsx
+++ b/apps/web/src/components/presence/team-presence-panel.tsx
@@ -82,11 +82,9 @@ function PresenceRow({ item }: { item: TeamPresenceItem }) {
  */
 export function TeamPresencePanel({
   items,
-  mode = 'inline',
   onClose,
 }: {
   items: TeamPresenceItem[];
-  mode?: 'inline' | 'drawer';
   onClose?: () => void;
 }) {
   const t = useTranslations('presence');
@@ -96,7 +94,7 @@ export function TeamPresencePanel({
     <GlassPanel className="flex h-full min-h-0 flex-col overflow-hidden rounded-xl">
       <header className="flex shrink-0 items-center justify-between border-b border-border/60 px-4 py-3">
         <h2 className="text-sm font-semibold text-foreground">{t('panelTitle')}</h2>
-        {mode === 'drawer' && onClose ? (
+        {onClose ? (
           <button
             type="button"
             onClick={onClose}


### PR DESCRIPTION
## 선생님 캐치 (스샷)
패널 **open 상태서 FAB가 그대로 보임 = redundant/겹침**(≥2xl rail-open 시 FAB↔rail 시각 충돌·유나양이 우려했던 그것).

## 수정
- **FAB는 패널 닫힘일 때만 렌더**(`!inlinePanelOpen && !drawerOpen`)·onClick=`openPanel`. 열림 시 숨김 → 겹침 0.
- **패널 자체 X로 닫음 → FAB 재등장.** inline rail에도 X 노출(기존 drawer 한정 → **양쪽 모드**)·`onClose` 모드별(inline=`setInlinePanelOpen(false)` / drawer=`closePanel`). 미사용 `mode` prop 제거.
- ⚠️ **shared `useTeamPresence` 폴은 렌더와 무관하게 유지** — 배지 count 최신성 보존(폴≠렌더·`document.hidden` 가드 유지).

## 가디언 라이브 픽셀 + 선생님 재확인
- 패널 닫힘 → FAB+배지 보임 / **open(inline rail/drawer) → FAB 숨김·겹침0** / 패널 X로 닫기 → FAB 재등장.
- ≥2xl inline rail X로 닫힘·<2xl drawer X로 닫힘. light/dark.

## 검증
`pnpm type-check` ✅ / `pnpm lint`(변경 파일 0) ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)