### PR TITLE
fix(stories): accept {items:[...]} wrapper in PATCH /bulk (FE body contract)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -215,17 +215,23 @@ class BulkUpdateItem(BaseModel):
     position: int | None = None
 
 
+class BulkUpdateRequest(BaseModel):
+    # FE(kanban-board.tsx)는 `{ items: [...] }` 래퍼로 전송한다. BE 도 동일 계약을 수용해야
+    # "Input should be a valid list" 422 안 난다(맨 배열 아님). /bulk 유일 소비자=FE dnd.
+    items: list[BulkUpdateItem]
+
+
 # ⚠️ /bulk 은 /{id} 보다 **먼저** 선언해야 한다(FastAPI 라우트 매칭=선언 순서·specific-before-
 # parameterized). 아니면 PATCH /api/v2/stories/bulk 가 /{id} 에 매칭돼 id="bulk" UUID 파싱
 # 422 → /bulk 핸들러 영영 shadow(dnd 보드 상태저장이 처음부터 깨져있던 근본). 선생님 dnd 실테스트 적출.
 @router.patch("/bulk", response_model=list[StoryResponse])
 async def bulk_update_stories(
-    items: list[BulkUpdateItem],
+    payload: BulkUpdateRequest,
     db: AsyncSession = Depends(get_db),
     repo: StoryRepository = Depends(_get_repo),
 ) -> list[StoryResponse]:
     updated: list[Story] = []
-    for item in items:
+    for item in payload.items:
         q = await db.execute(select(Story).where(Story.id == item.id))
         story = q.scalar_one_or_none()
         if not story:

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -1,0 +1,53 @@
+"""stories /bulk body 계약 가드 — FE 실 shape `{items:[...]}` 수용.
+
+P0 2차(선생님 dnd): #1386 라우트 fix 후 /bulk 핸들러 도달했으나, FE(kanban-board.tsx)는
+`{items:[...]}` 래퍼를 보내는데 BE 는 맨 배열 `[...]` 기대 → "Input should be a valid list" 422.
+(전 probe가 맨 배열로 false-green 받은 게 갭 — 이 테스트는 FE 실 shape 로 잠근다.)
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.routers import stories as stories_mod
+from app.routers.stories import BulkUpdateRequest, bulk_update_stories
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_bulk_request_accepts_fe_wrapper_shape():
+    """FE 실 shape `{items:[{id,status}]}` 래퍼 파싱(맨 배열 아님)."""
+    sid = str(uuid.uuid4())
+    req = BulkUpdateRequest(**{"items": [{"id": sid, "status": "done"}]})
+    assert len(req.items) == 1
+    assert str(req.items[0].id) == sid
+    assert req.items[0].status == "done"
+
+
+@pytest.mark.anyio
+async def test_bulk_handler_iterates_payload_items(monkeypatch):
+    """래퍼 payload → 핸들러가 payload.items 순회·setattr 적용·결과 반환(FE shape→200 등가)."""
+    story = SimpleNamespace(id=uuid.uuid4(), assignee_id=None, status=None)
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none = MagicMock(return_value=story)
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=exec_result)
+    db.commit = AsyncMock()
+    repo = MagicMock()
+    repo.org_id = uuid.uuid4()
+
+    monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
+    monkeypatch.setattr(stories_mod.StoryResponse, "model_validate", staticmethod(lambda s: {"id": str(s.id)}))
+
+    payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
+    result = await bulk_update_stories(payload, db, repo)
+
+    assert result == [{"id": str(story.id)}]
+    assert story.status == "done"  # payload.items 순회·setattr 적용 입증
+    db.commit.assert_awaited_once()


### PR DESCRIPTION
## 🔴 P0 2차 — /bulk body 계약 불일치 (dnd 저장 422)

#1386 라우트 fix 후 `/bulk` 핸들러 도달 성공·이번엔 **body shape 불일치**:
- **FE**(`kanban-board.tsx:558,611`) = `JSON.stringify({ items: [{id,status}] })` = **`{items:[...]}` 래퍼**
- **BE** = `list[BulkUpdateItem]` 맨 배열 기대 → 래퍼 받으면 **422 "Input should be a valid list"**

**놓친 근본**: 레이어별 격리 검증(라우트·핸들러·프록시 각각 OK)만 하고 **FE 실제 body shape로 전 체인 E2E 0**. 내 #1386 probe가 맨 배열로 보내 false-green 받은 게 갭(인정).

### fix
`BulkUpdateRequest{items: list[BulkUpdateItem]}` 신설 → 핸들러 `payload: BulkUpdateRequest` → `payload.items` 순회. `/bulk` 유일 소비자=FE dnd·MCP는 단건 update_story라 무영향.

### 검증
회귀 가드 테스트를 **FE 실 shape(`{items:[...]}`)**로 잠금: `BulkUpdateRequest`가 래퍼 파싱(맨 배열 아님) + 핸들러가 `payload.items` 순회·setattr 적용. stories/bulk 99 PASS·마이그0. 배포 후 **FE 실제 payload 그대로** 라이브 probe 예정(임의 구성 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)