### PR TITLE
fix(docs): doc share P0 — drop permission_audit_logs write (CHECK rollback) [SID:b1574f5a]

### DIFF
--- a/backend/app/services/doc_share.py
+++ b/backend/app/services/doc_share.py
@@ -2,10 +2,15 @@
 
 opaque token(슬러그 무관)·문서당 1 active. enable=발급 / disable=revoke /
 regenerate=구 토큰 즉사+신규. 공개 resolve 는 404(unknown/malformed) / 410(revoked·doc 삭제).
-audit 는 기존 `permission_audit_logs`(AuditLog) 재사용(action=doc.share.*).
+
+⚠️ audit 는 **app 로그**(logger.info)로 남긴다. `permission_audit_logs`(AuditLog)는 action 에
+   CHECK 제약(member_added|member_removed|role_changed 만 허용)이 있어 doc.share.* 를 INSERT 하면
+   commit 시 전체 트랜잭션이 롤백돼 토큰이 persist 되지 않는다(P0 — verify-first 적발). 구조화 DB
+   audit 은 적합 테이블/CHECK 확장으로 후속.
 """
 from __future__ import annotations
 
+import logging
 import secrets
 import uuid
 from datetime import datetime, timezone
@@ -13,8 +18,9 @@ from datetime import datetime, timezone
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.audit import AuditLog
 from app.models.doc import Doc, DocShareToken
+
+logger = logging.getLogger(__name__)
 
 _TOKEN_BYTES = 32  # secrets.token_urlsafe(32) → ~43 chars opaque
 
@@ -42,12 +48,13 @@ async def _active_token(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID) 
     )).scalar_one_or_none()
 
 
-def _audit(db: AsyncSession, org_id: uuid.UUID, actor_id: uuid.UUID, action: str,
+def _audit(org_id: uuid.UUID, actor_id: uuid.UUID, action: str,
            doc_id: uuid.UUID, token_id: uuid.UUID | None = None) -> None:
-    meta: dict = {"doc_id": str(doc_id)}
-    if token_id is not None:
-        meta["token_id"] = str(token_id)
-    db.add(AuditLog(org_id=org_id, actor_id=actor_id, action=action, audit_metadata=meta))
+    """app 로그 audit 트레일(non-fatal·트랜잭션 무관). DB audit 은 후속(적합 테이블 필요)."""
+    logger.info(
+        "%s org=%s actor=%s doc=%s token=%s",
+        action, org_id, actor_id, doc_id, token_id,
+    )
 
 
 async def get_status(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID) -> DocShareToken | None:
@@ -66,7 +73,7 @@ async def enable(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
     )
     db.add(tok)
     await db.flush()
-    _audit(db, org_id, actor_id, "doc.share.enabled", doc_id, tok.id)
+    _audit(org_id, actor_id, "doc.share.enabled", doc_id, tok.id)
     return tok
 
 
@@ -84,7 +91,7 @@ async def regenerate(db: AsyncSession, org_id: uuid.UUID, project_id: uuid.UUID,
     )
     db.add(tok)
     await db.flush()
-    _audit(db, org_id, actor_id, "doc.share.regenerated", doc_id, tok.id)
+    _audit(org_id, actor_id, "doc.share.regenerated", doc_id, tok.id)
     return tok
 
 
@@ -96,7 +103,7 @@ async def revoke(db: AsyncSession, org_id: uuid.UUID, doc_id: uuid.UUID, actor_i
     existing.status = "revoked"
     existing.revoked_at = datetime.now(timezone.utc)
     await db.flush()
-    _audit(db, org_id, actor_id, "doc.share.disabled", doc_id, existing.id)
+    _audit(org_id, actor_id, "doc.share.disabled", doc_id, existing.id)
     return True
 
 

--- a/backend/tests/test_doc_share_b1574f5a.py
+++ b/backend/tests/test_doc_share_b1574f5a.py
@@ -156,3 +156,15 @@ def test_share_resp_disabled():
     from app.routers.docs import _share_resp
     resp = _share_resp(None)
     assert resp.enabled is False and resp.token is None
+
+
+def test_doc_share_does_not_write_permission_audit_logs():
+    """회귀 가드: doc_share 는 permission_audit_logs(AuditLog) 에 쓰지 않는다.
+
+    그 테이블 action CHECK(member_added|member_removed|role_changed)가 doc.share.* INSERT 를
+    거부 → commit 롤백 → 토큰 미persist(P0). audit 는 logger.info 트레일. AuditLog import/INSERT
+    가 재유입되면 이 테스트가 실패한다.
+    """
+    import app.services.doc_share as m
+
+    assert not hasattr(m, "AuditLog"), "doc_share 는 AuditLog(permission_audit_logs) 쓰기 금지"


### PR DESCRIPTION
## 🔴 P0 — Part B 공유가 dev에서 비기능(토큰 미persist)

### 근본 원인
`permission_audit_logs.action` CHECK 제약 = `member_added|member_removed|role_changed` 전용(baseline:1542). doc_share가 `action='doc.share.*'`로 INSERT → **commit 시 CHECK 위반 → 트랜잭션 전체 롤백** → 공유 토큰 미persist. 200은 commit 前 응답이라 떴고(**mock은 실 CHECK 안 타서 통과**), 실제론 공개 GET 404·enable 비멱등·revoke/regenerate no-op. **라이브 dev probe(verify-first)로 적발.**

### fix
`enable`/`disable`/`regenerate`의 `AuditLog`(permission_audit_logs) 쓰기 **제거**. MVP audit = **`logger.info` 트레일**(non-fatal·롤백 0·오염 0·`org_id/actor_id/doc_id/token_id/action`). durable DB audit = **후속 스토리**(적합 테이블/CHECK 확장·보드 flag·PO 동의).

### 검증 (실 DB — mock 아님)
`pgvector:pg16`(CHECK 제약 존재)에서:
- enable → **별도 session**으로 `resolve_public` 성공(=persist 입증·까심 체크포인트 ③)
- enable 멱등(같은 token)·active_count=1·revoke→410
- 회귀 가드 테스트(doc_share가 AuditLog import 금지) + 11 Part B + 60 인접 PASS

머지 후 dev 배포 시 재probe(멱등·공개200 3필드·revoke410·bogus404·regenerate) 전수 받겠음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)