### PR TITLE
feat(access): agent multi-project access via grants [SID:18073a52]

### DIFF
--- a/backend/alembic/versions/0110_agent_project_access_in_team_members_view.py
+++ b/backend/alembic/versions/0110_agent_project_access_in_team_members_view.py
@@ -1,0 +1,107 @@
+"""team_members 뷰 — 에이전트 project_access grant surface (18073a52 A안).
+
+기존(0106) agent 브랜치는 프로젝트 소속을 `agent_project_profiles`(app)에서만 도출 → grant만 주고
+profile 없는 프로젝트는 뷰에 안 떠서 chat 참가자 발견·list_members·dispatch assignee resolve 누락
+(한쪽만 전환 트랩). A안=grant이 SSOT·뷰는 surface만 → **agent-grant-only 3번째 UNION 브랜치** 추가:
+project_access(granted)는 있으나 그 프로젝트에 profile 없는 에이전트도 뷰 행 emit(런타임 컬럼 NULL·
+role 'member'). profile+grant 동시 존재 시 기존 2번 브랜치가 처리하고 3번은 `app.project_id IS NULL`로
+배제 → 중복 0. **profile 행 증식 0**(곱연산 패턴 회피·선생님 의도 정합).
+
++ partial unique `(project_id, member_id) WHERE member_id IS NOT NULL` — 에이전트 grant 1프로젝트 1행
+보장(휴먼은 member_id=org_member_id가 이미 uq_project_access_project_member로 유일이라 충돌 0·additive).
+
+순수 additive·backward-safe(기존 행 제거 0·grant-only 행만 추가). 마이그-first prod 안전.
+
+Revision ID: 0110
+Revises: 0109
+Create Date: 2026-06-10
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0110"
+down_revision = "0109"
+branch_labels = None
+depends_on = None
+
+# 0106(human ∪ agent-profile) + agent-grant-only 3번째 브랜치. 컬럼 순서/타입 전 브랜치 동일.
+_VIEW_WITH_GRANT = """
+CREATE VIEW team_members AS
+ SELECT m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, m.is_active, pa.color,
+    NULL::text AS agent_role, NULL::integer AS fakechat_port, owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.message_policy_mode, m.runtime_type, m.created_at, m.updated_at
+   FROM members m
+     JOIN project_access pa ON pa.member_id = m.id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+ SELECT m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, m.is_active, COALESCE(pa.color, '#3385f8') AS color,
+    app.agent_role, app.fakechat_port, owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode, m.runtime_type,
+    m.created_at, m.updated_at
+   FROM members m
+     JOIN agent_project_profiles app ON app.member_id = m.id
+     LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'agent' AND m.deleted_at IS NULL
+UNION ALL
+ SELECT m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, NULL::jsonb AS agent_config, m.is_active, COALESCE(pa.color, '#3385f8') AS color,
+    NULL::text AS agent_role, NULL::integer AS fakechat_port, owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode, m.runtime_type,
+    m.created_at, m.updated_at
+   FROM members m
+     JOIN project_access pa ON pa.member_id = m.id AND pa.permission = 'granted'
+     LEFT JOIN agent_project_profiles app ON app.member_id = m.id AND app.project_id = pa.project_id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'agent' AND m.deleted_at IS NULL AND app.project_id IS NULL
+"""
+
+# 0106 원본(human ∪ agent-profile) — downgrade 복원용.
+_VIEW_0106 = """
+CREATE VIEW team_members AS
+ SELECT m.id, pa.project_id, m.org_id, m.user_id, m.type, m.name, pa.role,
+    m.avatar_url, NULL::jsonb AS agent_config, m.is_active, pa.color,
+    NULL::text AS agent_role, NULL::integer AS fakechat_port, owner.user_id AS created_by,
+    NULL::timestamptz AS last_seen_at, NULL::uuid AS active_story_id, NULL::text AS agent_status,
+    pa.can_manage_members, m.message_policy_mode, m.runtime_type, m.created_at, m.updated_at
+   FROM members m
+     JOIN project_access pa ON pa.member_id = m.id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'human' AND m.deleted_at IS NULL
+UNION ALL
+ SELECT m.id, app.project_id, m.org_id, m.user_id, m.type, m.name, COALESCE(pa.role, 'member') AS role,
+    m.avatar_url, app.agent_config, m.is_active, COALESCE(pa.color, '#3385f8') AS color,
+    app.agent_role, app.fakechat_port, owner.user_id AS created_by,
+    app.last_seen_at, app.active_story_id, app.agent_status,
+    COALESCE(pa.can_manage_members, false) AS can_manage_members, m.message_policy_mode, m.runtime_type,
+    m.created_at, m.updated_at
+   FROM members m
+     JOIN agent_project_profiles app ON app.member_id = m.id
+     LEFT JOIN project_access pa ON pa.member_id = m.id AND pa.project_id = app.project_id
+     LEFT JOIN members owner ON owner.id = m.owner_member_id
+  WHERE m.type = 'agent' AND m.deleted_at IS NULL
+"""
+
+
+def upgrade() -> None:
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_WITH_GRANT)
+    op.create_index(
+        "uq_project_access_project_member_id",
+        "project_access",
+        ["project_id", "member_id"],
+        unique=True,
+        postgresql_where=sa.text("member_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("uq_project_access_project_member_id", table_name="project_access")
+    op.execute("DROP VIEW team_members")
+    op.execute(_VIEW_0106)

--- a/backend/app/routers/project_access.py
+++ b/backend/app/routers/project_access.py
@@ -16,7 +16,9 @@ router = APIRouter(prefix="/api/v2/projects", tags=["project-access"])
 
 
 class ProjectAccessCreate(BaseModel):
-    org_member_id: uuid.UUID
+    # 18073a52: 휴먼 grant = org_member_id / 에이전트 grant = member_id(=agent members.id). 정확히 1개 필수.
+    org_member_id: uuid.UUID | None = None
+    member_id: uuid.UUID | None = None
     permission: str = "granted"
 
 
@@ -83,25 +85,61 @@ async def create_project_access(
     await _require_owner_or_admin(project_id, auth, session)
     if body.permission != "granted":
         raise HTTPException(status_code=400, detail="permission must be 'granted'")
-    existing = await session.execute(
-        select(ProjectAccess).where(
-            ProjectAccess.project_id == project_id,
-            ProjectAccess.org_member_id == body.org_member_id,
+    if (body.member_id is None) == (body.org_member_id is None):
+        raise HTTPException(
+            status_code=422, detail="exactly one of org_member_id (human) or member_id (agent) required"
         )
-    )
-    if existing.scalar_one_or_none() is not None:
-        raise HTTPException(status_code=409, detail="Access record already exists")
-    # AC3-2c grant write-sync: canonical member_id(=org_member.id) 세팅 — AC3-4 projection의 member_id
-    # 읽기 토대 + (A) resolver-cutover 통일. 휴먼 members 행을 선행 보장(fk_project_access_member NOT VALID이나
-    # 신규 INSERT 검증). members 보장 실패(org_member 부재) 시 member_id 미세팅(레거시 호환).
-    from app.services.agent_anchor_sync import ensure_human_member
-    member_ok = await ensure_human_member(session, body.org_member_id)
-    record = ProjectAccess(
-        project_id=project_id,
-        org_member_id=body.org_member_id,
-        permission=body.permission,
-        member_id=body.org_member_id if member_ok else None,
-    )
+
+    if body.member_id is not None:
+        # 18073a52: 에이전트 grant — member_id(=agent members.id) 앵커, org_member_id 없음.
+        # 대상이 프로젝트 org 의 활성 에이전트인지 검증(ensure_human_member skip).
+        from sqlalchemy import text
+        agent_ok = (await session.execute(
+            text(
+                "SELECT 1 FROM members m JOIN projects p ON p.id = :pid "
+                "WHERE m.id = :mid AND m.type = 'agent' AND m.deleted_at IS NULL "
+                "AND m.org_id = p.org_id LIMIT 1"
+            ),
+            {"pid": str(project_id), "mid": str(body.member_id)},
+        )).scalar_one_or_none()
+        if agent_ok is None:
+            raise HTTPException(
+                status_code=400, detail="member_id must be an active agent in the project's org"
+            )
+        existing = await session.execute(
+            select(ProjectAccess).where(
+                ProjectAccess.project_id == project_id,
+                ProjectAccess.member_id == body.member_id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise HTTPException(status_code=409, detail="Access record already exists")
+        record = ProjectAccess(
+            project_id=project_id,
+            org_member_id=None,
+            member_id=body.member_id,
+            permission=body.permission,
+        )
+    else:
+        existing = await session.execute(
+            select(ProjectAccess).where(
+                ProjectAccess.project_id == project_id,
+                ProjectAccess.org_member_id == body.org_member_id,
+            )
+        )
+        if existing.scalar_one_or_none() is not None:
+            raise HTTPException(status_code=409, detail="Access record already exists")
+        # AC3-2c grant write-sync: canonical member_id(=org_member.id) 세팅 — AC3-4 projection의 member_id
+        # 읽기 토대 + (A) resolver-cutover 통일. 휴먼 members 행을 선행 보장(fk_project_access_member NOT VALID이나
+        # 신규 INSERT 검증). members 보장 실패(org_member 부재) 시 member_id 미세팅(레거시 호환).
+        from app.services.agent_anchor_sync import ensure_human_member
+        member_ok = await ensure_human_member(session, body.org_member_id)
+        record = ProjectAccess(
+            project_id=project_id,
+            org_member_id=body.org_member_id,
+            permission=body.permission,
+            member_id=body.org_member_id if member_ok else None,
+        )
     session.add(record)
     await session.commit()
     await session.refresh(record)

--- a/backend/app/services/project_auth.py
+++ b/backend/app/services/project_auth.py
@@ -46,6 +46,19 @@ async def has_project_access(
                       AND (CAST(:org_id AS uuid) IS NULL OR om.org_id = :org_id)
                 )
                 OR EXISTS (
+                    -- 18073a52: 에이전트 grant 분기. 에이전트는 org_member/user_id가 없고
+                    -- auth.user_id=members.id 이므로 project_access를 member_id(=에이전트 member id)로
+                    -- 직접 매칭. 단일 에이전트(단일 API key)가 grant로 복수 프로젝트 접근(키 증식 0).
+                    SELECT 1 FROM project_access pa
+                    JOIN members m ON pa.member_id = m.id
+                    WHERE pa.project_id = p.id
+                      AND m.id = :user_id
+                      AND m.type = 'agent'
+                      AND m.deleted_at IS NULL
+                      AND pa.permission = 'granted'
+                      AND (CAST(:org_id AS uuid) IS NULL OR m.org_id = :org_id)
+                )
+                OR EXISTS (
                     SELECT 1 FROM org_members om
                     WHERE om.user_id = :user_id
                       AND om.deleted_at IS NULL
@@ -200,6 +213,17 @@ async def accessible_project_ids_in_org(
                       AND om.deleted_at IS NULL
                       AND pa.permission = 'granted'
                       AND om.org_id = :org_id
+                )
+                OR EXISTS (
+                    -- 18073a52: 에이전트 grant 분기 (has_project_access와 lockstep).
+                    SELECT 1 FROM project_access pa
+                    JOIN members m ON pa.member_id = m.id
+                    WHERE pa.project_id = p.id
+                      AND m.id = :user_id
+                      AND m.type = 'agent'
+                      AND m.deleted_at IS NULL
+                      AND pa.permission = 'granted'
+                      AND m.org_id = :org_id
                 )
                 OR EXISTS (
                     SELECT 1 FROM org_members om

--- a/backend/tests/test_agent_multiproject_grant_18073a52.py
+++ b/backend/tests/test_agent_multiproject_grant_18073a52.py
@@ -1,0 +1,133 @@
+"""18073a52 — 에이전트 멀티 프로젝트 access grant (A안: grant=SSOT, 뷰 surface).
+
+- has_project_access / accessible_project_ids_in_org 에 에이전트 grant 분기(member_id 직매칭) 존재 가드.
+- project_access POST 의 에이전트 grant(member_id) 경로 라우팅(422/400/409/201).
+(실 DB 경로 — 뷰 surface·has_access true/false·partial unique·revoke — 는 pgvector e2e 로 검증.)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.project_auth import accessible_project_ids_in_org, has_project_access
+
+ORG = uuid.uuid4()
+AGENT = uuid.uuid4()
+PROJ = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _session(scalar_value=None, all_rows=None):
+    s = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = scalar_value
+    result.all.return_value = all_rows or []
+    s.execute = AsyncMock(return_value=result)
+    return s
+
+
+def _last_sql(session) -> str:
+    return str(session.execute.call_args[0][0])
+
+
+# ── 에이전트 grant 분기 SQL 존재 가드 (회귀 방지) ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_has_project_access_includes_agent_grant_branch():
+    s = _session(scalar_value=None)
+    await has_project_access(s, AGENT, PROJ, ORG)
+    sql = _last_sql(s)
+    assert "pa.member_id = m.id" in sql
+    assert "m.type = 'agent'" in sql
+    assert "pa.permission = 'granted'" in sql
+
+
+@pytest.mark.anyio
+async def test_accessible_project_ids_includes_agent_grant_branch():
+    s = _session(all_rows=[])
+    await accessible_project_ids_in_org(s, AGENT, ORG)
+    sql = _last_sql(s)
+    assert "pa.member_id = m.id" in sql
+    assert "m.type = 'agent'" in sql
+
+
+# ── project_access POST — 에이전트 grant(member_id) 경로 ──────────────────────
+
+async def _call_create(body_dict, execute_results):
+    """create_project_access 직접 호출 — _require_owner_or_admin no-op, execute 시퀀스 주입."""
+    from app.routers.project_access import ProjectAccessCreate, create_project_access
+
+    session = AsyncMock()
+    results = list(execute_results)
+
+    async def _execute(*a, **k):
+        r = results.pop(0) if results else MagicMock()
+        return r
+    session.execute = AsyncMock(side_effect=_execute)
+    session.add = MagicMock()
+    session.commit = AsyncMock()
+
+    async def _refresh(rec):  # DB가 채울 id/created_at을 model_validate 통과하도록 채움
+        if getattr(rec, "id", None) is None:
+            rec.id = uuid.uuid4()
+        rec.created_at = datetime.now(timezone.utc)
+    session.refresh = AsyncMock(side_effect=_refresh)
+
+    auth = MagicMock()
+    auth.user_id = str(uuid.uuid4())
+    with patch("app.routers.project_access._require_owner_or_admin", new=AsyncMock()):
+        return await create_project_access(PROJ, ProjectAccessCreate(**body_dict), auth, session), session
+
+
+def _scalar(v):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = v
+    return r
+
+
+@pytest.mark.anyio
+async def test_create_both_ids_422():
+    with pytest.raises(Exception) as ei:
+        await _call_create({"member_id": AGENT, "org_member_id": uuid.uuid4()}, [])
+    assert getattr(ei.value, "status_code", None) == 422
+
+
+@pytest.mark.anyio
+async def test_create_neither_id_422():
+    with pytest.raises(Exception) as ei:
+        await _call_create({}, [])
+    assert getattr(ei.value, "status_code", None) == 422
+
+
+@pytest.mark.anyio
+async def test_create_agent_not_found_400():
+    # 1st execute = agent 검증 → None
+    with pytest.raises(Exception) as ei:
+        await _call_create({"member_id": AGENT}, [_scalar(None)])
+    assert getattr(ei.value, "status_code", None) == 400
+
+
+@pytest.mark.anyio
+async def test_create_agent_duplicate_409():
+    # agent 검증 OK(1) → existing 존재(record)
+    with pytest.raises(Exception) as ei:
+        await _call_create({"member_id": AGENT}, [_scalar(1), _scalar(MagicMock())])
+    assert getattr(ei.value, "status_code", None) == 409
+
+
+@pytest.mark.anyio
+async def test_create_agent_success_sets_member_id_only():
+    # agent 검증 OK(1) → existing 없음(None) → record 생성
+    _, session = await _call_create({"member_id": AGENT}, [_scalar(1), _scalar(None)])
+    session.add.assert_called_once()
+    rec = session.add.call_args[0][0]
+    assert rec.member_id == AGENT
+    assert rec.org_member_id is None
+    assert rec.permission == "granted"


### PR DESCRIPTION
## E-FEATURE-ADD S1 — 에이전트 멀티 프로젝트 접근 = access grant

단일 에이전트(1 members 행·1 API key)가 **grant로 복수 프로젝트 접근** — 에이전트 복사·키 증식·**profile 행 증식 0**(PO 콜=A안: grant=SSOT·뷰 surface만, B안의 agent_project_profiles 증식=곱연산 재유입 회피).

### AC1 — `has_project_access` SSOT가 에이전트 grant 인식
- `project_auth.has_project_access` + `accessible_project_ids_in_org`에 에이전트 분기 추가: `project_access JOIN members ON pa.member_id=m.id WHERE m.type='agent' AND pa.permission='granted'`. (에이전트 auth.user_id=members.id·org_member 없음 → 기존 휴먼 org_member 분기 미매칭이던 갭.)
- `first_accessible_project_id`는 휴먼 로그인/switch-org 랜딩 전용(에이전트 API key는 미호출) → 의도적 미변경.

### AC2 — 에이전트 grant/revoke
- `POST /api/v2/projects/{id}/access`: `member_id`(에이전트) XOR `org_member_id`(휴먼). 에이전트 경로=프로젝트 org의 활성 agent 검증·member_id 세팅(org_member_id NULL)·ensure_human_member skip.
- revoke: 기존 DELETE-by-record_id가 에이전트 행에도 동작.

### 뷰 / 마이그 0110
- `team_members` 뷰 **3번째 UNION 브랜치(agent-grant-only)**: grant은 있으나 그 프로젝트에 profile 없는 에이전트도 뷰 행 emit(런타임 NULL·role member). `app.project_id IS NULL` 가드로 기존 agent-profile 브랜치와 **중복 0**. → AC3 downstream(chat 참가자 발견·list_members·dispatch assignee resolve)이 granted 프로젝트서 에이전트 인식.
- partial unique `(project_id, member_id) WHERE member_id NOT NULL`. additive·backward-safe(휴먼 member_id=org_member_id 이미 유일).

### 검증 (실 DB — pgvector:pg16)
에이전트를 projA만 grant → team_members 행 emit·`has_project_access(A)=True`/`(B)=False`·accessible_ids=[A]·중복 grant IntegrityError·revoke→뷰 행 소멸+access False. 신규 7 테스트(분기 SQL 가드 + grant-create 라우팅 422/400/409/201). 전체 **1782 passed**(3 무관: e2e_dev 네트워크 2·subprocess 1). alembic single-head 0110.

### 참고
- AC3(granted 프로젝트서 chat/board/dispatch 실동작)=머지+dev 배포 후 라이브 E2E 검증.
- me/memberships 에이전트 노출=범위 밖(휴먼 switcher). api_key project_id pin은 chat/board가 요청 project_id 사용이라 무영향.

🤖 Generated with [Claude Code](https://claude.com/claude-code)