### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 13 — notification-display + persona-composer (단언 드리프트)

### DIFF
--- a/apps/web/src/services/notification-display.test.ts
+++ b/apps/web/src/services/notification-display.test.ts
@@ -7,7 +7,6 @@ import {
 
 const translations: Record<string, string> = {
   filter_story: '스토리',
-  filter_memo: '메모',
   filter_task: '태스크',
   filter_reward: '리워드',
   filter_info: '안내',
@@ -16,12 +15,14 @@ const translations: Record<string, string> = {
 };
 
 describe('notification-display', () => {
-  it('localizes info and warning notification labels', () => {
+  it('localizes known notification labels and passes unknown types through raw', () => {
     const t = (key: string) => translations[key] ?? key;
 
     expect(getInboxNotificationLabel(t, 'info')).toBe('안내');
     expect(getInboxNotificationLabel(t, 'warning')).toBe('경고');
-    expect(getInboxNotificationLabel(t, 'memo')).toBe('메모');
+    // 837a36c4: 'memo'는 NOTIFICATION_TYPES 비포함 → switch default가 raw 타입 반환(localize 안 함).
+    // 구 테스트는 존재하지 않는 filter_memo 키로 '메모'를 기대했으나, 현 계약은 unknown=raw passthrough.
+    expect(getInboxNotificationLabel(t, 'memo')).toBe('memo');
   });
 
   it('keeps info and warning filter types available for the inbox surface', () => {

--- a/apps/web/src/services/persona-composer.test.ts
+++ b/apps/web/src/services/persona-composer.test.ts
@@ -77,7 +77,9 @@ describe('persona-composer helpers', () => {
 
     const options = await listProjectPersonaToolOptions(db as never, 'project-1');
 
-    expect(listProjectApprovedMcpToolOptionsMock).toHaveBeenCalledWith({ tag: 'admin' }, 'project-1');
+    // 837a36c4: 구현이 listProjectApprovedMcpToolOptions(undefined as never, projectId)로 호출
+    // (OSS storage 계층이 db-context를 내부 해소 — 구 {tag:'admin'} 컨텍스트 인자 폐기). projectId 전달 검증.
+    expect(listProjectApprovedMcpToolOptionsMock).toHaveBeenCalledWith(undefined, 'project-1');
     expect(options.find((option) => option.name === 'linear.search_issues')).toMatchObject({
       source: 'mcp',
       groupKind: 'mcp',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -44,8 +44,6 @@ export default defineConfig({
       'apps/web/src/services/docs.test.ts',
       'apps/web/src/services/memo-assignment-dispatch.test.ts',
       'apps/web/src/services/memo.test.ts',
-      'apps/web/src/services/notification-display.test.ts',
-      'apps/web/src/services/persona-composer.test.ts',
       'apps/web/src/services/slack-outbound-dispatcher.test.ts',
       'apps/web/src/services/teams-outbound-dispatcher.test.ts',
     ],


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 13 · services/* 범주 진입)

`services/*` 유닛 테스트 첫 배치 — **route mock 인프라 문제가 아니라 단언 드리프트**(구현 동작이 바뀌었는데 테스트 기대만 stale). 각 단언이 stale인지 실 회귀인지 **정독 판정** 후 교정.

- **notification-display**: `getInboxNotificationLabel(t, 'memo')` — `'memo'`는 `NOTIFICATION_TYPES` 비포함 → switch `default`가 **raw 타입 반환**(localize 안 함). 구 테스트는 존재하지 않는 `filter_memo` 키로 `'메모'`를 기대 → 현 계약(**unknown = raw passthrough**)으로 교정. (실 버그 아님 — memo는 인박스 알림 타입이 아님.)
- **persona-composer**: 구현이 `listProjectApprovedMcpToolOptions(undefined as never, projectId)` 호출(OSS storage 계층이 db-context 내부 해소). 구 `{tag:'admin'}` 컨텍스트 인자 기대 stale → `undefined`로 교정(projectId 전달은 유지 검증).

## 검증

- 6 green + **전체 vitest 845 passed**(141파일·회귀 0).

## 진행

Group B 67 중 **49 소거**. 잔여 ~18 — `services/*` 다수(agent-*·dispatcher·memo·docs 등) + docs/comments 등. 각 단언 드리프트/mock 계약 정독.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)