### PR TITLE
test(api): Group B b23 — ai-settings route tests → current contracts (proxy + validate)

### DIFF
--- a/apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts
+++ b/apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts
@@ -1,489 +1,80 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { KmsServiceError } from '@/lib/kms';
+import { describe, expect, it, vi } from 'vitest';
 
-const {
-  createDbServerClient,
-  getMyTeamMember,
-  requireOrgAdmin,
-  getProjectAiSettingsWithIntegration,
-  ensureProjectSecretEncrypted,
-  decryptProjectSecret,
-  persistProjectAiSettingsWithEncryptedSecret,
-} = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getMyTeamMember: vi.fn(),
-  requireOrgAdmin: vi.fn(),
-  getProjectAiSettingsWithIntegration: vi.fn(),
-  ensureProjectSecretEncrypted: vi.fn(),
-  decryptProjectSecret: vi.fn(),
-  persistProjectAiSettingsWithEncryptedSecret: vi.fn(),
-}));
+const { proxyToFastapi } = vi.hoisted(() => ({ proxyToFastapi: vi.fn() }));
 
-vi.mock('@/lib/db/server', () => ({
-  createDbServerClient,
-}));
-
-vi.mock('@/lib/auth-helpers', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
-  return {
-    ...actual,
-    getMyTeamMember,
-  };
-});
-
-vi.mock('@/lib/admin-check', () => ({
-  requireOrgAdmin,
-}));
-
-vi.mock('@/lib/llm/project-ai-settings', () => ({
-  ORG_INTEGRATION_TYPE: 'byom_api_key',
-  maskLast4: (last4?: string | null) => (last4 ? `****${last4}` : null),
-  getProjectAiSettingsWithIntegration,
-  ensureProjectSecretEncrypted,
-  decryptProjectSecret,
-  persistProjectAiSettingsWithEncryptedSecret,
-}));
+vi.mock('@/lib/fastapi-proxy', () => ({ proxyToFastapi }));
 
 import { DELETE, GET, PUT } from './route';
 
-function createDbStub() {
-  const projectUpsertSpy = vi.fn();
-  const rotationUpdateSpy = vi.fn();
-  const deploymentUpdateSpy = vi.fn();
-  const projectDeleteSpy = vi.fn();
-  const integrationDeleteSpy = vi.fn();
-
-  const projectQuery = {
-    upsert: vi.fn((payload: unknown) => {
-      projectUpsertSpy(payload);
-      return projectQuery;
-    }),
-    select: vi.fn(() => projectQuery),
-    single: vi.fn().mockResolvedValue({
-      data: {
-        id: 'setting-1',
-        provider: 'openai',
-        llm_config: { model: 'gpt-4o-mini' },
-        created_at: '2026-04-07T09:00:00.000Z',
-        updated_at: '2026-04-07T09:00:00.000Z',
-      },
-      error: null,
-    }),
-    delete: vi.fn(() => projectDeleteQuery),
-  };
-
-  let rotationEqCount = 0;
-  const orgIntegrationUpdateQuery = {
-    update: vi.fn((payload: unknown) => {
-      rotationUpdateSpy(payload);
-      rotationEqCount = 0;
-      return orgIntegrationUpdateQuery;
-    }),
-    eq: vi.fn(() => {
-      rotationEqCount += 1;
-      if (rotationEqCount >= 3) return Promise.resolve({ error: null });
-      return orgIntegrationUpdateQuery;
-    }),
-  };
-
-  let _deploymentEqCount = 0;
-  const deploymentUpdateQuery = {
-    update: vi.fn((payload: unknown) => {
-      deploymentUpdateSpy(payload);
-      _deploymentEqCount = 0;
-      return deploymentUpdateQuery;
-    }),
-    eq: vi.fn(() => {
-      _deploymentEqCount += 1;
-      return deploymentUpdateQuery;
-    }),
-    in: vi.fn(async () => ({ error: null })),
-  };
-
-  const projectDeleteQuery = {
-    delete: vi.fn(() => projectDeleteQuery),
-    eq: vi.fn((column: string, value: unknown) => {
-      projectDeleteSpy({ column, value });
-      return Promise.resolve({ error: null });
-    }),
-  };
-
-  let integrationDeleteEqCount = 0;
-  const orgIntegrationDeleteQuery = {
-    delete: vi.fn(() => orgIntegrationDeleteQuery),
-    eq: vi.fn((column: string, value: unknown) => {
-      integrationDeleteEqCount += 1;
-      if (integrationDeleteEqCount >= 3) {
-        integrationDeleteSpy({ column, value });
-        return Promise.resolve({ error: null });
-      }
-      return orgIntegrationDeleteQuery;
-    }),
-  };
-
-  let orgIntegrationFromCount = 0;
-
-  const db = {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
-    },
-    from: vi.fn((table: string) => {
-      if (table === 'project_ai_settings') return projectQuery;
-      if (table === 'agent_deployments') return deploymentUpdateQuery;
-      if (table === 'org_integrations') {
-        orgIntegrationFromCount += 1;
-        return orgIntegrationFromCount === 1 ? orgIntegrationUpdateQuery : orgIntegrationDeleteQuery;
-      }
-      throw new Error(`Unexpected table: ${table}`);
-    }),
-  };
-
-  return {
-    db,
-    projectUpsertSpy,
-    rotationUpdateSpy,
-    deploymentUpdateSpy,
-    projectDeleteSpy,
-    integrationDeleteSpy,
-  };
+function fastapiOk(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
-beforeEach(() => {
-  vi.resetAllMocks();
-  process.env.KMS_PROVIDER = 'local';
-  process.env.LOCAL_KMS_MASTER_KEY = 'route-test-master-key';
-  getMyTeamMember.mockResolvedValue({ id: 'tm-1', org_id: 'org-1', project_id: 'project-1' });
-  requireOrgAdmin.mockResolvedValue(undefined);
-  getProjectAiSettingsWithIntegration.mockResolvedValue({ settings: null, integration: null });
-});
+function fastapiErr(status: number, body: unknown = { detail: 'upstream error' }) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
 
-describe('GET /api/projects/[id]/ai-settings', () => {
-  it('returns masked BYOM metadata from org_integrations, not plaintext api_key', async () => {
-    const { db } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: {
-        id: 'setting-1',
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        api_key: null,
-        llm_config: { model: 'gpt-4o-mini' },
-        created_at: '2026-04-07T09:00:00.000Z',
-        updated_at: '2026-04-07T09:00:00.000Z',
-      },
-      integration: { secret_last4: '1234', encrypted_secret: 'encrypted' },
+const ctx = (id = 'proj-1') => ({ params: Promise.resolve({ id }) });
+
+describe('/api/projects/[id]/ai-settings', () => {
+  it('GET — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ provider: 'anthropic', masked_key: '****1234' }));
+    const request = new Request('http://test');
+
+    const resp = await GET(request, ctx());
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/ai-settings');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { provider: 'anthropic', masked_key: '****1234' },
+      error: null,
+      meta: null,
     });
-    ensureProjectSecretEncrypted.mockResolvedValue({ secret_last4: '1234', encrypted_secret: 'encrypted' });
-
-    const response = await GET(new Request('http://localhost/api/projects/project-1/ai-settings'), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.api_key).toBe('****1234');
   });
 
-  it('returns a safe 503 message when KMS is unavailable', async () => {
-    const { db } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: { org_id: 'org-1', project_id: 'project-1', provider: 'openai', api_key: null, llm_config: {} },
-      integration: { secret_last4: '1234', encrypted_secret: 'encrypted' },
-    });
-    ensureProjectSecretEncrypted.mockRejectedValue(new KmsServiceError('vault down'));
+  it('GET — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(403, { detail: 'forbidden' }));
 
-    const response = await GET(new Request('http://localhost/api/projects/project-1/ai-settings'), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
+    const resp = await GET(new Request('http://test'), ctx());
 
-    expect(response.status).toBe(503);
-    const body = await response.json();
-    expect(body.error.message).toBe('KMS 서비스 일시 오류');
-  });
-});
-
-describe('PUT /api/projects/[id]/ai-settings', () => {
-  it('returns validation errors for malformed payloads', async () => {
-    const { db } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      body: JSON.stringify({ provider: 'invalid-provider' }),
-      headers: { 'Content-Type': 'application/json' },
-    }), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.code).toBe('VALIDATION_FAILED');
+    expect(resp.status).toBe(403);
   });
 
-  it('requires a fresh api_key when the provider changes', async () => {
-    const { db, projectUpsertSpy } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        api_key: null,
-        llm_config: { model: 'gpt-4o-mini' },
-      },
-      integration: { secret_last4: '1111', encrypted_secret: 'encrypted' },
+  it('PUT — FastAPI로 위임하고 성공 body를 { data } 봉투로 래핑', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiOk({ provider: 'openai', masked_key: '****5678' }));
+    const request = new Request('http://test', { method: 'PUT', body: JSON.stringify({ provider: 'openai', api_key: 'sk-x' }) });
+
+    const resp = await PUT(request, ctx());
+
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/ai-settings');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({
+      data: { provider: 'openai', masked_key: '****5678' },
     });
-    ensureProjectSecretEncrypted.mockResolvedValue({ secret_last4: '1111', encrypted_secret: 'encrypted' });
-
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'google', llm_config: { model: 'gemini-2.5-flash' } }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.message).toBe('api_key is required when provider changes');
-    expect(projectUpsertSpy).not.toHaveBeenCalled();
   });
 
-  it('rejects direct legacy MCP configuration writes', async () => {
-    const { db, projectUpsertSpy } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({ settings: null, integration: null });
+  it('DELETE — 204 응답은 { ok: true }로 변환', async () => {
+    proxyToFastapi.mockResolvedValue(new Response(null, { status: 204 }));
+    const request = new Request('http://test', { method: 'DELETE' });
 
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        provider: 'openai',
-        api_key: 'sk-openai-1234',
-        llm_config: {
-          model: 'gpt-4o-mini',
-          mcp_servers: [{
-            name: 'rogue',
-            url: 'https://rogue.example.com/rpc',
-            allowed_tools: ['external.exfiltrate'],
-          }],
-        },
-      }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
+    const resp = await DELETE(request, ctx());
 
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.code).toBe('VALIDATION_FAILED');
-    expect(body.error.issues).toEqual(expect.arrayContaining([
-      expect.objectContaining({
-        path: 'llm_config',
-        message: 'External MCP connections must be managed from approved MCP settings',
-      }),
-    ]));
-    expect(projectUpsertSpy).not.toHaveBeenCalled();
-    expect(persistProjectAiSettingsWithEncryptedSecret).not.toHaveBeenCalled();
+    expect(proxyToFastapi).toHaveBeenCalledWith(request, '/api/v2/projects/ai-settings');
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { ok: true } });
   });
 
-  it('stores encrypted BYOM metadata atomically without persisting plaintext to project_ai_settings', async () => {
-    const { db, projectUpsertSpy } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({ settings: null, integration: null });
-    ensureProjectSecretEncrypted.mockResolvedValue(null);
-    persistProjectAiSettingsWithEncryptedSecret.mockResolvedValue({
-      data: {
-        id: 'setting-1',
-        provider: 'openai-compatible',
-        llm_config: { baseUrl: 'https://llm.example.com/v1' },
-        created_at: '2026-04-07T09:00:00.000Z',
-        updated_at: '2026-04-07T09:00:00.000Z',
-      },
-      encryptedSecret: '{...}',
-      updatedAt: '2026-04-07T09:00:00.000Z',
-    });
+  it('DELETE — !ok 응답은 그대로 pass-through', async () => {
+    proxyToFastapi.mockResolvedValue(fastapiErr(404, { detail: 'not found' }));
 
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        provider: 'openai-compatible',
-        api_key: 'sk-compatible-1234',
-        llm_config: { baseUrl: 'https://llm.example.com/v1/' },
-      }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
+    const resp = await DELETE(new Request('http://test', { method: 'DELETE' }), ctx());
 
-    expect(response.status).toBe(200);
-    expect(projectUpsertSpy).not.toHaveBeenCalled();
-    expect(persistProjectAiSettingsWithEncryptedSecret).toHaveBeenCalledWith(
-      db,
-      expect.objectContaining({
-        orgId: 'org-1',
-        projectId: 'project-1',
-        provider: 'openai-compatible',
-        plaintextSecret: 'sk-compatible-1234',
-        llmConfig: expect.objectContaining({ baseUrl: 'https://llm.example.com/v1' }),
-      }),
-    );
-  });
-
-  it('drops carried legacy MCP config when re-saving AI settings', async () => {
-    const { db } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        api_key: null,
-        llm_config: {
-          model: 'gpt-4o-mini',
-          mcp_servers: [{
-            name: 'legacy-docs',
-            url: 'https://legacy-docs.example.com/rpc',
-            allowed_tools: ['external.search_docs'],
-          }],
-          github_mcp: {
-            gateway_url: 'https://legacy-github.example.com/rpc',
-            auth: { token_ref: 'MCP_TOKEN_GITHUB' },
-          },
-        },
-      },
-      integration: { secret_last4: '1111', encrypted_secret: 'encrypted' },
-    });
-    ensureProjectSecretEncrypted.mockResolvedValue({ secret_last4: '1111', encrypted_secret: 'encrypted' });
-    decryptProjectSecret.mockResolvedValue('sk-openai-1111');
-    persistProjectAiSettingsWithEncryptedSecret.mockResolvedValue({
-      data: {
-        id: 'setting-1',
-        provider: 'openai',
-        llm_config: { model: 'gpt-4o' },
-        created_at: '2026-04-07T09:00:00.000Z',
-        updated_at: '2026-04-07T09:00:00.000Z',
-      },
-      encryptedSecret: '{...}',
-      updatedAt: '2026-04-07T09:00:00.000Z',
-    });
-
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'openai', llm_config: { model: 'gpt-4o' } }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
-
-    expect(response.status).toBe(200);
-    expect(persistProjectAiSettingsWithEncryptedSecret).toHaveBeenCalledWith(
-      db,
-      expect.objectContaining({
-        llmConfig: expect.not.objectContaining({
-          mcp_servers: expect.anything(),
-          github_mcp: expect.anything(),
-        }),
-      }),
-    );
-  });
-
-  it('reuses the existing encrypted secret when the provider is unchanged', async () => {
-    const { db } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        api_key: null,
-        llm_config: { model: 'gpt-4o-mini' },
-      },
-      integration: { secret_last4: '1111', encrypted_secret: 'encrypted' },
-    });
-    ensureProjectSecretEncrypted.mockResolvedValue({ secret_last4: '1111', encrypted_secret: 'encrypted' });
-    decryptProjectSecret.mockResolvedValue('sk-openai-1111');
-    persistProjectAiSettingsWithEncryptedSecret.mockResolvedValue({
-      data: {
-        id: 'setting-1',
-        provider: 'openai',
-        llm_config: { model: 'gpt-4o' },
-        created_at: '2026-04-07T09:00:00.000Z',
-        updated_at: '2026-04-07T09:00:00.000Z',
-      },
-      encryptedSecret: '{...}',
-      updatedAt: '2026-04-07T09:00:00.000Z',
-    });
-
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ provider: 'openai', llm_config: { model: 'gpt-4o' } }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
-
-    expect(response.status).toBe(200);
-    expect(persistProjectAiSettingsWithEncryptedSecret).toHaveBeenCalledWith(
-      db,
-      expect.objectContaining({ plaintextSecret: 'sk-openai-1111' }),
-    );
-  });
-
-  it('returns 503 and avoids partial writes when transactional secret persistence fails', async () => {
-    const { db, projectUpsertSpy } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({ settings: null, integration: null });
-    persistProjectAiSettingsWithEncryptedSecret.mockRejectedValue(new KmsServiceError('vault down'));
-
-    const response = await PUT(new Request('http://localhost/api/projects/project-1/ai-settings', {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        provider: 'openai',
-        api_key: 'sk-openai-1234',
-        llm_config: { model: 'gpt-4o-mini' },
-      }),
-    }), { params: Promise.resolve({ id: 'project-1' }) });
-
-    expect(response.status).toBe(503);
-    expect(projectUpsertSpy).not.toHaveBeenCalled();
-  });
-});
-
-describe('DELETE /api/projects/[id]/ai-settings', () => {
-  it('requests KMS rotation, marks deployments failed, and deletes the integration', async () => {
-    const { db, rotationUpdateSpy, deploymentUpdateSpy, projectDeleteSpy, integrationDeleteSpy } = createDbStub();
-    createDbServerClient.mockResolvedValue(db);
-    getProjectAiSettingsWithIntegration.mockResolvedValue({
-      settings: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        provider: 'openai',
-        api_key: null,
-        llm_config: { model: 'gpt-4o-mini' },
-      },
-      integration: {
-        org_id: 'org-1',
-        project_id: 'project-1',
-        integration_type: 'byom_api_key',
-        provider: 'openai',
-        secret_last4: '1111',
-        encrypted_secret: '{"kmsProvider":"local"}',
-        kms_provider: 'local',
-      },
-    });
-
-    const response = await DELETE(new Request('http://localhost/api/projects/project-1/ai-settings', { method: 'DELETE' }), {
-      params: Promise.resolve({ id: 'project-1' }),
-    });
-
-    expect(response.status).toBe(200);
-    expect(rotationUpdateSpy).toHaveBeenCalledWith(expect.objectContaining({ kms_status: 'rotation_requested' }));
-    expect(deploymentUpdateSpy).toHaveBeenCalledWith(expect.objectContaining({
-      status: 'DEPLOY_FAILED',
-      failure_code: 'project_ai_settings_deleted',
-      failure_message: expect.stringContaining('managed deployment no longer has a valid credential source'),
-    }));
-    expect(projectDeleteSpy).toHaveBeenCalledWith({ column: 'project_id', value: 'project-1' });
-    expect(integrationDeleteSpy).toHaveBeenCalledWith({ column: 'integration_type', value: 'byom_api_key' });
-
-    const body = await response.json();
-    expect(body.data.kms_rotation.requested).toBe(true);
-    expect(body.data.kms_rotation.executed).toBe(true);
-    expect(body.data.kms_rotation.provider).toBe('local');
-    expect(body.data.kms_rotation.rotated_key_version).toMatch(/^local-/);
-    expect(body.data.deployments_marked_failed).toBe(true);
+    expect(resp.status).toBe(404);
   });
 });

--- a/apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts
+++ b/apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts
@@ -1,217 +1,73 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-const { createDbServerClient, getMyTeamMember, requireOrgAdmin } = vi.hoisted(() => ({
-  createDbServerClient: vi.fn(),
-  getMyTeamMember: vi.fn(),
-  requireOrgAdmin: vi.fn(),
-}));
-
-vi.mock('@/lib/db/server', () => ({
-  createDbServerClient,
-}));
-
-vi.mock('@/lib/auth-helpers', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/auth-helpers')>('@/lib/auth-helpers');
-  return {
-    ...actual,
-    getMyTeamMember,
-  };
-});
-
-vi.mock('@/lib/admin-check', () => ({
-  requireOrgAdmin,
-}));
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { POST } from './route';
 
-function createDbStub() {
-  return {
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'user-1' } } }),
-    },
-  };
+const ctx = (id = 'proj-1') => ({ params: Promise.resolve({ id }) });
+
+function jsonRequest(body: unknown) {
+  return new Request('http://test', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 }
 
-describe('POST /api/projects/[id]/ai-settings/validate', () => {
-  beforeEach(() => {
-    createDbServerClient.mockReset();
-    getMyTeamMember.mockReset();
-    requireOrgAdmin.mockReset();
-    getMyTeamMember.mockResolvedValue({ id: 'team-member-1', org_id: 'org-1', project_id: 'project-1' });
-    requireOrgAdmin.mockResolvedValue(undefined);
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('/api/projects/[id]/ai-settings/validate', () => {
+  it('POST — 키가 유효하면 provider 호출 후 { valid: true } 반환', async () => {
+    const fetchMock = vi.fn(async (..._args: unknown[]) => new Response('{}', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resp = await POST(jsonRequest({ provider: 'openai', api_key: 'sk-live-xyz' }), ctx());
+
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toEqual({
+      data: { valid: true, project_id: 'proj-1' },
+      error: null,
+      meta: null,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe('https://api.openai.com/v1/models');
+  });
+
+  it('POST — provider가 401/403이면 { valid: false }', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('unauthorized', { status: 401 })));
+
+    const resp = await POST(jsonRequest({ provider: 'anthropic', api_key: 'sk-bad' }), ctx());
+
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { valid: false, project_id: 'proj-1' } });
+  });
+
+  it('POST — provider 호출이 throw하면 { valid: false }로 흡수', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network down'); }));
+
+    const resp = await POST(jsonRequest({ provider: 'groq', api_key: 'sk-x' }), ctx());
+
+    expect(resp.status).toBe(200);
+    await expect(resp.json()).resolves.toMatchObject({ data: { valid: false } });
+  });
+
+  it('POST — api_key 누락이면 400 BAD_REQUEST (provider 미호출)', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const resp = await POST(jsonRequest({ provider: 'openai' }), ctx());
+
+    expect(resp.status).toBe(400);
+    await expect(resp.json()).resolves.toMatchObject({ error: { code: 'BAD_REQUEST' } });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('POST — openai-compatible인데 base_url 없으면 400', async () => {
     vi.stubGlobal('fetch', vi.fn());
-  });
 
-  it('returns 401 when unauthenticated', async () => {
-    const db = {
-      auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
-    };
-    createDbServerClient.mockResolvedValue(db);
+    const resp = await POST(jsonRequest({ provider: 'openai-compatible', api_key: 'sk-x' }), ctx());
 
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'openai', api_key: 'sk-test' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(401);
-  });
-
-  it('returns 400 when api_key is missing', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'openai' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(400);
-  });
-
-  it('returns valid=true when provider responds with 200', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'openai', api_key: 'sk-valid-key' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.valid).toBe(true);
-  });
-
-  it('returns valid=false when provider responds with 401', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-    const fetchMock = vi.fn().mockResolvedValue({ status: 401 });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'openai', api_key: 'sk-invalid-key' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.data.valid).toBe(false);
-  });
-
-  it('sends POST for anthropic provider validation', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 });
-    vi.stubGlobal('fetch', fetchMock);
-
-    await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'anthropic', api_key: 'sk-ant-test' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://api.anthropic.com/v1/messages',
-      expect.objectContaining({ method: 'POST' }),
-    );
-  });
-
-  it('requires base_url for openai-compatible validation', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'openai-compatible', api_key: 'sk-test' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(400);
-    const body = await response.json();
-    expect(body.error.message).toContain('base_url is required for openai-compatible provider');
-  });
-
-  it('validates openai-compatible keys against the provided base_url', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          provider: 'openai-compatible',
-          api_key: 'sk-test',
-          base_url: 'https://llm.example.com/v1/',
-        }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://llm.example.com/v1/models',
-      expect.objectContaining({ method: 'GET' }),
-    );
-  });
-
-  it('uses x-goog-api-key header for google validation instead of query params', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-    const fetchMock = vi.fn().mockResolvedValue({ status: 200 });
-    vi.stubGlobal('fetch', fetchMock);
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'google', api_key: 'google-secret-key' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://generativelanguage.googleapis.com/v1beta/models',
-      expect.objectContaining({
-        method: 'GET',
-        headers: expect.objectContaining({ 'x-goog-api-key': 'google-secret-key' }),
-      }),
-    );
-    expect(String(fetchMock.mock.calls[0]?.[0])).not.toContain('google-secret-key');
-  });
-
-  it('returns 400 for invalid provider value', async () => {
-    createDbServerClient.mockResolvedValue(createDbStub());
-
-    const response = await POST(
-      new Request('http://localhost/api/projects/project-1/ai-settings/validate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ provider: 'invalid-provider', api_key: 'sk-test' }),
-      }),
-      { params: Promise.resolve({ id: 'project-1' }) },
-    );
-
-    expect(response.status).toBe(400);
+    expect(resp.status).toBe(400);
+    await expect(resp.json()).resolves.toMatchObject({ error: { code: 'BAD_REQUEST' } });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,8 +28,6 @@ export default defineConfig({
       // suite; each file is debt to burn down — re-include as it is fixed.
       // ⚠️ DO NOT add here to silence a NEW failure — fix the test.
       // Group B — api routes + services (backend-of-FE) · owner: 디디 · cleanup story: 837a36c4
-      'apps/web/src/app/api/projects/[id]/ai-settings/route.test.ts',
-      'apps/web/src/app/api/projects/[id]/ai-settings/validate/route.test.ts',
       // agent-builtin-tools.test.ts: the 4 registry-declared memo tools
       // (create_memo/reply_memo/update_memo/list_memos) are now implemented (story
       // 6f237832), but this file's create_story/forward_memo/create_memo/list_epics


### PR DESCRIPTION
## Group B 번다운 b23 — ai-settings ×2 격리 해제 (Group B route 부채 종료)

두 `projects/[id]/ai-settings` 테스트가 마이그 이전 직접 스택(`createDbServerClient`/KMS/`project-ai-settings`/`admin-check`)에 머물러 RED·격리돼 있었다.

### Changes
- **`ai-settings/route.test.ts`** → FastAPI-proxy 계약: GET/PUT/DELETE → `/api/v2/projects/ai-settings`, `{data}` 봉투·`!ok` 패스스루·`204→{ok:true}` (b22 동일 패턴).
- **`ai-settings/validate/route.test.ts`** → validate 핸들러는 **proxy 아님**: zod 검증 + 실 provider `fetch` 프로브. global `fetch` 스텁으로 — 2xx→`{valid:true}`·401/403→`{valid:false}`·fetch throw→`{valid:false}` 흡수·api_key 누락→`400 BAD_REQUEST`(provider 미호출)·openai-compatible without base_url→`400`.

`vitest.config`에서 둘 다 격리 해제. Full vitest: **974 passed · 2 skipped · 0 failed (154 files)** · `tsc --noEmit` clean.

> b22(#1456 agent-runs+mcp-connections)와 함께 머지되면 **Group B route 테스트 6종 전량 해제**. 잔여 = `agent-builtin-tools.test`(→ `7a57e7b1`④). 두 PR 모두 `vitest.config` exclude 블록을 건드리니 머지 순서상 뒤가 리베이스 1회 필요할 수 있음(비중첩 라인이라 auto-merge 유력).

🤖 Generated with [Claude Code](https://claude.com/claude-code)