### PR TITLE
feat(chat): per-conversation new session (revert 1-DM-per-pair) + title edit [SID:db75ecd0]

### DIFF
--- a/backend/alembic/versions/0111_drop_dm_pair_unique.py
+++ b/backend/alembic/versions/0111_drop_dm_pair_unique.py
@@ -1,0 +1,37 @@
+"""채팅 세션 정책 회귀 — uq_conversations_dm_pair drop (db75ecd0 EF-S2 AC1).
+
+선생님 지시(ce13ff0a): "이전 정책과 같이 신규 채팅 세션으로 생성되도록 회귀". 179db213(마이그 0100)이
+넣은 1-DM-per-pair dedup unique index 를 제거해 동일 2인 pair여도 매 "new conversation" 마다 신규
+conversation(=세션) 공존(각 1주제·hermes 세션별). create_conversation 의 _find_existing_dm 재사용 +
+IntegrityError DM-reuse fallback 도 함께 제거(코드).
+
+⚠️ "방 1개 제약"에만 국한된 회귀 — 보존 불변식 3종은 불변: ①메시지 dedup(send_message·별개)
+②_enforce_agent_creator_policy(creator 동석/allow_list) ③thread=스토리. (agent_comms_unified 보안 핵심.)
+
+`dm_pair_key` 컬럼은 유지(2인 룸 태깅·non-unique). drop index = backward-safe(데이터 변화 0·구 코드의
+_find_existing_dm 은 기존 DM 있으면 반환·없으면 신규라 migrate-first 무해).
+
+Revision ID: 0111
+Revises: 0110
+Create Date: 2026-06-10
+"""
+from alembic import op
+
+revision = "0111"
+down_revision = "0110"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_conversations_dm_pair")
+
+
+def downgrade() -> None:
+    # 0100 정의 복원. 단, drop 이후 동일 pair 다중 DM 이 생겼다면 재생성이 실패할 수 있음
+    # (정책 회귀 롤백은 사전 dedup 필요 — 비상시 수동).
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_conversations_dm_pair "
+        "ON conversations (org_id, project_id, dm_pair_key) "
+        "WHERE type = 'dm' AND dm_pair_key IS NOT NULL"
+    )

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -566,6 +566,11 @@ class UpdateStatusRequest(BaseModel):
     status: str  # open | resolved
 
 
+class UpdateConversationRequest(BaseModel):
+    # EF-S2 (db75ecd0) AC3: 방 title 사용자 편집. title 제공 시만 갱신(기본 생성 title 보존).
+    title: str | None = None
+
+
 class AddParticipantRequest(BaseModel):
     member_id: uuid.UUID
 
@@ -585,26 +590,14 @@ async def create_conversation(
     # ⭐ 인가 불변식: 휴먼↔에이전트 대화 — 에이전트 creator 동석 필수
     await _enforce_agent_creator_policy(sender, body.participant_ids, db)
 
-    # 179db213: 1-pair=1-DM enforce — resolved member set 이 정확히 2명이면 DM 으로 dedup
-    # (body.type label 무관). dm_pair_key(정렬쌍)로 기존 DM 조회→반환. ≥3명/단독은 group.
+    # EF-S2 (db75ecd0): "기존방 다이렉트" 제거 — 동일 2인 pair여도 매 호출 신규 conversation 생성
+    # (여러 conversation 공존·각 1주제·hermes 세션별 1방=1주제). 179db213 의 1-DM-per-pair
+    # dedup + uq_conversations_dm_pair 정책 회귀(마이그 0111 에서 unique index drop).
+    # 불변 보존: creator 동석/allow_list(_enforce_agent_creator_policy 위), 메시지 dedup(send_message·별개),
+    # thread=스토리. dm_pair_key 컬럼은 2인 룸 태깅용으로 유지(non-unique·dedup 아님).
     all_members = sorted({sender.id, *body.participant_ids})
     is_dm = len(all_members) == 2
     dm_pair_key = "|".join(str(m) for m in all_members) if is_dm else None
-
-    async def _find_existing_dm() -> uuid.UUID | None:
-        return (await db.execute(
-            select(Conversation.id).where(
-                Conversation.type == "dm",
-                Conversation.org_id == org_id,
-                Conversation.project_id == body.project_id,
-                Conversation.dm_pair_key == dm_pair_key,
-            )
-        )).scalar_one_or_none()
-
-    if is_dm:
-        existing = await _find_existing_dm()
-        if existing is not None:
-            return {"id": str(existing), "type": "dm", "existing": True}
 
     conv = Conversation(
         project_id=body.project_id,
@@ -621,12 +614,8 @@ async def create_conversation(
             db.add(ConversationParticipant(conversation_id=conv.id, member_id=mid))
         await db.commit()
     except IntegrityError:
-        # CP2: 동시 동일 pair 생성 레이스 → uq_conversations_dm_pair 위반 → 기존 DM 반환.
+        # dedup unique 제거 후엔 DM pair 레이스 충돌 없음 — 잔여 무결성 오류는 reuse 없이 전파.
         await db.rollback()
-        if is_dm:
-            existing = await _find_existing_dm()
-            if existing is not None:
-                return {"id": str(existing), "type": "dm", "existing": True}
         raise
     await db.refresh(conv)
     return {"id": str(conv.id), "type": conv.type, "title": conv.title, "existing": False}
@@ -1315,3 +1304,40 @@ async def update_conversation_status(
         "resolved_by": str(conv.resolved_by) if conv.resolved_by else None,
         "resolved_at": conv.resolved_at.isoformat() if conv.resolved_at else None,
     }
+
+
+@router.patch("/{conversation_id}", status_code=200)
+async def update_conversation(
+    conversation_id: uuid.UUID,
+    body: UpdateConversationRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """PATCH /api/v2/conversations/{id} — 방 title 사용자 편집 (EF-S2 AC3·참여자 권한).
+
+    title 제공 시만 갱신(기본 생성 title 보존). status PATCH 와 동일 참여자 게이트.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    requester = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant.id).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == requester.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    if body.title is not None:
+        conv.title = body.title
+        conv.updated_at = datetime.now(timezone.utc)
+        await db.commit()
+        await db.refresh(conv)
+
+    return {"id": str(conv.id), "title": conv.title}

--- a/backend/tests/test_chat_session_policy_db75ecd0.py
+++ b/backend/tests/test_chat_session_policy_db75ecd0.py
@@ -1,0 +1,107 @@
+"""EF-S2 db75ecd0 — 채팅 세션 정책 회귀(신규세션) + 방 title PATCH.
+
+AC1: create_conversation "기존방 다이렉트"(DM dedup) 제거 → 매 호출 신규 conversation(existing false).
+AC3: PATCH /conversations/{id} {title} (참여자 게이트·기본 title 보존).
+보존 불변식(체크리스트 ④): _enforce_agent_creator_policy(creator/allow_list) 보존 / 메시지 dedup
+(send_message·미변경) / thread=스토리(미변경). dup-DM 공존은 pgvector e2e 로 검증.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import app.routers.conversations as conv_mod
+
+CONV = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── AC1 회귀 가드 (소스) ───────────────────────────────────────────────────────
+
+def test_create_conversation_removed_dm_direct_reuse():
+    src = inspect.getsource(conv_mod.create_conversation)
+    # 기존방 다이렉트(DM dedup) 재사용 제거
+    assert "_find_existing_dm" not in src
+    # 신규 세션 = existing 항상 false
+    assert '"existing": False' in src
+    # 보존 불변식: creator 동석/allow_list 인가 그대로
+    assert "_enforce_agent_creator_policy" in src
+
+
+def test_message_dedup_and_thread_paths_untouched():
+    """보존 불변식 ①메시지 dedup ③thread=스토리 — 내 diff가 건드리지 않음(send_message 존재 확인)."""
+    # send_message(메시지 dedup 경로)는 별개 함수로 그대로 존재
+    assert hasattr(conv_mod, "send_message")
+    src = inspect.getsource(conv_mod.create_conversation)
+    # create_conversation 은 메시지 dedup/thread 로직을 포함하지 않음(방 생성만) — 회귀 국한 확인
+    assert "dm_pair_key" in src  # 컬럼은 유지(태깅·non-unique)
+
+
+# ── AC3 title PATCH ───────────────────────────────────────────────────────────
+
+async def _call_update(title, conv_obj, participant):
+    """update_conversation 직접 호출 — _resolve_member 패치, execute 시퀀스 [conv, participant]."""
+    from app.routers.conversations import UpdateConversationRequest, update_conversation
+
+    session = AsyncMock()
+    results = []
+    r1 = MagicMock(); r1.scalar_one_or_none.return_value = conv_obj
+    r2 = MagicMock(); r2.scalar_one_or_none.return_value = participant
+    results = [r1, r2]
+
+    async def _execute(*a, **k):
+        return results.pop(0) if results else MagicMock()
+    session.execute = AsyncMock(side_effect=_execute)
+    session.commit = AsyncMock()
+    session.refresh = AsyncMock()
+
+    auth = MagicMock(); auth.user_id = str(uuid.uuid4())
+    requester = MagicMock(); requester.id = uuid.uuid4()
+    with patch("app.routers.conversations._resolve_member", new=AsyncMock(return_value=requester)):
+        return await update_conversation(
+            CONV, UpdateConversationRequest(title=title), session, auth, uuid.uuid4()
+        ), session
+
+
+def _conv():
+    c = MagicMock(); c.id = CONV; c.project_id = uuid.uuid4(); c.title = "default-gen-title"
+    return c
+
+
+@pytest.mark.anyio
+async def test_title_patch_404_when_missing():
+    with pytest.raises(Exception) as ei:
+        await _call_update("New", None, None)
+    assert getattr(ei.value, "status_code", None) == 404
+
+
+@pytest.mark.anyio
+async def test_title_patch_403_when_not_participant():
+    with pytest.raises(Exception) as ei:
+        await _call_update("New", _conv(), None)  # participant lookup → None
+    assert getattr(ei.value, "status_code", None) == 403
+
+
+@pytest.mark.anyio
+async def test_title_patch_updates_title():
+    c = _conv()
+    out, session = await _call_update("Q3 Planning", c, uuid.uuid4())
+    assert c.title == "Q3 Planning"
+    assert out["title"] == "Q3 Planning"
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_title_patch_none_preserves_default():
+    c = _conv()
+    out, session = await _call_update(None, c, uuid.uuid4())
+    assert c.title == "default-gen-title"  # 미변경(기본 보존)
+    session.commit.assert_not_awaited()  # title None → no-op commit

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -203,8 +203,11 @@ async def test_group_request_2members_coerced_to_dm():
 # ─── AC4: POST /conversations — DM 중복 방지 ────────────────────────────────
 
 @pytest.mark.anyio
-async def test_create_dm_deduplication():
-    """dm 중복 시 기존 conversation 반환 + existing=True."""
+async def test_create_dm_no_dedup_creates_new_session():
+    """db75ecd0(EF-S2) AC1: 같은 pair여도 dedup 없이 매 호출 신규 conversation(existing False).
+
+    179db213 의 1-DM-per-pair dedup 회귀 — _find_existing_dm 제거로 항상 신규 세션 생성.
+    """
     client, session, app = await _make_client()
     try:
         mock_member = _make_member()
@@ -212,13 +215,14 @@ async def test_create_dm_deduplication():
 
         member_result = MagicMock()
         member_result.scalars.return_value.first.return_value = mock_member
+        # _find_existing_dm 제거 → member resolve 만(2번째는 안전 여분)
+        session.execute = AsyncMock(side_effect=[member_result, MagicMock()])
 
-        # 179db213: 새 dedup — _find_existing_dm() = scalar_one_or_none(dm_pair_key 조회)
-        existing_dm_result = MagicMock()
-        existing_dm_result.scalar_one_or_none.return_value = CONV_ID
-
-        # execute 순서: member resolve → _find_existing_dm(scalar_one_or_none)
-        session.execute = AsyncMock(side_effect=[member_result, existing_dm_result])
+        async def _refresh(obj):
+            obj.id = CONV_ID
+            obj.type = "dm"
+            obj.title = None
+        session.refresh.side_effect = _refresh
 
         async with client as c:
             resp = await c.post("/api/v2/conversations", json={
@@ -229,8 +233,8 @@ async def test_create_dm_deduplication():
 
         assert resp.status_code == 201
         body = resp.json()
-        assert body["existing"] is True
-        assert body["id"] == str(CONV_ID)
+        assert body["existing"] is False  # dedup 제거 — 기존방 다이렉트 없이 항상 신규
+        assert body["type"] == "dm"
     finally:
         app.dependency_overrides.clear()
 

--- a/backend/tests/test_dm_dedup_179db213.py
+++ b/backend/tests/test_dm_dedup_179db213.py
@@ -41,6 +41,7 @@ def _key(*ids):
 
 
 @pytest.mark.anyio
+@pytest.mark.skip(reason="db75ecd0(EF-S2): 1-DM-per-pair dedup 정책 회귀(uq_conversations_dm_pair drop)로 폐기 — 신규세션 정책은 test_chat_session_policy_db75ecd0")
 @pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
 async def test_unique_index_and_concurrent_race_realdb():
     """CP1/CP2: 같은 (org,project,dm_pair_key) DM 2개 insert → unique 위반(동시성 포함 단일 보장)."""
@@ -94,6 +95,7 @@ _DEDUP_SQL = [
 
 
 @pytest.mark.anyio
+@pytest.mark.skip(reason="db75ecd0(EF-S2): 기존방 다이렉트(DM dedup) 제거로 폐기 — 동일 pair도 신규세션. test_chat_session_policy_db75ecd0 참조")
 @pytest.mark.skipif(not _ASYNC, reason="real-DB URL 미설정 — skip")
 async def test_concurrent_api_create_same_pair_single_dm_realdb(monkeypatch):
     """CP2: 핸들러 API 레벨 동시 POST(같은 pair) 2건 → 둘 다 동일 DM id·DB 단일 DM.


### PR DESCRIPTION
## E-FEATURE-ADD S2 — 채팅 세션 정책 회귀(신규세션) + 방 title 편집 (BE)

선생님 ce13ff0a: "신규 채팅 세션으로 생성되도록 회귀" = 179db213 의 1-DM-per-pair dedup 제거.

### AC1 — "기존방 다이렉트" 제거 (conversation별 신규세션)
- `create_conversation`: `_find_existing_dm` 재사용 + IntegrityError DM-reuse fallback **제거** → 매 호출 신규 conversation(`existing` 항상 false)·동일 pair 다중 공존(각 1주제·hermes 1방=1세션).
- **마이그 0111**: `uq_conversations_dm_pair`(179db213) drop. `dm_pair_key` 컬럼 유지(non-unique 태깅).
- **보존 불변식(미변경)**: `_enforce_agent_creator_policy`(creator 동석/allow_list)·send_message 메시지 dedup(별개)·thread=스토리.

### AC3 — 방 title 편집
- `PATCH /api/v2/conversations/{id}` `{title}` 신설 — 참여자 권한 게이트(`/status` 동형)·title 제공 시만 갱신(기본 생성 title 보존).

### 검증 (실 DB pgvector)
0111 후 `uq_conversations_dm_pair` 부재 확인 + 동일 (org,project,dm_pair_key) DM 2건 공존(count=2). 신규 6테스트(재사용 제거 가드·불변식 가드·title PATCH 404/403/갱신/no-op). `test_conversations` dedup 테스트를 신규정책으로 반전·179db213 real-DB dedup 테스트 skip 마킹(회귀). 전체 **1788 passed**(3 무관: e2e_dev 네트워크 2·subprocess 1)·alembic single-head 0111.

### FE 계약 (미르코 핸드오프)
- 신규세션: `POST /conversations` → `existing` 항상 false(다중 공존)
- title 편집: `PATCH /conversations/{id}` `{title}` → `{id, title}`(참여자만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)