### PR TITLE
[SID:2505d27d] fix(presence): FAB → 헤더 people 토글 (선생님 결정·충돌0)

### DIFF
--- a/apps/web/src/app/dashboard/dashboard-shell.tsx
+++ b/apps/web/src/app/dashboard/dashboard-shell.tsx
@@ -3,7 +3,6 @@
 import { createContext, useContext, useCallback } from 'react';
 import { usePathname } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { Users } from 'lucide-react';
 import { RealtimeProvider } from '@/components/realtime-provider';
 import { AppSidebar } from '@/components/nav/app-sidebar';
 import { TopBar } from '@/components/nav/top-bar';
@@ -13,7 +12,7 @@ import { ContextualPanelLayout, useContextualPanelState } from '@/components/ui/
 import { TeamPresencePanel } from '@/components/presence/team-presence-panel';
 import { useTeamPresence } from '@/components/presence/use-team-presence';
 import { RefreshProvider } from '@/contexts/refresh-context';
-import { cn } from '@/lib/utils';
+import { TeamPresenceToggleProvider } from '@/components/presence/team-presence-toggle';
 import type { OrgSwitcherItem } from '@/components/nav/unified-switcher';
 
 export interface DashboardProjectOption {
@@ -49,11 +48,12 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
   const t = useTranslations('presence');
   // 2505d27d: 상시 팀 presence 패널 — 2xl=inline right-rail / <2xl=drawer. storageKey로 open 영속.
   const panel = useContextualPanelState({ storageKey: 'team-presence', defaultOpen: true });
-  // 폴 상향(단일 폴) — FAB working-count 배지가 패널 닫힘 상태서도 갱신돼야 하므로 상시 폴(document.hidden 가드는 hook 내).
+  // 폴 상향(단일 폴) — 헤더 토글 working-count 배지가 패널 닫힘 상태서도 갱신돼야 하므로 상시 폴(document.hidden 가드는 hook 내).
   const items = useTeamPresence(true);
   const workingCount = items.filter((i) => i.working).length;
 
   return (
+    <TeamPresenceToggleProvider value={{ toggle: panel.togglePanel, workingCount, open: panel.inlinePanelOpen || panel.drawerOpen }}>
     <SidebarInset className="relative flex flex-col overflow-hidden">
       <div ref={setRef} className="flex flex-1 min-h-0 flex-col overflow-y-auto">
         {showTopBar && <TopBar />}
@@ -80,33 +80,8 @@ function ScrollShell({ showTopBar, children }: { showTopBar: boolean; children: 
           {children}
         </ContextualPanelLayout>
       </div>
-
-      {/* 2505d27d: presence FAB(선생님 안·우하단) — **패널 닫힘일 때만 렌더**(열림 시 redundant/겹침=선생님 캐치).
-          패널은 자체 X로 닫음 → FAB 재등장. working-count 배지=닫힘서도 "N 작업 중". 모바일 GNB(lg:hidden) 회피 bottom↑.
-          ⚠️ 폴(useTeamPresence)은 렌더와 무관하게 유지 — 배지 count 최신성 보존(폴≠렌더). */}
-      {!panel.inlinePanelOpen && !panel.drawerOpen ? (
-      <button
-        type="button"
-        onClick={panel.openPanel}
-        aria-label={workingCount > 0 ? t('fabLabelWorking', { count: workingCount }) : t('panelTitle')}
-        title={t('panelTitle')}
-        className={cn(
-          'fixed bottom-20 right-4 z-50 flex size-14 items-center justify-center rounded-full bg-brand text-brand-foreground shadow-lg transition-transform hover:scale-105 lg:bottom-6 lg:right-6',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-        )}
-      >
-        <Users className="size-[22px]" />
-        {workingCount > 0 ? (
-          <span
-            className="absolute -right-1 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full bg-brand-foreground px-1 text-xs font-bold tabular-nums text-brand shadow ring-2 ring-brand"
-            aria-hidden
-          >
-            {workingCount}
-          </span>
-        ) : null}
-      </button>
-      ) : null}
     </SidebarInset>
+    </TeamPresenceToggleProvider>
   );
 }
 

--- a/apps/web/src/components/nav/top-bar.tsx
+++ b/apps/web/src/components/nav/top-bar.tsx
@@ -3,6 +3,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar';
 import { cn } from '@/lib/utils';
 import { NotificationBell } from './notification-bell';
+import { PresenceToggleButton } from '@/components/presence/team-presence-toggle';
 import { useTopBar } from './top-bar-context';
 
 interface TopBarProps {
@@ -28,6 +29,8 @@ export function TopBar({ className }: TopBarProps) {
       </div>
       <div className="flex shrink-0 items-center gap-1">
         {actions}
+        {/* 2505d27d: presence 패널 토글(선생님 결정·FAB 대체) — Bell 옆·working-count 배지 */}
+        <PresenceToggleButton />
         <NotificationBell />
       </div>
     </div>

--- a/apps/web/src/components/presence/team-presence-toggle.tsx
+++ b/apps/web/src/components/presence/team-presence-toggle.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+import { useTranslations } from 'next-intl';
+import { Users } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+// 2505d27d: presence 패널 토글을 헤더(TopBar)서 제어하기 위한 context.
+// 패널 state(useContextualPanelState)는 ScrollShell 소유 → provider로 TopBar에 toggle/count/open 공급.
+// (선생님 결정: FAB→상단 헤더 people 토글. composer 충돌0·발견성↑.)
+interface TeamPresenceToggleValue {
+  toggle: () => void;
+  workingCount: number;
+  open: boolean;
+}
+
+const TeamPresenceToggleContext = createContext<TeamPresenceToggleValue | null>(null);
+
+export const TeamPresenceToggleProvider = TeamPresenceToggleContext.Provider;
+
+export function useTeamPresenceToggle(): TeamPresenceToggleValue | null {
+  return useContext(TeamPresenceToggleContext);
+}
+
+/**
+ * 헤더(TopBar·NotificationBell 옆) presence 토글 버튼 — people 아이콘 + working-count 배지(bell unread 패턴 일관).
+ * provider 밖(컨텍스트 없음)이면 미렌더(graceful).
+ */
+export function PresenceToggleButton() {
+  const t = useTranslations('presence');
+  const ctx = useTeamPresenceToggle();
+  if (!ctx) return null;
+  const { toggle, workingCount, open } = ctx;
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      aria-label={workingCount > 0 ? t('fabLabelWorking', { count: workingCount }) : t('panelTitle')}
+      aria-pressed={open}
+      title={t('panelTitle')}
+      className={cn(
+        'relative flex size-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand',
+        open && 'bg-muted/60 text-foreground',
+      )}
+    >
+      <Users className="size-4" />
+      {workingCount > 0 ? (
+        <span
+          className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-brand px-1 text-[10px] font-bold tabular-nums text-brand-foreground"
+          aria-hidden
+        >
+          {workingCount}
+        </span>
+      ) : null}
+    </button>
+  );
+}


### PR DESCRIPTION
## 선생님 결정
FAB(우하단)가 chat composer **send 버튼 가림**(충돌)·플로팅 방향 의문 → **상단 헤더(Bell 옆) people 아이콘 토글 + working-count 배지**로 재방향.

## 수정 (진입점 swap·패널 본체 재사용)
- **FAB 완전 제거**(`dashboard-shell` 잔여 0).
- 신규 `team-presence-toggle.tsx`: `TeamPresenceToggleProvider`(context) + `PresenceToggleButton`(헤더용·`Users` 아이콘·**working-count 배지**=Bell unread 패턴·`aria-pressed`·동적 aria).
- `dashboard-shell`: 패널 state(`useContextualPanelState`)를 **provider로 상향**(toggle/workingCount/open) → ScrollShell이 래핑 → TopBar서 토글.
- `top-bar.tsx`: `NotificationBell` 옆 `<PresenceToggleButton />`.
- **원형 보존**: `TeamPresencePanel`·`useTeamPresence`(폴)·`useContextualPanelState`(rail/drawer)·배지 = 그대로. **진입점만 교체.**

## 충돌0
헤더는 명확 영역 → composer/콘텐츠 안 겹침(floating 근본문제 제거). 발견성↑(항상 헤더·Bell 옆).

## 게이트
PO·까심 QA·CI·유나 가디언(헤더 토글 가시·배지·패널 open/close·light/dark·**충돌0**) → **선생님 재확인**(이번엔 충돌0).

## 검증
`pnpm type-check` ✅ / `pnpm lint`(변경 파일 0) ✅ / `pnpm build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)