### PR TITLE
[SID:270c87e6] feat(chat): 휴먼 개입 한 벌 (BE) — 발화 403 auto-join + carve-out + per-대화 mute

### DIFF
--- a/backend/alembic/versions/0115_add_conversation_participant_muted_at.py
+++ b/backend/alembic/versions/0115_add_conversation_participant_muted_at.py
@@ -1,0 +1,37 @@
+"""270c87e6: conversation_participants.muted_at — per-대화 알림 mute.
+
+Revision ID: 0115
+Revises: 0114
+Create Date: 2026-06-11
+
+mute set=무음·null=알림 ON. 참여자 지위·가시성·메시지 수신은 불변(알림 노출만 억제).
+additive·nullable — 구코드 호환. idempotent(컬럼 부재 시만 추가).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0115"
+down_revision = "0114"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("conversation_participants")}
+    if "muted_at" not in cols:
+        op.add_column(
+            "conversation_participants",
+            sa.Column("muted_at", sa.DateTime(timezone=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    cols = {c["name"] for c in insp.get_columns("conversation_participants")}
+    if "muted_at" in cols:
+        op.drop_column("conversation_participants", "muted_at")

--- a/backend/app/models/conversation.py
+++ b/backend/app/models/conversation.py
@@ -56,6 +56,8 @@ class ConversationParticipant(Base):
     joined_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
+    # 270c87e6: per-대화 알림 mute. set=무음·null=알림 ON. 참여자 지위·가시성·수신은 불변(알림만).
+    muted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     conversation: Mapped[Conversation] = relationship("Conversation", back_populates="participants")
 

--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -575,6 +575,10 @@ class AddParticipantRequest(BaseModel):
     member_id: uuid.UUID
 
 
+class MuteRequest(BaseModel):
+    muted: bool
+
+
 # ─── Endpoints ────────────────────────────────────────────────────────────────
 
 @router.post("", status_code=201)
@@ -893,6 +897,40 @@ async def list_working_members(
     return {"data": items}
 
 
+@router.patch("/{conversation_id}/mute")
+async def set_conversation_mute(
+    conversation_id: uuid.UUID,
+    body: MuteRequest,
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(get_current_user),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> dict:
+    """PATCH /api/v2/conversations/{id}/mute — per-대화 알림 mute/unmute (270c87e6).
+
+    caller의 participant 행에 muted_at set(mute)/null(unmute). 참여자 지위·가시성·메시지 수신은
+    불변 — 알림 노출만 억제(mute가 발화 carve-out보다 우선). 비참여자는 403.
+    """
+    conv = (await db.execute(
+        select(Conversation).where(Conversation.id == conversation_id, Conversation.org_id == org_id)
+    )).scalar_one_or_none()
+    if conv is None:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    sender = await _resolve_member(auth, org_id, db, project_id=conv.project_id)
+    participant = (await db.execute(
+        select(ConversationParticipant).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    if participant is None:
+        raise HTTPException(status_code=403, detail="Not a participant")
+
+    participant.muted_at = datetime.now(timezone.utc) if body.muted else None
+    await db.commit()
+    return {"conversation_id": str(conversation_id), "muted": body.muted}
+
+
 @router.post("/{conversation_id}/participants", status_code=201)
 async def add_participant(
     conversation_id: uuid.UUID,
@@ -1007,7 +1045,14 @@ async def send_message(
         )
     )).scalar_one_or_none()
     if participant is None:
-        raise HTTPException(status_code=403, detail="Not a participant")
+        # 발화 403 해소(270c87e6): 프로젝트 접근권 휴먼이 그룹/스레드 대화에 발화하면 auto-join.
+        # _resolve_member가 이미 project 접근을 검증했으므로 접근권은 성립. 단 타인 간 1:1 DM은
+        # 예외(비공개 보호·여전히 403)이고, 에이전트 인가(allowlist·creator 동석)는 불변(403 유지).
+        if sender.type == "human" and conv.type != "dm":
+            db.add(ConversationParticipant(conversation_id=conversation_id, member_id=sender.id))
+            await db.flush()
+        else:
+            raise HTTPException(status_code=403, detail="Not a participant")
 
     # 1aeecdde P2: sender 가 이 conversation 에 메시지를 보냄 = 답장 생성 종료 → working clear.
     # fork 분기(아래) 전 **원본 conversation_id** 기준 — working 은 그 conversation 에 set 됐다.

--- a/backend/app/routers/event_notifications.py
+++ b/backend/app/routers/event_notifications.py
@@ -8,41 +8,61 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import and_, exists, func, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
 from app.dependencies.database import get_db
-from app.models.conversation import Conversation, ConversationMessage
+from app.models.conversation import Conversation, ConversationMessage, ConversationParticipant
 from app.models.event import Event
 from app.models.team import TeamMember
 
 router = APIRouter(prefix="/api/v2/event-notifications", tags=["event-notifications"])
 
+# 대화 이벤트 종류(휴먼 알림 정책 분기 대상). 비-대화 이벤트(dispatched 등)는 항상 노출.
+_CONVERSATION_EVENT_TYPES = ("conversation.message_created", "conversation:mention")
 
-def _is_spectator_message_event():
-    """관전 동석 알림 판별 (story 48dbada0 · 선생님 제보).
 
-    휴먼 알림 도배의 근원: conversation fan-out이 participant **전원**에게
-    `conversation.message_created` Event를 적재 → 인가 불변식/킥오프로 동석한 휴먼이
-    그룹 대화의 모든 발화를 알림으로 받는다. "직접 필요한 알림만" 정책에 따라
-    **그룹 대화의 message_created는 휴먼 알림에서 제외**한다.
+def _is_hidden_notification(member_id: uuid.UUID):
+    """휴먼 알림에서 숨길 대화 이벤트 판별 (48dbada0 + 270c87e6 · 선생님 정책).
 
-    유지(직접 필요): ①DM 메시지(`type='dm'`) ②@mention(`conversation:mention`은 별도
-    event_type이라 본 필터 비대상) ③dispatched/story_assigned 등 비-대화 이벤트.
+    숨김(둘 중 하나):
+    1. **mute**(270c87e6 ③): member가 그 대화를 mute → 그 대화의 모든 conversation 이벤트
+       (message_created·mention) 숨김. carve-out·DM보다 우선. 참여/가시성/수신은 불변(알림만).
+    2. **spectator**(48dbada0): 그룹 대화의 message_created인데 member가 그 대화에서 **발화한 적
+       없음** → 관전 동석 알림이라 숨김. ⇄ **carve-out**(270c87e6 ②): 발화한 적 있으면 노출.
 
-    ⚠️ Event/SSE/에이전트 주입 경로는 불변 — 본 필터는 **휴먼 알림 읽기 단**에만 적용한다
-    (Event는 그대로 적재되어 에이전트 SSE/poll·DB 추적은 무영향).
+    노출(직접 필요): DM 메시지·@mention(별도 type)·발화한 그룹 대화·dispatched 등 비-대화 이벤트.
+    ⚠️ Event/SSE/에이전트 주입 경로 불변 — 휴먼 알림 읽기 단에만 적용.
     """
-    return and_(
-        Event.event_type == "conversation.message_created",
-        exists(
-            select(1)
-            .select_from(ConversationMessage)
-            .join(Conversation, Conversation.id == ConversationMessage.conversation_id)
-            .where(
-                ConversationMessage.id == Event.source_entity_id,
-                Conversation.type != "dm",
-            )
-        ),
+    # 이 Event의 소스 메시지(EvtMsg). EXISTS가 EvtMsg.id == Event.source_entity_id로 outer Event에
+    # correlate된다(scalar 서브쿼리 오-correlate 회피). 비-대화 이벤트면 EvtMsg 매칭 0 → 전부 false.
+    evt_msg = aliased(ConversationMessage)
+    my_msg = aliased(ConversationMessage)
+    muted = exists(
+        select(1)
+        .select_from(evt_msg)
+        .join(ConversationParticipant, ConversationParticipant.conversation_id == evt_msg.conversation_id)
+        .where(
+            evt_msg.id == Event.source_entity_id,
+            ConversationParticipant.member_id == member_id,
+            ConversationParticipant.muted_at.isnot(None),
+        )
+    )
+    is_group = exists(
+        select(1)
+        .select_from(evt_msg)
+        .join(Conversation, Conversation.id == evt_msg.conversation_id)
+        .where(evt_msg.id == Event.source_entity_id, Conversation.type != "dm")
+    )
+    spoke = exists(
+        select(1)
+        .select_from(evt_msg)
+        .join(my_msg, my_msg.conversation_id == evt_msg.conversation_id)
+        .where(evt_msg.id == Event.source_entity_id, my_msg.sender_id == member_id)
+    )
+    return or_(
+        and_(Event.event_type.in_(_CONVERSATION_EVENT_TYPES), muted),         # mute: 대화 전체 무음
+        and_(Event.event_type == "conversation.message_created", is_group, ~spoke),  # 미발화 그룹 관전
     )
 
 
@@ -122,7 +142,7 @@ async def list_notifications(
         .where(
             Event.org_id == org_id,
             Event.recipient_id == member_id,
-            ~_is_spectator_message_event(),  # 48dbada0: 그룹 대화 관전 알림 제외
+            ~_is_hidden_notification(member_id),  # 48dbada0+270c87e6: mute·미발화 그룹 관전 제외
         )
         .order_by(Event.created_at.desc())
         .limit(limit)
@@ -149,7 +169,7 @@ async def get_unread_count(
             Event.org_id == org_id,
             Event.recipient_id == member_id,
             Event.read_at.is_(None),
-            ~_is_spectator_message_event(),  # 48dbada0: 그룹 대화 관전 알림 제외
+            ~_is_hidden_notification(member_id),  # 48dbada0+270c87e6: mute·미발화 그룹 관전 제외
         )
     )
     count = result.scalar_one()

--- a/backend/tests/test_human_intervention_270c87e6.py
+++ b/backend/tests/test_human_intervention_270c87e6.py
@@ -1,0 +1,141 @@
+"""270c87e6: 휴먼 개입 한 벌 — 발화 403 auto-join + per-대화 mute 토글 (BE).
+
+filter(carve-out+mute)의 SQL 정합은 실 DB 스모크에서 검증. 여기선 라우터 분기:
+①auto-join 게이트(접근권 휴먼+그룹→자동참여 / 타인 DM·에이전트→403 유지) ②mute 토글 set/clear·비참여 403.
+patch 기반(광역 mock 순서의존 회피) — _resolve_member·session.execute를 명시 시퀀스로 제어.
+"""
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.services.member_resolver import ResolvedMember
+
+ORG = uuid.uuid4()
+CONV = uuid.uuid4()
+MEMBER = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _result(scalar=None):
+    r = MagicMock()
+    r.scalar_one_or_none = MagicMock(return_value=scalar)
+    return r
+
+
+async def _client(session):
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    ctx = MagicMock(); ctx.user_id = str(MEMBER); ctx.claims = {"app_metadata": {"org_id": str(ORG)}}
+
+    async def _db():
+        yield session
+
+    async def _auth():
+        return ctx
+
+    async def _org():
+        return ORG
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = _auth
+    app.dependency_overrides[get_verified_org_id] = _org
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+def _member(mtype="human"):
+    return ResolvedMember(id=MEMBER, user_id=uuid.uuid4() if mtype == "human" else None,
+                          name="t", type=mtype, role="member", org_id=ORG)
+
+
+def _session(*results):
+    s = AsyncMock(); s.execute = AsyncMock(side_effect=list(results))
+    s.add = MagicMock(); s.flush = AsyncMock(); s.commit = AsyncMock()
+    return s
+
+
+# ── ① auto-join 게이트 (send_message) ─────────────────────────────────────────
+
+async def test_send_agent_nonparticipant_keeps_403():
+    """에이전트 비참여자는 auto-join 안 됨 — 인가 불변(403 유지)."""
+    conv = SimpleNamespace(id=CONV, org_id=ORG, project_id=uuid.uuid4(), type="group")
+    s = _session(_result(conv), _result(None))  # conv 조회 → participant None
+    client, app = await _client(s)
+    try:
+        with patch("app.routers.conversations._resolve_member", AsyncMock(return_value=_member("agent"))):
+            async with client as c:
+                resp = await c.post(f"/api/v2/conversations/{CONV}/messages", json={"content": "x"})
+        assert resp.status_code == 403
+        s.add.assert_not_called()  # auto-join 미발생
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_send_human_nonparticipant_dm_keeps_403():
+    """타인 간 1:1 DM은 비참여 휴먼도 auto-join 예외 — 403 유지(비공개 보호)."""
+    conv = SimpleNamespace(id=CONV, org_id=ORG, project_id=uuid.uuid4(), type="dm")
+    s = _session(_result(conv), _result(None))
+    client, app = await _client(s)
+    try:
+        with patch("app.routers.conversations._resolve_member", AsyncMock(return_value=_member("human"))):
+            async with client as c:
+                resp = await c.post(f"/api/v2/conversations/{CONV}/messages", json={"content": "x"})
+        assert resp.status_code == 403
+        s.add.assert_not_called()
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── ② mute 토글 ───────────────────────────────────────────────────────────────
+
+async def test_mute_sets_muted_at():
+    conv = SimpleNamespace(id=CONV, org_id=ORG, project_id=uuid.uuid4(), type="group")
+    participant = SimpleNamespace(id=uuid.uuid4(), muted_at=None)
+    s = _session(_result(conv), _result(participant))
+    client, app = await _client(s)
+    try:
+        with patch("app.routers.conversations._resolve_member", AsyncMock(return_value=_member("human"))):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/conversations/{CONV}/mute", json={"muted": True})
+        assert resp.status_code == 200 and resp.json()["muted"] is True
+        assert participant.muted_at is not None  # mute set
+        s.commit.assert_awaited()
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_unmute_clears_muted_at():
+    from datetime import datetime, timezone
+    conv = SimpleNamespace(id=CONV, org_id=ORG, project_id=uuid.uuid4(), type="group")
+    participant = SimpleNamespace(id=uuid.uuid4(), muted_at=datetime.now(timezone.utc))
+    s = _session(_result(conv), _result(participant))
+    client, app = await _client(s)
+    try:
+        with patch("app.routers.conversations._resolve_member", AsyncMock(return_value=_member("human"))):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/conversations/{CONV}/mute", json={"muted": False})
+        assert resp.status_code == 200 and resp.json()["muted"] is False
+        assert participant.muted_at is None  # unmute clear
+    finally:
+        app.dependency_overrides.clear()
+
+
+async def test_mute_nonparticipant_403():
+    conv = SimpleNamespace(id=CONV, org_id=ORG, project_id=uuid.uuid4(), type="group")
+    s = _session(_result(conv), _result(None))  # participant 없음
+    client, app = await _client(s)
+    try:
+        with patch("app.routers.conversations._resolve_member", AsyncMock(return_value=_member("human"))):
+            async with client as c:
+                resp = await c.patch(f"/api/v2/conversations/{CONV}/mute", json={"muted": True})
+        assert resp.status_code == 403
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## 무엇을 (선생님 정책 확정 · #1420 후속)

동석 휴먼이 **개입(발화)하려면 403**이고, 발화로 알림이 켜지면 **끌 수단(mute)** 이 있어야 정책 완성. BE 3파트 (FE mute 토글 UI ⑤는 미르코 큐).

### ① 발화 403 해소 — auto-join (`conversations.py` send_message)
프로젝트 접근권 휴먼이 그룹/스레드 비참여 발화 → **자동 참여자 추가 + 전송 성공**. `_resolve_member`가 접근 검증 후라 접근권 성립. ⚠️ **타인 간 1:1 DM은 예외**(403 유지·비공개) · **에이전트 인가(allowlist·creator 동석) 불변**(에이전트 비참여=403 유지).

### ② 알림 carve-out + ③ per-대화 mute (`event_notifications` 휴먼 알림 읽기 단)
- 필터를 **recipient-aware**로 확장(`_is_hidden_notification`): **mute**(대화 전체 알림 숨김 · carve-out·DM보다 **우선**) **OR** 미발화 그룹 `message_created`(관전). **발화한 대화는 노출**(carve-out — 48dbada0 spectator 완화). DM·@mention·dispatched 유지. `EXISTS`+`aliased`로 outer Event correlate.
- mute 저장 = `conversation_participants.muted_at`(migration **0115**·idempotent). **참여/가시성/수신 불변 — 알림만 무음.**
- mute 토글: **`PATCH /api/v2/conversations/{id}/mute {muted}`** — caller participant `muted_at` set/clear, 비참여 403.

⚠️ **Event/SSE/에이전트 주입 경로 불변** — 분기는 휴먼 알림 읽기 단 + 발화 게이트에만.

## 검증

- **필터 실 DB 스모크**: 미발화그룹 숨김 · **발화 carve-out 노출** · **발화+mute 숨김(mute>carve)** · DM/mention 노출 · mention(muted) 숨김 · shown=3.
- **단위 5**: auto-join 게이트(agent→403·타인DM→403·auto-join 미발생) · mute set/clear · 비참여 403.
- **전체 backend pytest 1876 passed · 0 failed**(CI=1) — conversation/notification **127 무회귀** 포함.

## AC

- [x] ① 접근권 휴먼 그룹 발화→200+참여자 추가 (타인 DM 403 유지)
- [x] ② 발화한 대화 새 메시지 알림 노출
- [x] ③ mute한 대화 알림 0 (unmute 복원) · mute>carve-out
- [x] ④ 에이전트 경로(Event/SSE/주입·인가) 무영향
- [ ] ⑤ FE 토글 (미르코 큐)
- [ ] ⑥ 라이브 풀사이클 (PO dev 게이트)

## 리뷰

PO 검수 → 까심 QA + AC⑥ 라이브. FE mute 토글(⑤)은 미르코 인계. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)