### PR TITLE
[SID:d67e5478] fix(chat): 모바일 메시지 버블 가로 overflow — bubble column min-w-0

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -190,8 +190,11 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
           </div>
         )}
 
-        {/* Bubble + meta */}
-        <div className={`flex max-w-[72%] flex-col gap-0.5 ${isMine ? 'items-end' : 'items-start'}`}>
+        {/* Bubble + meta. min-w-0 breaks the flex min-width:auto trap (d67e5478): without it
+            a long unbreakable code line/URL's min-content overrides max-w-[72%] and overflows
+            the row → page. With it, the column respects max-w and the inner content contains
+            itself — whitespace-pre-wrap code wraps, <pre> scrolls (overflow-x-auto), URLs break. */}
+        <div className={`flex min-w-0 max-w-[72%] flex-col gap-0.5 ${isMine ? 'items-end' : 'items-start'}`}>
           {/* Sender name — hidden when grouped */}
           {!isGrouped && (
             <div className="flex items-center gap-1.5">


### PR DESCRIPTION
## 무엇을 (스토리 `d67e5478` · 채팅·모바일 · FE 소형 · 선생님 제보)

코드 명령줄(`set -a; . ~/.hermes/.env; …`) 포함 메시지 버블이 **모바일에서 가로 overflow** — 화면 폭을 뚫음(선생님 모바일 스크린샷·뭉크리 채팅).

## 근본 — flex `min-width:auto` 함정

버블 column(`flex max-w-[72%] flex-col`)에 **`min-w-0` 부재** → 긴 비줄바꿈 코드라인/URL의 min-content가 `max-w-[72%]`를 무시하고 column을 row 밖으로 밀어냄 → 페이지 가로 overflow. 내부 조각은 이미 정상(cmd 코드 `whitespace-pre-wrap`+`break-words`·markdown `<pre>` `overflow-x-auto`·텍스트 `break-words`)이나 부모 column이 팽창해 수렴 불가였음.

## 픽스

버블 column에 **`min-w-0` 추가** → column이 `max-w-[72%]` 준수 → 내부가 자체 수렴: 코드 wrap·`<pre>` 버블 내 가로 스크롤·긴 URL break. **데스크탑 무회귀**(콘텐츠가 이미 72% 내라 변화 0).

## AC 매핑
①코드블록 메시지 모바일 버블 내 수렴·페이지 가로 overflow 0 ②긴 URL/연속 문자열 break(break-words) ③데스크탑 무회귀 ④실 제보 메시지 양 뷰포트 재현→검증(유나 라이브 게이트).

## 검증
`pnpm build`(next webpack) ✅ exit 0 · lint 0. 게이트=뭉크리 제보 메시지 390px 재현(버블 수렴·overflow 0) + 데스크탑 무회귀(유나 픽셀).

🤖 Generated with [Claude Code](https://claude.com/claude-code)