### PR TITLE
[P0] fix(test): dispatch reason 테스트 anchor 격리 — develop pytest RED 복구

### DIFF
--- a/backend/tests/test_dispatch_reason_7f8066a3.py
+++ b/backend/tests/test_dispatch_reason_7f8066a3.py
@@ -106,10 +106,14 @@ async def test_dispatch_success_reason_ok():
     try:
         with patch("app.routers.dispatch._fetch_entity", new_callable=AsyncMock) as mfetch, \
              patch("app.routers.dispatch.resolve_member_identity", new_callable=AsyncMock) as mresolve, \
-             patch("app.routers.dispatch.dispatch_notification", new_callable=AsyncMock) as mnotif:
+             patch("app.routers.dispatch.dispatch_notification", new_callable=AsyncMock) as mnotif, \
+             patch("app.services.hypothesis.resolve_dispatch_anchor", new_callable=AsyncMock) as manchor:
             mfetch.return_value = (aid, "Story T", "desc", PROJECT_ID)
             mresolve.return_value = member
             mnotif.return_value = None
+            # E1-S6: dispatch가 anchor 해소 쿼리를 추가하므로, reason 검증 전용인 이 테스트는
+            # anchor를 None으로 격리한다(이 테스트의 광역 execute mock은 sender용 UUID만 의도).
+            manchor.return_value = None
             async with client as c:
                 resp = await c.post("/api/v2/dispatch", json=_body())
         assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## 🔴 P0 — develop backend pytest RED (전 PR 머지 블로커)

`test_dispatch_reason_7f8066a3.py::test_dispatch_success_reason_ok` FAIL:
`AttributeError: 'UUID' object has no attribute 'metric_definition'`.

## 근본 원인

#1410(E1-S6)이 dispatch 흐름에 `resolve_dispatch_anchor` 해소 쿼리를 추가했다. 이 테스트는 `session.execute`를 **광역 mock**(모든 호출에 sender용 UUID를 반환하는 단일 result)으로 두는데, 새 anchor 쿼리(`_primary_via_story`)가 그 UUID를 `scalar_one_or_none()`으로 받아 `build_anchor_dict(UUID)`에서 터졌다.

**프로덕션 코드는 정상** — `resolve_primary_anchor`는 `select(Hypothesis)→모델/None`을 반환한다(실 DB·AC④ 끝단 실증에서 검증됨). 원인은 **구 테스트 mock의 순서 의존**(미르코 #1412 CI 적발·그의 FE diff는 backend 0).

## 수정

이 테스트는 `DispatchResponse.reason` 검증 전용이므로 `resolve_dispatch_anchor`를 `None`으로 격리(기존 `_fetch_entity`/`resolve_member_identity`/`dispatch_notification` 패치와 동형). **프로덕션 코드·다른 dispatch 테스트 무변경.** `no_assignee`/`unresolved_assignee` 케이스는 anchor 전 early-return이라 무영향.

## 검증

- 대상 파일 **3/3** 통과.
- 전 dispatch 엔드포인트 테스트(`member_ssot_ac2_2`·`event_inject_s4_e2e` 포함) **14/14** 통과.
- **전체 backend pytest: 1861 passed, 47 skipped, 8 xfailed** (잔여 2 fail = `tests/mcp/test_e2e_dev.py` — `skipif(... or bool(_CI))`로 **CI에선 skip**·로컬 라이브연결 시도 McpError·본 변경 무관).

## 리뷰

P0 핫픽스 — base `develop`. 머지되면 develop CI green·전 PR 머지 게이트 해제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)