### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 16 — dispatcher 3종 (OSS-stub MemoService 격리)

### DIFF
--- a/apps/web/src/services/discord-outbound-dispatcher.test.ts
+++ b/apps/web/src/services/discord-outbound-dispatcher.test.ts
@@ -199,6 +199,23 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+
+// 837a36c4(b16): recordFailure가 MemoService.fromDb(db).addReply로 실패코멘트 기록 — OSS ApiMemoRepository
+// stub(this.repo.getById 미보유)으로 인한 크래시 격리. dispatcher 테스트는 auth_failed 처리(알림/상태)를
+// 검증하지 대상이지 memo 코멘트 write가 아니라, addReply를 no-op로 모킹(코멘트 내용 단언 없음).
+vi.mock('@/services/memo', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/memo')>()),
+  // OSS ApiMemoRepository는 빈 stub(SaaS overlay가 실구현) — 실 MemoService.addReply는 repo→db로
+  // memo_replies insert. dispatcher 테스트는 그 실패코멘트 write를 state.insertedReplies로 검증하므로,
+  // fromDb가 받은 db에 동일 insert를 수행하는 thin mock으로 실동작을 재현(코멘트 write 보존).
+  MemoService: {
+    fromDb: (db: any) => ({
+      addReply: async (memoId: string, content: string, createdBy: string) =>
+        db.from('memo_replies').insert({ memo_id: memoId, content, created_by: createdBy, review_type: 'comment' }),
+    }),
+  },
+}));
+
 describe('discord outbound helpers', () => {
   it('identifies Discord source memos', () => {
     expect(isDiscordSourceMemo({ source: 'discord', channel_id: 'channel-1' })).toBe(true);

--- a/apps/web/src/services/slack-outbound-dispatcher.test.ts
+++ b/apps/web/src/services/slack-outbound-dispatcher.test.ts
@@ -122,6 +122,23 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+
+// 837a36c4(b16): recordFailure가 MemoService.fromDb(db).addReply로 실패코멘트 기록 — OSS ApiMemoRepository
+// stub(this.repo.getById 미보유)으로 인한 크래시 격리. dispatcher 테스트는 auth_failed 처리(알림/상태)를
+// 검증하지 대상이지 memo 코멘트 write가 아니라, addReply를 no-op로 모킹(코멘트 내용 단언 없음).
+vi.mock('@/services/memo', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/memo')>()),
+  // OSS ApiMemoRepository는 빈 stub(SaaS overlay가 실구현) — 실 MemoService.addReply는 repo→db로
+  // memo_replies insert. dispatcher 테스트는 그 실패코멘트 write를 state.insertedReplies로 검증하므로,
+  // fromDb가 받은 db에 동일 insert를 수행하는 thin mock으로 실동작을 재현(코멘트 write 보존).
+  MemoService: {
+    fromDb: (db: any) => ({
+      addReply: async (memoId: string, content: string, createdBy: string) =>
+        db.from('memo_replies').insert({ memo_id: memoId, content, created_by: createdBy, review_type: 'comment' }),
+    }),
+  },
+}));
+
 describe('slack outbound helpers', () => {
   it('identifies Slack source memos', () => {
     expect(isSlackSourceMemo({ source: 'slack', channel_id: 'C1' })).toBe(true);

--- a/apps/web/src/services/teams-outbound-dispatcher.test.ts
+++ b/apps/web/src/services/teams-outbound-dispatcher.test.ts
@@ -204,6 +204,23 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+
+// 837a36c4(b16): recordFailure가 MemoService.fromDb(db).addReply로 실패코멘트 기록 — OSS ApiMemoRepository
+// stub(this.repo.getById 미보유)으로 인한 크래시 격리. dispatcher 테스트는 auth_failed 처리(알림/상태)를
+// 검증하지 대상이지 memo 코멘트 write가 아니라, addReply를 no-op로 모킹(코멘트 내용 단언 없음).
+vi.mock('@/services/memo', async (importActual) => ({
+  ...(await importActual<typeof import('@/services/memo')>()),
+  // OSS ApiMemoRepository는 빈 stub(SaaS overlay가 실구현) — 실 MemoService.addReply는 repo→db로
+  // memo_replies insert. dispatcher 테스트는 그 실패코멘트 write를 state.insertedReplies로 검증하므로,
+  // fromDb가 받은 db에 동일 insert를 수행하는 thin mock으로 실동작을 재현(코멘트 write 보존).
+  MemoService: {
+    fromDb: (db: any) => ({
+      addReply: async (memoId: string, content: string, createdBy: string) =>
+        db.from('memo_replies').insert({ memo_id: memoId, content, created_by: createdBy, review_type: 'comment' }),
+    }),
+  },
+}));
+
 describe('teams outbound helpers', () => {
   it('identifies Teams source memos and builds adaptive cards', () => {
     expect(isTeamsSourceMemo({ source: 'teams', channel_id: 'teams-channel-1' })).toBe(true);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,11 +40,8 @@ export default defineConfig({
       'apps/web/src/services/agent-execution-loop.test.ts',
       'apps/web/src/services/agent-tool-execution-engine.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
-      'apps/web/src/services/discord-outbound-dispatcher.test.ts',
       'apps/web/src/services/memo-assignment-dispatch.test.ts',
       'apps/web/src/services/memo.test.ts',
-      'apps/web/src/services/slack-outbound-dispatcher.test.ts',
-      'apps/web/src/services/teams-outbound-dispatcher.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 16 · dispatcher 군 묶음 — PO GO)

**dispatcher 군 묶음 진단 + 해결**. discord/slack/teams-outbound-dispatcher의 `recordFailure`가 `MemoService.fromDb(db).addReply(...)`로 실패코멘트를 기록하는데, **OSS `ApiMemoRepository` 빈 stub**(SaaS overlay가 실구현 — b15 memo와 **동일 근본**)의 `this.repo.getById`에서 크래시.

## 수정

`@/services/memo`를 **`importActual` 스프레드 모킹**, `MemoService.fromDb(db)`가 받은 db에 `memo_replies` insert를 수행하는 thin `addReply` 반환 → 실 `ApiMemoRepository.addReply`의 db write를 재현해 dispatcher 테스트의 실패코멘트 단언(`state.insertedReplies`: memo_id·created_by·content) **보존**. (no-op 모킹은 그 단언을 파손 → db-insert 재현이 정답.)

## 검증

- 3파일/20 green(각 auth_failed 실패코멘트 경로 + 기존 통과분) + **전체 vitest 868 passed**(145파일·회귀 0).

## 진행 + 연계

- Group B 67 중 **53 소거**. 
- dispatcher 군 OSS-stub 해결이 **b15 memo(repo 주입) 접근을 검증**하고 **`[OSS·무결성] OSS-stub/overlay 분리 점검` 스토리 입력**이 되는(fromDb→OSS stub 의존 서비스 군 = discord/slack/teams dispatcher·agent-execution-loop·agent-builtin-tools — self-host 크래시 후보).
- 잔여 ~14: memo·agent-*·memo-assignment-dispatch·slack-inbound 등.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)