### PR TITLE
[SID:2a72ebf4] fix(docs): 마크다운 왕복 변환 멱등화 — 열람만으로 본문 변형 저장 정지

### DIFF
--- a/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
@@ -37,6 +37,10 @@ describe('content-converter round-trip idempotency (2a72ebf4)', () => {
     'code fence no lang': '```\nplain code\n```',
     'gfm table plain': '| name | role |\n| --- | --- |\n| didi | dev |',
     'gfm table inline cells': '| field | value |\n| --- | --- |\n| **bold** | `code` |\n| [link](https://x.com) | _em_ |',
+    // Pipe-in-cell edge (guardian review): serializeTableCell escapes `|`→`\|`,
+    // parseTableCells un-escapes it on the markdownToHtml side — must round-trip.
+    'gfm table escaped pipe in cell': '| expr | note |\n| --- | --- |\n| a \\| b | ok |',
+    'gfm table pipe + inline in cell': '| expr | note |\n| --- | --- |\n| **a \\| b** | `x` |',
   };
 
   for (const [name, md] of Object.entries(fixtures)) {

--- a/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { htmlToMarkdown, markdownToHtml } from './content-converter';
+
+// ---------------------------------------------------------------------------
+// Round-trip idempotency suite (story 2a72ebf4 / FIX-3)
+//
+// The editor stores markdown. On load it runs markdown → HTML (markdownToHtml)
+// into TipTap, and on any update serializes HTML → markdown (htmlToMarkdown).
+// If htmlToMarkdown(markdownToHtml(md)) !== md for already-saved content, the
+// doc is judged dirty *on load with zero typing* → autosave persists a mutated
+// body (incl. table cells losing inline formatting). The fix: the converter
+// round-trip must be a fixed point on its own canonical output.
+//
+// Each fixture below is written in the converter's CANONICAL output form, so a
+// correct converter satisfies rt(fixture) === fixture. We also assert the
+// stabilization property rt(rt(x)) === rt(x) for arbitrary inputs.
+// ---------------------------------------------------------------------------
+
+/** One editor load→serialize round-trip. */
+const rt = (md: string): string => htmlToMarkdown(markdownToHtml(md));
+
+describe('content-converter round-trip idempotency (2a72ebf4)', () => {
+  const fixtures: Record<string, string> = {
+    'plain paragraph': 'Hello world.',
+    'headings': '# H1\n\n## H2\n\n### H3',
+    'bold + italic': '**bold** and _italic_ text',
+    'nested bold in sentence': 'a **bold _and italic_** tail',
+    'inline code': 'use `const x = 1` here',
+    'link': '[example](https://example.com)',
+    'unordered list': '- one\n- two\n- three',
+    'ordered list': '1. one\n2. two\n3. three',
+    'task list': '- [ ] todo\n- [x] done',
+    'horizontal rule': 'before\n\n---\n\nafter',
+    'blockquote single': '> quoted line',
+    'blockquote multi-line': '> line one\n> line two',
+    'code fence with lang': '```js\nconst x = 1;\nconst y = 2;\n```',
+    'code fence no lang': '```\nplain code\n```',
+    'gfm table plain': '| name | role |\n| --- | --- |\n| didi | dev |',
+    'gfm table inline cells': '| field | value |\n| --- | --- |\n| **bold** | `code` |\n| [link](https://x.com) | _em_ |',
+  };
+
+  for (const [name, md] of Object.entries(fixtures)) {
+    it(`is a fixed point: ${name}`, () => {
+      expect(rt(md)).toBe(md);
+    });
+  }
+
+  // Combined complex document — the real "복잡 마크다운" repro shape.
+  const COMPLEX = [
+    '# Title',
+    '',
+    'Intro **paragraph** with `code` and a [link](https://example.com).',
+    '',
+    '## Table',
+    '',
+    '| field | value |',
+    '| --- | --- |',
+    '| **bold** | `code` |',
+    '| [link](https://x.com) | plain |',
+    '',
+    '> A quote',
+    '> spanning lines',
+    '',
+    '---',
+    '',
+    '- [ ] open task',
+    '- [x] done task',
+    '',
+    '```ts',
+    'const n = 1;',
+    '```',
+  ].join('\n');
+
+  it('is a fixed point: combined complex document', () => {
+    expect(rt(COMPLEX)).toBe(COMPLEX);
+  });
+
+  it('stabilizes after one round-trip (rt(rt(x)) === rt(x))', () => {
+    const once = rt(COMPLEX);
+    expect(rt(once)).toBe(once);
+  });
+});
+
+describe('content-converter table cell inline preservation (AC③)', () => {
+  it('preserves bold/code/link inside table cells through a round-trip', () => {
+    const md = '| a | b |\n| --- | --- |\n| **x** | `y` |';
+    const out = rt(md);
+    expect(out).toContain('**x**');
+    expect(out).toContain('`y`');
+  });
+});

--- a/apps/web/src/components/docs/lib/content-converter.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.test.ts
@@ -73,7 +73,11 @@ describe('markdownToHtml', () => {
 
   it('converts code blocks', () => {
     const result = markdownToHtml('```js\nconst x = 1;\n```');
-    expect(result).toContain('<pre><code>');
+    // Fenced blocks carry their language as data-language + language-* class
+    // (syntax highlighting); assert that real shape, not the legacy plain <pre><code>.
+    expect(result).toContain('<pre');
+    expect(result).toContain('data-language="js"');
+    expect(result).toContain('<code');
     expect(result).toContain('const x = 1;');
   });
 

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -30,8 +30,13 @@ turndown.addRule('taskListItem', {
 // TipTap wrapped the content in <p> tags (which it always does via schema normalization).
 // Without this, Turndown outputs "loose" lists with blank lines between items:
 //   -   item\n    \n-   next  →  fixed to:  - item\n- next
+// Excludes taskItem LIs explicitly: Turndown 7.x resolves rules most-recently-added-first,
+// so this generic rule would otherwise shadow taskListItem above and drop the `- [ ]` marker
+// (round-trip non-idempotency → dirty-on-load, story 2a72ebf4).
 turndown.addRule('compactListItem', {
-  filter: 'li',
+  filter: (node) =>
+    node.nodeName === 'LI' &&
+    (node as HTMLElement).getAttribute('data-type') !== 'taskItem',
   replacement: (content, node) => {
     const clean = content
       .replace(/^\n+/, '')       // strip leading newlines from <p>
@@ -210,13 +215,47 @@ turndown.addRule('table', {
     const table = node as HTMLTableElement;
     const rows: string[] = [];
     Array.from(table.querySelectorAll('tr')).forEach((tr, i) => {
-      const cells = Array.from(tr.querySelectorAll('th, td')).map((cell) => cell.textContent?.trim() ?? '');
+      const cells = Array.from(tr.querySelectorAll('th, td')).map((cell) => serializeTableCell(cell));
       rows.push(`| ${cells.join(' | ')} |`);
       if (i === 0) {
         rows.push(`| ${cells.map(() => '---').join(' | ')} |`);
       }
     });
     return `\n${rows.join('\n')}\n`;
+  },
+});
+
+// Serialize a table cell's inline content to markdown — NOT textContent, which
+// strips bold/italic/code/link formatting (round-trip data loss, story 2a72ebf4 AC③).
+// Re-run Turndown on the cell's inner HTML, then flatten to a single inline cell:
+// collapse any newlines to spaces and escape literal pipes so they don't split columns.
+function serializeTableCell(cell: Element): string {
+  const inner = (cell as HTMLElement).innerHTML;
+  return turndown
+    .turndown(inner)
+    .replace(/\r?\n+/g, ' ')
+    .replace(/\|/g, '\\|')
+    .trim();
+}
+
+// Horizontal rule — Turndown's default emits `* * *`, but markdownToHtml only
+// recognizes `---` (and that is what users type), so the default broke round-trip
+// idempotency (`---` → `<hr>` → `* * *`) → dirty-on-load (story 2a72ebf4).
+turndown.addRule('horizontalRule', {
+  filter: 'hr',
+  replacement: () => '\n---\n',
+});
+
+// Blockquote — Turndown's default puts a blank quoted line (`>`) between paragraphs,
+// so a multi-line quote serialized to `> a\n>\n> b` instead of the tight `> a\n> b`
+// that markdownToHtml round-trips from. Collapse internal blank lines so the round
+// trip is idempotent (story 2a72ebf4). The callout rule (data-callout) handles 💡
+// blocks separately and is unaffected.
+turndown.addRule('blockquote', {
+  filter: 'blockquote',
+  replacement: (content) => {
+    const inner = content.replace(/^\n+|\n+$/g, '').replace(/\n\s*\n/g, '\n');
+    return `\n\n${inner.replace(/^/gm, '> ')}\n\n`;
   },
 });
 
@@ -329,7 +368,18 @@ export function markdownToHtml(rawMd: string): string {
 
   // Blockquotes (including callout pattern)
   html = html.replace(/^> 💡 (.+)$/gm, '<div data-callout class="callout">$1</div>');
-  html = html.replace(/^> (.+)$/gm, '<blockquote><p>$1</p></blockquote>');
+  // Merge consecutive '>' lines into ONE blockquote (one <p> per line). Emitting a
+  // separate <blockquote> per line round-tripped back with a blank line between them,
+  // mutating multi-line quotes on load (story 2a72ebf4). Paired with the blockquote
+  // Turndown rule below, which re-joins the paragraphs into tight `> a\n> b`.
+  html = html.replace(/(?:^> .+$\n?)+/gm, (block) => {
+    const paras = block
+      .replace(/\n+$/, '')
+      .split('\n')
+      .map((line) => `<p>${line.replace(/^> /, '')}</p>`)
+      .join('');
+    return `<blockquote>${paras}</blockquote>`;
+  });
 
   // Bold and italic
   html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');


### PR DESCRIPTION
## 무엇을 (스토리 `2a72ebf4` · FIX-3 · high · 모스토리 `fc4d4264` 트리거 제거)

에디터는 마크다운을 저장하고, 로드 시 `markdownToHtml`→TipTap, 갱신 시 `htmlToMarkdown`으로 되돌린다. 이 왕복이 복잡 마크다운에서 **비멱등**이라 문서를 **열기만 해도(무타이핑)** 본문이 변형 → dirty 판정 → (FIX-1 이후) **1회 silent autosave로 변형본 영속**(표 cell 인라인 유실 등) — 데이터 무결성 결함.

## 비멱등 표면 4종 (content-converter 수정)

1. **task list** — Turndown 7.x는 룰을 **나중 등록 우선**으로 해소해서, 일반 `compactListItem`가 `taskListItem`을 가려 `- [ ]`/`- [x]` 마커를 떨궜는. `compactListItem` 필터가 taskItem LI를 제외하도록(순서 무관).
2. **표 cell (AC③)** — `table` 룰이 `cell.textContent`로 읽어 bold/italic/code/link 통째 유실. 이제 cell innerHTML을 인라인 마크다운으로 직렬화(파이프 escape).
3. **hr** — Turndown 기본 `* * *` ≠ `markdownToHtml`이 인식하는 `---`. `---` 방출 룰 추가.
4. **여러 줄 인용블록** — `>` 줄마다 별도 `<blockquote>` → 사이 빈 줄 삽입되며 왕복 변형. `markdownToHtml`이 연속 `>` 줄을 하나의 blockquote로 병합 + blockquote Turndown 룰이 단락을 tight `> a\n> b`로 재결합.

## 테스트

- **신규 `content-converter.roundtrip.test.ts`**: 구성요소별 fixed-point + 복합 문서 + **stabilization `rt(rt(x))===rt(x)`**(= 이미 저장된 문서가 변형 없이 로드되는 형식 속성·AC①②④). 표 cell 인라인 보존(AC③).
- AC② "raw/Wrapped envelope 경계 케이스"는 #1397에서 추가한 `unwrapDocResponse` 단위테스트(use-doc-sync.test.ts·raw+enveloped)가 커버.
- **기존 stale 테스트 1건 수정**: `'converts code blocks'`가 `<pre><code>`를 기대했으나 코드펜스는 오래전부터 `data-language`/`language-*`를 달고 나옴. **CI가 `pnpm vitest run 2>&1 | tail -80`로 vitest 종료코드를 마스킹**(pipefail 미설정)해 그간 빨간 채로 묻혀 있던 것 — 같은 파일 손대는 김에 실제 출력에 맞게 정정.

## 검증

- `vitest` 변환기/왕복/use-doc-sync 스위트 ✅ (roundtrip 19/19·converter 25/25) — repo 전역엔 환경의존(DB/cron/analytics) 선존 실패 다수 있으나 CI 마스킹 대상·본 변경과 무관(`doc-content-renderer` 1건도 base 선존 확인).
- `pnpm build`(next 16.2.2 webpack) ✅ exit 0 · `tsc` 소스 0 errors · 변경분 lint 0.

## ⚠️ 발견·이 PR 범위 밖 (PO 판단 요청)

- **baseline 설정 견고성**(유나 진단): use-doc-sync의 baseline 설정이 `setTimeout(0)` + `currentSnapshot` deps라 content 변동 시 cancel되는 구조. 본 멱등화로 oscillation이 멎어 증상(=md-heavy 저장 불가)은 해소되나, 구조 자체의 race 여지는 남는. **use-doc-sync 동시성 변경은 변환기 로직과 리뷰 관심사가 달라** 별도 PR 권장 — 같은 스토리 후속으로 처리할지 PO 콜 바라겠는.
- **CI vitest 마스킹**(`| tail`)도 별건으로 보고 — 단위테스트 게이트가 실효 0인 상태.

## 리뷰

**디디군 교차 리뷰 필수**(변환기 로직). 까심군 QA(유나 재현 절차 `9f19eb30`: 복잡 MD 로드 무타이핑 → PATCH 0건) · 유나신 가디언(시각 회귀).

🤖 Generated with [Claude Code](https://claude.com/claude-code)