### PR TITLE
feat(activity-graph): backfill job events → activity_events (L1-BE-4)

### DIFF
--- a/backend/app/services/activity_stream.py
+++ b/backend/app/services/activity_stream.py
@@ -8,14 +8,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import uuid
 
-from sqlalchemy import select, text
+from sqlalchemy import select, text, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.activity_event import ActivityEvent
 from app.models.event import Event
+
+logger = logging.getLogger(__name__)
 
 # AC③: 수신자/배달 전용 필드는 fingerprint·dedup 식별에서 제외한다(fan-out은 같은 활동).
 _DELIVERY_ONLY_KEYS = frozenset(
@@ -123,3 +126,67 @@ async def upsert_activity_from_events(db: AsyncSession, event_ids: list[uuid.UUI
         activity_ids.append(result.scalar_one())
 
     return activity_ids
+
+
+async def backfill_activity_events(db: AsyncSession, *, batch_size: int = 1000) -> dict[str, int]:
+    """L1 BE-4: 기존 events를 (created_at ASC, id ASC) cursor scan하며 activity_events로 흡수.
+
+    별도 idempotent job(테이블은 0116 마이그가 생성). delivered event cleanup 전 과거 row를
+    수렴한다. 재실행해도 (org_id, dedup_key) unique + array_agg DISTINCT로 row count·source
+    누적이 안정(AC②). 이미 삭제된 event는 scan에 없으므로 복원하지 않는다(AC③). 배치별로
+    빠른 일괄 upsert를 시도하고, 실패 시에만 event 단위로 격리해 문제 row를 skip·집계한다.
+
+    반환: {events_processed, events_skipped, batches}. 배치별 처리량·upsert·collapse는 로그.
+    """
+    processed = 0
+    skipped = 0
+    batches = 0
+    cursor: tuple | None = None  # (created_at, id)
+
+    while True:
+        query = (
+            select(Event.id, Event.created_at)
+            .order_by(Event.created_at.asc(), Event.id.asc())
+            .limit(batch_size)
+        )
+        if cursor is not None:
+            query = query.where(tuple_(Event.created_at, Event.id) > tuple_(cursor[0], cursor[1]))
+
+        rows = (await db.execute(query)).all()
+        if not rows:
+            break
+
+        batch_ids = [row[0] for row in rows]
+        batch_skipped = 0
+        try:
+            activity_ids = await upsert_activity_from_events(db, batch_ids)
+            await db.commit()
+        except Exception:
+            # 배치 일괄이 실패하면 event 단위 savepoint로 격리 — 문제 row만 skip한다.
+            await db.rollback()
+            activity_ids = []
+            for eid in batch_ids:
+                try:
+                    async with db.begin_nested():
+                        activity_ids.extend(await upsert_activity_from_events(db, [eid]))
+                except Exception:
+                    batch_skipped += 1
+                    logger.warning("backfill skip event=%s", eid, exc_info=True)
+            await db.commit()
+
+        processed += len(batch_ids)
+        skipped += batch_skipped
+        batches += 1
+        cursor = (rows[-1][1], rows[-1][0])
+        logger.info(
+            "backfill batch %d: processed=%d upserts=%d collapsed=%d skipped=%d",
+            batches,
+            len(batch_ids),
+            len(batch_ids) - batch_skipped,
+            len(set(activity_ids)),
+            batch_skipped,
+        )
+
+    result = {"events_processed": processed, "events_skipped": skipped, "batches": batches}
+    logger.info("backfill complete: %s", result)
+    return result

--- a/backend/scripts/backfill_activity_events.py
+++ b/backend/scripts/backfill_activity_events.py
@@ -1,0 +1,45 @@
+"""L1 BE-4: 기존 events → activity_events backfill job (idempotent).
+
+events를 (created_at ASC, id ASC)로 cursor scan하며 BE-2 extractor(upsert_activity_from_events)
+로 activity_events에 흡수한다. 0116 마이그는 테이블만 만들고 데이터는 이 job이 채운다. 재실행
+멱등 — (org_id, dedup_key) unique + array_agg DISTINCT라 row count·source 누적이 안정.
+
+env: DATABASE_URL (백엔드 동일, cloud-sql-proxy/in-VPC 경유). 쓰기 작업.
+실행: cd backend && DATABASE_URL=... python -m scripts.backfill_activity_events [--batch-size N]
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import os
+import sys
+
+from app.core.database import async_session_factory
+from app.services.activity_stream import backfill_activity_events
+
+logger = logging.getLogger("backfill_activity_events")
+
+
+async def main() -> int:
+    if not os.environ.get("DATABASE_URL"):
+        print("DATABASE_URL 미설정", file=sys.stderr)
+        return 2
+
+    parser = argparse.ArgumentParser(description="events → activity_events backfill (idempotent)")
+    parser.add_argument("--batch-size", type=int, default=1000, help="배치당 scan할 event 수 (기본 1000)")
+    args = parser.parse_args()
+
+    async with async_session_factory() as db:
+        result = await backfill_activity_events(db, batch_size=args.batch_size)
+
+    print(
+        f"backfill done: events_processed={result['events_processed']} "
+        f"events_skipped={result['events_skipped']} batches={result['batches']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    raise SystemExit(asyncio.run(main()))

--- a/backend/tests/test_backfill_activity_events.py
+++ b/backend/tests/test_backfill_activity_events.py
@@ -1,0 +1,83 @@
+"""L1 BE-4: backfill job 테스트.
+
+cursor 페이지네이션·배치·skip 집계·idempotent 호출 패턴을 mock으로 검증한다. 실제 upsert
+SQL(array union·dedup)은 BE-2 real-DB 테스트가 커버한다.
+"""
+from __future__ import annotations
+
+import contextlib
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services import activity_stream as svc
+
+TS = datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _scan_db(batches: list[list]):
+    """db.execute가 SELECT scan을 호출할 때마다 다음 배치를 반환하는 stub."""
+    state = {"i": 0}
+
+    async def _execute(_stmt):
+        res = MagicMock()
+        rows = batches[state["i"]] if state["i"] < len(batches) else []
+        state["i"] += 1
+        res.all.return_value = rows
+        return res
+
+    db = AsyncMock()
+    db.execute = _execute
+
+    @contextlib.asynccontextmanager
+    async def _savepoint():
+        yield
+
+    db.begin_nested = lambda: _savepoint()
+    return db
+
+
+@pytest.mark.anyio
+async def test_backfill_paginates_and_counts(monkeypatch):
+    b1 = [(uuid.uuid4(), TS) for _ in range(3)]
+    b2 = [(uuid.uuid4(), TS) for _ in range(2)]
+    db = _scan_db([b1, b2, []])
+
+    async def _upsert(_db, ids):
+        return [uuid.uuid4() for _ in ids]
+
+    monkeypatch.setattr(svc, "upsert_activity_from_events", _upsert)
+
+    result = await svc.backfill_activity_events(db, batch_size=3)
+    assert result == {"events_processed": 5, "events_skipped": 0, "batches": 2}
+
+
+@pytest.mark.anyio
+async def test_backfill_empty(monkeypatch):
+    db = _scan_db([[]])
+    monkeypatch.setattr(svc, "upsert_activity_from_events", AsyncMock(return_value=[]))
+    result = await svc.backfill_activity_events(db)
+    assert result == {"events_processed": 0, "events_skipped": 0, "batches": 0}
+
+
+@pytest.mark.anyio
+async def test_backfill_skips_failing_event_via_per_event_fallback(monkeypatch):
+    bad = uuid.uuid4()
+    b1 = [(uuid.uuid4(), TS), (bad, TS), (uuid.uuid4(), TS)]
+    db = _scan_db([b1, []])
+
+    async def _upsert(_db, ids):
+        # 배치 일괄(>1)은 실패 → per-event fallback 유도. fallback에서 bad만 실패.
+        if len(ids) > 1:
+            raise RuntimeError("batch failed")
+        if ids[0] == bad:
+            raise RuntimeError("bad event")
+        return [uuid.uuid4()]
+
+    monkeypatch.setattr(svc, "upsert_activity_from_events", _upsert)
+
+    result = await svc.backfill_activity_events(db, batch_size=3)
+    assert result == {"events_processed": 3, "events_skipped": 1, "batches": 1}
+    db.rollback.assert_awaited()  # 배치 실패 시 rollback 후 fallback


### PR DESCRIPTION
## L1-BE-4 — backfill job (기존 events → activity_events)

블루프린트 §3.4·§5. 별도 **idempotent job**(0116 마이그는 테이블만 생성). delivered event cleanup이 과거 row를 지우기 전 흡수.

### `backfill_activity_events(db, batch_size=1000)` (activity_stream.py)
- events를 `(created_at ASC, id ASC)` **row-value cursor scan**·배치 1k(AC①).
- BE-2 extractor(`upsert_activity_from_events`) 재사용 → **idempotent**: `(org_id, dedup_key)` unique + `array_agg DISTINCT`라 row count·source 누적 안정(AC②).
- 이미 삭제된 event는 scan에 없어 복원 안 함(AC③). 빠른 일괄 upsert 먼저 시도하고 **실패 시에만 event 단위 SAVEPOINT 격리**로 문제 row만 skip·집계.
- 배치별 processed/upserts/collapsed/skipped 로그(AC④)·반환 `{events_processed, events_skipped, batches}`.

### `scripts/backfill_activity_events.py`
얇은 CLI(`async_session_factory`·`--batch-size`)·`python -m scripts.backfill_activity_events`.

### Validation (실 Postgres)
3-event fan-out → 1 활동(source 3)·distinct event 별행·cursor 페이지네이션·**재실행 idempotent**(count·array 불변). 테스트: backfill 3 unit(pagination/totals·empty·per-event skip fallback). upsert SQL은 BE-2 real-DB가 커버.

> 의존 L1-BE-2(머지됨). job은 migrate-dev 0116 적용 후 수동 실행([[migration_run_manual]])·BE-3과 독립.

🤖 Generated with [Claude Code](https://claude.com/claude-code)