### PR TITLE
[SID:4dd399c6] fix(build): transpilePackages — stale-dist done-blocker 근본 fix

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -35,6 +35,13 @@ const nextConfig: NextConfig = {
   // Set NEXT_DEV_ALLOWED_ORIGINS=host1,host2 in .env.local to enable
   allowedDevOrigins: process.env['NEXT_DEV_ALLOWED_ORIGINS']?.split(',').map((s) => s.trim()).filter(Boolean) ?? [],
   output: 'standalone',
+  // Bundle workspace packages from source (resolved via tsconfig paths) rather than
+  // externalizing their built dist. The Cloud Build context uploads the host's
+  // packages/*/dist (no .gcloudignore) and `next build --webpack` never rebuilds it,
+  // so without this the server bundle consumed a STALE dist — e.g. an old
+  // updateDocSchema that silently stripped slug/slug_locked (broke #4dd399c6 live).
+  // Forcing src-transpile makes src the single source of truth for every consumer.
+  transpilePackages: ['@sprintable/shared', '@sprintable/core-storage', '@sprintable/storage-api'],
   outputFileTracingRoot: path.resolve(__dirname, '../..'),
   outputFileTracingIncludes: {
     '/docs/design-tokens': ['./src/app/globals.css'],


### PR DESCRIPTION
## 근본 (4dd399c6 done-blocker)

URL편집 다이얼로그의 명시 슬러그 편집(`{slug, slug_locked:true}`)이 dev에서 **409가 아닌 200 무음 -N suffix**로 떨어지고 `slug_locked`도 안 stick → 409 suggestion UX 발생 불가 (유나 가디언 라이브 픽셀 FAIL).

**근본 = 배포 번들이 stale `packages/shared/dist` 소비** → `parseBody(updateDocSchema)`의 zod가 구 스키마(slug/slug_locked 부재)로 두 필드를 **무음 strip** → BE가 auto 경로 처리.

### 메커니즘 (PO 4단 봉인 + 내 probe/repro)
1. `next build --webpack`(turbo 아님) → `^build`(shared dist 재빌드) 미실행.
2. `.gcloudignore`/`.dockerignore` 부재 → 호스트 stale `packages/*/dist`가 빌드 컨텍스트로 업로드 → `COPY packages/`가 이미지에 구움.
3. `transpilePackages` 부재 → next build가 src 아닌 구운 stale dist를 externalize·런타임 소비.
4. **probe로 BE 무죄·strip=FE 봉인:** dev BE 00861 직접 PATCH `{slug:충돌, slug_locked:true}` → **409 SLUG_TAKEN** (BE 정상). 로컬 repro: `updateDocSchema.safeParse({slug,slug_locked:true}).data → {slug}` (slug_locked strip 재현).

## Fix
`next.config` `transpilePackages: ['@sprintable/shared','@sprintable/core-storage','@sprintable/storage-api']` — Next가 워크스페이스 패키지를 **src에서 번들**(tsconfig paths) → external dist 의존 근본 제거·src 단일소스. 3패키지 전부 포함해 **#1369 Part B FE 프록시(core-storage/storage-api 신규 메서드)도 동일 트랩 봉인** + clean-checkout-CI(dist 부재) 잠재 실패도 해소.

## 검증
- ✅ `pnpm type-check` PASS · `pnpm build` PASS (3 패키지 src 트랜스파일·shared consumer 회귀 0).
- 머지+dev 배포 후 까심군 probe1 `{slug_locked:"x"}`→**400** / probeB `{slug:"분기-회의록-2026",slug_locked:true}`→**409+suggestion** + 유나양 409 다이얼로그 재픽셀 = `4dd399c6` done.

> band-aid(stale dist 수동 재빌드)는 재현불가·차주 재발이라 근본(config)으로 감.

🤖 Generated with [Claude Code](https://claude.com/claude-code)