### PR TITLE
[SID:fd23185a] feat(hypotheses): Hypothesis scorer 최소형 + score-hypotheses cron (E1-S4)

### DIFF
--- a/backend/app/routers/cron.py
+++ b/backend/app/routers/cron.py
@@ -301,3 +301,29 @@ async def score_ga4_outcomes(
     except Exception as exc:
         logger.exception("cron error: %s", exc)
         return _err("INTERNAL_ERROR", "Internal server error", 500)
+
+
+# ─── POST /api/v2/internal/cron/score-hypotheses ──────────────────────────────
+
+@router.post("/score-hypotheses")
+async def score_hypotheses_cron(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+) -> JSONResponse:
+    """E1-S4: Hypothesis 지연 채점 잡(블루프린트 §8.3).
+
+    measure_after <= now 인 active/measuring 가설을 채점 — active→measuring 전이 후
+    ga4/internal_ops 지표로 verified|falsified 판정(실패·미지원은 measuring 유지). legacy
+    /score-ga4-outcomes와 분리(hypotheses 테이블만). 스케줄 배선은 별도 운영 story.
+    """
+    verify_cron(request)
+
+    from app.services.hypothesis_scorer import score_hypotheses
+
+    try:
+        summary = await score_hypotheses(session)
+        await session.commit()
+        return _ok(summary)
+    except Exception as exc:
+        logger.exception("score-hypotheses cron error: %s", exc)
+        return _err("INTERNAL_ERROR", "Internal server error", 500)

--- a/backend/app/services/hypothesis_scorer.py
+++ b/backend/app/services/hypothesis_scorer.py
@@ -1,0 +1,113 @@
+"""E1-S4: Hypothesis scorer 최소형 (블루프린트 §8.3·§2.5).
+
+measure_after가 도래한 가설을 채점한다. legacy outcome_scorer(sprint/story/epic)와
+완전히 분리 — 본 서비스는 hypotheses 테이블만 건드린다.
+
+상태 전이(§2.5):
+    active → measuring   (measure_after <= now, 채점 대상 진입)
+    measuring → verified (지표가 임계값 통과 = hit)
+    measuring → falsified(통과 못 함 = miss)
+    measuring 유지       (GA4 인증불가·데이터없음·회수실패·미지원 source = pending)
+
+지표 채점은 legacy helper를 재사용한다(§8.3.2):
+    source='ga4'          → score_ga4_outcome (GA4 Data API)
+    source='internal_ops' (metric=completion_pct) → 링크된 스토리 완료율 → score_epic_outcome
+    그 외(manual 등)       → 자동 채점 안 함(§10.4), measuring 유지.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.hypothesis import Hypothesis, HypothesisStoryLink
+from app.models.pm import Story
+from app.services.outcome_scorer import score_epic_outcome, score_ga4_outcome
+
+logger = logging.getLogger(__name__)
+
+# outcome_scorer의 hit/miss → hypothesis lifecycle 상태.
+_OUTCOME_TO_STATUS = {"hit": "verified", "miss": "falsified"}
+
+
+async def _linked_story_completion_pct(session: AsyncSession, hypothesis_id) -> float:
+    """internal_ops completion_pct — 가설에 링크된 스토리의 done 비율(%)."""
+    rows = (await session.execute(
+        select(Story.status)
+        .join(HypothesisStoryLink, HypothesisStoryLink.story_id == Story.id)
+        .where(
+            HypothesisStoryLink.hypothesis_id == hypothesis_id,
+            Story.deleted_at.is_(None),
+        )
+    )).scalars().all()
+    total = len(rows)
+    done = sum(1 for s in rows if s == "done")
+    return round((done / total * 100) if total > 0 else 0.0, 2)
+
+
+def _score_metric(scoring_source: str | None) -> bool:
+    return scoring_source in ("ga4", "internal_ops")
+
+
+async def score_hypotheses(session: AsyncSession) -> dict[str, Any]:
+    """measure_after 도래 가설을 채점. 반환은 카운트/목록(관측 정직성).
+
+    active는 먼저 measuring으로 전이한 뒤 같은 패스에서 채점한다(hit/miss면 verified/falsified,
+    아니면 measuring 유지). 호출자(cron route)가 commit한다.
+    """
+    now = datetime.now(timezone.utc)
+    to_measuring: list[str] = []
+    verified: list[str] = []
+    falsified: list[str] = []
+    pending: list[str] = []
+    failed: list[dict] = []
+
+    hyps = (await session.execute(
+        select(Hypothesis).where(
+            Hypothesis.measure_after <= now,
+            Hypothesis.status.in_(["active", "measuring"]),
+        )
+    )).scalars().all()
+
+    for hyp in hyps:
+        # active → measuring (measure_after 도래)
+        if hyp.status == "active":
+            hyp.status = "measuring"
+            to_measuring.append(str(hyp.id))
+
+        md = hyp.metric_definition or {}
+        source = md.get("source")
+        try:
+            if source == "ga4":
+                scoring = score_ga4_outcome(md)
+            elif source == "internal_ops":
+                pct = await _linked_story_completion_pct(session, hyp.id)
+                result = score_epic_outcome(md, pct)
+                scoring = result if result is not None else {"outcome_status": "pending", "outcome_result": None}
+            else:
+                # manual·미지원 source → 자동 채점 금지(거짓 신호 차단). measuring 유지.
+                scoring = {"outcome_status": "pending", "outcome_result": None}
+        except Exception as exc:  # GA4 회수 등 실패 → measuring 유지(위장 금지)
+            logger.warning("hypothesis scoring failed id=%s: %s", hyp.id, exc)
+            failed.append({"id": str(hyp.id), "error": str(exc)})
+            continue
+
+        new_status = _OUTCOME_TO_STATUS.get(scoring["outcome_status"])
+        if new_status is not None:
+            hyp.status = new_status
+            hyp.outcome_result = scoring["outcome_result"]
+            (verified if new_status == "verified" else falsified).append(str(hyp.id))
+        else:
+            pending.append(str(hyp.id))  # measuring 유지
+
+    return {
+        "to_measuring": to_measuring,
+        "verified": verified,
+        "falsified": falsified,
+        "pending": pending,
+        "failed": failed,
+        "total": len(hyps),
+    }

--- a/backend/tests/test_hypothesis_scorer.py
+++ b/backend/tests/test_hypothesis_scorer.py
@@ -1,0 +1,120 @@
+"""E1-S4: Hypothesis scorer 단위 테스트 (블루프린트 §8.3·§2.5).
+
+핵심 불변식: active→measuring(measure_after 도래)→verified/falsified(hit/miss)·GA4 실패/미지원
+source는 measuring 유지(거짓 신호 차단)·legacy outcome_scorer 무영향(hypotheses 테이블만).
+"""
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import hypothesis_scorer as sc
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _hyp(status="active", source="ga4", **ov):
+    md = {"metric": "signups", "source": source, "target": 100, "direction": "up"}
+    base = dict(
+        id=uuid.uuid4(), status=status, metric_definition=md,
+        measure_after=datetime(2026, 1, 1, tzinfo=timezone.utc), outcome_result=None,
+    )
+    base.update(ov)
+    return SimpleNamespace(**base)
+
+
+def _result(items):
+    r = MagicMock()
+    r.scalars.return_value.all.return_value = items
+    return r
+
+
+def _session(execute_results):
+    s = AsyncMock()
+    s.execute = AsyncMock(side_effect=execute_results)
+    s.commit = AsyncMock()
+    return s
+
+
+async def _run(hyps, *, ga4=None, epic=None, story_statuses=None):
+    # 첫 execute = hyps 목록. internal_ops면 두 번째 execute = 링크 스토리 상태.
+    results = [_result(hyps)]
+    if story_statuses is not None:
+        results.append(_result(story_statuses))
+    session = _session(results)
+    patches = []
+    if ga4 is not None:
+        patches.append(patch.object(sc, "score_ga4_outcome", side_effect=ga4 if callable(ga4) else MagicMock(return_value=ga4)))
+    if epic is not None:
+        patches.append(patch.object(sc, "score_epic_outcome", MagicMock(return_value=epic)))
+    for p in patches:
+        p.start()
+    try:
+        return await sc.score_hypotheses(session)
+    finally:
+        for p in patches:
+            p.stop()
+
+
+async def test_active_ga4_hit_to_verified():
+    h = _hyp(status="active", source="ga4")
+    summary = await _run([h], ga4={"outcome_status": "hit", "outcome_result": {"actual": 120}})
+    assert h.status == "verified" and h.outcome_result == {"actual": 120}
+    assert str(h.id) in summary["to_measuring"] and str(h.id) in summary["verified"]
+
+
+async def test_active_ga4_miss_to_falsified():
+    h = _hyp(status="active", source="ga4")
+    summary = await _run([h], ga4={"outcome_status": "miss", "outcome_result": {"actual": 10}})
+    assert h.status == "falsified"
+    assert str(h.id) in summary["falsified"]
+
+
+async def test_active_ga4_pending_stays_measuring():
+    h = _hyp(status="active", source="ga4")
+    summary = await _run([h], ga4={"outcome_status": "pending", "outcome_result": None})
+    assert h.status == "measuring"  # active→measuring, 채점은 pending이라 유지
+    assert str(h.id) in summary["to_measuring"] and str(h.id) in summary["pending"]
+
+
+async def test_measuring_ga4_hit_no_double_to_measuring():
+    h = _hyp(status="measuring", source="ga4")
+    summary = await _run([h], ga4={"outcome_status": "hit", "outcome_result": {}})
+    assert h.status == "verified"
+    assert str(h.id) not in summary["to_measuring"]  # 이미 measuring
+    assert str(h.id) in summary["verified"]
+
+
+async def test_manual_source_stays_measuring():
+    h = _hyp(status="active", source="manual")
+    summary = await _run([h])  # ga4 미패치 — manual은 호출 안 함
+    assert h.status == "measuring"
+    assert str(h.id) in summary["pending"]
+
+
+async def test_ga4_exception_keeps_measuring_and_records_failed():
+    h = _hyp(status="active", source="ga4")
+    def boom(_md):
+        raise RuntimeError("GA4 회수 실패")
+    summary = await _run([h], ga4=boom)
+    assert h.status == "measuring"  # 위장 금지 — 실패는 verified/falsified로 안 떨어뜨림
+    assert summary["failed"] and summary["failed"][0]["id"] == str(h.id)
+
+
+async def test_internal_ops_completion_scores_via_epic_helper():
+    h = _hyp(status="active", source="internal_ops",
+             metric_definition={"metric": "completion_pct", "source": "internal_ops", "target": 80, "direction": "up"})
+    # 링크 스토리 3개 중 2 done → pct 계산은 실DB 스모크에서, 여기선 epic helper 반환만 검증
+    summary = await _run([h], story_statuses=["done", "done", "backlog"],
+                         epic={"outcome_status": "hit", "outcome_result": {"actual": 66.67}})
+    assert h.status == "verified"
+    assert str(h.id) in summary["verified"]
+
+
+def test_outcome_to_status_mapping():
+    assert sc._OUTCOME_TO_STATUS == {"hit": "verified", "miss": "falsified"}


### PR DESCRIPTION
## 무엇을 (스토리 `fd23185a` · E1-S4 · S1/S2 위)

measure_after가 도래한 가설을 채점하는 **scorer + internal cron route**(블루프린트 §8.3·§2.5). **legacy `outcome_scorer`(sprint/story/epic)와 완전 분리** — 본 경로는 `hypotheses` 테이블만 건드린다(무영향).

## scorer (`services/hypothesis_scorer.py: score_hypotheses`)

- `measure_after<=now` · `status∈(active,measuring)` 조회. **active는 먼저 `measuring` 전이**(§2.5.3) 후 같은 패스에서 채점.
- 지표 채점은 **legacy helper 재사용**(§8.3.2):
  - `source='ga4'` → `score_ga4_outcome` (GA4 Data API)
  - `source='internal_ops'`(metric=completion_pct) → **링크 스토리 done 비율** → `score_epic_outcome`
  - `manual`·미지원 → 자동 채점 안 함(§10.4)
- **hit→verified · miss→falsified** · 그 외(GA4 인증불가/데이터없음/회수실패/pending) → **`measuring` 유지**(거짓 신호 차단·관측 정직성). 예외도 measuring 유지 + `failed` 기록.

## cron (`routers/cron.py: POST /api/v2/internal/cron/score-hypotheses`)

- `verify_cron` + `score_hypotheses` + commit. 기존 `/score-ga4-outcomes`는 **legacy로 유지**(무영향). 스케줄 배선은 별도 운영 story(§8.3.3 — route까지만).

## 검증

- **단위 8건**: active→ga4 `hit`/`miss`/`pending` · measuring 무중복 `to_measuring` · manual 유지 · **GA4 예외 시 measuring 유지 + failed**(위장 금지) · internal_ops `score_epic_outcome` 경유 · 매핑.
- **실 DB 스모크**(`pgvector/pgvector:pg16`) 5종: ①ga4 due active→verified ②future 미조회(active 유지) ③manual due→measuring ④internal_ops **실 완료율(2/3=66.67%≥50)→verified** ⑤proposed 미조회.
- app import · `/score-hypotheses` route 등록 · pytest 수집 무결.

## AC (§9 S4)

- [x] measure_after 도래 active→measuring→verified/falsified
- [x] GA4 실패 시 measuring 유지(pending semantics)
- [x] legacy scorer 무영향(hypotheses 테이블만)
- [x] score_hypotheses service + internal cron route

## 리뷰

PO 오르테가군 검수 → 까심군 QA. base `develop`. S1/S2 위·S3/S6과 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)