### PR TITLE
chore(auth): remove vestigial Supabase config [SID:fc7bce47]

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -36,10 +36,6 @@ class Settings(BaseSettings):
     # JWT
     jwt_secret: str = ""
 
-    # Supabase (Phase C 과도기 — DB 쿼리 라우트 125개 전환 완료 전까지 유지)
-    supabase_jwt_secret: str = ""
-    supabase_url: str = ""
-
     # CORS (쉼표 구분 origins, Cloud Run 환경변수 CORS_ORIGINS로 주입)
     cors_origins: str = "http://localhost:3000,http://localhost:3108,https://app.sprintable.ai"
 
@@ -86,10 +82,6 @@ class Settings(BaseSettings):
     @property
     def is_ee_enabled(self) -> bool:
         return self.license_consent.lower() == "agreed"
-
-    @property
-    def effective_jwt_secret(self) -> str:
-        return self.jwt_secret or self.supabase_jwt_secret
 
 
 settings = Settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -42,7 +42,9 @@ def verify_password(plain: str, hashed: str) -> bool:
 # ─── JWT ──────────────────────────────────────────────────────────────────────
 
 def _get_secret() -> str:
-    secret = getattr(settings, "jwt_secret", None) or settings.supabase_jwt_secret or os.environ.get("JWT_SECRET", "")
+    # fc7bce47: Supabase 잔재 제거 — supabase_jwt_secret 폴백 삭제(jwt_secret 단일).
+    # dev/prod 둘 다 JWT_SECRET 세팅 확인됨(PO gcloud 실측) → 기존 토큰 동일 secret 검증·로그아웃 0.
+    secret = getattr(settings, "jwt_secret", None) or os.environ.get("JWT_SECRET", "")
     if not secret:
         raise JWTError("JWT_SECRET not configured")
     return secret

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -20,12 +20,12 @@ router = APIRouter(prefix="/api/v2", tags=["notifications"])
 
 
 async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> uuid.UUID:
-    """auth context → Notification.user_id (supabase user_id) 파생.
+    """auth context → Notification.user_id 파생. (fc7bce47: misleading 'supabase' 명명 정리.)
 
-    API key 경로: auth.user_id = team_member.id → TeamMember.user_id (supabase) 조회.
-                  agent는 supabase user 없음(user_id=NULL) → team_member.id fallback
+    API key 경로: auth.user_id = team_member.id → TeamMember.user_id 조회.
+                  agent는 user_id=NULL → team_member.id fallback
                   (알림 dispatch 시 user_id IS NOT NULL 조건으로 agent 제외됨 → 빈 배열 200 반환)
-    JWT 경로: auth.user_id = supabase user_id → 직접 사용
+    JWT 경로: auth.user_id = user_id → 직접 사용
     """
     is_api_key = bool(auth.claims.get("app_metadata", {}).get("api_key_id"))
     if is_api_key:
@@ -35,8 +35,8 @@ async def _resolve_notification_user_id(auth: AuthContext, db: AsyncSession) -> 
         row = result.one_or_none()
         if row is None:
             raise HTTPException(status_code=400, detail="Team member not found")
-        member_id, supabase_user_id = row
-        return supabase_user_id or member_id  # agent: user_id=NULL → member.id fallback
+        member_id, user_id = row
+        return user_id or member_id  # agent: user_id=NULL → member.id fallback
     return uuid.UUID(auth.user_id)
 
 

--- a/backend/tests/test_supabase_vestige_fc7bce47.py
+++ b/backend/tests/test_supabase_vestige_fc7bce47.py
@@ -1,0 +1,37 @@
+"""fc7bce47: Supabase 잔재 제거 — JWT secret 단일화(jwt_secret) 토큰 호환 가드.
+
+supabase_jwt_secret 폴백 + supabase_url/effective_jwt_secret 제거. dev/prod JWT_SECRET 세팅
+확인됨(PO gcloud) → jwt_secret 단일로 발급↔검증 round-trip 동일 secret = 기존 토큰 호환(로그아웃 0).
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.core.config import Settings
+
+
+def test_settings_has_no_supabase_fields():
+    """config 에서 supabase_* 필드·effective_jwt_secret 완전 제거."""
+    s = Settings()
+    assert not hasattr(s, "supabase_jwt_secret")
+    assert not hasattr(s, "supabase_url")
+    assert not hasattr(s, "effective_jwt_secret")
+
+
+def test_get_secret_uses_jwt_secret_only(monkeypatch):
+    """_get_secret() = jwt_secret 단일(supabase 폴백 없음)."""
+    from app.core import security
+
+    monkeypatch.setattr(security.settings, "jwt_secret", "known-secret-at-least-32-chars-long")
+    assert security._get_secret() == "known-secret-at-least-32-chars-long"
+
+
+def test_token_round_trip_jwt_secret_only(monkeypatch):
+    """jwt_secret 단일로 발급한 토큰이 동일 secret 로 검증됨(기존 토큰 호환·로그아웃 0)."""
+    from app.core import security
+
+    monkeypatch.setattr(security.settings, "jwt_secret", "roundtrip-secret-at-least-32-chars")
+    sub = str(uuid.uuid4())
+    token = security.create_access_token(sub, {"org_id": "o"})
+    decoded = security.decode_jwt(token)
+    assert decoded.get("sub") == sub


### PR DESCRIPTION
## TECH-DEBT — Supabase 잔재 제거 (BE·AC1/AC2)

실 인증=앱 JWT(HS256)+OAuth·DB=Cloud SQL. Supabase 잔재가 slug done-blocker 추적서 헛가설 유발(선생님 지적·high).

### AC1 — JWT secret 단일화
`_get_secret()`(security.py)에서 `supabase_jwt_secret` 폴백 제거 → `jwt_secret` 단일. **PO gcloud 실측: dev+prod 둘 다 `JWT_SECRET` 세팅** → `jwt_secret` 우선 해소로 폴백은 이미 dead → **제거 투명(동일 secret 검증·로그아웃 0)**.

### AC2 (code) — dead config 제거
`Settings.supabase_jwt_secret`/`supabase_url` 필드 + 사용처 0인 `effective_jwt_secret` property 제거. Settings `extra="ignore"`라 env에 SUPABASE_* 잔존해도 무시(startup 크래시 0·env-first 불요). `notifications`의 misleading `supabase_user_id` 지역변수→`user_id` rename(실체=TeamMember.user_id).

### 검증
신규 3테스트(supabase 필드 부재·`_get_secret` jwt_secret 단일·토큰 round-trip 호환) + 전체 **1791 passed**(3 무관: e2e_dev 네트워크 2·subprocess 1). 残 supabase 코드참조 0(주석 1줄 제외).

### Infra (PO lane·별개)
dev/prod Cloud Run env + Secret Manager의 `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`/`NEXT_PUBLIC_SUPABASE_URL` 제거(코드참조 0·dead·SERVICE_ROLE_KEY 死노출 보안정리). AC3(FE 미스리딩 명명/죽은 라우트)=미르코. AC4 회귀(login/OAuth/refresh/docs) 머지+dev 배포 후 라이브 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)