### PR TITLE
[SID:2628fd4d] fix(chat): 채팅 상세 단일헤더 + 폐기 '<메모' 백버튼 제거 (E-MOBILE-UX S2)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -147,10 +147,8 @@ export default function ConversationPage() {
           key={conversation_id}
           threadId={conversation_id}
           currentTeamMemberId={currentTeamMemberId}
-          threadTitle={headerTitle}
           projectId={projectId}
           apiPrefix="/api/conversations"
-          backRoute="/chats"
           commandTargets={commandTargets}
           presenceById={presenceById}
         />

--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -16,10 +16,8 @@ import { EmptyState } from '@/components/ui/empty-state';
 interface ChatViewProps {
   threadId: string;
   currentTeamMemberId: string;
-  threadTitle?: string | null;
   projectId?: string;
   apiPrefix?: string;
-  backRoute?: string | null;
   // S8 #2: pre-send capability 경고 대상(에이전트 participant runtime). 빈 배열이면 경고 미표시(graceful).
   commandTargets?: CommandTarget[];
   // 1aeecdde P2: 에이전트 member_id → presence_status(연결축 dot). 없으면 dot 미표시(graceful).
@@ -42,7 +40,7 @@ function groupByDate(messages: ChatMessage[]): MessageGroup[] {
   return Object.entries(groups).map(([date, msgs]) => ({ date, messages: msgs }));
 }
 
-export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId, apiPrefix = '/api/chats', backRoute = '/memos', commandTargets, presenceById }: ChatViewProps) {
+export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix = '/api/chats', commandTargets, presenceById }: ChatViewProps) {
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations('chats');
@@ -373,30 +371,19 @@ export function ChatView({ threadId, currentTeamMemberId, threadTitle, projectId
 
   return (
     <div className="flex h-full flex-col overflow-hidden">
-      {/* Mobile back nav — 스레드 뷰 중이면 스레드 뒤로가기 표시 (AC8) */}
-      {(backRoute || isMobileThreadView) && (
+      {/* Mobile thread back — only while a thread panel is open (closes it). The page
+          TopBar owns the conversation header, so this no longer duplicates it (S2). */}
+      {isMobileThreadView && (
         <div className="flex flex-shrink-0 items-center gap-2 border-b border-border/80 px-3 py-2 lg:hidden">
           <button
             type="button"
-            onClick={() => {
-              if (isMobileThreadView) { closeThread(); }
-              else if (backRoute) { router.push(backRoute); }
-            }}
+            onClick={closeThread}
             className="flex min-h-[44px] items-center gap-1 px-1 text-sm text-muted-foreground hover:text-foreground"
           >
             <ChevronLeft className="h-4 w-4" />
-            {isMobileThreadView ? '대화' : '메모'}
+            대화
           </button>
-          <span className="truncate text-sm font-medium text-foreground">
-            {isMobileThreadView ? '스레드' : (threadTitle ?? '')}
-          </span>
-        </div>
-      )}
-
-      {/* Desktop thread title (lg+) — 스레드 패널 없을 때만 표시 */}
-      {threadTitle && !activeThread && (
-        <div className="hidden flex-shrink-0 border-b border-border/80 px-4 py-2.5 lg:flex">
-          <h2 className="truncate text-sm font-medium text-foreground">{threadTitle}</h2>
+          <span className="truncate text-sm font-medium text-foreground">스레드</span>
         </div>
       )}
 


### PR DESCRIPTION
## 근본 (선생님 제보 261ebeb9)
채팅 상세 뷰가 **이중헤더** + 폐기 `< 메모` 백버튼(메모=죽은 개념·/inbox로 redirect) 노출.

`chats/[conversation_id]/page.tsx`가 canonical sticky `TopBarSlot`(`< 채팅` back + 제목 + 참여자추가)을 렌더하는데, `ChatView`도 **자체 헤더 2종**(모바일 back nav `< 메모`·`backRoute='/memos'` / 데스크탑 thread title)을 또 렌더 → 페이지 헤더와 중복(모바일 2줄·데스크탑 제목 2개).

## Fix (단일헤더화·canonical=TopBar)
**ChatView 사용처 = 이 페이지 단 1곳(grep 확인) → 회귀 0.**
- ChatView 모바일 back nav를 **thread 패널 열림 시에만** 렌더(스레드 닫기 "대화"/"스레드"·내부기능 유지)·페이지 back 중복 제거.
- ChatView **데스크탑 thread title 제거**(TopBar 제목이 커버).
- `threadTitle`/`backRoute` props + **폐기 `/memos` default 제거** → `메모` 잔존 0.

TopBar가 이미 back(→/chats)·제목·참여자추가 보유 → **기능 손실 0**(유나양 caveat 충족).

## 결과
- 모바일: `< 채팅 [대화제목]` + 참여자추가 — **단일 헤더·메모 0**(스레드 열면만 "대화" back).
- 데스크탑: `< [대화제목]` + 참여자추가 — 단일 제목.

## 검증
✅ `pnpm type-check` PASS · `pnpm build` PASS · lint clean.
모바일+데스크탑 라이브 픽셀(이중헤더0·`<메모`0·canonical 정렬·기능누락0)은 유나양 가디언이 dev 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)