### PR TITLE
[SID:e2608901] feat(notifications): message_created payload에 사람-친화 summary 생성 (BE)

### DIFF
--- a/backend/app/routers/conversations.py
+++ b/backend/app/routers/conversations.py
@@ -218,7 +218,26 @@ async def _conversations_with_human_participant(conv_ids: list[uuid.UUID], db: A
     return result
 
 
+_SUMMARY_PREVIEW_MAX = 80
+
+
+def _build_message_summary(content: str | None, sender_name: str | None, has_attachment: bool) -> str:
+    """알림 카피용 사람-친화 summary (e2608901). 형식: "{발신자}: {내용 미리보기 80자}".
+
+    notification-bell이 `payload.summary ?? event_type`로 렌더하므로, summary 미생성 시 raw
+    이벤트명(`conversation.message_created`)이 노출됐다. 발신자+미리보기로 "무슨 일인지" 1초 노출.
+    """
+    name = sender_name or "Someone"
+    preview = " ".join((content or "").split())  # 개행/연속공백 정규화
+    if len(preview) > _SUMMARY_PREVIEW_MAX:
+        preview = preview[:_SUMMARY_PREVIEW_MAX].rstrip() + "…"
+    if not preview:
+        preview = "📎" if has_attachment else ""
+    return f"{name}: {preview}" if preview else name
+
+
 def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember | None") -> dict:
+    attachments = msg.attachments if isinstance(msg.attachments, list) else []
     return {
         "id": str(msg.id),
         "conversation_id": str(msg.conversation_id),
@@ -228,12 +247,14 @@ def _msg_payload(msg: ConversationMessage, sender: "ResolvedMember | TeamMember 
         "content": msg.content,
         "mentioned_ids": [str(m) for m in (msg.mentioned_ids or [])],
         # E-FILE S1: 첨부 직렬화 (SSE + GET messages 공통). list 아니면 [](레거시/None/mock 안전).
-        "attachments": msg.attachments if isinstance(msg.attachments, list) else [],
+        "attachments": attachments,
         "sender": {
             "id": str(sender.id),
             "name": sender.name,
             "type": sender.type,
         } if sender else None,
+        # e2608901: 알림 카피 — raw event_type 대신 사람-친화 summary를 payload에 동봉.
+        "summary": _build_message_summary(msg.content, sender.name if sender else None, bool(attachments)),
         "created_at": msg.created_at.isoformat(),
     }
 

--- a/backend/tests/test_conversations.py
+++ b/backend/tests/test_conversations.py
@@ -99,6 +99,35 @@ async def _make_client(session=None):
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), session, app
 
 
+# ─── e2608901: 알림 카피 summary 생성 ────────────────────────────────────────
+
+def test_build_message_summary_formats():
+    from app.routers.conversations import _build_message_summary as f
+    # 정상: "{발신자}: {내용}"
+    assert f("Hello team", "디디", False) == "디디: Hello team"
+    # 80자 초과 → 절삭 + … (이름+": " 접두 제외 본문만 80)
+    long = f("x" * 100, "A", False)
+    assert long.startswith("A: ") and long.endswith("…") and len(long.split(": ", 1)[1]) == 81
+    # 개행/연속공백 정규화
+    assert f("line1\n\nline2   x", "D", False) == "D: line1 line2 x"
+    # 내용 없음 + 첨부 → 📎 마커
+    assert f("", "B", True) == "B: 📎"
+    # 내용 없음 + 첨부 없음 → 발신자명만 (raw event_type 노출 방지)
+    assert f("", "C", False) == "C"
+    # 발신자 미상 폴백
+    assert f("hi", None, False) == "Someone: hi"
+
+
+def test_msg_payload_includes_summary():
+    """_msg_payload(message_created·mention 공통)에 summary 동봉 — notification-bell raw 노출 차단."""
+    from app.routers.conversations import _msg_payload
+    msg = _make_msg()
+    sender = _make_member()
+    payload = _msg_payload(msg, sender)
+    assert "summary" in payload
+    assert payload["summary"].startswith(f"{sender.name}: ")
+
+
 # ─── AC1: Alembic migration 파일 + 테이블 확인 ───────────────────────────────
 
 def test_migration_file_exists():


### PR DESCRIPTION
## 무엇을 (선생님 제보 · [알림·정책]과 페어)

알림 항목이 `conversation.message_created` 같은 **raw 이벤트명 그대로** 노출("성의없음"). **근본**(PO 실측 `notification-bell.tsx:253`): `{n.payload?.summary ?? n.event_type}` — summary 폴백 구조는 있으나 message_created payload에 **summary가 생성되지 않아** raw 이벤트명이 뜬다.

## BE 조치 (AC②)

`_msg_payload`(message_created·mention fan-out 공통)에 **`summary` 동봉**:
- 형식 `"{발신자}: {내용 미리보기}"`.
- 미리보기 **80자 초과 → 절삭 + …**, 개행/연속공백 정규화.
- 첨부전용(내용 없음) → `📎` 마커, 내용·첨부 모두 없음 → 발신자명. **어떤 경우든 raw event_type 비노출.**

## FE (ⓑ · 미르코 큐 · #1426 계열)

레거시(summary 부재) 알림 `event_type→카피` 매핑 폴백 + 발신자 아바타/이름 라인 + i18n(en/ko) + 클릭 이동.

## 검증

- `_build_message_summary` 단위(정상·80자 절삭·첨부 📎·빈내용·발신자미상) + `_msg_payload` summary 동봉.
- conversation 15 + **전체 backend pytest 1878 passed · 0 failed**(CI=1).

## AC

- [x] ② message_created 알림 = "{발신자}: 미리보기" 형식 (BE)
- [x] ① 신규 알림 raw event_type 노출 0 (BE summary 생성 → FE 폴백과 합쳐 완성)
- [ ] ③④⑤ FE 매핑·i18n·이동 (미르코)

## 리뷰

PO 검수 → 까심 QA. base `develop`. FE(ⓑ)는 미르코 인계.

🤖 Generated with [Claude Code](https://claude.com/claude-code)