### PR TITLE
[SID:2338a0af] fix(board): 상세 status 실 영속 — 전용 엔드포인트 (S6 AC2 ④ 진짜근본)

### DIFF
--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -356,11 +356,21 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     const prev = localStatus;
     setSavingStatus(true);
     setLocalStatus(newStatus); // optimistic — badge reflects immediately (local, no prop round-trip)
-    const updated = await patchStory({ status: newStatus });
+    // The dedicated status endpoint runs the state-machine validation + events; the general
+    // /stories/{id} PATCH (patchStory) intentionally omits `status`, so it would 200 without
+    // persisting — the root of the badge reverting after a "successful" change.
+    let ok = false;
+    try {
+      const res = await fetch(`/api/stories/${story.id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      ok = res.ok;
+    } catch { /* network error — treat as failure, roll back below */ }
     setSavingStatus(false);
-    if (updated) {
-      setLocalStatus(updated.status);
-      onStoryUpdate?.({ ...story, status: updated.status }); // sync the board
+    if (ok) {
+      onStoryUpdate?.({ ...story, status: newStatus }); // persisted → sync the board
     } else {
       setLocalStatus(prev); // BE rejected (e.g. invalid transition) — roll back
     }


### PR DESCRIPTION
## 진짜 근본 (PO+유나양 라이브 검증 수렴)
④ localStatus 낙관(#1384)은 **작동**(배지 250ms 내 변경)이나 **underlying PATCH가 status 미영속**:
- `handleChangeStatus`가 `patchStory({status})` = 일반 `/api/stories/{id}` PATCH 호출.
- BE `StoryUpdate` 스키마(story.py:127~148)에 **`status` 필드 없음**(검증/이벤트 우회 방지로 의도적 제외) → status **drop** → 200인데 DB 미변경.
- → 패널이 실데이터(여전 backlog) re-sync → 배지 "백로그" 복귀(관측 증상).

## Fix
`handleChangeStatus`를 **전용 `PATCH /api/stories/{id}/status`**(`StoryStatusUpdate`·상태머신 전이검증) 호출로 전환 — **보드 dnd가 bulk로 쓰던 영속 경로와 동치**. 낙관 localStatus 유지·**엔드포인트 거부 시에만 롤백**. (`patchStory`는 title/assignee용 유지.)

## 검증 (이번 교훈)
✅ TC·build·lint green.
⚠️ **끝단 검증 필수**(낙관 배지만 아님): 단건 status PATCH→200 **+ GET DB status 실제 변경** 확인. PO/유나양 끝단 픽셀(배지 변경 + 실 persist + invalid 롤백).

🤖 Generated with [Claude Code](https://claude.com/claude-code)