### PR TITLE
fix(hypotheses): drafted_by_member_id를 non-human caller 술어로 정합 (가설1호 회귀)

### DIFF
--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -108,7 +108,10 @@ async def create_hypothesis(
         owner_member_id=owner_id,
         created_by_member_id=caller.id,
         confirmed_by_member_id=caller.id if status == "active" else None,
-        drafted_by_member_id=caller.id if caller.type == "agent" else None,
+        # 비-휴먼(에이전트/API-key) caller = 초안 작성자. proposed 강제(위 `!= "human"`)와 동일
+        # 술어로 정합 — API-key resolve의 type이 정확히 "agent"가 아닌 케이스(가설 1호 drafted_by
+        # null 회귀)도 포착. 휴먼 직생성만 drafted_by None.
+        drafted_by_member_id=caller.id if caller.type != "human" else None,
         statement=payload.statement,
         metric_definition=payload.metric_definition,
         measure_after=payload.measure_after,

--- a/backend/tests/test_hypothesis_service.py
+++ b/backend/tests/test_hypothesis_service.py
@@ -165,6 +165,25 @@ async def test_create_agent_forces_proposed():
     assert kwargs["confirmed_by_member_id"] is None
 
 
+async def test_create_nonhuman_caller_sets_drafted_by():
+    """non-human caller(type이 정확히 'agent'가 아니어도)는 drafted_by 채움 — proposed 강제와 동일
+    술어(`!= human`)로 정합. 가설 1호(API-key resolve type≠'agent')에서 drafted_by null 회귀 방지."""
+    repo = _repo_mock(_hyp_stub())
+    p_repo, p_lookup = _patch(repo, "human")  # owner는 human
+    odd_caller = ResolvedMember(
+        id=CALLER_AGENT_ID, user_id=None, name="k", type="api_key", role="member", org_id=ORG_ID,
+    )
+    payload = HypothesisCreate(
+        project_id=PROJECT_ID, statement="s", metric_definition=VALID_METRIC,
+        measure_after=datetime(2026, 7, 1, tzinfo=timezone.utc), owner_member_id=OWNER_ID,
+    )
+    with p_repo, p_lookup:
+        await svc.create_hypothesis(MagicMock(), ORG_ID, odd_caller, payload)
+    kwargs = repo.create.call_args.kwargs
+    assert kwargs["drafted_by_member_id"] == CALLER_AGENT_ID  # non-human → drafted
+    assert kwargs["status"] == "proposed"                     # non-human → proposed
+
+
 async def test_create_human_defaults_owner_to_self():
     repo = _repo_mock(_hyp_stub())
     # owner=None → caller.id 사용. lookup은 caller.id를 human으로 응답해야 함.


### PR DESCRIPTION
## 무엇을 (#1418 후속·가설 1호 활성화 회귀 · PO ⓑ)

유나/PO 관찰: **API-key(에이전트 키 Bearer) 직호출**로 가설 생성 시 `status`는 `proposed`로 강제됐으나 **`drafted_by_member_id`가 null**로 남아 FE `isDraft`=false → 초안에도 [활성화]가 떠버림(가설 1호 `ad1b4b9f`).

## 근본 — 비대칭 술어

`create_hypothesis`에서:
- proposed 강제: `caller.type != "human"` ✅ (작동)
- drafted_by: `caller.type == "agent"` ❌ (미작동)

API-key resolve의 `ResolvedMember.type`이 **정확히 `"agent"`가 아닌 값**이면(proposed는 forced인데 drafted_by는 안 채워진 PO 실측이 증거) drafted_by 분기가 빠진다. 두 술어를 **`!= "human"`으로 정합** — 비-휴먼 caller(에이전트/API-key)는 초안 작성자로 일관 기록, 휴먼 직생성만 None. PO 가이드("create/draft type 비교 정합화")와 일치.

## 검증

- 단위: 정확히 `'agent'`가 아닌 non-human(`type='api_key'`) caller도 `drafted_by` 채움 + `proposed` 강제 — 신규 테스트로 회귀 잠금. 전 service 스위트 **26 통과** · app import.
- #1418(Response 노출)과 합쳐지면 가설 1호 isDraft 정상 → [활성화] 라이브.

## 리뷰

PO 검수 → 까심 QA. base `develop`. #1418과 독립(다른 파일)·둘 다 활성화 언블록.

🤖 Generated with [Claude Code](https://claude.com/claude-code)