### PR TITLE
fix(hypotheses): resolve_dispatch_anchor type 가드 — optional anchor가 dispatch crash 금지

### DIFF
--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -10,12 +10,15 @@
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.hypothesis import HYPOTHESIS_STATUSES, is_valid_transition
+from app.models.hypothesis import HYPOTHESIS_STATUSES, Hypothesis, is_valid_transition
+
+logger = logging.getLogger(__name__)
 from app.repositories.hypothesis import HypothesisRepository
 from app.schemas.hypothesis import (
     HypothesisCreate,
@@ -377,6 +380,14 @@ async def resolve_dispatch_anchor(
     """dispatch 대상의 대표 가설 anchor dict(§5.2). 없으면 None(에픽/스토리 외엔 항상 None)."""
     repo = HypothesisRepository(session, org_id)
     hyp = await repo.resolve_primary_anchor(entity_type, entity_id)
-    if hyp is None:
+    # type 가드: anchor는 dispatch의 optional 보강이므로, resolve가 Hypothesis가 아닌 값을
+    # 내면 dispatch(critical path)를 crash시키지 말고 graceful하게 anchor 없이 진행한다.
+    # (실 DB는 Hypothesis|None만 반환 — 비-모델은 비정상 신호라 warning.)
+    if not isinstance(hyp, Hypothesis):
+        if hyp is not None:
+            logger.warning(
+                "resolve_dispatch_anchor: non-Hypothesis result %r for %s %s — anchor skipped",
+                type(hyp).__name__, entity_type, entity_id,
+            )
         return None
     return build_anchor_dict(hyp)

--- a/backend/tests/test_hypothesis_dispatch_anchor.py
+++ b/backend/tests/test_hypothesis_dispatch_anchor.py
@@ -6,11 +6,11 @@ resolve_primary_anchor의 link 해소(story primary→epic fallback·active 우�
 """
 import uuid
 from datetime import datetime, timezone
-from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from app.models.hypothesis import Hypothesis
 from app.services import hypothesis as svc
 
 HID = uuid.uuid4()
@@ -22,13 +22,14 @@ def anyio_backend():
 
 
 def _hyp(**ov):
+    # 실 Hypothesis 인스턴스(인메모리·DB 불요) — resolve_dispatch_anchor의 isinstance 가드와 정합.
     base = dict(
         id=HID, statement="가입 전환율을 높인다", status="active",
         metric_definition={"metric": "signups", "source": "manual", "target": 100, "direction": "up"},
         measure_after=datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc),
     )
     base.update(ov)
-    return SimpleNamespace(**base)
+    return Hypothesis(**base)
 
 
 def test_build_anchor_dict_flattens_metric():
@@ -80,4 +81,17 @@ async def test_resolve_dispatch_anchor_none_when_no_primary():
     repo.resolve_primary_anchor = AsyncMock(return_value=None)
     with patch.object(svc, "HypothesisRepository", return_value=repo):
         a = await svc.resolve_dispatch_anchor(MagicMock(), uuid.uuid4(), "epic", uuid.uuid4())
+    assert a is None
+
+
+async def test_resolve_dispatch_anchor_guards_non_hypothesis():
+    """type 가드: resolve가 비-Hypothesis(예: UUID)를 내도 dispatch를 crash시키지 않고 None.
+
+    실 DB는 Hypothesis|None만 반환하나, mock 오염 등 비정상 신호가 critical dispatch path를
+    터뜨리지 않도록 graceful degrade(anchor 없이 진행)를 보장한다.
+    """
+    repo = MagicMock()
+    repo.resolve_primary_anchor = AsyncMock(return_value=uuid.uuid4())  # 비-Hypothesis
+    with patch.object(svc, "HypothesisRepository", return_value=repo):
+        a = await svc.resolve_dispatch_anchor(MagicMock(), uuid.uuid4(), "story", uuid.uuid4())
     assert a is None


### PR DESCRIPTION
## 무엇을 (P0 #1414 후속 하드닝 · PO GO)

dispatch hypothesis anchor(S6)는 dispatch(**critical path**)의 **optional 보강**이다. `resolve_primary_anchor`가 Hypothesis가 아닌 값을 내더라도 dispatch를 crash시키지 말고 **graceful degrade**(anchor 없이 진행)해야 한다.

`resolve_dispatch_anchor`에 **`isinstance(hyp, Hypothesis)` 가드** 추가 — 비-모델(None 제외)이면 `warning` 로그 후 `None` 반환. 실 DB는 `Hypothesis|None`만 반환하므로 **정상 경로 무변경**. #1414가 격리한 "mock 오염이 dispatch를 crash" 클래스의 표면을 prod 레벨에서 닫는다(defense-in-depth — #1414의 테스트 격리와 belt-and-suspenders).

## 검증

- 단위: 비-Hypothesis(UUID)→None 가드 **신규 1건** + 기존 anchor/build 테스트는 **실 Hypothesis 인스턴스**(인메모리)로 정합 전환.
- 전 hypothesis 스위트(S2·S3·S4·S5·S6) **70 통과** · app import 정상.

## 리뷰

경량 하드닝 PR — base `develop`. PO 검수 → 까심 QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)