### PR TITLE
[SID:3b8fc77b] fix(standup): 헤더 date 네비 버튼 겹침 fix (E-MOBILE-UX S4)

### DIFF
--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -367,19 +367,19 @@ export default function StandupPage() {
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
         actions={
           <div className="flex flex-wrap items-center gap-1.5">
-            <Button variant="ghost" size="icon" onClick={() => setDate((d) => shiftDate(d, -1))} title={t('previousDay')}>
+            <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, -1))} title={t('previousDay')}>
               ←
             </Button>
             <OperatorInput
               type="date"
               value={date}
               onChange={(event) => setDate(event.target.value)}
-              className="w-auto"
+              className="w-auto shrink-0"
             />
-            <Button variant="ghost" size="icon" onClick={() => setDate((d) => shiftDate(d, 1))} title={t('nextDay')}>
+            <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, 1))} title={t('nextDay')}>
               →
             </Button>
-            <Button variant="ghost" size="sm" onClick={() => setDate(formatSeoulDate())}>
+            <Button variant="ghost" size="sm" className="shrink-0" onClick={() => setDate(formatSeoulDate())}>
               {t('today')}
             </Button>
           </div>


### PR DESCRIPTION
## 근본 (선생님 제보 261ebeb9)
스탠드업 헤더 date 좌우 이동 버튼이 overlay(겹침)되는 깨진 UI.

## Fix (코드 기반 · flex-shrink 겹침)
date 네비(← / native date input / → / today)가 헤더 flex 행에 있는데 **크기 고정이 없어 좁은 헤더서 shrink**됨 — 특히 shrink된 native `<input type="date">`는 **날짜 텍스트와 캘린더 picker 아이콘이 겹침**. 전 컨트롤에 **`shrink-0`** → 고유 크기 유지·겹침 0(정말 폭 부족하면 `flex-wrap`이 graceful 줄바꿈).

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green. 1파일.
⚠️ **브라우저 픽셀 도구 일시 다운** → 헤더 레이아웃 정확 검증(모바일+데스크탑·겹침0)은 복구 후 가디언/PO 배치. 본 PR은 flex-shrink 겹침에 대한 코드추론 fix(shrink-0). 만약 근본이 다른 지점(헤더 overflow 등)이면 픽셀 후 1자 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)