### PR TITLE
[SID:b42b3b60] fix(epics): 에픽 생성 모달 내부 스크롤 — outcome 추가 시 입력가능 (E-MOBILE-UX S5)

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -691,8 +691,8 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
         onClick={onClose}
         aria-label={t('cancel')}
       />
-      <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-card p-6 shadow-xl">
-        <div className="mb-4 flex items-center justify-between">
+      <div className="relative z-10 flex max-h-[calc(100vh-2rem)] w-full max-w-md flex-col rounded-2xl border border-border bg-card shadow-xl">
+        <div className="flex flex-shrink-0 items-center justify-between px-6 pb-4 pt-6">
           <h2 className="text-base font-bold text-foreground">{t('createEpic')}</h2>
           <button
             type="button"
@@ -702,12 +702,16 @@ function CreateModal({ projectId, orgId, onCreated, onClose }: CreateModalProps)
             <X className="size-4" />
           </button>
         </div>
-        <EpicCreateForm
-          projectId={projectId}
-          orgId={orgId}
-          onCreated={(epic) => { onCreated(epic); onClose(); }}
-          onCancel={onClose}
-        />
+        {/* Scrollable body — long forms (outcome 추가 등) overflow the viewport otherwise;
+            internal scroll keeps every field + the submit button reachable (S5). */}
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-6">
+          <EpicCreateForm
+            projectId={projectId}
+            orgId={orgId}
+            onCreated={(epic) => { onCreated(epic); onClose(); }}
+            onCancel={onClose}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 근본 (선생님 제보 261ebeb9 · "메인 정신병의 근원")
새 에픽 추가 시 **outcome를 추가하면 레이아웃이 넘쳐 입력 불가**.

`CreateModal`(epics-client.tsx) 패널(`fixed inset-0` 오버레이 내부)에 **높이 캡·내부 스크롤 부재** → 폼이 뷰포트를 초과해 필드·저장버튼 도달 불가. (에픽 *편집* 폼은 `overflow-y-auto` 패널 안이라 이미 정상 — **생성 모달만 결함**.)

## Fix
패널을 **`max-h-[calc(100vh-2rem)]` flex 컬럼**으로 — **sticky 헤더**(`flex-shrink-0`) + **스크롤 바디**(`min-h-0 flex-1 overflow-y-auto`)로 `EpicCreateForm` 래핑. 긴 폼(outcome 추가 포함)도 **전 필드 + 저장버튼이 모든 뷰포트(모바일 포함)서 도달·입력 가능.**

## AC
- **AC1** ✅ 에픽 생성 모달 내부 스크롤 가능화 → outcome 등 필드 추가해도 입력 가능.
- **AC2** ✅ `CreateModal`은 **epics-client.tsx 로컬 컴포넌트**(공통 모달 아님) → **전파 0**. 다른 모달(편집폼·delete Dialog·스토리/스프린트 생성) 무영향·회귀 0.

## 검증
✅ `pnpm type-check` PASS · `pnpm build` PASS · lint clean.
모바일+데스크탑 라이브 픽셀(긴 폼 스크롤·하단 저장버튼 도달·outcome 입력)은 유나양 가디언이 dev 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)