### PR TITLE
feat(l2): exactly-once wake dedup + real firing (L2-S6)

### DIFF
--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -1,8 +1,12 @@
-"""L2-S5: L2 트리거 워커 루프 (lifespan task · default-off · advisory lock).
+"""L2-S5/S6: L2 트리거 워커 루프 (lifespan · default-off · advisory lock · dedup 발사).
 
-블루프린트 §3·§5 S5. L1 활동 스트림 cursor poll(`L1ActivitySource`·S3) + 주기 데드라인 스캔으로
+블루프린트 §3·§5/§6. L1 활동 스트림 cursor poll(`L1ActivitySource`·S3) + 주기 데드라인 스캔으로
 휴리스틱 evaluator(S4)를 구동하는 백그라운드 워커. `pg_pubsub.listen_loop`의 lifespan task 패턴을
 재사용한다.
+
+S6: 각 트리거 결정을 `l2_trigger_firings`에 dedup insert(ON CONFLICT (dedup_key) DO NOTHING
+RETURNING)하고, **insert 승자만** dispatch service(S1·`dispatch_entity_to_assignee`)를 호출해
+Event(dispatched)+wake한다 — 멀티인스턴스/재처리에도 정확히 1 wake.
 
 설계 원칙:
   · **default-off (AC①)** — `settings.l2_trigger_enabled`가 true일 때만 lifespan이 task를 만든다.
@@ -13,16 +17,15 @@
     `pg_try_advisory_lock` holder인 인스턴스만 poll/evaluate. 멀티인스턴스 중복 구동 방지.
   · **backoff** — iteration 실패 시 1s→30s 지수 백오프, 성공 시 리셋.
   · **graceful shutdown** — CancelledError 수신 시 advisory lock 해제·커넥션 정리 후 종료.
-
-실 wake/dispatch(=`l2_trigger_firings` dedup + 발사 + 에이전트 wake)는 **S6**에서 `_dispatch_decisions`
-seam을 채운다. S5는 결정(`TriggerDecision`)만 산출·로깅한다.
 """
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+import uuid
+from datetime import datetime, time as dt_time, timedelta, timezone
 
 from sqlalchemy import bindparam, text
 
@@ -37,6 +40,10 @@ from app.services.l2_heuristics import (
 
 logger = logging.getLogger(__name__)
 
+# dispatch service(S1)가 처리 가능한 anchor entity. 이 외(sprint/hypothesis 등)는 firing만 기록하고
+# wake는 skip한다(해당 타입 dispatch 경로는 후속 확장).
+_DISPATCHABLE_ANCHORS = frozenset({"epic", "story", "doc"})
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -48,8 +55,9 @@ class L2TriggerWorker:
     WORKER_NAME = "l2_trigger"
     # 멀티인스턴스 단일 holder 보장용 advisory lock 키("L2TR" ASCII). 다른 advisory 사용처와 비충돌.
     _ADVISORY_LOCK_KEY = 0x4C325452
-    # 데드라인 nudge 불필요한 hypothesis 종결 상태.
+    # 데드라인 nudge 불필요한 종결 상태(타입별).
     _HYPOTHESIS_TERMINAL = ("verified", "falsified", "killed", "archived")
+    _EPIC_TERMINAL = ("completed", "done", "closed", "archived", "cancelled", "canceled")
 
     def __init__(
         self,
@@ -155,19 +163,19 @@ class L2TriggerWorker:
             self._holds_lock = False
 
     # ── cursor poll (AC②) ────────────────────────────────────────────────────────
-    async def _poll_once(self, db) -> list[TriggerDecision]:
-        """cursor 이후 활동을 poll·평가하고, **성공 시에만** cursor를 전진(AC②)."""
+    async def _poll_once(self, db) -> list:
+        """cursor 이후 활동을 poll·평가·발사하고, **성공 시에만** cursor를 전진(AC②)."""
         cursor = await self._read_cursor(db)
         signals, _next = await self.source.poll_after_seq(
             db, cursor, limit=self.batch_limit, org_id=None
         )
         if not signals:
             return []
-        decisions = await self._evaluate_signals(db, signals)
-        self._dispatch_decisions(decisions)
+        firings = await self._evaluate_signals(db, signals)
+        await self._dispatch_decisions(db, firings)
         # 처리 중 예외가 났다면 여기 도달 못 함 → cursor 미전진 → 다음 iter 재처리(AC②).
         await self._write_cursor(db, signals[-1].activity_seq)
-        return decisions
+        return firings
 
     async def _read_cursor(self, db) -> int:
         row = (
@@ -200,60 +208,187 @@ class L2TriggerWorker:
             )
         await db.commit()
 
-    async def _evaluate_signals(self, db, signals) -> list[TriggerDecision]:
-        """활동-구동 평가 seam. 활동별 엔티티 상태 fetch + drought/velocity 평가는 **S6**가 채운다
-        (실 발사와 동일 트랜잭션이라 firing과 함께 구현). S5는 빈 결정으로 cursor 머신러리만 검증."""
+    async def _evaluate_signals(self, db, signals) -> list[tuple[TriggerDecision, uuid.UUID]]:
+        """활동-구동 평가 seam → (decision, org_id) 페어 리스트.
+
+        활동별 엔티티 상태 fetch + drought/velocity 평가는 후속(S7 E2E·확장)에서 채운다 — S6는
+        주기 deadline 스캔으로 실 발사 경로를 확정하고, cursor 머신러리는 빈 배치로도 검증된다."""
         _ = (db, signals)
         return []
 
     # ── 주기 데드라인 스캔 (시간-구동·활동 무관) ──────────────────────────────────
-    async def _scan_deadlines(self, db) -> list[TriggerDecision]:
-        """measure_after가 임박한 비종결 hypothesis를 스캔해 deadline 휴리스틱을 평가.
+    async def _scan_deadlines(self, db) -> list:
+        """마감 임박 엔티티를 스캔해 deadline 휴리스틱을 평가·발사. → (decision, org_id) 페어.
 
         deadline은 활동이 발생하지 않으므로 cursor poll로는 못 잡는다 — 별도 주기 스캔.
-        target은 agent-가능한 drafted_by/created_by(휴먼 owner는 wake 대상 아님). 둘 다 없으면 skip.
-        Sprint.end_date·Epic.target_date 스캔은 해당 엔티티 fetch·target 해소와 함께 S6에서 확장.
+        · Epic.target_date — assignee_id를 target으로 dispatch service가 wake(dispatchable).
+        · Hypothesis.measure_after — drafted_by/created_by(agent-가능)를 target으로 firing 기록
+          (현 dispatch 서비스는 hypothesis 미지원이라 wake는 skip·후속 확장).
+        Sprint.end_date 스캔은 sprint dispatch 경로 확정과 함께 후속 확장.
         """
         now = _utcnow()
+        firings = await self._collect_epic_deadlines(db, now)
+        firings += await self._collect_hypothesis_deadlines(db, now)
+        await self._dispatch_decisions(db, firings)
+        return firings
+
+    async def _collect_epic_deadlines(self, db, now) -> list[tuple[TriggerDecision, uuid.UUID]]:
+        horizon_date = (now + timedelta(hours=self.evaluator.t.deadline_epic_target_h)).date()
+        rows = (
+            await db.execute(
+                text(
+                    "SELECT id, org_id, target_date, status, assignee_id FROM epics "
+                    "WHERE assignee_id IS NOT NULL AND target_date IS NOT NULL "
+                    "AND status NOT IN :terminal AND target_date <= :horizon"
+                ).bindparams(bindparam("terminal", expanding=True)),
+                {"terminal": list(self._EPIC_TERMINAL), "horizon": horizon_date},
+            )
+        ).mappings().all()
+        out: list[tuple[TriggerDecision, uuid.UUID]] = []
+        for r in rows:
+            # target_date는 DATE — 마감일 23:59:59Z를 deadline으로(당일 내 임박 판정).
+            deadline = datetime.combine(r["target_date"], dt_time(23, 59, 59), tzinfo=timezone.utc)
+            for d in self.evaluator.evaluate_deadline(
+                DeadlineTarget(
+                    entity_type="epic",
+                    entity_id=r["id"],
+                    deadline=deadline,
+                    status=r["status"],
+                    target_agent_id=r["assignee_id"],
+                ),
+                now,
+            ):
+                out.append((d, r["org_id"]))
+        return out
+
+    async def _collect_hypothesis_deadlines(self, db, now) -> list[tuple[TriggerDecision, uuid.UUID]]:
         horizon = now + timedelta(hours=self.evaluator.t.deadline_measure_after_h)
         rows = (
             await db.execute(
                 text(
-                    "SELECT id, measure_after, status, drafted_by_member_id, created_by_member_id "
-                    "FROM hypotheses "
+                    "SELECT id, org_id, measure_after, status, drafted_by_member_id, "
+                    "created_by_member_id FROM hypotheses "
                     "WHERE status NOT IN :terminal AND measure_after <= :horizon"
                 ).bindparams(bindparam("terminal", expanding=True)),
                 {"terminal": list(self._HYPOTHESIS_TERMINAL), "horizon": horizon},
             )
         ).mappings().all()
-
-        decisions: list[TriggerDecision] = []
+        out: list[tuple[TriggerDecision, uuid.UUID]] = []
         for r in rows:
             target = r["drafted_by_member_id"] or r["created_by_member_id"]
-            decisions.extend(
-                self.evaluator.evaluate_deadline(
-                    DeadlineTarget(
-                        entity_type="hypothesis",
-                        entity_id=r["id"],
-                        deadline=r["measure_after"],
-                        status=r["status"],
-                        target_agent_id=target,
-                    ),
-                    now,
-                )
-            )
-        self._dispatch_decisions(decisions)
-        return decisions
+            for d in self.evaluator.evaluate_deadline(
+                DeadlineTarget(
+                    entity_type="hypothesis",
+                    entity_id=r["id"],
+                    deadline=r["measure_after"],
+                    status=r["status"],
+                    target_agent_id=target,
+                ),
+                now,
+            ):
+                out.append((d, r["org_id"]))
+        return out
 
-    # ── 발사 seam (S6에서 dedup + firing + wake 구현) ─────────────────────────────
-    def _dispatch_decisions(self, decisions: list[TriggerDecision]) -> None:
-        """S6 seam: `l2_trigger_firings` dedup(dedup_key) + firing insert + 에이전트 wake/dispatch.
+    # ── dedup 발사 (S6: 정확히 1 wake·멀티인스턴스 안전) ──────────────────────────
+    @staticmethod
+    def _dedup_key(d: TriggerDecision) -> str:
+        """발사 dedup 키. 활동-구동은 활동당 1회, 시간-구동(deadline 등)은 UTC 일자당 1회."""
+        if d.source_activity_seq is not None:
+            bucket = f"a{d.source_activity_seq}"
+        else:
+            bucket = _utcnow().strftime("%Y%m%d")
+        return f"{d.trigger_type}:{d.anchor_type}:{d.anchor_id}:{d.target_agent_id}:{bucket}"
 
-        S5는 실 발사를 하지 않고 산출된 결정만 로깅한다.
+    async def _dispatch_decisions(self, db, firings: list) -> None:
+        """각 (decision, org_id)에 대해 dedup insert 승자만 실 dispatch(AC①②④).
+
+        한 결정의 실패가 배치 전체를 막지 않도록 결정 단위 격리(실패 시 rollback 후 계속).
         """
-        if decisions:
+        for decision, org_id in firings:
+            try:
+                await self._fire_one(db, decision, org_id)
+            except Exception as exc:
+                await db.rollback()
+                logger.warning(
+                    "L2 fire failed (%s anchor=%s): %s", decision.trigger_type, decision.anchor_id, exc
+                )
+
+    async def _fire_one(self, db, decision: TriggerDecision, org_id: uuid.UUID) -> None:
+        dedup_key = self._dedup_key(decision)
+        # AC①④: dedup insert. 동일 dedup_key를 두 워커가 동시에 넣어도 unique로 1행만 — 패자는
+        # ON CONFLICT DO NOTHING으로 0행(RETURNING 없음)이라 dispatch를 호출하지 않는다.
+        won = await self._claim_firing(db, decision, org_id, dedup_key)
+        if not won:
+            await db.rollback()
+            logger.debug("L2 firing dedup conflict — wake skip: %s", dedup_key)
+            return
+
+        if decision.anchor_type not in _DISPATCHABLE_ANCHORS:
+            # firing은 기록(같은 트랜잭션 commit)하되 wake는 미지원 타입이라 skip.
+            await db.commit()
             logger.info(
-                "L2 worker produced %d trigger decision(s) [firing deferred to S6]: %s",
-                len(decisions),
-                [d.trigger_type for d in decisions],
+                "L2 firing recorded (anchor=%s non-dispatchable, wake skip): %s",
+                decision.anchor_type,
+                dedup_key,
             )
+            return
+
+        # AC②③: 승자만 dispatch service 호출 → Event(event_type=dispatched·기존 allow-list 재사용,
+        # 신규 type 0) 생성 + commit + wake. firing은 같은 세션이라 event와 원자 commit.
+        from app.services.agent_dispatch import dispatch_entity_to_assignee
+
+        resp, delivery = await dispatch_entity_to_assignee(
+            db,
+            org_id,
+            decision.anchor_type,
+            decision.anchor_id,
+            message=decision.reason,
+            trigger_metadata={
+                "source": "l2_heuristic",
+                "trigger_type": decision.trigger_type,
+                "reason": decision.reason,
+                "source_activity_seq": decision.source_activity_seq,
+            },
+        )
+        # firing.event_id 링크(best-effort). dispatched=False(unresolved 등)면 firing만 commit.
+        if resp.dispatched and resp.event_id is not None:
+            await self._link_event(db, dedup_key, resp.event_id)
+        else:
+            await db.commit()
+
+        if resp.dispatched and delivery is not None:
+            # CC 릴레이(member webhook) — 라우터의 background_tasks 대신 워커는 직접 await.
+            from app.services.conversation_webhook import deliver_injected_event_webhook
+
+            await deliver_injected_event_webhook(**delivery)
+
+    async def _claim_firing(
+        self, db, decision: TriggerDecision, org_id: uuid.UUID, dedup_key: str
+    ) -> bool:
+        res = await db.execute(
+            text(
+                "INSERT INTO l2_trigger_firings "
+                "(id, org_id, trigger_type, target_agent_id, anchor_type, anchor_id, dedup_key, "
+                "source_activity_seq, payload) "
+                "VALUES (gen_random_uuid(), :org, :tt, :tgt, :at, :aid, :dk, :seq, CAST(:payload AS jsonb)) "
+                "ON CONFLICT (dedup_key) DO NOTHING RETURNING id"
+            ),
+            {
+                "org": org_id,
+                "tt": decision.trigger_type,
+                "tgt": decision.target_agent_id,
+                "at": decision.anchor_type,
+                "aid": decision.anchor_id,
+                "dk": dedup_key,
+                "seq": decision.source_activity_seq,
+                "payload": json.dumps({"reason": decision.reason, "source": "l2_heuristic"}),
+            },
+        )
+        return res.first() is not None
+
+    async def _link_event(self, db, dedup_key: str, event_id: uuid.UUID) -> None:
+        await db.execute(
+            text("UPDATE l2_trigger_firings SET event_id = :eid WHERE dedup_key = :dk"),
+            {"eid": event_id, "dk": dedup_key},
+        )
+        await db.commit()

--- a/backend/tests/test_l2_trigger_worker.py
+++ b/backend/tests/test_l2_trigger_worker.py
@@ -6,6 +6,8 @@ AC① default-off·AC② cursor 성공 후만 전진(실패 시 미전진)·AC�
 from __future__ import annotations
 
 import asyncio
+import os
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -14,7 +16,11 @@ import pytest
 
 from app.core.config import settings
 from app.services.l1_activity_source import ActivitySignal
+from app.services.l2_heuristics import TriggerDecision
 from app.services.l2_trigger_worker import L2TriggerWorker
+
+# 실 Postgres가 있을 때만 도는 동시성 테스트(CI alembic-fresh-db가 0117 적용). 로컬은 temp PG로 실증.
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
 
 
 @pytest.fixture
@@ -144,39 +150,144 @@ async def test_release_lock_unlocks_and_closes():
 
 # ── deadline scan: evaluator 통합 ─────────────────────────────────────────────
 
+def _rows_result(rows):
+    res = MagicMock()
+    res.mappings.return_value.all.return_value = rows
+    return res
+
+
 @pytest.mark.anyio
-async def test_scan_deadlines_fires_for_imminent_hypothesis():
+async def test_collect_hypothesis_deadlines_pairs_org():
     w = L2TriggerWorker(use_advisory_lock=False)
-    agent = uuid.uuid4()
-    hyp_id = uuid.uuid4()
+    agent, org, hyp_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
     now = datetime.now(timezone.utc)
     rows = [
-        {  # 임박(5h 후) + drafted_by 있음 → 발사.
-            "id": hyp_id,
-            "measure_after": now + timedelta(hours=5),
-            "status": "measuring",
-            "drafted_by_member_id": agent,
-            "created_by_member_id": None,
+        {  # 임박 + drafted_by → 발사.
+            "id": hyp_id, "org_id": org, "measure_after": now + timedelta(hours=5),
+            "status": "measuring", "drafted_by_member_id": agent, "created_by_member_id": None,
         },
-        {  # target 없음(drafted/created 둘 다 None) → evaluator skip.
-            "id": uuid.uuid4(),
-            "measure_after": now + timedelta(hours=2),
-            "status": "active",
-            "drafted_by_member_id": None,
-            "created_by_member_id": None,
+        {  # target 없음 → evaluator skip.
+            "id": uuid.uuid4(), "org_id": org, "measure_after": now + timedelta(hours=2),
+            "status": "active", "drafted_by_member_id": None, "created_by_member_id": None,
         },
     ]
-    result = MagicMock()
-    result.mappings.return_value.all.return_value = rows
     db = AsyncMock()
-    db.execute = AsyncMock(return_value=result)
-    with patch.object(w, "_dispatch_decisions") as disp:
-        decisions = await w._scan_deadlines(db)
-    assert len(decisions) == 1
-    d = decisions[0]
-    assert d.trigger_type == "deadline_approaching"
+    db.execute = AsyncMock(return_value=_rows_result(rows))
+    pairs = await w._collect_hypothesis_deadlines(db, now)
+    assert len(pairs) == 1
+    d, pair_org = pairs[0]
     assert d.anchor_type == "hypothesis" and d.anchor_id == hyp_id and d.target_agent_id == agent
-    disp.assert_called_once()
+    assert pair_org == org
+
+
+@pytest.mark.anyio
+async def test_collect_epic_deadlines_dispatchable_anchor():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    assignee, org, epic_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    rows = [{
+        "id": epic_id, "org_id": org,
+        "target_date": (now + timedelta(hours=10)).date(),  # 임박(epic 3d 윈도우 내).
+        "status": "active", "assignee_id": assignee,
+    }]
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_rows_result(rows))
+    pairs = await w._collect_epic_deadlines(db, now)
+    assert len(pairs) == 1
+    d, pair_org = pairs[0]
+    assert d.anchor_type == "epic" and d.anchor_id == epic_id and d.target_agent_id == assignee
+    assert pair_org == org and d.anchor_type in ("epic", "story", "doc")  # dispatchable.
+
+
+# ── S6: dedup 발사 ─────────────────────────────────────────────────────────────
+
+def _decision(anchor_type="epic", seq=None):
+    return TriggerDecision(
+        trigger_type="deadline_approaching",
+        target_agent_id=uuid.uuid4(),
+        anchor_type=anchor_type,
+        anchor_id=uuid.uuid4(),
+        reason="마감 임박",
+        source_activity_seq=seq,
+    )
+
+
+def test_dedup_key_time_vs_activity_bucket():
+    d_time = _decision(seq=None)
+    d_act = _decision(seq=77)
+    k_time = L2TriggerWorker._dedup_key(d_time)
+    k_act = L2TriggerWorker._dedup_key(d_act)
+    assert L2TriggerWorker._dedup_key(d_time) == k_time  # 결정적(같은 결정·같은 날).
+    assert k_act.endswith(":a77") and d_act.trigger_type in k_act
+    assert k_time != k_act
+
+
+@pytest.mark.anyio
+async def test_fire_one_winner_dispatches_and_links_event():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    d = _decision("epic")
+    org = uuid.uuid4()
+    db = AsyncMock()
+    event_id = uuid.uuid4()
+    resp = MagicMock(dispatched=True, event_id=event_id)
+    delivery = {"org_id": org, "recipient_id": d.target_agent_id, "content": "x", "event_type": "dispatched"}
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=True)), \
+         patch.object(w, "_link_event", AsyncMock()) as link, \
+         patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+               AsyncMock(return_value=(resp, delivery))) as disp, \
+         patch("app.services.conversation_webhook.deliver_injected_event_webhook",
+               AsyncMock()) as web:
+        await w._fire_one(db, d, org)
+    disp.assert_awaited_once()
+    # dispatch는 anchor(entity_type, entity_id)로 호출·trigger_metadata 동봉.
+    args, kwargs = disp.await_args
+    assert args[2] == "epic" and args[3] == d.anchor_id
+    assert kwargs["trigger_metadata"]["source"] == "l2_heuristic"
+    link.assert_awaited_once()  # event_id 링크.
+    web.assert_awaited_once()   # CC 릴레이.
+
+
+@pytest.mark.anyio
+async def test_fire_one_conflict_loser_skips_dispatch():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    d = _decision("epic")
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=False)), \
+         patch("app.services.agent_dispatch.dispatch_entity_to_assignee", AsyncMock()) as disp:
+        await w._fire_one(db, d, uuid.uuid4())
+    disp.assert_not_awaited()  # AC②④: 패자는 dispatch 0.
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_fire_one_non_dispatchable_records_firing_no_wake():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    d = _decision("hypothesis")  # 비-dispatchable anchor.
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=True)), \
+         patch("app.services.agent_dispatch.dispatch_entity_to_assignee", AsyncMock()) as disp:
+        await w._fire_one(db, d, uuid.uuid4())
+    disp.assert_not_awaited()  # firing은 기록되나 wake skip.
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_dispatch_decisions_isolates_per_decision_failure():
+    w = L2TriggerWorker(use_advisory_lock=False)
+    good, bad = _decision("epic"), _decision("epic")
+    org = uuid.uuid4()
+    db = AsyncMock()
+    calls = []
+
+    async def fire(_db, decision, _org):
+        calls.append(decision)
+        if decision is bad:
+            raise RuntimeError("boom")
+
+    with patch.object(w, "_fire_one", side_effect=fire):
+        await w._dispatch_decisions(db, [(bad, org), (good, org)])
+    assert bad in calls and good in calls  # 한 결정 실패가 배치를 막지 않음.
+    db.rollback.assert_awaited()  # 실패 결정은 rollback 후 계속.
 
 
 # ── graceful shutdown ─────────────────────────────────────────────────────────
@@ -196,3 +307,64 @@ async def test_run_cancels_gracefully_and_releases_lock():
         task.cancel()
         await task  # CancelledError를 run이 흡수 → 정상 종료.
     rel.assert_awaited_once()  # shutdown 시 lock 해제 보장.
+
+
+# ── AC①: 멀티인스턴스 동시성 — 동일 dedup_key 2 워커 동시 INSERT → firing 1개만 ──────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+def test_concurrent_dedup_exactly_one_winner():
+    """동일 dedup_key를 두 커넥션이 동시에 INSERT ON CONFLICT DO NOTHING RETURNING.
+
+    두 워커가 같은 트리거 후보를 동시에 발사해도 unique(dedup_key)가 정확히 1행만 허용 —
+    패자는 RETURNING 0행이라 dispatch를 호출하지 않는다(정확히 1 wake).
+    """
+    import psycopg2
+
+    sync_url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql://").replace(
+        "postgresql+asyncpg://", "postgresql://"
+    )
+    dedup_key = f"concurrency-test-{uuid.uuid4()}"
+    org = str(uuid.uuid4())
+    insert = (
+        "INSERT INTO l2_trigger_firings "
+        "(id, org_id, trigger_type, target_agent_id, anchor_type, anchor_id, dedup_key) "
+        "VALUES (gen_random_uuid(), %(org)s, 'deadline_approaching', gen_random_uuid(), "
+        "'epic', gen_random_uuid(), %(dk)s) ON CONFLICT (dedup_key) DO NOTHING RETURNING id"
+    )
+    barrier = threading.Barrier(2)
+    won: list[bool] = []
+    lock = threading.Lock()
+
+    def race():
+        conn = psycopg2.connect(sync_url)
+        try:
+            cur = conn.cursor()
+            barrier.wait(timeout=10)  # 두 스레드 동시 시작.
+            cur.execute(insert, {"org": org, "dk": dedup_key})
+            row = cur.fetchone()
+            conn.commit()
+            with lock:
+                won.append(row is not None)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=race) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    try:
+        assert sum(won) == 1, f"정확히 1 승자여야 함(got {sum(won)})"
+        # 실제로도 firing 1행만 존재.
+        conn = psycopg2.connect(sync_url)
+        cur = conn.cursor()
+        cur.execute("SELECT count(*) FROM l2_trigger_firings WHERE dedup_key = %s", (dedup_key,))
+        assert cur.fetchone()[0] == 1
+        conn.close()
+    finally:
+        conn = psycopg2.connect(sync_url)
+        cur = conn.cursor()
+        cur.execute("DELETE FROM l2_trigger_firings WHERE dedup_key = %s", (dedup_key,))
+        conn.commit()
+        conn.close()


### PR DESCRIPTION
## L2-S6 — 정확히 1 wake dedup + 실 트리거 발사

블루프린트 §3·§5·§6. S5 워커의 `_dispatch_decisions` seam을 채워 **실 트리거 wake**를 배선. 멀티인스턴스/재처리에도 정확히 1 wake. **DB변경 0**(0117 firings 사용). ⚠️ default-off라 머지해도 inert.

### dedup 발사 (AC①②④)
각 `TriggerDecision` → `l2_trigger_firings`에 **`INSERT ... ON CONFLICT (dedup_key) DO NOTHING RETURNING id`**.
- **AC①④**: 동일 `dedup_key`를 두 워커가 동시에 넣어도 unique로 1행만 — 패자는 RETURNING 0행이라 **dispatch 미호출**. `dedup_key = trigger_type:anchor_type:anchor_id:target:bucket`(활동-구동=활동당 1회·시간-구동=UTC 일자당 1회).
- **AC②③**: insert **승자만** dispatch service(S1 `dispatch_entity_to_assignee`) 호출 → **`Event.event_type=dispatched`**(기존 allow-list 재사용·신규 type 0) + commit + wake. firing은 같은 세션이라 event와 **원자 commit**. `event_id` best-effort 링크 + CC 릴레이(`deliver_injected_event_webhook`) 직접 await(워커라 background 대신).

### deadline scan 확정
- **Epic.target_date**(assignee_id→target): dispatchable anchor라 **실 wake**(epic→assignee).
- **Hypothesis.measure_after**(drafted_by/created_by→target): dispatch 서비스 미지원 타입이라 **firing 기록·wake skip**(flag). Sprint.end_date는 sprint dispatch 경로 확정과 함께 후속.
- `org_id`는 `(decision, org_id)` 페어로 스레딩 — S4 frozen `TriggerDecision` **무수정**. 결정 단위 격리(한 실패가 배치 비차단·rollback 후 계속).

### Validation
`test_l2_trigger_worker.py` **16 passed + 실 PG 동시성 1 passed** — dedup_key 활동/시간 버킷·승자 dispatch+event_id 링크+CC 릴레이·패자 skip(rollback·dispatch 0)·비-dispatchable firing 기록·배치 결정-격리·epic/hypothesis collect+org 페어·**실 Postgres 2스레드 레이스→정확히 1 승자**(temp PG 실증, CI alembic-fresh-db 재검증). dispatch/eventbus/heuristics/adapter **44 무회귀**·no import cycle.

> L2 에픽 `4e8d3405` S6. 다음 S7(E2E)→S8(config). ⚠️ 실 발사 지점이나 default-off라 안전·dedup 정확성 실 PG 실증.

🤖 Generated with [Claude Code](https://claude.com/claude-code)