### PR TITLE
[SID:efcb3840] fix(inbox): 모바일 master-detail 토글 — 탭한 디테일 off-screen 수정 (ⓑ 긴급)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -1346,6 +1346,7 @@
     "revoke_failed": "Failed to revoke access.",
     "cancel": "Cancel",
     "noNotifications": "No notifications",
+    "backToList": "Inbox",
     "statusChangeCount": "{count} status changes",
     "expandHistory": "Expand history",
     "collapseHistory": "Collapse history",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -1346,6 +1346,7 @@
     "revoke_failed": "접근 권한 취소에 실패했습니다.",
     "cancel": "취소",
     "noNotifications": "알림이 없습니다",
+    "backToList": "인박스",
     "statusChangeCount": "{count}회 변경",
     "expandHistory": "이력 펼치기",
     "collapseHistory": "이력 접기",

--- a/apps/web/src/app/(authenticated)/inbox/page.tsx
+++ b/apps/web/src/app/(authenticated)/inbox/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { ChevronDown, ChevronRight, Inbox as InboxIcon, Zap, ZapOff } from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronRight, Inbox as InboxIcon, Zap, ZapOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { Badge } from '@/components/ui/badge';
@@ -405,8 +405,9 @@ export default function InboxPage() {
         )}
 
         <div className="flex min-h-0 flex-1 overflow-hidden">
-        {/* Left: notification list */}
-        <div className="flex w-full max-w-[420px] min-w-[320px] flex-col border-r border-border/80">
+        {/* Left: notification list. max-md master-detail (efcb3840 ⓑ): full-width list,
+            hidden once a detail is open so the detail can take the screen (md+ unchanged). */}
+        <div className={`flex w-full min-w-[320px] flex-col border-r border-border/80 md:max-w-[420px] max-md:min-w-0 ${selectedId ? 'max-md:hidden' : ''}`}>
           <div className="flex-1 overflow-y-auto px-3 py-3">
             {loading ? (
               <div className="space-y-2">
@@ -523,8 +524,19 @@ export default function InboxPage() {
           </div>
         </div>
 
-        {/* Right: detail panel */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-y-auto">
+        {/* Right: detail panel. max-md: hidden when nothing selected (the list owns the
+            screen); full-screen with a back button when an item is tapped (efcb3840 ⓑ). */}
+        <div className={`flex min-w-0 flex-1 flex-col overflow-y-auto ${!selectedId ? 'max-md:hidden' : ''}`}>
+          {selectedNotification ? (
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              className="flex shrink-0 items-center gap-1.5 border-b border-border/80 px-4 py-2.5 text-sm font-medium text-muted-foreground transition hover:text-foreground md:hidden"
+            >
+              <ArrowLeft className="size-4" />
+              {t('backToList')}
+            </button>
+          ) : null}
           {selectedNotification ? (
             selectedNotification.type === 'agent_joined' ? (
               <AgentJoinedDetailPanel


### PR DESCRIPTION
## 무엇을 (스토리 `efcb3840` · 슬라이스 ⓑ 긴급 · BE 무관 · 소형)

인박스 2-pane(`inbox/page.tsx` 좌 `w-full max-w-[420px]`·우 `flex-1`)에 반응형 분기가 없어, 모바일에서 우 디테일이 **width≈0·x=390 off-screen** → 탭→선택은 되나 화면이 안 바뀜(유나 재현·390×844).

## 픽스 — `max-md` master-detail 토글

- **선택 없음** → 리스트 전체화면(디테일 `max-md:hidden`).
- **선택됨** → 디테일 전체화면(리스트 `max-md:hidden`) + **[← 인박스] 백버튼**(`md:hidden`·탭 시 `setSelectedId(null)` 복귀).
- **`md+`는 현 2-pane 무회귀**(데스크탑 변화 0).
- i18n 신규 `inbox.backToList`(en/ko)·토큰0·hex0.

## 검증

- `pnpm build`(next webpack) ✅ exit 0 · `tsc`/lint 0 · i18n JSON 유효.
- 게이트=유나 재현 절차(390×844 touch 탭→디테일 전체화면+백버튼 복귀 / 데스크탑 2-pane 무회귀). 머지+dev 후 유나 픽셀.

ⓐ(도달 사유 가시화·인터림 FE)는 이 PR 다음 슬라이스로 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)