### PR TITLE
[SID:e491d087] fix(db): PK 드리프트 일괄 교정 — ORM-모델 39개 PRIMARY KEY 복원 (0114)

### DIFF
--- a/backend/alembic/versions/0114_restore_missing_primary_keys.py
+++ b/backend/alembic/versions/0114_restore_missing_primary_keys.py
@@ -1,0 +1,105 @@
+"""PK 드리프트 일괄 교정: ORM이 PK를 가정하나 DB에 부재한 39개 테이블 PRIMARY KEY 복원.
+
+Revision ID: 0114
+Revises: 0113
+Create Date: 2026-06-11
+
+배경 (스토리 e491d087): baseline 스냅샷(dev 0096 pg_dump, alembic/baseline/schema.sql)이
+PRIMARY KEY를 정확히 43개만 선언 → fresh-from-baseline DB(head)에서 127 base 테이블 중
+75개가 DB PK 부재. ORM 메타데이터 교차 대조 결과 그 중 39개가 "모델은 PK 정의·DB 부재"
+진짜 드리프트(docs 0107·epics 0113 step0와 동일 클래스). 이 마이그가 그 39개를 한 번에 닫는다.
+
+PK 컬럼은 ORM 메타데이터(`Base.metadata.tables[t].primary_key.columns`)에서 도출 — 38개는
+`id`, `project_settings`만 `project_id`. 각 테이블은 PK 부재 시에만 추가(idempotent).
+downgrade는 되돌리지 않는다(드리프트 교정 — 되돌리면 결함 재현, 0107/0113 step0와 동일).
+
+⚠️ ADD PRIMARY KEY는 대상 컬럼에 중복/NULL이 있으면 실패한다. fresh/clean DB에선 무조건
+성공하나 real dev/prod 적용 전 dup-id/NULL 전수 preflight 필수 —
+backend/scripts/preflight/0114_missing_pk_preflight.sql 동봉. preflight 0건 확인 후 머지.
+② ORM 미모델 36개(legacy/append 로그류)는 본 마이그 범위 밖(별도 트리아지 a74bdc84).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0114"
+down_revision = "0113"
+branch_labels = None
+depends_on = None
+
+# (table, [pk_columns]) — ORM 메타데이터 도출. 전부 ['id'] 예외 project_settings=['project_id'].
+TABLES_MISSING_PK: list[tuple[str, list[str]]] = [
+    ("agent_api_keys", ["id"]),
+    ("agent_audit_logs", ["id"]),
+    ("agent_deployments", ["id"]),
+    ("agent_hitl_policies", ["id"]),
+    ("agent_hitl_requests", ["id"]),
+    ("agent_personas", ["id"]),
+    ("agent_routing_rules", ["id"]),
+    ("agent_runs", ["id"]),
+    ("agent_sessions", ["id"]),
+    ("doc_comments", ["id"]),
+    ("doc_revisions", ["id"]),
+    ("inbox_items", ["id"]),
+    ("meetings", ["id"]),
+    ("messaging_bridge_channels", ["id"]),
+    ("messaging_bridge_users", ["id"]),
+    ("mockup_components", ["id"]),
+    ("mockup_pages", ["id"]),
+    ("mockup_scenarios", ["id"]),
+    ("mockup_versions", ["id"]),
+    ("notification_settings", ["id"]),
+    ("notifications", ["id"]),
+    ("org_subscriptions", ["id"]),
+    ("permission_audit_logs", ["id"]),
+    ("policy_documents", ["id"]),
+    ("project_settings", ["project_id"]),
+    ("retro_actions", ["id"]),
+    ("retro_items", ["id"]),
+    ("retro_sessions", ["id"]),
+    ("retro_votes", ["id"]),
+    ("reward_ledger", ["id"]),
+    ("sprints", ["id"]),
+    ("standup_entries", ["id"]),
+    ("standup_feedback", ["id"]),
+    ("story_activities", ["id"]),
+    ("story_comments", ["id"]),
+    ("tasks", ["id"]),
+    ("usage_meters", ["id"]),
+    ("webhook_configs", ["id"]),
+    ("workflow_versions", ["id"]),
+]
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    for table, pk_cols in TABLES_MISSING_PK:
+        if table not in existing:
+            # 방어: 대상 테이블이 없으면 건너뛴다(환경 편차 — 본 마이그는 추가만, 생성 안 함).
+            continue
+        cols_sql = ", ".join(f'"{c}"' for c in pk_cols)
+        # PK 부재 시에만 추가(idempotent). 컬럼은 ADD PRIMARY KEY가 NOT NULL을 자동 부여.
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_constraint
+                    WHERE conrelid = 'public.{table}'::regclass AND contype = 'p'
+                ) THEN
+                    ALTER TABLE public.{table}
+                        ADD CONSTRAINT {table}_pkey PRIMARY KEY ({cols_sql});
+                END IF;
+            END $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    # 드리프트 교정이므로 되돌리지 않는다 — PK를 drop하면 원래 결함(ORM↔DB 불일치)을 재현한다.
+    # (0107 docs_pkey / 0113 epics_pkey step0와 동일 정책.)
+    pass

--- a/backend/scripts/preflight/0114_missing_pk_preflight.sql
+++ b/backend/scripts/preflight/0114_missing_pk_preflight.sql
@@ -1,0 +1,169 @@
+-- 0114 PRIMARY KEY 복원 — preflight (스토리 e491d087 머지 게이트)
+--
+-- real dev/prod 양쪽에 실행. ADD PRIMARY KEY는 대상 컬럼에 NULL 또는 중복이 있으면 실패하므로,
+-- 0114 머지/적용 전 이 쿼리로 39개 테이블을 전수 점검한다. null_cnt>0 또는 dup_groups>0 인
+-- 행이 하나라도 있으면 그 테이블은 데이터 정리 선행이 필요(머지 블로커). 전 행 0이면 GO.
+--
+-- 실행: psql "$PROD_OR_DEV_URL" -f backend/scripts/preflight/0114_missing_pk_preflight.sql
+-- (cloud-sql-proxy 경유 — reference_prod_db_query 참조. 인프라 lane.)
+
+\pset format aligned
+SELECT * FROM (
+  SELECT 'agent_api_keys' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_api_keys WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_api_keys GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_audit_logs' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_audit_logs WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_audit_logs GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_deployments' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_deployments WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_deployments GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_hitl_policies' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_hitl_policies WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_hitl_policies GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_hitl_requests' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_hitl_requests WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_hitl_requests GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_personas' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_personas WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_personas GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_routing_rules' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_routing_rules WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_routing_rules GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_runs' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_runs WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_runs GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'agent_sessions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM agent_sessions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM agent_sessions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'doc_comments' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM doc_comments WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM doc_comments GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'doc_revisions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM doc_revisions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM doc_revisions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'inbox_items' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM inbox_items WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM inbox_items GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'meetings' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM meetings WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM meetings GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'messaging_bridge_channels' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM messaging_bridge_channels WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM messaging_bridge_channels GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'messaging_bridge_users' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM messaging_bridge_users WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM messaging_bridge_users GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'mockup_components' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM mockup_components WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM mockup_components GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'mockup_pages' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM mockup_pages WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM mockup_pages GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'mockup_scenarios' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM mockup_scenarios WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM mockup_scenarios GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'mockup_versions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM mockup_versions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM mockup_versions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'notification_settings' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM notification_settings WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM notification_settings GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'notifications' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM notifications WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM notifications GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'org_subscriptions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM org_subscriptions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM org_subscriptions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'permission_audit_logs' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM permission_audit_logs WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM permission_audit_logs GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'policy_documents' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM policy_documents WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM policy_documents GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'project_settings' AS tbl, 'project_id' AS pk,
+    (SELECT count(*) FROM project_settings WHERE "project_id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "project_id" FROM project_settings GROUP BY "project_id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'retro_actions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM retro_actions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM retro_actions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'retro_items' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM retro_items WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM retro_items GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'retro_sessions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM retro_sessions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM retro_sessions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'retro_votes' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM retro_votes WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM retro_votes GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'reward_ledger' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM reward_ledger WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM reward_ledger GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'sprints' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM sprints WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM sprints GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'standup_entries' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM standup_entries WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM standup_entries GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'standup_feedback' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM standup_feedback WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM standup_feedback GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'story_activities' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM story_activities WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM story_activities GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'story_comments' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM story_comments WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM story_comments GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'tasks' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM tasks WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM tasks GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'usage_meters' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM usage_meters WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM usage_meters GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'webhook_configs' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM webhook_configs WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM webhook_configs GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+  UNION ALL
+  SELECT 'workflow_versions' AS tbl, 'id' AS pk,
+    (SELECT count(*) FROM workflow_versions WHERE "id" IS NULL) AS null_cnt,
+    (SELECT count(*) FROM (SELECT "id" FROM workflow_versions GROUP BY "id" HAVING count(*) > 1) d) AS dup_groups
+) chk
+WHERE null_cnt > 0 OR dup_groups > 0   -- 블로커만 출력. 0행이면 전부 깨끗 = GO.
+ORDER BY tbl;


### PR DESCRIPTION
## 무엇을 (스토리 `e491d087` · high · 전수 감사 후속 — docs 0107·epics 0113 클래스 닫기)

baseline 스냅샷(dev 0096 pg_dump)이 PRIMARY KEY를 **정확히 43개만** 선언 → fresh-from-baseline DB(head)에서 **127 base 테이블 중 75개 DB PK 부재**. ORM 메타데이터 교차 대조로 그 중 **39개가 "모델은 PK 정의·DB 부재" 진짜 드리프트**(나머지 36 = ORM 미모델 legacy/append). 이 마이그가 39개를 일괄 복원한다.

> ⚠️ **머지 순서**: down_revision=`0113`(#1402)이라 체인상 #1402 **머지 후** 본 PR이 develop에 올라간다. 현재 diff에 0113 파일이 함께 보이면 #1402 선머지로 해소(스택 브랜치).

## 마이그레이션 (`0114_restore_missing_primary_keys`)

- **PK 컬럼 = ORM 메타데이터 도출**(`Base.metadata.tables[t].primary_key.columns`): 38개 `id`, **`project_settings`만 `project_id`**(blind id 금지 — 명시 처리).
- 테이블별 **`IF NOT EXISTS pg_constraint(contype='p')` 가드** → 부재 시만 `ADD CONSTRAINT <t>_pkey PRIMARY KEY (...)`. idempotent. `downgrade` 미복구(드리프트 교정 — 되돌리면 결함 재현, 0107/0113 step0 정책).
- 대상 39: agent_*(9)·retro_*(4)·mockup_*(4)·standup_*(2)·messaging_bridge_*(2)·doc_comments·doc_revisions·tasks·sprints·meetings·notifications·notification_settings·inbox_items·org_subscriptions·policy_documents·permission_audit_logs·reward_ledger·usage_meters·webhook_configs·workflow_versions·story_comments·story_activities·**project_settings**(project_id).
- **② ORM 미모델 36개**(analytics_events·memo_*·subscriptions·workflow 런타임 등)는 **범위 밖** — 별도 트리아지 스토리 `a74bdc84`.

## ⑤ 원인 규명 (클래스 재발 방지 근거)

1. **pg_dump 옵션 아티팩트 아님**: pg_dump는 존재하는 PK를 빠짐없이 `ADD CONSTRAINT _pkey`로 덤프한다. baseline에 정확히 43개가 존재 = 소스 dev DB가 **실제로 43개만** 보유했다는 뜻(블랭킷 옵션 누락이면 0개여야).
2. **Supabase→Cloud SQL cutover가 떨군 것도 아님**: 이관 스크립트(`scripts/migrate_supabase_to_cloud_sql.sh`)는 `pg_dump --format=custom`(전체 스키마+데이터) + `pg_restore --exit-on-error`로, **PK를 보존**하는 방식.
3. **결론**: PK는 **Supabase 소스 단계에서 이미 부재**였다. 초기 Supabase 시대 raw SQL/TS 마이그가 일부 테이블에만 PRIMARY KEY를 선언했고(43개), ORM 모델은 후행(FastAPI 이관)에 PK를 가정. 물리 스키마는 그 가정을 가진 적이 없다.
4. **재발 안 함**: 동결된 역사적 현실 → 전진 교정으로 닫는다. post-cutover 신규 테이블은 alembic `create_table(primary_key=True)`로 PK를 항상 얻는다(예: 0113 hypotheses). baseline 재생성해도 본 0114 적용 후 상태가 반영되어 재드롭 없음.

## preflight (머지 게이트, `backend/scripts/preflight/0114_missing_pk_preflight.sql`)

`ADD PRIMARY KEY`는 대상 컬럼에 **NULL/중복 시 실패**. real dev/prod 39 테이블 전수 점검 쿼리 동봉 — `null_cnt>0` 또는 `dup_groups>0` 행이 **머지 블로커**, 0행이면 GO. **실행은 인프라 lane**(gcloud 재인증 후 cloud-sql-proxy 경유, PO 협동) — 쿼리는 본 PR에 동봉, 결과 첨부를 머지 게이트로 한다.

## 검증 (`pgvector/pgvector:pg16` — CI 동일)

- fresh-from-baseline `upgrade head`: 미존 PK **75→36**(39 복원). `tasks_pkey`·`sprints_pkey`·`project_settings_pkey`(=project_id) 등 부여 확인.
- **re-run no-op** / preflight 쿼리 0행(빈 DB = 블로커 없음).

## AC

- [x] ① ORM-모델 39개 PK 복원 (메타데이터 도출·project_settings=project_id 예외·IF NOT EXISTS 가드)
- [x] idempotent / downgrade 미복구
- [x] preflight dup-id/NULL 전수 쿼리 동봉
- [x] ⑤ 원인 규명(pg_dump 충실·cutover 무관·Supabase 소스 부재)
- [ ] **머지 게이트**: real dev/prod preflight 결과 0건 첨부(인프라 lane)
- [ ] #1402(0113) 선머지

## 리뷰

PO 오르테가군 검수 → 까심군 QA. base `develop`. #1402 후 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)