### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 17 — memo.test repo 주입 재작성 (OSS-stub)

### DIFF
--- a/apps/web/src/services/memo.test.ts
+++ b/apps/web/src/services/memo.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { MemoService } from './memo';
 
+// 837a36c4(b17): OSS ApiMemoRepository는 빈 stub(SaaS overlay가 실구현)이라 MemoService.fromDb로는
+// this.repo.getById/getReplies/list 크래시. MemoService 자체를 테스트하므로 모킹 불가 → 기존 db 픽스로
+// 위임하는 repo를 주입(new MemoService(repoFromDb(db), db)). 실 ApiMemoRepository가 db로 해소하는 것을 재현.
+function repoFromDb(db: any): any {
+  return {
+    getById: async (id: string) => (await db.from('memos').select().eq('id', id).single()).data,
+    getReplies: async (memoId: string) =>
+      (await db.from('memo_replies').select().eq('memo_id', memoId).order('created_at', { ascending: true })).data ?? [],
+    list: async (filters: any) =>
+      (await db.from('memos').select().eq('project_id', filters?.project_id).order('created_at', { ascending: false })).data ?? [],
+    create: async (payload: any) => (await db.from('memos').insert(payload).select().single()).data,
+    addReply: async (payload: any) => (await db.from('memo_replies').insert(payload).select().single()).data,
+    resolve: async () => ({}),
+  };
+}
+
 describe('MemoService.getByIdWithDetails', () => {
   it('enriches memo details with replies, reply summary, project name, timeline, and linked docs', async () => {
     const db = {
@@ -116,7 +132,7 @@ describe('MemoService.getByIdWithDetails', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
     const memo = await service.getByIdWithDetails('memo-1');
 
     expect(memo.reply_count).toBe(2);
@@ -175,7 +191,7 @@ describe('MemoService.create', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
 
     await expect(service.create({
       project_id: 'project-1',
@@ -256,7 +272,7 @@ describe('MemoService.linkDoc and markRead', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
 
     await expect(service.linkDoc('memo-1', 'doc-1', 'author-1')).resolves.toMatchObject({ doc_id: 'doc-1', memo_id: 'memo-1' });
     await expect(service.markRead('memo-1', 'author-1')).resolves.toMatchObject({ memo_id: 'memo-1', team_member_id: 'author-1' });
@@ -314,7 +330,7 @@ describe('MemoService.linkDoc and markRead', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
     await expect(service.markRead('memo-1', 'author-1')).resolves.toMatchObject({
       memo_id: 'memo-1',
       team_member_id: 'author-1',
@@ -391,7 +407,7 @@ describe('MemoService.list', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
     const memos = await service.list({ project_id: 'project-1' });
 
     expect(memos).toEqual([
@@ -489,7 +505,7 @@ describe('MemoService.list', () => {
       },
     } as any;
 
-    const service = MemoService.fromDb(db);
+    const service = new MemoService(repoFromDb(db), db);
     const memos = await service.list({ project_id: 'project-1' });
 
     expect(memos).toEqual([

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,6 @@ export default defineConfig({
       'apps/web/src/services/agent-tool-execution-engine.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
       'apps/web/src/services/memo-assignment-dispatch.test.ts',
-      'apps/web/src/services/memo.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 17 · b15 진단 실행)

**b15 정밀 진단 실행** — `memo.test.ts` repo 주입 재작성. MemoService가 memo/replies/list 페치를 `this.repo`로 이행했는데 **OSS `ApiMemoRepository`는 빈 stub**(SaaS overlay가 실구현)이라 `MemoService.fromDb` 경유 6테스트가 `this.repo.getById is not a function` 크래시.

## 수정 (MemoService 자체 테스트 → 모킹 불가 → repo 주입)

`MemoService.fromDb(db)` → **`new MemoService(repoFromDb(db), db)`**. `repoFromDb`가 **기존 db 픽스로 위임**(getById/getReplies/list/addReply/create) — 실 ApiMemoRepository의 db 해소를 재현해 6테스트의 기존 픽스·단언을 **그대로 보존**. supersedes 체인은 `depth < 10` 가드라 고정-memo 반환에도 안전.

## 검증

- memo 6 green(getByIdWithDetails·create·linkDoc·markRead×2·list×2) + **전체 vitest 874 passed**(146파일·회귀 0).

## 진행

Group B 67 중 **54 소거**. 잔여 ~13 — agent-*·memo-assignment-dispatch·slack-inbound·background-runtime 등(fromDb 경유면 b16/b17 OSS-stub 패턴 재사용). `[OSS·무결성]` 스토리 입력 지속.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)