### PR TITLE
[SID:db75ecd0] feat(chat): 방 title 인라인 편집 + 참여자 subtitle (E-FEATURE-ADD S2 FE)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -40,6 +40,8 @@ export default function ConversationPage() {
   const { currentTeamMemberId, projectId } = useDashboardContext();
   const [meta, setMeta] = useState<ConversationMeta | null>(null);
   const [showAddParticipant, setShowAddParticipant] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
 
   const fetchMeta = useCallback(async () => {
     if (!projectId) return;
@@ -53,6 +55,21 @@ export default function ConversationPage() {
       if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [] });
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
+
+  // EF-S2: rename a group room. Optimistic; the BE PATCH persists the title.
+  const handleSaveTitle = useCallback(async () => {
+    const next = titleDraft.trim();
+    setEditingTitle(false);
+    if (!next || next === (meta?.title ?? '')) return;
+    setMeta((m) => (m ? { ...m, title: next } : m));
+    try {
+      await fetch(`/api/conversations/${conversation_id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: next }),
+      });
+    } catch { /* optimistic; a later refetch reconciles */ }
+  }, [titleDraft, meta, conversation_id]);
 
   // 1aeecdde P2: 에이전트 presence_status(연결축 dot) 폴링 — P1 진실값. 15s 갱신(시간 기반 상태).
   const [presenceById, setPresenceById] = useState<Record<string, PresenceStatus>>({});
@@ -123,9 +140,32 @@ export default function ConversationPage() {
               <ChevronLeft className="h-4 w-4" />
               <span className="lg:hidden">채팅</span>
             </button>
-            <span className="min-w-0 truncate text-sm font-medium text-foreground">
-              {headerTitle}
-            </span>
+            {editingTitle && meta?.type === 'group' ? (
+              <input
+                autoFocus
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleSaveTitle();
+                  else if (e.key === 'Escape') setEditingTitle(false);
+                }}
+                onBlur={() => void handleSaveTitle()}
+                aria-label="방 이름 편집"
+                className="min-w-0 rounded border border-border bg-background px-1.5 py-0.5 text-sm font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              />
+            ) : meta?.type === 'group' ? (
+              <button
+                type="button"
+                onClick={() => { setTitleDraft(meta.title ?? ''); setEditingTitle(true); }}
+                className="group/title flex min-w-0 items-center gap-1"
+                aria-label="방 이름 편집"
+              >
+                <span className="min-w-0 truncate text-sm font-medium text-foreground">{headerTitle}</span>
+                <span className="flex-shrink-0 text-xs text-muted-foreground opacity-0 transition-opacity group-hover/title:opacity-100">✎</span>
+              </button>
+            ) : (
+              <span className="min-w-0 truncate text-sm font-medium text-foreground">{headerTitle}</span>
+            )}
           </div>
         }
         actions={

--- a/apps/web/src/app/api/conversations/[conversation_id]/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/route.ts
@@ -1,0 +1,10 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+type RouteParams = { params: Promise<{ conversation_id: string }> };
+
+/** PATCH — edit a conversation (e.g. room title). Thin-proxy to the BE (EF-S2). */
+export async function PATCH(request: NextRequest, { params }: RouteParams): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}`);
+}


### PR DESCRIPTION
## 배경 (선생님 제보 261ebeb9 · BE 계약 핸드오프)
채팅 방 이름 편집 + 참여자 목록을 subtitle로 격하. BE 계약: `PATCH /conversations/{id} {title}`·`existing` 항상 false.

## Fix (FE분 · 기존 인라인 편집 패턴 재사용)
- **신규 thin-proxy 라우트** `/api/conversations/[conversation_id]` PATCH → BE.
- **AC3 방 title 인라인 편집**(그룹 한정): 헤더 title 클릭→input·**Enter 저장/Esc 취소/blur 저장**·hover **✎** affordance·낙관적 `setMeta`. (DM은 상대명 파생이라 읽기전용 유지.) 스토리 상세 title 편집과 동형.
- **conversation.title 우선 폴백**: `formatHeaderTitle`이 `conversation.title` > 파생명 → 설정 시 헤더·리스트 primary, 빈 title→파생명.

## AC2 (참여자 subtitle 격하) — 기존 위계로 충족
`chat-list-view`의 `displayName`(`text-sm font-medium text-foreground`=주)이 `conv.title ?? 참여자명` → **AC3 title이 리스트 primary**·`participantLayer`는 이미 muted subtitle(종). 즉 title 기능이 방title=주/참여자=종 위계를 완성.
> ⚠️ 유나양 가디언: 무제목 그룹의 displayName 폴백(참여자명) 트리트먼트를 추가 격하할지(제너릭 primary 등) 픽셀서 콜 주면 즉 반영.

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green.
유나양 가디언 픽셀(title 편집 동작·Enter/Esc/blur·✎·위계·thin-proxy PATCH·a11y·라/다크)은 dev 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)