### PR TITLE
feat(epics): hypothesis_count + risky_status on epic list (8a5daae5 S8b BE)

### DIFF
--- a/backend/app/repositories/epic.py
+++ b/backend/app/repositories/epic.py
@@ -1,16 +1,87 @@
 import uuid
+from collections.abc import Sequence
+from datetime import datetime
+from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.hypothesis import Hypothesis, HypothesisEpicLink
 from app.models.pm import Epic, Story
 from app.repositories.base import BaseRepository
 from app.schemas.epic import EpicProgressResponse
+
+# risky_status 우선순위: 최위험(falsified) → 최저위험(archived). 인덱스가 곧 rank.
+_RISK_ORDER: tuple[str, ...] = (
+    "falsified",
+    "measuring",
+    "active",
+    "proposed",
+    "verified",
+    "killed",
+    "archived",
+)
 
 
 class EpicRepository(BaseRepository[Epic]):
     def __init__(self, session: AsyncSession, org_id: uuid.UUID) -> None:
         super().__init__(Epic, session, org_id)
+
+    async def list_paginated(
+        self,
+        *,
+        limit: int | None = None,
+        cursor: datetime | None = None,
+        order_by: str = "created_at",
+        **filters: Any,
+    ) -> tuple[list[Epic], int]:
+        """기본 페이지네이션 + 연결 가설 집계(hypothesis_count·risky_status) 부착."""
+        epics, total = await super().list_paginated(
+            limit=limit, cursor=cursor, order_by=order_by, **filters
+        )
+        await self._attach_hypothesis_aggregates(epics)
+        return epics, total
+
+    async def _attach_hypothesis_aggregates(self, epics: Sequence[Epic]) -> None:
+        """페이지 전체 epic의 연결 가설 수/최위험 상태를 단일 쿼리로 집계해 부착.
+
+        N+1 회피: epic_id IN (page) GROUP BY로 1회 집계. risky_status는 위험도
+        rank의 MIN을 골라 다시 상태명으로 환원. 링크/가설이 없으면 count 0·risky
+        None. 비-매핑 인스턴스 속성이라 읽기 경로에서 flush 영향 없음.
+        """
+        for epic in epics:
+            epic.hypothesis_count = 0  # type: ignore[attr-defined]
+            epic.risky_status = None  # type: ignore[attr-defined]
+        if not epics:
+            return
+
+        epic_ids = [epic.id for epic in epics]
+        rank_case = case(
+            *[(Hypothesis.status == status, rank) for rank, status in enumerate(_RISK_ORDER)],
+            else_=len(_RISK_ORDER),
+        )
+        result = await self.session.execute(
+            select(
+                HypothesisEpicLink.epic_id.label("epic_id"),
+                func.count(func.distinct(HypothesisEpicLink.hypothesis_id)).label("cnt"),
+                func.min(rank_case).label("risk_rank"),
+            )
+            .join(Hypothesis, Hypothesis.id == HypothesisEpicLink.hypothesis_id)
+            .where(
+                HypothesisEpicLink.epic_id.in_(epic_ids),
+                Hypothesis.org_id == self.org_id,
+            )
+            .group_by(HypothesisEpicLink.epic_id)
+        )
+        by_epic = {row.epic_id: row for row in result.all()}
+        for epic in epics:
+            row = by_epic.get(epic.id)
+            if row is None:
+                continue
+            epic.hypothesis_count = int(row.cnt or 0)  # type: ignore[attr-defined]
+            rank = row.risk_rank
+            if rank is not None and 0 <= rank < len(_RISK_ORDER):
+                epic.risky_status = _RISK_ORDER[rank]  # type: ignore[attr-defined]
 
     async def get_progress(self, id: uuid.UUID) -> EpicProgressResponse:
         result = await self.session.execute(

--- a/backend/app/schemas/epic.py
+++ b/backend/app/schemas/epic.py
@@ -59,6 +59,11 @@ class EpicResponse(BaseModel):
     measure_after: datetime | None = None
     outcome_status: str = "n_a"
     outcome_result: dict[str, Any] | None = None
+    # E1 S8b: 연결 가설 집계(list 응답서 N+1 없이 부착). additive — 링크 0건이면
+    # count 0 / risky None. risky_status는 최위험 1개(falsified>measuring>active>
+    # proposed>verified>killed>archived). 미부착 경로(get/create/update)는 기본값.
+    hypothesis_count: int = 0
+    risky_status: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_e_board_schema_s1_epic_outcome.py
+++ b/backend/tests/test_e_board_schema_s1_epic_outcome.py
@@ -112,6 +112,9 @@ def _base_epic_mock(outcome_status: str = "n_a") -> MagicMock:
     e.measure_after = datetime(2026, 6, 1, tzinfo=timezone.utc)
     e.outcome_status = outcome_status
     e.outcome_result = None
+    # E1 S8b: EpicResponse 신규 집계 필드 — MagicMock auto-attr ValidationError 방지.
+    e.hypothesis_count = 0
+    e.risky_status = None
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e

--- a/backend/tests/test_epics.py
+++ b/backend/tests/test_epics.py
@@ -31,6 +31,10 @@ def _mock_epic(status: str = "active") -> MagicMock:
     e.measure_after = None
     e.outcome_status = "n_a"
     e.outcome_result = None
+    # E1 S8b: 연결 가설 집계. MagicMock auto-attr이면 from_attributes ValidationError이라
+    # 신규 필드를 명시 세팅(기본값 동형). _attach_hypothesis_aggregates가 덮어쓸 수 있음.
+    e.hypothesis_count = 0
+    e.risky_status = None
     e.created_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     e.updated_at = datetime(2026, 5, 1, tzinfo=timezone.utc)
     return e
@@ -68,8 +72,20 @@ async def _client():
 
 # ── GET list ──────────────────────────────────────────────────────────────────
 
-def _paginated_execute(total: int, rows: list):
-    """list_paginated: 1번째 execute=count(scalar_one), 2번째=list(scalars().all())."""
+def _agg_row(epic_id, cnt: int, risk_rank: int | None):
+    """EpicRepository._attach_hypothesis_aggregates 집계 한 행(epic_id·cnt·risk_rank)."""
+    row = MagicMock()
+    row.epic_id = epic_id
+    row.cnt = cnt
+    row.risk_rank = risk_rank
+    return row
+
+
+def _paginated_execute(total: int, rows: list, agg_rows: list | None = None):
+    """EpicRepository.list_paginated의 execute 순서를 모킹.
+
+    1=count(scalar_one), 2=list(scalars().all()), 3=가설 집계(_attach.. → result.all()).
+    """
     state = {"n": 0}
 
     async def _exec(stmt, *args, **kwargs):
@@ -77,8 +93,10 @@ def _paginated_execute(total: int, rows: list):
         r = MagicMock()
         if state["n"] == 1:
             r.scalar_one.return_value = total
-        else:
+        elif state["n"] == 2:
             r.scalars.return_value.all.return_value = rows
+        else:
+            r.all.return_value = agg_rows or []
         return r
 
     return _exec
@@ -97,6 +115,41 @@ async def test_list_epics_200():
         assert isinstance(resp.json(), list)
         # 569f5316: 전체 카운트는 항상 헤더로 노출 → silent-truncation 불가
         assert resp.headers["X-Total-Count"] == "1"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_includes_hypothesis_aggregates():
+    """E1 S8b: list 응답에 hypothesis_count + risky_status(최위험 환원)가 실린다."""
+    client, session, app = await _client()
+    try:
+        # risk_rank 0 = falsified(최위험), 연결 가설 3
+        session.execute = _paginated_execute(
+            1, [_mock_epic()], agg_rows=[_agg_row(EPIC_ID, 3, 0)]
+        )
+        async with client as c:
+            resp = await c.get("/api/v2/epics")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body[0]["hypothesis_count"] == 3
+        assert body[0]["risky_status"] == "falsified"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_list_epics_zero_hypotheses_defaults_count0_risky_null():
+    """E1 S8b additive: 연결 가설 0건이면 count 0 / risky None."""
+    client, session, app = await _client()
+    try:
+        session.execute = _paginated_execute(1, [_mock_epic()], agg_rows=[])
+        async with client as c:
+            resp = await c.get("/api/v2/epics")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body[0]["hypothesis_count"] == 0
+        assert body[0]["risky_status"] is None
     finally:
         app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Story 8a5daae5 (S8b) — BE 선행분

E1 epic board needs, per epic in the **list** response, the linked-hypothesis count and the single riskiest linked status — so the FE (S8b, unblocking 미르코 after S8c) is not idle on BE.

### Changes
- **`EpicResponse`** — additive `hypothesis_count: int = 0` and `risky_status: str | None = None`. Existing fields untouched. `get`/`create`/`update` return defaults (S8b is list-scoped).
- **`EpicRepository.list_paginated`** — overrides base to attach the aggregates **without N+1**: one batched query over the page's epic ids (`hypothesis_epic_links` JOIN `hypotheses`, `GROUP BY epic_id`):
  - `hypothesis_count` = `COUNT(DISTINCT hypothesis_id)`
  - `risky_status` = `MIN` over a CASE rank `falsified > measuring > active > proposed > verified > killed > archived`, mapped back to the status name
  - org-scoped join; no links → `count 0` / `risky None`; aggregates set as non-mapped instance attrs (read path, no flush impact)
- **Tests** — new `test_list_epics_includes_hypothesis_aggregates` (count + risky mapping) and `test_list_epics_zero_hypotheses_defaults_count0_risky_null`; updated the MagicMock epic fixtures (`test_epics`, s1) with the new fields so `from_attributes` doesn't raise on auto-attrs, and extended the list execute mock for the 3rd aggregate query.

### AC
- ✅ additive (기존 필드 무변경)
- ✅ 0건이면 `count 0` / `risky null`
- ✅ N+1 없음 (페이지 단일 배치 집계)
- ✅ schema 회귀 테스트 (from_attributes + mock fixture 동시 갱신)

### Validation
Affected backend suites green: `test_epics` (+2 new), `test_e_board_schema_s1/s2/s3`, `test_ss1_auth_context`, `test_ss4_security_regression`, `test_integration`, `test_mcp_hypotheses`, MCP contract (27). `py_compile` clean.

> Note: `test_s7_2_epic_dod::test_contract_tests_pass` fails **only in a git worktree** — it `subprocess.run`s `BACKEND_ROOT/.venv/bin/pytest`, and a worktree has no `.venv` (FileNotFoundError). Passes on the main checkout and CI; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)