### PR TITLE
[SID:38df51af] feat(hypotheses): 에픽 상세 AI 초안 확인 CTA + confirm 플로우 (S10 FE)

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2312,7 +2312,12 @@
     "crossEpic": "Other epic",
     "crossEpicHint": "This hypothesis belongs to a different epic",
     "createElsewhereHint": "Hypotheses are created from the epic detail",
-    "summaryTitle": "{count} linked hypotheses"
+    "summaryTitle": "{count} linked hypotheses",
+    "draftCta": "Review draft",
+    "drafting": "Drafting…",
+    "draftReviewTitle": "AI draft",
+    "draftNote": "AI-suggested from activity. Review before adding.",
+    "draftAccept": "Confirm & add"
   },
   "epics": {
     "title": "Epics",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2313,7 +2313,7 @@
     "crossEpicHint": "이 가설은 다른 에픽 소속입니다",
     "createElsewhereHint": "가설은 에픽 상세에서 생성합니다",
     "summaryTitle": "연결 가설 {count}개",
-    "draftCta": "초안 확인",
+    "draftCta": "초안 검토",
     "drafting": "초안 생성 중…",
     "draftReviewTitle": "AI 초안",
     "draftNote": "AI가 흐름에서 제안한 초안입니다. 확인 후 추가하세요.",

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2312,7 +2312,12 @@
     "crossEpic": "다른 에픽",
     "crossEpicHint": "이 가설은 다른 에픽 소속입니다",
     "createElsewhereHint": "가설은 에픽 상세에서 생성합니다",
-    "summaryTitle": "연결 가설 {count}개"
+    "summaryTitle": "연결 가설 {count}개",
+    "draftCta": "초안 확인",
+    "drafting": "초안 생성 중…",
+    "draftReviewTitle": "AI 초안",
+    "draftNote": "AI가 흐름에서 제안한 초안입니다. 확인 후 추가하세요.",
+    "draftAccept": "확인하고 추가"
   },
   "epics": {
     "title": "에픽",

--- a/apps/web/src/app/api/hypotheses/draft/route.ts
+++ b/apps/web/src/app/api/hypotheses/draft/route.ts
@@ -1,0 +1,27 @@
+import { draftHypothesisSchema } from '@sprintable/shared';
+import { HypothesisService } from '@/services/hypothesis';
+import { createHypothesisRepository } from '@/lib/storage/factory';
+import { handleApiError } from '@/lib/api-error';
+import { apiSuccess, ApiErrors } from '@/lib/api-response';
+import { getAuthContext } from '@/lib/auth-helpers';
+
+// POST — 흐름 부산물에서 가설 초안 생성(E1-S10 §3.9). persist=false(기본)=미리보기,
+// persist=true=status='proposed' row 생성(drafted_by_member_id 기록). thin proxy over
+// HypothesisService → BE raw 응답을 apiSuccess {data} 엔벨로프로 래핑(hypotheses/route.ts 패턴).
+// 정적 세그먼트 `draft`는 `[id]`보다 우선되어 라우트 shadow 없음(BE §3.9.7과 동형).
+export async function POST(request: Request) {
+  try {
+    const me = await getAuthContext(request);
+    if (!me) return ApiErrors.unauthorized();
+    if (me.rateLimitExceeded) return ApiErrors.tooManyRequests(me.rateLimitRemaining, me.rateLimitResetAt);
+
+    const parsed = draftHypothesisSchema.safeParse(await request.json());
+    if (!parsed.success) return ApiErrors.badRequest(parsed.error.issues[0]?.message ?? 'Invalid body');
+
+    const service = new HypothesisService(await createHypothesisRepository());
+    const draft = await service.draft(parsed.data);
+    return apiSuccess(draft);
+  } catch (err: unknown) {
+    return handleApiError(err);
+  }
+}

--- a/apps/web/src/components/hypotheses/hypotheses-section.tsx
+++ b/apps/web/src/components/hypotheses/hypotheses-section.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Plus } from 'lucide-react';
-import type { Hypothesis } from '@sprintable/core-storage';
+import { Plus, Sparkles } from 'lucide-react';
+import type { Hypothesis, HypothesisDraft } from '@sprintable/core-storage';
 import { HypothesisRow, type HypothesisRowActions } from './hypothesis-row';
 import { HypothesisVerdictCard } from './hypothesis-verdict-card';
 import { HypothesisForm, type HypothesisFormValue } from './hypothesis-form';
@@ -18,11 +18,78 @@ import { HypothesisForm, type HypothesisFormValue } from './hypothesis-form';
  */
 const isVerdict = (h: Hypothesis) => h.status === 'verified' || h.status === 'falsified';
 
+/**
+ * AI 초안 미리보기 카드(S10 §3.9·§7). persist=false 응답을 읽기전용으로 보여주고 휴먼
+ * 확인을 받는다 — work-about-work 0(가설문장+지표+측정일 3필드만). "확인하고 추가"가
+ * persist=true(proposed row·drafted_by_member_id) 경로. 설익은 자동화로 신뢰를 깨지 않게
+ * 항상 휴먼 confirm 게이트(블루프린트 §10-9).
+ */
+function HypothesisDraftPreview({
+  draft,
+  confirming,
+  onAccept,
+  onCancel,
+}: {
+  draft: HypothesisDraft;
+  confirming: boolean;
+  onAccept: () => void;
+  onCancel: () => void;
+}) {
+  const t = useTranslations('hypotheses');
+  const md = draft.metric_definition;
+  const dir = md.direction === 'up' ? t('dirUp') : t('dirDown');
+
+  return (
+    <div className="space-y-3 rounded-xl border border-primary/30 bg-primary/5 p-3">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-primary">
+        <Sparkles className="size-3.5" aria-hidden />
+        {t('draftReviewTitle')}
+      </div>
+
+      <div className="space-y-2">
+        <div className="space-y-0.5">
+          <p className="text-[11px] font-medium text-muted-foreground">{t('statementField')}</p>
+          <p className="text-sm text-foreground">{draft.statement}</p>
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          <span><span className="font-medium">{t('metricField')}:</span> {md.metric} {dir} {md.target}</span>
+          <span><span className="font-medium">{t('measureAfterField')}:</span> {draft.measure_after.slice(0, 10)}</span>
+        </div>
+      </div>
+
+      <p className="text-[11px] text-muted-foreground">{t('draftNote')}</p>
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={confirming}
+          className="rounded-lg px-3 py-1.5 text-sm text-muted-foreground transition hover:text-foreground disabled:opacity-50"
+        >
+          {t('cancel')}
+        </button>
+        <button
+          type="button"
+          onClick={onAccept}
+          disabled={confirming}
+          className="rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-50"
+        >
+          {confirming ? t('saving') : t('draftAccept')}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function HypothesesSection({ epicId, projectId }: { epicId: string; projectId: string }) {
   const t = useTranslations('hypotheses');
   const [items, setItems] = useState<Hypothesis[] | null>(null);
   const [formOpen, setFormOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  // S10: AI 초안 미리보기(persist=false 응답)·생성 중·확인 중.
+  const [draft, setDraft] = useState<HypothesisDraft | null>(null);
+  const [drafting, setDrafting] = useState(false);
+  const [confirming, setConfirming] = useState(false);
 
   const load = useCallback(async () => {
     try {
@@ -54,6 +121,41 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
       if (res.ok) { setFormOpen(false); await load(); }
     } finally {
       setSubmitting(false);
+    }
+  }, [epicId, projectId, load]);
+
+  // S10 §3.9: 흐름 부산물에서 AI 초안 생성. persist=false → 미리보기만(active row 0·AC①).
+  const handleDraft = useCallback(async () => {
+    setDrafting(true);
+    setFormOpen(false);
+    try {
+      const res = await fetch('/api/hypotheses/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId, source_type: 'epic', source_id: epicId, persist: false }),
+      });
+      if (res.ok) {
+        const json = await res.json();
+        setDraft((json?.data ?? null) as HypothesisDraft | null);
+      }
+    } finally {
+      setDrafting(false);
+    }
+  }, [epicId, projectId]);
+
+  // 휴먼 확인(AC②): persist=true → status='proposed' row 생성(drafted_by_member_id 기록·AC④).
+  // active로 만들지 않는다 — 활성화는 별도 onActivate(휴먼 1스텝).
+  const handleAcceptDraft = useCallback(async () => {
+    setConfirming(true);
+    try {
+      const res = await fetch('/api/hypotheses/draft', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ project_id: projectId, source_type: 'epic', source_id: epicId, persist: true }),
+      });
+      if (res.ok) { setDraft(null); await load(); }
+    } finally {
+      setConfirming(false);
     }
   }, [epicId, projectId, load]);
 
@@ -98,23 +200,45 @@ export function HypothesesSection({ epicId, projectId }: { epicId: string; proje
 
   return (
     <section aria-label={t('sectionTitle')} className="rounded-xl border border-border bg-muted/20 p-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-2">
         <h2 className="text-sm font-semibold text-foreground">{t('sectionTitle')}</h2>
-        {!formOpen ? (
-          <button
-            type="button"
-            onClick={() => setFormOpen(true)}
-            className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
-          >
-            <Plus className="size-3.5" />
-            {t('add')}
-          </button>
+        {!formOpen && !draft ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => void handleDraft()}
+              disabled={drafting}
+              className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:border-primary hover:text-primary disabled:opacity-50"
+            >
+              <Sparkles className="size-3.5" />
+              {drafting ? t('drafting') : t('draftCta')}
+            </button>
+            <button
+              type="button"
+              onClick={() => setFormOpen(true)}
+              className="inline-flex items-center gap-1 rounded-lg border border-border px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:border-primary hover:text-primary"
+            >
+              <Plus className="size-3.5" />
+              {t('add')}
+            </button>
+          </div>
         ) : null}
       </div>
 
       {formOpen ? (
         <div className="mt-3">
           <HypothesisForm submitting={submitting} onSubmit={handleCreate} onCancel={() => setFormOpen(false)} />
+        </div>
+      ) : null}
+
+      {draft ? (
+        <div className="mt-3">
+          <HypothesisDraftPreview
+            draft={draft}
+            confirming={confirming}
+            onAccept={() => void handleAcceptDraft()}
+            onCancel={() => setDraft(null)}
+          />
         </div>
       ) : null}
 

--- a/packages/core-storage/src/interfaces/IHypothesisRepository.ts
+++ b/packages/core-storage/src/interfaces/IHypothesisRepository.ts
@@ -86,6 +86,9 @@ export interface HypothesisDraftInput {
   source_type: string;
   source_id: string;
   context?: Record<string, unknown> | null;
+  // persist=false(기본)=미리보기(active row 0)·true=status='proposed' row 생성
+  // (drafted_by_member_id 기록·E1-S10 AC④). BE HypothesisDraftRequest와 동기.
+  persist?: boolean;
 }
 
 export interface HypothesisDraft {

--- a/packages/shared/src/schemas/hypotheses.ts
+++ b/packages/shared/src/schemas/hypotheses.ts
@@ -64,4 +64,7 @@ export const draftHypothesisSchema = z.object({
   source_type: z.string().min(1),
   source_id: z.string().min(1),
   context: z.record(z.string(), z.unknown()).optional().nullable(),
+  // persist=true이면 status='proposed' row 생성(drafted_by_member_id 기록·E1-S10 AC④).
+  // 기본 false=미리보기. BE HypothesisDraftRequest.persist와 동기.
+  persist: z.boolean().optional(),
 });


### PR DESCRIPTION
## 무엇을 (E1 코어 마지막 조각 · 블루프린트 §3.9·§7)

에픽 상세 `HypothesesSection`에 **"초안 확인" CTA → AI 초안 미리보기 → 휴먼 confirm → proposed row 생성** 플로우. 흐름 부산물(에픽)에서 deterministic template 초안을 제안하되, **설익은 자동화로 신뢰를 깨지 않게 항상 휴먼 confirm 게이트**(§10-9). BE는 S3에서 이미 구현(`POST /hypotheses/draft`).

## BE 계약 (코드 실측 · develop `backend/app/routers/hypotheses.py:106`)

```
req  { project_id, source_type, source_id, context?, persist=false }
resp { statement, metric_definition, measure_after, source_snapshot,
       requires_confirmation=true, hypothesis?(persist=true 시만) }
```
`persist=false`=미리보기(active row 0)·`persist=true`=`status='proposed'` row 생성(`drafted_by_member_id` 기록).

## FE 구현

- **신규 `/api/hypotheses/draft` 프록시 라우트**(POST·`draftHypothesisSchema` 검증·`service.draft`·`apiSuccess {data}`). 정적 `draft` 세그먼트가 `[id]`보다 우선 → route shadow 없음(BE §3.9.7과 동형).
- **FE 체인에 `persist` 추가**: `draftHypothesisSchema`(shared) + `HypothesisDraftInput`(core-storage). repo는 input을 body로 그대로 전달 → 타입 추가만으로 흐름. shared/core는 `./src` export + `transpilePackages`라 dist staleness 무관.
  - **AC④ 핵심**: `drafted_by_member_id`(agent 초안 추적)는 `/draft persist=true`로만 기록 → confirm을 일반 create로 하면 추적이 silently 깨짐. **confirm = `/draft persist=true` 경유 필수.**
- **UI**: CTA(`Sparkles`) → `draft(persist=false)` 미리보기 카드(가설문장+지표+측정일 **3필드 · work-about-work 0** · "AI 초안" 톤 · 확인 필요 note) → **"확인하고 추가"** = `draft(persist=true)` → proposed → reload. 활성화는 기존 `onActivate`(휴먼 1스텝). 기존 `HypothesesSection` 디자인 결 유지.
- i18n `hypotheses` ns 5키(`draftCta`/`drafting`/`draftReviewTitle`/`draftNote`/`draftAccept`) en/ko.

## AC

- [x] ① draft가 active row 안 만듦 (persist=false=미리보기·persist=true=proposed만)
- [x] ② 사람 confirm 후에만 active 경로 (proposed→active는 기존 onActivate 휴먼)
- [x] ③ source_snapshot 입력 일부만 (BE 산출·FE는 표시 안 함)
- [x] ④ drafted_by_member_id 기록 (persist=true 경유 보장 — confirm 설계 핵심)
- [x] ⑤ requires_confirmation=true 고정 (BE 응답·FE는 항상 confirm 게이트)

## 검증

- BE 계약 **코드 실측** · `tsc --noEmit` exit 0 · `eslint` clean · `next build` PASS · i18n 키 패리티.

## 리뷰

base `develop`. 게이트: **유나 픽셀(소울 일관·confirm UX) → 까심 QA → PO**. 머지되면 **E1 코어 10/10 = 진짜 완주.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)