### PR TITLE
fix(stories): declare PATCH /bulk before /{id} (route-shadow → dnd save 422)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -206,6 +206,44 @@ async def get_story(
     return StoryResponse.model_validate(story)
 
 
+class BulkUpdateItem(BaseModel):
+    id: uuid.UUID
+    status: str | None = None
+    sprint_id: uuid.UUID | None = None
+    assignee_id: uuid.UUID | None = None
+    priority: str | None = None
+    position: int | None = None
+
+
+# ⚠️ /bulk 은 /{id} 보다 **먼저** 선언해야 한다(FastAPI 라우트 매칭=선언 순서·specific-before-
+# parameterized). 아니면 PATCH /api/v2/stories/bulk 가 /{id} 에 매칭돼 id="bulk" UUID 파싱
+# 422 → /bulk 핸들러 영영 shadow(dnd 보드 상태저장이 처음부터 깨져있던 근본). 선생님 dnd 실테스트 적출.
+@router.patch("/bulk", response_model=list[StoryResponse])
+async def bulk_update_stories(
+    items: list[BulkUpdateItem],
+    db: AsyncSession = Depends(get_db),
+    repo: StoryRepository = Depends(_get_repo),
+) -> list[StoryResponse]:
+    updated: list[Story] = []
+    for item in items:
+        q = await db.execute(select(Story).where(Story.id == item.id))
+        story = q.scalar_one_or_none()
+        if not story:
+            continue
+        update_data = item.model_dump(exclude={"id"}, exclude_none=True)
+        for k, v in update_data.items():
+            setattr(story, k, v)
+        # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
+        if "assignee_id" in update_data:
+            single = [story.assignee_id] if story.assignee_id else []
+            await StoryAssigneeRepository(db, repo.org_id).set_for_story(story.id, single)
+        updated.append(story)
+    await _attach_assignee_ids(db, repo.org_id, updated)
+    results = [StoryResponse.model_validate(s) for s in updated]
+    await db.commit()
+    return results
+
+
 @router.patch("/{id}", response_model=StoryResponse)
 async def update_story(
     id: uuid.UUID,
@@ -589,15 +627,6 @@ class ActivityResponse(BaseModel):
     model_config = {"from_attributes": True}
 
 
-class BulkUpdateItem(BaseModel):
-    id: uuid.UUID
-    status: str | None = None
-    sprint_id: uuid.UUID | None = None
-    assignee_id: uuid.UUID | None = None
-    priority: str | None = None
-    position: int | None = None
-
-
 # ─── Comments ─────────────────────────────────────────────────────────────────
 
 @router.get("/{id}/comments", response_model=list[CommentResponse])
@@ -676,31 +705,3 @@ async def list_activities(
     ).order_by(StoryActivity.created_at.desc()).limit(limit)
     result = await db.execute(q)
     return [ActivityResponse.model_validate(r) for r in result.scalars()]
-
-
-# ─── Bulk update ──────────────────────────────────────────────────────────────
-
-@router.patch("/bulk", response_model=list[StoryResponse])
-async def bulk_update_stories(
-    items: list[BulkUpdateItem],
-    db: AsyncSession = Depends(get_db),
-    repo: StoryRepository = Depends(_get_repo),
-) -> list[StoryResponse]:
-    updated: list[Story] = []
-    for item in items:
-        q = await db.execute(select(Story).where(Story.id == item.id))
-        story = q.scalar_one_or_none()
-        if not story:
-            continue
-        update_data = item.model_dump(exclude={"id"}, exclude_none=True)
-        for k, v in update_data.items():
-            setattr(story, k, v)
-        # E-BOARD S5: 단일 assignee_id 변경 시 join 미러(단일↔복수 공존 정합)
-        if "assignee_id" in update_data:
-            single = [story.assignee_id] if story.assignee_id else []
-            await StoryAssigneeRepository(db, repo.org_id).set_for_story(story.id, single)
-        updated.append(story)
-    await _attach_assignee_ids(db, repo.org_id, updated)
-    results = [StoryResponse.model_validate(s) for s in updated]
-    await db.commit()
-    return results

--- a/backend/tests/test_stories_bulk_route_order.py
+++ b/backend/tests/test_stories_bulk_route_order.py
@@ -1,0 +1,24 @@
+"""stories PATCH 라우트 순서 가드 — /bulk 가 /{id} 보다 먼저 선언돼야(shadow 방지).
+
+근본(선생님 dnd 실테스트): /{id}(PATCH)가 /bulk 보다 먼저 선언되면 PATCH /api/v2/stories/bulk 가
+/{id} 에 매칭돼 id="bulk" UUID 파싱 422 → /bulk 핸들러 영영 shadow → dnd 보드 상태저장 깨짐.
+FastAPI 는 선언 순서로 매칭(first match wins)하므로 specific(/bulk) 을 parameterized(/{id}) 앞에 둔다.
+"""
+from __future__ import annotations
+
+
+def test_bulk_patch_declared_before_id_patch():
+    from app.main import app
+
+    patch_paths: list[str] = []
+    for r in app.routes:
+        path = getattr(r, "path", "")
+        methods = getattr(r, "methods", set()) or set()
+        if path.startswith("/api/v2/stories") and "PATCH" in methods:
+            patch_paths.append(path)
+
+    assert "/api/v2/stories/bulk" in patch_paths, patch_paths
+    assert "/api/v2/stories/{id}" in patch_paths, patch_paths
+    bulk_i = patch_paths.index("/api/v2/stories/bulk")
+    id_i = patch_paths.index("/api/v2/stories/{id}")
+    assert bulk_i < id_i, f"/bulk 은 /{{id}} 보다 먼저 선언돼야(shadow 방지): {patch_paths}"


### PR DESCRIPTION
## 🔴 P0 — PATCH /stories/bulk 가 /{id} 에 shadow돼 422 (dnd 보드 저장 깨짐)

선생님 dnd 실테스트 적출. **FastAPI 라우트 매칭=선언 순서**인데 `@router.patch("/{id}")`(id: uuid.UUID)가 `@router.patch("/bulk")`보다 **먼저** 선언돼 있어 → `PATCH /api/v2/stories/bulk` 가 `/{id}` 에 매칭·`id="bulk"` UUID 파싱 **422 uuid_parsing** → `/bulk` 핸들러 영영 **shadow**(미도달). dnd 보드 상태저장이 이 라우트라 **처음부터 깨져있던 근본**(센서 fix #1378과 독립 레이어).

### fix
`BulkUpdateItem` + `/bulk` 핸들러를 `@router.patch("/{id}")` **위로 이동**(specific-before-parameterized). 순수 reorder·로직 변화 0. `BulkUpdateItem`(param 타입)도 핸들러와 함께 이동(정의-전-사용 보장). 라우트 순서 경고 주석 추가(재발 방지).

### 검증
신규 라우트-순서 가드 테스트(`/api/v2/stories/bulk` PATCH 가 `/{id}` PATCH보다 app.routes서 먼저 선언) + stories/bulk 97 테스트 PASS. 마이그 0·코드 reorder only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)