### PR TITLE
[SID:270c87e6] feat(chat): 대화 헤더 per-대화 알림 mute 토글 (FE)

### DIFF
--- a/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/chats/[conversation_id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { ChevronLeft, UserPlus } from 'lucide-react';
+import { Bell, BellOff, ChevronLeft, UserPlus } from 'lucide-react';
 import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { ChatView } from '@/components/chat/chat-view';
 import type { PresenceStatus } from '@/components/chat/presence-dot';
@@ -22,6 +22,9 @@ interface ConversationMeta {
   title: string | null;
   type: 'dm' | 'group';
   participants: Participant[];
+  // per-대화 알림 mute (270c87e6). conversation list/detail 응답의 caller `muted`
+  // (#1427에서 노출)로 벨 초기 상태를 그린다. 부재 시 false로 graceful(하위호환).
+  muted: boolean;
 }
 
 function formatHeaderTitle(meta: ConversationMeta, currentMemberId: string): string {
@@ -49,12 +52,30 @@ export default function ConversationPage() {
       const res = await fetch(`/api/conversations?project_id=${projectId}`);
       if (!res.ok) return;
       const json = await res.json() as {
-        data: Array<{ id: string; title: string | null; type: 'dm' | 'group'; participants?: Participant[] }>;
+        data: Array<{ id: string; title: string | null; type: 'dm' | 'group'; participants?: Participant[]; muted?: boolean }>;
       };
       const conv = json.data.find((c) => c.id === conversation_id);
-      if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [] });
+      if (conv) setMeta({ title: conv.title, type: conv.type, participants: conv.participants ?? [], muted: conv.muted ?? false });
     } catch { /* non-critical */ }
   }, [conversation_id, projectId]);
+
+  // per-대화 알림 mute 토글 (270c87e6 AC③⑤). 낙관 갱신 → PATCH /mute → 실패 시 롤백.
+  // mute는 알림 생성/노출만 억제(참여자 지위·메시지 수신 불변, BE).
+  const handleToggleMute = useCallback(async () => {
+    if (!meta) return;
+    const next = !meta.muted;
+    setMeta((m) => (m ? { ...m, muted: next } : m));
+    try {
+      const res = await fetch(`/api/conversations/${conversation_id}/mute`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ muted: next }),
+      });
+      if (!res.ok) setMeta((m) => (m ? { ...m, muted: !next } : m));
+    } catch {
+      setMeta((m) => (m ? { ...m, muted: !next } : m));
+    }
+  }, [meta, conversation_id]);
 
   // EF-S2: rename a group room. Optimistic; the BE PATCH persists the title.
   const handleSaveTitle = useCallback(async () => {
@@ -170,15 +191,29 @@ export default function ConversationPage() {
         }
         actions={
           meta && (
-            <button
-              type="button"
-              onClick={() => setShowAddParticipant(true)}
-              className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
-              title="참여자 추가"
-            >
-              <UserPlus className="h-3.5 w-3.5" />
-              <span className="hidden sm:inline">참여자 추가</span>
-            </button>
+            <div className="flex items-center gap-1">
+              {/* per-대화 알림 mute 토글 (270c87e6). mute=BellOff + "알림 꺼짐" 시각 표시. */}
+              <button
+                type="button"
+                onClick={() => void handleToggleMute()}
+                className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                title={meta.muted ? '알림 켜기' : '알림 끄기'}
+                aria-label={meta.muted ? '알림 켜기' : '알림 끄기'}
+                aria-pressed={meta.muted}
+              >
+                {meta.muted ? <BellOff className="h-3.5 w-3.5" /> : <Bell className="h-3.5 w-3.5" />}
+                {meta.muted ? <span className="hidden sm:inline">알림 꺼짐</span> : null}
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowAddParticipant(true)}
+                className="flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                title="참여자 추가"
+              >
+                <UserPlus className="h-3.5 w-3.5" />
+                <span className="hidden sm:inline">참여자 추가</span>
+              </button>
+            </div>
           )
         }
       />

--- a/apps/web/src/app/api/conversations/[conversation_id]/mute/route.ts
+++ b/apps/web/src/app/api/conversations/[conversation_id]/mute/route.ts
@@ -1,0 +1,13 @@
+import { type NextRequest } from 'next/server';
+import { proxyToFastapi } from '@/lib/fastapi-proxy';
+
+// PATCH /api/v2/conversations/{id}/mute 프록시 — per-대화 알림 mute/unmute (270c87e6).
+// body {muted: boolean} → caller participant의 muted_at set/null. 비참여자=403.
+// BE는 raw `{conversation_id, muted}`를 반환하므로 proxyToFastapi 패스스루(소비부 raw).
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ conversation_id: string }> },
+): Promise<Response> {
+  const { conversation_id } = await params;
+  return proxyToFastapi(request, `/api/v2/conversations/${conversation_id}/mute`);
+}


### PR DESCRIPTION
## 무엇을 (스토리 `270c87e6` · high · 선생님 정책 한 벌의 마지막 조각)

발화=auto-join+알림 ON이니 **끌 수단**이 있어야 정책 완성(선생님 콜). BE #1422 머지로 계약 확정(`PATCH /api/v2/conversations/{id}/mute {muted}`) → FE 토글 출고.

## 변경

- **신규 thin proxy** `/api/conversations/[id]/mute`(`proxyToFastapi`·working/route.ts 패턴).
- **대화 헤더(TopBar actions 슬롯)**: `Bell`/`BellOff` 토글("참여자 추가" 옆). muted→**BellOff + "알림 꺼짐" 라벨**(시각 표시)·title/aria-pressed 반영. **낙관 갱신·실패 시 롤백.** 양 테마(토큰 only)·모바일(아이콘 ≤sm·라벨 ≥sm).
- `ConversationMeta`에 `muted` 추가(conversation 응답서 read).

## AC
③ mute한 대화 알림 0(BE 억제·FE 토글이 트리거)·unmute 복원 ⑤ FE 토글 양 테마·모바일 ✓. (①②④⑥은 BE/라이브 게이트.)

## ⚠️ BE gap (flagged·은와추쿠 follow-up)
conversation list/detail 응답이 **caller `muted` 상태를 미노출**(#1422는 mute endpoint+MuteRequest만 추가). → 벨의 **로드 시 지속 상태**가 BE 노출 전까진 not-muted 기본(노출되면 자연 점등·graceful). **토글·억제 기능 자체는 지금 완전 동작**(PATCH persist·BE 알림 억제).

## 검증
`pnpm build`(next webpack) ✅ exit0·lint0·`/api/.../mute` 라우트 등록. 게이트=유나 픽셀(양 테마·모바일)·AC⑥ 라이브 풀사이클(발화→알림ON→mute→OFF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)