### PR TITLE
[SID:506bb63f] feat(story): 상세 패널 연결 가설 chip + picker (S8c · S9 fold)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2281,7 +2281,17 @@
     "dirDown": "≤",
     "measureAfterField": "Measure on",
     "cancel": "Cancel",
-    "saving": "Saving…"
+    "saving": "Saving…",
+    "linkedTitle": "Linked hypotheses",
+    "linkHypothesis": "Link hypothesis",
+    "noLinked": "No linked hypotheses",
+    "unlink": "Unlink",
+    "pickerTitle": "Select a hypothesis to link",
+    "pickerSearch": "Search hypotheses…",
+    "pickerEmpty": "No hypotheses to link",
+    "crossEpic": "Other epic",
+    "crossEpicHint": "This hypothesis belongs to a different epic",
+    "createElsewhereHint": "Hypotheses are created from the epic detail"
   },
   "epics": {
     "title": "Epics",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2281,7 +2281,17 @@
     "dirDown": "≤",
     "measureAfterField": "측정일",
     "cancel": "취소",
-    "saving": "저장 중…"
+    "saving": "저장 중…",
+    "linkedTitle": "연결 가설",
+    "linkHypothesis": "가설 연결",
+    "noLinked": "연결된 가설이 없습니다",
+    "unlink": "연결 해제",
+    "pickerTitle": "연결할 가설 선택",
+    "pickerSearch": "가설 검색…",
+    "pickerEmpty": "연결할 가설이 없습니다",
+    "crossEpic": "다른 에픽",
+    "crossEpicHint": "이 가설은 다른 에픽 소속입니다",
+    "createElsewhereHint": "가설은 에픽 상세에서 생성합니다"
   },
   "epics": {
     "title": "에픽",

--- a/apps/web/src/app/api/hypotheses/[id]/links/route.ts
+++ b/apps/web/src/app/api/hypotheses/[id]/links/route.ts
@@ -1,4 +1,4 @@
-import { linkHypothesisSchema } from '@sprintable/shared';
+import { linkHypothesisSchema, unlinkHypothesisSchema } from '@sprintable/shared';
 import { HypothesisService } from '@/services/hypothesis';
 import { createHypothesisRepository } from '@/lib/storage/factory';
 import { handleApiError } from '@/lib/api-error';
@@ -20,6 +20,25 @@ export async function POST(request: Request, { params }: RouteParams) {
 
     const service = new HypothesisService(await createHypothesisRepository());
     const updated = await service.link(id, parsed.data);
+    return apiSuccess(updated);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}
+
+// DELETE — unlink epics/stories from a hypothesis (story 패널 연결 해제·E1-S8c AC①).
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { id } = await params;
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const parsed = unlinkHypothesisSchema.safeParse(await request.json());
+    if (!parsed.success) return ApiErrors.badRequest(parsed.error.issues[0]?.message ?? 'Invalid body');
+
+    const service = new HypothesisService(await createHypothesisRepository());
+    const updated = await service.unlink(id, parsed.data);
     return apiSuccess(updated);
   } catch (err: unknown) {
     return handleApiError(err);

--- a/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/story-hypotheses-section.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { AlertTriangle, Link2, Plus, Search, X } from 'lucide-react';
+import type { Hypothesis } from '@sprintable/core-storage';
+import { HypothesisStatusBadge } from './hypothesis-status-badge';
+
+/**
+ * Story-detail panel "linked hypotheses" surface (E1-S8c / S9 fold · blueprint §6.5).
+ *
+ * Replaces the legacy inline outcome-intent input. A story can only **link/unlink**
+ * existing hypotheses — never create one (AC①: creation lives on the epic detail / MCP).
+ * Linking defaults link_type=supports (AC②). Hypotheses owned by a different epic than
+ * the story are still linkable, but flagged with a cross-epic warning (AC③).
+ *
+ * Data path: GET /api/hypotheses (thin proxy → {data} envelope), so we read json.data.
+ */
+const LINK_TYPE_DEFAULT = 'supports';
+
+export function StoryHypothesesSection({
+  storyId,
+  epicId,
+  projectId,
+}: {
+  storyId: string;
+  epicId: string | null;
+  projectId: string;
+}) {
+  const t = useTranslations('hypotheses');
+  const [linked, setLinked] = useState<Hypothesis[] | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [candidates, setCandidates] = useState<Hypothesis[] | null>(null);
+  const [query, setQuery] = useState('');
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  // story.epic_id에 속하지 않은 가설 = 다른 에픽 소속(AC③ 경고 대상). epic 미지정 story는 판정 보류.
+  const isCrossEpic = useCallback(
+    (h: Hypothesis) => epicId != null && !h.epic_ids.includes(epicId),
+    [epicId],
+  );
+
+  const loadLinked = useCallback(async () => {
+    try {
+      const res = await fetch(
+        `/api/hypotheses?project_id=${projectId}&story_id=${storyId}`,
+        { cache: 'no-store' },
+      );
+      if (!res.ok) { setLinked([]); return; }
+      const json = await res.json();
+      setLinked((json?.data ?? []) as Hypothesis[]);
+    } catch {
+      setLinked([]);
+    }
+  }, [projectId, storyId]);
+
+  useEffect(() => { void loadLinked(); }, [loadLinked]);
+
+  const loadCandidates = useCallback(async () => {
+    setCandidates(null);
+    try {
+      const res = await fetch(`/api/hypotheses?project_id=${projectId}`, { cache: 'no-store' });
+      if (!res.ok) { setCandidates([]); return; }
+      const json = await res.json();
+      const all = (json?.data ?? []) as Hypothesis[];
+      // 이미 이 story에 연결된 가설은 후보에서 제외.
+      setCandidates(all.filter((h) => !h.story_ids.includes(storyId)));
+    } catch {
+      setCandidates([]);
+    }
+  }, [projectId, storyId]);
+
+  const openPicker = useCallback(() => {
+    setPickerOpen(true);
+    setQuery('');
+    void loadCandidates();
+  }, [loadCandidates]);
+
+  const linkHypothesis = useCallback(async (h: Hypothesis) => {
+    setBusyId(h.id);
+    try {
+      const res = await fetch(`/api/hypotheses/${h.id}/links`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ story_ids: [storyId], link_type: LINK_TYPE_DEFAULT }),
+      });
+      if (res.ok) {
+        await loadLinked();
+        setCandidates((prev) => (prev ? prev.filter((c) => c.id !== h.id) : prev));
+      }
+    } finally {
+      setBusyId(null);
+    }
+  }, [storyId, loadLinked]);
+
+  const unlinkHypothesis = useCallback(async (h: Hypothesis) => {
+    setBusyId(h.id);
+    try {
+      const res = await fetch(`/api/hypotheses/${h.id}/links`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ story_ids: [storyId] }),
+      });
+      if (res.ok) await loadLinked();
+    } finally {
+      setBusyId(null);
+    }
+  }, [storyId, loadLinked]);
+
+  const filteredCandidates = (candidates ?? []).filter((h) =>
+    query.trim() ? h.statement.toLowerCase().includes(query.trim().toLowerCase()) : true,
+  );
+
+  return (
+    <section aria-label={t('linkedTitle')} className="space-y-2 rounded-xl border border-border bg-muted/20 p-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-foreground">{t('linkedTitle')}</h3>
+        {!pickerOpen ? (
+          <button
+            type="button"
+            onClick={openPicker}
+            className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
+          >
+            <Plus className="size-3.5" />
+            {t('linkHypothesis')}
+          </button>
+        ) : null}
+      </div>
+
+      {/* 연결된 가설 read-only chips */}
+      {linked === null ? (
+        <p className="text-xs text-muted-foreground">…</p>
+      ) : linked.length === 0 ? (
+        !pickerOpen ? <p className="py-2 text-xs text-muted-foreground">{t('noLinked')}</p> : null
+      ) : (
+        <ul className="space-y-1.5">
+          {linked.map((h) => (
+            <li
+              key={h.id}
+              className="flex items-center gap-2 rounded-lg border border-border bg-background px-2.5 py-1.5"
+            >
+              <Link2 className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+              <span className="min-w-0 flex-1 truncate text-xs text-foreground" title={h.statement}>
+                {h.statement}
+              </span>
+              {isCrossEpic(h) ? (
+                <span
+                  className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning"
+                  title={t('crossEpicHint')}
+                >
+                  <AlertTriangle className="size-3" aria-hidden />
+                  {t('crossEpic')}
+                </span>
+              ) : null}
+              <HypothesisStatusBadge status={h.status} className="shrink-0" />
+              <button
+                type="button"
+                onClick={() => void unlinkHypothesis(h)}
+                disabled={busyId === h.id}
+                aria-label={t('unlink')}
+                title={t('unlink')}
+                className="shrink-0 rounded p-0.5 text-muted-foreground transition hover:bg-accent hover:text-destructive disabled:opacity-50"
+              >
+                <X className="size-3.5" />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* 가설 연결 picker (기존 가설 link 전용 — 생성 affordance 없음·AC①) */}
+      {pickerOpen ? (
+        <div className="space-y-2 rounded-lg border border-border bg-background p-2">
+          <div className="flex items-center justify-between">
+            <p className="text-xs font-medium text-muted-foreground">{t('pickerTitle')}</p>
+            <button
+              type="button"
+              onClick={() => setPickerOpen(false)}
+              aria-label={t('cancel')}
+              className="rounded p-0.5 text-muted-foreground transition hover:bg-accent hover:text-foreground"
+            >
+              <X className="size-3.5" />
+            </button>
+          </div>
+          <div className="flex items-center gap-1.5 rounded-md border border-border px-2">
+            <Search className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t('pickerSearch')}
+              className="w-full bg-transparent py-1.5 text-xs focus:outline-none"
+            />
+          </div>
+          {/* story에선 가설을 생성하지 않는다 — 생성은 에픽 상세/MCP 경로(AC①). */}
+          <p className="text-[11px] text-muted-foreground">{t('createElsewhereHint')}</p>
+          {candidates === null ? (
+            <p className="px-1 py-2 text-xs text-muted-foreground">…</p>
+          ) : filteredCandidates.length === 0 ? (
+            <p className="px-1 py-2 text-xs text-muted-foreground">{t('pickerEmpty')}</p>
+          ) : (
+            <ul className="max-h-48 space-y-1 overflow-y-auto">
+              {filteredCandidates.map((h) => (
+                <li key={h.id}>
+                  <button
+                    type="button"
+                    onClick={() => void linkHypothesis(h)}
+                    disabled={busyId === h.id}
+                    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left transition hover:bg-muted disabled:opacity-50"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-xs text-foreground" title={h.statement}>
+                      {h.statement}
+                    </span>
+                    {isCrossEpic(h) ? (
+                      <span
+                        className="inline-flex shrink-0 items-center gap-1 text-[11px] text-warning"
+                        title={t('crossEpicHint')}
+                      >
+                        <AlertTriangle className="size-3" aria-hidden />
+                        {t('crossEpic')}
+                      </span>
+                    ) : null}
+                    <HypothesisStatusBadge status={h.status} className="shrink-0" />
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -14,8 +14,8 @@ import { AttachmentImage } from '@/components/chat/attachment-image';
 import { AttachmentFile } from '@/components/chat/attachment-file';
 import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/label-chip';
 import { DependencyGraph } from './dependency-graph';
-import { OutcomeIntentFields, type OutcomeIntentValue } from '@/components/outcome/outcome-intent-fields';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
+import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
@@ -138,14 +138,6 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
   const [attachError, setAttachError] = useState(false);
   const attachInputRef = useRef<HTMLInputElement>(null);
 
-  const [intent, setIntent] = useState<OutcomeIntentValue>({
-    success_hypothesis: story.success_hypothesis ?? '',
-    metric_definition: story.metric_definition ?? null,
-    measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
-  });
-  const [intentOpen, setIntentOpen] = useState(!!story.success_hypothesis || !!story.metric_definition);
-  const [savingIntent, setSavingIntent] = useState(false);
-
   const [editingAssignee, setEditingAssignee] = useState(false);
   const [savingAssignee, setSavingAssignee] = useState(false);
 
@@ -190,13 +182,7 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     setTitleDraft(story.title);
     setDescriptionDraft(story.description ?? '');
     setAcDraft(story.acceptance_criteria ?? '');
-    setIntent({
-      success_hypothesis: story.success_hypothesis ?? '',
-      metric_definition: story.metric_definition ?? null,
-      measure_after: story.measure_after ? story.measure_after.slice(0, 10) : '',
-    });
-    setIntentOpen(!!story.success_hypothesis || !!story.metric_definition);
-  }, [story.id, story.title, story.description, story.acceptance_criteria, story.success_hypothesis, story.metric_definition, story.measure_after]);
+  }, [story.id, story.title, story.description, story.acceptance_criteria]);
 
   useEffect(() => {
     if (editingTitle) {
@@ -479,16 +465,6 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
     const next = (story.attachments ?? []).filter((a) => a.url !== url); // filter → 전체 교체
     const updated = await patchStory({ attachments: next });
     onStoryUpdate?.({ ...story, attachments: updated?.attachments ?? next });
-  };
-
-  const handleSaveIntent = async () => {
-    setSavingIntent(true);
-    await patchStory({
-      success_hypothesis: intent.success_hypothesis.trim() || null,
-      metric_definition: intent.metric_definition,
-      measure_after: intent.measure_after ? `${intent.measure_after}T00:00:00Z` : null,
-    });
-    setSavingIntent(false);
   };
 
   // Fetch comments
@@ -1226,7 +1202,9 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
               )}
             </div>
 
-            {/* Outcome intent + result */}
+            {/* Outcome result (read-only) + 연결 가설 chip/picker — 인라인 intent 입력은
+                S8c서 연결 가설 affordance로 대체(스토리서 가설 생성 금지·AC①). 결과 카드는
+                legacy outcome 백필(1519fc60) 전까지 보존. */}
             <div className="space-y-3">
               {story.outcome_status && story.outcome_status !== 'n_a' ? (
                 <OutcomeResultCard
@@ -1236,19 +1214,12 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   pendingMetricLabel={story.metric_definition?.metric}
                 />
               ) : null}
-              <OutcomeIntentFields
-                value={intent}
-                onChange={setIntent}
-                open={intentOpen}
-                onOpenChange={setIntentOpen}
-                context="story"
-              />
-              {intentOpen ? (
-                <div className="flex justify-end gap-2">
-                  <Button size="sm" onClick={() => { void handleSaveIntent(); }} disabled={savingIntent}>
-                    {savingIntent ? t('loading') : t('save')}
-                  </Button>
-                </div>
+              {projectId ? (
+                <StoryHypothesesSection
+                  storyId={story.id}
+                  epicId={story.epic_id}
+                  projectId={projectId}
+                />
               ) : null}
             </div>
 


### PR DESCRIPTION
## 무엇을 (블루프린트 §6.5 · S9 흡수)

story-detail-panel의 **인라인 outcome intent 입력**을 **"연결 가설" read-only chip + "가설 연결" picker**로 대체. 스토리는 기존 가설을 **link/unlink만** 하고 새 가설을 생성하지 않는다(AC①). 중복 스토리 **S9(`476b04fb`)의 AC를 흡수**해 한 번에 구현(S9는 보드서 fold).

> BE先行 아님 — `GET /api/hypotheses?story_id=` + `POST/DELETE /{id}/links` 모두 실재(S3 라우터 done). FE-only.

## 구현

- **신규 `story-hypotheses-section.tsx`**:
  - **linked chip** = `GET /api/hypotheses?project_id=&story_id=`({data} 엔벨로프·read-only). statement + 상태배지(`HypothesisStatusBadge` 재사용) + 연결 해제(X).
  - **picker** = 프로젝트 가설 중 **미연결분** 검색·연결. `POST /{id}/links` `{story_ids, link_type:'supports'}`. **생성 affordance 없음**(AC①·생성은 에픽 상세/MCP).
- **AC② link_type 기본 `supports`** — 연결 시 항상 supports.
- **AC③ 다른 에픽 연결 허용 + FE 경고** — `epic_ids`에 `story.epic_id` 미포함 시 chip/후보 양쪽에 ⚠️ "다른 에픽" 표식(연결은 허용). epic 미지정 story는 판정 보류(graceful).
- **AC④ 레이아웃 무결** — 패널 기존 `space-y-3` 흐름 유지, OutcomeResultCard 위.
- **unlink 경로 추가**: `links/route.ts`에 `DELETE` 핸들러(`unlinkHypothesisSchema`). BE `DELETE /api/v2/hypotheses/{id}/links` 실재 → **FE 프록시 1핸들러만** 추가(BE 작업 0).
- **정리**: story-detail-panel의 죽은 intent state(`intent`/`intentOpen`/`savingIntent`)·`handleSaveIntent`·`OutcomeIntentFields` import 제거.
- **보존**: `OutcomeResultCard`(read-only 결과뷰)는 legacy outcome 백필(`1519fc60`) 전까지 유지 — §12.3 공존 금지는 **입력측** 중복 얘기(PO 확인).

## 검증

- `tsc --noEmit` exit 0 · `eslint` clean · `next build` PASS(✓ Compiled · 159/159) · i18n 키 패리티(en/ko 10키).
- 인터랙티브 컴포넌트 단위테스트는 코드베이스 관행상 미작성(기존 hypotheses 컴포넌트 동일)·라이브 게이트 검증.

## AC

- [x] ① 스토리서 새 가설 생성 불가 — link/unlink만
- [x] ② 연결 시 link_type 기본 supports
- [x] ③ 다른 에픽 소속 가설 연결 허용 + FE 경고
- [x] ④ 패널 레이아웃 무결

## 리뷰

base `develop`. 게이트: **유나 픽셀(레이아웃 무결·경고 표식·chip/picker) → 까심 QA → PO**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)