### PR TITLE
test(services): Group B — un-isolate background-runtime (stale Supabase factory contract)

### DIFF
--- a/apps/web/src/services/background-runtime.test.ts
+++ b/apps/web/src/services/background-runtime.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
-  createClientMock,
   slackCtorMock,
   slackStartMock,
   slackStopMock,
@@ -18,7 +17,6 @@ const {
   memoStartMock,
   memoStopMock,
 } = vi.hoisted(() => ({
-  createClientMock: vi.fn(),
   slackCtorMock: vi.fn(),
   slackStartMock: vi.fn(),
   slackStopMock: vi.fn().mockResolvedValue(undefined),
@@ -199,7 +197,6 @@ describe('background-runtime settings', () => {
 
 describe('BackgroundRuntimeWorker', () => {
   beforeEach(() => {
-    createClientMock.mockReset();
     slackCtorMock.mockReset();
     slackStartMock.mockReset();
     slackStopMock.mockClear();
@@ -274,74 +271,70 @@ describe('BackgroundRuntimeWorker', () => {
     expect(memoStopMock).toHaveBeenCalledTimes(1);
   });
 
-  it('creates a worker from env using the shared service-role client', () => {
-    createClientMock.mockReturnValue({ tag: 'db-client' });
-
+  // C-S11(e17719fc)에서 Supabase admin client(createAdminClient/lib/db/admin.ts)가
+  // 전량 제거됐다. createBackgroundRuntimeWorkerFromEnv는 더 이상 db 클라이언트를
+  // 만들지 않고 db: undefined로 dispatcher를 구성한다(영속은 FastAPI 경유). 아래는
+  // 그 현 계약을 검증한다 — 옛 service-role 팩토리/널-가드는 폐기됐다.
+  it('creates a worker from env with db-less dispatchers (post-Supabase)', () => {
     const worker = createBackgroundRuntimeWorkerFromEnv({
       NODE_ENV: 'production',
-      DATABASE_URL: 'https://db.example.com',
-      DATABASE_SERVICE_KEY: 'service-role-key',
       NEXT_PUBLIC_APP_URL: 'https://app.example.com',
       SPRINTABLE_RUNTIME_ROLE: 'worker',
       SPRINTABLE_BACKGROUND_POLL_INTERVAL_MS: '45000',
     } as NodeJS.ProcessEnv);
 
-    expect(createClientMock).toHaveBeenCalledWith('https://db.example.com', 'service-role-key');
     expect(worker).toBeInstanceOf(BackgroundRuntimeWorker);
     expect(slackCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://app.example.com',
     });
     expect(discordCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://app.example.com',
       pollingIntervalMs: 45000,
     });
     expect(teamsCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://app.example.com',
       pollingIntervalMs: 45000,
     });
     expect(memoCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       pollingIntervalMs: 45000,
     });
   });
 
-  it('falls back to the Vercel URL when APP_BASE_URL is missing', () => {
-    createClientMock.mockReturnValue({ tag: 'db-client' });
-
+  it('falls back to the Vercel URL when NEXT_PUBLIC_APP_URL is missing', () => {
     createBackgroundRuntimeWorkerFromEnv({
       NODE_ENV: 'production',
-      DATABASE_URL: 'https://db.example.com',
-      DATABASE_SERVICE_KEY: 'service-role-key',
       VERCEL_PROJECT_PRODUCTION_URL: 'myapp.vercel.app',
       SPRINTABLE_RUNTIME_ROLE: 'worker',
     } as NodeJS.ProcessEnv);
 
     expect(slackCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://myapp.vercel.app',
     });
     expect(discordCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://myapp.vercel.app',
       pollingIntervalMs: DEFAULT_PRODUCTION_BACKGROUND_POLLING_INTERVAL_MS,
     });
     expect(teamsCtorMock).toHaveBeenCalledWith({
-      db: { tag: 'db-client' },
+      db: undefined,
       appUrl: 'https://myapp.vercel.app',
       pollingIntervalMs: DEFAULT_PRODUCTION_BACKGROUND_POLLING_INTERVAL_MS,
     });
   });
 
-  it('returns null when service-role env is incomplete', () => {
+  it('still creates a worker without service-role db env (no admin client gate)', () => {
     const worker = createBackgroundRuntimeWorkerFromEnv({
       NODE_ENV: 'production',
-      DATABASE_URL: 'https://db.example.com',
+      NEXT_PUBLIC_APP_URL: 'https://app.example.com',
+      SPRINTABLE_RUNTIME_ROLE: 'worker',
     } as NodeJS.ProcessEnv);
 
-    expect(worker).toBeNull();
-    expect(createClientMock).not.toHaveBeenCalled();
+    // 옛 동작: service-role env 불완전 시 null. 현재: admin client가 없어 게이트도 없다.
+    expect(worker).toBeInstanceOf(BackgroundRuntimeWorker);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,7 +43,6 @@ export default defineConfig({
       // requires reworking the suite to inject db-stub-backed fake services — tracked as a
       // follow-up; un-isolating now would turn the suite red on pre-existing debt.
       'apps/web/src/services/agent-builtin-tools.test.ts',
-      'apps/web/src/services/background-runtime.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## Group B 번다운 — `background-runtime.test.ts` 격리 해제

`background-runtime.test.ts`는 세 `createBackgroundRuntimeWorkerFromEnv` 케이스가 **Supabase 제거 이전 계약**을 붙들고 있어 격리돼 있었다:
- `createClient(DATABASE_URL, DATABASE_SERVICE_KEY)` service-role 팩토리 호출
- 그 db-client를 모든 dispatcher에 주입 (`db: { tag: 'db-client' }`)
- service-role env 불완전 시 `null` 반환

**C-S11 (`e17719fc`)** 에서 Supabase admin client(`createAdminClient` / `lib/db/admin.ts`)가 전량 제거되면서, 이 함수는 이제 `db: undefined`로 dispatcher를 구성하고(영속은 FastAPI 경유) 항상 worker를 반환한다. hoisted `createClientMock`은 애초에 어떤 모듈에도 `vi.mock` 배선되지 않은 **제거된 팩토리의 잔재**였다.

### Changes
- 세 케이스를 현 계약으로 재작성: `db: undefined` 주입, appUrl 해석 유지(`NEXT_PUBLIC_APP_URL` → `VERCEL_PROJECT_PRODUCTION_URL` 폴백 포함), worker 항상 생성.
- dead `createClientMock` 제거(hoisted 정의 + beforeEach reset).
- 순수 함수 settings 테스트 + 주입-db start/stop 테스트는 이미 정상이라 무변경.
- `vitest.config.ts`에서 격리 해제.

### Validation
Full vitest: **964 passed · 2 skipped · 0 failed (152 files)** — background-runtime 8 케이스 합류·회귀 0. `tsc --noEmit` clean.

Group B: background-runtime 해제로 잔여 = docs/comments → 이후 `7a57e7b1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)