### PR TITLE
[SID:fc4d4264] fix(docs): autosave envelope 회귀 → 무한 저장 루프 + silent 데이터손실 정지

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -188,7 +188,9 @@ export default function DocSlugPage() {
     if (!projectId || !slug) return;
     setDocLoading(true);
     try {
-      const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`);
+      // AC3 (fc4d4264): never serve the doc body from HTTP/bf cache — a stale load
+      // re-seeds the editor with an outdated baseline and can re-trigger an overwrite.
+      const res = await fetch(`/api/docs?project_id=${projectId}&slug=${slug}`, { cache: 'no-store' });
       if (!res.ok) {
         setSelectedDoc(null);
         return;

--- a/apps/web/src/components/docs/use-doc-sync.test.ts
+++ b/apps/web/src/components/docs/use-doc-sync.test.ts
@@ -1,5 +1,33 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { createAutosaveScheduler } from './use-doc-sync';
+import { createAutosaveScheduler, unwrapDocResponse } from './use-doc-sync';
+
+// ---------------------------------------------------------------------------
+// unwrapDocResponse — envelope-boundary regression guard (fc4d4264)
+// The docs PATCH route is a raw proxyToFastapi passthrough, so the live response
+// is the bare DocResponse. Reading json.data.updated_at against it threw and broke
+// save() settlement → infinite autosave + silent overwrite. Lock both shapes.
+// ---------------------------------------------------------------------------
+
+describe('unwrapDocResponse', () => {
+  it('reads updated_at + doc from the raw FastAPI passthrough shape', () => {
+    const raw = { id: 'doc-1', title: 'T', updated_at: '2026-06-11T00:00:00Z' };
+    const { doc, updatedAt } = unwrapDocResponse<typeof raw>(raw);
+    expect(updatedAt).toBe('2026-06-11T00:00:00Z');
+    expect(doc).toBe(raw);
+  });
+
+  it('still reads the legacy enveloped { data } shape (route re-wrap safety)', () => {
+    const enveloped = { data: { id: 'doc-1', updated_at: '2026-06-11T00:00:00Z' } };
+    const { doc, updatedAt } = unwrapDocResponse<{ id: string; updated_at: string }>(enveloped);
+    expect(updatedAt).toBe('2026-06-11T00:00:00Z');
+    expect(doc).toBe(enveloped.data);
+  });
+
+  it('returns undefined updatedAt when the response carries no timestamp', () => {
+    expect(unwrapDocResponse({ id: 'doc-1' }).updatedAt).toBeUndefined();
+    expect(unwrapDocResponse(null).updatedAt).toBeUndefined();
+  });
+});
 
 // ---------------------------------------------------------------------------
 // createAutosaveScheduler — pure debounce factory (no React / no DOM needed)

--- a/apps/web/src/components/docs/use-doc-sync.ts
+++ b/apps/web/src/components/docs/use-doc-sync.ts
@@ -3,6 +3,24 @@ import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 export type SaveStatus = 'idle' | 'unsaved' | 'saving' | 'saved' | 'conflict' | 'remote-changed' | 'error';
 
 /**
+ * Read the saved doc + its `updated_at` out of a PATCH response, tolerating both
+ * shapes the docs endpoint can return. The PATCH route is a raw `proxyToFastapi`
+ * passthrough (`/api/docs/[id]/route.ts`), so the live shape is the bare
+ * `DocResponse` (`{ updated_at, ... }`) — NOT the legacy enveloped `{ data: {...} }`.
+ * Reading `json.data.updated_at` against the raw body threw (`json.data` undefined),
+ * which left `save()` un-settled → permanent dirty → infinite autosave + missing
+ * baseline → BE 409 protection disarmed → silent overwrite of external edits
+ * (fc4d4264 envelope-boundary regression). The `??` keeps this robust if the route
+ * is ever re-wrapped with `proxyToFastapiWrapped`.
+ */
+export function unwrapDocResponse<TDoc>(json: unknown): { doc: TDoc; updatedAt: string | undefined } {
+  const root = (json ?? {}) as { data?: { updated_at?: string }; updated_at?: string };
+  const doc = (root.data ?? root) as TDoc;
+  const updatedAt = root.data?.updated_at ?? root.updated_at;
+  return { doc, updatedAt };
+}
+
+/**
  * Pure debounce scheduler — exported for unit tests.
  * Each `schedule(fn)` cancels the previous pending call so rapid invocations
  * coalesce into a single execution after `delay` ms.
@@ -131,6 +149,15 @@ export function useDocSync<TDoc = { updated_at: string }>({
       return true;
     }
 
+    // FIX-2 (fc4d4264): never fire a non-force PATCH without a baseline. A missing
+    // `expected_updated_at` disables the BE 409 optimistic-concurrency check, so the
+    // save would blindly last-write-wins over a concurrent external/agent edit.
+    // Refuse rather than clobber — surface 'error' so the state is visible, not silent.
+    if (!isForce && !baselineUpdatedAt) {
+      setStatus('error');
+      return false;
+    }
+
     savingRef.current = true;
     setStatus('saving');
 
@@ -168,14 +195,22 @@ export function useDocSync<TDoc = { updated_at: string }>({
       }
 
       const json = await res.json();
-      const nextUpdatedAt = json.data.updated_at as string;
+      const { doc: savedDoc, updatedAt: nextUpdatedAt } = unwrapDocResponse<TDoc>(json);
+      // A response with no `updated_at` cannot establish a baseline — treating it as
+      // success would re-arm the exact unguarded-overwrite loop this story fixes, so
+      // fail loudly instead of advancing into an undefined baseline.
+      if (!nextUpdatedAt) {
+        setStatus('error');
+        savingRef.current = false;
+        return false;
+      }
       previousServerUpdatedAtRef.current = nextUpdatedAt;
       conflictRef.current = false;
       remoteChangedRef.current = false;
       setLastSavedSnapshot(nextSnapshot);
       setBaselineUpdatedAt(nextUpdatedAt);
       setStatus('saved');
-      onSaved?.(json.data as TDoc);
+      onSaved?.(savedDoc);
       savingRef.current = false;
       return true;
     } catch {


### PR DESCRIPTION
## 무엇을 (스토리 `fc4d4264` · high · 라이브 데이터손실 fast-track 출혈정지)

docs PATCH 라우트는 raw `proxyToFastapi` 패스스루(`route.ts:23`)라 응답이 bare `DocResponse`(`{ updated_at, ... }`)인데, `use-doc-sync.ts`가 구 enveloped `json.data.updated_at`을 읽어 raw body에서 throw → `save()`가 영원히 settle 못 함 → 영구 dirty → autosave ~1.5초 무한 발사 → baseline 미추적 → `expected_updated_at` 미동봉 → BE 409(151e05f1) 무발동 → **탭 열린 동안 외부/에이전트 갱신을 ~1.5초 내 무조건 덮어씀**.

## 변경 (이 PR = 출혈정지)

- **FIX-1** `use-doc-sync.ts` — 신규 `unwrapDocResponse()` 헬퍼로 un-envelope 수용(`json.data?.updated_at ?? json.updated_at`, `doc = json.data ?? json`). save settle·루프 정지·baseline 추적·409 재가동. `updated_at` 부재 응답은 silent 성공 대신 loud `error`.
- **FIX-2** baseline 부재 시 non-force PATCH 발사 금지 — `expected_updated_at` 없는 무조건 덮어쓰기 폴백 제거.
- **AC③** doc 로드 fetch `cache: 'no-store'` — stale body 가 구 baseline 재seed 못 하게.
- **테스트** `unwrapDocResponse` 단위테스트(raw + enveloped 양 형상 회귀가드) 추가.

## 이 PR 범위 밖 (동일 스토리 추적 follow-up)

- **FIX-3** content-converter md↔HTML 왕복 멱등화(트리거 제거 · AC⑤) — 디디군 교차 필요, 별도 작업.
- **FIX-4** conflict/remote-changed 데드엔드 UX(AC⑥) — 유나 핸드오프 설계 doc 대기 중.

> FIX-1/2/3/4가 한 스토리에 묶여 있고 FIX-4가 설계-게이트라 단일 원자 PR 불가 → 출혈정지(AC①②④)를 먼저 분리 출고. 스토리 분할 여부는 PO 판단 요청.

## 검증

- `pnpm build` (next 16.2.2 webpack) ✅ — 158/158 static pages, TypeScript 통과
- `tsc --noEmit` (apps/web 소스) ✅ 0 errors
- `vitest run use-doc-sync.test.ts` ✅ 9/9 (신규 3 + 기존 6)
- lint ✅ 변경분 신규 경고 0 (기존 InlineSaveIndicator 의 unused-directive 경고 2건은 base develop 선존·무관)

스크린샷: 본 변경은 비주얼 변화 없는 autosave 동작 수정 → before/after 스크린샷 비해당. 동작 검증은 까심군 E2E 게이트(AC④⑤: 복잡 마크다운 fixture, 탭 열린 상태 외부 PATCH→5초→외부본 유지)에서.

🤖 Generated with [Claude Code](https://claude.com/claude-code)