### PR TITLE
feat(l2): Phase 1 휴리스틱 evaluator deadline/drought/velocity (L2-S4)

### DIFF
--- a/backend/app/services/l2_heuristics.py
+++ b/backend/app/services/l2_heuristics.py
@@ -1,0 +1,283 @@
+"""L2-S4: Phase 1 휴리스틱 evaluator (deadline / drought / velocity).
+
+블루프린트 §2·§5 S4. L1 활동 스트림과 엔티티 상태로부터 L2 트리거 후보를 산출하는 **순수
+(pure)·read-only** 휴리스틱 모듈. LLM·네트워크·DB I/O를 일절 하지 않는다(AC①) — 워커(S5)가 상태를
+조회해 입력 dataclass로 넘기면, 이 모듈은 threshold만 적용해 `TriggerDecision` 리스트를 반환한다.
+
+휴리스틱 3종:
+  ① 데드라인  — Sprint.end_date≤24h · Epic.target_date≤3d · Hypothesis.measure_after≤24h
+                (terminal 상태 done/closed/n_a는 skip). story-level due_date는 없음(AC④).
+  ② 이벤트 가뭄 — story in-progress 24h · in-review 12h · sprint 36h 무활동.
+  ③ 속도 급변  — lag(elapsed≥30% & done<expected*0.5) · spike(done>expected*2.5) ·
+                scope_creep(committed>capacity*120%).
+
+threshold는 env로 오버라이드(AC②). decision은 trigger_type/target_agent_id/anchor_type/
+anchor_id/reason/source_activity_seq를 담는다(AC③).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+logger = logging.getLogger(__name__)
+
+def _norm_status(status: str | None) -> str:
+    return (status or "").strip().lower().replace(" ", "-").replace("_", "-").replace("/", "-")
+
+
+# AC① / AC④: terminal 상태는 데드라인·가뭄 평가에서 제외(이미 종료된 작업은 nudge 불필요).
+_TERMINAL_STATUSES = frozenset({"done", "closed", "n-a", "na", "cancelled", "canceled"})
+
+
+def _is_terminal(status: str | None) -> bool:
+    return _norm_status(status) in _TERMINAL_STATUSES
+
+
+def _hours_until(target: datetime, now: datetime) -> float:
+    """target까지 남은 시간(h). 음수면 이미 초과(overdue)."""
+    return (target - now).total_seconds() / 3600.0
+
+
+def _hours_since(past: datetime, now: datetime) -> float:
+    return (now - past).total_seconds() / 3600.0
+
+
+# ── 산출물 / 설정 계약 ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TriggerDecision:
+    """휴리스틱 1건의 트리거 결정(AC③). source_activity_seq는 활동-구동 평가에서만 채워진다."""
+
+    trigger_type: str
+    target_agent_id: uuid.UUID
+    anchor_type: str
+    anchor_id: uuid.UUID
+    reason: str
+    source_activity_seq: int | None = None
+
+
+@dataclass(frozen=True)
+class HeuristicThresholds:
+    """휴리스틱 임계값 — env로 오버라이드(AC②). 시간 단위는 시간(h), 비율은 0..1+ 배수."""
+
+    # ① 데드라인 — 남은 시간이 이 값 이하이면 발사.
+    deadline_sprint_end_h: float = 24.0
+    deadline_epic_target_h: float = 72.0  # 3d
+    deadline_measure_after_h: float = 24.0
+    # ② 이벤트 가뭄 — 무활동 시간이 이 값 이상이면 발사.
+    drought_in_progress_h: float = 24.0
+    drought_in_review_h: float = 12.0
+    drought_sprint_h: float = 36.0
+    # ③ 속도 급변.
+    velocity_lag_elapsed_ratio: float = 0.30  # 경과율 하한.
+    velocity_lag_done_ratio: float = 0.50     # 기대 대비 done 비율 하한.
+    velocity_spike_factor: float = 2.5        # 기대 대비 done 배수 상한.
+    velocity_scope_creep_factor: float = 1.20  # capacity 대비 committed 배수 상한.
+
+    @classmethod
+    def from_env(cls, env: dict | None = None) -> "HeuristicThresholds":
+        """`L2_*` env 키로 기본값을 오버라이드. 파싱 실패 시 기본값으로 폴백(startup 안전)."""
+        src = env if env is not None else os.environ
+        defaults = cls()
+
+        def num(key: str, default: float) -> float:
+            raw = src.get(key)
+            if raw is None or str(raw).strip() == "":
+                return default
+            try:
+                return float(raw)
+            except (TypeError, ValueError):
+                logger.warning("L2 threshold %s 파싱 실패(%r) — 기본값 %s 사용", key, raw, default)
+                return default
+
+        return cls(
+            deadline_sprint_end_h=num("L2_DEADLINE_SPRINT_END_H", defaults.deadline_sprint_end_h),
+            deadline_epic_target_h=num("L2_DEADLINE_EPIC_TARGET_H", defaults.deadline_epic_target_h),
+            deadline_measure_after_h=num("L2_DEADLINE_MEASURE_AFTER_H", defaults.deadline_measure_after_h),
+            drought_in_progress_h=num("L2_DROUGHT_IN_PROGRESS_H", defaults.drought_in_progress_h),
+            drought_in_review_h=num("L2_DROUGHT_IN_REVIEW_H", defaults.drought_in_review_h),
+            drought_sprint_h=num("L2_DROUGHT_SPRINT_H", defaults.drought_sprint_h),
+            velocity_lag_elapsed_ratio=num("L2_VELOCITY_LAG_ELAPSED_RATIO", defaults.velocity_lag_elapsed_ratio),
+            velocity_lag_done_ratio=num("L2_VELOCITY_LAG_DONE_RATIO", defaults.velocity_lag_done_ratio),
+            velocity_spike_factor=num("L2_VELOCITY_SPIKE_FACTOR", defaults.velocity_spike_factor),
+            velocity_scope_creep_factor=num("L2_VELOCITY_SCOPE_CREEP_FACTOR", defaults.velocity_scope_creep_factor),
+        )
+
+
+# ── 입력 계약(워커 S5가 조회해 채워 넘김 — 평가기는 read-only) ───────────────────
+
+
+@dataclass(frozen=True)
+class DeadlineTarget:
+    """데드라인 평가 대상. entity_type ∈ {sprint, epic, hypothesis}, deadline은 해당 마감 timestamp."""
+
+    entity_type: str
+    entity_id: uuid.UUID
+    deadline: datetime | None
+    status: str | None
+    target_agent_id: uuid.UUID | None
+
+
+@dataclass(frozen=True)
+class DroughtTarget:
+    """가뭄 평가 대상. entity_type ∈ {story, sprint}. story는 status로 in-progress/in-review 구분."""
+
+    entity_type: str
+    entity_id: uuid.UUID
+    status: str | None
+    last_activity_at: datetime | None
+    target_agent_id: uuid.UUID | None
+
+
+@dataclass(frozen=True)
+class VelocityTarget:
+    """속도 평가 대상(sprint). elapsed_ratio=(now-start)/(end-start) [0..1+], 포인트는 SP."""
+
+    sprint_id: uuid.UUID
+    target_agent_id: uuid.UUID | None
+    elapsed_ratio: float
+    done_points: float
+    committed_points: float
+    capacity_points: float | None = None
+
+
+class HeuristicEvaluator:
+    """threshold를 주입받아 휴리스틱 3종을 평가하는 순수 evaluator(AC①: I/O·LLM 없음)."""
+
+    def __init__(self, thresholds: HeuristicThresholds | None = None) -> None:
+        self.t = thresholds or HeuristicThresholds.from_env()
+
+    # ── ① 데드라인 ──────────────────────────────────────────────────────────────
+    def evaluate_deadline(
+        self, target: DeadlineTarget, now: datetime, *, source_activity_seq: int | None = None
+    ) -> list[TriggerDecision]:
+        if target.target_agent_id is None or target.deadline is None:
+            return []  # 알릴 대상/마감이 없으면 발사 불가.
+        if _is_terminal(target.status):
+            return []  # done/closed/n_a skip(AC①·④).
+
+        kind = _norm_status(target.entity_type)
+        window = {
+            "sprint": self.t.deadline_sprint_end_h,
+            "epic": self.t.deadline_epic_target_h,
+            "hypothesis": self.t.deadline_measure_after_h,
+        }.get(kind)
+        if window is None:
+            return []  # 데드라인 소스는 sprint/epic/hypothesis만(AC④).
+
+        remaining_h = _hours_until(target.deadline, now)
+        if remaining_h > window:
+            return []  # 아직 윈도우 밖.
+
+        if remaining_h < 0:
+            reason = f"{kind} 마감이 {abs(remaining_h):.0f}h 초과됨"
+        else:
+            reason = f"{kind} 마감까지 {remaining_h:.0f}h 남음(임계 {window:.0f}h)"
+        return [
+            TriggerDecision(
+                trigger_type="deadline_approaching",
+                target_agent_id=target.target_agent_id,
+                anchor_type=kind,
+                anchor_id=target.entity_id,
+                reason=reason,
+                source_activity_seq=source_activity_seq,
+            )
+        ]
+
+    # ── ② 이벤트 가뭄 ───────────────────────────────────────────────────────────
+    def evaluate_drought(
+        self, target: DroughtTarget, now: datetime, *, source_activity_seq: int | None = None
+    ) -> list[TriggerDecision]:
+        if target.target_agent_id is None or target.last_activity_at is None:
+            return []  # 알릴 대상/활동 기준점이 없으면 평가 불가.
+
+        etype = _norm_status(target.entity_type)
+        status = _norm_status(target.status)
+        if etype == "story":
+            if status == "in-progress":
+                threshold = self.t.drought_in_progress_h
+            elif status == "in-review":
+                threshold = self.t.drought_in_review_h
+            else:
+                return []  # 가뭄은 진행/리뷰 중 story만(terminal·todo 제외).
+        elif etype == "sprint":
+            threshold = self.t.drought_sprint_h
+        else:
+            return []
+
+        idle_h = _hours_since(target.last_activity_at, now)
+        if idle_h < threshold:
+            return []
+        return [
+            TriggerDecision(
+                trigger_type="event_drought",
+                target_agent_id=target.target_agent_id,
+                anchor_type=etype,
+                anchor_id=target.entity_id,
+                reason=f"{etype}{'/' + status if status else ''} {idle_h:.0f}h 무활동(임계 {threshold:.0f}h)",
+                source_activity_seq=source_activity_seq,
+            )
+        ]
+
+    # ── ③ 속도 급변 ─────────────────────────────────────────────────────────────
+    def evaluate_velocity(
+        self, target: VelocityTarget, now: datetime, *, source_activity_seq: int | None = None
+    ) -> list[TriggerDecision]:
+        if target.target_agent_id is None:
+            return []
+
+        decisions: list[TriggerDecision] = []
+        elapsed = target.elapsed_ratio
+        committed = target.committed_points
+        done = target.done_points
+        expected = committed * elapsed if committed > 0 else 0.0
+
+        def mk(trigger_type: str, reason: str) -> TriggerDecision:
+            return TriggerDecision(
+                trigger_type=trigger_type,
+                target_agent_id=target.target_agent_id,  # type: ignore[arg-type]
+                anchor_type="sprint",
+                anchor_id=target.sprint_id,
+                reason=reason,
+                source_activity_seq=source_activity_seq,
+            )
+
+        # lag: 충분히 경과했는데(≥30%) done이 기대의 절반 미만.
+        if (
+            elapsed >= self.t.velocity_lag_elapsed_ratio
+            and expected > 0
+            and done < expected * self.t.velocity_lag_done_ratio
+        ):
+            decisions.append(
+                mk(
+                    "velocity_lag",
+                    f"경과 {elapsed * 100:.0f}%인데 done {done:.0f}SP < 기대 {expected:.0f}SP의 "
+                    f"{self.t.velocity_lag_done_ratio * 100:.0f}%",
+                )
+            )
+
+        # spike: done이 기대를 크게 초과(과소추정·범위 누락 신호).
+        if expected > 0 and done > expected * self.t.velocity_spike_factor:
+            decisions.append(
+                mk(
+                    "velocity_spike",
+                    f"done {done:.0f}SP가 기대 {expected:.0f}SP의 {self.t.velocity_spike_factor:.1f}x 초과",
+                )
+            )
+
+        # scope creep: committed가 capacity를 120% 초과.
+        cap = target.capacity_points
+        if cap is not None and cap > 0 and committed > cap * self.t.velocity_scope_creep_factor:
+            decisions.append(
+                mk(
+                    "scope_creep",
+                    f"committed {committed:.0f}SP가 capacity {cap:.0f}SP의 "
+                    f"{self.t.velocity_scope_creep_factor * 100:.0f}% 초과",
+                )
+            )
+
+        return decisions

--- a/backend/tests/test_l2_heuristics.py
+++ b/backend/tests/test_l2_heuristics.py
@@ -1,0 +1,197 @@
+"""L2-S4: Phase 1 휴리스틱 evaluator 단위 테스트.
+
+AC① pure/read-only·LLM/외부호출 0(import 가드)·AC② threshold env·AC③ decision 필드·
+AC④ Sprint.end_date/Epic.target_date/measure_after만(story due_date 없음).
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from app.services import l2_heuristics as mod
+from app.services.l2_heuristics import (
+    DeadlineTarget,
+    DroughtTarget,
+    HeuristicEvaluator,
+    HeuristicThresholds,
+    TriggerDecision,
+    VelocityTarget,
+)
+
+NOW = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+AGENT = uuid.uuid4()
+
+
+def _eval(**over):
+    return HeuristicEvaluator(HeuristicThresholds(**over)) if over else HeuristicEvaluator(HeuristicThresholds())
+
+
+# ── ① 데드라인 ─────────────────────────────────────────────────────────────────
+
+def test_deadline_sprint_within_24h_fires():
+    t = DeadlineTarget("sprint", uuid.uuid4(), NOW + timedelta(hours=10), "active", AGENT)
+    out = _eval().evaluate_deadline(t, NOW, source_activity_seq=42)
+    assert len(out) == 1
+    d = out[0]
+    assert d.trigger_type == "deadline_approaching"
+    assert d.target_agent_id == AGENT and d.anchor_type == "sprint" and d.anchor_id == t.entity_id
+    assert d.source_activity_seq == 42 and "남음" in d.reason
+
+
+def test_deadline_sprint_outside_window_skips():
+    t = DeadlineTarget("sprint", uuid.uuid4(), NOW + timedelta(hours=48), "active", AGENT)
+    assert _eval().evaluate_deadline(t, NOW) == []
+
+
+def test_deadline_epic_uses_3d_window():
+    # 50h 남음: sprint(24h) 윈도우면 skip이지만 epic(72h) 윈도우면 발사.
+    t = DeadlineTarget("epic", uuid.uuid4(), NOW + timedelta(hours=50), "active", AGENT)
+    assert len(_eval().evaluate_deadline(t, NOW)) == 1
+
+
+def test_deadline_hypothesis_measure_after_24h():
+    t = DeadlineTarget("hypothesis", uuid.uuid4(), NOW + timedelta(hours=5), "testing", AGENT)
+    out = _eval().evaluate_deadline(t, NOW)
+    assert len(out) == 1 and out[0].anchor_type == "hypothesis"
+
+
+def test_deadline_overdue_fires_with_overdue_reason():
+    t = DeadlineTarget("sprint", uuid.uuid4(), NOW - timedelta(hours=6), "active", AGENT)
+    out = _eval().evaluate_deadline(t, NOW)
+    assert len(out) == 1 and "초과" in out[0].reason
+
+
+def test_deadline_terminal_status_skips():
+    for s in ("done", "closed", "n/a", "n_a", "cancelled"):
+        t = DeadlineTarget("sprint", uuid.uuid4(), NOW + timedelta(hours=1), s, AGENT)
+        assert _eval().evaluate_deadline(t, NOW) == [], s
+
+
+def test_deadline_none_deadline_or_agent_skips():
+    assert _eval().evaluate_deadline(DeadlineTarget("sprint", uuid.uuid4(), None, "active", AGENT), NOW) == []
+    assert _eval().evaluate_deadline(
+        DeadlineTarget("sprint", uuid.uuid4(), NOW + timedelta(hours=1), "active", None), NOW
+    ) == []
+
+
+def test_deadline_unknown_entity_type_skips():
+    # story-level due_date는 없음(AC④) — story는 데드라인 소스가 아님.
+    t = DeadlineTarget("story", uuid.uuid4(), NOW + timedelta(hours=1), "in-progress", AGENT)
+    assert _eval().evaluate_deadline(t, NOW) == []
+
+
+# ── ② 이벤트 가뭄 ──────────────────────────────────────────────────────────────
+
+def test_drought_in_progress_24h_fires():
+    t = DroughtTarget("story", uuid.uuid4(), "in-progress", NOW - timedelta(hours=25), AGENT)
+    out = _eval().evaluate_drought(t, NOW)
+    assert len(out) == 1 and out[0].trigger_type == "event_drought" and out[0].anchor_type == "story"
+
+
+def test_drought_in_review_uses_12h():
+    # 18h 무활동: in-progress(24h)면 skip이나 in-review(12h)면 발사.
+    assert len(_eval().evaluate_drought(DroughtTarget("story", uuid.uuid4(), "in-review", NOW - timedelta(hours=18), AGENT), NOW)) == 1
+    assert _eval().evaluate_drought(DroughtTarget("story", uuid.uuid4(), "in-progress", NOW - timedelta(hours=18), AGENT), NOW) == []
+
+
+def test_drought_sprint_36h():
+    assert len(_eval().evaluate_drought(DroughtTarget("sprint", uuid.uuid4(), "active", NOW - timedelta(hours=40), AGENT), NOW)) == 1
+    assert _eval().evaluate_drought(DroughtTarget("sprint", uuid.uuid4(), "active", NOW - timedelta(hours=30), AGENT), NOW) == []
+
+
+def test_drought_below_threshold_skips():
+    assert _eval().evaluate_drought(DroughtTarget("story", uuid.uuid4(), "in-progress", NOW - timedelta(hours=2), AGENT), NOW) == []
+
+
+def test_drought_none_last_activity_or_non_active_story_skips():
+    assert _eval().evaluate_drought(DroughtTarget("story", uuid.uuid4(), "in-progress", None, AGENT), NOW) == []
+    # todo/done story는 가뭄 대상 아님.
+    assert _eval().evaluate_drought(DroughtTarget("story", uuid.uuid4(), "todo", NOW - timedelta(hours=99), AGENT), NOW) == []
+
+
+# ── ③ 속도 급변 ────────────────────────────────────────────────────────────────
+
+def test_velocity_lag_fires():
+    # 경과 60%, committed 100 → 기대 60SP, done 20 < 30(=60*0.5) → lag.
+    t = VelocityTarget(uuid.uuid4(), AGENT, elapsed_ratio=0.6, done_points=20, committed_points=100, capacity_points=100)
+    out = _eval().evaluate_velocity(t, NOW)
+    types = {d.trigger_type for d in out}
+    assert "velocity_lag" in types
+
+
+def test_velocity_spike_fires():
+    # 경과 20%, committed 100 → 기대 20SP, done 60 > 50(=20*2.5) → spike.
+    t = VelocityTarget(uuid.uuid4(), AGENT, elapsed_ratio=0.2, done_points=60, committed_points=100, capacity_points=200)
+    assert "velocity_spike" in {d.trigger_type for d in _eval().evaluate_velocity(t, NOW)}
+
+
+def test_velocity_scope_creep_fires():
+    # committed 130 > capacity 100*1.2=120 → scope_creep.
+    t = VelocityTarget(uuid.uuid4(), AGENT, elapsed_ratio=0.5, done_points=50, committed_points=130, capacity_points=100)
+    assert "scope_creep" in {d.trigger_type for d in _eval().evaluate_velocity(t, NOW)}
+
+
+def test_velocity_healthy_sprint_no_decisions():
+    # 경과 50%, 기대 50SP, done 50(정시)·committed≤capacity → 무발사.
+    t = VelocityTarget(uuid.uuid4(), AGENT, elapsed_ratio=0.5, done_points=50, committed_points=100, capacity_points=100)
+    assert _eval().evaluate_velocity(t, NOW) == []
+
+
+def test_velocity_multiple_fire_together():
+    # lag(경과 50%·done 10<25) + scope_creep(committed 200>capacity 100*1.2).
+    t = VelocityTarget(uuid.uuid4(), AGENT, elapsed_ratio=0.5, done_points=10, committed_points=200, capacity_points=100)
+    types = {d.trigger_type for d in _eval().evaluate_velocity(t, NOW)}
+    assert {"velocity_lag", "scope_creep"} <= types
+
+
+def test_velocity_no_target_agent_skips():
+    t = VelocityTarget(uuid.uuid4(), None, elapsed_ratio=0.9, done_points=0, committed_points=100, capacity_points=10)
+    assert _eval().evaluate_velocity(t, NOW) == []
+
+
+# ── AC②: threshold env config ──────────────────────────────────────────────────
+
+def test_thresholds_from_env_override_and_bad_value_fallback():
+    env = {
+        "L2_DEADLINE_SPRINT_END_H": "6",
+        "L2_VELOCITY_SPIKE_FACTOR": "3.0",
+        "L2_DROUGHT_SPRINT_H": "not-a-number",  # 폴백.
+    }
+    t = HeuristicThresholds.from_env(env)
+    assert t.deadline_sprint_end_h == 6.0
+    assert t.velocity_spike_factor == 3.0
+    assert t.drought_sprint_h == HeuristicThresholds().drought_sprint_h  # 폴백 기본값.
+
+
+def test_env_threshold_changes_decision():
+    # 기본 24h면 skip인 10h 잔여가, env로 6h→12h 늘리면 발사.
+    t = DeadlineTarget("sprint", uuid.uuid4(), NOW + timedelta(hours=10), "active", AGENT)
+    assert HeuristicEvaluator(HeuristicThresholds(deadline_sprint_end_h=6.0)).evaluate_deadline(t, NOW) == []
+    assert len(HeuristicEvaluator(HeuristicThresholds(deadline_sprint_end_h=12.0)).evaluate_deadline(t, NOW)) == 1
+
+
+# ── AC①: pure / read-only · LLM·네트워크 import 0 (import 가드) ─────────────────
+
+def test_module_has_no_llm_or_network_imports():
+    src = inspect.getsource(mod)
+    forbidden = ("openai", "anthropic", "httpx", "requests", "aiohttp", "urllib", "boto3", "litellm")
+    for name in forbidden:
+        assert f"import {name}" not in src and f"from {name}" not in src, name
+
+
+def test_evaluator_methods_take_no_db_session():
+    # read-only 보증: 평가 메서드 시그니처에 db/session/AsyncSession 파라미터가 없어야 한다.
+    for m in ("evaluate_deadline", "evaluate_drought", "evaluate_velocity"):
+        params = set(inspect.signature(getattr(HeuristicEvaluator, m)).parameters)
+        assert not (params & {"db", "session", "conn"}), m
+
+
+def test_decision_is_frozen_and_has_ac3_fields():
+    d = TriggerDecision("t", AGENT, "sprint", uuid.uuid4(), "r", 1)
+    for f in ("trigger_type", "target_agent_id", "anchor_type", "anchor_id", "reason", "source_activity_seq"):
+        assert hasattr(d, f)
+    import pytest
+
+    with pytest.raises(Exception):
+        d.reason = "x"  # type: ignore[misc]


### PR DESCRIPTION
## L2-S4 — Phase 1 휴리스틱 evaluator (deadline / drought / velocity)

블루프린트 §2·§5 S4. L1 활동·엔티티 상태로부터 L2 트리거 후보를 산출하는 **순수(pure)·read-only** 휴리스틱 모듈(`app/services/l2_heuristics.py`). **DB변경 0**·`ActivitySignal`(S3) 입력.

### `HeuristicEvaluator` — I/O·LLM·네트워크 0 (AC①)
워커(S5)가 조회한 상태를 입력 dataclass(`DeadlineTarget`/`DroughtTarget`/`VelocityTarget`)로 넘기면, threshold만 적용해 **`TriggerDecision`**(`trigger_type`/`target_agent_id`/`anchor_type`/`anchor_id`/`reason`/`source_activity_seq`) 리스트를 반환(**AC③**).

- **① 데드라인** `deadline_approaching`: `Sprint.end_date≤24h`·`Epic.target_date≤3d`·`Hypothesis.measure_after≤24h`(entity_type별 윈도우)·terminal(done/closed/n_a) skip·overdue도 발사. **story-level due_date는 없음 → 위 3개 소스만(AC④).**
- **② 이벤트 가뭄** `event_drought`: story `in-progress 24h`·`in-review 12h`·sprint `36h` 무활동(`last_activity_at` 기준). terminal·todo story 제외.
- **③ 속도 급변**: `velocity_lag`(elapsed≥30% & done<기대*0.5)·`velocity_spike`(done>기대*2.5)·`scope_creep`(committed>capacity*120%). 기대=`committed*elapsed_ratio`. 복수 동시 발사 가능.

### `HeuristicThresholds.from_env` — env config (AC②)
`L2_DEADLINE_*`·`L2_DROUGHT_*`·`L2_VELOCITY_*` 키로 오버라이드. 파싱 실패 시 기본값 폴백(startup 안전).

### Validation
신규 `test_l2_heuristics.py` **24 passed** — 3종 윈도우·epic 3d vs sprint 24h 분기·overdue·terminal/None skip·가뭄 임계·속도 lag/spike/scope_creep/복수발사/healthy·env override+bad-value 폴백·**import 가드(LLM·네트워크 import 0·평가 메서드 db/session 파라미터 부재)**·frozen decision. py_compile·import OK.

> L2 에픽 `4e8d3405` S4. consumer는 S5 워커(상태 조회→평가→firing dedup). 다음 S5(worker)→S6(dedup)→S7(E2E)→S8(config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)