### PR TITLE
[SID:1dace253] feat(hypotheses): hypotheses 1급 엔티티 + 링크 테이블 모델·마이그 0113 (E1-S1)

### DIFF
--- a/backend/alembic/versions/0113_add_hypotheses.py
+++ b/backend/alembic/versions/0113_add_hypotheses.py
@@ -1,0 +1,212 @@
+"""E1 L3: hypotheses 1급 엔티티 + epic/story 링크 테이블.
+
+Revision ID: 0113
+Revises: 0112
+Create Date: 2026-06-11
+
+블루프린트 `blueprint-e1-hypothesis-entity` §2·§8. 가설을 outcome 컬럼에서 1급
+엔티티로 승격(기존 outcome 컬럼 삭제 없음). epic/story는 링크 테이블로 무접촉 연결.
+
+idempotent: 테이블 단위 inspect 가드(0067 gate 선례). 자동 backfill 없음(§8.2 —
+owner_member_id NOT NULL 해소 불가, 별도 운영 command로 수동 이관). downgrade는
+링크 테이블을 먼저 drop 후 hypotheses drop.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision = "0113"
+down_revision = "0112"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    # step0: epics.id PRIMARY KEY 드리프트 교정 (0107 docs_pkey 선례와 동일 클래스).
+    # baseline 스냅샷(dev 0096)에 epics_pkey가 소실 — projects/stories엔 PK 있는데 epics만 부재.
+    # hypothesis_epic_links.epic_id FK가 referenced 유일성을 요구하므로 선행 필수. PK 부재 시만
+    # 추가(idempotent). downgrade에서 되돌리지 않는다(되돌리면 결함 재현).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_constraint
+                WHERE conrelid = 'public.epics'::regclass AND contype = 'p'
+            ) THEN
+                ALTER TABLE public.epics ADD CONSTRAINT epics_pkey PRIMARY KEY (id);
+            END IF;
+        END $$;
+        """
+    )
+
+    if "hypotheses" not in existing:
+        op.create_table(
+            "hypotheses",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+            sa.Column(
+                "project_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("projects.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("owner_member_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("created_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("confirmed_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("statement", sa.Text(), nullable=False),
+            sa.Column("metric_definition", JSONB, nullable=False),
+            sa.Column("measure_after", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("status", sa.String(24), nullable=False, server_default="proposed"),
+            sa.Column("outcome_result", JSONB, nullable=True),
+            sa.Column("confidence", sa.Numeric(5, 4), nullable=True),
+            sa.Column("source_type", sa.String(32), nullable=True),
+            sa.Column("source_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("source_snapshot", JSONB, nullable=True),
+            sa.Column("drafted_by_member_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("draft_metadata", JSONB, nullable=True),
+            sa.Column(
+                "human_accounting",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "gate_contract",
+                JSONB,
+                nullable=False,
+                server_default=sa.text("'{}'::jsonb"),
+            ),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True),
+            sa.CheckConstraint(
+                "status IN ('proposed','active','measuring','verified','falsified','killed','archived')",
+                name="ck_hypotheses_status",
+            ),
+            sa.CheckConstraint(
+                "jsonb_typeof(metric_definition) = 'object'",
+                name="ck_hypotheses_metric_object",
+            ),
+        )
+        # OrgScopedMixin tenant 필터용 단일 org_id 인덱스 + §2.4 인덱스 5종
+        op.create_index("ix_hypotheses_org_id", "hypotheses", ["org_id"])
+        op.create_index(
+            "ix_hypotheses_org_project_status_created_at",
+            "hypotheses",
+            ["org_id", "project_id", "status", sa.text("created_at DESC")],
+        )
+        op.create_index(
+            "ix_hypotheses_owner",
+            "hypotheses",
+            ["org_id", "owner_member_id", sa.text("created_at DESC")],
+        )
+        op.create_index(
+            "ix_hypotheses_measure_due",
+            "hypotheses",
+            ["org_id", "status", "measure_after"],
+            postgresql_where=sa.text("status IN ('active','measuring')"),
+        )
+        op.create_index(
+            "ix_hypotheses_metric_gin",
+            "hypotheses",
+            ["metric_definition"],
+            postgresql_using="gin",
+        )
+        op.create_index(
+            "ix_hypotheses_source",
+            "hypotheses",
+            ["org_id", "source_type", "source_id"],
+        )
+
+    if "hypothesis_epic_links" not in existing:
+        op.create_table(
+            "hypothesis_epic_links",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "hypothesis_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("hypotheses.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "epic_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("epics.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("link_type", sa.String(24), nullable=False, server_default="primary"),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.UniqueConstraint("hypothesis_id", "epic_id", name="uq_hypothesis_epic_links"),
+        )
+        op.create_index(
+            "ix_hypothesis_epic_links_epic",
+            "hypothesis_epic_links",
+            ["epic_id", "link_type"],
+        )
+
+    if "hypothesis_story_links" not in existing:
+        op.create_table(
+            "hypothesis_story_links",
+            sa.Column("id", UUID(as_uuid=True), primary_key=True),
+            sa.Column(
+                "hypothesis_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("hypotheses.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column(
+                "story_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey("stories.id", ondelete="CASCADE"),
+                nullable=False,
+            ),
+            sa.Column("link_type", sa.String(24), nullable=False, server_default="supports"),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                server_default=sa.func.now(),
+                nullable=False,
+            ),
+            sa.UniqueConstraint("hypothesis_id", "story_id", name="uq_hypothesis_story_links"),
+        )
+        op.create_index(
+            "ix_hypothesis_story_links_story",
+            "hypothesis_story_links",
+            ["story_id"],
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    # 링크 테이블 먼저 — hypotheses FK 의존이라 역순 drop. drop_table이 인덱스/제약 동반 제거.
+    if "hypothesis_story_links" in existing:
+        op.drop_table("hypothesis_story_links")
+    if "hypothesis_epic_links" in existing:
+        op.drop_table("hypothesis_epic_links")
+    if "hypotheses" in existing:
+        op.drop_table("hypotheses")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -22,6 +22,7 @@ from app.models.notification import InboxItem, Notification, NotificationSetting
 from app.models.notification_preference import NotificationPreference
 from app.models.organization import Organization
 from app.models.pm import Epic, Sprint, Story, Task
+from app.models.hypothesis import Hypothesis, HypothesisEpicLink, HypothesisStoryLink
 from app.models.story_assignee import StoryAssignee
 from app.models.project import OrgMember, Project
 from app.models.project_setting import ProjectSetting
@@ -61,6 +62,9 @@ __all__ = [
     "WebhookConfig",
     "Doc",
     "Epic",
+    "Hypothesis",
+    "HypothesisEpicLink",
+    "HypothesisStoryLink",
     "InboxItem",
     "Meeting",
     "Notification",

--- a/backend/app/models/hypothesis.py
+++ b/backend/app/models/hypothesis.py
@@ -1,0 +1,191 @@
+"""E1 L3: Hypothesis 1급 엔티티 + epic/story 링크 테이블.
+
+블루프린트 `blueprint-e1-hypothesis-entity` §2 구현. 가설을 epic/story/sprint의
+숨은 outcome 컬럼에서 꺼내 `hypotheses` 1급 엔티티로 승격한다. epic/story는 새 FK를
+직접 달지 않고 링크 테이블(`hypothesis_epic_links`·`hypothesis_story_links`)로 무접촉 연결.
+
+상태기계 (§2.5):
+    proposed → active → measuring → verified | falsified
+    proposed | active | measuring → killed
+    verified | falsified | killed → archived
+    (verified|falsified|killed → active 역전이는 v1 금지 — 새 가설을 만든다.)
+
+owner_member_id: 책임 주체. v1은 반드시 type='human' resolved member.
+    canonical member id를 저장하고 FK는 강제하지 않는다(기존 assignee_id와 동형 —
+    grant-only 휴먼 회귀 방지). 신원 해소는 API/service의 resolve_member에서.
+"""
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+from app.models.base import OrgScopedMixin, TimestampMixin
+
+# §2.3.1 상태 7종 (DB CHECK와 동기)
+HYPOTHESIS_STATUSES = frozenset(
+    {"proposed", "active", "measuring", "verified", "falsified", "killed", "archived"}
+)
+
+# §2.5 합법 전이: (from, to). verified|falsified|killed → active 역전이는 금지.
+_VALID_TRANSITIONS: set[tuple[str, str]] = {
+    ("proposed", "active"),
+    ("active", "measuring"),
+    ("measuring", "verified"),
+    ("measuring", "falsified"),
+    ("proposed", "killed"),
+    ("active", "killed"),
+    ("measuring", "killed"),
+    ("verified", "archived"),
+    ("falsified", "archived"),
+    ("killed", "archived"),
+}
+
+
+def is_valid_transition(from_status: str, to_status: str) -> bool:
+    return (from_status, to_status) in _VALID_TRANSITIONS
+
+
+class Hypothesis(Base, OrgScopedMixin, TimestampMixin):
+    __tablename__ = "hypotheses"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    project_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("projects.id", ondelete="CASCADE"), nullable=False
+    )
+    # §2.2 휴먼/에이전트 신원. owner는 휴먼 전용, created_by/drafted_by는 에이전트 가능.
+    # FK 비강제 — canonical member id 보유(assignee_id 선례). 해소는 service resolve_member.
+    owner_member_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    created_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    confirmed_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+    # §2.2.4 유일한 수동 텍스트 입력
+    statement: Mapped[str] = mapped_column(Text, nullable=False)
+    # §2.2.5 기존 outcome validator 호환 {metric, source, target, direction}
+    metric_definition: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    # §2.2.6 기존 measure_after 의미 승격
+    measure_after: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    status: Mapped[str] = mapped_column(String(24), nullable=False, server_default="proposed")
+    outcome_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    confidence: Mapped[float | None] = mapped_column(Numeric(5, 4), nullable=True)
+
+    # §2.2.7-8 AI 드래프트 추적. source_snapshot은 입력 일부만(원문 전체 복제 금지).
+    source_type: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    source_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    source_snapshot: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    drafted_by_member_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    draft_metadata: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # §2.8 휴먼 회계 연결 고리(v1 비어 있어도 됨). §2.9 E2 verdict gate가 읽을 anchor.
+    human_accounting: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+    gate_contract: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"), default=dict
+    )
+
+    # §3.10 archive=soft. hard delete는 마이그/감사 정책 확정 전까지 금지.
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        # §2.3 제약
+        CheckConstraint(
+            "status IN ('proposed','active','measuring','verified','falsified','killed','archived')",
+            name="ck_hypotheses_status",
+        ),
+        CheckConstraint(
+            "jsonb_typeof(metric_definition) = 'object'",
+            name="ck_hypotheses_metric_object",
+        ),
+        # §2.4 인덱스
+        Index(
+            "ix_hypotheses_org_project_status_created_at",
+            "org_id",
+            "project_id",
+            "status",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_hypotheses_owner",
+            "org_id",
+            "owner_member_id",
+            text("created_at DESC"),
+        ),
+        Index(
+            "ix_hypotheses_measure_due",
+            "org_id",
+            "status",
+            "measure_after",
+            postgresql_where=text("status IN ('active','measuring')"),
+        ),
+        Index(
+            "ix_hypotheses_metric_gin",
+            "metric_definition",
+            postgresql_using="gin",
+        ),
+        Index(
+            "ix_hypotheses_source",
+            "org_id",
+            "source_type",
+            "source_id",
+        ),
+    )
+
+
+class HypothesisEpicLink(Base):
+    """§2.6 가설↔에픽 연결. link_type='primary'는 대표 가설 배지."""
+
+    __tablename__ = "hypothesis_epic_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    hypothesis_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="CASCADE"), nullable=False
+    )
+    epic_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("epics.id", ondelete="CASCADE"), nullable=False
+    )
+    link_type: Mapped[str] = mapped_column(String(24), nullable=False, server_default="primary")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("hypothesis_id", "epic_id", name="uq_hypothesis_epic_links"),
+        Index("ix_hypothesis_epic_links_epic", "epic_id", "link_type"),
+    )
+
+
+class HypothesisStoryLink(Base):
+    """§2.6 가설↔스토리 연결. link_type='supports'는 실행 근거·dispatch 앵커."""
+
+    __tablename__ = "hypothesis_story_links"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    hypothesis_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("hypotheses.id", ondelete="CASCADE"), nullable=False
+    )
+    story_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("stories.id", ondelete="CASCADE"), nullable=False
+    )
+    link_type: Mapped[str] = mapped_column(String(24), nullable=False, server_default="supports")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    __table_args__ = (
+        UniqueConstraint("hypothesis_id", "story_id", name="uq_hypothesis_story_links"),
+        Index("ix_hypothesis_story_links_story", "story_id"),
+    )


### PR DESCRIPTION
## 무엇을 (스토리 `1dace253` · E1-S1 · 에픽 E1 `76509305` Hypothesis 1급 엔티티 · L3 첫 단계)

가설을 epic/story/sprint의 숨은 outcome 컬럼에서 꺼내 `hypotheses` 1급 엔티티로 승격한다. 스펙 SSOT = 블루프린트 `blueprint-e1-hypothesis-entity` §2(스키마·제약·인덱스·상태머신)·§8(마이그레이션). **범위 = 모델 3종 + Alembic 0113 only** — schemas/repo/service(S2)·API(S3)·MCP(S5)·FE(S7~9)는 후속.

## 모델 (`backend/app/models/hypothesis.py`)

- **`Hypothesis`** (22 컬럼, §2.1): `owner_member_id` = 휴먼 전용 canonical member id(FK 비강제 — 기존 `assignee_id` 선례, grant-only 휴먼 회귀 방지). `statement`/`metric_definition`(JSONB NOT NULL)/`measure_after`/`status`/`outcome_result` 승격. `human_accounting`·`gate_contract` = E2 verdict gate가 읽을 anchor(§2.8·2.9). `source_*`/`drafted_by_member_id`/`draft_metadata` = AI 드래프트 추적. `archived_at` = soft archive(§3.10).
- **`HypothesisEpicLink` / `HypothesisStoryLink`** (§2.6): epic/story **무접촉** 연결 — 기존 테이블에 FK 직접 추가 안 함. `unique(hypothesis, epic|story)` + `link_type`(primary/supports) + index.
- **상태머신 7종 + 전이 헬퍼**(`is_valid_transition`, §2.5) — `gate.py` 선례 패턴. verified/falsified/killed → active 역전이 금지.
- **제약**: `CHECK status IN (7종)` / `CHECK jsonb_typeof(metric_definition)='object'`. **인덱스 §2.4 5종** + GIN(metric_definition) + 부분 인덱스(measure_due, `status IN ('active','measuring')`) + org 합성.

## 마이그레이션 (`0113_add_hypotheses`, head 0112→0113)

- **idempotent**: 테이블 단위 `inspect` 가드(0067 gate 선례). downgrade는 링크 테이블 먼저 drop 후 hypotheses.
- **자동 backfill 없음**(§8.2 — `owner_member_id` NOT NULL 해소 불가). 기존 outcome 컬럼 **삭제 없음**. baseline REVISION `0096` 불변(CI parity invariant).

### ⚠️ step0 — epics.id PRIMARY KEY 드리프트 교정 (발견·이 PR에서 처리)

fresh-from-baseline DB에서 `hypothesis_epic_links.epic_id → epics(id)` FK 생성이 **`InvalidForeignKey: no unique constraint matching given keys for referenced table "epics"`** 로 실패. 원인: **baseline 스냅샷(dev 0096)에 `epics_pkey`가 소실** — `projects`/`stories`엔 PK 있으나 `epics`만 부재. `docs` PK 드리프트(0107 step0)와 **동일 클래스**의 선존 스키마 결함. 0107 선례대로 `IF NOT EXISTS pg_constraint(contype='p')` 가드로 조건부 PK 추가, downgrade 미복구(되돌리면 결함 재현). **prod/dev 실 DB도 동일 드리프트 가능성** — 가드라 안전하나 PO 인지 요망.

## 검증 (`pgvector/pgvector:pg16` — CI 동일 이미지)

- **fresh DB** `alembic upgrade head`: baseline 0096 → incremental → **0113 성공**, current=head.
- **existing-DB no-op** / **downgrade 0113→0112 → re-upgrade** 순환 idempotent(링크 3 drop/복원, epics_pkey 유지).
- **실측 동작**: CHECK 거부(bad status·non-object metric) / default(`proposed`·`{}`·`{}`·updated_at) / link_type(`primary`·`supports`) / unique 거부 / `ON DELETE CASCADE`(hypothesis 삭제 → 링크 0/0). **epics/stories/sprints outcome 컬럼 5종 보존** 확인.
- `import app.models` 매퍼 정상 / `pytest --co` 1858건 무결.

## AC (§9 S1)

- [x] fresh DB upgrade 성공
- [x] 기존 outcome 컬럼 삭제 없음
- [x] idempotent

## 리뷰

PO 오르테가군 검수 → 까심군 QA. base `develop`(파이프라인 V2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)