### PR TITLE
chore(db): drop redundant project_access partial-unique index (0112, CP2)

### DIFF
--- a/backend/alembic/versions/0112_drop_redundant_project_access_member_index.py
+++ b/backend/alembic/versions/0112_drop_redundant_project_access_member_index.py
@@ -1,0 +1,30 @@
+"""중복 partial unique 인덱스 정리 — uq_project_access_project_member_id drop (tech-debt·CP2).
+
+0110(18073a52)이 `uq_project_access_project_member_id`(project_id, member_id WHERE member_id NOT NULL)
+를 신설했으나, baseline(0075)에 동일 정의 `uq_project_access_project_member_v2`가 이미 존재해 100%
+중복이었다(까심 CP2·기능 영향 0). 유일성은 v2 가 계속 enforce 하므로 0110 신설본만 drop.
+
+backward-safe: 데이터 변화 0·v2 가 (project_id, member_id) 유일성 유지·구/신 코드 무영향.
+
+Revision ID: 0112
+Revises: 0111
+Create Date: 2026-06-10
+"""
+from alembic import op
+
+revision = "0112"
+down_revision = "0111"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_project_access_project_member_id")
+
+
+def downgrade() -> None:
+    # 0110 정의 복원(v2 와 중복이지만 0110→0112 롤백 정합).
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_project_access_project_member_id "
+        "ON project_access (project_id, member_id) WHERE member_id IS NOT NULL"
+    )


### PR DESCRIPTION
## tech-debt — 0110 중복 partial unique 인덱스 정리 (CP2)

0110(18073a52)이 만든 `uq_project_access_project_member_id`(`(project_id, member_id) WHERE member_id IS NOT NULL`)는 baseline(0075)의 `uq_project_access_project_member_v2`와 **정의 100% 동일**한 중복(까심 CP2·기능 영향 0). 마이그 0112가 0110 신설본만 drop, v2가 유일성 계속 enforce.

backward-safe(데이터0·v2 유지·코드 무영향). 검증: pgvector upgrade head→0112 후 `uq_project_access_project_member%` = `uq_project_access_project_member`(org_member 제약) + `_v2`(canonical)만 잔존, `_id`(0110) 제거 확인. single-head 0112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)