### PR TITLE
[SID:2a72ebf4] fix(docs): baseline-reset를 content churn에 의해 취소되지 않게 (baseline race)

### DIFF
--- a/apps/web/src/components/docs/use-doc-sync.ts
+++ b/apps/web/src/components/docs/use-doc-sync.ts
@@ -81,6 +81,16 @@ export function useDocSync<TDoc = { updated_at: string }>({
   const conflictRef = useRef(false);
   const remoteChangedRef = useRef(false);
 
+  // Mirror currentSnapshot into a ref so the baseline-reset effects below can read the
+  // latest snapshot WITHOUT listing currentSnapshot in their deps. With it in the deps,
+  // content churn (e.g. a non-idempotent load round-trip) re-ran the effect, its cleanup
+  // cancelled the pending setTimeout, and the docId/serverUpdatedAt guard then blocked
+  // rescheduling → baselineUpdatedAt stuck null → every save refused by FIX-2. The
+  // markdown trigger is gone (FIX-3/3b), but the baseline-set must not be cancellable by
+  // content at all (story 2a72ebf4 baseline race).
+  const currentSnapshotRef = useRef(currentSnapshot);
+  useEffect(() => { currentSnapshotRef.current = currentSnapshot; }, [currentSnapshot]);
+
   const clearSyncAlerts = useCallback((nextStatus: SaveStatus = 'saved') => {
     conflictRef.current = false;
     remoteChangedRef.current = false;
@@ -96,13 +106,13 @@ export function useDocSync<TDoc = { updated_at: string }>({
     remoteChangedRef.current = false;
 
     const timer = window.setTimeout(() => {
-      setLastSavedSnapshot(currentSnapshot);
+      setLastSavedSnapshot(currentSnapshotRef.current);
       setBaselineUpdatedAt(serverUpdatedAt);
       setStatus('idle');
     }, 0);
 
     return () => window.clearTimeout(timer);
-  }, [currentSnapshot, docId, serverUpdatedAt]);
+  }, [docId, serverUpdatedAt]);
 
   useEffect(() => {
     if (!serverUpdatedAt || serverUpdatedAt === previousServerUpdatedAtRef.current) return;
@@ -112,13 +122,13 @@ export function useDocSync<TDoc = { updated_at: string }>({
     remoteChangedRef.current = false;
 
     const timer = window.setTimeout(() => {
-      setLastSavedSnapshot(currentSnapshot);
+      setLastSavedSnapshot(currentSnapshotRef.current);
       setBaselineUpdatedAt(serverUpdatedAt);
       setStatus(editing ? 'saved' : 'idle');
     }, 0);
 
     return () => window.clearTimeout(timer);
-  }, [currentSnapshot, editing, serverUpdatedAt]);
+  }, [editing, serverUpdatedAt]);
 
   const isDirty = editing && currentSnapshot !== lastSavedSnapshot;
 


### PR DESCRIPTION
## 무엇을 (스토리 `2a72ebf4` · AC⑥ baseline race · 유나 진단 ②)

`use-doc-sync`의 두 baseline-reset 이펙트가 `currentSnapshot`을 deps에 두고 `baselineUpdatedAt`를 `setTimeout(0)`으로 설정했는. content가 churn하면(예: 비멱등 로드 왕복) 이펙트 re-run → cleanup이 pending setTimeout을 **취소** → docId/serverUpdatedAt 가드가 early-return으로 **재스케줄 차단** → `baselineUpdatedAt`=null 고착 → FIX-2 가드가 전 저장 refuse('error'·PATCH 0). 유나신 #1397 빌드 라이브 진단의 그 구조.

FIX-3/3b가 마크다운 트리거를 제거해 실사용선 더는 발화 안 하나, **baseline-set이 content에 의해 취소되면 안 되는 것 자체**가 결함이라 하드닝(AC⑥·방어적).

## 변경

- `currentSnapshotRef` 신설 + 동기화 이펙트. 두 baseline 이펙트가 **ref를 읽고 deps에서 `currentSnapshot` 제거** → content 변동이 baseline-reset을 re-run/취소 못 함. 지연 read는 ref로 최신 스냅샷을 그대로 봄.

## 검증

- `use-doc-sync` 단위테스트(scheduler + unwrapDocResponse) ✅ 9/9.
- `pnpm build` ✅ exit 0 · `tsc` 소스 0 · lint 0(exhaustive-deps 무경고 — ref 읽기).

## 비고

- **이펙트 타이밍 회귀 커버리지**는 renderHook(`@testing-library/react`·현재 미설치)이 필요 — 소형 **테스트 인프라 후속**으로 제안하는(jsdom은 #1404로 develop에 들어옴). 본 PR은 최소·targeted 변경이라 reasoning + build로 검증.
- 디자인/동작 변화 없음(내부 동기화 견고화).

🤖 Generated with [Claude Code](https://claude.com/claude-code)