### PR TITLE
feat(hypotheses): HypothesisResponse에 draft_metadata·drafted_by_member_id 노출 (S8 활성화 언블록)

### DIFF
--- a/backend/app/schemas/hypothesis.py
+++ b/backend/app/schemas/hypothesis.py
@@ -91,6 +91,10 @@ class HypothesisResponse(BaseModel):
     confidence: float | None = None
     source_type: str | None = None
     source_id: uuid.UUID | None = None
+    # FE가 "AI 초안 vs 사람 생성 proposed"를 구분(isDraft)해 [활성화] 버튼 게이팅하도록 노출(48dbada0 선행).
+    # drafted_by_member_id 존재 = agent 초안. additive·null default — 구 소비자 호환.
+    drafted_by_member_id: uuid.UUID | None = None
+    draft_metadata: dict[str, Any] | None = None
     human_accounting: dict[str, Any]
     gate_contract: dict[str, Any]
     epic_ids: list[uuid.UUID] = []

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -18,6 +18,7 @@ from app.models.hypothesis import is_valid_transition
 from app.schemas.hypothesis import (
     HypothesisCreate,
     HypothesisLinkRequest,
+    HypothesisResponse,
     HypothesisTransition,
     HypothesisUpdate,
 )
@@ -54,6 +55,7 @@ def _hyp_stub(**overrides) -> SimpleNamespace:
         statement="s", metric_definition=VALID_METRIC,
         measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc), status="proposed",
         outcome_result=None, confidence=None, source_type=None, source_id=None,
+        drafted_by_member_id=None, draft_metadata=None,
         human_accounting={}, gate_contract={},
         created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
         updated_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
@@ -327,3 +329,17 @@ async def test_link_adds_epic_and_story():
         )
     repo.add_epic_links.assert_awaited_once_with(HYP_ID, [eid], "primary")
     repo.add_story_links.assert_awaited_once_with(HYP_ID, [sid], "supports")
+
+
+def test_response_exposes_draft_fields():
+    """48dbada0 선행: Response가 drafted_by_member_id·draft_metadata 노출 — FE isDraft 게이팅.
+
+    agent 초안(drafted_by 채워짐) vs 사람 생성 proposed(None) 구분이 [활성화] 버튼 게이트.
+    """
+    drafted = HypothesisResponse.from_model(
+        _hyp_stub(drafted_by_member_id=CALLER_AGENT_ID, draft_metadata={"template": True}), [], []
+    )
+    assert drafted.drafted_by_member_id == CALLER_AGENT_ID
+    assert drafted.draft_metadata == {"template": True}
+    human_made = HypothesisResponse.from_model(_hyp_stub(), [], [])
+    assert human_made.drafted_by_member_id is None and human_made.draft_metadata is None


### PR DESCRIPTION
## 무엇을 (선행 소형 · E1-S8 활성화 경로 언블록 · 가설 1호 dogfood)

유나 가디언이 #1417(E1-S8)서 적발: `HypothesisResponse`에 draft 필드가 없어 FE가 **"AI 초안 vs 사람 생성 proposed"를 구분 못 함** → `isDraft` 영구 true → **[활성화] 버튼 dead** → 가설 1호(`ad1b4b9f`)도 활성화 불가. FE 인터임(계약 우회)은 기각, **BE 노출(A) 채택**.

## 수정 (additive)

- `HypothesisResponse`에 **`drafted_by_member_id`·`draft_metadata`** 추가(`uuid|None`·`dict|None`, null default). 모델(S1)에 이미 존재하는 컬럼이라 `from_attributes`로 자연 노출 — **`drafted_by_member_id` 존재 = agent 초안**(FE isDraft 게이트).
- ⚠️ 스키마 변경 회귀 클래스: S2 테스트 `_hyp_stub`에 두 필드 추가(없으면 `from_attributes` ValidationError) + 계약 테스트 신규(agent 초안→drafted_by 채워짐 / 사람 생성→None).

## 검증

- 전 hypothesis 스위트(S2·S3·S4·S5·S6) **70 통과**.
- **실 DB 스모크**: agent-drafted Hypothesis → Response `drafted_by_member_id`+`draft_metadata` 노출 / human-made → 둘 다 None (FE isDraft 구분 end-to-end).
- app import 정상.

## 리뷰

PO 검수 → 까심 QA. base `develop`. 머지 후 가설 1호 [활성화] 버튼 라이브 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)