### PR TITLE
[SID:bcef3a5f] refactor(epics): edit/create 폼 inline outcome intent 제거 (S8d · AC5 풀)

### DIFF
--- a/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/epics/[id]/page.tsx
@@ -16,7 +16,6 @@ import { TopBarSlot } from '@/components/nav/top-bar-slot';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
-import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 import { HypothesesSection } from '@/components/hypotheses/hypotheses-section';
 
 type EpicStatus = 'draft' | 'active' | 'done' | 'archived';
@@ -151,11 +150,6 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
   const [priority, setPriority] = useState<EpicPriority>(epic.priority);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined && epic.target_sp !== null ? String(epic.target_sp) : '');
-  const [intent, setIntent] = useState<OutcomeIntentValue>({
-    success_hypothesis: epic.success_hypothesis ?? '',
-    metric_definition: (epic.metric_definition as import('@sprintable/core-storage').MetricDefinition | null) ?? null,
-    measure_after: epic.measure_after?.slice(0, 10) ?? '',
-  });
   const [saving, setSaving] = useState(false);
 
   const handleSave = useCallback(async () => {
@@ -172,9 +166,6 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
           success_criteria: successCriteria.trim() || undefined,
           status,
           priority,
-          success_hypothesis: intent.success_hypothesis.trim() || null,
-          metric_definition: intent.metric_definition ?? null,
-          measure_after: intent.measure_after || null,
           ...(targetDate ? { target_date: targetDate } : {}),
           ...(targetSp ? { target_sp: Number(targetSp) } : {}),
         }),
@@ -185,7 +176,7 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
     } finally {
       setSaving(false);
     }
-  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, intent, epic, onSaved]);
+  }, [title, description, objective, successCriteria, status, priority, targetDate, targetSp, epic, onSaved]);
 
   const inputCls = 'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40';
 
@@ -211,7 +202,6 @@ function EpicEditInline({ epic, onSaved, onCancel }: { epic: Epic; onSaved: (e: 
         <input type="date" value={targetDate} onChange={(e) => setTargetDate(e.target.value)} className={inputCls} />
         <input type="number" min="0" value={targetSp} onChange={(e) => setTargetSp(e.target.value)} className={inputCls} placeholder="목표 SP" />
       </div>
-      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
       <div className="flex justify-end gap-2">
         <Button variant="ghost" size="sm" onClick={onCancel}>취소</Button>
         <Button size="sm" disabled={saving || !title.trim()} onClick={() => void handleSave()}>

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -14,7 +14,6 @@ import {
 } from '@/components/ui/dialog';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
-import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -137,7 +136,6 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
   const [priority, setPriority] = useState<EpicPriority>('medium');
   const [targetDate, setTargetDate] = useState('');
   const [targetSp, setTargetSp] = useState('');
-  const [intent, setIntent] = useState<OutcomeIntentValue>({ success_hypothesis: '', metric_definition: null, measure_after: '' });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -158,9 +156,6 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
       };
       if (targetDate) body.target_date = targetDate;
       if (targetSp) body.target_sp = Number(targetSp);
-      if (intent.success_hypothesis.trim()) body.success_hypothesis = intent.success_hypothesis.trim();
-      if (intent.metric_definition) body.metric_definition = intent.metric_definition;
-      if (intent.measure_after) body.measure_after = intent.measure_after;
 
       const res = await fetch('/api/epics', {
         method: 'POST',
@@ -177,7 +172,7 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
     } finally {
       setSubmitting(false);
     }
-  }, [title, description, priority, targetDate, targetSp, intent, projectId, orgId, onCreated]);
+  }, [title, description, priority, targetDate, targetSp, projectId, orgId, onCreated]);
 
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
@@ -242,8 +237,6 @@ function EpicCreateForm({ projectId, orgId, onCreated, onCancel }: EpicCreateFor
         />
       </div>
 
-      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
-
       {error ? <p className="text-xs text-destructive">{error}</p> : null}
 
       <div className="flex justify-end gap-2 pt-2">
@@ -274,11 +267,6 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
   const [status, setStatus] = useState<EpicStatus>(epic.status);
   const [targetDate, setTargetDate] = useState(epic.target_date?.slice(0, 10) ?? '');
   const [targetSp, setTargetSp] = useState(epic.target_sp !== undefined ? String(epic.target_sp) : '');
-  const [intent, setIntent] = useState<OutcomeIntentValue>({
-    success_hypothesis: epic.success_hypothesis ?? '',
-    metric_definition: (epic.metric_definition as import('@sprintable/core-storage').MetricDefinition | null) ?? null,
-    measure_after: epic.measure_after?.slice(0, 10) ?? '',
-  });
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -295,9 +283,6 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
         description: description.trim() || undefined,
         priority,
         status,
-        success_hypothesis: intent.success_hypothesis.trim() || null,
-        metric_definition: intent.metric_definition ?? null,
-        measure_after: intent.measure_after || null,
       };
       if (targetDate) body.target_date = targetDate;
       if (targetSp) body.target_sp = Number(targetSp);
@@ -317,7 +302,7 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
     } finally {
       setSubmitting(false);
     }
-  }, [title, description, priority, status, targetDate, targetSp, intent, epic.id, epic.stories, onSaved]);
+  }, [title, description, priority, status, targetDate, targetSp, epic.id, epic.stories, onSaved]);
 
   return (
     <form onSubmit={(e) => { void handleSubmit(e); }} className="space-y-4">
@@ -395,8 +380,6 @@ function EpicEditForm({ epic, onSaved, onCancel }: EpicEditFormProps) {
           />
         </div>
       </div>
-
-      <OutcomeIntentFields value={intent} onChange={setIntent} context="epic" />
 
       {error ? <p className="text-xs text-destructive">{error}</p> : null}
 


### PR DESCRIPTION
## 무엇을 (S8 split · PO §12.3 공존 금지)

S8(#1417)서 **view측** legacy(`OutcomeResultCard`)는 제거됐으나, **input측** inline `OutcomeIntentFields`가 에픽 폼에 잔존 — HypothesesSection(가설 생성 대체)과 **공존**하는 상태(§12.3 위반). 이 입력측 잔존을 전량 제거(AC5 풀).

## 제거 대상 3폼

intent state · `handleSave`/`handleSubmit` 페이로드 · `<OutcomeIntentFields>` render · useCallback deps · import 정리:

| 파일 | 폼 |
|---|---|
| `epics/[id]/page.tsx` | `EpicEditInline` |
| `epics/epics-client.tsx` | `EpicCreateForm` |
| `epics/epics-client.tsx` | `EpicEditForm` |

> 스토리 본문은 측정 시점 2폼(`EpicEditInline:214`·create `:245`)을 명시했으나, `epics-client`의 `EpicEditForm`에도 동일 inline intent가 잔존 → **§12.3 공존 금지 일관 적용** 위해 3폼 전부 제거.

## 영향

- `success_hypothesis`/`metric_definition`/`measure_after` 폼 페이로드 제거 → 에픽 edit 저장이 더 이상 outcome 필드를 덮어쓰지 않음(**기존 값 보존** — 종전 폼은 매 저장 시 null 덮어쓰기 위험이 있었음).
- 가설 관리는 **HypothesesSection**(에픽 상세 `[id]/page.tsx:349` 렌더)이 단일 경로로 담당.
- `OutcomeIntentFields` 공유 컴포넌트는 **sprints-client·story-detail-panel에서 계속 사용** → 컴포넌트 자체는 보존(에픽 폼 import만 정리).
- Epic 데이터 인터페이스 필드(BE 응답 형상)는 유지 — 폼 관심사 아님.

## 검증

- `tsc --noEmit` exit 0 · `eslint` clean · `next build` PASS.
- intent 참조 단위 테스트 0건(회귀 없음).

## AC

- [x] AC5 풀 — 에픽 edit/create 폼 input측 inline outcome intent 0
- [x] 가설 생성 경로 = HypothesesSection 단일화(공존 해소)

## 리뷰

base `develop`. 순수 제거 리팩터(FE-only). 게이트: 까심 QA → PO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)