### PR TITLE
[SID:2bd91dd8] feat(chat/story): 클립보드 이미지 paste 첨부 (E-MOBILE-UX S3)

### DIFF
--- a/apps/web/src/components/chat/chat-input.tsx
+++ b/apps/web/src/components/chat/chat-input.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import { useEffect, useRef, useState, type ClipboardEvent, type KeyboardEvent } from 'react';
 import Link from 'next/link';
 import { AlertTriangle, Loader2, Paperclip, Send, Terminal, Type, X } from 'lucide-react';
 import { useTranslations } from 'next-intl';
@@ -9,6 +9,7 @@ import { getFileIcon } from '@/lib/file-icon';
 import { commandName, dequoteLiteral, isCommand } from '@/lib/command-classifier';
 import { resolveRuntimeStatus, runtimeLabel } from '@/lib/runtime-capabilities';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
+import { imageFilesFromClipboard } from '@/lib/clipboard-image';
 
 /** S8 #2: pre-send capability 경고 대상 — 대화의 에이전트 participant(본인 제외) runtime. */
 export interface CommandTarget {
@@ -261,6 +262,16 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
     setPendingFiles((prev) => [...prev, ...files].slice(0, MAX_ATTACHMENTS));
   };
 
+  // S3: paste an image from the clipboard → queue it as an attachment (same path as
+  // file-select/drop). Non-image pastes fall through to the normal textarea paste.
+  const handlePaste = (e: ClipboardEvent) => {
+    const images = imageFilesFromClipboard(e);
+    if (images.length > 0) {
+      e.preventDefault();
+      addFiles(images);
+    }
+  };
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     addFiles(Array.from(e.target.files ?? []));
     e.target.value = '';
@@ -437,6 +448,7 @@ export function ChatInput({ onSend, onUploadFile, disabled, placeholder, project
           value={text}
           onChange={(e) => handleTextChange(e.target.value, e.target.selectionStart ?? e.target.value.length)}
           onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
           onBlur={() => {
             window.setTimeout(() => {
               setMentionQuery(null);

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ClipboardEvent } from 'react';
 import { useTranslations } from 'next-intl';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -9,6 +9,7 @@ import { AlertTriangle, Check, GitFork, Loader2, Paperclip, Plus, Tag, Trash2, X
 import type { KanbanStory, KanbanMember, DependencyEdge } from './types';
 import type { SendAttachment } from '@/hooks/use-chat-sse';
 import { getFileIcon } from '@/lib/file-icon';
+import { imageFilesFromClipboard } from '@/lib/clipboard-image';
 import { AttachmentImage } from '@/components/chat/attachment-image';
 import { AttachmentFile } from '@/components/chat/attachment-file';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
@@ -464,6 +465,16 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     }
   };
 
+  // S3: paste an image while editing a story → upload as an attachment (same path as the
+  // file picker). Non-image pastes fall through to normal textarea paste.
+  const handlePasteAttach = (e: ClipboardEvent) => {
+    const images = imageFilesFromClipboard(e);
+    if (images.length > 0) {
+      e.preventDefault();
+      void handleAttachFiles(images);
+    }
+  };
+
   const handleRemoveAttachment = async (url: string) => {
     const next = (story.attachments ?? []).filter((a) => a.url !== url); // filter → 전체 교체
     const updated = await patchStory({ attachments: next });
@@ -808,6 +819,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   <textarea
                     value={descriptionDraft}
                     onChange={(e) => setDescriptionDraft(e.target.value)}
+                    onPaste={handlePasteAttach}
                     placeholder="Markdown 형식으로 작성하세요..."
                     className="flex field-sizing-content min-h-[160px] w-full resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-sm outline-none transition-colors placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
                     autoFocus

--- a/apps/web/src/lib/clipboard-image.ts
+++ b/apps/web/src/lib/clipboard-image.ts
@@ -1,0 +1,19 @@
+import type { ClipboardEvent } from 'react';
+
+/**
+ * Extract image files from a paste event's clipboard (E-MOBILE-UX S3).
+ * Returns the image File objects so the caller can reuse its existing upload path;
+ * non-image clipboard content (text, etc.) yields an empty array so normal paste proceeds.
+ */
+export function imageFilesFromClipboard(e: ClipboardEvent): File[] {
+  const items = e.clipboardData?.items;
+  if (!items) return [];
+  const files: File[] = [];
+  for (const item of items) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      const file = item.getAsFile();
+      if (file) files.push(file);
+    }
+  }
+  return files;
+}


### PR DESCRIPTION
## 배경 (선생님 제보 261ebeb9)
첨부가 파일 선택만 가능 → 클립보드 이미지 **paste** 등록 지원.

## Fix (기존 업로드 경로 재사용)
- **신규 헬퍼** `imageFilesFromClipboard(e)` — paste 이벤트 clipboard에서 이미지 `File` 추출(비-이미지 paste는 `[]` → 일반 텍스트 paste 무영향).
- **AC1 채팅 컴포저**: textarea `onPaste` → `addFiles`(파일선택·드래그드롭이 쓰던 동일 큐 → 미리보기 칩 → 메시지와 함께 전송).
- **AC2 스토리 상세**: description textarea `onPaste` → `handleAttachFiles`(파일선택과 동일 GCS 업로드 경로).
- **AC2 멀티 paste + 파일선택 병행**: 공통 핸들러라 자동 양립.

업로드/미리보기/전송 흐름은 전부 재사용 — **신규는 클립보드 추출 한 조각**(docs 이미지 paste 패턴과 동류).

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green.
⚠️ **AC3 끝단 E2E**(이번 교훈): 까심군/유나양 **실 클립보드 이미지 paste→업로드→전송/첨부 영속** 라이브 검증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)