### PR TITLE
fix(hypotheses): link draft to its source epic/story (S10 reopen ⓐ)

### DIFF
--- a/backend/app/services/hypothesis.py
+++ b/backend/app/services/hypothesis.py
@@ -311,6 +311,11 @@ async def draft_hypothesis(
     measure_after = datetime.now(timezone.utc) + timedelta(days=_DEFAULT_MEASURE_DAYS)
     snapshot = _build_source_snapshot(payload.context)
 
+    # source_type='epic'/'story'면 source_id로 실 링크를 만든다. source 필드만 저장하면
+    # epic 상세의 가설 리스트(hypothesis_epic_links 조인)에 안 떠 초안→확인이 무의미해진다.
+    epic_ids = [payload.source_id] if payload.source_type == "epic" else []
+    story_ids = [payload.source_id] if payload.source_type == "story" else []
+
     hyp_resp: HypothesisResponse | None = None
     if payload.persist:
         hyp_resp = await create_hypothesis(
@@ -321,6 +326,8 @@ async def draft_hypothesis(
                 metric_definition=metric_definition,
                 measure_after=measure_after,
                 status="proposed",
+                epic_ids=epic_ids,
+                story_ids=story_ids,
                 source_type=payload.source_type,
                 source_id=payload.source_id,
                 draft_metadata={"template": True, "source_snapshot": snapshot},

--- a/backend/tests/test_hypotheses_router.py
+++ b/backend/tests/test_hypotheses_router.py
@@ -135,8 +135,9 @@ async def test_draft_template_no_persist():
 
 async def test_draft_persist_creates_proposed_row():
     from app.services import hypothesis as service
+    story_id = uuid.uuid4()
     payload = HypothesisDraftRequest(
-        project_id=PROJECT_ID, source_type="story", source_id=uuid.uuid4(), persist=True,
+        project_id=PROJECT_ID, source_type="story", source_id=story_id, persist=True,
     )
     created = _hyp_response()  # create_hypothesis는 실제로 HypothesisResponse를 반환
     with patch.object(service, "create_hypothesis", AsyncMock(return_value=created)) as mock_create:
@@ -144,7 +145,44 @@ async def test_draft_persist_creates_proposed_row():
     mock_create.assert_awaited_once()
     created_payload = mock_create.call_args.args[3]
     assert created_payload.status == "proposed"
+    # S10 reopen ⓐ: source_type='story' → story_id로 실 링크(빈 list 회귀 방지).
+    assert created_payload.story_ids == [story_id]
+    assert created_payload.epic_ids == []
     assert out.hypothesis is not None and out.hypothesis.status == "proposed"
+
+
+async def test_draft_persist_links_epic_source():
+    """S10 reopen ⓐ: source_type='epic'이면 epic_ids=[source_id]로 넘겨 실 링크 생성.
+
+    이전엔 source_type/source_id 필드만 저장하고 epic_ids=[]라 add_epic_links([])→
+    에픽 상세 가설 리스트(hypothesis_epic_links 조인)에 안 떴다.
+    """
+    from app.services import hypothesis as service
+    epic_id = uuid.uuid4()
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="epic", source_id=epic_id,
+        context={"title": "온보딩 개선"}, persist=True,
+    )
+    created = _hyp_response()
+    with patch.object(service, "create_hypothesis", AsyncMock(return_value=created)) as mock_create:
+        await service.draft_hypothesis(MagicMock(), ORG_ID, _member(OWNER_ID), payload)
+    created_payload = mock_create.call_args.args[3]
+    assert created_payload.epic_ids == [epic_id]
+    assert created_payload.story_ids == []
+
+
+async def test_draft_persist_non_linkable_source_no_links():
+    """source_type='conversation'/'dispatch'는 링크 테이블이 없어 epic_ids/story_ids 비움."""
+    from app.services import hypothesis as service
+    payload = HypothesisDraftRequest(
+        project_id=PROJECT_ID, source_type="conversation", source_id=uuid.uuid4(), persist=True,
+    )
+    created = _hyp_response()
+    with patch.object(service, "create_hypothesis", AsyncMock(return_value=created)) as mock_create:
+        await service.draft_hypothesis(MagicMock(), ORG_ID, _member(OWNER_ID), payload)
+    created_payload = mock_create.call_args.args[3]
+    assert created_payload.epic_ids == []
+    assert created_payload.story_ids == []
 
 
 # ── ⓒ 엔드포인트 와이어링 + dict-detail 계약 ──────────────────────────────────


### PR DESCRIPTION
## S10 reopen ⓐ — draft → source epic 미연결 fix

유나 probe 적출: `POST /hypotheses/draft persist=true` → 200·proposed지만 **`epic_ids=[]`** → 초안→"확인하고 추가"해도 에픽 상세 가설 리스트(`hypothesis_epic_links` 조인)에 안 뜸.

### 근본
`draft_hypothesis`가 `create_hypothesis`에 **epic_ids/story_ids 미전달** → `add_epic_links([])` → 링크 0. source_type/source_id는 **필드로만** 저장되고 실 링크가 안 생김.

### Fix (ⓐ만)
draft source를 실 링크로 변환: `source_type='epic'`→`epic_ids=[source_id]`, `source_type='story'`→`story_ids=[source_id]` (`conversation`/`dispatch`는 링크 테이블 없어 비움).

### 스코프 노트
- **ⓑ(drafted_by null)는 설계대로** — AI/템플릿 출처는 `draft_metadata.template=true`로 추적, 휴먼 confirm은 drafted_by null 정상(PO 확인). **변경 0.**
- **form "가설 추가" 경로는 정상** — 이미 `epic_ids`를 `create_hypothesis`에 전달(draft-only 갭).
- ℹ️ (관찰·PO 판단) draft 경로는 create 라우트의 `_assert_targets_same_project`(§3.7.2 cross-project 403 가드)를 안 탄다. source_id가 FE 에픽 상세 CTA(동일 프로젝트)서 오지만, 엄밀 패리티 원하면 후속으로 draft에도 가드 추가 가능 — 이 PR 스코프(ⓐ)엔 미포함.

### Validation
backend hypotheses suites (router/service/mcp): **57 passed** · py_compile OK. draft persist가 epic/story source에 링크 전달, non-linkable source는 비움 검증 추가.

> done 게이트 = 까심 cross-model QA + 유나 E2E 재probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)