### PR TITLE
feat(activity-graph): Activity Stream read API (L1-BE-5)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -38,7 +38,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -124,6 +124,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(health.router)
 app.include_router(activity_logs.router)
+app.include_router(activity_stream.router)
 app.include_router(events.router)
 app.include_router(agent_gateway.router)
 app.include_router(dispatch.router)

--- a/backend/app/routers/activity_stream.py
+++ b/backend/app/routers/activity_stream.py
@@ -1,0 +1,50 @@
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.dependencies.auth import get_verified_org_id
+from app.dependencies.database import get_db
+from app.schemas.activity_stream import ActivityStreamItem, ActivityStreamResponse
+from app.services.activity_stream import query_activity_stream
+
+router = APIRouter(prefix="/api/v2/activity-stream", tags=["activity-stream"])
+
+
+@router.get("", response_model=ActivityStreamResponse)
+async def get_activity_stream(
+    project_id: uuid.UUID | None = Query(default=None),
+    actor_id: uuid.UUID | None = Query(default=None),
+    verb: str | None = Query(default=None),
+    object_type: str | None = Query(default=None),
+    object_id: uuid.UUID | None = Query(default=None),
+    since: datetime | None = Query(default=None, description="occurred_at >= since"),
+    until: datetime | None = Query(default=None, description="occurred_at <= until"),
+    after_seq: int | None = Query(default=None, description="activity_seq > after_seq (cursor)"),
+    limit: int = Query(default=50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+) -> ActivityStreamResponse:
+    """GET /api/v2/activity-stream — 에이전트 team-context 읽기.
+
+    org-scope 강제(AC①). activity_seq ASC cursor 페이지네이션(AC③). 응답은 canonical
+    활동(source/recipient/payload·AC④)만 — delivery-only status/read는 미포함(AC⑤).
+    """
+    rows, next_after_seq = await query_activity_stream(
+        db,
+        org_id,
+        project_id=project_id,
+        actor_id=actor_id,
+        verb=verb,
+        object_type=object_type,
+        object_id=object_id,
+        since=since,
+        until=until,
+        after_seq=after_seq,
+        limit=limit,
+    )
+    return ActivityStreamResponse(
+        items=[ActivityStreamItem.model_validate(row) for row in rows],
+        next_after_seq=next_after_seq,
+    )

--- a/backend/app/schemas/activity_stream.py
+++ b/backend/app/schemas/activity_stream.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ActivityStreamItem(BaseModel):
+    """canonical 활동 1행(L1 BE-5). delivery-only status/read는 노출하지 않는다(AC⑤)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    activity_id: uuid.UUID
+    project_id: uuid.UUID
+    actor_id: uuid.UUID | None = None
+    verb: str
+    object_type: str | None = None
+    object_id: uuid.UUID | None = None
+    occurred_at: datetime
+    source_event_ids: list[uuid.UUID]
+    recipient_ids: list[uuid.UUID]
+    recipient_types: list[str]
+    payload: dict[str, Any]
+    activity_seq: int
+
+
+class ActivityStreamResponse(BaseModel):
+    items: list[ActivityStreamItem]
+    # activity_seq ASC cursor: 다음 페이지는 ?after_seq=next_after_seq. None이면 더 없음.
+    next_after_seq: int | None = None

--- a/backend/app/services/activity_stream.py
+++ b/backend/app/services/activity_stream.py
@@ -207,3 +207,47 @@ async def extract_activities_best_effort(db: AsyncSession, event_ids: list[uuid.
             await upsert_activity_from_events(db, event_ids)
     except Exception:
         logger.warning("activity extractor skipped (best-effort) for events=%s", event_ids, exc_info=True)
+
+
+async def query_activity_stream(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    *,
+    project_id: uuid.UUID | None = None,
+    actor_id: uuid.UUID | None = None,
+    verb: str | None = None,
+    object_type: str | None = None,
+    object_id: uuid.UUID | None = None,
+    since=None,
+    until=None,
+    after_seq: int | None = None,
+    limit: int = 50,
+) -> tuple[list[ActivityEvent], int | None]:
+    """L1 BE-5: activity_events를 org-scope + 필터로 조회(activity_seq ASC cursor).
+
+    반환: (rows, next_after_seq). next_after_seq는 페이지가 가득 찼을 때만 마지막 seq —
+    None이면 더 없음. org_id는 항상 강제(AC①). after_seq는 strict(> after_seq) cursor라
+    중복 없이 다음 페이지를 잇는다.
+    """
+    query = select(ActivityEvent).where(ActivityEvent.org_id == org_id)
+    if project_id is not None:
+        query = query.where(ActivityEvent.project_id == project_id)
+    if actor_id is not None:
+        query = query.where(ActivityEvent.actor_id == actor_id)
+    if verb is not None:
+        query = query.where(ActivityEvent.verb == verb)
+    if object_type is not None:
+        query = query.where(ActivityEvent.object_type == object_type)
+    if object_id is not None:
+        query = query.where(ActivityEvent.object_id == object_id)
+    if since is not None:
+        query = query.where(ActivityEvent.occurred_at >= since)
+    if until is not None:
+        query = query.where(ActivityEvent.occurred_at <= until)
+    if after_seq is not None:
+        query = query.where(ActivityEvent.activity_seq > after_seq)
+
+    query = query.order_by(ActivityEvent.activity_seq.asc()).limit(limit)
+    rows = list((await db.execute(query)).scalars().all())
+    next_after_seq = rows[-1].activity_seq if len(rows) == limit else None
+    return rows, next_after_seq

--- a/backend/tests/test_activity_stream_api.py
+++ b/backend/tests/test_activity_stream_api.py
@@ -1,0 +1,141 @@
+"""L1 BE-5: Activity Stream API (GET /api/v2/activity-stream) 테스트.
+
+query_activity_stream(org scope·필터·activity_seq cursor)은 real-DB로, 라우터 wiring/응답
+shape는 mock으로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+TS = datetime(2026, 6, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── query_activity_stream — real-DB ──────────────────────────────────────────────
+
+_RAW = os.environ.get("PARITY_TEST_DATABASE_URL") or os.environ.get("ALEMBIC_DATABASE_URL") or ""
+_ASYNC_URL = (
+    _RAW.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace("postgresql://", "postgresql+asyncpg://")
+    if _RAW
+    else ""
+)
+_db = pytest.mark.skipif(not _ASYNC_URL, reason="real-DB URL 미설정 — skip")
+
+
+@_db
+@pytest.mark.anyio
+async def test_query_org_scope_filters_and_cursor():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.activity_event import ActivityEvent
+    from app.services.activity_stream import query_activity_stream
+
+    engine = create_async_engine(_ASYNC_URL)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    org_a, org_b, proj = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(ActivityEvent.__table__.create, checkfirst=True)
+        async with Session() as s:
+            def _act(org, verb, dk):
+                return ActivityEvent(
+                    org_id=org, project_id=proj, actor_id=None, verb=verb,
+                    object_type="memo", object_id=uuid.uuid4(), occurred_at=TS,
+                    source_event_ids=[uuid.uuid4()], recipient_ids=[uuid.uuid4()],
+                    recipient_types=["human"], payload={"title": "t"}, dedup_key=dk,
+                )
+            s.add_all([
+                _act(org_a, "memo_created", "a1"),
+                _act(org_a, "memo_replied", "a2"),
+                _act(org_a, "memo_created", "a3"),
+                _act(org_b, "memo_created", "b1"),  # 다른 org — 노출되면 안 됨
+            ])
+            await s.commit()
+
+            # AC① org scope: org_a만.
+            rows, nxt = await query_activity_stream(s, org_a, limit=50)
+            assert len(rows) == 3 and all(r.org_id == org_a for r in rows)
+            assert [r.activity_seq for r in rows] == sorted(r.activity_seq for r in rows)  # seq ASC
+
+            # AC② verb 필터.
+            rows_v, _ = await query_activity_stream(s, org_a, verb="memo_created", limit=50)
+            assert len(rows_v) == 2 and all(r.verb == "memo_created" for r in rows_v)
+
+            # AC③ cursor: limit=2 → next_after_seq, after_seq로 다음 페이지.
+            page1, nxt1 = await query_activity_stream(s, org_a, limit=2)
+            assert len(page1) == 2 and nxt1 == page1[-1].activity_seq
+            page2, nxt2 = await query_activity_stream(s, org_a, after_seq=nxt1, limit=2)
+            assert len(page2) == 1 and nxt2 is None  # 더 없음
+            assert page2[0].activity_seq > nxt1  # strict cursor — 중복 없음
+    finally:
+        await engine.dispose()
+
+
+# ── 라우터 wiring/응답 shape — mock ───────────────────────────────────────────────
+
+async def _client(activity_rows):
+    from app.dependencies.auth import get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    mock_session = AsyncMock()
+    result = MagicMock()
+    result.scalars.return_value.all.return_value = activity_rows
+    mock_session.execute = AsyncMock(return_value=result)
+
+    async def override_db():
+        yield mock_session
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_verified_org_id] = lambda: uuid.uuid4()
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), app
+
+
+def _row():
+    r = MagicMock()
+    r.activity_id = uuid.uuid4(); r.project_id = uuid.uuid4(); r.actor_id = None
+    r.verb = "memo_created"; r.object_type = "memo"; r.object_id = uuid.uuid4()
+    r.occurred_at = TS; r.source_event_ids = [uuid.uuid4()]; r.recipient_ids = [uuid.uuid4()]
+    r.recipient_types = ["human"]; r.payload = {"title": "t"}; r.activity_seq = 7
+    return r
+
+
+@pytest.mark.anyio
+async def test_activity_stream_endpoint_shape_and_cursor():
+    client, app = await _client([_row()])
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/activity-stream?limit=1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert len(body["items"]) == 1
+        item = body["items"][0]
+        assert item["verb"] == "memo_created"
+        assert "source_event_ids" in item and "recipient_ids" in item and "payload" in item
+        assert "status" not in item and "read_at" not in item  # AC⑤ delivery-only 미포함
+        assert body["next_after_seq"] == 7  # limit=1·1행 → cursor
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_activity_stream_empty_no_cursor():
+    client, app = await _client([])
+    try:
+        async with client as c:
+            resp = await c.get("/api/v2/activity-stream")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["items"] == [] and body["next_after_seq"] is None
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## L1-BE-5 — Activity Stream API (`GET /api/v2/activity-stream`)

블루프린트 §4·§5. canonical `activity_events` 위 에이전트 team-context read.

- **`query_activity_stream(db, org_id, ...)`** (activity_stream.py): **org-scope 강제**(AC①)·필터 `project_id/actor_id/verb/object_type/object_id/since/until`(AC②)·**`activity_seq ASC` + strict `after_seq` cursor → `next_after_seq`**(AC③). 반환 `(rows, next_after_seq)` — 페이지 가득 찼을 때만 마지막 seq, 아니면 None.
- **`ActivityStreamItem`**: canonical 활동(`source_event_ids`/`recipient_ids`/`recipient_types`/`payload`·AC④) 노출·**delivery-only status/read 미포함**(AC⑤). `ActivityStreamResponse{items, next_after_seq}`.
- `routers/activity_stream.py` main.py 등록.

### Validation (실 Postgres)
org isolation(타 org row 미노출)·verb 필터·activity_seq cursor(full page→next_after_seq·다음 페이지 strict·끝은 None). 테스트: real-DB query + mock 라우터(응답 shape·AC⑤ no status/read·empty→null cursor). py_compile·route 등록 확인.

> 의존 BE-1(테이블·머지됨)·데이터는 BE-3/BE-4. 활동 흐르기 전엔 빈 스트림. **머지는 migrate-dev 0116 후**. done 게이트=까심 QA + 유나 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)