### PR TITLE
[SID:d67e5478] fix(chat): 메시지 텍스트 overflow-wrap:anywhere 하드닝 (재제보·+cache-bust)

### DIFF
--- a/apps/web/src/components/chat/chat-bubble.tsx
+++ b/apps/web/src/components/chat/chat-bubble.tsx
@@ -48,7 +48,7 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
 
   if (!hasMarkdown && !hasMention) {
     return (
-      <span className={`whitespace-pre-wrap break-words text-sm leading-relaxed ${text}`}>
+      <span className={`whitespace-pre-wrap [overflow-wrap:anywhere] text-sm leading-relaxed ${text}`}>
         {content}
       </span>
     );
@@ -63,10 +63,10 @@ function ChatMarkdown({ content, isMine }: { content: string; isMine: boolean })
         url.startsWith('entity:') || url.startsWith('mention:') ? url : defaultUrlTransform(url)
       }
       components={{
-        p: ({ children }) => <p className={`mb-1.5 break-words text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
+        p: ({ children }) => <p className={`mb-1.5 [overflow-wrap:anywhere] text-sm leading-relaxed last:mb-0 ${text}`}>{children}</p>,
         strong: ({ children }) => <strong className={`font-semibold ${text}`}>{children}</strong>,
         em: ({ children }) => <em className={`italic ${text}`}>{children}</em>,
-        code: ({ children }) => <code className={`rounded px-1 py-0.5 font-mono text-xs ${codeBg}`}>{children}</code>,
+        code: ({ children }) => <code className={`rounded px-1 py-0.5 font-mono text-xs [overflow-wrap:anywhere] ${codeBg}`}>{children}</code>,
         pre: ({ children }) => <pre className={`mb-1.5 overflow-x-auto rounded-lg p-2.5 text-xs ${codeBg}`}>{children}</pre>,
         ul: ({ children }) => <ul className={`mb-1.5 ml-4 list-disc space-y-0.5 text-sm ${text}`}>{children}</ul>,
         ol: ({ children }) => <ol className={`mb-1.5 ml-4 list-decimal space-y-0.5 text-sm ${text}`}>{children}</ol>,
@@ -214,13 +214,13 @@ export function ChatBubble({ message, isMine, isGrouped = false, onOpenThread, o
                 <Terminal className="h-3 w-3" aria-hidden />
                 {t('commandTag')}
               </div>
-              <code className="block break-words whitespace-pre-wrap font-mono text-sm">
+              <code className="block whitespace-pre-wrap [overflow-wrap:anywhere] font-mono text-sm">
                 <span className="text-brand">/{cmdName}</span>
                 <span className="text-muted-foreground">{message.content.slice(1 + (cmdName?.length ?? 0))}</span>
               </code>
             </div>
           ) : (
-            <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed break-words ${
+            <div className={`rounded-2xl px-3.5 py-2 text-sm leading-relaxed [overflow-wrap:anywhere] ${
               isMine
                 ? 'rounded-tr-sm bg-primary text-primary-foreground'
                 : 'rounded-tl-sm bg-muted text-foreground'


### PR DESCRIPTION
## 무엇을 (스토리 `d67e5478` 재오픈 · 선생님 실기기 재제보)

채팅 overflow 재발(이번엔 일반 텍스트 — 한글 장문 + 백틱 `·`연결 무공백 토큰 + UUID).

## 재현 시도 (puppeteer·390px·현재 CSS 그대로·#1423 min-w-0 포함)

**plain text·inline code·code block 3종 모두 — overflow 재현 안 됨**(측정: 어느 요소도 390 뷰포트 안 넘음·`break-word`+`min-w-0`가 전부 수렴). ⇒ **디바이스 stale 청크 캐시 가능성 높음**(PO 제기 축: 스샷vs배포 타이밍·모바일 청크 캐시) 또는 라이브 앱+정확한 콘텐츠 필요한 미캡처 표면.

## 이 PR — 블라인드 추측 대신 robustness 하드닝 + cache-bust

모든 메시지 텍스트/코드 표면 `break-word`→**`overflow-wrap:anywhere`**(anywhere ⊇ break-word·min-content도 줄여 break-word가 못 꺾는 토큰까지 수렴). **비회귀**(break 기회만 추가). 새 청크 해시로 cache-bust 동반. build green·lint0.

surfaces: plain span·markdown `p`·inline `code`·cmd code·일반 버블 div.

## ⚠️ 검증 요청
디바이스에서 **하드 리프레시/캐시 클리어 후 재확인** 부탁하는. **fresh load에서도 재발하면** 정확한 메시지 원문 + dev-app 재현 주면 실표면 핀해서 정밀 수정하겠는(#1423 블라인드 반복 안 하려는).

🤖 Generated with [Claude Code](https://claude.com/claude-code)