### PR TITLE
feat(l2): L1 activity stream adapter L1ActivitySource (L2-S3)

### DIFF
--- a/backend/app/services/l1_activity_source.py
+++ b/backend/app/services/l1_activity_source.py
@@ -1,0 +1,146 @@
+"""L2-S3: L1 activity stream adapter (`L1ActivitySource`).
+
+블루프린트 §5 S3. L2 휴리스틱 트리거가 L1 canonical 활동 스트림을 소비하기 위한 얇은 어댑터.
+BE-6 helper(`poll_activities_after_seq`·`latest_activity_for_object`)를 감싸 ORM `ActivityEvent`
+행을 L2 내부 계약인 `ActivitySignal` dataclass로 normalize한다 — evaluator(S4) 등 다운스트림을
+ORM 모델 변화로부터 격리.
+
+AC②: L1 모듈 import가 실패해도(미배포·리팩터 등) startup은 깨지지 않고 source가 disabled로 떨어진다
+(7a57e7b1 OSS-stub graceful guard 선례). disabled면 poll은 빈 배치·latest는 None을 반환해 L2
+트리거가 조용히 무동작한다.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ActivitySignal:
+    """L1 canonical 활동 1행의 L2-내부 정규화 표현.
+
+    evaluator(S4)가 의존하는 안정 계약 — 트리거 로직을 ActivityEvent ORM 스키마로부터 분리한다.
+    payload/recipient/source 컬렉션은 frozen dataclass 불변성을 위해 복사(tuple/dict)한다.
+    """
+
+    activity_seq: int
+    activity_id: uuid.UUID
+    org_id: uuid.UUID
+    project_id: uuid.UUID
+    verb: str
+    occurred_at: datetime
+    actor_id: uuid.UUID | None = None
+    object_type: str | None = None
+    object_id: uuid.UUID | None = None
+    dedup_key: str = ""
+    payload: dict = field(default_factory=dict)
+    recipient_ids: tuple[uuid.UUID, ...] = ()
+    recipient_types: tuple[str, ...] = ()
+    representative_event_id: uuid.UUID | None = None
+    source_event_ids: tuple[uuid.UUID, ...] = ()
+
+    @classmethod
+    def from_activity(cls, row) -> "ActivitySignal":
+        """`ActivityEvent` ORM 행(혹은 동형 객체)을 ActivitySignal로 normalize(AC①)."""
+        return cls(
+            activity_seq=row.activity_seq,
+            activity_id=row.activity_id,
+            org_id=row.org_id,
+            project_id=row.project_id,
+            verb=row.verb,
+            occurred_at=row.occurred_at,
+            actor_id=row.actor_id,
+            object_type=row.object_type,
+            object_id=row.object_id,
+            dedup_key=row.dedup_key,
+            payload=dict(row.payload or {}),
+            recipient_ids=tuple(row.recipient_ids or ()),
+            recipient_types=tuple(row.recipient_types or ()),
+            representative_event_id=row.representative_event_id,
+            source_event_ids=tuple(row.source_event_ids or ()),
+        )
+
+
+# AC②: L1 활동 스트림 import 실패해도 startup crash 0 — source는 disabled로 격리.
+try:
+    from app.services.activity_stream import (
+        latest_activity_for_object as _latest_activity_for_object,
+        poll_activities_after_seq as _poll_activities_after_seq,
+    )
+
+    _L1_AVAILABLE = True
+    _L1_IMPORT_ERROR: str | None = None
+except Exception as exc:  # pragma: no cover - 방어적 가드(정상 경로에선 import 성공)
+    _poll_activities_after_seq = None  # type: ignore[assignment]
+    _latest_activity_for_object = None  # type: ignore[assignment]
+    _L1_AVAILABLE = False
+    _L1_IMPORT_ERROR = repr(exc)
+
+
+class L1ActivitySource:
+    """L1 canonical 활동 스트림을 L2 트리거에 공급하는 어댑터.
+
+    - `poll_after_seq`: cursor 이후 신규 활동을 activity_seq ASC(AC③)로 ActivitySignal 배치 + next
+      cursor로 반환.
+    - `latest_for_object`: object 기준 최신 활동 1건(L4 anchoring 경로 재사용).
+
+    L1 미가용 시 `enabled=False` — poll은 `([], None)`, latest는 `None`을 반환하고 트리거는 조용히
+    무동작(AC②). 인스턴스 생성 시 disabled를 1회 경고한다.
+    """
+
+    def __init__(self) -> None:
+        self._enabled = _L1_AVAILABLE
+        if not self._enabled:
+            logger.warning(
+                "L1ActivitySource disabled — L1 activity stream import 실패(%s); "
+                "L2 트리거는 무동작으로 격리됨.",
+                _L1_IMPORT_ERROR,
+            )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def poll_after_seq(
+        self,
+        db: "AsyncSession",
+        after_seq: int,
+        *,
+        limit: int = 100,
+        org_id: uuid.UUID | None = None,
+    ) -> tuple[list[ActivitySignal], int | None]:
+        """after_seq 초과 활동을 activity_seq ASC ActivitySignal 배치 + next cursor로.
+
+        org_id 생략 = 전 org(시스템 트리거 워커). disabled면 `([], None)`.
+        """
+        if not self._enabled:
+            return [], None
+        rows, next_after_seq = await _poll_activities_after_seq(
+            db, after_seq, limit=limit, org_id=org_id
+        )
+        signals = [ActivitySignal.from_activity(r) for r in rows]
+        # AC③: helper가 이미 ASC를 보장하나, 어댑터 계약으로 명시 재정렬(불변식 방어 — cursor 진행은
+        # 마지막 원소 seq에 의존하므로 순서 역전은 누락·재처리를 유발).
+        signals.sort(key=lambda s: s.activity_seq)
+        return signals, next_after_seq
+
+    async def latest_for_object(
+        self,
+        db: "AsyncSession",
+        org_id: uuid.UUID,
+        object_type: str,
+        object_id: uuid.UUID,
+    ) -> ActivitySignal | None:
+        """object의 최신 canonical 활동 1건을 ActivitySignal로. 없거나 disabled면 None."""
+        if not self._enabled:
+            return None
+        row = await _latest_activity_for_object(db, org_id, object_type, object_id)
+        return ActivitySignal.from_activity(row) if row is not None else None

--- a/backend/tests/test_l1_activity_source.py
+++ b/backend/tests/test_l1_activity_source.py
@@ -1,0 +1,123 @@
+"""L2-S3: L1ActivitySource 어댑터 단위 테스트.
+
+AC① normalize·AC② disabled graceful·AC③ activity_seq ASC 보장.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import l1_activity_source as mod
+from app.services.l1_activity_source import ActivitySignal, L1ActivitySource
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _row(seq: int, **over):
+    base = dict(
+        activity_seq=seq,
+        activity_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        verb="dispatched",
+        occurred_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+        actor_id=uuid.uuid4(),
+        object_type="story",
+        object_id=uuid.uuid4(),
+        dedup_key=f"dk-{seq}",
+        payload={"k": "v"},
+        recipient_ids=[uuid.uuid4()],
+        recipient_types=["agent"],
+        representative_event_id=uuid.uuid4(),
+        source_event_ids=[uuid.uuid4(), uuid.uuid4()],
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+# ── AC①: normalize ─────────────────────────────────────────────────────────────
+
+def test_from_activity_normalizes_all_fields():
+    row = _row(7)
+    sig = ActivitySignal.from_activity(row)
+    assert sig.activity_seq == 7
+    assert sig.activity_id == row.activity_id
+    assert sig.org_id == row.org_id and sig.project_id == row.project_id
+    assert sig.verb == "dispatched" and sig.object_type == "story"
+    assert sig.payload == {"k": "v"}
+    # frozen dataclass — 컬렉션은 복사(tuple/dict)되어 원본과 격리.
+    assert isinstance(sig.recipient_ids, tuple) and isinstance(sig.source_event_ids, tuple)
+    assert sig.payload is not row.payload
+
+
+def test_from_activity_handles_null_collections():
+    row = _row(1, payload=None, recipient_ids=None, recipient_types=None, source_event_ids=None)
+    sig = ActivitySignal.from_activity(row)
+    assert sig.payload == {} and sig.recipient_ids == () and sig.source_event_ids == ()
+
+
+def test_signal_is_frozen():
+    sig = ActivitySignal.from_activity(_row(1))
+    with pytest.raises(Exception):
+        sig.activity_seq = 99  # type: ignore[misc]
+
+
+# ── AC③: poll ASC + normalize + cursor passthrough ─────────────────────────────
+
+@pytest.mark.anyio
+async def test_poll_returns_sorted_signals_and_cursor():
+    # helper가 (방어 시나리오상) 뒤섞여 와도 어댑터는 activity_seq ASC를 보장.
+    unsorted = [_row(5), _row(2), _row(9)]
+    with patch.object(mod, "_poll_activities_after_seq", new=AsyncMock(return_value=(unsorted, 9))):
+        src = L1ActivitySource()
+        signals, nxt = await src.poll_after_seq(AsyncMock(), after_seq=1, limit=3, org_id=None)
+    assert [s.activity_seq for s in signals] == [2, 5, 9]  # ASC
+    assert all(isinstance(s, ActivitySignal) for s in signals)
+    assert nxt == 9
+
+
+@pytest.mark.anyio
+async def test_poll_passes_org_and_limit_to_helper():
+    org = uuid.uuid4()
+    spy = AsyncMock(return_value=([], None))
+    with patch.object(mod, "_poll_activities_after_seq", new=spy):
+        await L1ActivitySource().poll_after_seq(AsyncMock(), after_seq=10, limit=50, org_id=org)
+    _, kwargs = spy.call_args
+    assert kwargs["limit"] == 50 and kwargs["org_id"] == org
+
+
+# ── latest_for_object ──────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_latest_for_object_normalizes_and_none_passthrough():
+    row = _row(3)
+    with patch.object(mod, "_latest_activity_for_object", new=AsyncMock(return_value=row)):
+        sig = await L1ActivitySource().latest_for_object(AsyncMock(), row.org_id, "story", row.object_id)
+    assert isinstance(sig, ActivitySignal) and sig.activity_seq == 3
+
+    with patch.object(mod, "_latest_activity_for_object", new=AsyncMock(return_value=None)):
+        assert await L1ActivitySource().latest_for_object(AsyncMock(), uuid.uuid4(), "story", uuid.uuid4()) is None
+
+
+# ── AC②: disabled graceful (import 실패 시 crash 0·무동작) ──────────────────────
+
+@pytest.mark.anyio
+async def test_disabled_source_is_inert_and_skips_helpers():
+    poll_spy = AsyncMock(return_value=([_row(1)], 1))
+    latest_spy = AsyncMock(return_value=_row(1))
+    with patch.object(mod, "_L1_AVAILABLE", False), \
+         patch.object(mod, "_poll_activities_after_seq", new=poll_spy), \
+         patch.object(mod, "_latest_activity_for_object", new=latest_spy):
+        src = L1ActivitySource()  # 생성만으로 crash 없음(AC②)
+        assert src.enabled is False
+        assert await src.poll_after_seq(AsyncMock(), 0) == ([], None)
+        assert await src.latest_for_object(AsyncMock(), uuid.uuid4(), "story", uuid.uuid4()) is None
+    poll_spy.assert_not_awaited()
+    latest_spy.assert_not_awaited()


### PR DESCRIPTION
## L2-S3 — L1 activity stream adapter (`L1ActivitySource`)

블루프린트 §5 S3. L2 휴리스틱 트리거가 **L1 canonical 활동 스트림**을 소비하기 위한 얇은 어댑터. **DB변경 0**(CI fresh DB가 0117 적용).

### Changes (`app/services/l1_activity_source.py`)
- **`ActivitySignal`** (frozen dataclass): `ActivityEvent` ORM 1행의 L2-내부 정규화 표현 — evaluator(S4) 등 다운스트림을 ORM 스키마 변화로부터 격리. `payload`/`recipient_ids`/`source_event_ids` 등 컬렉션은 불변성 위해 복사(dict/tuple)·null→빈 컬렉션 (**AC①**).
- **`L1ActivitySource`**: BE-6 helper(`poll_activities_after_seq`·`latest_activity_for_object`) 래핑.
  - `poll_after_seq(db, after_seq, *, limit, org_id=None)` → `(list[ActivitySignal], next_after_seq)`. **activity_seq ASC 명시 재정렬(AC③)** — cursor 진행이 마지막 원소 seq에 의존하므로 순서 역전은 누락·재처리를 유발(불변식 방어). org_id 생략=전 org(시스템 워커).
  - `latest_for_object(...)` → object 최신 canonical 활동 1건(L4 anchoring 경로 재사용).
- **AC②**: L1 모듈 import 실패해도 **startup crash 0** — 모듈-레벨 `try/except`로 `enabled=False` 격리(1회 disabled 경고), poll→`([], None)`·latest→`None`으로 트리거 조용히 무동작 (7a57e7b1 OSS-stub graceful 선례).

### Validation
신규 `test_l1_activity_source.py` **7 passed** — normalize 전필드·null 컬렉션·frozen 불변·**ASC 재정렬**·org/limit passthrough·None passthrough·**disabled inert + helper 미호출**(AC②). import OK(정상경로 `_L1_AVAILABLE=True`)·py_compile·no cycle(activity_stream는 본 모듈 미참조).

> L2 에픽 `4e8d3405` S3. consumer는 S5 워커. 다음 S4(evaluator)→S5(worker)→S6(dedup)→S7(E2E)→S8(config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)