### PR TITLE
[SID:731c3f25] feat(hypotheses): FE 4층 등록 (shared·core·storage-api·service)

### DIFF
--- a/apps/web/src/lib/storage/factory.ts
+++ b/apps/web/src/lib/storage/factory.ts
@@ -12,6 +12,7 @@ import type {
   IAgentRunRepository,
   IAgentApiKeyRepository,
   IInboxItemRepository,
+  IHypothesisRepository,
 } from '@sprintable/core-storage';
 
 async function getSpAt(): Promise<string> {
@@ -39,6 +40,11 @@ export async function createEpicRepository(): Promise<IEpicRepository> {
 export async function createStoryRepository(): Promise<IStoryRepository> {
   const { ApiStoryRepository } = await import('@sprintable/storage-api');
   return new ApiStoryRepository(await getSpAt());
+}
+
+export async function createHypothesisRepository(): Promise<IHypothesisRepository> {
+  const { ApiHypothesisRepository } = await import('@sprintable/storage-api');
+  return new ApiHypothesisRepository(await getSpAt());
 }
 
 export async function createTaskRepository(): Promise<ITaskRepository> {

--- a/apps/web/src/services/hypothesis.ts
+++ b/apps/web/src/services/hypothesis.ts
@@ -1,0 +1,84 @@
+import type {
+  IHypothesisRepository,
+  CreateHypothesisInput,
+  UpdateHypothesisInput,
+  HypothesisListFilters,
+  HypothesisTransitionInput,
+  HypothesisLinkInput,
+  HypothesisUnlinkInput,
+  HypothesisDraftInput,
+} from '@sprintable/core-storage';
+import { ApiHypothesisRepository } from '@sprintable/storage-api';
+import { NotFoundError } from './sprint';
+
+export type { CreateHypothesisInput, UpdateHypothesisInput };
+
+export class HypothesisService {
+  private readonly repo: IHypothesisRepository;
+
+  constructor(repo: IHypothesisRepository) {
+    this.repo = repo;
+  }
+
+  static fromToken(accessToken: string): HypothesisService {
+    return new HypothesisService(new ApiHypothesisRepository(accessToken));
+  }
+
+  async list(filters: HypothesisListFilters) {
+    if (!filters.project_id) throw new Error('project_id is required');
+    return this.repo.list(filters);
+  }
+
+  async create(input: CreateHypothesisInput) {
+    if (!input.project_id) throw new Error('project_id is required');
+    if (!input.statement?.trim()) throw new Error('statement is required');
+    return this.repo.create(input);
+  }
+
+  async getById(id: string) {
+    try {
+      return await this.repo.getById(id);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'NotFoundError') throw new NotFoundError('Hypothesis not found');
+      throw err;
+    }
+  }
+
+  /**
+   * AC①: ALLOWED_FIELDS는 shared `updateHypothesisSchema`·core `UpdateHypothesisInput`과
+   * 1:1로 동기화한다. `status`/`outcome_result`는 transition endpoint 전용이라 절대 통과
+   * 금지 — zod가 strip하더라도 서비스 레이어가 다시 걸러 silent strip 함정을 차단한다.
+   */
+  async update(id: string, input: UpdateHypothesisInput) {
+    const ALLOWED_FIELDS: (keyof UpdateHypothesisInput)[] = [
+      'statement', 'metric_definition', 'measure_after',
+      'owner_member_id', 'confidence', 'draft_metadata', 'human_accounting',
+    ];
+    const sanitized: Record<string, unknown> = {};
+    for (const key of ALLOWED_FIELDS) {
+      if (key in input) sanitized[key] = input[key];
+    }
+    if (Object.keys(sanitized).length === 0) throw new Error('No valid fields to update');
+    return this.repo.update(id, sanitized as UpdateHypothesisInput);
+  }
+
+  async transition(id: string, input: HypothesisTransitionInput) {
+    return this.repo.transition(id, input);
+  }
+
+  async link(id: string, input: HypothesisLinkInput) {
+    return this.repo.link(id, input);
+  }
+
+  async unlink(id: string, input: HypothesisUnlinkInput) {
+    return this.repo.unlink(id, input);
+  }
+
+  async archive(id: string) {
+    return this.repo.archive(id);
+  }
+
+  async draft(input: HypothesisDraftInput) {
+    return this.repo.draft(input);
+  }
+}

--- a/packages/core-storage/src/index.ts
+++ b/packages/core-storage/src/index.ts
@@ -22,6 +22,21 @@ export type {
 } from './interfaces/IStoryRepository';
 
 export type {
+  IHypothesisRepository,
+  Hypothesis,
+  HypothesisStatus,
+  CreateHypothesisInput,
+  UpdateHypothesisInput,
+  HypothesisTransitionInput,
+  HypothesisLinkInput,
+  HypothesisUnlinkInput,
+  HypothesisDraftInput,
+  HypothesisDraft,
+  HypothesisListFilters,
+} from './interfaces/IHypothesisRepository';
+export { HYPOTHESIS_STATUSES } from './interfaces/IHypothesisRepository';
+
+export type {
   ITaskRepository,
   Task,
   CreateTaskInput,

--- a/packages/core-storage/src/interfaces/IHypothesisRepository.ts
+++ b/packages/core-storage/src/interfaces/IHypothesisRepository.ts
@@ -1,0 +1,116 @@
+import type { PaginationOptions } from '../types';
+import type { RepositoryScopeContext } from './IEpicRepository';
+import type { MetricDefinition } from './outcome';
+
+// §2.5 상태 7종 (BE HYPOTHESIS_STATUSES와 동기).
+export const HYPOTHESIS_STATUSES = [
+  'proposed', 'active', 'measuring', 'verified', 'falsified', 'killed', 'archived',
+] as const;
+export type HypothesisStatus = (typeof HYPOTHESIS_STATUSES)[number];
+
+export interface Hypothesis {
+  id: string;
+  org_id: string;
+  project_id: string;
+  owner_member_id: string;
+  created_by_member_id: string | null;
+  confirmed_by_member_id: string | null;
+  statement: string;
+  metric_definition: MetricDefinition;
+  measure_after: string;
+  status: HypothesisStatus;
+  outcome_result: Record<string, unknown> | null;
+  confidence: number | null;
+  source_type: string | null;
+  source_id: string | null;
+  human_accounting: Record<string, unknown>;
+  gate_contract: Record<string, unknown>;
+  epic_ids: string[];
+  story_ids: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateHypothesisInput {
+  project_id: string;
+  statement: string;
+  metric_definition: MetricDefinition;
+  measure_after: string;
+  owner_member_id?: string | null;
+  status?: HypothesisStatus;
+  epic_ids?: string[];
+  story_ids?: string[];
+  source_type?: string | null;
+  source_id?: string | null;
+  draft_metadata?: Record<string, unknown> | null;
+}
+
+/**
+ * §3.5 update allowlist — `status`/`outcome_result`는 transition endpoint 전용이라
+ * 절대 포함하지 않는다. 이 타입·shared `updateHypothesisSchema`·`HypothesisService`의
+ * ALLOWED_FIELDS 세 곳이 1:1로 동기화되어야 silent strip 함정이 없다 (E1-S7 AC①).
+ */
+export interface UpdateHypothesisInput {
+  statement?: string;
+  metric_definition?: MetricDefinition;
+  measure_after?: string;
+  owner_member_id?: string | null;
+  confidence?: number | null;
+  draft_metadata?: Record<string, unknown> | null;
+  human_accounting?: Record<string, unknown> | null;
+}
+
+export interface HypothesisTransitionInput {
+  status: HypothesisStatus;
+  note?: string | null;
+  outcome_result?: Record<string, unknown> | null;
+}
+
+export interface HypothesisLinkInput {
+  epic_ids?: string[];
+  story_ids?: string[];
+  link_type?: string | null;
+}
+
+export interface HypothesisUnlinkInput {
+  epic_ids?: string[];
+  story_ids?: string[];
+}
+
+export interface HypothesisDraftInput {
+  project_id: string;
+  source_type: string;
+  source_id: string;
+  context?: Record<string, unknown> | null;
+}
+
+export interface HypothesisDraft {
+  statement: string;
+  metric_definition: MetricDefinition;
+  measure_after: string;
+  source_snapshot: Record<string, unknown>;
+  confidence: number | null;
+  requires_confirmation: boolean;
+  /** persist=true(=hypothesis row 생성)일 때만 채워진다. */
+  hypothesis: Hypothesis | null;
+}
+
+export interface HypothesisListFilters extends PaginationOptions {
+  project_id: string;
+  epic_id?: string | null;
+  story_id?: string | null;
+  status?: HypothesisStatus | null;
+  owner_member_id?: string | null;
+}
+
+export interface IHypothesisRepository {
+  list(filters: HypothesisListFilters): Promise<Hypothesis[]>;
+  create(input: CreateHypothesisInput): Promise<Hypothesis>;
+  getById(id: string, scope?: RepositoryScopeContext): Promise<Hypothesis>;
+  update(id: string, input: UpdateHypothesisInput): Promise<Hypothesis>;
+  transition(id: string, input: HypothesisTransitionInput): Promise<Hypothesis>;
+  link(id: string, input: HypothesisLinkInput): Promise<Hypothesis>;
+  unlink(id: string, input: HypothesisUnlinkInput): Promise<Hypothesis>;
+  archive(id: string): Promise<void>;
+  draft(input: HypothesisDraftInput): Promise<HypothesisDraft>;
+}

--- a/packages/shared/src/schemas/hypotheses.ts
+++ b/packages/shared/src/schemas/hypotheses.ts
@@ -1,0 +1,67 @@
+import { z } from 'zod/v4';
+import { metricDefinitionSchema } from './outcome';
+
+// §2.5 상태 7종 (BE HYPOTHESIS_STATUSES와 동기).
+export const HYPOTHESIS_STATUSES = [
+  'proposed', 'active', 'measuring', 'verified', 'falsified', 'killed', 'archived',
+] as const;
+// transition endpoint가 허용하는 목표 상태(생성 시 proposed는 별도).
+export const HYPOTHESIS_TRANSITION_TARGETS = [
+  'active', 'measuring', 'verified', 'falsified', 'killed', 'archived',
+] as const;
+export const HYPOTHESIS_LINK_TYPES = ['primary', 'supports'] as const;
+
+const hypothesisStatusEnum = z.enum(HYPOTHESIS_STATUSES);
+
+export const createHypothesisSchema = z.object({
+  project_id: z.string().min(1),
+  statement: z.string().min(1),
+  metric_definition: metricDefinitionSchema,
+  measure_after: z.string().datetime(),
+  owner_member_id: z.string().optional().nullable(),
+  status: hypothesisStatusEnum.optional(),
+  epic_ids: z.array(z.string()).optional(),
+  story_ids: z.array(z.string()).optional(),
+  source_type: z.string().optional().nullable(),
+  source_id: z.string().optional().nullable(),
+  draft_metadata: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+/**
+ * §3.5 update allowlist — `status`/`outcome_result`는 transition endpoint 전용이라 제외.
+ * 이 스키마 키는 `HypothesisService.update`의 ALLOWED_FIELDS·core `UpdateHypothesisInput`과
+ * 1:1 동기화되어야 한다 (E1-S7 AC① — silent strip 함정 방지).
+ */
+export const updateHypothesisSchema = z.object({
+  statement: z.string().min(1).optional(),
+  metric_definition: metricDefinitionSchema.optional(),
+  measure_after: z.string().datetime().optional(),
+  owner_member_id: z.string().optional().nullable(),
+  confidence: z.number().optional().nullable(),
+  draft_metadata: z.record(z.string(), z.unknown()).optional().nullable(),
+  human_accounting: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+export const transitionHypothesisSchema = z.object({
+  status: z.enum(HYPOTHESIS_TRANSITION_TARGETS),
+  note: z.string().optional().nullable(),
+  outcome_result: z.record(z.string(), z.unknown()).optional().nullable(),
+});
+
+export const linkHypothesisSchema = z.object({
+  epic_ids: z.array(z.string()).optional(),
+  story_ids: z.array(z.string()).optional(),
+  link_type: z.enum(HYPOTHESIS_LINK_TYPES).optional().nullable(),
+});
+
+export const unlinkHypothesisSchema = z.object({
+  epic_ids: z.array(z.string()).optional(),
+  story_ids: z.array(z.string()).optional(),
+});
+
+export const draftHypothesisSchema = z.object({
+  project_id: z.string().min(1),
+  source_type: z.string().min(1),
+  source_id: z.string().min(1),
+  context: z.record(z.string(), z.unknown()).optional().nullable(),
+});

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -132,6 +132,17 @@ export const updateSprintSchema = z.object({
 
 // ─── Story ───────────────────────────────────
 export { createStorySchema, updateStorySchema, bulkUpdateStoriesSchema as bulkUpdateStorySchema, VALID_STORY_TRANSITIONS, STORY_STATUSES, STORY_PRIORITIES, STORY_SP_VALUES } from './stories';
+export {
+  createHypothesisSchema,
+  updateHypothesisSchema,
+  transitionHypothesisSchema,
+  linkHypothesisSchema,
+  unlinkHypothesisSchema,
+  draftHypothesisSchema,
+  HYPOTHESIS_STATUSES,
+  HYPOTHESIS_TRANSITION_TARGETS,
+  HYPOTHESIS_LINK_TYPES,
+} from './hypotheses';
 
 // ─── Task ────────────────────────────────────
 export const TASK_STATUSES = ['todo', 'in-progress', 'done'] as const;

--- a/packages/storage-api/src/ApiHypothesisRepository.ts
+++ b/packages/storage-api/src/ApiHypothesisRepository.ts
@@ -1,0 +1,75 @@
+import type {
+  IHypothesisRepository,
+  Hypothesis,
+  CreateHypothesisInput,
+  UpdateHypothesisInput,
+  HypothesisListFilters,
+  HypothesisTransitionInput,
+  HypothesisLinkInput,
+  HypothesisUnlinkInput,
+  HypothesisDraftInput,
+  HypothesisDraft,
+  RepositoryScopeContext,
+} from '@sprintable/core-storage';
+import { fastapiCall } from './utils';
+
+/**
+ * Hypothesis repository — FastAPI BE(/api/v2/hypotheses)에 `fastapiCall`로 직타한다.
+ *
+ * ⚠️ Api* 명명(Supabase* 아님): Supabase 클라이언트 미사용. 기존 레포지토리의 "Supabase*"
+ * 명명은 미스리딩 레거시(내용물은 이미 fastapiCall)이며 신규는 Api* 명명만 쓴다.
+ *
+ * envelope 경계(E1-S7 AC③ · fc4d4264 교훈): BE는 성공 시 **raw model/list**를 반환한다
+ * (블루프린트 §3.1/§3.5). `fastapiCall`은 그 raw 바디(`res.json()`)를 그대로 돌려주므로
+ * **이 레이어에는 `{data}` envelope가 없다** — Next proxy가 라우트에서 다시 감쌀 때만
+ * `{data}`가 생기며 그건 이 레이어 밖이다. 소비부는 항상 raw로 다룬다.
+ */
+export class ApiHypothesisRepository implements IHypothesisRepository {
+  constructor(private readonly accessToken: string = '') {}
+
+  async list(filters: HypothesisListFilters): Promise<Hypothesis[]> {
+    return fastapiCall<Hypothesis[]>('GET', '/api/v2/hypotheses', this.accessToken, {
+      query: {
+        project_id: filters.project_id,
+        epic_id: filters.epic_id,
+        story_id: filters.story_id,
+        status: filters.status,
+        owner_member_id: filters.owner_member_id,
+        limit: filters.limit,
+        cursor: filters.cursor,
+      },
+    });
+  }
+
+  async create(input: CreateHypothesisInput): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('POST', '/api/v2/hypotheses', this.accessToken, { body: input });
+  }
+
+  async getById(id: string, _scope?: RepositoryScopeContext): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('GET', `/api/v2/hypotheses/${id}`, this.accessToken);
+  }
+
+  async update(id: string, input: UpdateHypothesisInput): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('PATCH', `/api/v2/hypotheses/${id}`, this.accessToken, { body: input });
+  }
+
+  async transition(id: string, input: HypothesisTransitionInput): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('POST', `/api/v2/hypotheses/${id}/transition`, this.accessToken, { body: input });
+  }
+
+  async link(id: string, input: HypothesisLinkInput): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('POST', `/api/v2/hypotheses/${id}/links`, this.accessToken, { body: input });
+  }
+
+  async unlink(id: string, input: HypothesisUnlinkInput): Promise<Hypothesis> {
+    return fastapiCall<Hypothesis>('DELETE', `/api/v2/hypotheses/${id}/links`, this.accessToken, { body: input });
+  }
+
+  async archive(id: string): Promise<void> {
+    await fastapiCall<void>('DELETE', `/api/v2/hypotheses/${id}`, this.accessToken);
+  }
+
+  async draft(input: HypothesisDraftInput): Promise<HypothesisDraft> {
+    return fastapiCall<HypothesisDraft>('POST', '/api/v2/hypotheses/draft', this.accessToken, { body: input });
+  }
+}

--- a/packages/storage-api/src/index.ts
+++ b/packages/storage-api/src/index.ts
@@ -9,6 +9,9 @@ export { SupabaseNotificationRepository } from './SupabaseNotificationRepository
 export { SupabaseTeamMemberRepository } from './SupabaseTeamMemberRepository';
 export { SupabaseInboxItemRepository } from './SupabaseInboxItemRepository';
 
+// Api* 명명 신규(Supabase* 레거시 alias 없음): hypotheses FastAPI 직타 레포지토리 (E1-S7).
+export { ApiHypothesisRepository } from './ApiHypothesisRepository';
+
 // Alias: supabase 없는 이름으로 re-export
 export { SupabaseEpicRepository as ApiEpicRepository } from './SupabaseEpicRepository';
 export { SupabaseStoryRepository as ApiStoryRepository } from './SupabaseStoryRepository';


### PR DESCRIPTION
## 무엇을 (스토리 `E1-S7 731c3f25` · high · 의존 S3=#1408 머지됨)

S3가 확정한 `/api/v2/hypotheses` 계약(라우터 9종·성공 raw·오류 dict-detail)의 **FE 소비 기반 4층을 동시 등록**(블루프린트 §6.1 — stale schema 재발 방지).

## 4층

1. **shared** `packages/shared/src/schemas/hypotheses.ts`(+index export): zod create/update/transition/link/unlink/draft. `updateHypothesisSchema`는 §3.5 allowlist대로 **status/outcome_result 제외**(전이 전용).
2. **core-storage** `IHypothesisRepository`(+index): `Hypothesis` 엔티티 + 입력 타입 + 9-메서드 인터페이스.
3. **storage-api** `ApiHypothesisRepository`(+index): **Api\* 명명·`fastapiCall` 직타·Supabase 클라이언트 금지**(기존 Supabase* 명명은 미스리딩 레거시). 클래스 docstring에 **envelope 경계 명시** — BE 성공=raw(§3.1/§3.5)·`fastapiCall`이 bare 엔티티 반환·이 레이어엔 `{data}` 없음(Next proxy 재래핑 시에만 생기며 범위 밖).
4. **service** `apps/web/src/services/hypothesis.ts`(+factory `createHypothesisRepository`): `HypothesisService.update`의 `ALLOWED_FIELDS`를 zod update 스키마·core `UpdateHypothesisInput`과 **1:1 동기** → status/outcome_result 통과 불가.

## AC 매핑

- **①** create/update zod ↔ service allowlist ↔ core 타입 3곳 1:1 동기(silent strip 0 · 3-place-gate 클래스).
- **②** 4층 동시 등록(stale schema 함정 차단).
- **③** 성공 raw vs `{data}` 경계 **명시 처리**(ApiHypothesisRepository docstring·소비부 raw 고정 — fc4d4264 교훈).
- **④** 빌드·기존 테스트 무회귀.

## 검증

- **full turbo build** ✅ `5 successful, 5 total`·web ✓ Compiled.
- 패키지+서비스 테스트 ✅ 90 + 273 green · apps/web `tsc` 0 errors · apps/web 변경분 lint 0.
- 본 스토리 범위=4층 등록. Next API route(§6.1.7)는 별도 스토리.

## 비고

⚠️ pnpm-workspace 특성상 cross-package 변경은 worktree에 `pnpm install` 후 turbo build로 검증(단독 tsc는 root node_modules의 stale 심링크를 봐서 오탐). CI clean install에선 정상.

🤖 Generated with [Claude Code](https://claude.com/claude-code)