### PR TITLE
feat(docs): optimistic-concurrency 409 on doc update [SID:151e05f1]

### DIFF
--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -242,14 +242,19 @@ async def update_doc(
     # 151e05f1: 낙관적 동시성 — expected_updated_at 제공 & 현재 updated_at 불일치 & not force
     # → 409 DOC_CONFLICT(동시편집 clobber 방지). mutation 前 검사·미제공=무체크(하위호환).
     # detail dict → #1372 핸들러 패스스루 → FE 가 error.code/error.current_updated_at 언랩.
-    if expected_updated_at is not None and not force_overwrite:
-        if doc.updated_at != expected_updated_at:
+    # ⚠️ **ms 절삭 비교**(PO 콜): FE가 JS Date(ms 정밀도)로 round-trip하면 μs 손실 → μs-exact면
+    # 매 저장 false-409(상시 차단·원본보다 악화 footgun). 양쪽 ms 절삭 후 ==로 FE 직렬화 무관 robust
+    # (동시편집 <1ms 간격은 비현실이라 보호 granularity 손실 무의미·defense in depth).
+    if expected_updated_at is not None and not force_overwrite and doc.updated_at is not None:
+        cur_ms = doc.updated_at.replace(microsecond=(doc.updated_at.microsecond // 1000) * 1000)
+        exp_ms = expected_updated_at.replace(microsecond=(expected_updated_at.microsecond // 1000) * 1000)
+        if cur_ms != exp_ms:
             raise HTTPException(
                 status_code=409,
                 detail={
                     "code": "DOC_CONFLICT",
                     "message": "문서가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요",
-                    "current_updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+                    "current_updated_at": doc.updated_at.isoformat(),
                 },
             )
 

--- a/backend/app/routers/docs.py
+++ b/backend/app/routers/docs.py
@@ -231,10 +231,27 @@ async def update_doc(
     # 4dd399c6: slug/slug_locked 는 유일성·alias 처리가 필요해 일반 필드와 분리.
     slug_in = data.pop("slug", None)
     slug_locked_in = data.pop("slug_locked", None)
+    # 151e05f1: 동시성 제어 필드 — Doc 컬럼이 아니므로 분리(setattr 루프서 제외).
+    expected_updated_at = data.pop("expected_updated_at", None)
+    force_overwrite = data.pop("force_overwrite", None)
 
     doc = await repo.get(id)
     if doc is None:
         raise HTTPException(status_code=404, detail="Doc not found")
+
+    # 151e05f1: 낙관적 동시성 — expected_updated_at 제공 & 현재 updated_at 불일치 & not force
+    # → 409 DOC_CONFLICT(동시편집 clobber 방지). mutation 前 검사·미제공=무체크(하위호환).
+    # detail dict → #1372 핸들러 패스스루 → FE 가 error.code/error.current_updated_at 언랩.
+    if expected_updated_at is not None and not force_overwrite:
+        if doc.updated_at != expected_updated_at:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "code": "DOC_CONFLICT",
+                    "message": "문서가 다른 곳에서 수정됨 — 최신본을 다시 불러오세요",
+                    "current_updated_at": doc.updated_at.isoformat() if doc.updated_at else None,
+                },
+            )
 
     # 일반 필드 적용 (slug 제외)
     for attr, val in data.items():

--- a/backend/app/schemas/doc.py
+++ b/backend/app/schemas/doc.py
@@ -32,6 +32,11 @@ class DocUpdate(BaseModel):
     content_format: str | None = None
     tags: list[str] | None = None
     assignee_id: uuid.UUID | None = None
+    # 151e05f1: 낙관적 동시성(문서 동시편집 충돌 보호). expected_updated_at 제공 시 BE가 현재
+    # updated_at 과 exact match 검사 → 불일치면 409 DOC_CONFLICT(opt-in·미제공=무체크 하위호환).
+    # force_overwrite=True 면 검사 우회(last-write-wins 의도적). ⚠️ 이 2필드는 strip 금지(BE 수용).
+    expected_updated_at: datetime | None = None
+    force_overwrite: bool | None = None
 
 
 class DocSummaryResponse(BaseModel):

--- a/backend/tests/test_doc_concurrency_151e05f1.py
+++ b/backend/tests/test_doc_concurrency_151e05f1.py
@@ -1,0 +1,92 @@
+"""151e05f1: 문서 동시편집 낙관적 동시성(409 DOC_CONFLICT) — BE 구현.
+
+근본 갭(verify-first): BE update_doc 가 expected_updated_at/force_overwrite 를 미구현(DocUpdate
+스키마에 필드 없어 silent-drop) → 동시편집 last-write-wins clobber. opt-in 409 추가.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers.docs import update_doc
+from app.schemas.doc import DocUpdate
+
+T1 = datetime(2026, 6, 10, 10, 0, 0, tzinfo=timezone.utc)
+T2 = datetime(2026, 6, 10, 11, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _doc(updated_at=T1):
+    return SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), parent_id=None,
+        created_by=None, assignee_id=None, title="t", slug="s", canonical_slug="s",
+        slug_locked=False, content="c", icon=None, sort_order=0, doc_type="page",
+        content_format="markdown", tags=[], created_at=T1, updated_at=updated_at,
+    )
+
+
+async def _call(body_kwargs, doc_updated_at=T1):
+    repo = MagicMock()
+    repo.org_id = uuid.uuid4()
+    d = _doc(doc_updated_at)
+    repo.get = AsyncMock(return_value=d)
+    session = AsyncMock()
+    session.execute = AsyncMock()
+    session.flush = AsyncMock()
+    session.refresh = AsyncMock()
+    resp = await update_doc(d.id, DocUpdate(**body_kwargs), repo, session)
+    return resp, d
+
+
+# ── strip-trap 재발 방지: DocUpdate 가 2필드 수용 ───────────────────────────────
+
+def test_docupdate_accepts_concurrency_fields():
+    """BE 스키마가 expected_updated_at/force_overwrite 를 strip 하지 않고 수용(ISO str→datetime)."""
+    m = DocUpdate(expected_updated_at="2026-06-10T10:00:00+00:00", force_overwrite=True)
+    assert m.expected_updated_at == T1
+    assert m.force_overwrite is True
+
+
+# ── 409 동시성 ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_stale_expected_updated_at_409():
+    """expected_updated_at ≠ 현재 updated_at → 409 DOC_CONFLICT + current_updated_at."""
+    with pytest.raises(Exception) as ei:
+        await _call({"title": "x", "expected_updated_at": T2}, doc_updated_at=T1)
+    exc = ei.value
+    assert getattr(exc, "status_code", None) == 409
+    assert exc.detail["code"] == "DOC_CONFLICT"
+    assert exc.detail["current_updated_at"] == T1.isoformat()
+
+
+@pytest.mark.anyio
+async def test_matching_expected_updated_at_proceeds():
+    """expected_updated_at == 현재 → 통과(title 적용·409 없음)."""
+    resp, d = await _call({"title": "x", "expected_updated_at": T1}, doc_updated_at=T1)
+    assert d.title == "x"
+    assert resp.title == "x"
+
+
+@pytest.mark.anyio
+async def test_force_overwrite_bypasses_check():
+    """force_overwrite=True → stale여도 우회(last-write-wins 의도적)."""
+    resp, d = await _call(
+        {"title": "forced", "expected_updated_at": T2, "force_overwrite": True}, doc_updated_at=T1
+    )
+    assert d.title == "forced"
+
+
+@pytest.mark.anyio
+async def test_omitted_expected_updated_at_no_check():
+    """expected_updated_at 미제공 → 무체크(하위호환·stale여도 통과)."""
+    resp, d = await _call({"title": "legacy"}, doc_updated_at=T1)
+    assert d.title == "legacy"

--- a/backend/tests/test_doc_concurrency_151e05f1.py
+++ b/backend/tests/test_doc_concurrency_151e05f1.py
@@ -77,6 +77,16 @@ async def test_matching_expected_updated_at_proceeds():
 
 
 @pytest.mark.anyio
+async def test_microsecond_diff_same_ms_no_false_409():
+    """FE JS Date(ms) round-trip 시뮬: doc μs=.123456 vs expected μs=.123000(같은 ms·sub-ms만 차이)
+    → ms 절삭 후 일치 → 통과(μs-exact였다면 매 저장 false-409 footgun)."""
+    doc_ts = T1.replace(microsecond=123456)
+    expected_ts = T1.replace(microsecond=123000)  # JS Date 가 ms 로 절삭한 echo
+    resp, d = await _call({"title": "ok", "expected_updated_at": expected_ts}, doc_updated_at=doc_ts)
+    assert d.title == "ok"  # 409 안 남(ms 동일)
+
+
+@pytest.mark.anyio
 async def test_force_overwrite_bypasses_check():
     """force_overwrite=True → stale여도 우회(last-write-wins 의도적)."""
     resp, d = await _call(


### PR DESCRIPTION
## 151e05f1 — 문서 동시편집 409 보호 (BE 구현)

**verify-first 결론(PO 가설 ⓐ 적중)**: FE 프록시 zod strip이 아니라 **BE가 409 동시성 체크를 처음부터 미구현**한 게 진짜 갭. `DocUpdate`에 `expected_updated_at`/`force_overwrite` 필드가 없어 MCP 도구(+FE)가 보낸 params를 BE가 **silent-drop**(extra=ignore) → 체크 0 → last-write-wins clobber. (스토리가 의심한 FE strip은 #1374 raw thin-proxy로 이미 해소.)

### 구현
- `DocUpdate` += `expected_updated_at: datetime|None` + `force_overwrite: bool|None`.
- `update_doc`: **opt-in mutation-前 체크** — expected_updated_at 제공 & `!= doc.updated_at` & not force_overwrite → **409 `{code:"DOC_CONFLICT", message, current_updated_at}`**(dict detail → #1372 핸들러 패스스루 → FE `error.code`/`error.current_updated_at` 언랩). 미제공=무체크(하위호환)·force_overwrite=true 우회(의도적 LWW)·current_content 미포함(FE re-GET·minimal).

### 검증
신규 5테스트(2필드 수용=strip-trap 가드·stale→409·match 통과·force 우회·omit 무체크) + 전체 **1796 passed**(3 무관). **마이그 0**·기존 update_doc 테스트 통과(하위호환).

### FE 핸드오프 (미르코·머지 후)
use-doc-sync가 expected_updated_at 전송 + 409 핸들(current_updated_at로 re-GET/머지) + [id] thin-proxy 통과. 2-session 라이브 재현(stale→409·force→통과)은 머지+dev 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)