### PR TITLE
[SID:837a36c4] test(tasks): Group B 번다운 batch 8 — tasks 직접 서비스 핸들러 (TaskService)

### DIFF
--- a/apps/web/src/app/api/tasks/route.test.ts
+++ b/apps/web/src/app/api/tasks/route.test.ts
@@ -1,85 +1,81 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, createAdminClient, getAuthContext, createTaskRepository } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  createAdminClient: vi.fn(),
-  getAuthContext: vi.fn(),
-  createTaskRepository: vi.fn(),
+// 837a36c4(Group B b8): 직접 서비스 핸들러(TaskService) — b7 정석 재사용. proxy 아님.
+// GET=service.list(+story_id면 counts) / POST=parseBody→service.create(201). pagination 헬퍼는 실제 사용.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), createTaskRepository: vi.fn(),
+  list: vi.fn(), create: vi.fn(), parseBody: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createTaskRepository: h.createTaskRepository }));
+vi.mock('@/services/task', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/task')>()),
+  TaskService: class { list = h.list; create = h.create; },
+}));
+vi.mock('@sprintable/shared', async (importActual) => ({
+  // 공유 모듈은 export 다수(VALID_STORY_TRANSITIONS 등 타 소비자 참조) — importActual로 전부 유지·parseBody만 오버라이드.
+  ...(await importActual<typeof import('@sprintable/shared')>()),
+  parseBody: h.parseBody,
 }));
 
-const listMock = vi.fn();
+import { GET, POST } from './route';
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-vi.mock('@/lib/storage/factory', () => ({ createTaskRepository }));
-vi.mock('@/services/task', () => ({ TaskService: class { list = listMock; } }));
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const task = (id: string, status = 'todo') => ({ id, status, created_at: `2026-06-1${id}T00:00:00Z` });
 
-import { GET } from './route';
-
-const mockAuth = {
-  id: 'team-member-1',
-  org_id: 'org-1',
-  project_id: 'project-1',
-  project_name: 'Test',
-  type: 'human' as const,
-  rateLimitExceeded: false,
-};
-
-function createCountBuilder() {
-  const state: Record<string, unknown> = {};
-  const builder = {
-    select: vi.fn(() => builder),
-    eq: vi.fn((column: string, value: unknown) => {
-      state[column] = value;
-      return builder;
-    }),
-    then: (resolve: (value: { count: number; error: null }) => unknown) => resolve({
-      count: state.status === 'done' ? 3 : 7,
-      error: null,
-    }),
-  };
-  return builder;
-}
-
-describe('GET /api/tasks', () => {
+describe('/api/tasks (직접 서비스 TaskService)', () => {
   beforeEach(() => {
-    listMock.mockReset();
-    createDbServerClient.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockReset();
-    createTaskRepository.mockReset();
-
-    const dbMock = { from: vi.fn(() => createCountBuilder()) };
-    createDbServerClient.mockResolvedValue(dbMock);
-    createAdminClient.mockReturnValue(dbMock);
-    getAuthContext.mockResolvedValue(mockAuth);
-    createTaskRepository.mockResolvedValue({});
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createTaskRepository.mockResolvedValue({});
   });
 
-  it('returns bounded pagination metadata plus story task counts', async () => {
-    listMock.mockResolvedValue([
-      { id: 'task-3', created_at: '2026-04-13T03:00:00.000Z', status: 'done' },
-      { id: 'task-2', created_at: '2026-04-13T02:00:00.000Z', status: 'todo' },
-      { id: 'task-1', created_at: '2026-04-13T01:00:00.000Z', status: 'todo' },
-    ]);
+  it('GET: 401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(new Request('http://localhost/api/tasks'))).status).toBe(401);
+    expect(h.list).not.toHaveBeenCalled();
+  });
 
-    const response = await GET(new Request('http://localhost/api/tasks?story_id=story-1&limit=2'));
-    const body = await response.json();
-
-    expect(listMock).toHaveBeenCalledWith(expect.objectContaining({
-      story_id: 'story-1',
-      limit: 2,
-      cursor: null,
-    }));
+  it('GET: lists via service.list and wraps page+meta (no story_id)', async () => {
+    h.list.mockResolvedValue([task('1'), task('2')]);
+    const res = await GET(new Request('http://localhost/api/tasks?project_id=p'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
     expect(body.data).toHaveLength(2);
-    expect(body.meta).toEqual(expect.objectContaining({
-      hasMore: true,
-      nextCursor: '2026-04-13T02:00:00.000Z',
-      totalCount: 7,
-      doneCount: 3,
-    }));
+    expect(body.meta).toBeTruthy();
   });
 
-});
+  it('GET: single story_id adds totalCount/doneCount (getStoryTaskCounts)', async () => {
+    // main list + counts(all, done) = 3 호출
+    h.list
+      .mockResolvedValueOnce([task('1', 'todo'), task('2', 'done')])  // main page
+      .mockResolvedValueOnce([task('1'), task('2')])                  // all
+      .mockResolvedValueOnce([task('2', 'done')]);                    // done
+    const res = await GET(new Request('http://localhost/api/tasks?story_id=s1'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.meta.totalCount).toBe(2);
+    expect(body.meta.doneCount).toBe(1);
+  });
 
+  it('POST: 401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await POST(new Request('http://localhost/api/tasks', { method: 'POST', body: '{}' }))).status).toBe(401);
+  });
+
+  it('POST: invalid body → parseBody 400 response', async () => {
+    h.parseBody.mockResolvedValue({ success: false, response: new Response('bad', { status: 400 }) });
+    const res = await POST(new Request('http://localhost/api/tasks', { method: 'POST', body: '{}' }));
+    expect(res.status).toBe(400);
+    expect(h.create).not.toHaveBeenCalled();
+  });
+
+  it('POST: valid body → service.create wrapped as 201', async () => {
+    h.parseBody.mockResolvedValue({ success: true, data: { title: 'T', story_id: 's1' } });
+    h.create.mockResolvedValue({ id: 't1', title: 'T' });
+    const res = await POST(new Request('http://localhost/api/tasks', { method: 'POST', body: '{}' }));
+    expect(res.status).toBe(201);
+    expect(h.create).toHaveBeenCalledWith({ title: 'T', story_id: 's1' });
+    expect((await res.json()).data).toMatchObject({ id: 't1' });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -42,7 +42,6 @@ export default defineConfig({
       'apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts',
       'apps/web/src/app/api/stories/[id]/route.test.ts',
-      'apps/web/src/app/api/tasks/route.test.ts',
       'apps/web/src/app/api/v1/bridge/slack/events/route.test.ts',
       'apps/web/src/app/api/v1/bridge/slack/interactions/route.test.ts',
       'apps/web/src/app/api/v1/bridge/teams/events/route.test.ts',


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 8 · 직접 서비스 계속)

b7 직접-서비스 정석 재사용 — `tasks` route 재작성. proxy 아니라 `new TaskService(repo)` 직접 호출.
- **GET**: `TaskService.list(...)` + `buildCursorPageMeta`(실제 헬퍼) → page+meta. `story_id` 있으면 `getStoryTaskCounts`(service.list 추가 2회)로 `totalCount/doneCount` 부가.
- **POST**: `parseBody(createTaskSchema)` → 실패 시 400 / 성공 시 `TaskService.create` → 201.

## 추가 함정 규명

`@sprintable/shared`도 **`importActual` 스프레드 필수** — `VALID_STORY_TRANSITIONS` 등 타 소비자가 참조하는 export 다수라 전체 mock 시 `No "X" export` 폭발. `parseBody`만 오버라이드. (b7의 `@/services/X` importActual 교훈과 동류 — **공유/서비스 모듈은 항상 스프레드 후 부분 오버라이드**.)

## 검증

- GET: 401 · list page+meta · single `story_id` `totalCount/doneCount`(3-call counts 검증). POST: 401 · parseBody 400 · create 201+인자.
- 6 green + **전체 vitest 796 passed**(127파일·회귀 0).

## 진행

Group B 67 중 **35 소거**(절반 돌파). 잔여 ~32 — 직접서비스(stories/[id]·current-project·notifications) · docs/[id] 혼합 · bridge/cron/webhooks · services ~14.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)