### PR TITLE
[SID:151e05f1] fix(docs): 저장 충돌 시 서버 updated_at 채택 (use-doc-sync CP2)

### DIFF
--- a/apps/web/src/components/docs/use-doc-sync.ts
+++ b/apps/web/src/components/docs/use-doc-sync.ts
@@ -148,6 +148,14 @@ export function useDocSync<TDoc = { updated_at: string }>({
       if (res.status === 409) {
         conflictRef.current = true;
         remoteChangedRef.current = false;
+        // BE conflict body: { error: { code: 'DOC_CONFLICT', current_updated_at } }. Adopt the
+        // server's current updated_at as the new baseline so an acknowledged retry reconciles
+        // against the live version instead of conflicting again (151e05f1 CP2).
+        try {
+          const conflictBody = await res.json() as { error?: { current_updated_at?: string } };
+          const current = conflictBody.error?.current_updated_at;
+          if (current) setBaselineUpdatedAt(current);
+        } catch { /* malformed conflict body — still surface the conflict */ }
         setStatus('conflict');
         savingRef.current = false;
         return false;


### PR DESCRIPTION
## 배경 (디디군 BE 봉인 · 동시편집 409)
BE: `PATCH /api/v2/docs/{id}`에 `expected_updated_at`(+옵션 `force_overwrite`) 보내면 ms-truncation 비교로 stale이면 **409** `{error:{code:"DOC_CONFLICT", current_updated_at}}` 반환.

## 진단 — use-doc-sync.ts 거의 완비
- ✅ **CP1**: `expected_updated_at` = `serverUpdatedAt`(raw 로드 updated_at) echo.
- ✅ **CP3**: 미제공(null/force)=무체크 하위호환.
- ✅ **CP4**: `force_overwrite:true` 우회.
- ✅ **CP6**: 저장 성공 응답의 새 `updated_at`→baseline 갱신(연속 저장 정합).
- ❌→✅ **CP2(유일 갭)**: 409 핸들러가 body의 `current_updated_at`를 안 읽었음.

## Fix
409 분기서 `{error:{code:'DOC_CONFLICT', current_updated_at}}` 읽어 **`current_updated_at`를 새 baseline으로 채택** → acknowledged retry가 라이브 버전 대조(또 충돌 방지). 파싱 실패해도 conflict는 surface.

## 검증
✅ `pnpm type-check`·`pnpm build`·lint green. 1파일·기존 동작 무변경(CP1/3/4/6 그대로).
끝단(409→충돌상태→재시도/force) 검증은 dev 배포 후.

🤖 Generated with [Claude Code](https://claude.com/claude-code)