### PR TITLE
[SID:837a36c4] test: Group B 번다운 batch 10 — docs/[id] 혼합 + current-project (cookies·dynamic import)

### DIFF
--- a/apps/web/src/app/api/current-project/route.test.ts
+++ b/apps/web/src/app/api/current-project/route.test.ts
@@ -1,87 +1,58 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { cookieSet, createDbServerClient } = vi.hoisted(() => ({
-  cookieSet: vi.fn(),
-  createDbServerClient: vi.fn(),
+// 837a36c4(Group B b10): cookies + dynamic import(fastapiCall·getServerSession) 핸들러.
+// GET=게이트+프로젝트명 조회(실패 fallback) / POST=게이트 없음·parseBody→쿠키 set→프로젝트명.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), fastapiCall: vi.fn(), getServerSession: vi.fn(),
+  cookieSet: vi.fn(), parseBody: vi.fn(),
+}));
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext, CURRENT_PROJECT_COOKIE: 'sp_cur_proj' }));
+vi.mock('@sprintable/storage-api', () => ({ fastapiCall: h.fastapiCall }));
+vi.mock('@/lib/db/server', () => ({ getServerSession: h.getServerSession }));
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => ({ set: h.cookieSet })) }));
+vi.mock('@sprintable/shared', async (importActual) => ({
+  ...(await importActual<typeof import('@sprintable/shared')>()),
+  parseBody: h.parseBody,
 }));
 
-vi.mock('next/headers', () => ({
-  cookies: vi.fn(async () => ({ set: cookieSet })),
-}));
+import { GET, POST } from './route';
 
-vi.mock('@/lib/db/server', () => ({
-  createDbServerClient,
-}));
+const me = () => ({ id: 'a', type: 'human', org_id: 'org-1', project_id: 'p1', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
 
-import { POST } from './route';
-import { CURRENT_PROJECT_COOKIE } from '@/lib/auth-helpers';
-
-function createMembershipDbStub(membership: { project_id: string; projects: { name: string } | null } | null) {
-  const query = {
-    select: vi.fn(() => query),
-    eq: vi.fn(() => query),
-    maybeSingle: vi.fn().mockResolvedValue({ data: membership, error: null }),
-  };
-
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
-    },
-    from: vi.fn(() => query),
-  };
-}
-
-describe('POST /api/current-project', () => {
+describe('/api/current-project (cookies + dynamic import)', () => {
   beforeEach(() => {
-    cookieSet.mockReset();
-    createDbServerClient.mockReset();
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(me());
+    h.getServerSession.mockResolvedValue({ access_token: 'tok' });
+    h.fastapiCall.mockResolvedValue({ name: 'Alpha', id: 'p1' });
   });
 
-  it('persists current project cookie when the requested project belongs to the user', async () => {
-    createDbServerClient.mockResolvedValue(createMembershipDbStub({
-      project_id: 'project-1',
-      projects: { name: 'Alpha' },
-    }));
-
-    const response = await POST(new Request('http://localhost/api/current-project', {
-      method: 'POST',
-      body: JSON.stringify({ project_id: 'project-1' }),
-      headers: { 'Content-Type': 'application/json' },
-    }));
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.project_name).toBe('Alpha');
-    expect(cookieSet).toHaveBeenCalledWith(CURRENT_PROJECT_COOKIE, 'project-1', expect.objectContaining({ path: '/' }));
+  it('GET: 401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(new Request('http://localhost/api/current-project'))).status).toBe(401);
+  });
+  it('GET: returns project_id/org_id + name from fastapiCall', async () => {
+    const res = await GET(new Request('http://localhost/api/current-project'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ project_id: 'p1', org_id: 'org-1', project_name: 'Alpha' });
+  });
+  it('GET: fastapiCall 실패해도 200 + 기본 이름(fallback)', async () => {
+    h.fastapiCall.mockRejectedValue(new Error('be down'));
+    const res = await GET(new Request('http://localhost/api/current-project'));
+    expect(res.status).toBe(200);
+    expect((await res.json()).data).toMatchObject({ project_id: 'p1', project_name: 'My Project' });
   });
 
-  it('returns validation errors for malformed payloads', async () => {
-    createDbServerClient.mockResolvedValue(createMembershipDbStub(null));
-
-    const response = await POST(new Request('http://localhost/api/current-project', {
-      method: 'POST',
-      body: JSON.stringify({}),
-      headers: { 'Content-Type': 'application/json' },
-    }));
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.code).toBe('VALIDATION_FAILED');
-    expect(cookieSet).not.toHaveBeenCalled();
+  it('POST: invalid body → parseBody 400', async () => {
+    h.parseBody.mockResolvedValue({ success: false, response: new Response('bad', { status: 400 }) });
+    expect((await POST(new Request('http://localhost/api/current-project', { method: 'POST', body: '{}' }))).status).toBe(400);
+    expect(h.cookieSet).not.toHaveBeenCalled();
   });
-
-  it('rejects switching to a project without membership', async () => {
-    createDbServerClient.mockResolvedValue(createMembershipDbStub(null));
-
-    const response = await POST(new Request('http://localhost/api/current-project', {
-      method: 'POST',
-      body: JSON.stringify({ project_id: 'project-2' }),
-      headers: { 'Content-Type': 'application/json' },
-    }));
-
-    expect(response.status).toBe(403);
-    const body = await response.json();
-    expect(body.error.code).toBe('FORBIDDEN');
-    expect(cookieSet).not.toHaveBeenCalled();
+  it('POST: valid → 쿠키 set + 200 + project_id', async () => {
+    h.parseBody.mockResolvedValue({ success: true, data: { project_id: 'p2' } });
+    const res = await POST(new Request('http://localhost/api/current-project', { method: 'POST', body: '{}' }));
+    expect(res.status).toBe(200);
+    expect(h.cookieSet).toHaveBeenCalledWith('sp_cur_proj', 'p2', expect.objectContaining({ path: '/' }));
+    expect((await res.json()).data).toMatchObject({ project_id: 'p2' });
   });
 });

--- a/apps/web/src/app/api/docs/[id]/route.test.ts
+++ b/apps/web/src/app/api/docs/[id]/route.test.ts
@@ -1,144 +1,66 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, createAdminClient, getAuthContext, parseBody } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  createAdminClient: vi.fn(),
-  getAuthContext: vi.fn(),
-  parseBody: vi.fn(),
+// 837a36c4(Group B b10): 혼합 핸들러 — PATCH=proxyToFastapi(verbatim) / GET·DELETE=DocsService 직접.
+const h = vi.hoisted(() => ({
+  getAuthContext: vi.fn(), createDocRepository: vi.fn(), proxyToFastapi: vi.fn(),
+  getDocTimestamp: vi.fn(), deleteDoc: vi.fn(),
 }));
-const updateDoc = vi.fn();
-const getDocTimestamp = vi.fn();
-
-vi.mock('@sprintable/shared', () => ({
-  parseBody,
-  updateDocSchema: {},
-  VALID_STORY_TRANSITIONS: {
-    backlog: ['ready-for-dev'],
-    'ready-for-dev': ['in-progress', 'backlog'],
-    'in-progress': ['in-review', 'ready-for-dev'],
-    'in-review': ['done', 'in-progress'],
-    done: ['in-review'],
-  },
+vi.mock('@/lib/auth-helpers', () => ({ getAuthContext: h.getAuthContext }));
+vi.mock('@/lib/storage/factory', () => ({ createDocRepository: h.createDocRepository }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi: h.proxyToFastapi }));
+vi.mock('@/services/docs', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/docs')>()),
+  DocsService: class { getDocTimestamp = h.getDocTimestamp; deleteDoc = h.deleteDoc; },
 }));
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
-vi.mock('@/lib/storage/factory', () => ({
-  createDocRepository: vi.fn().mockResolvedValue({
-    getById: vi.fn().mockResolvedValue({ id: 'doc-1', org_id: 'org-1', doc_type: 'page' }),
-    update: vi.fn().mockResolvedValue({ id: 'doc-1', updated_at: '2026-04-09T15:21:00.000Z' }),
-    delete: vi.fn().mockResolvedValue(undefined),
-  }),
-}));
-vi.mock('@/services/docs', () => {
-  class DocsServiceMock {
-    updateDoc = updateDoc;
-    getDocTimestamp = getDocTimestamp;
-  }
 
-  return { DocsService: DocsServiceMock };
-});
+import { GET, PATCH, DELETE } from './route';
 
-import { GET, PATCH } from './route';
+const ID = 'doc-1';
+const ctx = () => ({ params: Promise.resolve({ id: ID }) });
+const agent = () => ({ id: 'a', type: 'agent', rateLimitExceeded: false, rateLimitRemaining: 299, rateLimitResetAt: 0 });
+const okRes = (b: unknown = { ok: 1 }) =>
+  new Response(JSON.stringify(b), { status: 200, headers: { 'content-type': 'application/json' } });
+const req = (m = 'GET') => new Request(`http://localhost/x/${ID}`, { method: m });
 
-const mockAuth = {
-  id: 'team-member-1',
-  org_id: 'org-1',
-  project_id: 'project-1',
-  project_name: 'Test',
-  type: 'human' as const,
-  rateLimitExceeded: false,
-};
-
-describe('/api/docs/[id] route', () => {
+describe('/api/docs/[id] (혼합: proxy + DocsService)', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    createDbServerClient.mockResolvedValue({});
-    createAdminClient.mockReturnValue({});
-    getAuthContext.mockResolvedValue(mockAuth);
-    parseBody.mockResolvedValue({
-      success: true,
-      data: {
-        content: 'updated content',
-        content_format: 'markdown',
-        icon: '📘',
-        tags: ['docs', 'mobile'],
-        expected_updated_at: '2026-04-09T15:20:00.000Z',
-        force_overwrite: false,
-      },
-    });
-    updateDoc.mockResolvedValue({
-      id: 'doc-1',
-      content: 'updated content',
-      content_format: 'markdown',
-      updated_at: '2026-04-09T15:21:00.000Z',
-    });
-    getDocTimestamp.mockResolvedValue({ updated_at: '2026-04-09T15:21:00.000Z' });
+    Object.values(h).forEach((m) => m.mockReset());
+    h.getAuthContext.mockResolvedValue(agent());
+    h.createDocRepository.mockResolvedValue({});
   });
 
-  it('passes optimistic concurrency fields through PATCH', async () => {
-    const response = await PATCH(new Request('http://localhost/api/docs/doc-1', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: 'updated content' }),
-    }), {
-      params: Promise.resolve({ id: 'doc-1' }),
-    });
-
-    expect(response.status).toBe(200);
-    expect(updateDoc).toHaveBeenCalledWith('doc-1', {
-      content: 'updated content',
-      content_format: 'markdown',
-      icon: '📘',
-      tags: ['docs', 'mobile'],
-      expected_updated_at: '2026-04-09T15:20:00.000Z',
-      force_overwrite: false,
-      created_by: 'team-member-1',
-    });
+  it('PATCH: 401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await PATCH(req('PATCH'), ctx())).status).toBe(401);
+  });
+  it('PATCH: proxies to /api/v2/docs/{id} verbatim (200)', async () => {
+    h.proxyToFastapi.mockResolvedValue(okRes());
+    const res = await PATCH(req('PATCH'), ctx());
+    expect(res.status).toBe(200);
+    expect(h.proxyToFastapi).toHaveBeenCalledWith(expect.anything(), `/api/v2/docs/${ID}`);
+  });
+  it('PATCH: passes through proxy 409 (slug taken) verbatim', async () => {
+    h.proxyToFastapi.mockResolvedValue(new Response('conflict', { status: 409 }));
+    expect((await PATCH(req('PATCH'), ctx())).status).toBe(409);
   });
 
-  it('returns 409 when the docs service raises a conflict', async () => {
-    const error = Object.assign(new Error('Document was modified by another user'), { code: 'CONFLICT' });
-    updateDoc.mockRejectedValue(error);
-
-    const response = await PATCH(new Request('http://localhost/api/docs/doc-1', {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ content: 'updated content' }),
-    }), {
-      params: Promise.resolve({ id: 'doc-1' }),
-    });
-
-    const json = await response.json();
-    expect(response.status).toBe(409);
-    expect(json.error).toEqual({ code: 'CONFLICT', message: 'Document was modified by another user' });
+  it('GET: 401 when unauthenticated', async () => {
+    h.getAuthContext.mockResolvedValue(null);
+    expect((await GET(req(), ctx())).status).toBe(401);
+  });
+  it('GET: returns timestamp via DocsService.getDocTimestamp(id)', async () => {
+    h.getDocTimestamp.mockResolvedValue({ updated_at: '2026-06-11' });
+    const res = await GET(req(), ctx());
+    expect(res.status).toBe(200);
+    expect(h.getDocTimestamp).toHaveBeenCalledWith(ID);
+    expect((await res.json()).data).toMatchObject({ updated_at: '2026-06-11' });
   });
 
-  it('exposes a lightweight timestamp GET for remote-change polling', async () => {
-    const response = await GET(new Request('http://localhost/api/docs/doc-1'), {
-      params: Promise.resolve({ id: 'doc-1' }),
-    });
-
-    const json = await response.json();
-    expect(response.status).toBe(200);
-    expect(getDocTimestamp).toHaveBeenCalledWith('doc-1');
-    expect(json.data).toEqual({ updated_at: '2026-04-09T15:21:00.000Z' });
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    getAuthContext.mockResolvedValue(null);
-    const response = await PATCH(new Request('http://localhost/api/docs/doc-1', {
-      method: 'PATCH',
-      body: JSON.stringify({}),
-    }), { params: Promise.resolve({ id: 'doc-1' }) });
-    expect(response.status).toBe(401);
-  });
-
-  it('returns 429 when rate limit exceeded', async () => {
-    getAuthContext.mockResolvedValue({ ...mockAuth, rateLimitExceeded: true, rateLimitRemaining: 0, rateLimitResetAt: 9999 });
-    const response = await GET(new Request('http://localhost/api/docs/doc-1'), {
-      params: Promise.resolve({ id: 'doc-1' }),
-    });
-    expect(response.status).toBe(429);
+  it('DELETE: deletes via DocsService.deleteDoc(id) → {ok:true}', async () => {
+    h.deleteDoc.mockResolvedValue(undefined);
+    const res = await DELETE(req('DELETE'), ctx());
+    expect(res.status).toBe(200);
+    expect(h.deleteDoc).toHaveBeenCalledWith(ID);
+    expect((await res.json()).data).toMatchObject({ ok: true });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,8 +33,6 @@ export default defineConfig({
       'apps/web/src/app/api/cron/agent-session-recovery/route.test.ts',
       'apps/web/src/app/api/cron/hitl-timeouts/route.test.ts',
       'apps/web/src/app/api/cron/inbox-outbox/route.test.ts',
-      'apps/web/src/app/api/current-project/route.test.ts',
-      'apps/web/src/app/api/docs/[id]/route.test.ts',
       'apps/web/src/app/api/integrations/mcp/github/callback/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 10 · 혼합/특수 패턴)

- **docs/[id]**: 한 파일에 **PATCH=`proxyToFastapi`(verbatim 패스스루** — slug 권위 로직이 BE에 있어 raw 전달·409 envelope 그대로) + **GET·DELETE=`DocsService` 직접**(`getDocTimestamp`·`deleteDoc`)이 공존. 각 메서드별로 맞춰 mock·검증(proxy 200/**409 verbatim** + DocsService 인자).
- **current-project**: `cookies`(next/headers) + **dynamic import**(`@sprintable/storage-api` `fastapiCall` · `@/lib/db/server` `getServerSession`). GET=게이트 + 프로젝트명 조회(`fastapiCall` 실패 시 **fallback 200**) / POST=**게이트 없음** · `parseBody` → 쿠키 set → 프로젝트명. dynamic import 모듈도 `vi.mock`으로 가로채짐.

## 검증

- 11 green(proxy verbatim 200/409 · DocsService 호출 인자 · fastapiCall fallback · 쿠키 set 인자) + **전체 vitest 819 passed**(131파일·회귀 0).

## 진행

Group B 67 중 **39 소거**. 잔여 ~28 — bridge slack/teams(서명검증) · cron · webhooks · integrations/mcp · services ~14 · docs/comments 등.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)