### PR TITLE
fix(dispatch): deliver INJECTABLE events to member webhook for CC injection [SID:1f01c1ad]

### DIFF
--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -3,7 +3,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -83,6 +83,7 @@ async def _fetch_entity(
 @router.post("", response_model=DispatchResponse)
 async def dispatch_entity(
     body: DispatchRequest,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
     org_id: uuid.UUID = Depends(get_verified_org_id),
@@ -192,6 +193,20 @@ async def dispatch_entity(
             wake_agent(str(assignee_id), event.recipient_seq)
         else:
             _push_to_agent(str(assignee_id), _event_to_payload(event))
+
+    # 1f01c1ad: wake_agent(SSE)는 CC 세션에 도달하지 않으므로 member webhook(=CC 릴레이 경로)으로도
+    # 주입한다. conversation.message_created가 deliver_conversation_message_webhook로 주입되는 것과 동형.
+    # webhook 없는 수신자는 no-op. (human도 webhook 보유 시 동일 경로 — 없으면 위 dispatch_notification만)
+    from app.services.conversation_webhook import deliver_injected_event_webhook
+    background_tasks.add_task(
+        deliver_injected_event_webhook,
+        org_id=org_id,
+        recipient_id=assignee_id,
+        content=content,
+        event_type="dispatched",
+        source_entity_type=body.entity_type,
+        source_entity_id=body.entity_id,
+    )
     return DispatchResponse(
         dispatched=True,
         event_id=event.id,

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -330,6 +330,18 @@ async def update_story(
                 await db.commit()  # commit BEFORE wake — seq 확정, 이중전달 방지
                 if sa_event.recipient_seq is not None:
                     wake_agent(str(story.assignee_id), sa_event.recipient_seq)
+                # 1f01c1ad: wake_agent(SSE)는 CC 세션 미도달 → member webhook(CC 릴레이)으로도 주입.
+                # dispatch.py 동형 — INJECTABLE 이벤트의 단일 CC 주입 경로(member webhook)로 일관 전달.
+                from app.services.conversation_webhook import deliver_injected_event_webhook
+                background_tasks.add_task(
+                    deliver_injected_event_webhook,
+                    org_id=org_id,
+                    recipient_id=story.assignee_id,
+                    content=_content,
+                    event_type="story_assigned",
+                    source_entity_type="story",
+                    source_entity_id=story.id,
+                )
             else:
                 # human: 기존 dispatch_notification 유지 (변경 0)
                 await dispatch_notification(

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -74,6 +74,84 @@ async def _attempt_delivery(url: str, secret: str | None, payload: dict) -> None
         resp.raise_for_status()
 
 
+async def deliver_injected_event_webhook(
+    *,
+    org_id: uuid.UUID,
+    recipient_id: uuid.UUID,
+    content: str,
+    event_type: str,
+    source_entity_type: str | None = None,
+    source_entity_id: uuid.UUID | None = None,
+) -> None:
+    """1f01c1ad: INJECTABLE 이벤트(dispatched/story_assigned 등)를 수신자 member webhook으로 전달.
+
+    배경(선생님 제보 2026-06-09): ``conversation.message_created``는
+    :func:`deliver_conversation_message_webhook`로 수신자 member webhook(=CC 릴레이가 소비하는
+    Discord/fakechat 경로)에 주입되지만, ``/api/v2/dispatch``·story 배정이 만드는
+    ``dispatched``/``story_assigned`` 이벤트는 ``wake_agent`` (SSE)로만 통지됐다. CC 세션은 SSE
+    dial-out이 아니라 member webhook으로 구동되므로, 이 이벤트들은 CC 세션에 영영 도달하지 못했다
+    (문서 dispatch → CC 주입 0). 이 함수가 그 갭을 메워 INJECTABLE 이벤트도 conversation message와
+    **동일한 webhook 경로**로 CC 세션에 주입한다.
+
+    dup 0: webhook은 이 호출에서 수신자 webhook당 정확히 1회 발송된다. 기존 ``wake_agent`` (SSE)는
+    별개 채널이고, conversation message가 이미 SSE+webhook 양쪽으로 전달되는 것과 동형이다
+    (채널별 1회 — acked_seq seq-dedup은 SSE 채널 내부 전용이라 본 webhook 채널과 무관). conversation
+    message가 아니므로 ``ConversationWebhookDelivery`` 추적 행은 만들지 않는다(그 ``message_id``는
+    ``conversation_messages``를 가리키는 FK라 dispatched 이벤트에 부적합).
+    """
+    if not content or not content.strip():
+        return
+
+    from app.core.database import async_session_factory
+    from sqlalchemy import select
+
+    async with async_session_factory() as db:
+        try:
+            wh_rows = (await db.execute(
+                select(WebhookConfig).where(
+                    WebhookConfig.org_id == org_id,
+                    WebhookConfig.member_id == recipient_id,
+                    WebhookConfig.is_active.is_(True),
+                )
+            )).scalars().all()
+        except Exception:
+            logger.exception(
+                "injected-event webhook lookup failed recipient=%s event=%s",
+                recipient_id, event_type,
+            )
+            return
+
+    # events가 NULL/빈 배열이면 전체 이벤트 구독으로 간주 (deliver_conversation_message_webhook 동형)
+    targets = [wh for wh in wh_rows if not wh.events or event_type in wh.events]
+    if not targets:
+        return
+
+    payload = {
+        "event_type": event_type,
+        "content": content,
+        "source_entity_type": source_entity_type,
+        "source_entity_id": str(source_entity_id) if source_entity_id else None,
+    }
+
+    seen_urls: set[str] = set()
+    for wh in targets:
+        if wh.url in seen_urls:  # 같은 endpoint 중복 발송 방지 (dup 0)
+            continue
+        seen_urls.add(wh.url)
+        for attempt in range(1, _MAX_RETRIES + 1):
+            try:
+                await _attempt_delivery(wh.url, wh.secret, payload)
+                break
+            except Exception as exc:
+                if attempt < _MAX_RETRIES:
+                    await asyncio.sleep(_BACKOFF_BASE * (2 ** (attempt - 1)))
+                else:
+                    logger.warning(
+                        "injected-event webhook delivery failed recipient=%s event=%s url=%s: %s",
+                        recipient_id, event_type, wh.url, str(exc)[:200],
+                    )
+
+
 async def deliver_conversation_message_webhook(
     message_id: uuid.UUID,
     conversation_id: uuid.UUID,

--- a/backend/tests/test_event_inject_webhook_1f01c1ad.py
+++ b/backend/tests/test_event_inject_webhook_1f01c1ad.py
@@ -1,0 +1,138 @@
+"""1f01c1ad: INJECTABLE 이벤트(dispatched/story_assigned) → member webhook 주입.
+
+배경: dispatched/story_assigned는 wake_agent(SSE)로만 통지돼 CC 세션(member webhook 구동)에
+영영 도달하지 못했다. deliver_injected_event_webhook이 conversation.message_created와 동일한
+member webhook 경로로 INJECTABLE 이벤트를 주입한다(CC 릴레이 갭 보강).
+"""
+from __future__ import annotations
+
+import contextlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.conversation_webhook import (
+    _to_discord_payload,
+    deliver_injected_event_webhook,
+)
+
+ORG_ID = uuid.uuid4()
+RECIPIENT_ID = uuid.uuid4()
+DISCORD_URL = "https://discord.com/api/webhooks/123/abc"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _wh(url=DISCORD_URL, events=None, secret=None, member_id=RECIPIENT_ID):
+    return SimpleNamespace(
+        id=uuid.uuid4(), url=url, secret=secret, events=events,
+        member_id=member_id, is_active=True,
+    )
+
+
+def _patch_factory(wh_rows):
+    """async_session_factory mock — execute().scalars().all() → wh_rows."""
+    db = MagicMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = list(wh_rows)
+    db.execute = AsyncMock(return_value=result)
+
+    def _factory():
+        @contextlib.asynccontextmanager
+        async def _cm():
+            yield db
+        return _cm()
+
+    return _factory, db
+
+
+async def _run(wh_rows, **kwargs):
+    """deliver_injected_event_webhook 실행 — _attempt_delivery 호출 캡처."""
+    factory, db = _patch_factory(wh_rows)
+    calls: list[tuple] = []
+
+    async def _capture(url, secret, payload):
+        calls.append((url, secret, payload))
+
+    base = dict(
+        org_id=ORG_ID, recipient_id=RECIPIENT_ID,
+        content="[story] Build — ship it", event_type="dispatched",
+        source_entity_type="story", source_entity_id=uuid.uuid4(),
+    )
+    base.update(kwargs)
+    with patch("app.core.database.async_session_factory", factory), \
+         patch("app.services.conversation_webhook._attempt_delivery", new=AsyncMock(side_effect=_capture)):
+        await deliver_injected_event_webhook(**base)
+    return calls, db
+
+
+# ── 핵심: 수신자 member webhook으로 1회 주입 ──────────────────────────────────
+
+@pytest.mark.anyio
+async def test_delivers_to_recipient_member_webhook():
+    calls, _ = await _run([_wh()])
+    assert len(calls) == 1
+    url, _secret, payload = calls[0]
+    assert url == DISCORD_URL
+    assert payload["event_type"] == "dispatched"
+    assert payload["content"] == "[story] Build — ship it"
+    assert payload["source_entity_type"] == "story"
+
+
+@pytest.mark.anyio
+async def test_discord_payload_carries_content_for_cc_relay():
+    """_to_discord_payload가 content를 CC 릴레이가 파싱하는 '📩 새 메시지' 포맷으로 변환."""
+    calls, _ = await _run([_wh()])
+    discord = _to_discord_payload(calls[0][2])
+    assert "📩" in discord["content"]
+    assert "[story] Build — ship it" in discord["content"]
+
+
+# ── events 구독 필터 ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_subscribed_event_delivered():
+    calls, _ = await _run([_wh(events=["dispatched", "conversation.message_created"])])
+    assert len(calls) == 1
+
+
+@pytest.mark.anyio
+async def test_unsubscribed_event_dropped():
+    calls, _ = await _run([_wh(events=["conversation.message_created"])])
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_empty_events_means_subscribe_all():
+    calls, _ = await _run([_wh(events=[])])
+    assert len(calls) == 1
+
+
+# ── dup 0: 같은 endpoint 중복 발송 방지 ───────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_duplicate_url_delivered_once():
+    """동일 URL webhook이 2건이어도 1회만 발송 (acked_seq 전례 — 채널당 dup 0)."""
+    calls, _ = await _run([_wh(), _wh(member_id=uuid.uuid4())])
+    assert len(calls) == 1
+
+
+# ── no-op 경로 ────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_no_webhook_no_delivery():
+    calls, db = await _run([])
+    assert calls == []
+
+
+@pytest.mark.anyio
+async def test_blank_content_short_circuits_before_db():
+    """content 없으면 DB 조회 전 즉시 반환 (불필요한 쿼리 0)."""
+    calls, db = await _run([_wh()], content="   ")
+    assert calls == []
+    db.execute.assert_not_awaited()


### PR DESCRIPTION
## 1f01c1ad — dispatch(`dispatched`)/`story_assigned`가 CC 에이전트 세션에 미전달

### 문제 (선생님 제보 2026-06-09)
문서/스토리 dispatch → CC 세션 주입 0건.

### 진단 (AC1: CC 주입 경로 확정)
CC 에이전트 세션은 **수신자 member webhook**(`deliver_conversation_message_webhook` → Discord/fakechat 릴레이, `📩 새 메시지` 포맷)으로 구동된다 — SSE dial-out이 아니다. 그런데 `/api/v2/dispatch`와 스토리 배정은 `dispatched`/`story_assigned` 이벤트를 **`wake_agent`(SSE)로만** 통지했다. 따라서 SSE를 소비하지 않는 CC 세션엔 영영 도달하지 못했다. (`conversation.message_created`만 webhook으로 중계되던 갭.)

SDK/hermes adapter의 `INJECTABLE_EVENT_TYPES`엔 `dispatched`/`story_assigned`가 포함돼 있으나, 그 경로(SSE)는 CC 세션이 쓰지 않는다.

### 수정 (AC2: 전달경로 보강 · dup 0)
`deliver_injected_event_webhook` 신설 — `deliver_conversation_message_webhook`와 동형으로 수신자의 활성 member webhook(events allow-list 인지)을 조회해 이벤트 content를 **동일 webhook 경로**로 전달.
- `dispatch.py`(`dispatched`) · `stories.py`(`story_assigned`)에서 commit 후 `BackgroundTask`로 호출.
- **dup 0**: 수신자 webhook당 1회 발송 + 동일 URL 중복 제거. SSE `wake_agent`는 별개 채널(= conversation message가 이미 SSE+webhook 양쪽 전달하는 것과 동형, `acked_seq` seq-dedup은 SSE 채널 내부 전용이라 무관).
- `ConversationWebhookDelivery` 추적 행 미생성(그 `message_id` FK가 `conversation_messages`를 가리켜 dispatched엔 부적합).
- **마이그 0**.

### 검증
- 신규 8건: member webhook 전달 · Discord content 포맷 · events 구독 필터 · dup-0(동일 URL 1회) · no-op(webhook 없음/빈 content 단락).
- 인접 스위트 193 passed(stories/conversation_webhook/dispatch/webhook/agent_gateway/event_inject) · 전체 1802 collected 임포트 에러 0.
- AC3(라이브 실증)은 dev 배포 후 문서 dispatch → CC 주입으로 확인 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)