### PR TITLE
[SID:2338a0af] feat(board): 스토리 상세 상태전이 컨트롤 (E-MOBILE-UX S6 AC2)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
-import { AlertTriangle, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
+import { AlertTriangle, Check, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X } from 'lucide-react';
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import { getFileIcon } from '@/lib/file-icon';
@@ -18,6 +18,8 @@ import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outc
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { VALID_TRANSITIONS, COLUMNS } from './types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   Dialog, DialogContent, DialogDescription,
@@ -122,6 +124,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [editingTitle, setEditingTitle] = useState(false);
   const [titleDraft, setTitleDraft] = useState(story.title);
   const [savingTitle, setSavingTitle] = useState(false);
+  const [savingStatus, setSavingStatus] = useState(false);
 
   const [editingDescription, setEditingDescription] = useState(false);
   const [descriptionDraft, setDescriptionDraft] = useState(story.description ?? '');
@@ -340,6 +343,17 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     if (!res.ok) return null;
     const json = await res.json();
     return json.data as KanbanStory;
+  };
+
+  const handleChangeStatus = async (newStatus: string) => {
+    if (newStatus === story.status || savingStatus) return;
+    const prev = story.status;
+    setSavingStatus(true);
+    onStoryUpdate?.({ ...story, status: newStatus }); // optimistic
+    const updated = await patchStory({ status: newStatus });
+    setSavingStatus(false);
+    // BE enforces the state machine — roll back if it rejects (e.g. invalid transition).
+    onStoryUpdate?.({ ...story, status: updated ? updated.status : prev });
   };
 
   const handleSaveTitle = async () => {
@@ -636,7 +650,31 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                 <span className="mt-1 shrink-0 text-xs text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">✎</span>
               </button>
             )}
-            <StatusBadge status={story.status} label={statusLabel} />
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <button type="button" disabled={savingStatus} aria-label={t('status')}>
+                    <StatusBadge status={story.status} label={statusLabel} interactive />
+                  </button>
+                }
+              />
+              <DropdownMenuContent align="start">
+                {COLUMNS.map((col) => {
+                  const isCurrent = col.id === story.status;
+                  const allowed = isCurrent || (VALID_TRANSITIONS[story.status] ?? []).includes(col.id);
+                  return (
+                    <DropdownMenuItem
+                      key={col.id}
+                      disabled={!allowed}
+                      onClick={() => { if (!isCurrent) void handleChangeStatus(col.id); }}
+                    >
+                      <Check className={`size-4 ${isCurrent ? '' : 'opacity-0'}`} />
+                      {t(statusKeyMap[col.id] ?? col.i18nKey)}
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             <button
@@ -652,10 +690,6 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
         </div>
         <div className="flex-1 overflow-y-auto p-5">
           <div className="space-y-5">
-            <div>
-              <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('status')}</span>
-              <p className="mt-1 text-sm text-foreground">{statusLabel}</p>
-            </div>
             <div>
               <div className="flex items-center justify-between">
                 <span className="text-[10px] font-mono uppercase tracking-wider text-muted-foreground">{t('assignee')}</span>

--- a/apps/web/src/components/ui/status-badge.tsx
+++ b/apps/web/src/components/ui/status-badge.tsx
@@ -1,3 +1,4 @@
+import { ChevronDown } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
 const VARIANT_MAP: Record<string, 'default' | 'secondary' | 'outline' | 'destructive' | 'success' | 'info'> = {
@@ -20,7 +21,14 @@ const VARIANT_MAP: Record<string, 'default' | 'secondary' | 'outline' | 'destruc
   done: 'success',
 };
 
-export function StatusBadge({ status, label }: { status: string; label?: string }) {
+export function StatusBadge({ status, label, interactive }: { status: string; label?: string; interactive?: boolean }) {
   const variant = VARIANT_MAP[status] ?? 'outline';
-  return <Badge variant={variant}>{label ?? status}</Badge>;
+  // `interactive` turns the badge into a control affordance (cursor + chevron) — the
+  // caller wraps it in a trigger. Default off, so existing read-only usages are unchanged.
+  return (
+    <Badge variant={variant} className={interactive ? 'cursor-pointer transition hover:brightness-95' : undefined}>
+      {label ?? status}
+      {interactive ? <ChevronDown aria-hidden /> : null}
+    </Badge>
+  );
 }


### PR DESCRIPTION
## 배경 (선생님 제보 261ebeb9 · 유나양 디자인 콜)
보드 dnd(AC1·#1378 머지됨) 외에 **스토리 상세에서도 상태 전이** 요청. 상세 헤더는 읽기전용 StatusBadge뿐이고 "상태" 속성행이 중복.

## Fix (StatusBadge click→dropdown · Linear/Notion 패턴=인디케이터가 컨트롤)
- **StatusBadge** `interactive` variant 추가(cursor + chevron) — **default off·기존 읽기전용 사용처 전부 무영향.**
- 헤더 배지 → **DropdownMenu**: 5상태 전부 표시·**현재 상태 체크**·**invalid 전이 disabled**(`VALID_TRANSITIONS` 상태머신 클라 준수 + BE 재검증·거부 시 낙관적 롤백).
- 중복된 읽기전용 **"상태" 속성행 제거**.

## 구현
패널 자체완결 — 기존 `patchStory` + `onStoryUpdate`(title/assignee 편집과 동일 메커니즘·낙관적+롤백) 재사용. **보드 변경 0.** PATCH = `/api/stories/{id}`(status, 상태머신 BE 검증).

## AC
- **AC2** ✅ 상세 status 전이 컨트롤(상태머신 backlog→ready-for-dev→in-progress→in-review→done 준수).

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green.
유나양 가디언 픽셀(드롭다운 열림·현재 체크·valid만 활성·전이 동작·상태행 중복 0·라이트/다크)은 dev 배포 후.

> AC1(#1378 dnd·머지됨)과 같은 스토리(2338a0af)·별 증분 PR(PO "신규 독립" 재량).

🤖 Generated with [Claude Code](https://claude.com/claude-code)