### PR TITLE
[SID:2adf2b68] fix(chat): 모바일 컴포저 placeholder 잘림 fix (E-MOBILE-UX S1)

### DIFF
--- a/apps/web/src/components/chat/chat-view.tsx
+++ b/apps/web/src/components/chat/chat-view.tsx
@@ -10,6 +10,7 @@ import { CommandHintNotice, type BlockedHint } from './command-hint-notice';
 import { ChatInput, type CommandTarget } from './chat-input';
 import { ThreadPanel } from './thread-panel';
 import type { ChatMessage, SendAttachment } from '@/hooks/use-chat-sse';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { normalizeToMessage, useChatSse } from '@/hooks/use-chat-sse';
 import { EmptyState } from '@/components/ui/empty-state';
 
@@ -44,6 +45,7 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
   const router = useRouter();
   const pathname = usePathname();
   const t = useTranslations('chats');
+  const isMobile = useIsMobile();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -513,7 +515,9 @@ export function ChatView({ threadId, currentTeamMemberId, projectId, apiPrefix =
             onUploadFile={handleUploadFile}
             projectId={projectId}
             commandTargets={commandTargets}
-            placeholder="메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)"
+            placeholder={isMobile
+              ? '메시지를 입력하세요… (@ 멘션)'
+              : '메시지를 입력하세요… (Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티)'}
           />
         </div>
 


### PR DESCRIPTION
## 근본 (선생님 제보 261ebeb9)
채팅 컴포저 placeholder가 모바일서 2줄 wrap → textarea `rows=1`(minHeight 36px)라 2번째 줄 잘림.

## Fix (반응형 카피 · 데스크탑 유지)
긴 하드코딩 placeholder를 **기존 `useIsMobile()` 훅으로 반응형 선택**:
- **모바일**: `"메시지를 입력하세요… (@ 멘션)"`(짧음·@멘션 발견성 힌트 1개 유지) → 1줄·잘림 0.
- **데스크탑**: 현 전체 카피 유지(`Enter 전송 / Shift+Enter 줄바꿈 / @ 멘션 / # 엔티티`).

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green. 1파일(chat-view).
⚠️ 라이브 픽셀(모바일 390px 1줄·잘림0·데스크탑 카피 유지)은 배포 후 가디언(브라우저 도구 복구 후). 모바일 390px서 ⓑ가 혹 wrap이면 최소 카피(ⓐ)로 1자 조정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)