### PR TITLE
[SID:837a36c4] test: Group B FE 테스트 부채 번다운 batch 1 — analytics route 6종 (proxy 계약 재작성)

### DIFF
--- a/apps/web/src/app/api/analytics/activity/route.test.ts
+++ b/apps/web/src/app/api/analytics/activity/route.test.ts
@@ -1,74 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.in = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.limit = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/activity';
+const URL = 'http://localhost/api/analytics/activity?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/activity', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/activity'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
+  it('returns 401 when unauthenticated', async () => {
     getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(new Request('http://localhost/api/analytics/activity?project_id=p'));
-
-    expect(response.status).toBe(401);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 200 with activity data', async () => {
-    const db = { from: vi.fn(() => createQueryStub([])) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
+  });
 
-    const response = await GET(new Request('http://localhost/api/analytics/activity?project_id=project-alpha'));
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({
-      recent_stories: expect.any(Array),
-      recent_memos: expect.any(Array),
-      recent_agent_runs: expect.any(Array),
-    });
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/analytics/epic-progress/route.test.ts
+++ b/apps/web/src/app/api/analytics/epic-progress/route.test.ts
@@ -1,76 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/epic-progress';
+const URL = 'http://localhost/api/analytics/epic-progress?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/epic-progress', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/epic-progress?epic_id=epic-1'));
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error?.message).toMatch(/project_id/);
+  it('returns 401 when unauthenticated', async () => {
+    getAuthContext.mockResolvedValue(null);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 400 when epic_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/epic-progress?project_id=p'));
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error?.message).toMatch(/epic_id/);
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
   });
 
-  it('returns 200 with epic progress stats', async () => {
-    const stories = [
-      { status: 'done', story_points: 5 },
-      { status: 'done', story_points: 3 },
-      { status: 'in-progress', story_points: 2 },
-    ];
-    const db = { from: vi.fn(() => createQueryStub(stories)) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    const response = await GET(new Request('http://localhost/api/analytics/epic-progress?project_id=project-alpha&epic_id=epic-1'));
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ total_stories: 3, done_stories: 2, total_points: 10, done_points: 8, completion_pct: 67 });
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/analytics/health/route.test.ts
+++ b/apps/web/src/app/api/analytics/health/route.test.ts
@@ -1,74 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNull?: boolean } = {}) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.is = vi.fn(chain);
-  q.neq = vi.fn(chain);
-  q.single = vi.fn(() =>
-    opts.singleNull
-      ? Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } })
-      : Promise.resolve({ data: rows[0] ?? null, error: null }),
-  );
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/health';
+const URL = 'http://localhost/api/analytics/health?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/health', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/health'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
+  it('returns 401 when unauthenticated', async () => {
     getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(new Request('http://localhost/api/analytics/health?project_id=p'));
-
-    expect(response.status).toBe(401);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 200 with health data when no active sprint', async () => {
-    const db = { from: vi.fn(() => createQueryStub([], { singleNull: true })) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
+  });
 
-    const response = await GET(new Request('http://localhost/api/analytics/health?project_id=project-alpha'));
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ active_sprint: null, sprint_progress: 0, health: 'good' });
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/analytics/overview/route.test.ts
+++ b/apps/web/src/app/api/analytics/overview/route.test.ts
@@ -1,80 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.is = vi.fn(chain);
-  q.in = vi.fn(chain);
-  q.single = vi.fn(() => Promise.resolve({ data: rows[0] ?? null, error: rows[0] ? null : { message: 'not found' } }));
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/overview';
+const URL = 'http://localhost/api/analytics/overview?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/overview', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/overview'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
+  it('returns 401 when unauthenticated', async () => {
     getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(new Request('http://localhost/api/analytics/overview?project_id=p'));
-
-    expect(response.status).toBe(401);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 200 with overview data for agent', async () => {
-    const db = { from: vi.fn(() => createQueryStub([])) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/overview?project_id=project-alpha'));
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ sprints: expect.objectContaining({ total: 0 }) });
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
   });
 
-  it('uses user db client for human auth type', async () => {
-    getAuthContext.mockResolvedValue({ id: 'user-1', type: 'human', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
-    const db = { from: vi.fn(() => createQueryStub([])) };
-    createDbServerClient.mockResolvedValue(db);
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    await GET(new Request('http://localhost/api/analytics/overview?project_id=project-alpha'));
-
-    expect(createAdminClient).not.toHaveBeenCalled();
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/analytics/velocity-history/route.test.ts
+++ b/apps/web/src/app/api/analytics/velocity-history/route.test.ts
@@ -1,69 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/velocity-history';
+const URL = 'http://localhost/api/analytics/velocity-history?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/velocity-history', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/velocity-history'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
+  it('returns 401 when unauthenticated', async () => {
     getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(new Request('http://localhost/api/analytics/velocity-history?project_id=p'));
-
-    expect(response.status).toBe(401);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 200 with velocity history', async () => {
-    const sprint = { id: 'sprint-1', title: 'Sprint 1', velocity: 21, status: 'closed', start_date: '2026-04-01', end_date: '2026-04-14' };
-    const db = { from: vi.fn(() => createQueryStub([sprint])) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
+  });
 
-    const response = await GET(new Request('http://localhost/api/analytics/velocity-history?project_id=project-alpha'));
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toEqual(expect.arrayContaining([expect.objectContaining({ id: 'sprint-1', velocity: 21 })]));
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/apps/web/src/app/api/analytics/workload/route.test.ts
+++ b/apps/web/src/app/api/analytics/workload/route.test.ts
@@ -1,81 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B): 라우트가 FastAPI proxy 위임으로 리팩토링됨 — 테스트를 현 계약
+// (auth → proxyToFastapi → apiSuccess 래핑)에 맞춰 재작성. 구 createDbServerClient 직쿼리
+// mock은 폐기(라우트가 더는 DB를 직접 안 쓰며, 비즈니스 로직은 FastAPI backend pytest가 검증).
+const { getAuthContext, proxyToFastapi } = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  proxyToFastapi: vi.fn(),
 }));
-
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
 vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET } from './route';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
-
-function createQueryStub(rows: Record<string, unknown>[] = []) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
+const PROXY_PATH = '/api/v2/analytics/workload';
+const URL = 'http://localhost/api/analytics/workload?project_id=p';
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
 describe('GET /api/analytics/workload', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
     getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    proxyToFastapi.mockReset();
+    getAuthContext.mockResolvedValue(agent());
   });
 
-  it('returns 400 when project_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/workload?member_id=member-1'));
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error?.message).toMatch(/project_id/);
-  });
-
-  it('returns 400 when member_id missing', async () => {
-    const db = { from: vi.fn(() => createQueryStub()) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(new Request('http://localhost/api/analytics/workload?project_id=p'));
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error?.message).toMatch(/member_id/);
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
+  it('returns 401 when unauthenticated', async () => {
     getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(new Request('http://localhost/api/analytics/workload?project_id=p&member_id=m'));
-
-    expect(response.status).toBe(401);
+    expect((await GET(new Request(URL))).status).toBe(401);
+    expect(proxyToFastapi).not.toHaveBeenCalled();
   });
 
-  it('returns 200 with workload data', async () => {
-    const db = { from: vi.fn(() => createQueryStub([])) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
+  it('returns 429 when rate limited', async () => {
+    getAuthContext.mockResolvedValue({ ...agent(), rateLimitExceeded: true });
+    expect((await GET(new Request(URL))).status).toBe(429);
+  });
 
-    const response = await GET(new Request('http://localhost/api/analytics/workload?project_id=project-alpha&member_id=member-1'));
+  it('delegates to FastAPI proxy and wraps success in {data}', async () => {
+    proxyToFastapi.mockResolvedValue(
+      new Response(JSON.stringify({ ok: 1 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const res = await GET(new Request(URL));
+    expect(res.status).toBe(200);
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), PROXY_PATH);
+    expect((await res.json()).data).toMatchObject({ ok: 1 });
+  });
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ stories: expect.objectContaining({ total: 0 }), tasks: expect.objectContaining({ total: 0 }) });
+  it('passes through proxy error responses unchanged', async () => {
+    proxyToFastapi.mockResolvedValue(new Response('err', { status: 502 }));
+    expect((await GET(new Request(URL))).status).toBe(502);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,12 +30,6 @@ export default defineConfig({
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
       'apps/web/src/app/api/agent-runs/[id]/route.test.ts',
       'apps/web/src/app/api/agent-runs/route.test.ts',
-      'apps/web/src/app/api/analytics/activity/route.test.ts',
-      'apps/web/src/app/api/analytics/epic-progress/route.test.ts',
-      'apps/web/src/app/api/analytics/health/route.test.ts',
-      'apps/web/src/app/api/analytics/overview/route.test.ts',
-      'apps/web/src/app/api/analytics/velocity-history/route.test.ts',
-      'apps/web/src/app/api/analytics/workload/route.test.ts',
       'apps/web/src/app/api/cron/agent-session-recovery/route.test.ts',
       'apps/web/src/app/api/cron/hitl-timeouts/route.test.ts',
       'apps/web/src/app/api/cron/inbox-outbox/route.test.ts',


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 1/N · in-progress)

격리분(2d5c8662 QUARANTINE manifest)의 **app/api/analytics route 테스트 6종**을 현 계약으로 재작성 + 격리 해제.

## 근본 (진단)

해당 테스트들은 **FastAPI-proxy 마이그 이전 경로를 mock하는 stale 테스트**였다. 라우트는 이제 `getAuthContext → proxyToFastapi → apiSuccess` 위임인데, 테스트는 구 `createDbServerClient` 직쿼리를 mock → `proxyToFastapi` 내부의 `getServerSession`(@/lib/db/server) 미mock으로 `No "getServerSession" export` → 400. **1줄 추가가 아닌 rewrite-to-contract**.

## 재작성 (현 계약)

- mock = `getAuthContext` + `proxyToFastapi` (구 db client/admin/query stub 폐기 — 비즈니스 로직은 FastAPI **backend pytest**가 검증, FE route 테스트는 **위임/래핑/auth 게이트**만 검증).
- 검증/파일 = `401`(미인증·proxy 미호출)·`429`(rate-limit)·**proxy 위임 + `{data}` 래핑**(올바른 `/api/v2/analytics/*` path)·**proxy 에러 패스스루**.
- 대상 6: activity · epic-progress · health · overview · velocity-history · workload.
- `vitest.config.ts` QUARANTINE manifest에서 6종 제거.

## 검증

- analytics 7파일/27 테스트 green.
- **전체 vitest 670 passed**(95파일·회귀 0).

## 진행

Group B 67 중 **6 소거**. 잔여 61(route ~47 = 동일 proxy 패턴 / services ~14 = stale repo mock)은 도메인 배치로 후속(batch 2+). 매 배치 풀 vitest green 후 해제.

## 리뷰

PO 검수 → 까심 QA. base `develop`. 후속 배치는 동일 PR 또는 분리 — PO 콜.

🤖 Generated with [Claude Code](https://claude.com/claude-code)