### PR TITLE
[SID:8a5daae5] feat(epics): 에픽 목록 카드 연결 가설 요약 (S8b FE)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2311,7 +2311,8 @@
     "pickerEmpty": "No hypotheses to link",
     "crossEpic": "Other epic",
     "crossEpicHint": "This hypothesis belongs to a different epic",
-    "createElsewhereHint": "Hypotheses are created from the epic detail"
+    "createElsewhereHint": "Hypotheses are created from the epic detail",
+    "summaryTitle": "{count} linked hypotheses"
   },
   "epics": {
     "title": "Epics",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2311,7 +2311,8 @@
     "pickerEmpty": "연결할 가설이 없습니다",
     "crossEpic": "다른 에픽",
     "crossEpicHint": "이 가설은 다른 에픽 소속입니다",
-    "createElsewhereHint": "가설은 에픽 상세에서 생성합니다"
+    "createElsewhereHint": "가설은 에픽 상세에서 생성합니다",
+    "summaryTitle": "연결 가설 {count}개"
   },
   "epics": {
     "title": "에픽",

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/ui/dialog';
 import { ToastContainer, useToast } from '@/components/ui/toast';
 import { OutcomeStatusBadge } from '@/components/outcome/outcome-status-badge';
+import { HypothesesSummary } from '@/components/hypotheses/hypotheses-summary';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -42,6 +43,9 @@ interface Epic {
   measure_after?: string | null;
   outcome_status?: 'n_a' | 'pending' | 'hit' | 'miss' | null;
   outcome_result?: Record<string, unknown> | null;
+  // E1 S8b: BE EpicResponse가 list 응답에 부착하는 연결 가설 집계(미부착 경로는 기본값).
+  hypothesis_count?: number;
+  risky_status?: string | null;
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -464,6 +468,7 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
             <span>{t('targetDate')}: {formatDate(epic.target_date)}</span>
           ) : null}
           <span>{done}/{total} {t('stories')}</span>
+          <HypothesesSummary count={epic.hypothesis_count ?? 0} riskyStatus={epic.risky_status ?? null} />
           {spExceeded ? (
             <span className="rounded-full bg-destructive/10 px-1.5 py-0.5 text-[10px] font-semibold text-destructive">
               {t('spExceeded')}

--- a/apps/web/src/app/(authenticated)/epics/epics-client.tsx
+++ b/apps/web/src/app/(authenticated)/epics/epics-client.tsx
@@ -463,7 +463,9 @@ function EpicRow({ epic, isSelected, onClick, onDeleteRequest }: EpicRowProps) {
           <p className="text-xs text-muted-foreground line-clamp-1">{epic.description.split('\n')[0]?.replace(/^#+\s*/, '')}</p>
         ) : null}
 
-        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+        {/* 가설요약 추가로 메타 항목이 늘어 고밀도 카드(마감일+SP초과 동반)가 narrow 폭서
+            가로 오버플로 잠재 → flex-wrap 헤지(가디언 라이브게이트 선제·기존 행 robustness↑). */}
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
           {epic.target_date ? (
             <span>{t('targetDate')}: {formatDate(epic.target_date)}</span>
           ) : null}

--- a/apps/web/src/components/hypotheses/hypotheses-summary.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-summary.tsx
@@ -1,0 +1,41 @@
+import { useTranslations } from 'next-intl';
+import { FlaskConical } from 'lucide-react';
+import { HYPOTHESIS_STATUSES, type HypothesisStatus } from '@sprintable/core-storage';
+import { cn } from '@/lib/utils';
+import { HypothesisStatusBadge } from './hypothesis-status-badge';
+
+/**
+ * Epic-list 카드 연결 가설 요약(E1-S8b · BE #1453 부착분 소비).
+ *
+ * BE `EpicResponse.hypothesis_count`(연결 수) + `risky_status`(최위험 1개 ·
+ * ordering falsified>measuring>active>proposed>verified>killed>archived ·
+ * 링크 0건이면 count 0/risky null)를 카드 메타에 노출한다. **0건은 미표시**(AC).
+ * risky_status가 알 수 없는 값이면 배지만 graceful 생략(count는 표시).
+ */
+export function HypothesesSummary({
+  count,
+  riskyStatus,
+  className,
+}: {
+  count: number;
+  riskyStatus: string | null;
+  className?: string;
+}) {
+  const t = useTranslations('hypotheses');
+  if (!count || count <= 0) return null;
+
+  const known = (HYPOTHESIS_STATUSES as readonly string[]).includes(riskyStatus ?? '');
+
+  return (
+    <span
+      className={cn('inline-flex items-center gap-1.5', className)}
+      title={t('summaryTitle', { count })}
+    >
+      <span className="inline-flex items-center gap-1 text-muted-foreground">
+        <FlaskConical className="size-3.5" aria-hidden />
+        {count}
+      </span>
+      {known ? <HypothesisStatusBadge status={riskyStatus as HypothesisStatus} /> : null}
+    </span>
+  );
+}


### PR DESCRIPTION
## 무엇을 (E1 마지막 split · BE #1453 동반)

BE #1453(`23b5c577`·까심 6-CP APPROVE 머지)이 `EpicResponse`에 부착한 집계 필드를 **에픽 목록 카드**에 노출. 에픽 단위로 "연결 가설 몇 개 · 가장 위험한 상태"를 카드에서 1초에 읽히게 한다.

## BE 계약 (코드 실측 · `backend/app/schemas/epic.py:62-66`)

- `hypothesis_count: int = 0` — 연결 가설 수.
- `risky_status: str | None = None` — 최위험 1개. ordering **falsified > measuring > active > proposed > verified > killed > archived**.
- **링크 0건 → count 0 / risky null**. epic **list** 응답에만 N+1 없이 부착(get/create/update는 기본값).

## FE 구현

- **신규 `hypotheses-summary.tsx`**: 🧪 `count`(lucide `FlaskConical`) + 최위험 상태 배지(`HypothesisStatusBadge` 재사용 — falsified=info청 소울 정합·destructive 금지). **count 0건 미표시**(AC). risky_status가 `HYPOTHESIS_STATUSES` 외 값이면 배지만 graceful 생략(count는 표시).
- **EpicRow 메타 행**(`stories` 카운트 옆)에 배치 — 0건 카드는 시각 변화 0.
- `Epic` 인터페이스에 `hypothesis_count?`/`risky_status?` 추가. 소비부 `?? 0`/`?? null`로 **forward-compat**(미부착 경로 안전).
- i18n `hypotheses.summaryTitle`({count}) en/ko.

## 검증

- BE 계약 **코드 실측**(스키마 필드 + ordering 주석 확인) · `tsc --noEmit` exit 0 · `eslint` clean · `next build` PASS(✓ Compiled · 159/159) · i18n 키 패리티.

## AC

- [x] 에픽 카드에 연결 가설 count(🧪) + 최위험 상태 배지
- [x] 0건 미표시
- [x] risky ordering = BE 계약 준수(BE 산출·FE는 표시)

## 리뷰

base `develop`. 게이트: **유나 픽셀(카드 메타 정렬·배지·0건 미표시) → 까심 QA → PO**. **E1 마지막 split.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)