### PR TITLE
fix(oss): graceful guard for stubbed memo repository (7a57e7b1 ①②③)

### DIFF
--- a/apps/web/src/services/memo.ts
+++ b/apps/web/src/services/memo.ts
@@ -1,6 +1,45 @@
 
 import type { ITeamMemberRepository, IProjectRepository } from '@sprintable/core-storage';
-const ApiMemoRepository = class { constructor(_db: any) {} } as any;
+
+// OSS self-host guard (story 7a57e7b1). The real memo repository is provided only by the
+// SaaS overlay, which shadows this module in the SaaS build — a pure OSS build has no memo
+// repository wired. Previously this was an empty `as any` class, so every unconditional
+// `this.repo.<method>()` (create/addReply/resolve/list/getById/getReplies) crashed with a
+// cryptic `this.repo.X is not a function` across agent-execution-loop, the slack/discord/
+// teams dispatchers, agent-builtin-tools, and bridge-inbound. This explicit stub keeps the
+// same fail-fast behaviour but surfaces an actionable error and a one-time startup warning.
+// Durable fix = a real OSS memo repository (db- or FastAPI-backed, like Story/Epic). See
+// docs/oss-memo-repository.md.
+let _ossMemoRepoWarned = false;
+
+class OssMemoRepositoryStub {
+  constructor(_db: unknown) {
+    if (!_ossMemoRepoWarned && process.env.NODE_ENV !== 'test') {
+      _ossMemoRepoWarned = true;
+      console.warn(
+        '[oss] No memo repository is configured — memo create/reply/resolve/list will fail. '
+        + 'This OSS build needs the SaaS overlay or a memo repository implementation. '
+        + 'See docs/oss-memo-repository.md.',
+      );
+    }
+  }
+
+  private unavailable(method: string): never {
+    throw new Error(
+      `MemoService memo persistence is unavailable: no memo repository is configured in this build (called \`${method}\`). `
+      + 'A pure OSS build needs the SaaS overlay or a memo repository implementation; see docs/oss-memo-repository.md.',
+    );
+  }
+
+  getById(): never { return this.unavailable('getById'); }
+  getReplies(): never { return this.unavailable('getReplies'); }
+  list(): never { return this.unavailable('list'); }
+  create(): never { return this.unavailable('create'); }
+  addReply(): never { return this.unavailable('addReply'); }
+  resolve(): never { return this.unavailable('resolve'); }
+}
+
+const ApiMemoRepository = OssMemoRepositoryStub as any;
 
 type IMemoRepository = any;
 type Memo = any;

--- a/docs/oss-memo-repository.md
+++ b/docs/oss-memo-repository.md
@@ -1,0 +1,73 @@
+# OSS memo repository — self-host integrity (story 7a57e7b1)
+
+## Summary
+
+In a **pure OSS build**, `MemoService` has **no memo repository**. `apps/web/src/services/memo.ts`
+historically defined the repository as an empty `as any` class:
+
+```ts
+const ApiMemoRepository = class { constructor(_db: any) {} } as any;
+```
+
+The real implementation is provided only by the **SaaS overlay** (a separate build that shadows
+this module), so prod is unaffected. But every OSS runtime path that calls an unconditional
+`this.repo.<method>()` crashed with a cryptic `this.repo.X is not a function`.
+
+Story/Epic do not have this problem because their repositories are real (`SupabaseXRepository`
+backed by `fastapiCall`). Memo is the only entity with an empty stub.
+
+## ① Stub inventory (`apps/web/src`)
+
+| File:line | Stub | Shadows | Methods |
+|---|---|---|---|
+| `services/memo.ts` (top) | `ApiMemoRepository` | real repo in SaaS overlay | none (empty) → now explicit fail-fast |
+
+No other empty `as any` repository/client stubs were found under `apps/web/src` (admin client,
+storage clients, etc. are real or already guarded).
+
+## ② Crash points
+
+`MemoService` calls `this.repo.<method>` for: `getById` (×7), `getReplies` (×2), `list`,
+`create`, `addReply` (×1 each), `resolve` (×2).
+
+**Unconditional (crash in OSS):**
+
+| Method | Notes |
+|---|---|
+| `list` | direct `this.repo.list(...)` |
+| `getById` | direct |
+| `addReply` | `repo.getById` + `repo.addReply` |
+| `resolve` | `repo.getById` + `repo.resolve` |
+| `create` | `fromDb()` passes neither `projectRepo` nor `teamMemberRepo`, so the OSS fallback branch is skipped and it falls through to `repo.create` |
+
+**Guarded (safe in OSS):** `enrichMemo`, `linkDoc`, `markRead` (early-return / throw on `!this.db`),
+`getByIdWithDetails` (`repo.getById` inside try/catch with fallback), `dispatchOssReplyWebhooks`
+(returns when `!teamMemberRepo`).
+
+**OSS runtime consumers that reach a crash point (11):**
+
+- `slack-outbound-dispatcher` / `discord-outbound-dispatcher` / `teams-outbound-dispatcher` — `recordFailure → addReply`
+- `agent-execution-loop` — HITL `addReply`, finalize `addReply` + `resolve`, forward `create`, HITL request `create`
+- `agent-builtin-tools` — `resolve_memo → resolve`, `reply_memo`/`add_memo_reply → addReply`
+- `bridge-inbound` — `processInboundMessage → create`
+
+## ③ Prescription (this story)
+
+**Graceful guard (shipped).** The empty stub is replaced with an explicit `OssMemoRepositoryStub`
+whose methods fail fast with an actionable error, plus a one-time startup `console.warn`. Behaviour
+is unchanged (the empty class already threw on every call) — the failure is now legible instead of
+`is not a function`, and operators get a clear pointer.
+
+This satisfies the story AC: pure-OSS memo paths fail with an explicit guard + documentation rather
+than a cryptic crash, and the SaaS overlay (real repo) is unaffected.
+
+## Durable fix (follow-up, not this story)
+
+Provide a **real OSS memo repository** so self-host memo paths work, mirroring Story/Epic:
+
+- Option A — **FastAPI-backed** `ApiMemoRepository` (like `SupabaseStoryRepository.fastapiCall`),
+  delegating memo CRUD to the Python backend. Consistent with the post-OSS-split architecture.
+- Option B — **db-client-backed** repository using the supabase-style client already used for reads.
+
+Either removes the 11 crash points and makes agent memo replies, HITL, forwarding, and the
+message bridges fully functional in OSS. Recommended: Option A (architecture-consistent).


### PR DESCRIPTION
## 7a57e7b1 ①②③ — OSS-stub 전수 점검 + self-host 크래시 처방

### ① 전수 점검
`apps/web/src` 전체에서 `as any` 빈 repository stub은 **`services/memo.ts`의 `ApiMemoRepository` 1개뿐**(다른 admin/storage 클라이언트는 실구현 또는 db-가드됨). 실구현은 SaaS overlay만 제공 → **순수 OSS 빌드엔 memo repository 부재**. Story/Epic은 `SupabaseXRepository`(fastapiCall) 실repo라 무해.

### ② self-host 크래시 경로 (11)
`MemoService`가 `this.repo.<method>`를 무조건 호출: `list`/`getById`/`addReply`/`resolve`, 그리고 `create`는 `fromDb`가 `projectRepo`·`teamMemberRepo`를 안 넘겨 OSS 폴백 분기를 건너뛰고 `repo.create`로 낙하. 도달 사이트:
- slack/discord/teams outbound dispatcher — `recordFailure → addReply`
- agent-execution-loop — HITL `addReply`, finalize `addReply`+`resolve`, forward `create`, HITL 요청 `create`
- agent-builtin-tools — `resolve_memo`·`reply_memo`
- bridge-inbound — `processInboundMessage → create`

전부 `this.repo.X is not a function`(cryptic) 크래시. `enrichMemo`/`linkDoc`/`markRead`는 `!this.db` 가드로 안전.

### ③ 처방 (graceful degrade)
빈 stub → 명시적 `OssMemoRepositoryStub`: 각 메서드가 **actionable 에러로 fail-fast** + **1회 기동 `console.warn`**. 동작 불변(빈 클래스도 이미 throw)이나 실패가 **명료**해지고 `docs/oss-memo-repository.md`를 가리킨다. SaaS prod 무영향(overlay가 이 모듈 shadow). 
- **durable fix**(별 스토리 권고): 실 OSS memo repository(FastAPI- 또는 db-backed·Story/Epic 동형) → 11 크래시 0. 문서에 옵션 A(FastAPI·아키텍처 정합)/B(db) 정리.

### 산출물
- `apps/web/src/services/memo.ts` — 명시적 guard stub + 기동 경고.
- `docs/oss-memo-repository.md` — 전수 점검·크래시 경로·처방·durable-fix 권고.

### Validation
Full vitest: **989 passed · 2 skipped · 0 failed** · `tsc --noEmit` clean. (동작 불변이라 회귀 0 — 기존 throw를 명료한 throw로 교체.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)