### PR TITLE
fix(api): pass structured dict HTTPException detail through error envelope

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -62,10 +62,22 @@ _HTTP_CODE_MAP: dict[int, str] = {
 
 @app.exception_handler(HTTPException)
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-    code = _HTTP_CODE_MAP.get(exc.status_code, f"HTTP_{exc.status_code}")
+    mapped = _HTTP_CODE_MAP.get(exc.status_code, f"HTTP_{exc.status_code}")
+    detail = exc.detail
+    # dict detail 은 구조화 에러 의도(code/message/suggestion·retry_after 등) → error 객체로 패스스루.
+    # 기존 str(detail) 은 dict 를 Python repr 로 직렬화해 FE JSON.parse 불가 + 의도한 code 유실
+    # (SLUG_TAKEN/SLUG_INVALID/USER_NOT_IN_ORG/RATE_LIMITED 4곳 동일 교정). 문자열 detail(대다수)은
+    # 기존 shape 그대로 — 회귀 0.
+    if isinstance(detail, dict):
+        error = {"code": detail.get("code", mapped), "message": detail.get("message", "")}
+        for k, v in detail.items():
+            if k not in ("code", "message"):
+                error[k] = v
+    else:
+        error = {"code": mapped, "message": str(detail)}
     return JSONResponse(
         status_code=exc.status_code,
-        content={"data": None, "error": {"code": code, "message": str(exc.detail)}, "meta": None},
+        content={"data": None, "error": error, "meta": None},
         headers=exc.headers,
     )
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -251,7 +251,10 @@ async def update_doc(
         if not new_slug:
             # 정규화 후 빈값: 명시 편집은 422, 자동파생은 기존 slug 유지(타이핑 보호)
             if explicit:
-                raise HTTPException(status_code=422, detail={"code": "SLUG_INVALID"})
+                raise HTTPException(
+                    status_code=422,
+                    detail={"code": "SLUG_INVALID", "message": "유효하지 않은 슬러그"},
+                )
         elif new_slug != doc.slug:
             if await is_slug_taken(session, repo.org_id, doc.project_id, new_slug, exclude_doc_id=doc.id):
                 if explicit:
@@ -260,7 +263,11 @@ async def update_doc(
                     )
                     raise HTTPException(
                         status_code=409,
-                        detail={"error": {"code": "SLUG_TAKEN", "suggestion": suggestion}},
+                        detail={
+                            "code": "SLUG_TAKEN",
+                            "message": "이미 사용 중인 슬러그",
+                            "suggestion": suggestion,
+                        },
                     )
                 # 자동파생 충돌 → 무음 -N suffix
                 new_slug = await resolve_unique_slug(

--- a/backend/tests/test_error_envelope_dict_detail.py
+++ b/backend/tests/test_error_envelope_dict_detail.py
@@ -1,0 +1,81 @@
+"""글로벌 HTTPException 핸들러 — dict detail 패스스루 + string detail 회귀 0.
+
+기존: `str(exc.detail)` → dict 가 Python repr 로 직렬화돼 FE JSON.parse 불가 + 의도 code 유실.
+수정: dict 면 code/message/추가필드(suggestion·retry_after)를 error 객체로 패스스루.
+str 이면 기존 shape 유지(회귀 0).
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.main import http_exception_handler
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _run(exc: HTTPException):
+    resp = await http_exception_handler(MagicMock(), exc)
+    return resp.status_code, json.loads(resp.body)
+
+
+# ── dict detail 패스스루 ──────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_dict_detail_passthrough_with_suggestion():
+    """SLUG_TAKEN: code + suggestion 이 error 객체로 그대로(FE 가 깔끔히 읽음)."""
+    s, body = await _run(HTTPException(409, detail={
+        "code": "SLUG_TAKEN", "message": "이미 사용 중인 슬러그", "suggestion": "q3-roadmap-2",
+    }))
+    assert s == 409
+    assert body["error"] == {"code": "SLUG_TAKEN", "message": "이미 사용 중인 슬러그", "suggestion": "q3-roadmap-2"}
+    assert body["data"] is None and body["meta"] is None
+
+
+@pytest.mark.anyio
+async def test_dict_detail_slug_invalid():
+    s, body = await _run(HTTPException(422, detail={"code": "SLUG_INVALID", "message": "유효하지 않은 슬러그"}))
+    assert s == 422
+    assert body["error"]["code"] == "SLUG_INVALID" and body["error"]["message"] == "유효하지 않은 슬러그"
+
+
+@pytest.mark.anyio
+async def test_dict_detail_retry_after_passthrough():
+    """rate_limit/agent_gateway 류 — retry_after 추가필드도 전달(기존엔 str화돼 유실)."""
+    s, body = await _run(HTTPException(429, detail={
+        "code": "AGENT_STREAM_LIMITED", "message": "limit", "retry_after": 5,
+    }))
+    assert body["error"]["code"] == "AGENT_STREAM_LIMITED" and body["error"]["retry_after"] == 5
+
+
+@pytest.mark.anyio
+async def test_dict_detail_without_code_falls_back_to_mapped():
+    s, body = await _run(HTTPException(409, detail={"message": "m"}))
+    assert body["error"]["code"] == "CONFLICT" and body["error"]["message"] == "m"
+
+
+@pytest.mark.anyio
+async def test_dict_detail_code_only_empty_message():
+    s, body = await _run(HTTPException(403, detail={"code": "USER_NOT_IN_ORG"}))
+    assert body["error"] == {"code": "USER_NOT_IN_ORG", "message": ""}
+
+
+# ── string detail 회귀 0 (대다수 raiser) ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_string_detail_unchanged():
+    s, body = await _run(HTTPException(404, detail="Doc not found"))
+    assert s == 404
+    assert body["error"] == {"code": "NOT_FOUND", "message": "Doc not found"}
+
+
+@pytest.mark.anyio
+async def test_unmapped_status_string_detail():
+    s, body = await _run(HTTPException(418, detail="teapot"))
+    assert body["error"] == {"code": "HTTP_418", "message": "teapot"}


### PR DESCRIPTION
## 글로벌 에러 envelope — dict detail 패스스루 (P2)

### 문제
`main.py` HTTPException 핸들러가 `message=str(exc.detail)` → dict detail이 **Python repr로 직렬화**(FE JSON.parse 불가) + 의도한 `error.code` 유실(status 매핑값으로 덮임). docs slug **409 suggestion**이 str화된 dict 안에 묻혀 FE 미도달(dev E2E 적발).

### fix
dict detail이면 키를 error 객체로 패스스루: `error={code: detail.code or mapped, message: detail.message or "", ...extras}`. **문자열 detail은 불변(회귀 0·대다수 raiser).**
- 부수 교정: `agent_gateway` AGENT_STREAM_LIMITED(429)·`team_members` USER_NOT_IN_ORG(403)·`rate_limit` RATE_LIMITED(429) — 셋 다 의도된 code/retry_after를 그동안 str화로 못 보냈는데 함께 정합.
- docs slug: 409→`{code:SLUG_TAKEN, message, suggestion}`(FE `error.suggestion` 직독·미르코군 page.tsx:258 이미 정합)·422→`{code:SLUG_INVALID, message}`.

### 검증
신규 7건(dict 패스스루·suggestion/retry_after·string 회귀·unmapped status·code fallback) + 전체 **1774 passed**(3 무관: e2e_dev 네트워크 2·subprocess env 1). blast radius=dict-detail raiser 4곳뿐(전수 개선).

🤖 Generated with [Claude Code](https://claude.com/claude-code)