### PR TITLE
[SID:48dbada0] fix(notifications): 그룹 대화 관전 알림 fan-out 제한 — 직접 필요한 알림만 (선생님 제보)

### DIFF
--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -6,15 +6,44 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
-from sqlalchemy import func, or_, select, update
+from sqlalchemy import and_, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
+from app.models.conversation import Conversation, ConversationMessage
 from app.models.event import Event
 from app.models.team import TeamMember
 
 router = APIRouter(prefix="/api/v2/event-notifications", tags=["event-notifications"])
+
+
+def _is_spectator_message_event():
+    """관전 동석 알림 판별 (story 48dbada0 · 선생님 제보).
+
+    휴먼 알림 도배의 근원: conversation fan-out이 participant **전원**에게
+    `conversation.message_created` Event를 적재 → 인가 불변식/킥오프로 동석한 휴먼이
+    그룹 대화의 모든 발화를 알림으로 받는다. "직접 필요한 알림만" 정책에 따라
+    **그룹 대화의 message_created는 휴먼 알림에서 제외**한다.
+
+    유지(직접 필요): ①DM 메시지(`type='dm'`) ②@mention(`conversation:mention`은 별도
+    event_type이라 본 필터 비대상) ③dispatched/story_assigned 등 비-대화 이벤트.
+
+    ⚠️ Event/SSE/에이전트 주입 경로는 불변 — 본 필터는 **휴먼 알림 읽기 단**에만 적용한다
+    (Event는 그대로 적재되어 에이전트 SSE/poll·DB 추적은 무영향).
+    """
+    return and_(
+        Event.event_type == "conversation.message_created",
+        exists(
+            select(1)
+            .select_from(ConversationMessage)
+            .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
+            .where(
+                ConversationMessage.id == Event.source_entity_id,
+                Conversation.type != "dm",
+            )
+        ),
+    )
 
 
 # ─── Helper ───────────────────────────────────────────────────────────────────
@@ -90,7 +119,11 @@ async def list_notifications(
     member_id = await _resolve_member_id(auth, org_id, db, project_id=project_id)
     result = await db.execute(
         select(Event)
-        .where(Event.org_id == org_id, Event.recipient_id == member_id)
+        .where(
+            Event.org_id == org_id,
+            Event.recipient_id == member_id,
+            ~_is_spectator_message_event(),  # 48dbada0: 그룹 대화 관전 알림 제외
+        )
         .order_by(Event.created_at.desc())
         .limit(limit)
         .offset(offset)
@@ -116,6 +149,7 @@ async def get_unread_count(
             Event.org_id == org_id,
             Event.recipient_id == member_id,
             Event.read_at.is_(None),
+            ~_is_spectator_message_event(),  # 48dbada0: 그룹 대화 관전 알림 제외
         )
     )
     count = result.scalar_one()


### PR DESCRIPTION
## 🔔 무엇을 (선생님 직지시 · 모바일 스크린샷 증거)

알림 패널이 `conversation.message_created`로 **1~3분 간격 도배** — 팀 에이전트 활동 시간대에 휴먼 알림이 무한 누적. **근본**: conversation fan-out(`conversations.py`)이 대화 participant **전원**에게 `Event(recipient_id=...)` 적재 → 인가 불변식/킥오프로 동석(spectator)한 휴먼이 그룹 대화의 **모든 발화**를 알림으로 받음.

## 정책: "직접 필요한 알림만"

휴먼 알림 **읽기 단**(`event_notifications` `list` + `unread-count`)에서 **그룹 대화의 `conversation.message_created`를 제외**. 유지(직접 필요):
- **DM 메시지** (`conversation.type='dm'`)
- **@mention** (`conversation:mention`은 별도 event_type → 본 필터 비대상)
- **dispatched/story_assigned 등 비-대화 이벤트**

## ⚠️ Event/SSE/에이전트 주입 경로 불변

fan-out의 Event 적재는 **그대로** — 에이전트 SSE/poll·DB 추적 무영향(게이트웨이 토대 보존, PO 제약). 분기는 **휴먼 읽기 쿼리에만**: `NOT EXISTS(message→conversation join where type!='dm')`를 `conversation.message_created`에 한해 적용 (SQL 레벨 → 페이지네이션·unread-count 정합).

## 검증

- **실 DB 스모크**: 그룹 msg `conversation.message_created` **제외** · DM msg **유지** · `conversation:mention` **유지** · `dispatched` **유지** · shown=unread=**3**(4중 1 제외).
- 기존 notification 엔드포인트 테스트(`test_notifications`·`test_notification_dispatch`) **20 무회귀**.
- **AC⑤ 라이브 게이트(PO dev)**: 에이전트 thread 발화 → 선생님 알림 미증가 / DM·mention → 증가.

## 리뷰

PO 검수 → 까심 QA + **AC⑤ 라이브 검증**. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)