### PR TITLE
[SID:2a72ebf4] fix(docs): fenced-code 룰이 <code>를 element children로 탐색 (가디언 노트)

### DIFF
--- a/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
+++ b/apps/web/src/components/docs/lib/content-converter.roundtrip.test.ts
@@ -93,3 +93,12 @@ describe('content-converter table cell inline preservation (AC③)', () => {
     expect(out).toContain('`y`');
   });
 });
+
+describe('content-converter fenced-code robustness (FIX-3b guardian note)', () => {
+  it('reads the language even with a whitespace node between <pre> and <code>', () => {
+    // The fence rule must find <code> via element children, not firstChild, so a stray
+    // text node between <pre> and <code> does not drop it to Turndown's default.
+    const html = '<pre data-language="ts">\n  <code class="language-ts">const x = 1;</code>\n</pre>';
+    expect(htmlToMarkdown(html)).toBe('```ts\nconst x = 1;\n```');
+  });
+});

--- a/apps/web/src/components/docs/lib/content-converter.ts
+++ b/apps/web/src/components/docs/lib/content-converter.ts
@@ -265,21 +265,25 @@ turndown.addRule('blockquote', {
 // (not <code>), so ```ts dropped to ``` on load → dirty → unsaveable code-block docs.
 // Order: <code> class (markdownToHtml output) → <pre> data-language / class (tiptap
 // getHTML + legacy). Belt-and-suspenders with the renderHTML fix in code-block-copy.tsx.
+// Find the <code> via element children rather than firstChild so a whitespace text node
+// between <pre> and <code> doesn't drop the rule to Turndown's default (디디 review note;
+// `children` is used instead of `:scope > code` which domino does not reliably support).
+const fenceCodeChild = (pre: HTMLElement): HTMLElement | null =>
+  (Array.from(pre.children).find((c) => c.nodeName === 'CODE') as HTMLElement | undefined) ?? null;
 turndown.addRule('fencedCodeBlock', {
   filter: (node) =>
     node.nodeName === 'PRE' &&
-    !!node.firstChild &&
-    node.firstChild.nodeName === 'CODE',
+    !!fenceCodeChild(node as HTMLElement),
   replacement: (_content, node) => {
     const pre = node as HTMLElement;
-    const code = pre.firstChild as HTMLElement;
+    const code = fenceCodeChild(pre);
     const langFromClass = (el: HTMLElement | null) => el?.className.match(/language-(\S+)/)?.[1] ?? null;
     const lang =
       langFromClass(code) ??
       pre.getAttribute('data-language') ??
       langFromClass(pre) ??
       '';
-    const text = (code.textContent ?? '').replace(/\n$/, '');
+    const text = (code?.textContent ?? '').replace(/\n$/, '');
     return `\n\n\`\`\`${lang}\n${text}\n\`\`\`\n\n`;
   },
 });


### PR DESCRIPTION
## 무엇을 (디디군 #1404 비차단 리뷰 노트 처리 · 소형)

FIX-3b(#1404)의 `fencedCodeBlock` Turndown 룰 견고화. `<pre>`와 `<code>` 사이에 **공백 텍스트 노드**가 있으면 `node.firstChild.nodeName === 'CODE'`가 false라 룰이 Turndown 기본으로 떨어져(=`<pre>`-only 언어 유실 가능). markdownToHtml·tiptap getHTML 둘 다 현재 그 공백을 안 내므로 **방어적**이나, 수정이 싸서 처리.

## 변경

- `<code>`를 `node.firstChild` 대신 **`pre.children`(엘리먼트 전용) 순회**로 탐색 → 공백 노드 무관. `:scope > code`는 domino 미지원 위험이라 피함(디디 노트 반영).
- 공백 노드 케이스 회귀 테스트 추가(roundtrip 스위트).

## 검증

- 변환기 roundtrip 22/22 green(신규 공백 테스트 포함)·트리오 51 green.
- `pnpm build` ✅ exit 0 · `tsc` 소스 0 · lint 0.
- 정상 인접 pre/code 동작 무변(기존 51 테스트 그대로).

🤖 Generated with [Claude Code](https://claude.com/claude-code)