### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 14 — docs 서비스 단언 드리프트 교정

### DIFF
--- a/apps/web/src/services/docs.test.ts
+++ b/apps/web/src/services/docs.test.ts
@@ -58,7 +58,7 @@ describe('DocsService.updateDoc', () => {
 
     expect(updateBuilder.eq).toHaveBeenCalledWith('id', 'doc-1');
     expect(updateBuilder.eq).toHaveBeenCalledWith('updated_at', '2026-04-09T15:19:00.000Z');
-    expect(db.rpc).toHaveBeenCalledWith('trim_doc_revisions', { _doc_id: 'doc-1', _keep: 50 });
+    // 837a36c4: updateDoc는 더 이상 trim_doc_revisions RPC를 호출하지 않음(리비전 트리밍 분리) — stale 단언 제거.
     expect(result).toEqual(expect.objectContaining({ id: 'doc-1', content: 'updated' }));
   });
 
@@ -95,6 +95,6 @@ describe('DocsService.updateDoc', () => {
 
     expect(updateBuilder.eq).toHaveBeenCalledWith('id', 'doc-1');
     expect(updateBuilder.eq).not.toHaveBeenCalledWith('updated_at', '2026-04-09T15:19:00.000Z');
-    expect(db.rpc).toHaveBeenCalledWith('trim_doc_revisions', { _doc_id: 'doc-1', _keep: 50 });
+    // 837a36c4: trim_doc_revisions RPC 미호출(리비전 트리밍 분리) — stale 단언 제거.
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
       'apps/web/src/services/agent-tool-execution-engine.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
       'apps/web/src/services/discord-outbound-dispatcher.test.ts',
-      'apps/web/src/services/docs.test.ts',
       'apps/web/src/services/memo-assignment-dispatch.test.ts',
       'apps/web/src/services/memo.test.ts',
       'apps/web/src/services/slack-outbound-dispatcher.test.ts',


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 14)

`DocsService.updateDoc` 테스트 **단언 드리프트** 교정. 두 테스트가 `db.rpc('trim_doc_revisions', { _doc_id, _keep: 50 })` 호출을 단언하나, **현 `updateDoc`은 trim_doc_revisions RPC를 더 이상 호출하지 않음**(리비전 트리밍이 updateDoc에서 분리). 나머지 단언(`eq('id')`·`eq('updated_at')`·force_overwrite 시 미적용·result)은 현 구현과 정합 → **stale rpc 단언만 제거**(실 회귀 아님).

## 분리 결정

진단 중 함께 본 `memo.test.ts`는 **별건** — repo stub이 `getById/getReplies/list` 미보유(인터페이스 드리프트로 substantial repo-mock 재작성 필요)라, 급조 대신 **전용 배치(b15)로 분리**하고 재격리 유지("느린 정확").

## 검증

- docs 3 green + **전체 vitest 848 passed**(142파일·회귀 0).

## 진행

Group B 67 중 **50 소거**. 잔여 ~17 — memo(repo-mock 재작성) · agent-* · dispatcher 등 services + docs/comments.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)