### PR TITLE
feat(activity-graph): canonical mapper/extractor + ActivityEvent model (L1-BE-2)

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -35,8 +35,10 @@ from app.models.file_lock import FileLock
 from app.models.org_invite import OrgInvite
 from app.models.project_access import ProjectAccess
 from app.models.member import AgentProjectProfile, Member, MemberIdentityAlias
+from app.models.activity_event import ActivityEvent
 
 __all__ = [
+    "ActivityEvent",
     "AgentProjectProfile",
     "Member",
     "MemberIdentityAlias",

--- a/backend/app/models/activity_event.py
+++ b/backend/app/models/activity_event.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Identity, Index, Text, func, text
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.database import Base
+
+
+class ActivityEvent(Base):
+    """L1 canonical 활동 그래프 행(0116 마이그 정합). events를 정규화·dedup한 1급 활동.
+
+    activity_seq는 Identity(DB 생성) — INSERT 시 명시 금지(0072 gateway_seq GeneratedAlways
+    교훈). source_event_ids/recipient_ids는 같은 dedup_key fan-out을 누적(array union).
+    """
+
+    __tablename__ = "activity_events"
+
+    # 0116 마이그와 정합(이름·컬럼 동일). create_all 기반 테스트·ON CONFLICT가 unique 인덱스를
+    # 찾도록 모델에도 선언한다.
+    __table_args__ = (
+        Index("uq_activity_events_org_dedup", "org_id", "dedup_key", unique=True),
+        Index("ix_activity_events_project_time", "org_id", "project_id", text("occurred_at DESC")),
+        Index("ix_activity_events_actor_time", "org_id", "actor_id", text("occurred_at DESC")),
+        Index("ix_activity_events_object_time", "org_id", "object_type", "object_id", text("occurred_at DESC")),
+        Index("ix_activity_events_verb_time", "org_id", "verb", text("occurred_at DESC")),
+    )
+
+    activity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    actor_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    verb: Mapped[str] = mapped_column(Text, nullable=False)
+    object_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    object_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    occurred_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    representative_event_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    source_event_ids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, server_default="{}"
+    )
+    recipient_ids: Mapped[list[uuid.UUID]] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=False, server_default="{}"
+    )
+    recipient_types: Mapped[list[str]] = mapped_column(ARRAY(Text), nullable=False, server_default="{}")
+    payload: Mapped[dict] = mapped_column(JSONB, nullable=False, server_default=text("'{}'::jsonb"))
+    dedup_key: Mapped[str] = mapped_column(Text, nullable=False)
+    activity_seq: Mapped[int] = mapped_column(BigInteger, Identity(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )

--- a/backend/app/services/activity_stream.py
+++ b/backend/app/services/activity_stream.py
@@ -1,0 +1,125 @@
+"""L1 BE-2: canonical 활동 mapper/extractor (블루프린트 §3.2·§5).
+
+events 행을 canonical 활동(activity_events)으로 정규화한다. 수신자 fan-out(1 dispatch →
+N recipient event)은 같은 dedup_key로 1 활동에 병합되고 source_event_ids/recipient_ids에
+누적된다(array union). 추출은 idempotent하다.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+
+from sqlalchemy import select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.activity_event import ActivityEvent
+from app.models.event import Event
+
+# AC③: 수신자/배달 전용 필드는 fingerprint·dedup 식별에서 제외한다(fan-out은 같은 활동).
+_DELIVERY_ONLY_KEYS = frozenset(
+    {"recipient", "recipient_id", "recipient_type", "is_backfill", "event_id", "recipient_seq"}
+)
+
+
+def canonical_verb(event: Event) -> str:
+    """AC②: 'dispatched' wrapper면 payload.event_type(내부 알림 verb)로 unwrap, 아니면 event_type."""
+    if event.event_type == "dispatched":
+        inner = (event.payload or {}).get("event_type")
+        if isinstance(inner, str) and inner:
+            return inner
+    return event.event_type
+
+
+def canonical_payload_fingerprint(payload: dict | None) -> str:
+    """AC③: delivery-only 필드를 뺀 의미 payload의 결정적 해시(정렬 JSON → sha256)."""
+    core = {k: v for k, v in (payload or {}).items() if k not in _DELIVERY_ONLY_KEYS}
+    serialized = json.dumps(core, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
+def build_dedup_key(event: Event) -> str:
+    """canonical 활동 식별자 — 수신자 fan-out은 같은 dedup_key로 1행 병합(AC④).
+
+    구성 = (verb, object_type, object_id, actor, occurred_at, payload_fingerprint).
+    fan-out 이벤트는 단일 dispatch flush라 created_at(occurred_at)을 공유하므로 시간을
+    포함해도 같은 활동은 병합되고 별개 dispatch는 분리된다. recipient 등 delivery-only는
+    fingerprint에서 이미 제외(AC③)되어 수신자별로 키가 갈리지 않는다.
+    """
+    parts = [
+        canonical_verb(event),
+        event.source_entity_type or "",
+        str(event.source_entity_id or ""),
+        str(event.sender_id or ""),
+        event.created_at.isoformat() if event.created_at else "",
+        canonical_payload_fingerprint(event.payload),
+    ]
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+
+
+def _canonical_payload(payload: dict | None) -> dict:
+    return {k: v for k, v in (payload or {}).items() if k not in _DELIVERY_ONLY_KEYS}
+
+
+# 같은 dedup_key 충돌 시 배열을 중복 없이 합집합(순서 무의미·set 의미). DO UPDATE라 양쪽 모두
+# 비어있지 않지만 coalesce로 방어.
+def _array_union_sql(column: str, cast: str) -> text:
+    return text(
+        f"(SELECT coalesce(array_agg(DISTINCT x), '{{}}'::{cast}) "
+        f"FROM unnest(activity_events.{column} || excluded.{column}) AS x)"
+    )
+
+
+async def upsert_activity_from_events(db: AsyncSession, event_ids: list[uuid.UUID]) -> list[uuid.UUID]:
+    """events → activity_events 추출/upsert. 같은 dedup_key는 source/recipient를 array union으로
+    누적(AC④)하며, 재실행해도 결과가 동일하다(AC⑤ idempotent — array_agg DISTINCT).
+
+    반환: 영향 활동의 activity_id 목록(입력 event 순서, created_at·id 정렬).
+    """
+    if not event_ids:
+        return []
+
+    rows = (
+        await db.execute(
+            select(Event).where(Event.id.in_(event_ids)).order_by(Event.created_at, Event.id)
+        )
+    ).scalars().all()
+
+    activity_ids: list[uuid.UUID] = []
+    for ev in rows:
+        recipient_ids = [ev.recipient_id] if ev.recipient_id is not None else []
+        recipient_types = [ev.recipient_type] if ev.recipient_type else []
+        stmt = (
+            pg_insert(ActivityEvent.__table__)
+            .values(
+                activity_id=uuid.uuid4(),
+                org_id=ev.org_id,
+                project_id=ev.project_id,
+                actor_id=ev.sender_id,
+                verb=canonical_verb(ev),
+                object_type=ev.source_entity_type,
+                object_id=ev.source_entity_id,
+                occurred_at=ev.created_at,
+                representative_event_id=ev.id,
+                source_event_ids=[ev.id],
+                recipient_ids=recipient_ids,
+                recipient_types=recipient_types,
+                payload=_canonical_payload(ev.payload),
+                dedup_key=build_dedup_key(ev),
+                # activity_seq 생략(Identity·DB 생성)·created_at 생략(default now()).
+            )
+            .on_conflict_do_update(
+                index_elements=["org_id", "dedup_key"],
+                set_={
+                    "source_event_ids": _array_union_sql("source_event_ids", "uuid[]"),
+                    "recipient_ids": _array_union_sql("recipient_ids", "uuid[]"),
+                    "recipient_types": _array_union_sql("recipient_types", "text[]"),
+                },
+            )
+            .returning(ActivityEvent.__table__.c.activity_id)
+        )
+        result = await db.execute(stmt)
+        activity_ids.append(result.scalar_one())
+
+    return activity_ids

--- a/backend/tests/test_activity_stream.py
+++ b/backend/tests/test_activity_stream.py
@@ -1,0 +1,182 @@
+"""L1 BE-2: canonical mapper/extractor 테스트.
+
+순수 함수(canonical_verb·fingerprint·dedup_key)는 DB 없이, upsert는 real-DB에서 검증한다
+(PARITY_TEST_DATABASE_URL/ALEMBIC_DATABASE_URL 없으면 skip — CI alembic-fresh-db 잡).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.activity_stream import (
+    build_dedup_key,
+    canonical_payload_fingerprint,
+    canonical_verb,
+)
+
+TS = datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ev(**kw):
+    base = dict(
+        id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        event_type="status_changed",
+        source_entity_type="story",
+        source_entity_id=uuid.uuid4(),
+        sender_id=uuid.uuid4(),
+        recipient_id=uuid.uuid4(),
+        recipient_type="human",
+        payload={},
+        created_at=TS,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ── canonical_verb (AC②) ────────────────────────────────────────────────────────
+
+def test_canonical_verb_plain():
+    assert canonical_verb(_ev(event_type="status_changed", payload={})) == "status_changed"
+
+
+def test_canonical_verb_dispatched_unwraps_inner():
+    ev = _ev(event_type="dispatched", payload={"event_type": "memo_replied", "title": "t"})
+    assert canonical_verb(ev) == "memo_replied"
+
+
+def test_canonical_verb_dispatched_without_inner_keeps_dispatched():
+    assert canonical_verb(_ev(event_type="dispatched", payload={"title": "t"})) == "dispatched"
+
+
+# ── fingerprint (AC③) ────────────────────────────────────────────────────────────
+
+def test_fingerprint_excludes_delivery_only_fields():
+    a = canonical_payload_fingerprint({"title": "x", "recipient_id": "r1", "recipient_seq": 1, "event_id": "e1"})
+    b = canonical_payload_fingerprint({"title": "x", "recipient_id": "r2", "recipient_seq": 9, "event_id": "e2"})
+    assert a == b  # delivery-only 차이는 fingerprint 불변
+
+
+def test_fingerprint_changes_with_semantic_payload():
+    assert canonical_payload_fingerprint({"title": "x"}) != canonical_payload_fingerprint({"title": "y"})
+
+
+def test_fingerprint_is_order_independent():
+    assert canonical_payload_fingerprint({"a": 1, "b": 2}) == canonical_payload_fingerprint({"b": 2, "a": 1})
+
+
+# ── dedup_key (AC④ identity) ─────────────────────────────────────────────────────
+
+def test_dedup_key_same_for_recipient_fanout():
+    """같은 dispatch의 수신자 fan-out(recipient만 다름·created_at 공유) → 같은 dedup_key."""
+    oid, sid, obj = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    common = dict(event_type="dispatched", org_id=oid, sender_id=None, source_entity_type="memo",
+                  source_entity_id=obj, created_at=TS, payload={"title": "t", "body": "b", "event_type": "memo_created"})
+    e1 = _ev(recipient_id=uuid.uuid4(), recipient_type="human", **common)
+    e2 = _ev(recipient_id=uuid.uuid4(), recipient_type="agent", **common)
+    assert build_dedup_key(e1) == build_dedup_key(e2)
+
+
+def test_dedup_key_differs_for_distinct_object():
+    e1 = _ev(source_entity_id=uuid.uuid4())
+    e2 = _ev(source_entity_id=uuid.uuid4())
+    assert build_dedup_key(e1) != build_dedup_key(e2)
+
+
+def test_dedup_key_differs_for_distinct_dispatch_time():
+    obj = uuid.uuid4()
+    e1 = _ev(source_entity_id=obj, created_at=TS)
+    e2 = _ev(source_entity_id=obj, created_at=datetime(2026, 6, 11, 13, 0, 0, tzinfo=timezone.utc))
+    assert build_dedup_key(e1) != build_dedup_key(e2)
+
+
+# ── upsert (AC①④⑤) — real-DB ─────────────────────────────────────────────────────
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = (
+    _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace("postgresql://", "postgresql+asyncpg://")
+    if _RAW
+    else ""
+)
+
+pytestmark_db = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+def _upsert_stmt(org, dedup, src_id, rid, rtype):
+    """activity_stream.upsert_activity_from_events가 이벤트당 발행하는 것과 동일한 on_conflict 문.
+
+    실 Event(projects/team_members FK)를 seed하지 않고 array-union ON CONFLICT 거동만
+    검증한다 — Event→활동 매핑(verb/dedup_key)은 위 순수 함수 테스트가 커버.
+    """
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from app.models.activity_event import ActivityEvent
+    from app.services.activity_stream import _array_union_sql
+
+    return (
+        pg_insert(ActivityEvent.__table__)
+        .values(
+            activity_id=uuid.uuid4(), org_id=org, project_id=uuid.uuid4(), actor_id=None,
+            verb="memo_created", object_type="memo", object_id=uuid.uuid4(), occurred_at=TS,
+            representative_event_id=src_id, source_event_ids=[src_id], recipient_ids=[rid],
+            recipient_types=[rtype], payload={"title": "t"}, dedup_key=dedup,
+        )
+        .on_conflict_do_update(
+            index_elements=["org_id", "dedup_key"],
+            set_={
+                "source_event_ids": _array_union_sql("source_event_ids", "uuid[]"),
+                "recipient_ids": _array_union_sql("recipient_ids", "uuid[]"),
+                "recipient_types": _array_union_sql("recipient_types", "text[]"),
+            },
+        )
+        .returning(ActivityEvent.__table__.c.activity_id)
+    )
+
+
+@pytestmark_db
+@pytest.mark.anyio
+async def test_upsert_array_union_merge_idempotent_and_distinct():
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.activity_event import ActivityEvent
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(ActivityEvent.__table__.create, checkfirst=True)
+        org, dk = uuid.uuid4(), "dedupA"
+        s1, s2, s3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        r1, r2, r3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        async with Session() as s:
+            a1 = (await s.execute(_upsert_stmt(org, dk, s1, r1, "human"))).scalar_one()
+            a2 = (await s.execute(_upsert_stmt(org, dk, s2, r2, "agent"))).scalar_one()
+            a3 = (await s.execute(_upsert_stmt(org, dk, s3, r3, "human"))).scalar_one()
+            await s.commit()
+            assert a1 == a2 == a3  # AC④ fan-out → 단일 활동
+
+            (a,) = (await s.execute(select(ActivityEvent).where(ActivityEvent.org_id == org))).scalars().all()
+            assert set(a.source_event_ids) == {s1, s2, s3}
+            assert set(a.recipient_ids) == {r1, r2, r3}
+            assert set(a.recipient_types) == {"human", "agent"}
+            assert a.activity_seq is not None  # Identity DB 생성
+
+            # AC⑤ idempotent.
+            await s.execute(_upsert_stmt(org, dk, s1, r1, "human"))
+            await s.commit()
+            (a2r,) = (await s.execute(select(ActivityEvent).where(ActivityEvent.org_id == org))).scalars().all()
+            assert set(a2r.source_event_ids) == {s1, s2, s3}
+
+            # 다른 dedup_key → 별 행.
+            await s.execute(_upsert_stmt(org, "dedupB", uuid.uuid4(), uuid.uuid4(), "human"))
+            await s.commit()
+            rows = (await s.execute(select(ActivityEvent).where(ActivityEvent.org_id == org))).scalars().all()
+            assert len(rows) == 2
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## L1-BE-2 — canonical mapper/extractor (dedup·1행 추출)

블루프린트 `blueprint-e-l1-activity-graph` §3.2·§5. `events`를 canonical `activity_events`(BE-1 0116 테이블)로 정규화. 수신자 fan-out(1 dispatch → N recipient event)을 **1 활동으로 병합**.

### `app/services/activity_stream.py`
- **`canonical_verb`** (AC②): `'dispatched'` wrapper면 `payload.event_type`로 unwrap, 아니면 raw `event_type`.
- **`canonical_payload_fingerprint`** (AC③): delivery-only 키(`recipient`·`recipient_id`·`recipient_type`·`is_backfill`·`event_id`·`recipient_seq`) 제외한 의미 payload의 결정적 sha256.
- **`build_dedup_key`** (AC④ identity): verb/object/actor/occurred_at/fingerprint. fan-out은 단일 dispatch flush라 `created_at` 공유 → 같은 활동 병합·별개 dispatch 분리.
- **`upsert_activity_from_events`** (AC①④⑤): 이벤트당 `ON CONFLICT (org_id, dedup_key)` upsert. `source_event_ids`/`recipient_ids`/`recipient_types`를 **distinct array union**으로 누적 → 재실행 idempotent. `activity_seq` 생략(Identity·DB 생성·0072 GeneratedAlways 회피).

### `ActivityEvent` 모델
0116 정합(unique + 조회 4종 인덱스를 `__table_args__`에 선언 → create_all 테스트·ON CONFLICT가 unique 인덱스 해소). `app/models` 등록. **마이그 무추가**(테이블은 BE-1).

### Validation (실 Postgres)
- fan-out 3건 → 단일 활동·`source_event_ids`/`recipient_ids` distinct union·재실행 idempotent·다른 dedup_key는 별 행·`activity_seq` DB 생성.
- **10 passed**(9 unit + 1 real-DB) · `test_migrate_env`+mcp contract **33 passed** · alembic head `0116` 불변.

> 의존: L1-BE-1(0116·머지됨). extractor consumer는 BE-3까지 없어 migrate-dev 0116 런타임 의존 아직 없음. 머지 순서는 BE-1 migrate-dev 적용과 무관(코드만).

🤖 Generated with [Claude Code](https://claude.com/claude-code)