### PR TITLE
feat(activity-graph): activity_events canonical table migration (L1-BE-1)

### DIFF
--- a/backend/alembic/versions/0116_add_activity_events.py
+++ b/backend/alembic/versions/0116_add_activity_events.py
@@ -1,0 +1,103 @@
+"""L1 BE-1: activity_events canonical 활동 테이블 (additive).
+
+Revision ID: 0116
+Revises: 0115
+Create Date: 2026-06-11
+
+블루프린트 `blueprint-e-l1-activity-graph` §3.1·§5 BE-1. 이벤트버스(events)를 canonical
+활동 그래프로 정규화하기 위한 신규 물리 테이블. 기존 `events` 스키마/인덱스는 무변경
+(additive). 이 마이그는 테이블+인덱스만 만들고 backfill은 하지 않는다(후속 BE story).
+
+FK 정책: canonical projection 테이블이라 actor/object/event 참조는 비강제(plain UUID).
+코드 컨벤션(hypotheses `assignee_id`·member 식별자 선례 — "FK 비강제 canonical id")과
+정합하며, 원본 event가 정리돼도 활동 기록(감사 그래프)은 보존된다.
+
+idempotent: 테이블 단위 inspect 가드(0113 선례). downgrade는 신규 테이블만 drop한다
+(AC④ — 기존 events 무영향).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+
+revision = "0116"
+down_revision = "0115"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    existing = set(insp.get_table_names())
+
+    if "activity_events" in existing:
+        return
+
+    op.create_table(
+        "activity_events",
+        sa.Column("activity_id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("org_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", UUID(as_uuid=True), nullable=False),
+        # actor = 활동 주체(agent/human member). 시스템 활동은 NULL 허용.
+        sa.Column("actor_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("verb", sa.Text(), nullable=False),
+        sa.Column("object_type", sa.Text(), nullable=True),
+        sa.Column("object_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        # 대표 원본 event(여러 event를 1 활동으로 합칠 때의 canonical pointer).
+        sa.Column("representative_event_id", UUID(as_uuid=True), nullable=True),
+        # 이 활동으로 합쳐진 원본 event들 / 수신자 fan-out(정규화 전 events에서 끌어온 투영).
+        sa.Column("source_event_ids", ARRAY(UUID(as_uuid=True)), nullable=False, server_default="{}"),
+        sa.Column("recipient_ids", ARRAY(UUID(as_uuid=True)), nullable=False, server_default="{}"),
+        sa.Column("recipient_types", ARRAY(sa.Text()), nullable=False, server_default="{}"),
+        sa.Column("payload", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        # (org_id, dedup_key) unique로 동일 활동 중복 흡수.
+        sa.Column("dedup_key", sa.Text(), nullable=False),
+        # 단조 증가 시퀀스(cursor 페이지네이션·정렬 안정성).
+        sa.Column("activity_seq", sa.BigInteger(), sa.Identity(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+    # AC②: (org_id, dedup_key) unique — 활동 dedup.
+    op.create_index(
+        "uq_activity_events_org_dedup",
+        "activity_events",
+        ["org_id", "dedup_key"],
+        unique=True,
+    )
+    # AC③: 조회 인덱스 4종(project/actor/object/verb × time). 멀티테넌트라 org_id 선두.
+    op.create_index(
+        "ix_activity_events_project_time",
+        "activity_events",
+        ["org_id", "project_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_activity_events_actor_time",
+        "activity_events",
+        ["org_id", "actor_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_activity_events_object_time",
+        "activity_events",
+        ["org_id", "object_type", "object_id", sa.text("occurred_at DESC")],
+    )
+    op.create_index(
+        "ix_activity_events_verb_time",
+        "activity_events",
+        ["org_id", "verb", sa.text("occurred_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    # AC④: 신규 테이블만 drop(인덱스 동반 제거). 기존 events 무영향.
+    conn = op.get_bind()
+    insp = sa.inspect(conn)
+    if "activity_events" in set(insp.get_table_names()):
+        op.drop_table("activity_events")


### PR DESCRIPTION
## L1-BE-1 — `activity_events` canonical 활동 테이블 (additive migration)

블루프린트 `blueprint-e-l1-activity-graph` §3.1·§5 BE-1. 이벤트버스(`events`)를 canonical 활동 그래프로 정규화하기 위한 신규 물리 테이블. **additive** — 기존 `events` 스키마/인덱스 무변경(AC⑤).

### Migration `0116` (Revises `0115`)
컬럼: `activity_id` PK · `org_id` · `project_id` · `actor_id`(nullable) · `verb` · `object_type`/`object_id`(nullable) · `occurred_at` · `representative_event_id` · `source_event_ids[]`/`recipient_ids[]`/`recipient_types[]`(NOT NULL default `'{}'`) · `payload`(jsonb) · `dedup_key` · `activity_seq`(bigint **IDENTITY**) · `created_at`.

- **AC②**: unique index `(org_id, dedup_key)` — 활동 dedup.
- **AC③**: 조회 인덱스 4종 — project/actor/object/verb × `occurred_at DESC`(멀티테넌트라 org_id 선두).
- **AC④**: downgrade는 `activity_events`만 drop.
- idempotent 테이블-단위 inspect 가드(0113 선례).

### FK 정책
canonical projection 테이블이라 actor/object/event 참조는 **비강제 plain UUID**(코드 컨벤션 "FK 비강제 canonical id" 정합). 원본 event가 정리돼도 활동 그래프(감사)는 보존. **ORM 모델 + backfill은 후속 L1-BE story**(이 PR=마이그만).

### Validation (실 Postgres)
`pgvector`-only env bootstrap을 우회해 Operations API로 실 PG에 적용 검증:
- upgrade → 16컬럼 타입/nullable/default 정확 + 인덱스 6종(pkey·4 query·unique).
- identity(`activity_seq`)·`uuid[]`/`text[]` `{}`·`jsonb` `{}` 기본값 동작.
- `(org_id, dedup_key)` 중복 INSERT → unique 강제(거부).
- downgrade → 테이블 clean drop.
- `test_migrate_env` 6 passed · alembic single head `0116` · `app.models` import clean.

> 머지 후 `sprintable-migrate-dev` job 수동 실행 필요([[migration_run_manual]]). 마이그 동반 PR 규율([[no_merge_without_migration_capability]]) 충족.

🤖 Generated with [Claude Code](https://claude.com/claude-code)