### PR TITLE
fix(docs): permanent server_default on docs.slug_locked (0107 deploy-window) [SID:4dd399c6]

### DIFF
--- a/backend/alembic/versions/0108_doc_share_tokens.py
+++ b/backend/alembic/versions/0108_doc_share_tokens.py
@@ -1,0 +1,53 @@
+"""doc_share_tokens — 문서 공유 공개 URL 토큰 (Part B b1574f5a).
+
+opaque token(슬러그 무관)·문서당 1 active(partial unique). doc_id FK 는 0107 의 docs_pkey 위.
+공개 read 는 `/api/v2/public/docs/{token}` 가 active 토큰 해소(404 unknown / 410 revoked).
+
+Revision ID: 0108
+Revises: 0107
+Create Date: 2026-06-10
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "0108"
+down_revision = "0107"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "doc_share_tokens",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "doc_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("docs.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("token", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="active"),
+        sa.Column("created_by", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint("token", name="uq_doc_share_tokens_token"),
+    )
+    op.create_index("ix_doc_share_tokens_doc_id", "doc_share_tokens", ["doc_id"])
+    op.create_index("ix_doc_share_tokens_token", "doc_share_tokens", ["token"])
+    # 문서당 active 토큰 1개 보장 (regenerate/disable 은 직전 active 를 revoked 로 전환)
+    op.create_index(
+        "uq_doc_share_tokens_active",
+        "doc_share_tokens",
+        ["doc_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'active'"),
+    )
+    op.alter_column("doc_share_tokens", "status", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_table("doc_share_tokens")

--- a/backend/alembic/versions/0109_slug_locked_server_default.py
+++ b/backend/alembic/versions/0109_slug_locked_server_default.py
@@ -1,0 +1,33 @@
+"""docs.slug_locked 영구 server_default false — 0107 deploy-window 하드닝.
+
+0107 이 `slug_locked` 를 NOT NULL 로 추가한 뒤 server_default 를 제거했다. 그 결과 **migrate-first**
+배포 순서(권장)에서 신 컬럼은 생겼으나 default 가 없어, 아직 갱신 안 된 **구 코드가 slug_locked 를
+지정하지 않고 docs INSERT** 하면 NOT NULL 위반으로 doc 생성이 실패하는 전환 윈도우가 생긴다.
+
+영구 server_default(false) 를 부여하면:
+- migrate-first: 구 코드 INSERT(slug_locked 미지정) → DB default false 채움 → 무사.
+- code-first: 신 코드가 컬럼 read → 컬럼 이미 존재 → 무사.
+→ 양 방향 전환 윈도우 0. 앱은 여전히 모델 default=False 를 명시하므로 동작 불변(순수 안전판).
+
+0107 은 이미 dev 적용돼 수정 불가 → 신규 마이그가 정도(PO GO). #1368(0108)과 같은 migrate-dev
+윈도우에 함께 태운다(0107→0108→0109 선형).
+
+Revision ID: 0109
+Revises: 0108
+Create Date: 2026-06-10
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0109"
+down_revision = "0108"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column("docs", "slug_locked", server_default=sa.false())
+
+
+def downgrade() -> None:
+    op.alter_column("docs", "slug_locked", server_default=None)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -131,6 +131,7 @@ app.include_router(hitl_config.router)
 app.include_router(gates.router)
 app.include_router(tasks.router)
 app.include_router(docs.router)
+app.include_router(public_docs.router)
 app.include_router(meetings.router)
 app.include_router(stories.router)
 app.include_router(projects.router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,7 +14,7 @@ from app.models.org_subscription import OrgSubscription
 from app.models.policy_document import PolicyDocument
 from app.models.audit import AuditLog
 from app.models.webhook_config import WebhookConfig
-from app.models.doc import Doc, DocSlugAlias
+from app.models.doc import Doc, DocShareToken, DocSlugAlias
 from app.models.meeting import Meeting
 from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.conversation_webhook_delivery import ConversationWebhookDelivery

--- a/backend/app/models/doc.py
+++ b/backend/app/models/doc.py
@@ -80,6 +80,28 @@ class DocSlugAlias(Base, OrgScopedMixin):
     )
 
 
+class DocShareToken(Base, OrgScopedMixin):
+    """b1574f5a: 문서 공유 공개 URL 토큰. opaque(슬러그 무관)·문서당 1 active.
+
+    공개 `GET /api/v2/public/docs/{token}` 가 active 토큰을 해소해 비인증 read 제공.
+    enable=발급 / disable=revoke / regenerate=구 토큰 즉사+신규. doc_id FK 는 0107 docs_pkey 위.
+    """
+    __tablename__ = "doc_share_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    doc_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("docs.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    token: Mapped[str] = mapped_column(Text, nullable=False, unique=True, index=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="active")  # active | revoked
+    created_by: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
 class DocComment(Base, OrgScopedMixin):
     __tablename__ = "doc_comments"
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import datetime
 
@@ -12,7 +13,7 @@ from app.models.doc import DocComment, DocRevision
 from app.models.team import TeamMember
 from app.repositories.doc import DocRepository
 from app.services.member_resolver import canonicalize_member_id
-from app.schemas.doc import DocCreate, DocResponse, DocSummaryResponse, DocUpdate
+from app.schemas.doc import DocCreate, DocResponse, DocSummaryResponse, DocUpdate, ShareStatusResponse
 
 router = APIRouter(prefix="/api/v2/docs", tags=["docs"])
 
@@ -346,6 +347,82 @@ async def _resolve_doc_member_id(auth: AuthContext, org_id: uuid.UUID, db: Async
     # member id(org_member.id)로 폴백. 비-멤버는 resolve_member가 400.
     from app.services.member_resolver import resolve_member
     return (await resolve_member(auth, org_id, db)).id
+
+
+# ─── Share (Part B b1574f5a) ──────────────────────────────────────────────────
+
+def _share_resp(tok) -> ShareStatusResponse:
+    if tok is None:
+        return ShareStatusResponse(enabled=False)
+    app_url = os.environ.get("NEXT_PUBLIC_APP_URL", "").rstrip("/")
+    share_url = f"{app_url}/share/{tok.token}" if app_url else None
+    return ShareStatusResponse(enabled=True, token=tok.token, share_url=share_url)
+
+
+@router.get("/{id}/share", response_model=ShareStatusResponse)
+async def get_doc_share(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> ShareStatusResponse:
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    await _resolve_doc_member_id(auth, repo.org_id, db)  # 멤버십 게이트(비멤버 차단)
+    from app.services import doc_share
+    return _share_resp(await doc_share.get_status(db, repo.org_id, id))
+
+
+@router.post("/{id}/share", response_model=ShareStatusResponse)
+async def enable_doc_share(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> ShareStatusResponse:
+    """opt-in 공개 활성 — active 토큰 발급(멱등)."""
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
+    from app.services import doc_share
+    tok = await doc_share.enable(db, repo.org_id, doc.project_id, id, actor_id)
+    return _share_resp(tok)
+
+
+@router.post("/{id}/share/regenerate", response_model=ShareStatusResponse)
+async def regenerate_doc_share(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> ShareStatusResponse:
+    """구 토큰 즉시 폐기 + 신규 발급(유출 방어)."""
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
+    from app.services import doc_share
+    tok = await doc_share.regenerate(db, repo.org_id, doc.project_id, id, actor_id)
+    return _share_resp(tok)
+
+
+@router.delete("/{id}/share", response_model=ShareStatusResponse)
+async def disable_doc_share(
+    id: uuid.UUID,
+    repo: DocRepository = Depends(_get_repo),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+) -> ShareStatusResponse:
+    """공개 중단 — active 토큰 revoke(이후 공개 read 410)."""
+    doc = await repo.get(id)
+    if doc is None:
+        raise HTTPException(status_code=404, detail="Doc not found")
+    actor_id = await _resolve_doc_member_id(auth, repo.org_id, db)
+    from app.services import doc_share
+    await doc_share.revoke(db, repo.org_id, id, actor_id)
+    return ShareStatusResponse(enabled=False)
 
 
 # ─── Comments ─────────────────────────────────────────────────────────────────

--- a/backend/app/routers/public_docs.py
+++ b/backend/app/routers/public_docs.py
@@ -1,0 +1,37 @@
+"""공개 문서 read (Part B b1574f5a) — **비인증** 라우트.
+
+⚠️ 인증 Depends 를 의도적으로 생략한다(글로벌 auth 미들웨어 부재·per-route Depends 구조라
+   생략=공개). opaque share token 만으로 단일 문서 read. 메타 누출 0·내부링크 비resolve 는
+   FE 공개 뷰어가 담당. FE 프록시(`/api/public/docs/[token]`) + proxy.ts `PUBLIC_PREFIX` 등록은
+   미르코군 FE 레인.
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.database import get_db
+from app.schemas.doc import PublicDocResponse
+from app.services import doc_share
+
+router = APIRouter(prefix="/api/v2/public/docs", tags=["public-docs"])
+
+
+@router.get("/{token}", response_model=PublicDocResponse)
+async def get_public_doc(
+    token: str,
+    db: AsyncSession = Depends(get_db),
+) -> PublicDocResponse:
+    """active share token → 단일 문서 공개 read. unknown→404 / revoked·삭제→410."""
+    # 토큰 길이 sanity (과도 입력 차단) — 형식 불일치는 unknown 취급(404)
+    if not token or len(token) > 128:
+        raise HTTPException(status_code=404, detail="유효하지 않은 링크")
+    try:
+        doc = await doc_share.resolve_public(db, token)
+    except doc_share.ShareTokenError as exc:
+        raise HTTPException(status_code=exc.status_code, detail=exc.detail)
+    return PublicDocResponse(
+        title=doc.title,
+        content=doc.content,
+        content_format=doc.content_format,
+    )

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -75,3 +75,17 @@ class DocResponse(BaseModel):
     tags: list[str]
     created_at: datetime
     updated_at: datetime
+
+
+class ShareStatusResponse(BaseModel):
+    """b1574f5a: 문서 공유 상태(관리 API). enabled=active 토큰 유무."""
+    enabled: bool
+    token: str | None = None
+    share_url: str | None = None
+
+
+class PublicDocResponse(BaseModel):
+    """b1574f5a: 공개 read 응답 — 메타 누출 0(project/org/author/tree/comment 미반환)."""
+    title: str
+    content: str
+    content_format: str

--- a/backend/app/services/doc_share.py
+++ b/backend/app/services/doc_share.py
@@ -1,0 +1,117 @@
+"""문서 공유 공개 토큰 서비스 (Part B b1574f5a).
+
+opaque token(슬러그 무관)·문서당 1 active. enable=발급 / disable=revoke /
+regenerate=구 토큰 즉사+신규. 공개 resolve 는 404(unknown/malformed) / 410(revoked·doc 삭제).
+audit 는 기존 `permission_audit_logs`(AuditLog) 재사용(action=doc.share.*).
+"""
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit import AuditLog
+from app.models.doc import Doc, DocShareToken
+
+_TOKEN_BYTES = 32  # secrets.token_urlsafe(32) → ~43 chars opaque
+
+
+class ShareTokenError(Exception):
+    """공개 토큰 해소 실패. status_code: 404(unknown/malformed) / 410(revoked·gone)."""
+
+    def __init__(self, status_code: int, detail: str) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(detail)
+
+
+def _new_token() -> str:
+    return secrets.token_urlsafe(_TOKEN_BYTES)
+
+
+async def _active_token(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID) -> DocShareToken | None:
+    return (await db.execute(
+        select(DocShareToken).where(
+            DocShareToken.org_id == org_id,
+            DocShareToken.doc_id == doc_id,
+            DocShareToken.status == "active",
+        ).limit(1)
+    )).scalar_one_or_none()
+
+
+def _audit(db: AsyncSession, org_id: uuid.UUID, actor_id: uuid.UUID, action: str,
+           doc_id: uuid.UUID, token_id: uuid.UUID | None = None) -> None:
+    meta: dict = {"doc_id": str(doc_id)}
+    if token_id is not None:
+        meta["token_id"] = str(token_id)
+    db.add(AuditLog(org_id=org_id, actor_id=actor_id, action=action, audit_metadata=meta))
+
+
+async def get_status(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID) -> DocShareToken | None:
+    return await _active_token(db, org_id, doc_id)
+
+
+async def enable(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
+                 doc_id: uuid.UUID, actor_id: uuid.UUID) -> DocShareToken:
+    """opt-in 활성. 이미 active 면 그대로 반환(멱등)."""
+    existing = await _active_token(db, org_id, doc_id)
+    if existing is not None:
+        return existing
+    tok = DocShareToken(
+        org_id=org_id, doc_id=doc_id, project_id=project_id,
+        token=_new_token(), status="active", created_by=actor_id,
+    )
+    db.add(tok)
+    await db.flush()
+    _audit(db, org_id, actor_id, "doc.share.enabled", doc_id, tok.id)
+    return tok
+
+
+async def regenerate(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
+                     doc_id: uuid.UUID, actor_id: uuid.UUID) -> DocShareToken:
+    """구 active 토큰 즉시 revoke + 신규 발급(유출 방어)."""
+    existing = await _active_token(db, org_id, doc_id)
+    if existing is not None:
+        existing.status = "revoked"
+        existing.revoked_at = datetime.now(timezone.utc)
+        await db.flush()  # partial-unique(active) 해제 후 신규 active insert
+    tok = DocShareToken(
+        org_id=org_id, doc_id=doc_id, project_id=project_id,
+        token=_new_token(), status="active", created_by=actor_id,
+    )
+    db.add(tok)
+    await db.flush()
+    _audit(db, org_id, actor_id, "doc.share.regenerated", doc_id, tok.id)
+    return tok
+
+
+async def revoke(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID, actor_id: uuid.UUID) -> bool:
+    """공개 중단 — active 토큰을 revoked 로. 토큰 즉시 무효(이후 410)."""
+    existing = await _active_token(db, org_id, doc_id)
+    if existing is None:
+        return False
+    existing.status = "revoked"
+    existing.revoked_at = datetime.now(timezone.utc)
+    await db.flush()
+    _audit(db, org_id, actor_id, "doc.share.disabled", doc_id, existing.id)
+    return True
+
+
+async def resolve_public(db: AsyncSession, token: str) -> Doc:
+    """공개 토큰 → Doc. unknown→404 / revoked·doc삭제→410. 문서 존재는 어느 쪽도 비노출."""
+    tok = (await db.execute(
+        select(DocShareToken).where(DocShareToken.token == token).limit(1)
+    )).scalar_one_or_none()
+    if tok is None:
+        raise ShareTokenError(404, "유효하지 않은 링크")
+    if tok.status != "active":
+        raise ShareTokenError(410, "더 이상 유효하지 않은 링크")
+    doc = (await db.execute(
+        select(Doc).where(Doc.id == tok.doc_id, Doc.deleted_at.is_(None)).limit(1)
+    )).scalar_one_or_none()
+    if doc is None:
+        raise ShareTokenError(410, "더 이상 유효하지 않은 링크")
+    return doc

--- a/backend/tests/test_doc_share_b1574f5a.py
+++ b/backend/tests/test_doc_share_b1574f5a.py
@@ -1,0 +1,158 @@
+"""Part B b1574f5a: 문서 공유 공개 토큰 — 공개 read 계약(404/410·메타 누출 0) + 관리 응답.
+
+DB 의존 라이프사이클(1 active·regenerate revoke·audit)은 실 Postgres e2e 로 별도 검증.
+여기선 mock 기반으로 공개 계약(보안 표면)·resolve 분기·응답 shape 을 고정.
+"""
+from __future__ import annotations
+
+import contextlib
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.schemas.doc import PublicDocResponse, ShareStatusResponse
+from app.services import doc_share
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _exec_returning(value):
+    """db.execute(...) → result.scalar_one_or_none()==value 인 AsyncMock 결과."""
+    res = MagicMock()
+    res.scalar_one_or_none.return_value = value
+    return res
+
+
+def _db_with(results):
+    """db.execute 가 호출 순서대로 results 를 반환하는 AsyncMock 세션."""
+    db = MagicMock()
+    seq = list(results)
+    async def _execute(*a, **k):
+        return seq.pop(0) if seq else _exec_returning(None)
+    db.execute = AsyncMock(side_effect=_execute)
+    return db
+
+
+# ── resolve_public 분기 (보안 핵심) ───────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_resolve_public_unknown_token_404():
+    db = _db_with([_exec_returning(None)])  # 토큰 없음
+    with pytest.raises(doc_share.ShareTokenError) as ei:
+        await doc_share.resolve_public(db, "nope")
+    assert ei.value.status_code == 404
+
+
+@pytest.mark.anyio
+async def test_resolve_public_revoked_token_410():
+    tok = SimpleNamespace(status="revoked", doc_id=uuid.uuid4())
+    db = _db_with([_exec_returning(tok)])
+    with pytest.raises(doc_share.ShareTokenError) as ei:
+        await doc_share.resolve_public(db, "t")
+    assert ei.value.status_code == 410
+
+
+@pytest.mark.anyio
+async def test_resolve_public_doc_deleted_410():
+    tok = SimpleNamespace(status="active", doc_id=uuid.uuid4())
+    db = _db_with([_exec_returning(tok), _exec_returning(None)])  # 토큰 active, doc 미존재(삭제)
+    with pytest.raises(doc_share.ShareTokenError) as ei:
+        await doc_share.resolve_public(db, "t")
+    assert ei.value.status_code == 410
+
+
+@pytest.mark.anyio
+async def test_resolve_public_active_returns_doc():
+    doc = SimpleNamespace(title="T", content="C", content_format="markdown")
+    tok = SimpleNamespace(status="active", doc_id=uuid.uuid4())
+    db = _db_with([_exec_returning(tok), _exec_returning(doc)])
+    out = await doc_share.resolve_public(db, "t")
+    assert out.title == "T"
+
+
+# ── 메타 누출 0: 공개 응답 필드 집합 고정 ──────────────────────────────────────
+
+def test_public_response_exposes_only_three_fields():
+    fields = set(PublicDocResponse.model_fields.keys())
+    assert fields == {"title", "content", "content_format"}
+    # project_id/org_id/created_by/slug/tags 등 누출 금지
+    for leak in ("project_id", "org_id", "created_by", "slug", "id", "assignee_id"):
+        assert leak not in fields
+
+
+# ── 공개 엔드포인트 (TestClient) — 404/410/200 + 비인증 ─────────────────────────
+
+async def _public_client():
+    from httpx import ASGITransport, AsyncClient
+    from app.main import app
+    from app.dependencies.database import get_db
+
+    async def override_db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_db] = override_db
+    transport = ASGITransport(app=app)
+    return AsyncClient(transport=transport, base_url="http://test"), app
+
+
+@pytest.mark.anyio
+async def test_public_endpoint_200_no_auth():
+    client, app = await _public_client()
+    doc = SimpleNamespace(title="Hello", content="# Hi", content_format="markdown")
+    try:
+        with patch("app.services.doc_share.resolve_public", new=AsyncMock(return_value=doc)):
+            r = await client.get("/api/v2/public/docs/sometoken")  # Authorization 헤더 없음
+        assert r.status_code == 200
+        body = r.json()
+        assert body == {"title": "Hello", "content": "# Hi", "content_format": "markdown"}
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_public_endpoint_404_and_410():
+    client, app = await _public_client()
+    try:
+        with patch("app.services.doc_share.resolve_public",
+                   new=AsyncMock(side_effect=doc_share.ShareTokenError(404, "x"))):
+            assert (await client.get("/api/v2/public/docs/unknown")).status_code == 404
+        with patch("app.services.doc_share.resolve_public",
+                   new=AsyncMock(side_effect=doc_share.ShareTokenError(410, "x"))):
+            assert (await client.get("/api/v2/public/docs/revoked")).status_code == 410
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_public_endpoint_oversize_token_404():
+    client, app = await _public_client()
+    try:
+        r = await client.get("/api/v2/public/docs/" + "a" * 200)
+        assert r.status_code == 404
+    finally:
+        app.dependency_overrides.clear()
+        await client.aclose()
+
+
+# ── 관리 응답 shape (_share_resp) ──────────────────────────────────────────────
+
+def test_share_resp_enabled_with_url(monkeypatch):
+    from app.routers.docs import _share_resp
+    monkeypatch.setenv("NEXT_PUBLIC_APP_URL", "https://app.sprintable.ai")
+    tok = SimpleNamespace(token="aB3xToken")
+    resp = _share_resp(tok)
+    assert resp.enabled is True and resp.token == "aB3xToken"
+    assert resp.share_url == "https://app.sprintable.ai/share/aB3xToken"
+
+
+def test_share_resp_disabled():
+    from app.routers.docs import _share_resp
+    resp = _share_resp(None)
+    assert resp.enabled is False and resp.token is None


### PR DESCRIPTION
## 0109 — `docs.slug_locked` 영구 server_default (0107 deploy-window 하드닝)

⚠️ **stacked on #1368** (base=`feat/doc-share-token-b1574f5a`). 0109 down_revision=0108 — #1368 머지 후 base 가 develop 으로 자동 retarget 되거나 #1368과 함께 머지. **migrate-dev 1회에 0108+0109 함께**(PO 시퀀스).

### 문제
0107 이 `slug_locked` 를 NOT NULL 추가 후 server_default 제거 → **migrate-first** 순서서 구 코드(slug_locked 미지정)가 docs INSERT 시 NOT NULL 위반(전환 윈도우).

### fix
영구 `server_default(false)` 부여. 앱은 여전히 모델 `default=False` 명시(동작 불변)·순수 DB 안전판.
- migrate-first: 구 코드 INSERT → DB default false. OK.
- code-first: 신 코드 read → 컬럼 존재. OK.
→ 양 방향 윈도우 0. 0107 dev 적용분은 불변이라 신규 마이그가 정도(PO GO).

### 검증
`pgvector:pg16` upgrade head→0109 후 **slug_locked 없이 docs INSERT 성공(=false 채움)** 실측 — 윈도우 닫힘 확인(0109 전엔 동일 INSERT NOT NULL 위반).

🤖 Generated with [Claude Code](https://claude.com/claude-code)