### PR TITLE
[SID:fc4d4264] fix(docs): 슬러그 편집/derive PATCH 응답 un-envelope (가디언 follow-up)

### DIFF
--- a/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
+++ b/apps/web/src/app/(authenticated)/docs/[slug]/page.tsx
@@ -7,7 +7,7 @@ import { DocEditor } from '@/components/docs/doc-editor';
 import { DocUrlChip } from '@/components/docs/doc-url-chip';
 import { DocUrlDialog, type SlugSubmitResult } from '@/components/docs/doc-url-dialog';
 import { slugifyDocTitle, isUntitledSlug } from '@/components/docs/lib/doc-slug';
-import { useDocSync, type SaveStatus } from '@/components/docs/use-doc-sync';
+import { useDocSync, unwrapDocResponse, type SaveStatus } from '@/components/docs/use-doc-sync';
 import { htmlToMarkdown } from '@/components/docs/lib/content-converter';
 import Link from 'next/link';
 import { AlertTriangle, Check, Copy, Eye, Link2, Loader2, MoreHorizontal, RotateCw, Share2, Trash2, XCircle } from 'lucide-react';
@@ -265,7 +265,11 @@ export default function DocSlugPage() {
       }
       if (res.status === 422) return { ok: false, code: 'invalid' };
       if (!res.ok) return { ok: false, code: 'invalid' };
-      const { data } = await res.json() as { data: DocDetail };
+      // Same raw-proxy envelope class as the autosave path: docs PATCH is a raw
+      // proxyToFastapi passthrough, so the body is the bare DocResponse — reading
+      // `json.data` yielded undefined → BE-success slug edits surfaced as 'invalid'
+      // and the derive nudge no-op'd (live since #1374). Reuse unwrapDocResponse.
+      const { doc: data } = unwrapDocResponse<DocDetail>(await res.json());
       handleDocSaved(data);
       return { ok: true };
     } catch {
@@ -288,7 +292,8 @@ export default function DocSlugPage() {
         body: JSON.stringify({ slug: derived, slug_locked: false }),
       });
       if (res.ok) {
-        const { data } = await res.json() as { data: DocDetail };
+        // Raw-proxy envelope class (see handleSubmitSlug) — un-envelope the bare DocResponse.
+        const { doc: data } = unwrapDocResponse<DocDetail>(await res.json());
         handleDocSaved(data);
       }
     } catch { /* derive failed — doc keeps its untitled slug */ }


### PR DESCRIPTION
## 무엇을 (스토리 `fc4d4264` · 유나 가디언 finding follow-up · trivial)

#1397에서 잡은 envelope-boundary 클래스의 **잔존 소비부 2곳**. `[slug]/page.tsx`의 `handleSubmitSlug`·`handleDeriveFromTitle`이 raw proxyToFastapi PATCH 응답을 여전히 `const { data } = await res.json()`로 읽음 → `json.data`=undefined → `handleDocSaved(undefined)` throw →

- **슬러그 명시 편집**: BE 성공해도 `catch`에서 `{ ok:false, code:'invalid' }` 반환 → 사용자에 "유효하지 않은 슬러그" 오표시.
- **derive-from-title 넛지**: `catch` 삼킴 → 클릭 무반응(no-op).

#1374(thin-proxy 전환)부터 살아있던 버그.

## 변경

- `unwrapDocResponse<DocDetail>(await res.json())`로 bare DocResponse 수용 (2곳). #1397 헬퍼 재사용, import 1줄 추가.

## 검증

- `pnpm build`(next 16.2.2 webpack) ✅ exit 0
- `tsc --noEmit`(apps/web 소스) ✅ 0 errors
- lint ✅ 변경분 신규 경고 0 (기존 InlineSaveIndicator unused-directive 2건은 base 선존·무관)

스크린샷: 비주얼 변화 없음(슬러그 편집 성공/derive 동작 복구 = 동작 수정). 까심군 경량 확인: 슬러그 편집 저장→URL 정규화 성공·derive 넛지 클릭→untitled 슬러그 파생 동작.

🤖 Generated with [Claude Code](https://claude.com/claude-code)