### PR TITLE
[SID:ef8fe3dd] feat(hypotheses): dispatch hypothesis anchor 주입 (E1-S6 · L4)

### DIFF
--- a/backend/app/repositories/hypothesis.py
+++ b/backend/app/repositories/hypothesis.py
@@ -8,10 +8,11 @@ from __future__ import annotations
 
 import uuid
 
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.hypothesis import Hypothesis, HypothesisEpicLink, HypothesisStoryLink
+from app.models.pm import Story
 from app.repositories.base import BaseRepository
 
 
@@ -161,3 +162,57 @@ class HypothesisRepository(BaseRepository[Hypothesis]):
         for link in links:
             await self.session.delete(link)
         await self.session.flush()
+
+    # ── dispatch anchor 해소 (S6 §5.2) ──────────────────────────────────────────
+    async def _primary_via_epic(self, epic_id: uuid.UUID) -> Hypothesis | None:
+        """epic의 link_type='primary' 가설. 여럿이면 active 우선·최신 created_at 순."""
+        row = await self.session.execute(
+            select(Hypothesis)
+            .join(HypothesisEpicLink, HypothesisEpicLink.hypothesis_id == Hypothesis.id)
+            .where(
+                Hypothesis.org_id == self.org_id,
+                HypothesisEpicLink.epic_id == epic_id,
+                HypothesisEpicLink.link_type == "primary",
+            )
+            .order_by(desc(Hypothesis.status == "active"), Hypothesis.created_at.desc())
+            .limit(1)
+        )
+        return row.scalar_one_or_none()
+
+    async def _primary_via_story(self, story_id: uuid.UUID) -> Hypothesis | None:
+        row = await self.session.execute(
+            select(Hypothesis)
+            .join(HypothesisStoryLink, HypothesisStoryLink.hypothesis_id == Hypothesis.id)
+            .where(
+                Hypothesis.org_id == self.org_id,
+                HypothesisStoryLink.story_id == story_id,
+                HypothesisStoryLink.link_type == "primary",
+            )
+            .order_by(desc(Hypothesis.status == "active"), Hypothesis.created_at.desc())
+            .limit(1)
+        )
+        return row.scalar_one_or_none()
+
+    async def resolve_primary_anchor(
+        self, entity_type: str, entity_id: uuid.UUID
+    ) -> Hypothesis | None:
+        """dispatch 대상의 대표 가설(§5.2).
+
+        story: story link primary 우선 → 없으면 story의 epic primary로 fallback.
+        epic: epic link primary. doc 등 그 외: None.
+        """
+        if entity_type == "story":
+            hyp = await self._primary_via_story(entity_id)
+            if hyp is not None:
+                return hyp
+            epic_id = await self.session.scalar(
+                select(Story.epic_id).where(
+                    Story.id == entity_id, Story.org_id == self.org_id
+                )
+            )
+            if epic_id is not None:
+                return await self._primary_via_epic(epic_id)
+            return None
+        if entity_type == "epic":
+            return await self._primary_via_epic(entity_id)
+        return None

--- a/backend/app/routers/dispatch.py
+++ b/backend/app/routers/dispatch.py
@@ -141,10 +141,17 @@ async def dispatch_entity(
             )
             sender_id = om_result.scalar_one_or_none()
 
+    # E1-S6 L4: 대표 가설 anchor 주입 — epic/story dispatch면 primary hypothesis를 해소해
+    # payload(hypothesis_anchor)와 content 한 줄로 동봉(additive — 구 webhook 소비자 호환).
+    from app.services.hypothesis import format_anchor_line, resolve_dispatch_anchor
+    hypothesis_anchor = await resolve_dispatch_anchor(db, org_id, body.entity_type, body.entity_id)
+
     # E-EVENT-INJECT S1: connector(adapter.py)가 content 없는 이벤트를 드롭(if not content: return)하므로
     # dispatched에 top-level content를 부여 → 에이전트 work-turn으로 실제 주입.
     _detail = (body.message or description or "").strip()
     content = f"[{body.entity_type}] {title}" + (f" — {_detail}" if _detail else "")
+    if hypothesis_anchor is not None:
+        content += "\n" + format_anchor_line(hypothesis_anchor)
     payload = {
         "entity_type": body.entity_type,
         "entity_id": str(body.entity_id),
@@ -152,6 +159,7 @@ async def dispatch_entity(
         "description": (description or "")[:500],
         "message": body.message,
         "content": content,
+        "hypothesis_anchor": hypothesis_anchor,
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -206,6 +214,7 @@ async def dispatch_entity(
         event_type="dispatched",
         source_entity_type=body.entity_type,
         source_entity_id=body.entity_id,
+        hypothesis_anchor=hypothesis_anchor,
     )
     return DispatchResponse(
         dispatched=True,

--- a/backend/app/services/conversation_webhook.py
+++ b/backend/app/services/conversation_webhook.py
@@ -82,6 +82,7 @@ async def deliver_injected_event_webhook(
     event_type: str,
     source_entity_type: str | None = None,
     source_entity_id: uuid.UUID | None = None,
+    hypothesis_anchor: dict | None = None,
 ) -> None:
     """1f01c1ad: INJECTABLE 이벤트(dispatched/story_assigned 등)를 수신자 member webhook으로 전달.
 
@@ -131,6 +132,8 @@ async def deliver_injected_event_webhook(
         "content": content,
         "source_entity_type": source_entity_type,
         "source_entity_id": str(source_entity_id) if source_entity_id else None,
+        # E1-S6 L4: 대표 가설 anchor(additive·null default — 구 소비자 호환).
+        "hypothesis_anchor": hypothesis_anchor,
     }
 
     seen_urls: set[str] = set()

--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -329,3 +329,54 @@ async def draft_hypothesis(
         requires_confirmation=True,
         hypothesis=hyp_resp,
     )
+
+
+# ── L4: dispatch hypothesis anchor (§5) ──────────────────────────────────────
+_ANCHOR_STATEMENT_MAX = 160
+
+
+def build_anchor_dict(hyp) -> dict:
+    """§5.1.1 payload anchor — metric/target/direction은 metric_definition에서 평탄화."""
+    md = hyp.metric_definition or {}
+    return {
+        "id": str(hyp.id),
+        "statement": hyp.statement,
+        "status": hyp.status,
+        "metric": md.get("metric"),
+        "target": md.get("target"),
+        "direction": md.get("direction"),
+        "measure_after": hyp.measure_after.isoformat() if hyp.measure_after else None,
+    }
+
+
+def format_anchor_line(anchor: dict) -> str:
+    """§5.3 content 한 줄: `[hypothesis] {statement} — {metric} {direction} {target} by {date}`.
+
+    statement는 160자 truncate. metric/target/measure_after가 없으면 해당 절을 생략한다.
+    """
+    stmt = (anchor.get("statement") or "")[:_ANCHOR_STATEMENT_MAX]
+    metric = anchor.get("metric") or ""
+    direction = anchor.get("direction") or ""
+    target = anchor.get("target")
+    measure_after = anchor.get("measure_after")
+    line = f"[hypothesis] {stmt}"
+    metric_part = " ".join(str(p) for p in (metric, direction, target) if p not in (None, "")).strip()
+    if metric_part:
+        line += f" — {metric_part}"
+    if isinstance(measure_after, str) and measure_after:
+        line += f" by {measure_after[:10]}"
+    return line
+
+
+async def resolve_dispatch_anchor(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    entity_type: str,
+    entity_id: uuid.UUID,
+) -> dict | None:
+    """dispatch 대상의 대표 가설 anchor dict(§5.2). 없으면 None(에픽/스토리 외엔 항상 None)."""
+    repo = HypothesisRepository(session, org_id)
+    hyp = await repo.resolve_primary_anchor(entity_type, entity_id)
+    if hyp is None:
+        return None
+    return build_anchor_dict(hyp)

--- a/backend/tests/test_hypothesis_dispatch_anchor.py
+++ b/backend/tests/test_hypothesis_dispatch_anchor.py
@@ -1,0 +1,83 @@
+"""E1-S6: dispatch hypothesis anchor 단위 테스트 (블루프린트 §5).
+
+anchor dict 평탄화·content 한 줄 포맷(truncate/절 생략/날짜)·resolve_dispatch_anchor 위임.
+resolve_primary_anchor의 link 해소(story primary→epic fallback·active 우선·최신순) SQL은
+실 DB 스모크에서 검증.
+"""
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import hypothesis as svc
+
+HID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _hyp(**ov):
+    base = dict(
+        id=HID, statement="가입 전환율을 높인다", status="active",
+        metric_definition={"metric": "signups", "source": "manual", "target": 100, "direction": "up"},
+        measure_after=datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    base.update(ov)
+    return SimpleNamespace(**base)
+
+
+def test_build_anchor_dict_flattens_metric():
+    a = svc.build_anchor_dict(_hyp())
+    assert a == {
+        "id": str(HID), "statement": "가입 전환율을 높인다", "status": "active",
+        "metric": "signups", "target": 100, "direction": "up",
+        "measure_after": "2026-07-01T12:00:00+00:00",
+    }
+
+
+def test_build_anchor_dict_handles_empty_metric():
+    a = svc.build_anchor_dict(_hyp(metric_definition=None, measure_after=None))
+    assert a["metric"] is None and a["target"] is None and a["measure_after"] is None
+
+
+def test_format_anchor_line_full():
+    a = svc.build_anchor_dict(_hyp())
+    assert svc.format_anchor_line(a) == "[hypothesis] 가입 전환율을 높인다 — signups up 100 by 2026-07-01"
+
+
+def test_format_anchor_line_truncates_statement_160():
+    long = "x" * 200
+    line = svc.format_anchor_line(svc.build_anchor_dict(_hyp(statement=long)))
+    # [hypothesis] + 160 x's + metric part
+    assert ("x" * 160) in line and ("x" * 161) not in line
+
+
+def test_format_anchor_line_omits_missing_metric_and_date():
+    a = {"statement": "s", "metric": None, "direction": None, "target": None, "measure_after": None}
+    assert svc.format_anchor_line(a) == "[hypothesis] s"
+
+
+def test_format_anchor_line_partial_metric_no_date():
+    a = {"statement": "s", "metric": "signups", "direction": "up", "target": 50, "measure_after": None}
+    assert svc.format_anchor_line(a) == "[hypothesis] s — signups up 50"
+
+
+async def test_resolve_dispatch_anchor_returns_dict():
+    repo = MagicMock()
+    repo.resolve_primary_anchor = AsyncMock(return_value=_hyp())
+    with patch.object(svc, "HypothesisRepository", return_value=repo):
+        a = await svc.resolve_dispatch_anchor(MagicMock(), uuid.uuid4(), "story", uuid.uuid4())
+    assert a["id"] == str(HID) and a["metric"] == "signups"
+
+
+async def test_resolve_dispatch_anchor_none_when_no_primary():
+    repo = MagicMock()
+    repo.resolve_primary_anchor = AsyncMock(return_value=None)
+    with patch.object(svc, "HypothesisRepository", return_value=repo):
+        a = await svc.resolve_dispatch_anchor(MagicMock(), uuid.uuid4(), "epic", uuid.uuid4())
+    assert a is None


### PR DESCRIPTION
## 무엇을 (스토리 `ef8fe3dd` · E1-S6 · L4 기본형 · S1/S2 위)

dispatch 시 대상의 **대표 가설을 payload·content에 동봉**(블루프린트 §5). 전부 **additive JSON 필드**라 구 webhook/SSE 소비자와 호환. "가설 읽기/쓰기부터"라는 백서 L4 원칙.

## 해소 (`repositories/hypothesis.py: resolve_primary_anchor`)

- **story** dispatch: `hypothesis_story_links` `link_type='primary'` 우선 → 없으면 **story의 epic primary로 fallback**. **epic** dispatch: `hypothesis_epic_links` primary. 그 외(doc 등): None.
- 여럿이면 **active 우선·최신 `created_at` 순**(`order by (status='active') desc, created_at desc`).

## 주입 (`routers/dispatch.py`)

- `_fetch_entity` 후 `resolve_dispatch_anchor` → `payload["hypothesis_anchor"]` = `{id, statement, status, metric, target, direction, measure_after}` | null.
- `content`에 한 줄 추가: `[hypothesis] {statement} — {metric} {direction} {target} by {date}` (statement 160 truncate·절 없으면 생략). content가 Event payload·webhook 양쪽으로 흐른다.
- `deliver_injected_event_webhook`(`conversation_webhook.py`)에 `hypothesis_anchor` optional param + payload 필드(null default) → **CC 릴레이 경로에도 anchor 도달**.

## 검증

- **단위 8건**: anchor dict 평탄화·content 포맷(full / 160 truncate / 절 생략 / 부분 / 날짜)·`resolve_dispatch_anchor` 위임(dict/None).
- **`resolve_primary_anchor` 실 DB 스모크**(`pgvector/pgvector:pg16`) 6종: ①story-primary 우선 ②story-link가 epic fallback에 우선 ③무링크·무에픽→None ④story→epic fallback(active 반환) ⑤epic active-우선(proposed보다) ⑥doc→None.
- app import 정상 · pytest 수집 1891 무결.

## AC (§9 S6)

- [x] primary hypothesis resolution (story links 우선 → epic fallback · active 우선 · 최신순)
- [x] payload `hypothesis_anchor` 필드 (기존 payload 유지)
- [x] content 한 줄 포함
- [x] webhook optional 필드 (additive)

## 리뷰

PO 오르테가군 검수 → 까심군 QA. base `develop`. S1/S2 위(머지됨)·S3와 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)