### PR TITLE
feat(agent-tools): implement builtin memo tool cases (6f237832)

### DIFF
--- a/apps/web/src/services/agent-builtin-tools.ts
+++ b/apps/web/src/services/agent-builtin-tools.ts
@@ -197,7 +197,12 @@ const updateMemoSchema = z.object({
   title: z.string().trim().min(1).max(200).nullable().optional(),
   content: z.string().trim().min(1).max(20_000).optional(),
   memo_type: z.string().trim().min(1).max(64).optional(),
-  status: z.string().trim().min(1).max(64).optional(),
+  // Constrained to non-terminal transitions only. 'resolved' is intentionally
+  // excluded: resolution is a gated lifecycle action (MemoService.resolve records
+  // resolved_by/resolved_at and rejects double-resolve), so update_memo must not be
+  // a backdoor that fabricates a resolved state outside that state machine. An open
+  // string would also let agents write arbitrary, invalid statuses.
+  status: z.enum(['open', 'archived']).optional(),
   assigned_to: z.string().uuid().nullable().optional(),
 });
 

--- a/apps/web/src/services/agent-builtin-tools.ts
+++ b/apps/web/src/services/agent-builtin-tools.ts
@@ -175,6 +175,39 @@ const MAX_FORWARD_CHAIN_DEPTH = 10;
 
 const legacyResolveMemoSchema = z.object({});
 
+// Canonical memo tools. reply_memo and list_memos are the named successors of the
+// legacy add_memo_reply / list_recent_project_memos isomorphs and share their
+// internals; create_memo and update_memo close the registry-declared gap so the
+// default-exposed builtin set no longer crashes on the unimplemented cases.
+const createMemoSchema = z.object({
+  title: z.string().trim().min(1).max(200).nullable().optional(),
+  content: z.string().trim().min(1).max(20_000),
+  memo_type: z.string().trim().min(1).max(64).optional(),
+  assigned_to: z.string().uuid().nullable().optional(),
+});
+
+const replyMemoSchema = z.object({
+  memo_id: z.string().uuid().optional(),
+  content: z.string().trim().min(1).max(20_000),
+  review_type: z.string().trim().min(1).max(64).optional(),
+});
+
+const updateMemoSchema = z.object({
+  memo_id: z.string().uuid().optional(),
+  title: z.string().trim().min(1).max(200).nullable().optional(),
+  content: z.string().trim().min(1).max(20_000).optional(),
+  memo_type: z.string().trim().min(1).max(64).optional(),
+  status: z.string().trim().min(1).max(64).optional(),
+  assigned_to: z.string().uuid().nullable().optional(),
+});
+
+const listMemosSchema = z.object({
+  limit: z.coerce.number().int().min(1).max(MAX_LIST_ITEMS).optional(),
+  status: z.string().trim().min(1).max(64).optional(),
+  memo_type: z.string().trim().min(1).max(64).optional(),
+  assigned_to: z.string().uuid().optional(),
+});
+
 function truncateText(text: string, maxChars = MAX_FIELD_CHARS): string {
   const normalized = text.replace(/\s+/g, ' ').trim();
   if (normalized.length <= maxChars) return normalized;
@@ -314,6 +347,35 @@ export class AgentBuiltinToolService {
         const resolved = await this.memoService.resolve(ctx.memo.id, ctx.agent.id);
         return { memo_id: resolved.id, status: resolved.status };
       }
+      case 'create_memo': {
+        const args = createMemoSchema.parse(rawArgs);
+        if (args.assigned_to) await this.ensureMemberInScope(args.assigned_to, ctx);
+        const memo = await this.memoService.create({
+          project_id: ctx.memo.project_id,
+          org_id: ctx.memo.org_id,
+          title: args.title ?? null,
+          content: args.content,
+          memo_type: args.memo_type,
+          assigned_to: args.assigned_to ?? null,
+          created_by: ctx.agent.id,
+        });
+        return { memo: this.presentMemo(memo as MemoScope) };
+      }
+      case 'reply_memo': {
+        // Canonical alias of add_memo_reply: targets an explicit memo_id (defaults to
+        // the active memo) and carries a review_type, routed through MemoService.addReply.
+        const args = replyMemoSchema.parse(rawArgs);
+        return this.replyMemoInternal({ memo_id: args.memo_id, content: args.content, review_type: args.review_type }, ctx);
+      }
+      case 'update_memo': {
+        const args = updateMemoSchema.parse(rawArgs);
+        return this.updateMemoInternal(args, ctx);
+      }
+      case 'list_memos': {
+        // Canonical superset of list_recent_project_memos with status/type/assignee filters.
+        const args = listMemosSchema.parse(rawArgs);
+        return this.listMemosInternal({ limit: args.limit, status: args.status, memo_type: args.memo_type, assigned_to: args.assigned_to }, ctx);
+      }
       case 'create_story': {
         const args = createStorySchema.parse(rawArgs);
         if (args.assignee_id) await this.ensureMemberInScope(args.assignee_id, ctx);
@@ -434,6 +496,33 @@ export class AgentBuiltinToolService {
     const memo = await this.getMemoInScope(args.memo_id ?? ctx.memo.id, ctx);
     const data = await this.memoService.addReply(memo.id, args.content, ctx.agent.id, args.review_type ?? 'comment');
     return { reply: this.presentReply(data as { id: string; memo_id: string; content: string; created_by: string; created_at: string }) };
+  }
+
+  private async updateMemoInternal(args: z.infer<typeof updateMemoSchema>, ctx: ToolExecutionContext) {
+    // Scope guard first (emits the cross-scope security audit) before any mutation.
+    const memo = await this.getMemoInScope(args.memo_id ?? ctx.memo.id, ctx);
+    if (args.assigned_to) await this.ensureMemberInScope(args.assigned_to, ctx);
+
+    const patch: Record<string, unknown> = {};
+    if (args.title !== undefined) patch.title = args.title;
+    if (args.content !== undefined) patch.content = args.content;
+    if (args.memo_type !== undefined) patch.memo_type = args.memo_type;
+    if (args.status !== undefined) patch.status = args.status;
+    if (args.assigned_to !== undefined) patch.assigned_to = args.assigned_to;
+
+    if (Object.keys(patch).length > 0) {
+      // No-returning update keeps this adapter-agnostic (matches MemoService.create's
+      // own supersedes update); the in-scope row is merged locally for the response.
+      const { error } = await this.db
+        .from('memos')
+        .update(patch)
+        .eq('id', memo.id)
+        .eq('org_id', ctx.memo.org_id)
+        .eq('project_id', ctx.memo.project_id);
+      if (error) throw error;
+    }
+
+    return { memo: this.presentMemo({ ...memo, ...patch } as MemoScope) };
   }
 
   private async getMemoInScope(memoId: string, ctx: ToolExecutionContext): Promise<MemoScope> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -34,8 +34,15 @@ export default defineConfig({
       'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts',
       'apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts',
+      // agent-builtin-tools.test.ts: the 4 registry-declared memo tools
+      // (create_memo/reply_memo/update_memo/list_memos) are now implemented (story
+      // 6f237832), but this file's create_story/forward_memo/create_memo/list_epics
+      // cases drive StoryService/EpicService/MemoService through their post-OSS-split
+      // persistence layer (FastAPI `fastapiCall` repos; MemoService has no repo at all),
+      // so they fail under the in-memory db stub the test was authored against. Re-include
+      // requires reworking the suite to inject db-stub-backed fake services — tracked as a
+      // follow-up; un-isolating now would turn the suite red on pre-existing debt.
       'apps/web/src/services/agent-builtin-tools.test.ts',
-      'apps/web/src/services/agent-execution-loop.test.ts',
       'apps/web/src/services/background-runtime.test.ts',
     ],
   },


### PR DESCRIPTION
## Story 6f237832 — builtin memo tools (CODE)

`BUILTIN_AGENT_TOOL_NAMES` declares `create_memo`, `reply_memo`, `update_memo`, `list_memos`, and `tool-acl-contract` consumes that registry as the **default ACL allowlist**. So these four tools were exposed to agents by default — but `AgentBuiltinToolService.dispatch` had no `case` for them, hitting `default: throw "Unsupported tool"` on first call. This closes that real-impact gap.

### Changes
- **`agent-builtin-tools.ts`** — 4 dispatch cases + schemas, reusing existing isomorphic internals:
  - `reply_memo` → `replyMemoInternal` (named successor of `add_memo_reply`; explicit `memo_id` + `review_type`)
  - `list_memos` → `listMemosInternal` (superset of `list_recent_project_memos`; `status`/`memo_type`/`assigned_to` filters applied **before** limit)
  - `create_memo` → `MemoService.create` (same path as `forward_memo`; defaults `memo_type='memo'`)
  - `update_memo` → new `updateMemoInternal`: `getMemoInScope` guards the cross-project boundary (with the security audit) before an adapter-agnostic no-returning db update; the in-scope row is merged locally for the response
- **`vitest.config.ts`** — un-isolate `agent-execution-loop.test.ts` (now that `list_memos` resolves)

### Validation
- Full vitest: **951 passed · 2 skipped · 0 failed** (151 files; +24 from un-isolated execution-loop, 0 regression)
- `tsc --noEmit` clean
- `agent-execution-loop.test.ts` alone: 24 passed

### Follow-up (not this PR)
`agent-builtin-tools.test.ts` stays quarantined. Its `create_story`/`forward_memo`/`create_memo`/`list_epics` cases drive the post-OSS-split persistence layer — `SupabaseStoryRepository`/`EpicService` go through `fastapiCall` HTTP, and `MemoService` has **no repository at all** (`memo.ts` uses a local no-op stub; storage-api exports no memo repo). The in-memory db stub the suite was authored against cannot satisfy these. Re-including the file requires reworking it to inject db-stub-backed fake services — orthogonal to this story's tool-dispatch gap. This pre-existing debt also affects already-shipped `forward_memo`/`add_memo_reply` in OSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)