### PR TITLE
feat(l2): L2 trigger worker loop lifespan/default-off/advisory-lock (L2-S5)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     # E-EVENTBUS: dev=true, prod=false (기존 웹훅 병행 운영)
     eventbus_enabled: bool = False
 
+    # E-L2 휴리스틱 트리거 워커. default-off — 명시 활성화 전엔 lifespan task 미생성(무동작).
+    # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
+    l2_trigger_enabled: bool = False
+    l2_trigger_advisory_lock: bool = False
+
     # E-MEMBER-SSOT AC2-3: 신원 해소를 anchor(members+member_identity_aliases) 기반으로 전환하는
     # shadow 플래그. off(기본)=레거시 resolver(org_members/team_members). on=anchor resolver.
     # 라이브 cutover는 AC3-1 — 여기선 shadow(parity 검증용), 기본 off라 실 read 경로 무변경.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,20 +21,35 @@ async def lifespan(app: FastAPI):
     from app.core.database import engine
     from app.services.pg_pubsub import listen_loop
     task = asyncio.create_task(listen_loop())
+    # E-L2 S5: 휴리스틱 트리거 워커는 default-off — 명시 활성화 시에만 task 생성(AC①).
+    l2_task = None
+    if settings.l2_trigger_enabled:
+        from app.services.l2_trigger_worker import L2TriggerWorker
+
+        l2_task = asyncio.create_task(L2TriggerWorker().run())
     try:
         yield
     finally:
         task.cancel()
+        if l2_task is not None:
+            l2_task.cancel()
         try:
-            await task
-        except asyncio.CancelledError:
-            pass
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            if l2_task is not None:
+                try:
+                    await l2_task
+                except asyncio.CancelledError:
+                    pass
         finally:
             # 좀비 연결 박멸(S:33e0c681): SIGTERM(Cloud Run 인스턴스 교체·스케일다운·리비전 삭제)
             # 시 SQLAlchemy 풀의 전 DB 연결을 정상 종료. dispose 누락 시 구 인스턴스가 연결을 안
             # 놓아 좀비 누적 → prod 100 cap 초과 → TooManyConnections(전 엔드포인트 500). lifespan
             # shutdown 은 in-flight 요청 drain 이후 실행되므로 dispose 순서 안전(AC3). pg_pubsub
-            # raw 커넥션은 task.cancel→listen_loop finally 에서 이미 close.
+            # raw 커넥션은 task.cancel→listen_loop finally 에서 이미 close. L2 워커는
+            # l2_task.cancel→run finally 에서 advisory lock 해제·전용 커넥션 close.
             await engine.dispose()
 
 

--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -1,0 +1,259 @@
+"""L2-S5: L2 트리거 워커 루프 (lifespan task · default-off · advisory lock).
+
+블루프린트 §3·§5 S5. L1 활동 스트림 cursor poll(`L1ActivitySource`·S3) + 주기 데드라인 스캔으로
+휴리스틱 evaluator(S4)를 구동하는 백그라운드 워커. `pg_pubsub.listen_loop`의 lifespan task 패턴을
+재사용한다.
+
+설계 원칙:
+  · **default-off (AC①)** — `settings.l2_trigger_enabled`가 true일 때만 lifespan이 task를 만든다.
+    꺼져 있으면 task 자체가 없어 오버헤드 0.
+  · **cursor 전진은 처리 성공 후에만 (AC②)** — 배치 처리 중 예외가 나면 cursor를 올리지 않아 다음
+    iteration이 같은 배치를 재처리한다(중복 발사는 S6 dedup이 흡수).
+  · **advisory lock (AC③)** — `settings.l2_trigger_advisory_lock`가 켜지면 전용 커넥션에서
+    `pg_try_advisory_lock` holder인 인스턴스만 poll/evaluate. 멀티인스턴스 중복 구동 방지.
+  · **backoff** — iteration 실패 시 1s→30s 지수 백오프, 성공 시 리셋.
+  · **graceful shutdown** — CancelledError 수신 시 advisory lock 해제·커넥션 정리 후 종료.
+
+실 wake/dispatch(=`l2_trigger_firings` dedup + 발사 + 에이전트 wake)는 **S6**에서 `_dispatch_decisions`
+seam을 채운다. S5는 결정(`TriggerDecision`)만 산출·로깅한다.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import bindparam, text
+
+from app.core.config import settings
+from app.services.l1_activity_source import L1ActivitySource
+from app.services.l2_heuristics import (
+    DeadlineTarget,
+    HeuristicEvaluator,
+    HeuristicThresholds,
+    TriggerDecision,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class L2TriggerWorker:
+    """L2 휴리스틱 트리거 워커. lifespan startup에서 `asyncio.create_task(worker.run())`."""
+
+    WORKER_NAME = "l2_trigger"
+    # 멀티인스턴스 단일 holder 보장용 advisory lock 키("L2TR" ASCII). 다른 advisory 사용처와 비충돌.
+    _ADVISORY_LOCK_KEY = 0x4C325452
+    # 데드라인 nudge 불필요한 hypothesis 종결 상태.
+    _HYPOTHESIS_TERMINAL = ("verified", "falsified", "killed", "archived")
+
+    def __init__(
+        self,
+        *,
+        poll_interval_s: float = 5.0,
+        deadline_scan_interval_s: float = 300.0,
+        batch_limit: int = 200,
+        backoff_min: float = 1.0,
+        backoff_max: float = 30.0,
+        thresholds: HeuristicThresholds | None = None,
+        use_advisory_lock: bool | None = None,
+    ) -> None:
+        self.poll_interval_s = poll_interval_s
+        self.deadline_scan_interval_s = deadline_scan_interval_s
+        self.batch_limit = batch_limit
+        self.backoff_min = backoff_min
+        self.backoff_max = backoff_max
+        self.source = L1ActivitySource()
+        self.evaluator = HeuristicEvaluator(thresholds)
+        self.use_advisory_lock = (
+            settings.l2_trigger_advisory_lock if use_advisory_lock is None else use_advisory_lock
+        )
+        self._lock_conn = None  # 전용 AsyncConnection — advisory lock 보유 동안 유지.
+        self._holds_lock = False
+
+    # ── 메인 루프 ────────────────────────────────────────────────────────────────
+    async def run(self) -> None:
+        logger.info(
+            "L2 trigger worker starting (advisory_lock=%s, poll=%.0fs, deadline_scan=%.0fs)",
+            self.use_advisory_lock,
+            self.poll_interval_s,
+            self.deadline_scan_interval_s,
+        )
+        delay = self.backoff_min
+        last_deadline_scan = 0.0
+        try:
+            while True:
+                try:
+                    if not await self._ensure_lock():
+                        # standby — 다른 인스턴스가 holder. 주기적으로 재시도.
+                        await asyncio.sleep(self.poll_interval_s)
+                        continue
+
+                    from app.core.database import async_session_factory
+
+                    async with async_session_factory() as db:
+                        await self._poll_once(db)
+                        now_mono = time.monotonic()
+                        if now_mono - last_deadline_scan >= self.deadline_scan_interval_s:
+                            await self._scan_deadlines(db)
+                            last_deadline_scan = now_mono
+
+                    delay = self.backoff_min  # 성공 → backoff 리셋(AC backoff).
+                    await asyncio.sleep(self.poll_interval_s)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning("L2 worker iteration error: %s — backoff %.1fs", exc, delay)
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self.backoff_max)
+        except asyncio.CancelledError:
+            logger.info("L2 trigger worker cancelled — shutting down")
+        finally:
+            await self._release_lock()
+
+    # ── advisory lock (AC③) ──────────────────────────────────────────────────────
+    async def _ensure_lock(self) -> bool:
+        """advisory lock 미사용 시 항상 True. 사용 시 holder만 True(전용 커넥션·AUTOCOMMIT)."""
+        if not self.use_advisory_lock:
+            return True
+        if self._holds_lock:
+            return True
+        if self._lock_conn is None:
+            from app.core.database import engine
+
+            self._lock_conn = await engine.connect()
+            await self._lock_conn.execution_options(isolation_level="AUTOCOMMIT")
+        got = (
+            await self._lock_conn.execute(
+                text("SELECT pg_try_advisory_lock(:k)"), {"k": self._ADVISORY_LOCK_KEY}
+            )
+        ).scalar()
+        self._holds_lock = bool(got)
+        if self._holds_lock:
+            logger.info("L2 worker acquired advisory lock")
+        else:
+            logger.debug("L2 worker standby — advisory lock held by another instance")
+        return self._holds_lock
+
+    async def _release_lock(self) -> None:
+        if self._lock_conn is None:
+            return
+        try:
+            if self._holds_lock:
+                await self._lock_conn.execute(
+                    text("SELECT pg_advisory_unlock(:k)"), {"k": self._ADVISORY_LOCK_KEY}
+                )
+            await self._lock_conn.close()
+        except Exception as exc:  # shutdown 경로 — 실패해도 조용히 정리.
+            logger.debug("L2 worker lock release error: %s", exc)
+        finally:
+            self._lock_conn = None
+            self._holds_lock = False
+
+    # ── cursor poll (AC②) ────────────────────────────────────────────────────────
+    async def _poll_once(self, db) -> list[TriggerDecision]:
+        """cursor 이후 활동을 poll·평가하고, **성공 시에만** cursor를 전진(AC②)."""
+        cursor = await self._read_cursor(db)
+        signals, _next = await self.source.poll_after_seq(
+            db, cursor, limit=self.batch_limit, org_id=None
+        )
+        if not signals:
+            return []
+        decisions = await self._evaluate_signals(db, signals)
+        self._dispatch_decisions(decisions)
+        # 처리 중 예외가 났다면 여기 도달 못 함 → cursor 미전진 → 다음 iter 재처리(AC②).
+        await self._write_cursor(db, signals[-1].activity_seq)
+        return decisions
+
+    async def _read_cursor(self, db) -> int:
+        row = (
+            await db.execute(
+                text(
+                    "SELECT last_activity_seq FROM l2_trigger_state "
+                    "WHERE worker_name = :w AND org_id IS NOT DISTINCT FROM :org"
+                ),
+                {"w": self.WORKER_NAME, "org": None},
+            )
+        ).scalar()
+        return int(row) if row is not None else 0
+
+    async def _write_cursor(self, db, seq: int) -> None:
+        # org_id NULL(global 시스템 워커) — IS NOT DISTINCT FROM으로 NULL 매칭. 행 없으면 INSERT.
+        res = await db.execute(
+            text(
+                "UPDATE l2_trigger_state SET last_activity_seq = :seq, updated_at = now() "
+                "WHERE worker_name = :w AND org_id IS NOT DISTINCT FROM :org"
+            ),
+            {"seq": seq, "w": self.WORKER_NAME, "org": None},
+        )
+        if res.rowcount == 0:
+            await db.execute(
+                text(
+                    "INSERT INTO l2_trigger_state (worker_name, org_id, last_activity_seq, updated_at) "
+                    "VALUES (:w, :org, :seq, now())"
+                ),
+                {"w": self.WORKER_NAME, "org": None, "seq": seq},
+            )
+        await db.commit()
+
+    async def _evaluate_signals(self, db, signals) -> list[TriggerDecision]:
+        """활동-구동 평가 seam. 활동별 엔티티 상태 fetch + drought/velocity 평가는 **S6**가 채운다
+        (실 발사와 동일 트랜잭션이라 firing과 함께 구현). S5는 빈 결정으로 cursor 머신러리만 검증."""
+        _ = (db, signals)
+        return []
+
+    # ── 주기 데드라인 스캔 (시간-구동·활동 무관) ──────────────────────────────────
+    async def _scan_deadlines(self, db) -> list[TriggerDecision]:
+        """measure_after가 임박한 비종결 hypothesis를 스캔해 deadline 휴리스틱을 평가.
+
+        deadline은 활동이 발생하지 않으므로 cursor poll로는 못 잡는다 — 별도 주기 스캔.
+        target은 agent-가능한 drafted_by/created_by(휴먼 owner는 wake 대상 아님). 둘 다 없으면 skip.
+        Sprint.end_date·Epic.target_date 스캔은 해당 엔티티 fetch·target 해소와 함께 S6에서 확장.
+        """
+        now = _utcnow()
+        horizon = now + timedelta(hours=self.evaluator.t.deadline_measure_after_h)
+        rows = (
+            await db.execute(
+                text(
+                    "SELECT id, measure_after, status, drafted_by_member_id, created_by_member_id "
+                    "FROM hypotheses "
+                    "WHERE status NOT IN :terminal AND measure_after <= :horizon"
+                ).bindparams(bindparam("terminal", expanding=True)),
+                {"terminal": list(self._HYPOTHESIS_TERMINAL), "horizon": horizon},
+            )
+        ).mappings().all()
+
+        decisions: list[TriggerDecision] = []
+        for r in rows:
+            target = r["drafted_by_member_id"] or r["created_by_member_id"]
+            decisions.extend(
+                self.evaluator.evaluate_deadline(
+                    DeadlineTarget(
+                        entity_type="hypothesis",
+                        entity_id=r["id"],
+                        deadline=r["measure_after"],
+                        status=r["status"],
+                        target_agent_id=target,
+                    ),
+                    now,
+                )
+            )
+        self._dispatch_decisions(decisions)
+        return decisions
+
+    # ── 발사 seam (S6에서 dedup + firing + wake 구현) ─────────────────────────────
+    def _dispatch_decisions(self, decisions: list[TriggerDecision]) -> None:
+        """S6 seam: `l2_trigger_firings` dedup(dedup_key) + firing insert + 에이전트 wake/dispatch.
+
+        S5는 실 발사를 하지 않고 산출된 결정만 로깅한다.
+        """
+        if decisions:
+            logger.info(
+                "L2 worker produced %d trigger decision(s) [firing deferred to S6]: %s",
+                len(decisions),
+                [d.trigger_type for d in decisions],
+            )

--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -1,0 +1,198 @@
+"""L2-S5: L2 트리거 워커 루프 단위 테스트.
+
+AC① default-off·AC② cursor 성공 후만 전진(실패 시 미전진)·AC③ advisory lock holder만 동작.
+백오프 리셋/성장·graceful shutdown·deadline scan evaluator 통합.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.services.l1_activity_source import ActivitySignal
+from app.services.l2_trigger_worker import L2TriggerWorker
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _sig(seq: int) -> ActivitySignal:
+    return ActivitySignal(
+        activity_seq=seq,
+        activity_id=uuid.uuid4(),
+        org_id=uuid.uuid4(),
+        project_id=uuid.uuid4(),
+        verb="dispatched",
+        occurred_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+    )
+
+
+# ── AC①: default-off ─────────────────────────────────────────────────────────
+
+def test_l2_trigger_disabled_by_default():
+    assert settings.l2_trigger_enabled is False
+    assert settings.l2_trigger_advisory_lock is False
+
+
+# ── AC②: cursor 성공 후만 전진 ────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_poll_advances_cursor_on_success():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    db = AsyncMock()
+    with patch.object(w, "_read_cursor", AsyncMock(return_value=10)), \
+         patch.object(w.source, "poll_after_seq", AsyncMock(return_value=([_sig(11), _sig(15)], None))), \
+         patch.object(w, "_evaluate_signals", AsyncMock(return_value=[])), \
+         patch.object(w, "_write_cursor", AsyncMock()) as wc:
+        await w._poll_once(db)
+    wc.assert_awaited_once()
+    assert wc.await_args.args[1] == 15  # 마지막 처리 seq로 전진.
+
+
+@pytest.mark.anyio
+async def test_poll_does_not_advance_cursor_when_processing_fails():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    db = AsyncMock()
+    with patch.object(w, "_read_cursor", AsyncMock(return_value=10)), \
+         patch.object(w.source, "poll_after_seq", AsyncMock(return_value=([_sig(11)], None))), \
+         patch.object(w, "_evaluate_signals", AsyncMock(side_effect=RuntimeError("boom"))), \
+         patch.object(w, "_write_cursor", AsyncMock()) as wc:
+        with pytest.raises(RuntimeError):
+            await w._poll_once(db)
+    wc.assert_not_awaited()  # 실패 시 cursor 미전진(AC②) → 다음 iter 재처리.
+
+
+@pytest.mark.anyio
+async def test_poll_empty_batch_no_cursor_write():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    with patch.object(w, "_read_cursor", AsyncMock(return_value=99)), \
+         patch.object(w.source, "poll_after_seq", AsyncMock(return_value=([], None))), \
+         patch.object(w, "_write_cursor", AsyncMock()) as wc:
+        out = await w._poll_once(AsyncMock())
+    assert out == [] and not wc.await_count
+
+
+@pytest.mark.anyio
+async def test_write_cursor_inserts_when_no_row():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    db = AsyncMock()
+    update_res = MagicMock()
+    update_res.rowcount = 0  # UPDATE가 0행 → INSERT 경로.
+    db.execute = AsyncMock(return_value=update_res)
+    await w._write_cursor(db, 42)
+    assert db.execute.await_count == 2  # UPDATE 후 INSERT.
+    db.commit.assert_awaited_once()
+
+
+# ── AC③: advisory lock ────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_ensure_lock_disabled_always_true():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    assert await w._ensure_lock() is True
+
+
+@pytest.mark.anyio
+async def test_ensure_lock_holder_true_standby_false():
+    # holder: pg_try_advisory_lock → True.
+    w = L2TriggerWorker(use_advisory_lock=True)
+    conn = AsyncMock()
+    lock_res = MagicMock()
+    lock_res.scalar.return_value = True
+    conn.execute = AsyncMock(return_value=lock_res)
+    conn.execution_options = AsyncMock()
+    with patch("app.core.database.engine") as eng:
+        eng.connect = AsyncMock(return_value=conn)
+        assert await w._ensure_lock() is True
+        assert w._holds_lock is True
+        # 이미 보유 시 재호출은 추가 lock 쿼리 없이 True.
+        conn.execute.reset_mock()
+        assert await w._ensure_lock() is True
+        conn.execute.assert_not_awaited()
+
+    # standby: 다른 인스턴스가 holder → False.
+    w2 = L2TriggerWorker(use_advisory_lock=True)
+    conn2 = AsyncMock()
+    res2 = MagicMock()
+    res2.scalar.return_value = False
+    conn2.execute = AsyncMock(return_value=res2)
+    conn2.execution_options = AsyncMock()
+    with patch("app.core.database.engine") as eng2:
+        eng2.connect = AsyncMock(return_value=conn2)
+        assert await w2._ensure_lock() is False
+        assert w2._holds_lock is False
+
+
+@pytest.mark.anyio
+async def test_release_lock_unlocks_and_closes():
+    w = L2TriggerWorker(use_advisory_lock=True)
+    conn = AsyncMock()
+    w._lock_conn = conn
+    w._holds_lock = True
+    await w._release_lock()
+    # pg_advisory_unlock 실행 + close.
+    assert conn.execute.await_count == 1
+    conn.close.assert_awaited_once()
+    assert w._lock_conn is None and w._holds_lock is False
+
+
+# ── deadline scan: evaluator 통합 ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_scan_deadlines_fires_for_imminent_hypothesis():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    agent = uuid.uuid4()
+    hyp_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [
+        {  # 임박(5h 후) + drafted_by 있음 → 발사.
+            "id": hyp_id,
+            "measure_after": now + timedelta(hours=5),
+            "status": "measuring",
+            "drafted_by_member_id": agent,
+            "created_by_member_id": None,
+        },
+        {  # target 없음(drafted/created 둘 다 None) → evaluator skip.
+            "id": uuid.uuid4(),
+            "measure_after": now + timedelta(hours=2),
+            "status": "active",
+            "drafted_by_member_id": None,
+            "created_by_member_id": None,
+        },
+    ]
+    result = MagicMock()
+    result.mappings.return_value.all.return_value = rows
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=result)
+    with patch.object(w, "_dispatch_decisions") as disp:
+        decisions = await w._scan_deadlines(db)
+    assert len(decisions) == 1
+    d = decisions[0]
+    assert d.trigger_type == "deadline_approaching"
+    assert d.anchor_type == "hypothesis" and d.anchor_id == hyp_id and d.target_agent_id == agent
+    disp.assert_called_once()
+
+
+# ── graceful shutdown ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_run_cancels_gracefully_and_releases_lock():
+    w = L2TriggerWorker(use_advisory_lock=False, poll_interval_s=0.01)
+    with patch.object(w, "_ensure_lock", AsyncMock(return_value=True)), \
+         patch.object(w, "_poll_once", AsyncMock(return_value=[])), \
+         patch.object(w, "_scan_deadlines", AsyncMock(return_value=[])), \
+         patch.object(w, "_release_lock", AsyncMock()) as rel, \
+         patch("app.core.database.async_session_factory") as sf:
+        sf.return_value.__aenter__ = AsyncMock(return_value=AsyncMock())
+        sf.return_value.__aexit__ = AsyncMock(return_value=False)
+        task = asyncio.create_task(w.run())
+        await asyncio.sleep(0.05)  # 몇 iteration 돌게.
+        task.cancel()
+        await task  # CancelledError를 run이 흡수 → 정상 종료.
+    rel.assert_awaited_once()  # shutdown 시 lock 해제 보장.


### PR DESCRIPTION
## L2-S5 — L2 트리거 워커 루프 (lifespan · default-off · advisory lock)

블루프린트 §3·§5 S5. L1 활동 cursor poll(`L1ActivitySource`·S3)+주기 데드라인 스캔으로 휴리스틱 evaluator(S4)를 구동하는 백그라운드 워커(`app/services/l2_trigger_worker.py`). `pg_pubsub.listen_loop`의 lifespan task 패턴 재사용. **L2 중앙부.**

### `L2TriggerWorker.run` 루프
poll→evaluate→`[firing은 S6]` · 주기 deadline scan · **1s→30s 지수 백오프**(성공 시 리셋) · graceful shutdown.

- **AC① default-off**: `settings.l2_trigger_enabled=true`일 때만 lifespan이 task 생성 — 꺼지면 task 자체가 없어 오버헤드 0.
- **AC② cursor 성공 후만 전진**: 배치 처리 성공 후에만 cursor 전진. 처리 중 예외 시 **미전진→다음 iter 재처리**(중복 발사는 S6 dedup이 흡수). global cursor(org_id NULL)는 `l2_trigger_state`에 `IS NOT DISTINCT FROM` 매칭·UPDATE 0행 시 INSERT.
- **AC③ advisory lock**: `settings.l2_trigger_advisory_lock=on`이면 전용 AUTOCOMMIT 커넥션에서 `pg_try_advisory_lock` **holder만 poll/evaluate**. standby 인스턴스는 무동작. shutdown 시 `pg_advisory_unlock`+close.
- **deadline scan**: `measure_after` 임박 비종결 hypothesis를 `evaluate_deadline`로 평가(target=agent-가능한 `drafted_by`/`created_by`, 휴먼 owner는 wake 대상 아님). Sprint.end_date·Epic.target_date 스캔은 해당 엔티티 fetch·target 해소와 함께 S6 확장.
- **firing 이연**: 실 wake/dispatch(`l2_trigger_firings` dedup + 발사 + 에이전트 wake)는 `_dispatch_decisions` seam으로 **S6**.

`main.py` lifespan: `l2_task` 조건부 생성 + graceful cancel, `engine.dispose` 보장(try/finally 재배치·좀비 연결 박멸 불변식 유지).

### Validation
신규 `test_l2_trigger_worker.py` **10 passed** — default-off·cursor 전진/미전진(처리 실패)/empty/insert·advisory lock holder/standby/재보유 no-op/release unlock+close·deadline scan evaluator 통합(target 없으면 skip)·**graceful shutdown 시 lock 해제**. `test_eventbus_s1` **9 무회귀**(lifespan 변경)·`app.main` import OK·py_compile.

> L2 에픽 `4e8d3405` S5. 다음 S6(dedup+firing·`_dispatch_decisions` 구현)→S7(E2E)→S8(config). DB변경 0(0117는 S2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)