### PR TITLE
feat(chat): conversation list/detail에 caller muted 노출 — FE mute 토글 초기상태 (270c87e6 BE gap)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -509,6 +509,8 @@ class ConversationResponse(BaseModel):
     created_by: uuid.UUID | None = None
     created_at: datetime
     updated_at: datetime
+    # 270c87e6: caller의 알림 mute 상태(participant muted_at 기반) — FE mute 토글 초기 상태용(#1426).
+    muted: bool = False
 
 
 # E-FILE S1: 채팅 첨부. GCS 기록은 FE-proxy(uploadToGcs)가 처리하고 BE는 URL+메타만 저장.
@@ -644,11 +646,15 @@ async def list_conversations(
         raise HTTPException(status_code=403, detail="Only owner/admin can view agent conversations.")
 
     conv_ids_result = await db.execute(
-        select(ConversationParticipant.conversation_id).where(
+        select(ConversationParticipant.conversation_id, ConversationParticipant.muted_at).where(
             ConversationParticipant.member_id == sender.id
         )
     )
-    conv_ids = set(r[0] for r in conv_ids_result.all())
+    _caller_rows = conv_ids_result.all()
+    conv_ids = set(r.conversation_id for r in _caller_rows)
+    # 270c87e6: caller의 대화별 mute 상태(FE 토글 초기 상태·#1426). admin-bypass로 추가되는
+    # agent-only 대화는 caller가 참여자 아니라 자연히 False.
+    caller_muted = {r.conversation_id: r.muted_at is not None for r in _caller_rows}
 
     # AC1/2 + #1262: admin-bypass는 **agent-only 대화로 한정**(사적 DM 프라이버시).
     # project 내 agent type member가 participant인 conversation 후보를 모으되,
@@ -740,6 +746,7 @@ async def list_conversations(
             "resolved_by": str(conv.resolved_by) if conv.resolved_by else None,
             "resolved_at": conv.resolved_at.isoformat() if conv.resolved_at else None,
             "participants": conv_participants.get(conv.id, []),
+            "muted": caller_muted.get(conv.id, False),  # 270c87e6: FE mute 토글 초기 상태
             "latest_message": {
                 "content": latest_msg.content,
                 "created_at": latest_msg.created_at.isoformat(),
@@ -784,7 +791,16 @@ async def get_conversation(
         if participant is None:
             raise HTTPException(status_code=403, detail="Not a participant")
 
-    return ConversationResponse.model_validate(conv)
+    # 270c87e6: caller의 mute 상태 노출(FE 토글 초기 상태·#1426). 비참여자(admin-bypass agent-only)는 False.
+    caller_muted_at = (await db.execute(
+        select(ConversationParticipant.muted_at).where(
+            ConversationParticipant.conversation_id == conversation_id,
+            ConversationParticipant.member_id == sender.id,
+        )
+    )).scalar_one_or_none()
+    resp = ConversationResponse.model_validate(conv)
+    resp.muted = caller_muted_at is not None
+    return resp
 
 
 @router.get("/{conversation_id}/messages")

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -254,7 +254,8 @@ async def test_list_conversations():
         member_result.scalars.return_value.first.return_value = mock_member
 
         conv_ids_result = MagicMock()
-        conv_ids_result.all.return_value = [(CONV_ID,)]
+        # 270c87e6: conv_ids 쿼리가 (conversation_id, muted_at) 2컬럼 반환 — Row 속성 접근 정합.
+        conv_ids_result.all.return_value = [MagicMock(conversation_id=CONV_ID, muted_at=None)]
 
         total_result = MagicMock()
         total_result.scalar_one.return_value = 1
@@ -360,7 +361,11 @@ async def test_get_conversation_200_returns_project_id():
         agents_result = MagicMock()
         agents_result.scalars.return_value.all.return_value = [agent_id]  # 전원 agent 확정
 
-        session.execute = AsyncMock(side_effect=[conv_result, member_result, pids_result, agents_result])
+        # 270c87e6: detail이 caller muted_at 조회 1건 추가 — 비참여(agent-only)면 None=미mute.
+        muted_result = MagicMock()
+        muted_result.scalar_one_or_none.return_value = None
+
+        session.execute = AsyncMock(side_effect=[conv_result, member_result, pids_result, agents_result, muted_result])
 
         async with client as c:
             resp = await c.get(f"/api/v2/conversations/{CONV_ID}")


### PR DESCRIPTION
## 무엇을 (270c87e6 후속 BE gap · 미르코 #1426 언블록)

#1422(270c87e6·머지됨)가 mute 저장(`conversation_participants.muted_at`)+토글(`PATCH /mute`)을 넣었으나, **conversation list/detail 응답에 caller의 mute 상태가 없어** FE mute 토글(#1426)이 벨 아이콘 초기 on/off를 못 그린다. caller의 `muted`(bool)를 노출(additive).

## 수정

- **detail** (`GET /conversations/{id}`): `ConversationResponse`에 `muted` 필드 + caller participant `muted_at` 조회로 세팅.
- **list** (`GET /conversations`): conv_ids 쿼리에 `muted_at` 동반 조회 → `caller_muted` 맵 → 각 항목 `muted`. admin-bypass agent-only 대화(caller 비참여)는 False.
- ⚠️ 응답 shape 변경 회귀: 기존 `test_conversations`의 conv_ids mock(플레인 튜플 → `(conversation_id, muted_at)` Row) · detail mock 시퀀스(caller_muted_at 1쿼리 추가)를 정합 갱신.

## 검증

- conversation 18 통과 + **전체 backend pytest 1876 passed · 0 failed**(CI=1).

## 리뷰

PO 검수 → 까심 QA. base `develop`. 머지되면 #1426 재정독→머지→270c87e6 done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)