### PR TITLE
fix(stories): refresh before serialize in PATCH /bulk (MissingGreenlet 500)

### DIFF
--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -244,6 +244,13 @@ async def bulk_update_stories(
             single = [story.assignee_id] if story.assignee_id else []
             await StoryAssigneeRepository(db, repo.org_id).set_for_story(story.id, single)
         updated.append(story)
+    # P0/MissingGreenlet: setattr 후 server-onupdate `updated_at` 등은 flush 시 expire 되어,
+    # model_validate(sync)가 lazy-reload 를 async greenlet 밖에서 시도 → MissingGreenlet 500.
+    # 단건 repo.update(flush+refresh) 패턴과 일치시켜 expired 컬럼을 async 컨텍스트서 선-reload.
+    await db.flush()
+    for s in updated:
+        await db.refresh(s)
+    # refresh 後 transient assignee_ids 세팅(refresh 는 매핑 컬럼만 reload·transient 보존).
     await _attach_assignee_ids(db, repo.org_id, updated)
     results = [StoryResponse.model_validate(s) for s in updated]
     await db.commit()

--- a/backend/tests/test_stories_bulk_body_contract.py
+++ b/backend/tests/test_stories_bulk_body_contract.py
@@ -7,6 +7,7 @@ P0 2차(선생님 dnd): #1386 라우트 fix 후 /bulk 핸들러 도달했으나,
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -31,23 +32,45 @@ def test_bulk_request_accepts_fe_wrapper_shape():
 
 
 @pytest.mark.anyio
-async def test_bulk_handler_iterates_payload_items(monkeypatch):
-    """래퍼 payload → 핸들러가 payload.items 순회·setattr 적용·결과 반환(FE shape→200 등가)."""
-    story = SimpleNamespace(id=uuid.uuid4(), assignee_id=None, status=None)
+def _full_story():
+    """StoryResponse(from_attributes) 직렬화에 필요한 전 필드 — 실 model_validate 통과용."""
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        id=uuid.uuid4(), project_id=uuid.uuid4(), org_id=uuid.uuid4(), epic_id=None,
+        sprint_id=None, assignee_id=None, assignee_ids=[], attachments=[], meeting_id=None,
+        title="t", status="todo", priority="medium", story_points=None, description=None,
+        acceptance_criteria=None, position=None, success_hypothesis=None, metric_definition=None,
+        measure_after=None, outcome_status="n_a", outcome_result=None, is_excluded=False,
+        created_at=now, updated_at=now,
+    )
+
+
+@pytest.mark.anyio
+async def test_bulk_handler_refreshes_and_serializes(monkeypatch):
+    """래퍼 payload → payload.items 순회·setattr·**db.refresh(MissingGreenlet fix)**·**실 StoryResponse 직렬화 통과**.
+
+    P0 3차 교훈: model_validate 를 모킹하면 직렬화를 안 태워 MissingGreenlet 류를 못 잡는다. 여기선
+    실 StoryResponse.model_validate 를 태우고 refresh 호출을 가드한다(refresh 누락 시 회귀 검출).
+    """
+    story = _full_story()
     exec_result = MagicMock()
     exec_result.scalar_one_or_none = MagicMock(return_value=story)
     db = AsyncMock()
     db.execute = AsyncMock(return_value=exec_result)
+    db.flush = AsyncMock()
+    db.refresh = AsyncMock()
     db.commit = AsyncMock()
     repo = MagicMock()
     repo.org_id = uuid.uuid4()
 
     monkeypatch.setattr(stories_mod, "_attach_assignee_ids", AsyncMock())
-    monkeypatch.setattr(stories_mod.StoryResponse, "model_validate", staticmethod(lambda s: {"id": str(s.id)}))
+    # ⚠️ model_validate 는 모킹하지 않는다 — 실 직렬화를 태워야 P0 3차류를 잡는다.
 
     payload = BulkUpdateRequest(items=[{"id": str(story.id), "status": "done"}])
     result = await bulk_update_stories(payload, db, repo)
 
-    assert result == [{"id": str(story.id)}]
-    assert story.status == "done"  # payload.items 순회·setattr 적용 입증
+    assert story.status == "done"  # setattr 적용
+    db.refresh.assert_awaited_once_with(story)  # MissingGreenlet fix 가드(refresh 누락 시 실패)
+    assert len(result) == 1 and result[0].status == "done"  # 실 StoryResponse 직렬화 통과
+    assert result[0].id == story.id
     db.commit.assert_awaited_once()


### PR DESCRIPTION
## 🔴 P0 3차 — bulk PATCH 500 MissingGreenlet (FE-shape 끝단 probe가 적출)

#1386(라우트)·#1387(body) 통과 후 **3번째 레이어**. `bulk_update_stories`가 raw setattr + `_attach`(autoflush) 후 **commit 前** `StoryResponse.model_validate` → server-onupdate `updated_at`이 flush 시 expire → sync model_validate가 lazy-reload 를 async greenlet 밖에서 시도 → `greenlet_spawn has not been called` 500.

단건 `/{id}`는 `repo.update`가 **flush+refresh**(server-onupdate 컬럼을 async 컨텍스트서 reload)라 정상·bulk만 refresh 누락.

### fix
루프 후 `await db.flush()` → `await db.refresh(s)`(per story·expired 컬럼 async reload) → `_attach_assignee_ids`(transient·refresh 後) → `model_validate`. `expire_on_commit`는 이미 False. 단건 패턴과 일치.

### 테스트가 못 잡은 이유 + 보강
이전 핸들러 테스트가 `model_validate`를 **모킹**해 직렬화를 안 태움(이번 교훈). 수정: ①**실 `StoryResponse.model_validate`**를 전-필드 story로 태움 ②`db.refresh` await 가드(누락 시 회귀 검출). ⚠️진짜 MissingGreenlet 가드는 **실 PG 라이브 FE-shape probe**(mock-session 단위테스트는 SQLAlchemy expire 재현 불가). stories/bulk 99 PASS·마이그0.

배포 후 **FE 실 payload(`{items:[{id,status}]}`) 끝단 probe → 200 + GET persist** 확인 후에야 선생님 재테스트(premature 금지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)