### PR TITLE
[SID:837a36c4] test(services): Group B 번다운 batch 20 — memo-assignment-dispatch + slack-inbound ((b) 잔여)

### DIFF
--- a/apps/web/src/services/__tests__/slack-inbound.test.ts
+++ b/apps/web/src/services/__tests__/slack-inbound.test.ts
@@ -20,6 +20,22 @@ import {
   type SlackMessageEvent,
 } from '../slack-inbound';
 
+// 837a36c4(Group B b20): BridgeInboundService가 MemoService.fromDb(db).create로 메모 생성 — OSS
+// ApiMemoRepository 빈 stub(this.repo.create 미보유) 크래시. fromDb가 받은 db에 memos insert를 재현하는
+// thin mock(실 ApiMemoRepository.create의 db write 재현·error throw로 중복-eventid 제약 핸들링 보존).
+vi.mock('@/services/memo', async (importActual) => ({
+  ...(await importActual<typeof import('../memo')>()),
+  MemoService: {
+    fromDb: (db: any) => ({
+      create: async (input: any) => {
+        const { data, error } = await db.from('memos').insert(input).select().single();
+        if (error) throw Object.assign(new Error(error.message ?? 'insert failed'), { code: error.code });
+        return data;
+      },
+    }),
+  },
+}));
+
 const SIGNING_SECRET = 'test-signing-secret';
 
 const CHANNEL_MAPPING: BridgeChannelMapping = {

--- a/apps/web/src/services/memo-assignment-dispatch.test.ts
+++ b/apps/web/src/services/memo-assignment-dispatch.test.ts
@@ -1,14 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { createAdminClient } = vi.hoisted(() => ({
-  createAdminClient: vi.fn(),
-}));
-
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-
-vi.mock('@/lib/storage/factory', () => ({
+// 837a36c4(Group B b20): 구현이 d64c4aaa("remove createAdminClient from memo-assignment-dispatch")로
+// 대폭 단순화됨 — createTeamMemberRepository().getById(assigned_to) → member.webhook_url → fetch.
+// webhook_configs 선호/createAdminClient/webhook_deliveries 경로는 제거(memo-event-dispatcher·
+// webhook-notify로 이전·거기서 테스트). 구 테스트(webhook_configs 선호·console.error·db)는 stale →
+// 현 계약(team-member webhook 직발송)으로 재작성. 회귀 아님(git 이력 확인).
+const { createTeamMemberRepository } = vi.hoisted(() => ({
   createTeamMemberRepository: vi.fn(),
 }));
+
+vi.mock('@/lib/storage/factory', () => ({ createTeamMemberRepository }));
 
 import { dispatchMemoAssignmentImmediately } from './memo-assignment-dispatch';
 
@@ -27,33 +28,6 @@ const baseMemo = {
   created_at: '2026-04-22T00:00:00.000Z',
 };
 
-function makeDb(results: Record<string, unknown>) {
-  return {
-    from: vi.fn((table: string) => {
-      if (table === 'webhook_deliveries') {
-        return {
-          insert: vi.fn().mockReturnValue({
-            select: vi.fn().mockReturnValue({
-              single: vi.fn().mockResolvedValue({ data: { id: 'delivery-1' }, error: null }),
-            }),
-          }),
-          update: vi.fn().mockReturnValue({
-            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
-          }),
-        };
-      }
-      const payload = results[table] ?? { data: null, error: null };
-      return {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
-        limit: vi.fn().mockReturnThis(),
-        maybeSingle: vi.fn().mockResolvedValue(payload),
-      };
-    }),
-  };
-}
-
 describe('dispatchMemoAssignmentImmediately', () => {
   const mockFetch = vi.fn();
 
@@ -63,24 +37,22 @@ describe('dispatchMemoAssignmentImmediately', () => {
     mockFetch.mockResolvedValue({ ok: true, status: 200 });
   });
 
-  it('skips unassigned memos without calling db', async () => {
+  it('skips unassigned memos without resolving the repo', async () => {
     await dispatchMemoAssignmentImmediately({ ...baseMemo, assigned_to: null });
-    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(createTeamMemberRepository).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('skips non-open memos without calling db', async () => {
+  it('skips non-open memos without resolving the repo', async () => {
     await dispatchMemoAssignmentImmediately({ ...baseMemo, status: 'resolved' });
-    expect(createAdminClient).not.toHaveBeenCalled();
+    expect(createTeamMemberRepository).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('sends webhook via team_members.webhook_url when webhook_configs is empty', async () => {
-    const db = makeDb({
-      webhook_configs: { data: null, error: null },
-      team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/token' }, error: null },
+  it('sends a webhook to the assigned team member webhook_url', async () => {
+    createTeamMemberRepository.mockResolvedValue({
+      getById: async () => ({ webhook_url: 'https://discord.com/api/webhooks/1/token' }),
     });
-    createAdminClient.mockReturnValue(db);
 
     await dispatchMemoAssignmentImmediately(baseMemo);
 
@@ -90,36 +62,21 @@ describe('dispatchMemoAssignmentImmediately', () => {
     );
   });
 
-  it('prefers webhook_configs url over team_members.webhook_url', async () => {
-    const db = makeDb({
-      webhook_configs: { data: { id: 'config-1', url: 'https://discord.com/api/webhooks/2/config', secret: null, channel: 'discord' }, error: null },
-      team_members: { data: { webhook_url: 'https://discord.com/api/webhooks/1/fallback' }, error: null },
-    });
-    createAdminClient.mockReturnValue(db);
-
+  it('skips fetch when the assigned member has no webhook_url', async () => {
+    createTeamMemberRepository.mockResolvedValue({ getById: async () => ({ webhook_url: null }) });
     await dispatchMemoAssignmentImmediately(baseMemo);
-
-    expect(mockFetch).toHaveBeenCalledWith(
-      'https://discord.com/api/webhooks/2/config',
-      expect.objectContaining({ method: 'POST' }),
-    );
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('logs console.error and skips fetch when no webhook url found', async () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const db = makeDb({
-      webhook_configs: { data: null, error: null },
-      team_members: { data: null, error: null },
-    });
-    createAdminClient.mockReturnValue(db);
-
+  it('skips fetch when the assigned member is not found', async () => {
+    createTeamMemberRepository.mockResolvedValue({ getById: async () => null });
     await dispatchMemoAssignmentImmediately(baseMemo);
-
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[MemoDispatch]'),
-      expect.anything(),
-    );
-    errorSpy.mockRestore();
+  });
+
+  it('swallows repo/fetch errors (fire-and-forget) without throwing', async () => {
+    createTeamMemberRepository.mockResolvedValue({ getById: async () => { throw new Error('repo down'); } });
+    await expect(dispatchMemoAssignmentImmediately(baseMemo)).resolves.toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,7 +28,6 @@ export default defineConfig({
       // suite; each file is debt to burn down — re-include as it is fixed.
       // ⚠️ DO NOT add here to silence a NEW failure — fix the test.
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
-      'apps/web/src/services/__tests__/slack-inbound.test.ts',
       'apps/web/src/app/api/agent-runs/[id]/route.test.ts',
       'apps/web/src/app/api/agent-runs/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts',
@@ -38,7 +37,6 @@ export default defineConfig({
       'apps/web/src/services/agent-builtin-tools.test.ts',
       'apps/web/src/services/agent-execution-loop.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
-      'apps/web/src/services/memo-assignment-dispatch.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## 무엇을 (Group B 번다운 · batch 20 · (b) 픽스 배치 완료)

2 서비스, 각기 다른 근본:

- **memo-assignment-dispatch**: 구현이 `d64c4aaa`("remove createAdminClient from memo-assignment-dispatch")로 **대폭 단순화** — `createTeamMemberRepository().getById → member.webhook_url → fetch`. webhook_configs 선호·createAdminClient·webhook_deliveries 경로는 제거되어 `memo-event-dispatcher`·`webhook-notify`로 **이전**(git 이력 확인 — **회귀 아님·의도적**). 구 테스트(webhook_configs 선호·console.error·db)는 stale → **현 단순 계약으로 재작성**(team-member webhook 직발송·no-webhook skip·fire-forget 에러 무던).
- **slack-inbound**: `BridgeInboundService`가 `MemoService.fromDb(db).create`로 메모 생성 → **OSS-stub `this.repo.create` 크래시**(b16 동형). `@/services/memo` 모킹·`fromDb.create`가 db `memos` insert 재현(**error throw로 중복-eventid 제약 핸들링 보존**).

## 검증

- memo-assignment-dispatch 6 + slack-inbound 16 green + **전체 vitest 927 passed**(150파일·회귀 0).

## 진행

Group B 67 중 **58 소거**. (b) 픽스 배치 완료. 잔여 ~9 — background-runtime(db-client 팩토리 변경 정독) · agent-builtin-tools/agent-execution-loop(**`6f237832` 구현과 합류**) · docs/comments 등.

## 리뷰

PO 검수 → 까심 QA. base `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)