### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 19 — agent-deployment-lifecycle + agent-tool-execution-engine (단언 드리프트)

### DIFF
--- a/apps/web/src/services/agent-deployment-lifecycle.test.ts
+++ b/apps/web/src/services/agent-deployment-lifecycle.test.ts
@@ -728,7 +728,8 @@ describe('AgentDeploymentLifecycleService', () => {
       },
     });
 
-    expect(validateProjectMcpConnectionsMock).toHaveBeenCalledWith({ tag: 'admin' }, { projectId: 'project-1' });
+    // 837a36c4(b19): 구현이 validateProjectMcpConnections(undefined, {projectId})로 호출(OSS storage가 db-context 내부 해소·구 {tag:'admin'} 폐기).
+    expect(validateProjectMcpConnectionsMock).toHaveBeenCalledWith(undefined, { projectId: 'project-1' });
     expect(state.createdDeployments).toHaveLength(0);
   });
 

--- a/apps/web/src/services/agent-tool-execution-engine.test.ts
+++ b/apps/web/src/services/agent-tool-execution-engine.test.ts
@@ -486,7 +486,8 @@ describe('AgentToolExecutionEngine', () => {
     const registry = await engine.loadRegistry('project-1', allowlistedToolNames('linear.search_issues'));
     const result = await engine.execute('linear.search_issues', { query: 'S426' }, createContext(), registry);
 
-    expect(resolveProjectMcpVaultTokenMock).toHaveBeenCalledWith({ tag: 'admin' }, 'project-1', 'vault:mcp_connection:linear');
+    // 837a36c4(b19): 구현이 resolveProjectMcpVaultToken(undefined, projectId, ref)로 호출(구 {tag:'admin'} 컨텍스트 폐기).
+    expect(resolveProjectMcpVaultTokenMock).toHaveBeenCalledWith(undefined, 'project-1', 'vault:mcp_connection:linear');
     expect(fetchFn).toHaveBeenCalledWith('https://linear-mcp.example.com/rpc', expect.objectContaining({
       headers: expect.objectContaining({ Authorization: 'Bearer linear-secret' }),
     }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,17 +28,15 @@ export default defineConfig({
       // suite; each file is debt to burn down — re-include as it is fixed.
       // ⚠️ DO NOT add here to silence a NEW failure — fix the test.
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
+      'apps/web/src/services/__tests__/slack-inbound.test.ts',
       'apps/web/src/app/api/agent-runs/[id]/route.test.ts',
       'apps/web/src/app/api/agent-runs/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts',
-      'apps/web/src/services/__tests__/slack-inbound.test.ts',
       'apps/web/src/services/agent-builtin-tools.test.ts',
-      'apps/web/src/services/agent-deployment-lifecycle.test.ts',
       'apps/web/src/services/agent-execution-loop.test.ts',
-      'apps/web/src/services/agent-tool-execution-engine.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
       'apps/web/src/services/memo-assignment-dispatch.test.ts',
     ],


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 19 · (b) 픽스 배치 일부)

단언 드리프트 2종(b13 persona-composer와 동형) — 구현이 MCP 헬퍼를 **OSS storage 컨텍스트 내부 해소**로 호출하며 구 `{ tag: 'admin' }` 컨텍스트 인자를 폐기. 테스트 단언을 현 시그니처로 교정(실 회귀 아님).

- `agent-deployment-lifecycle`: `validateProjectMcpConnections(undefined, { projectId })`
- `agent-tool-execution-engine`: `resolveProjectMcpVaultToken(undefined, projectId, ref)`

## 검증

- 2파일/31 green + **전체 vitest 905 passed**(148파일·회귀 0).

## 진행

Group B 67 중 **56 소거**. 잔여 ~11 — OSS-stub(memo-assignment-dispatch·slack-inbound, b16/b17 패턴) · background-runtime(db-client 팩토리 변경 정독 요) · agent-builtin-tools/execution-loop(**`6f237832` 구현과 합류** 해제) · docs/comments.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)