### PR TITLE
test(api): Group B b22 — agent-runs + mcp-connections route tests → FastAPI-proxy contract

### DIFF
--- a/apps/web/src/app/api/agent-runs/[id]/route.test.ts
+++ b/apps/web/src/app/api/agent-runs/[id]/route.test.ts
@@ -1,153 +1,58 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
-}));
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { PATCH } from './route';
 
-function makeRun(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'run-1',
-    org_id: 'org-1',
-    project_id: 'project-alpha',
-    agent_id: 'agent-1',
-    trigger: 'story_status_changed',
-    status: 'running',
-    retry_count: 0,
-    max_retries: 3,
-    next_retry_at: null,
-    created_at: '2026-04-15T06:00:00Z',
-    ...overrides,
-  };
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-function createQueryStub(rows: Record<string, unknown>[]) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.update = vi.fn(chain);
-  q.single = vi.fn(() =>
-    Promise.resolve({
-      data: rows[0] ?? null,
-      error: rows[0] ? null : { code: 'PGRST116', message: 'not found' },
-    }),
-  );
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(
-    Promise.resolve({ data: rows, error: null }),
-  );
-  return q;
+function fastapiErr(status: number, body: unknown = { detail: 'upstream error' }) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-describe('PATCH /api/agent-runs/[id]', () => {
-  beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue({
-      id: 'agent-1',
-      type: 'agent',
-      rateLimitExceeded: false,
-      rateLimitRemaining: 299,
-      rateLimitResetAt: 0,
+const ctx = (id = 'run-123') => ({ params: Promise.resolve({ id }) });
+
+describe('/api/agent-runs/[id]', () => {
+  it('PATCH — 보간된 run 경로로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ id: 'run-123', status: 'succeeded' }));
+    const request = new Request('http://test', { method: 'PATCH', body: JSON.stringify({ status: 'succeeded' }) });
+
+    const resp = await PATCH(request, ctx('run-123'));
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/agent-runs/run-123');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { id: 'run-123', status: 'succeeded' },
+      error: null,
+      meta: null,
     });
   });
 
-  it('updates run status to completed', async () => {
-    const existingRun = makeRun({ org_id: 'org-1', project_id: 'project-alpha' });
-    const updatedRun = makeRun({ status: 'completed' });
-    let callCount = 0;
-    const adminDb = {
-      from: vi.fn(() => {
-        callCount++;
-        return createQueryStub(callCount === 1 ? [existingRun] : [updatedRun]);
-      }),
-    };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
+  it('PATCH — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(404, { detail: 'run not found' }));
 
-    const response = await PATCH(
-      new Request('http://localhost/api/agent-runs/run-1', {
-        method: 'PATCH',
-        body: JSON.stringify({ status: 'completed', result_summary: 'Done' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-      { params: Promise.resolve({ id: 'run-1' }) },
-    );
+    const resp = await PATCH(new Request('http://test', { method: 'PATCH' }), ctx('missing'));
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ status: 'completed' });
+    expect(proxyToFastapi).toHaveBeenCalledWith(expect.anything(), '/api/v2/agent-runs/missing');
+    expect(resp.status).toBe(404);
   });
 
-  it('schedules retry when updated to failed with retries remaining', async () => {
-    const existingRun = makeRun({ org_id: 'org-1', project_id: 'project-alpha' });
-    const updatedRun = makeRun({ status: 'failed', retry_count: 1, max_retries: 3 });
-    let callCount = 0;
-    const adminDb = {
-      from: vi.fn(() => {
-        callCount++;
-        if (callCount === 1) return createQueryStub([existingRun]); // fetch existing
-        if (callCount === 2) return createQueryStub([updatedRun]); // update status
-        return createQueryStub([updatedRun]); // update next_retry_at
-      }),
-    };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
+  it('PATCH — 204 응답은 { ok: true }로 변환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
 
-    const response = await PATCH(
-      new Request('http://localhost/api/agent-runs/run-1', {
-        method: 'PATCH',
-        body: JSON.stringify({ status: 'failed', error_message: 'timeout' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-      { params: Promise.resolve({ id: 'run-1' }) },
-    );
+    const resp = await PATCH(new Request('http://test', { method: 'PATCH' }), ctx());
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ auto_retry_scheduled: true });
-  });
-
-  it('returns 400 for missing status', async () => {
-    createDbServerClient.mockResolvedValue({});
-    const adminDb = { from: vi.fn(() => createQueryStub([makeRun()])) };
-    createAdminClient.mockReturnValue(adminDb);
-
-    const response = await PATCH(
-      new Request('http://localhost/api/agent-runs/run-1', {
-        method: 'PATCH',
-        body: JSON.stringify({ result_summary: 'No status' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-      { params: Promise.resolve({ id: 'run-1' }) },
-    );
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.code).toBe('VALIDATION_FAILED');
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    createDbServerClient.mockResolvedValue({});
-    getAuthContext.mockResolvedValue(null);
-
-    const response = await PATCH(
-      new Request('http://localhost/api/agent-runs/run-1', {
-        method: 'PATCH',
-        body: JSON.stringify({ status: 'completed' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-      { params: Promise.resolve({ id: 'run-1' }) },
-    );
-
-    expect(response.status).toBe(401);
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
   });
 });

--- a/apps/web/src/app/api/agent-runs/route.test.ts
+++ b/apps/web/src/app/api/agent-runs/route.test.ts
@@ -1,199 +1,70 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-const { createDbServerClient, getAuthContext, createAdminClient } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getAuthContext: vi.fn(),
-  createAdminClient: vi.fn(),
-}));
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
 
-vi.mock('@/lib/db/server', () => ({ createDbServerClient }));
-vi.mock('@/lib/db/admin', () => ({ createAdminClient }));
-vi.mock('@/lib/auth-helpers', () => ({ getAuthContext }));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET, POST } from './route';
 
-function makeRun(overrides: Record<string, unknown> = {}) {
-  return {
-    id: 'run-1',
-    org_id: 'org-1',
-    project_id: 'project-alpha',
-    agent_id: 'agent-1',
-    trigger: 'story_status_changed',
-    status: 'completed',
-    retry_count: 0,
-    max_retries: 3,
-    next_retry_at: null,
-    created_at: '2026-04-15T06:00:00Z',
-    ...overrides,
-  };
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-function createQueryStub(rows: Record<string, unknown>[]) {
-  const q: Record<string, unknown> = {};
-  const chain = () => q;
-  q.select = vi.fn(chain);
-  q.eq = vi.fn(chain);
-  q.order = vi.fn(chain);
-  q.limit = vi.fn(chain);
-  q.insert = vi.fn(chain);
-  q.update = vi.fn(chain);
-  q.single = vi.fn(() =>
-    Promise.resolve({
-      data: rows[0] ?? null,
-      error: rows[0] ? null : { code: 'PGRST116', message: 'not found' },
-    }),
-  );
-  q.then = Promise.resolve({ data: rows, error: null }).then.bind(
-    Promise.resolve({ data: rows, error: null }),
-  );
-  return q;
+function fastapiErr(status: number, body: unknown = { detail: 'upstream error' }) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-describe('POST /api/agent-runs', () => {
-  beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue({
-      id: 'agent-1',
-      type: 'agent',
-      rateLimitExceeded: false,
-      rateLimitRemaining: 299,
-      rateLimitResetAt: 0,
+describe('/api/agent-runs', () => {
+  it('GET — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk([{ id: 'run-1', status: 'running' }]));
+    const request = new Request('http://test/api/agent-runs?project_id=p1');
+
+    const resp = await GET(request);
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/agent-runs');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: [{ id: 'run-1', status: 'running' }],
+      error: null,
+      meta: null,
     });
   });
 
-  it('creates agent run and returns 201', async () => {
-    const memberData = { project_id: 'project-alpha', org_id: 'org-1' };
-    const runData = makeRun();
-    const adminDb = {
-      from: vi.fn((table: string) => {
-        if (table === 'team_members') return createQueryStub([memberData]);
-        return createQueryStub([runData]);
-      }),
-    };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
+  it('GET — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(403, { detail: 'forbidden' }));
 
-    const response = await POST(
-      new Request('http://localhost/api/agent-runs', {
-        method: 'POST',
-        body: JSON.stringify({ agent_id: 'agent-1', trigger: 'story_status_changed', status: 'completed' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+    const resp = await GET(new Request('http://test/api/agent-runs'));
 
-    expect(response.status).toBe(201);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ id: 'run-1', status: 'completed' });
+    expect(resp.status).toBe(403);
   });
 
-  it('schedules retry when status is failed and retryCount < maxRetries', async () => {
-    const memberData = { project_id: 'project-alpha', org_id: 'org-1' };
-    const runData = makeRun({ status: 'failed', retry_count: 0, max_retries: 3 });
-    let callCount = 0;
-    const adminDb = {
-      from: vi.fn((table: string) => {
-        if (table === 'team_members') return createQueryStub([memberData]);
-        callCount++;
-        if (callCount === 1) return createQueryStub([runData]); // insert
-        return createQueryStub([runData]); // update next_retry_at
-      }),
-    };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
+  it('POST — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ id: 'run-1', status: 'queued' }));
+    const request = new Request('http://test', { method: 'POST', body: JSON.stringify({ agent_id: 'a1' }) });
 
-    const response = await POST(
-      new Request('http://localhost/api/agent-runs', {
-        method: 'POST',
-        body: JSON.stringify({ agent_id: 'agent-1', trigger: 'test', status: 'failed', error_message: 'timeout' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
+    const resp = await POST(request);
 
-    expect(response.status).toBe(201);
-    const body = await response.json();
-    expect(body.data).toMatchObject({ auto_retry_scheduled: true });
-    expect(typeof body.data.next_retry_at).toBe('string');
-  });
-
-  it('returns 400 for missing required fields', async () => {
-    createDbServerClient.mockResolvedValue({});
-
-    const response = await POST(
-      new Request('http://localhost/api/agent-runs', {
-        method: 'POST',
-        body: JSON.stringify({ agent_id: 'agent-1' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.code).toBe('VALIDATION_FAILED');
-  });
-
-  it('returns 401 when not authenticated', async () => {
-    createDbServerClient.mockResolvedValue({});
-    getAuthContext.mockResolvedValue(null);
-
-    const response = await POST(
-      new Request('http://localhost/api/agent-runs', {
-        method: 'POST',
-        body: JSON.stringify({ agent_id: 'agent-1', trigger: 'test' }),
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
-
-    expect(response.status).toBe(401);
-  });
-});
-
-describe('GET /api/agent-runs', () => {
-  beforeEach(() => {
-    createDbServerClient.mockReset();
-    getAuthContext.mockReset();
-    createAdminClient.mockReset();
-    getAuthContext.mockResolvedValue({
-      id: 'agent-1',
-      type: 'agent',
-      rateLimitExceeded: false,
-      rateLimitRemaining: 299,
-      rateLimitResetAt: 0,
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/agent-runs');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { id: 'run-1', status: 'queued' },
+      error: null,
+      meta: null,
     });
   });
 
-  it('returns recent runs for project', async () => {
-    const runs = [makeRun(), makeRun({ id: 'run-2' })];
-    const adminDb = { from: vi.fn(() => createQueryStub(runs)) };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
+  it('POST — 204 응답은 { ok: true }로 변환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
 
-    const response = await GET(
-      new Request('http://localhost/api/agent-runs?project_id=project-alpha'),
-    );
+    const resp = await POST(new Request('http://test', { method: 'POST' }));
 
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data).toHaveLength(2);
-  });
-
-  it('returns 400 when project_id missing', async () => {
-    createDbServerClient.mockResolvedValue({});
-
-    const response = await GET(new Request('http://localhost/api/agent-runs'));
-
-    expect(response.status).toBe(400);
-  });
-
-  it('uses admin client for agent auth', async () => {
-    const runs = [makeRun()];
-    const adminDb = { from: vi.fn(() => createQueryStub(runs)) };
-    createAdminClient.mockReturnValue(adminDb);
-    createDbServerClient.mockResolvedValue({});
-
-    await GET(new Request('http://localhost/api/agent-runs?project_id=project-alpha'));
-
-    expect(createAdminClient).toHaveBeenCalled();
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
   });
 });

--- a/apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts
+++ b/apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts
@@ -1,134 +1,67 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-const {
-  createDbServerClientMock,
-  createAdminClientMock,
-  getMyTeamMemberMock,
-  requireOrgAdminMock,
-  upsertProjectMcpConnectionMock,
-  deleteProjectMcpConnectionMock,
-  transitionDeploymentMock,
-} = vi.hoisted(() => ({
-  createDbServerClientMock: vi.fn(),
-  createAdminClientMock: vi.fn(() => ({ tag: 'admin' })),
-  getMyTeamMemberMock: vi.fn(),
-  requireOrgAdminMock: vi.fn(),
-  upsertProjectMcpConnectionMock: vi.fn(),
-  deleteProjectMcpConnectionMock: vi.fn(),
-  transitionDeploymentMock: vi.fn(),
-}));
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
 
-vi.mock('@/lib/db/server', () => ({
-  createDbServerClient: createDbServerClientMock,
-}));
-
-vi.mock('@/lib/db/admin', () => ({
-  createAdminClient: createAdminClientMock,
-}));
-
-vi.mock('@/lib/auth-helpers', () => ({
-  getMyTeamMember: getMyTeamMemberMock,
-}));
-
-vi.mock('@/lib/admin-check', () => ({
-  requireOrgAdmin: requireOrgAdminMock,
-}));
-
-vi.mock('@/services/project-mcp', () => ({
-  upsertProjectMcpConnection: upsertProjectMcpConnectionMock,
-  deleteProjectMcpConnection: deleteProjectMcpConnectionMock,
-}));
-
-vi.mock('@/services/agent-deployment-lifecycle', () => ({
-  AgentDeploymentLifecycleService: class {
-    transitionDeployment = transitionDeploymentMock;
-  },
-}));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { DELETE, PUT } from './route';
 
-function createDbStub() {
-  return {
-    auth: {
-      getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } } })),
-    },
-    from(table: string) {
-      if (table !== 'agent_deployments') {
-        throw new Error(`Unexpected table: ${table}`);
-      }
-      return {
-        select() { return this; },
-        eq() { return this; },
-        in: async () => ({
-          data: [{ id: 'deployment-1', status: 'ACTIVE' }],
-          error: null,
-        }),
-      };
-    },
-  };
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-describe('project mcp connection detail route', () => {
-  beforeEach(() => {
-    createDbServerClientMock.mockReset();
-    createAdminClientMock.mockClear();
-    getMyTeamMemberMock.mockReset();
-    requireOrgAdminMock.mockReset();
-    upsertProjectMcpConnectionMock.mockReset();
-    deleteProjectMcpConnectionMock.mockReset();
-    transitionDeploymentMock.mockReset();
+function fastapiErr(status: number, body: unknown = { detail: 'upstream error' }) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
-    createDbServerClientMock.mockResolvedValue(createDbStub());
-    getMyTeamMemberMock.mockResolvedValue({ id: 'member-1', org_id: 'org-1', project_id: 'project-1' });
-    requireOrgAdminMock.mockResolvedValue(undefined);
+const ctx = () => ({ params: Promise.resolve({ id: 'proj-1', serverKey: 'github' }) });
+
+describe('/api/projects/[id]/mcp-connections/[serverKey]', () => {
+  it('PUT — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ server_key: 'github', is_active: true }));
+    const request = new Request('http://test', { method: 'PUT', body: JSON.stringify({ is_active: true }) });
+
+    const resp = await PUT(request, ctx());
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/mcp-connections');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { server_key: 'github', is_active: true },
+      error: null,
+      meta: null,
+    });
   });
 
-  it('connects a manual MCP credential', async () => {
-    upsertProjectMcpConnectionMock.mockResolvedValue({ serverKey: 'linear', displayName: 'Linear' });
+  it('PUT — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(404, { detail: 'not found' }));
 
-    const response = await PUT(new Request('https://sprintable.app/api/projects/project-1/mcp-connections/linear', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ secret: 'lin_api_key', label: 'Moonklabs Linear' }),
-    }), {
-      params: Promise.resolve({ id: 'project-1', serverKey: 'linear' }),
-    });
-    expect(response).toBeDefined();
-    const body = await response!.json();
+    const resp = await PUT(new Request('http://test', { method: 'PUT' }), ctx());
 
-    expect(response!.status).toBe(200);
-    expect(upsertProjectMcpConnectionMock).toHaveBeenCalledWith({ tag: 'admin' }, {
-      orgId: 'org-1',
-      projectId: 'project-1',
-      actorId: 'member-1',
-      serverKey: 'linear',
-      secret: 'lin_api_key',
-      label: 'Moonklabs Linear',
-    });
-    expect(body.data.displayName).toBe('Linear');
+    expect(resp.status).toBe(404);
   });
 
-  it('deletes a connection and suspends live deployments', async () => {
-    const response = await DELETE(new Request('https://sprintable.app/api/projects/project-1/mcp-connections/github', {
-      method: 'DELETE',
-    }), {
-      params: Promise.resolve({ id: 'project-1', serverKey: 'github' }),
-    });
-    expect(response).toBeDefined();
-    const body = await response!.json();
+  it('DELETE — FastAPI로 위임하고 204는 { ok: true }로 변환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
+    const request = new Request('http://test', { method: 'DELETE' });
 
-    expect(response!.status).toBe(200);
-    expect(deleteProjectMcpConnectionMock).toHaveBeenCalledWith({ tag: 'admin' }, {
-      projectId: 'project-1',
-      serverKey: 'github',
-    });
-    expect(transitionDeploymentMock).toHaveBeenCalledWith({
-      orgId: 'org-1',
-      projectId: 'project-1',
-      actorId: 'member-1',
-      deploymentId: 'deployment-1',
-      status: 'SUSPENDED',
-    });
-    expect(body.data.suspended_deployments).toBe(1);
+    const resp = await DELETE(request, ctx());
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/mcp-connections');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
+  });
+
+  it('DELETE — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(403, { detail: 'forbidden' }));
+
+    const resp = await DELETE(new Request('http://test', { method: 'DELETE' }), ctx());
+
+    expect(resp.status).toBe(403);
   });
 });

--- a/apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts
+++ b/apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts
@@ -1,126 +1,67 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-const {
-  createDbServerClientMock,
-  createAdminClientMock,
-  getMyTeamMemberMock,
-  requireOrgAdminMock,
-  listProjectMcpConnectionSummariesMock,
-  createMcpConnectionReviewRequestMock,
-} = vi.hoisted(() => ({
-  createDbServerClientMock: vi.fn(),
-  createAdminClientMock: vi.fn(() => ({ tag: 'admin' })),
-  getMyTeamMemberMock: vi.fn(),
-  requireOrgAdminMock: vi.fn(),
-  listProjectMcpConnectionSummariesMock: vi.fn(),
-  createMcpConnectionReviewRequestMock: vi.fn(),
-}));
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
 
-vi.mock('@/lib/db/server', () => ({
-  createDbServerClient: createDbServerClientMock,
-}));
-
-vi.mock('@/lib/db/admin', () => ({
-  createAdminClient: createAdminClientMock,
-}));
-
-vi.mock('@/lib/auth-helpers', () => ({
-  getMyTeamMember: getMyTeamMemberMock,
-}));
-
-vi.mock('@/lib/admin-check', () => ({
-  requireOrgAdmin: requireOrgAdminMock,
-}));
-
-vi.mock('@/services/project-mcp', () => ({
-  listProjectMcpConnectionSummaries: listProjectMcpConnectionSummariesMock,
-  createMcpConnectionReviewRequest: createMcpConnectionReviewRequestMock,
-}));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { GET, POST } from './route';
 
-function createDbStub() {
-  return {
-    auth: {
-      getUser: vi.fn(async () => ({ data: { user: { id: 'user-1' } } })),
-    },
-  };
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-describe('project mcp connections route', () => {
-  beforeEach(() => {
-    createDbServerClientMock.mockReset();
-    createAdminClientMock.mockClear();
-    getMyTeamMemberMock.mockReset();
-    requireOrgAdminMock.mockReset();
-    listProjectMcpConnectionSummariesMock.mockReset();
-    createMcpConnectionReviewRequestMock.mockReset();
+function fastapiErr(status: number, body: unknown = { detail: 'upstream error' }) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
-    createDbServerClientMock.mockResolvedValue(createDbStub());
-    getMyTeamMemberMock.mockResolvedValue({ id: 'member-1', org_id: 'org-1', project_id: 'project-1' });
-    requireOrgAdminMock.mockResolvedValue(undefined);
+const ctx = (id = 'proj-1') => ({ params: Promise.resolve({ id }) });
+
+describe('/api/projects/[id]/mcp-connections', () => {
+  it('GET — OSS 모드: proxy 없이 빈 connections 정적 응답', async () => {
+    const resp = await GET(new Request('http://test'), ctx('proj-1'));
+
+    expect(proxyToFastapi).not.toHaveBeenCalled();
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({
+      data: { project_id: 'proj-1', connections: [] },
+    });
   });
 
-  it('returns approved connection summaries for the current project', async () => {
-    listProjectMcpConnectionSummariesMock.mockResolvedValue([
-      {
-        serverKey: 'github',
-        displayName: 'GitHub',
-        provider: 'github',
-        authStrategy: 'oauth',
-        connected: true,
-        connectUrl: 'https://github.com/login/oauth/authorize?...',
-        maskedSecret: '****1234',
-        label: 'octocat',
-        status: 'active',
-        toolNames: ['github.list_issues'],
-        validatedAt: '2026-04-09T00:00:00.000Z',
-        lastError: null,
-      },
-    ]);
+  it('POST — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ server_key: 'github', is_active: true }));
+    const request = new Request('http://test', { method: 'POST', body: JSON.stringify({ server_key: 'github' }) });
 
-    const response = await GET(new Request('https://sprintable.app/api/projects/project-1/mcp-connections'), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
-    expect(response).toBeDefined();
-    const body = await response!.json();
+    const resp = await POST(request, ctx());
 
-    expect(response!.status).toBe(200);
-    expect(listProjectMcpConnectionSummariesMock).toHaveBeenCalledWith({ tag: 'admin' }, {
-      orgId: 'org-1',
-      projectId: 'project-1',
-      origin: 'https://sprintable.app',
-      actorId: 'member-1',
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/mcp-connections');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { server_key: 'github', is_active: true },
+      error: null,
+      meta: null,
     });
-    expect(body.data.connections).toHaveLength(1);
   });
 
-  it('creates a custom review request', async () => {
-    createMcpConnectionReviewRequestMock.mockResolvedValue({ id: 'request-1', status: 'pending' });
+  it('POST — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(403, { detail: 'forbidden' }));
 
-    const response = await POST(new Request('https://sprintable.app/api/projects/project-1/mcp-connections', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        server_name: 'Custom Internal MCP',
-        server_url: 'https://mcp.example.com/rpc',
-        notes: 'Need manual review',
-      }),
-    }), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
-    expect(response).toBeDefined();
-    const body = await response!.json();
+    const resp = await POST(new Request('http://test', { method: 'POST' }), ctx());
 
-    expect(response!.status).toBe(201);
-    expect(createMcpConnectionReviewRequestMock).toHaveBeenCalledWith({ tag: 'admin' }, {
-      orgId: 'org-1',
-      projectId: 'project-1',
-      actorId: 'member-1',
-      serverName: 'Custom Internal MCP',
-      serverUrl: 'https://mcp.example.com/rpc',
-      notes: 'Need manual review',
-    });
-    expect(body.data.id).toBe('request-1');
+    expect(resp.status).toBe(403);
+  });
+
+  it('POST — 204 응답은 { ok: true }로 변환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const resp = await POST(new Request('http://test', { method: 'POST' }), ctx());
+
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,12 +28,8 @@ export default defineConfig({
       // suite; each file is debt to burn down — re-include as it is fixed.
       // ⚠️ DO NOT add here to silence a NEW failure — fix the test.
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
-      'apps/web/src/app/api/agent-runs/[id]/route.test.ts',
-      'apps/web/src/app/api/agent-runs/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts',
       'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',
-      'apps/web/src/app/api/projects/[id]/mcp-connections/[serverKey]/route.test.ts',
-      'apps/web/src/app/api/projects/[id]/mcp-connections/route.test.ts',
       // agent-builtin-tools.test.ts: the 4 registry-declared memo tools
       // (create_memo/reply_memo/update_memo/list_memos) are now implemented (story
       // 6f237832), but this file's create_story/forward_memo/create_memo/list_epics


### PR DESCRIPTION
## Group B 번다운 b22 — 4 route 테스트 격리 해제

`agent-runs` ×2 + `mcp-connections` ×2 route 핸들러는 **FastAPI-proxy 계약**으로 마이그됐으나(`proxyToFastapi` → `!ok` 패스스루 → `204→{ok:true}` → 성공 body를 `apiSuccess`로 `{data}` 재래핑), 테스트는 **마이그 이전 직-db 스택**(`createDbServerClient`/`createAdminClient`/`getMyTeamMember`/`@/services/project-mcp`)을 mock해 RED·격리돼 있었다.

### Changes (proxy-contract 패턴)
- `agent-runs/route.test.ts` — GET/POST → `/api/v2/agent-runs`
- `agent-runs/[id]/route.test.ts` — PATCH → 보간 경로 `/api/v2/agent-runs/{id}`
- `projects/[id]/mcp-connections/route.test.ts` — POST → `/api/v2/projects/mcp-connections`; **GET은 OSS 정적**(proxy 미호출·`{connections:[]}`)
- `projects/[id]/mcp-connections/[serverKey]/route.test.ts` — PUT/DELETE → `/api/v2/projects/mcp-connections`

각 파일: `vi.hoisted` proxy mock + `vi.mock('@/lib/fastapi-proxy')` → **위임 경로 정합·`{data}` 봉투·`!ok` 패스스루·`204→{ok:true}`** 검증. 구 db-mock 비즈니스 단언은 폐기(해당 로직은 FastAPI backend가 검증).

### Validation
Full vitest: **979 passed · 2 skipped · 0 failed (156 files)** — 4파일 15케이스 합류·회귀 0. `tsc --noEmit` clean.

Group B 잔여 = `ai-settings` ×2(route proxy + validate 특수, b23) → `7a57e7b1`④.

🤖 Generated with [Claude Code](https://claude.com/claude-code)