### PR TITLE
[SID:2338a0af] fix(board): 모바일 터치 드래그앤드롭 상태변경 (E-MOBILE-UX S6 AC1)

### DIFF
--- a/apps/web/src/components/kanban/kanban-board.tsx
+++ b/apps/web/src/components/kanban/kanban-board.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
 import { Check, ChevronDown, LayoutGrid, LayoutList, Search } from 'lucide-react';
-import { DndContext, DragEndEvent, PointerSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
+import { DndContext, DragEndEvent, PointerSensor, TouchSensor, useSensor, useSensors, DragOverlay } from '@dnd-kit/core';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -179,7 +179,13 @@ export function KanbanBoard({ projectId }: KanbanBoardProps) {
   const [storyTasks, setStoryTasks] = useState<Task[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  // Desktop: mouse drag begins after an 8px move. Touch: a 250ms press-and-hold is
+  // required before a drag starts, so vertical scrolling on mobile web isn't hijacked
+  // by the drag sensor — the root cause of "보드 dnd 안 됨" on touch (S6 AC1).
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
 
   const epicMap: Record<string, string> = {};
   for (const e of epics) epicMap[e.id] = e.title;

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -95,6 +95,9 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
+    // Required for touch dnd — without it the mobile browser claims the gesture as a
+    // scroll/pan and the drag never activates (S6 root cause). Pairs with the TouchSensor.
+    touchAction: 'none' as const,
   };
 
   // Close menu on click outside

--- a/apps/web/src/components/kanban/story-card.tsx
+++ b/apps/web/src/components/kanban/story-card.tsx
@@ -95,9 +95,11 @@ export function StoryCard({ story, epicName, assignee, assignees, onClick, onEdi
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.5 : 1,
-    // Required for touch dnd — without it the mobile browser claims the gesture as a
-    // scroll/pan and the drag never activates (S6 root cause). Pairs with the TouchSensor.
-    touchAction: 'none' as const,
+    // Touch dnd: pan-y keeps vertical column scroll working (a quick swipe scrolls,
+    // aborting the TouchSensor's 250ms delay) while a press-and-hold still starts a drag
+    // (dnd-kit preventDefaults once active). `none` would have killed scroll-on-card;
+    // pan-y is the scroll-preserving fix for the overflow-y-auto columns (S6 root cause).
+    touchAction: 'pan-y' as const,
   };
 
   // Close menu on click outside


### PR DESCRIPTION
## 근본 (선생님 제보 261ebeb9 · 유나양 라이브 재현 확증)
보드 카드 dnd로 상태변경 불가. **결정 증거(유나양 computed style)**: sortable 카드 `touch-action: auto` + **PointerSensor 단독**.
- 모바일 web: 브라우저가 터치 제스처를 스크롤/팬으로 가로채 pointer 드래그 활성 불가 = **모바일 FAIL**.
- 데스크탑 마우스: touch-action 무관 → **데스크탑 OK**(disambiguation 완료).

## Fix (dnd-kit 터치 정석)
- **`TouchSensor` 추가** (`activationConstraint: { delay: 250, tolerance: 5 }`) — press-and-hold로 드래그 개시, 빠른 스와이프는 스크롤.
- **draggable 카드에 `touch-action: none`** — 브라우저가 제스처를 dnd에 양보.

`handleDragEnd`(transition 검증·낙관적·bulk PATCH·롤백)는 **이미 정상** — 센서/CSS 배선만 누락이었던. AC2(상세 status 컨트롤)는 디자인 콜 후 별도.

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green.
⚠️ **실 드래그는 synthetic/CDP로 구동 불가**(dnd-kit=trusted pointer 필요) → **선생님 라이브 검증**(데스크탑 마우스 + 모바일 터치 드래그).
⚠️ **검증노트(정직 플래그):** `touch-action:none`은 카드 위 스와이프 스크롤을 막는다 → 선생님 모바일 검증 시 **①드래그 동작 + ②컬럼 스크롤 정상** 둘 다 확인 바라는. ②가 회귀면 follow-up=드래그 핸들(핸들만 touch-action:none·카드 바디 스크롤).

🤖 Generated with [Claude Code](https://claude.com/claude-code)