### PR TITLE
[SID:0956d838] test(docs): docs-UI 2파일 수선 + 격리 해제 (2d5c8662 클린업 A)

### DIFF
--- a/apps/web/src/components/docs/doc-content-renderer.test.tsx
+++ b/apps/web/src/components/docs/doc-content-renderer.test.tsx
@@ -32,7 +32,10 @@ describe('DocContentRenderer', () => {
 
     expect(markup).toContain('<h1 id="overview">Overview</h1>');
     expect(markup).toContain('<h2 id="html-heading-in-markdown">HTML Heading In Markdown</h2>');
-    expect(markup).toContain('data-doc-copy-button="true"');
+    // Markdown code blocks render via the self-contained React CodeBlock (own onClick +
+    // state), so the copy action is the data-doc-code-actions shell + label, not the
+    // HTML-path data-doc-copy-button marker (that marker is asserted in the html test below).
+    expect(markup).toContain('data-doc-code-actions="true"');
     expect(markup).toContain('Copy code');
     expect(markup).toContain('<table>');
   });

--- a/apps/web/src/components/docs/extensions/slash-command.test.tsx
+++ b/apps/web/src/components/docs/extensions/slash-command.test.tsx
@@ -116,7 +116,8 @@ describe('defaultSlashItems', () => {
   it('each item has a non-empty title, icon, and command function', () => {
     for (const item of defaultSlashItems) {
       expect(item.title.length).toBeGreaterThan(0);
-      expect(item.icon.length).toBeGreaterThan(0);
+      // icon is an FC<{ className?: string }> (lucide component), not a string — assert it exists
+      expect(item.icon).toBeTruthy();
       expect(typeof item.command).toBe('function');
     }
   });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -27,9 +27,6 @@ export default defineConfig({
       // pipefail) masked until now. Excluded so the gate is REAL for the healthy
       // suite; each file is debt to burn down — re-include as it is fixed.
       // ⚠️ DO NOT add here to silence a NEW failure — fix the test.
-      // Group A — docs UI components · owner: 미르코 · cleanup story: 0956d838
-      'apps/web/src/components/docs/doc-content-renderer.test.tsx',
-      'apps/web/src/components/docs/extensions/slash-command.test.tsx',
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
       'apps/web/src/app/api/agent-runs/[id]/route.test.ts',
       'apps/web/src/app/api/agent-runs/route.test.ts',


### PR DESCRIPTION
## 무엇을 (스토리 `0956d838` · `2d5c8662` 격리 Group A 번다운)

`2d5c8662`(#1401) quarantine manifest의 **Group A(docs UI 2파일)** 수선 + 격리 해제. 둘 다 CI 마스킹 뒤에 묻혀 있던 **stale 단위테스트**(구현은 정상, 테스트가 옛 계약 주장).

- **`slash-command.test.tsx`**: `SlashMenuItem.icon`이 이제 **FC 컴포넌트(lucide)**라 string 아님 → `item.icon.length`=undefined로 터졌던 것. `expect(item.icon).toBeTruthy()`로 정정.
- **`doc-content-renderer.test.tsx`**: 마크다운 코드블록은 **자기완결 React CodeBlock**(자체 onClick+state)로 렌더라, copy action이 `data-doc-code-actions` 셸+라벨이지 HTML-경로의 `data-doc-copy-button` 마커가 아님(그 마커는 html-format 테스트에서 여전히 검증). 마크다운 케이스 정정.
- `vitest.config.ts` quarantine manifest에서 **Group A 제거**.

## 검증

- 2파일 ✅ 15/15 green.
- 풀 스위트(격리 해제 반영) ✅ **91파일 / 640 테스트 green·exit 0**. Group B(api/services·`837a36c4`)는 격리 유지.
- `tsc` 소스 0 errors · 변경분 lint 0. (앱 코드 무변경 — 테스트+config만 → 빌드 영향 없음.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)