### PR TITLE
[SID:2bff12dc] feat(hypotheses): /api/v2/hypotheses 라우터 9 엔드포인트 (E1-S3)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -131,6 +131,7 @@ app.include_router(conversations.router)
 app.include_router(presence.router)
 app.include_router(sprints.router)
 app.include_router(epics.router)
+app.include_router(hypotheses.router)
 app.include_router(dependencies.router)
 app.include_router(labels.router)
 app.include_router(labels.item_label_router)

--- a/backend/app/routers/hypotheses.py
+++ b/backend/app/routers/hypotheses.py
@@ -1,0 +1,257 @@
+"""E1-S3: /api/v2/hypotheses 라우터 (9 엔드포인트, 블루프린트 §3.2~§3.10).
+
+계약: 성공은 raw model/list 반환, 오류는 HTTPException(dict detail {code,message}) —
+main.py 핸들러가 {data:null,error:{code,message,...},meta:null}로 감싼다.
+
+라우트 선언 순서: `/draft`를 `/{id}` 계열보다 먼저 선언한다(§3.9.7 — /bulk shadow #1386 재발 방지).
+
+라우터 레벨 가드(S2에서 인계·AC⑥):
+- §3.7.2 cross-project 링크 금지 — 대상 epic/story의 project가 hypothesis와 같아야 한다.
+- §3.1.7 'active' 전이는 owner 휴먼 또는 org owner/admin만.
+"""
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import (
+    AuthContext,
+    get_current_user,
+    get_project_scoped_org_id,
+    get_verified_org_id,
+)
+from app.dependencies.database import get_db
+from app.models.pm import Epic, Story
+from app.repositories.hypothesis import HypothesisRepository
+from app.schemas.hypothesis import (
+    HypothesisCreate,
+    HypothesisDraftRequest,
+    HypothesisDraftResponse,
+    HypothesisLinkRequest,
+    HypothesisResponse,
+    HypothesisTransition,
+    HypothesisUnlinkRequest,
+    HypothesisUpdate,
+)
+from app.services import hypothesis as svc
+from app.services.member_resolver import ResolvedMember, resolve_member
+
+router = APIRouter(prefix="/api/v2/hypotheses", tags=["hypotheses"])
+
+_ADMIN_ROLES = frozenset({"owner", "admin"})
+
+# 서비스 도메인 오류 code → HTTP status.
+_ERROR_STATUS: dict[str, int] = {
+    "HUMAN_OWNER_REQUIRED": 400,
+    "HUMAN_CONFIRM_REQUIRED": 403,
+    "INVALID_CREATE_STATUS": 422,
+    "INVALID_STATUS": 422,
+    "INVALID_HYPOTHESIS_TRANSITION": 409,
+    "NO_VALID_FIELDS": 400,
+    "HYPOTHESIS_NOT_FOUND": 404,
+    "CROSS_PROJECT_LINK_FORBIDDEN": 403,
+}
+
+
+def _raise(err: svc.HypothesisServiceError) -> None:
+    raise HTTPException(
+        status_code=_ERROR_STATUS.get(err.code, 400),
+        detail={"code": err.code, "message": err.message},
+    )
+
+
+async def _assert_targets_same_project(
+    session: AsyncSession,
+    project_id: uuid.UUID,
+    epic_ids: list[uuid.UUID],
+    story_ids: list[uuid.UUID],
+) -> None:
+    """§3.7.2 — 링크 대상 epic/story가 hypothesis와 다른 project면 403."""
+    if epic_ids:
+        rows = (await session.execute(
+            select(Epic.id, Epic.project_id).where(Epic.id.in_(epic_ids))
+        )).all()
+        if any(pid != project_id for _id, pid in rows) or len(rows) != len(set(epic_ids)):
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "CROSS_PROJECT_LINK_FORBIDDEN",
+                        "message": "다른 프로젝트의 에픽에는 연결할 수 없습니다."},
+            )
+    if story_ids:
+        rows = (await session.execute(
+            select(Story.id, Story.project_id).where(Story.id.in_(story_ids))
+        )).all()
+        if any(pid != project_id for _id, pid in rows) or len(rows) != len(set(story_ids)):
+            raise HTTPException(
+                status_code=403,
+                detail={"code": "CROSS_PROJECT_LINK_FORBIDDEN",
+                        "message": "다른 프로젝트의 스토리에는 연결할 수 없습니다."},
+            )
+
+
+def _assert_active_authorized(caller: ResolvedMember, owner_member_id: uuid.UUID) -> None:
+    """§3.1.7 — 'active' 전이는 owner 휴먼 또는 org owner/admin만."""
+    if caller.id == owner_member_id or caller.role in _ADMIN_ROLES:
+        return
+    raise HTTPException(
+        status_code=403,
+        detail={"code": "ACTIVE_TRANSITION_FORBIDDEN",
+                "message": "active 전이는 owner 또는 org owner/admin만 가능합니다."},
+    )
+
+
+# ── /draft — /{id} 계열보다 먼저 선언(§3.9.7) ────────────────────────────────────
+
+@router.post("/draft", response_model=HypothesisDraftResponse)
+async def draft(
+    body: HypothesisDraftRequest,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisDraftResponse:
+    caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    try:
+        return await svc.draft_hypothesis(session, org_id, caller, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+# ── list / create ──────────────────────────────────────────────────────────────
+
+@router.get("", response_model=list[HypothesisResponse])
+async def list_hypotheses(
+    response: Response,
+    project_id: uuid.UUID = Query(...),
+    epic_id: uuid.UUID | None = Query(default=None),
+    story_id: uuid.UUID | None = Query(default=None),
+    status_filter: str | None = Query(default=None, alias="status"),
+    owner_member_id: uuid.UUID | None = Query(default=None),
+    limit: int = Query(default=100, ge=1, le=2000),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_project_scoped_org_id),
+) -> list[HypothesisResponse]:
+    items = await svc.list_hypotheses(
+        session, org_id, project_id,
+        status=status_filter, owner_member_id=owner_member_id,
+        epic_id=epic_id, story_id=story_id, limit=limit,
+    )
+    response.headers["X-Total-Count"] = str(len(items))
+    return items
+
+
+@router.post("", response_model=HypothesisResponse, status_code=201)
+async def create_hypothesis(
+    body: HypothesisCreate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    # resolve_member(project_id)가 프로젝트 접근을 검증한다(§3.1.2).
+    caller = await resolve_member(auth, org_id, session, project_id=body.project_id)
+    try:
+        return await svc.create_hypothesis(session, org_id, caller, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+# ── by-id ────────────────────────────────────────────────────────────────────
+
+@router.get("/{hypothesis_id}", response_model=HypothesisResponse)
+async def get_hypothesis(
+    hypothesis_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    try:
+        return await svc.get_hypothesis(session, org_id, hypothesis_id)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.patch("/{hypothesis_id}", response_model=HypothesisResponse)
+async def update_hypothesis(
+    hypothesis_id: uuid.UUID,
+    body: HypothesisUpdate,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    caller = await resolve_member(auth, org_id, session)
+    try:
+        return await svc.update_hypothesis(session, org_id, caller, hypothesis_id, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.post("/{hypothesis_id}/transition", response_model=HypothesisResponse)
+async def transition_hypothesis(
+    hypothesis_id: uuid.UUID,
+    body: HypothesisTransition,
+    session: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    caller = await resolve_member(auth, org_id, session)
+    # §3.1.7 active 전이 권한은 라우터에서 보강(owner 휴먼 또는 org admin/owner).
+    if body.status == "active":
+        repo = HypothesisRepository(session, org_id)
+        hyp = await repo.get(hypothesis_id)
+        if hyp is None:
+            raise HTTPException(
+                status_code=404,
+                detail={"code": "HYPOTHESIS_NOT_FOUND", "message": "가설을 찾을 수 없습니다."},
+            )
+        _assert_active_authorized(caller, hyp.owner_member_id)
+    try:
+        return await svc.transition_hypothesis(session, org_id, caller, hypothesis_id, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.post("/{hypothesis_id}/links", response_model=HypothesisResponse)
+async def link_hypothesis(
+    hypothesis_id: uuid.UUID,
+    body: HypothesisLinkRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    # §3.7.2 cross-project 링크 금지는 라우터에서 — 대상 epic/story project 대조.
+    repo = HypothesisRepository(session, org_id)
+    hyp = await repo.get(hypothesis_id)
+    if hyp is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"code": "HYPOTHESIS_NOT_FOUND", "message": "가설을 찾을 수 없습니다."},
+        )
+    await _assert_targets_same_project(session, hyp.project_id, body.epic_ids, body.story_ids)
+    try:
+        return await svc.link_hypothesis(session, org_id, hypothesis_id, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.delete("/{hypothesis_id}/links", response_model=HypothesisResponse)
+async def unlink_hypothesis(
+    hypothesis_id: uuid.UUID,
+    body: HypothesisUnlinkRequest,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> HypothesisResponse:
+    try:
+        return await svc.unlink_hypothesis(session, org_id, hypothesis_id, body)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+
+
+@router.delete("/{hypothesis_id}", status_code=200)
+async def archive_hypothesis(
+    hypothesis_id: uuid.UUID,
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    try:
+        await svc.archive_hypothesis(session, org_id, hypothesis_id)
+    except svc.HypothesisServiceError as err:
+        _raise(err)
+    return {"ok": True}

--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -110,3 +110,23 @@ class HypothesisResponse(BaseModel):
         resp.epic_ids = epic_ids or []
         resp.story_ids = story_ids or []
         return resp
+
+
+class HypothesisDraftRequest(BaseModel):
+    """§3.9 — 흐름 부산물에서 AI 초안 생성. persist=true이면 status='proposed' row만 생성."""
+    project_id: uuid.UUID
+    source_type: str  # "epic" | "story" | "conversation" | "dispatch"
+    source_id: uuid.UUID
+    context: dict[str, Any] | None = None
+    persist: bool = False
+
+
+class HypothesisDraftResponse(BaseModel):
+    statement: str
+    metric_definition: dict[str, Any]
+    measure_after: datetime
+    source_snapshot: dict[str, Any]
+    confidence: float | None = None
+    requires_confirmation: bool = True
+    # persist=true일 때만 — 생성된 proposed row.
+    hypothesis: HypothesisResponse | None = None

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -11,7 +11,7 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +19,8 @@ from app.models.hypothesis import HYPOTHESIS_STATUSES, is_valid_transition
 from app.repositories.hypothesis import HypothesisRepository
 from app.schemas.hypothesis import (
     HypothesisCreate,
+    HypothesisDraftRequest,
+    HypothesisDraftResponse,
     HypothesisLinkRequest,
     HypothesisResponse,
     HypothesisTransition,
@@ -259,4 +261,71 @@ async def archive_hypothesis(
         raise HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "가설을 찾을 수 없습니다.")
     await repo.update(
         hypothesis_id, status="archived", archived_at=datetime.now(timezone.utc)
+    )
+
+
+# §2.2.4 statement 최대 길이(템플릿 truncate). §2.2.8 source_snapshot은 입력 일부만.
+_SNAPSHOT_VALUE_MAX = 500
+_DEFAULT_MEASURE_DAYS = 14
+
+
+def _build_source_snapshot(context: dict | None) -> dict:
+    """§2.2.8 — 원본 전체 복제 금지. context에서 title/description 일부만 truncate해 보관."""
+    if not context:
+        return {}
+    snap: dict = {}
+    for key in ("title", "description", "summary"):
+        val = context.get(key)
+        if isinstance(val, str) and val:
+            snap[key] = val[:_SNAPSHOT_VALUE_MAX]
+    return snap
+
+
+def _template_statement(context: dict | None) -> str:
+    """deterministic 템플릿 초안(§3.9.5). LLM draft service는 미확인이라 후속 story로 미룬다."""
+    title = (context or {}).get("title")
+    if isinstance(title, str) and title.strip():
+        return f"{title.strip()[:120]} — 이 실행 묶음이 목표 지표를 개선한다"
+    return "이 실행 묶음이 목표 지표를 개선한다"
+
+
+async def draft_hypothesis(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    caller: ResolvedMember,
+    payload: HypothesisDraftRequest,
+) -> HypothesisDraftResponse:
+    """§3.9 — 흐름 부산물에서 AI 초안 생성. DB에 active를 만들지 않는다.
+
+    persist=true이면 status='proposed' row만 생성(create 경로 재사용 — owner/agent 규칙 동일).
+    초기에는 deterministic 템플릿(LLM 미연결). 사람이 statement/metric을 다듬고 확정한다.
+    """
+    statement = _template_statement(payload.context)
+    metric_definition = {"metric": "outcome", "source": "manual", "target": 1, "direction": "up"}
+    measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
+    snapshot = _build_source_snapshot(payload.context)
+
+    hyp_resp: HypothesisResponse | None = None
+    if payload.persist:
+        hyp_resp = await create_hypothesis(
+            session, org_id, caller,
+            HypothesisCreate(
+                project_id=payload.project_id,
+                statement=statement,
+                metric_definition=metric_definition,
+                measure_after=measure_after,
+                status="proposed",
+                source_type=payload.source_type,
+                source_id=payload.source_id,
+                draft_metadata={"template": True, "source_snapshot": snapshot},
+            ),
+        )
+    return HypothesisDraftResponse(
+        statement=statement,
+        metric_definition=metric_definition,
+        measure_after=measure_after,
+        source_snapshot=snapshot,
+        confidence=None,
+        requires_confirmation=True,
+        hypothesis=hyp_resp,
     )

--- a/backend/tests/test_hypotheses_router.py
+++ b/backend/tests/test_hypotheses_router.py
@@ -1,0 +1,214 @@
+"""E1-S3: /api/v2/hypotheses 라우터 테스트.
+
+S3 고유 가치: ⓐ서비스 오류 code→HTTP status 매핑 ⓑ라우터 가드 2종(인계 — cross-project
+링크 금지 §3.7.2 / active 전이 owner·admin §3.1.7) ⓒ엔드포인트 와이어링 + dict-detail 계약.
+서비스 로직 자체는 S2(test_hypothesis_service)에서 검증됨 — 여기선 라우터 레이어만.
+"""
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.routers import hypotheses as r
+from app.schemas.hypothesis import HypothesisDraftRequest, HypothesisResponse
+from app.services.hypothesis import HypothesisServiceError
+from app.services.member_resolver import ResolvedMember
+
+ORG_ID = uuid.uuid4()
+PROJECT_ID = uuid.uuid4()
+OWNER_ID = uuid.uuid4()
+OTHER_ID = uuid.uuid4()
+HYP_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _member(mid: uuid.UUID, role: str = "member", mtype: str = "human") -> ResolvedMember:
+    return ResolvedMember(id=mid, user_id=uuid.uuid4(), name="t", type=mtype, role=role, org_id=ORG_ID)
+
+
+# ── ⓐ 오류 매핑 ────────────────────────────────────────────────────────────────
+
+def test_error_status_map_covers_service_codes():
+    expected = {
+        "HUMAN_OWNER_REQUIRED", "HUMAN_CONFIRM_REQUIRED", "INVALID_CREATE_STATUS",
+        "INVALID_STATUS", "INVALID_HYPOTHESIS_TRANSITION", "NO_VALID_FIELDS",
+        "HYPOTHESIS_NOT_FOUND", "CROSS_PROJECT_LINK_FORBIDDEN",
+    }
+    assert expected <= set(r._ERROR_STATUS)
+
+
+@pytest.mark.parametrize("code,status", [
+    ("HUMAN_OWNER_REQUIRED", 400), ("HYPOTHESIS_NOT_FOUND", 404),
+    ("INVALID_HYPOTHESIS_TRANSITION", 409), ("HUMAN_CONFIRM_REQUIRED", 403),
+    ("INVALID_CREATE_STATUS", 422), ("NO_VALID_FIELDS", 400),
+])
+def test_raise_maps_code_to_status(code, status):
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        r._raise(HypothesisServiceError(code, "msg"))
+    assert ei.value.status_code == status
+    assert ei.value.detail == {"code": code, "message": "msg"}
+
+
+def test_raise_unknown_code_defaults_400():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        r._raise(HypothesisServiceError("WHATEVER", "m"))
+    assert ei.value.status_code == 400
+
+
+# ── ⓑ active 전이 권한 가드 (§3.1.7) ──────────────────────────────────────────
+
+def test_active_authorized_owner_ok():
+    r._assert_active_authorized(_member(OWNER_ID), OWNER_ID)  # no raise
+
+
+def test_active_authorized_admin_ok():
+    r._assert_active_authorized(_member(OTHER_ID, role="admin"), OWNER_ID)
+    r._assert_active_authorized(_member(OTHER_ID, role="owner"), OWNER_ID)
+
+
+def test_active_unauthorized_non_owner_non_admin():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as ei:
+        r._assert_active_authorized(_member(OTHER_ID, role="member"), OWNER_ID)
+    assert ei.value.status_code == 403
+    assert ei.value.detail["code"] == "ACTIVE_TRANSITION_FORBIDDEN"
+
+
+# ── ⓑ cross-project 링크 가드 (§3.7.2) ────────────────────────────────────────
+
+def _session_returning(rows):
+    s = MagicMock()
+    result = MagicMock()
+    result.all = MagicMock(return_value=rows)
+    s.execute = AsyncMock(return_value=result)
+    return s
+
+
+async def test_link_same_project_ok():
+    eid = uuid.uuid4()
+    s = _session_returning([(eid, PROJECT_ID)])
+    await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])  # no raise
+
+
+async def test_link_cross_project_forbidden():
+    from fastapi import HTTPException
+    eid = uuid.uuid4()
+    s = _session_returning([(eid, uuid.uuid4())])  # 다른 project
+    with pytest.raises(HTTPException) as ei:
+        await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])
+    assert ei.value.status_code == 403
+    assert ei.value.detail["code"] == "CROSS_PROJECT_LINK_FORBIDDEN"
+
+
+async def test_link_missing_target_forbidden():
+    from fastapi import HTTPException
+    eid = uuid.uuid4()
+    s = _session_returning([])  # 대상 epic 없음(len mismatch)
+    with pytest.raises(HTTPException) as ei:
+        await r._assert_targets_same_project(s, PROJECT_ID, [eid], [])
+    assert ei.value.status_code == 403
+
+
+# ── ⓒ draft (§3.9) ────────────────────────────────────────────────────────────
+
+async def test_draft_template_no_persist():
+    from app.services.hypothesis import draft_hypothesis
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="epic", source_id=uuid.uuid4(),
+        context={"title": "신규 온보딩 플로우"}, persist=False,
+    )
+    out = await draft_hypothesis(MagicMock(), ORG_ID, _member(OWNER_ID), payload)
+    assert out.requires_confirmation is True
+    assert out.hypothesis is None  # persist=false → row 미생성
+    assert "신규 온보딩 플로우" in out.statement
+    assert out.source_snapshot["title"] == "신규 온보딩 플로우"
+    assert out.metric_definition["source"] == "manual"
+
+
+async def test_draft_persist_creates_proposed_row():
+    from app.services import hypothesis as service
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="story", source_id=uuid.uuid4(), persist=True,
+    )
+    created = _hyp_response()  # create_hypothesis는 실제로 HypothesisResponse를 반환
+    with patch.object(service, "create_hypothesis", AsyncMock(return_value=created)) as mock_create:
+        out = await service.draft_hypothesis(MagicMock(), ORG_ID, _member(OWNER_ID), payload)
+    mock_create.assert_awaited_once()
+    created_payload = mock_create.call_args.args[3]
+    assert created_payload.status == "proposed"
+    assert out.hypothesis is not None and out.hypothesis.status == "proposed"
+
+
+# ── ⓒ 엔드포인트 와이어링 + dict-detail 계약 ──────────────────────────────────
+
+def _hyp_response() -> HypothesisResponse:
+    return HypothesisResponse(
+        id=HYP_ID, org_id=ORG_ID, project_id=PROJECT_ID, owner_member_id=OWNER_ID,
+        statement="s", metric_definition={"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc), status="proposed",
+        human_accounting={}, gate_contract={},
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+
+@pytest.fixture
+def app_with_overrides(mock_session, auth_ctx):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    app.dependency_overrides[get_db] = lambda: iter([mock_session])
+    app.dependency_overrides[get_current_user] = lambda: auth_ctx
+    app.dependency_overrides[get_verified_org_id] = lambda: ORG_ID
+    yield app
+    app.dependency_overrides.clear()
+
+
+async def test_create_endpoint_happy_201(app_with_overrides):
+    from httpx import ASGITransport, AsyncClient
+    body = {
+        "project_id": str(PROJECT_ID), "statement": "s",
+        "metric_definition": {"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+        "measure_after": "2026-07-01T00:00:00+00:00", "owner_member_id": str(OWNER_ID),
+    }
+    with patch.object(r, "resolve_member", AsyncMock(return_value=_member(OWNER_ID))), \
+         patch.object(r.svc, "create_hypothesis", AsyncMock(return_value=_hyp_response())):
+        async with AsyncClient(transport=ASGITransport(app=app_with_overrides), base_url="http://t") as c:
+            resp = await c.post("/api/v2/hypotheses", json=body)
+    assert resp.status_code == 201
+    assert resp.json()["id"] == str(HYP_ID)
+
+
+async def test_create_endpoint_service_error_maps_dict_detail(app_with_overrides):
+    from httpx import ASGITransport, AsyncClient
+    body = {
+        "project_id": str(PROJECT_ID), "statement": "s",
+        "metric_definition": {"metric": "m", "source": "manual", "target": 1, "direction": "up"},
+        "measure_after": "2026-07-01T00:00:00+00:00",
+    }
+    err = HypothesisServiceError("HUMAN_OWNER_REQUIRED", "owner must be human")
+    with patch.object(r, "resolve_member", AsyncMock(return_value=_member(OWNER_ID, mtype="agent"))), \
+         patch.object(r.svc, "create_hypothesis", AsyncMock(side_effect=err)):
+        async with AsyncClient(transport=ASGITransport(app=app_with_overrides), base_url="http://t") as c:
+            resp = await c.post("/api/v2/hypotheses", json=body)
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "HUMAN_OWNER_REQUIRED"
+
+
+async def test_get_endpoint_not_found_404(app_with_overrides):
+    from httpx import ASGITransport, AsyncClient
+    err = HypothesisServiceError("HYPOTHESIS_NOT_FOUND", "없음")
+    with patch.object(r.svc, "get_hypothesis", AsyncMock(side_effect=err)):
+        async with AsyncClient(transport=ASGITransport(app=app_with_overrides), base_url="http://t") as c:
+            resp = await c.get(f"/api/v2/hypotheses/{HYP_ID}")
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "HYPOTHESIS_NOT_FOUND"


### PR DESCRIPTION
## 무엇을 (스토리 `2bff12dc` · E1-S3 · S2 #1405 머지 위)

S2 service를 **v2 라우터에 배선**(블루프린트 §3.2~§3.10). 9 엔드포인트 + main include. **성공=raw model/list · 오류=`HTTPException` dict-detail `{code,message}`** → `main.py` 핸들러가 `{data:null,error:{code,message,...},meta:null}`로 감싸는 v2 컨벤션.

## 9 엔드포인트
| 메서드 | 경로 | §  |
|---|---|---|
| POST | `/draft` (**·/{id}보다 먼저 선언** §3.9.7) | 3.9 |
| GET | `""` (list · `X-Total-Count`) | 3.2 |
| POST | `""` (create · 201) | 3.3 |
| GET | `/{id}` | 3.4 |
| PATCH | `/{id}` | 3.5 |
| POST | `/{id}/transition` | 3.6 |
| POST | `/{id}/links` | 3.7 |
| DELETE | `/{id}/links` | 3.8 |
| DELETE | `/{id}` (archive) | 3.10 |

## 라우터 레벨 가드 (S2 인계·AC⑥)
- **§3.7.2 cross-project 링크 금지**: 대상 epic/story의 project ≠ hypothesis project → **403 `CROSS_PROJECT_LINK_FORBIDDEN`**(대상 부재도 거부).
- **§3.1.7 active 전이 권한**: `owner 휴먼` 또는 `org owner/admin`만 → 아니면 403. (service의 `caller.type=='human'` 위에 라우터에서 owner·role 보강.)

## 부수
- **schemas**: `HypothesisDraftRequest/Response` 추가.
- **service**: `draft_hypothesis` — deterministic 템플릿(LLM 미연결, §3.9.5·§3.9.6 미확인이라 후속). `persist=true`면 **create 경로 재사용**해 `proposed` row만 생성. `source_snapshot`은 입력 일부만(원본 복제 금지 §2.2.8).
- 오류 code→HTTP status 매핑(`_ERROR_STATUS`): 400/403/404/409/422.
- 권한: list/create는 project 스코프 검증(`get_project_scoped_org_id`/`resolve_member(project_id)`), 그 외 org 스코프(epics 라우터 컨벤션 동형).

## 검증

- **라우터 단위 19건**: 오류 매핑(code→status·dict-detail)·**active 권한 가드**(owner/admin OK·non-owner 거부)·**cross-project 가드**(동일/타프로젝트/부재)·draft(템플릿·persist)·**엔드포인트 와이어링**(create 201·service오류→`error.code`·404 not-found). 9 라우트 등록 + `/draft` 우선순위 확인.
- pytest 수집 **1902건** 무결 · S2 service 25건 동반 통과(44/44).
- dev DB는 migrate-dev 단일 윈도우로 0113+0114 적용 완료(health 200) — 본 라우터가 라이브 스키마 위에 동작.

## AC (§9 S3 + 인계)

- [x] 9 엔드포인트 + main include
- [x] 성공=raw · 오류=dict-detail(code/message)
- [x] project gate + resolve_member
- [x] §3.7.2 cross-project 링크 금지 (인계)
- [x] §3.1.7 active 전이 owner/admin (인계)
- [x] `/draft` 라우트 선언 순서(§3.9.7)

## 리뷰

PO 오르테가군 검수 → 까심군 QA. base `develop`(S2 머지 반영).

🤖 Generated with [Claude Code](https://claude.com/claude-code)