### PR TITLE
[P0] fix: MCP 계약 동기화 — S5 6 hypothesis 도구 누락 반영 (develop RED 복구)

### DIFF
--- a/backend/app/services/mcp_toolset.py
+++ b/backend/app/services/mcp_toolset.py
@@ -247,11 +247,14 @@ ALL_TOOL_NAMES: tuple[str, ...] = (
     "sprintable_update_sprint", "sprintable_update_story", "sprintable_update_story_status",
     "sprintable_update_task", "sprintable_update_task_status", "sprintable_upsert_webhook_config",
     "sprintable_vote_retro_item",
+    # hypotheses (E1-S5)
+    "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
+    "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
 )
 
 # picker 표시 순서(비파괴 먼저). order 필드 힌트 + 배열 순서 둘 다 이 순서.
 _CATALOG_DISPLAY_ORDER: tuple[str, ...] = (
-    "stories", "tasks", "sprints", "epics", "chat", "docs", "analytics", "retro",
+    "stories", "tasks", "sprints", "epics", "hypotheses", "chat", "docs", "analytics", "retro",
     "standup", "meetings", "notifications", "webhooks", "rewards", "audit", "agent_runs",
 )
 

--- a/backend/tests/mcp/test_contract.py
+++ b/backend/tests/mcp/test_contract.py
@@ -1,4 +1,4 @@
-"""S3-6: 시스템 콜 계약 검증 — 89개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
+"""S3-6: 시스템 콜 계약 검증 — 95개 도구 등록 + 스키마 무결성 (Phase 3 완료)."""
 from __future__ import annotations
 
 import os
@@ -25,6 +25,9 @@ EXPECTED_TOOLS = {
     # epics (4)
     "sprintable_list_epics", "sprintable_add_epic", "sprintable_update_epic",
     "sprintable_delete_epic",
+    # hypotheses (6) — E1-S5
+    "sprintable_list_hypotheses", "sprintable_get_hypothesis", "sprintable_create_hypothesis",
+    "sprintable_update_hypothesis", "sprintable_link_hypothesis", "sprintable_confirm_hypothesis",
     # sprints (8)
     "sprintable_list_sprints", "sprintable_sprint_summary", "sprintable_activate_sprint",
     "sprintable_close_sprint", "sprintable_get_velocity", "sprintable_create_sprint",
@@ -78,7 +81,7 @@ EXPECTED_TOOLS = {
 
 
 def test_total_tool_count():
-    assert len(_TOOLS) == 89
+    assert len(_TOOLS) == 95
 
 
 def test_all_expected_tools_registered():

--- a/backend/tests/test_toolset_catalog.py
+++ b/backend/tests/test_toolset_catalog.py
@@ -30,8 +30,8 @@ def test_catalog_structure_and_contract_fields():
     cat = build_toolset_catalog()
     assert set(cat.keys()) == {"groups"}
     groups = cat["groups"]
-    # core + 15 비파괴 + admin = 17
-    assert len(groups) == 17
+    # core + 16 비파괴 + admin = 18 (E1-S5 hypotheses 그룹 추가)
+    assert len(groups) == 18
     for g in groups:
         assert set(g.keys()) == _CONTRACT_FIELDS, f"{g['key']} 필드 계약 불일치"
         assert isinstance(g["key"], str) and g["key"]
@@ -39,8 +39,8 @@ def test_catalog_structure_and_contract_fields():
         assert isinstance(g["is_core"], bool) and isinstance(g["is_destructive"], bool)
         assert isinstance(g["order"], int)
         assert g["tools"], f"{g['key']} 빈 그룹 — 모든 그룹은 멤버 보유"
-    # order = 배열 순서와 일치(0..16 단조)
-    assert [g["order"] for g in groups] == list(range(17))
+    # order = 배열 순서와 일치(0..17 단조)
+    assert [g["order"] for g in groups] == list(range(18))
 
 
 def test_core_first_admin_last_flags():
@@ -57,7 +57,7 @@ def test_group_keys_match_mcp_toolset_ssot():
     # core + admin + ALL_GROUPS 비-core = 전체
     assert "core" in keys and "admin" in keys
     non_core_admin = {k for k in keys if k not in ("core", "admin")}
-    assert non_core_admin == {g for g in ALL_GROUPS if g != "core"}  # 15 비파괴 그룹
+    assert non_core_admin == {g for g in ALL_GROUPS if g != "core"}  # 16 비파괴 그룹
 
 
 def test_every_tool_covered_exactly_once():


### PR DESCRIPTION
## 🔴 P0 — develop backend pytest RED (#1413 자기-유발·전 PR 머지 블로커)

#1413(E1-S5)이 hypothesis 6툴 + `hypotheses` group을 추가하면서 **계약 SSOT를 일부만 갱신**했다 — `_GROUP_KEYWORDS`·path는 추가했으나 **`ALL_TOOL_NAMES`·`_CATALOG_DISPLAY_ORDER` 누락**. 3개 계약 테스트가 결정적 RED:
- `test_contract.py::test_total_tool_count` — `89 != 95`
- `test_toolset_catalog.py` — catalog가 hypotheses group 미포함 → `ALL_GROUPS`와 불일치(group_keys_match) + 구조 카운트
- `test_s7_2_epic_dod.py` — 계약 테스트 subprocess 연쇄

## 수정

**prod 정합성 교정**(picker 카탈로그·매니페스트가 hypothesis 도구를 실제로 노출하도록 — S5 완결):
- `mcp_toolset.py` `ALL_TOOL_NAMES`: 6 hypothesis 도구 추가.
- `mcp_toolset.py` `_CATALOG_DISPLAY_ORDER`: `hypotheses` 추가(epics 뒤).

**테스트 동기화**:
- `test_contract.py`: count `89→95` · `EXPECTED_TOOLS` +6 · docstring.
- `test_toolset_catalog.py`: 그룹 카운트 `17→18` · `order range(18)` · 비파괴 16.

## 검증

- 영향 4파일(contract·catalog·s7_2 dod·mcp_hypotheses) **57 통과**.
- **전체 backend pytest 1868 passed · 0 failed**(`CI=1`, e2e skip) → 머지 시 develop green·전 PR 게이트 해제.

## 리뷰

P0 핫픽스 — base `develop`. 최우선 머지 부탁.

🤖 Generated with [Claude Code](https://claude.com/claude-code)