### PR TITLE
[SID:837a36c4] test: Group B 번다운 batch 7 — sprints 직접 서비스 핸들러 2종 (burndown·kickoff)

### DIFF
--- a/apps/web/src/app/api/sprints/[id]/burndown/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/burndown/route.test.ts
@@ -1,92 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B b7): 직접 서비스 핸들러 — auth 게이트 → SprintService(repo).getBurndown(id) → 래핑.
+// proxy 아님. 구 stale 테스트 폐기, 현 서비스 계약(메서드 호출·NotFoundError→404)으로 재작성.
+const h = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  createSprintRepository: vi.fn(),
+  getBurndown: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createSprintRepository: h.createSprintRepository }));
+vi.mock('@/services/sprint', async (importActual) => ({
+  // 에러클래스(NotFoundError·ForbiddenError 등)는 실제 유지(handleApiError가 instanceof로 참조)·SprintService만 오버라이드.
+  ...(await importActual<typeof import('@/services/sprint')>()),
+  SprintService: class { getBurndown = h.getBurndown; },
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-
 import { GET } from './route';
+import { NotFoundError } from '@/services/sprint';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
+const ID = 'sprint-1';
+const ctx = () => ({ params: Promise.resolve({ id: ID }) });
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const req = () => new Request(`http://localhost/api/sprints/${ID}/burndown`);
 
-function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNotFound?: boolean } = {}) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.is = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.limit = vi.fn(chain);
-  q.lt = vi.fn(chain);
-  q.single = vi.fn(() =>
-    opts.singleNotFound
-      ? Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } })
-      : Promise.resolve({ data: rows[0] ?? null, error: null }),
-  );
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
-
-describe('GET /api/sprints/[id]/burndown', () => {
+describe('GET /api/sprints/[id]/burndown (직접 서비스)', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    h.getAuthContext.mockReset(); h.createSprintRepository.mockReset(); h.getBurndown.mockReset();
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createSprintRepository.mockResolvedValue({});
   });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    getAuthContext.mockResolvedValue(null);
-
-    const response = await GET(
-      new Request('http://localhost/api/sprints/sprint-1/burndown'),
-      { params: Promise.resolve({ id: 'sprint-1' }) },
-    );
-
-    expect(response.status).toBe(401);
+  it('401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(req(), ctx())).status).toBe(401);
+    expect(h.getBurndown).not.toHaveBeenCalled();
   });
-
-  it('returns 200 with burndown data', async () => {
-    const sprint = { id: 'sprint-1', project_id: 'project-alpha', title: 'S1', status: 'active' };
-    const stories = [
-      { story_points: 5, status: 'done', updated_at: '2026-04-01' },
-      { story_points: 3, status: 'todo', updated_at: '2026-04-02' },
-    ];
-    const db = {
-      from: vi.fn((table: string) => createQueryStub(table === 'sprints' ? [sprint] : stories)),
-    };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(
-      new Request('http://localhost/api/sprints/sprint-1/burndown'),
-      { params: Promise.resolve({ id: 'sprint-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ total_points: 8, done_points: 5, remaining_points: 3, completion_pct: 63 });
+  it('returns burndown data via SprintService(id) wrapped', async () => {
+    h.getBurndown.mockResolvedValue({ days: [1, 2, 3] });
+    const res = await GET(req(), ctx());
+    expect(res.status).toBe(200);
+    expect(h.getBurndown).toHaveBeenCalledWith(ID);
+    expect((await res.json()).data).toMatchObject({ days: [1, 2, 3] });
   });
-
-  it('returns 404 when sprint not found', async () => {
-    const db = { from: vi.fn(() => createQueryStub([], { singleNotFound: true })) };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await GET(
-      new Request('http://localhost/api/sprints/sprint-missing/burndown'),
-      { params: Promise.resolve({ id: 'sprint-missing' }) },
-    );
-
-    expect(response.status).toBe(404);
+  it('NotFoundError → 404', async () => {
+    h.getBurndown.mockRejectedValue(new NotFoundError('sprint not found'));
+    expect((await GET(req(), ctx())).status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/sprints/[id]/kickoff/route.test.ts
+++ b/apps/web/src/app/api/sprints/[id]/kickoff/route.test.ts
@@ -1,83 +1,48 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B b7): 직접 서비스 핸들러 — auth 게이트 → SprintService(repo).kickoff(id, message) → 래핑.
+const h = vi.hoisted(() => ({
   getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
+  createSprintRepository: vi.fn(),
+  kickoff: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createSprintRepository: h.createSprintRepository }));
+vi.mock('@/services/sprint', async (importActual) => ({
+  // 에러클래스(NotFoundError·ForbiddenError 등)는 실제 유지(handleApiError가 instanceof로 참조)·SprintService만 오버라이드.
+  ...(await importActual<typeof import('@/services/sprint')>()),
+  SprintService: class { kickoff = h.kickoff; },
 }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-
 import { POST } from './route';
+import { NotFoundError } from '@/services/sprint';
 
-function makeAgent() {
-  return { id: 'agent-1', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 };
-}
+const ID = 'sprint-1';
+const ctx = () => ({ params: Promise.resolve({ id: ID }) });
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const req = (body: object = { message: 'go' }) =>
+  new Request(`http://localhost/api/sprints/${ID}/kickoff`, { method: 'POST', body: JSON.stringify(body) });
 
-function createQueryStub(rows: Record<string, unknown>[] = [], opts: { singleNotFound?: boolean; insertOk?: boolean } = {}) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.is = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.limit = vi.fn(chain);
-  q.lt = vi.fn(chain);
-  q.insert = vi.fn(() => (opts.insertOk !== false ? Promise.resolve({ error: null }) : Promise.resolve({ error: { message: 'insert failed' } })));
-  q.single = vi.fn(() =>
-    opts.singleNotFound
-      ? Promise.resolve({ data: null, error: { code: 'PGRST116', message: 'not found' } })
-      : Promise.resolve({ data: rows[0] ?? null, error: null }),
-  );
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(Promise.resolve({ data: rows, error: null }));
-  return q;
-}
-
-describe('POST /api/sprints/[id]/kickoff', () => {
+describe('POST /api/sprints/[id]/kickoff (직접 서비스)', () => {
   beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue(makeAgent());
+    h.getAuthContext.mockReset(); h.createSprintRepository.mockReset(); h.kickoff.mockReset();
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createSprintRepository.mockResolvedValue({});
   });
-
-  it('returns 401 when not authenticated', async () => {
-    const db = {};
-    createDbServerClient.mockResolvedValue(db);
-    getAuthContext.mockResolvedValue(null);
-
-    const response = await POST(
-      new Request('http://localhost/api/sprints/sprint-1/kickoff', { method: 'POST', body: '{}' }),
-      { params: Promise.resolve({ id: 'sprint-1' }) },
-    );
-
-    expect(response.status).toBe(401);
+  it('401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await POST(req(), ctx())).status).toBe(401);
+    expect(h.kickoff).not.toHaveBeenCalled();
   });
-
-  it('returns 200 with notified count', async () => {
-    const sprint = { id: 'sprint-1', project_id: 'project-alpha', title: 'Sprint 1', org_id: 'org-1' };
-    const project = { org_id: 'org-1' };
-    const members = [{ id: 'member-1' }, { id: 'member-2' }];
-    const db = {
-      from: vi.fn((table: string) => {
-        if (table === 'sprints') return createQueryStub([sprint]);
-        if (table === 'projects') return createQueryStub([project]);
-        if (table === 'team_members') return createQueryStub(members);
-        return createQueryStub([], { insertOk: true });
-      }),
-    };
-    createDbServerClient.mockResolvedValue(db);
-    createAdminClient.mockReturnValue(db);
-
-    const response = await POST(
-      new Request('http://localhost/api/sprints/sprint-1/kickoff', { method: 'POST', body: '{}' }),
-      { params: Promise.resolve({ id: 'sprint-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ notified: expect.any(Number) });
+  it('kicks off via SprintService(id, message) wrapped', async () => {
+    h.kickoff.mockResolvedValue({ started: true });
+    const res = await POST(req({ message: 'go team' }), ctx());
+    expect(res.status).toBe(200);
+    expect(h.kickoff).toHaveBeenCalledWith(ID, 'go team');
+    expect((await res.json()).data).toMatchObject({ started: true });
+  });
+  it('NotFoundError → 404', async () => {
+    h.kickoff.mockRejectedValue(new NotFoundError('sprint not found'));
+    expect((await POST(req(), ctx())).status).toBe(404);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
       'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts',
-      'apps/web/src/app/api/sprints/[id]/burndown/route.test.ts',
-      'apps/web/src/app/api/sprints/[id]/kickoff/route.test.ts',
       'apps/web/src/app/api/stories/[id]/route.test.ts',
       'apps/web/src/app/api/tasks/route.test.ts',
       'apps/web/src/app/api/v1/bridge/slack/events/route.test.ts',


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 7 · 하드 구간 진입)

proxy 아닌 **직접 서비스 핸들러** 첫 배치 — `sprints/[id]/burndown`·`kickoff`. 둘 다 `auth게이트 → createSprintRepository → new SprintService(repo).getBurndown/kickoff(id) → apiSuccess(data)` · `NotFoundError → 404`.

## 직접-서비스 mock 정석 (잔여 tasks/stories/notifications에 재사용)

- mock 대상: `@/lib/auth-helpers`(게이트) · `@/lib/storage/factory`(`createSprintRepository`) · `@/services/sprint`(SprintService).
- ⚠️ **`@/services/sprint`는 `importActual` 스프레드**로 에러클래스(`NotFoundError`·`ForbiddenError`) 실제 유지 — `api-error.ts`의 `handleApiError`가 `instanceof`로 참조하므로 미유지 시 `No "ForbiddenError" export` 폭발. SprintService만 오버라이드.
- ⚠️ SprintService 모킹은 **`class { method = h.method }`** — `vi.fn().mockImplementation(() => obj)`는 `new` 시 화살표를 생성자로 써 `is not a constructor` (vitest 함정, 디버그로 규명).

## 검증

- 401 · 서비스 메서드 호출 인자(`id`[, `message`]) · `{data}` 래핑 · `NotFoundError → 404`.
- 2파일/6 green + **전체 vitest 790 passed**(126파일·회귀 0).

## 진행

Group B 67 중 **34 소거**. 잔여 ~33 — 직접서비스(tasks·stories/[id]·current-project·notifications) · docs/[id] 혼합 · bridge/cron/webhooks · services ~14. 정독 페이스.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)