### PR TITLE
[SID:3b8fc77b] fix(standup): 모바일 date 네비 sub-header — 타이틀 crush RC (S4)

### DIFF
--- a/apps/web/src/app/(authenticated)/standup/page.tsx
+++ b/apps/web/src/app/(authenticated)/standup/page.tsx
@@ -361,30 +361,42 @@ export default function StandupPage() {
   // d9847ef0: projectId 전체 차단 제거 — org-level standup은 프로젝트 미선택에도 진입/작성/조회 가능.
   // project-scoped 섹션만 {projectId && ...}로 조건부 렌더(아래).
 
+  // S4: shared date-nav — desktop renders it in the header; mobile renders it as a
+  // full-width row below the header so the wide date input never crushes the fixed-height
+  // (h-12) TopBar title (the title and the shrink-0 controls competed for one row).
+  const dateNavControls = (
+    <>
+      <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, -1))} title={t('previousDay')}>
+        ←
+      </Button>
+      <OperatorInput
+        type="date"
+        value={date}
+        onChange={(event) => setDate(event.target.value)}
+        className="w-auto shrink-0"
+      />
+      <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, 1))} title={t('nextDay')}>
+        →
+      </Button>
+      <Button variant="ghost" size="sm" className="shrink-0" onClick={() => setDate(formatSeoulDate())}>
+        {t('today')}
+      </Button>
+    </>
+  );
+
   return (
     <>
       <TopBarSlot
         title={<h1 className="text-sm font-medium">{t('title')}</h1>}
         actions={
-          <div className="flex flex-wrap items-center gap-1.5">
-            <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, -1))} title={t('previousDay')}>
-              ←
-            </Button>
-            <OperatorInput
-              type="date"
-              value={date}
-              onChange={(event) => setDate(event.target.value)}
-              className="w-auto shrink-0"
-            />
-            <Button variant="ghost" size="icon" className="shrink-0" onClick={() => setDate((d) => shiftDate(d, 1))} title={t('nextDay')}>
-              →
-            </Button>
-            <Button variant="ghost" size="sm" className="shrink-0" onClick={() => setDate(formatSeoulDate())}>
-              {t('today')}
-            </Button>
-          </div>
+          <div className="hidden flex-wrap items-center gap-1.5 lg:flex">{dateNavControls}</div>
         }
       />
+
+      {/* S4: mobile date nav as its own full-width row (keeps the header title readable). */}
+      <div className="flex flex-wrap items-center gap-1.5 border-b border-border/80 px-4 py-2 lg:hidden">
+        {dateNavControls}
+      </div>
 
       <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {headerBadges.length > 0 ? (


### PR DESCRIPTION
## 회귀 (유나양 라이브 픽셀 발견)
이전 S4 fix(shrink-0)의 side-effect: 390px서 shrink-0 date nav가 전폭 유지 → `h-12` TopBar(title `flex-1`/actions `shrink-0`)가 **H1 "데일리 스탠드업"을 12px폭으로 짓눌러 세로 char-stacking·읽기 불가**. 정적/CI/diff는 390 레이아웃 못 봄 — 라이브 픽셀만 잡는 패턴.

## Fix (date-nav sub-header · CSS lg: breakpoint)
TopBar는 고정높이(h-12) 공유 row라 내부 stack 불가. 대신 **date nav를 데스크탑은 헤더(`hidden lg:flex`)·모바일은 헤더 바로 아래 full-width row(`lg:hidden`)**로. `dateNavControls` 추출해 양위치 렌더(shrink-0 유지).
- **데스크탑**: 헤더 내 date nav (무회귀).
- **모바일**: 타이틀이 헤더 전폭 차지(읽기 정상·crush0) + date nav 자체 row(겹침0).

## QA (까심군 CP)
- CP1 H1 390px 1줄 정상(char-stack0) ✅ — 헤더서 actions 숨김→title 전폭.
- CP2 ←→ 타이틀 침범0 ✅ — sub-row로 분리.
- CP3 date 겹침0(shrink-0 유지) ✅.
- CP4 데스크탑 무회귀 ✅ — `lg:flex` 헤더 유지.
- CP5 TC/build/lint green ✅.

⚠️ **자성**: 코드-only로 S4 done 성급(라이브 픽셀이 crush 끝단 회귀 잡음)·**특정 뷰포트 레이아웃은 라이브 픽셀 필수**. 유나양 390 재픽셀 → E-MOBILE-UX 진짜 완주.

🤖 Generated with [Claude Code](https://claude.com/claude-code)