### PR TITLE
feat(l2): activity-driven status_changed trigger + E2E harness (L2-S7)

### DIFF
--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -44,6 +44,9 @@ logger = logging.getLogger(__name__)
 # wake는 skip한다(해당 타입 dispatch 경로는 후속 확장).
 _DISPATCHABLE_ANCHORS = frozenset({"epic", "story", "doc"})
 
+# Phase 1 활동-구동 트리거 대상 verb(status_changed→담당자 wake). 확장 시 여기에 추가.
+_ACTIVITY_TRIGGER_VERBS = frozenset({"status_changed"})
+
 
 def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
@@ -209,12 +212,41 @@ class L2TriggerWorker:
         await db.commit()
 
     async def _evaluate_signals(self, db, signals) -> list[tuple[TriggerDecision, uuid.UUID]]:
-        """활동-구동 평가 seam → (decision, org_id) 페어 리스트.
+        """활동-구동 평가 → (decision, org_id) 페어 리스트.
 
-        활동별 엔티티 상태 fetch + drought/velocity 평가는 후속(S7 E2E·확장)에서 채운다 — S6는
-        주기 deadline 스캔으로 실 발사 경로를 확정하고, cursor 머신러리는 빈 배치로도 검증된다."""
-        _ = (db, signals)
-        return []
+        Phase 1 활동 트리거: dispatchable 엔티티(epic/story/doc)의 `status_changed` 활동은 해당
+        엔티티 assignee를 wake한다(dispatch service가 동일 assignee를 재해소). dedup_key가
+        source_activity_seq를 포함하므로 같은 활동 재처리는 추가 wake 0(S6 dedup).
+        """
+        out: list[tuple[TriggerDecision, uuid.UUID]] = []
+        for s in signals:
+            if s.verb not in _ACTIVITY_TRIGGER_VERBS:
+                continue
+            if s.object_type not in _DISPATCHABLE_ANCHORS or s.object_id is None:
+                continue
+            from app.services.agent_dispatch import _fetch_entity
+
+            assignee_id, _title, _desc, _proj = await _fetch_entity(
+                db, s.object_type, s.object_id, s.org_id
+            )
+            if not assignee_id:
+                continue  # 담당자 없으면 wake 대상 없음.
+            new_status = (s.payload or {}).get("to") or (s.payload or {}).get("status")
+            reason = f"{s.object_type} 상태 변경" + (f" → {new_status}" if new_status else "")
+            out.append(
+                (
+                    TriggerDecision(
+                        trigger_type="status_changed",
+                        target_agent_id=assignee_id,
+                        anchor_type=s.object_type,
+                        anchor_id=s.object_id,
+                        reason=reason,
+                        source_activity_seq=s.activity_seq,
+                    ),
+                    s.org_id,
+                )
+            )
+        return out
 
     # ── 주기 데드라인 스캔 (시간-구동·활동 무관) ──────────────────────────────────
     async def _scan_deadlines(self, db) -> list:

--- a/backend/tests/test_l2_e2e_status_changed.py
+++ b/backend/tests/test_l2_e2e_status_changed.py
@@ -1,0 +1,152 @@
+"""L2-S7: 끝단 E2E — status_changed 활동 1건 → 정확히 1 wake.
+
+블루프린트 §5 S7·§6. fake `poll_activities_after_seq`로 status_changed 활동을 주입하고 전 체인
+(adapter→evaluator→dedup→dispatch→wake)을 실제로 태운다(외부 의존만 fake). DB변경 0.
+
+AC: ①fake poll status_changed → 정확히 1 Event(dispatched) ②recipient_seq 有·commit 후 wake_agent
+1회 ③payload에 trigger_metadata+anchor ④같은 activity 재처리 무추가 wake(dedup) ⑤LLM import/call 0.
+"""
+from __future__ import annotations
+
+import inspect
+import uuid
+from contextlib import ExitStack
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services import agent_dispatch as dispatch_mod
+from app.services import conversation_webhook as webhook_mod
+from app.services.l1_activity_source import ActivitySignal
+from app.services.l2_trigger_worker import L2TriggerWorker
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+ORG = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+ASSIGNEE = uuid.uuid4()
+PROJECT = uuid.uuid4()
+
+
+def _status_changed_signal(seq: int = 101) -> ActivitySignal:
+    return ActivitySignal(
+        activity_seq=seq,
+        activity_id=uuid.uuid4(),
+        org_id=ORG,
+        project_id=PROJECT,
+        verb="status_changed",
+        occurred_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+        object_type="story",
+        object_id=STORY_ID,
+        payload={"to": "in_review"},
+    )
+
+
+async def _assign_seq(_db, event):
+    event.recipient_seq = 42  # per-recipient dense seq 모사.
+
+
+def _chain_patches(worker, added, *, claim_results):
+    """전 체인 외부 의존만 fake. evaluator/dedup/dispatch 본체는 실제로 태운다."""
+    stack = ExitStack()
+    # adapter poll: status_changed 활동 1건 주입(AC①).
+    stack.enter_context(
+        patch.object(worker.source, "poll_after_seq",
+                     AsyncMock(return_value=([_status_changed_signal()], None)))
+    )
+    stack.enter_context(patch.object(worker, "_read_cursor", AsyncMock(return_value=0)))
+    stack.enter_context(patch.object(worker, "_write_cursor", AsyncMock()))
+    # dedup claim: 승자/패자 시퀀스(AC④ 재처리).
+    stack.enter_context(patch.object(worker, "_claim_firing", AsyncMock(side_effect=claim_results)))
+    stack.enter_context(patch.object(worker, "_link_event", AsyncMock()))
+    # entity fetch(evaluator + dispatch 공용) → assignee 보유 story.
+    stack.enter_context(
+        patch.object(dispatch_mod, "_fetch_entity",
+                     AsyncMock(return_value=(ASSIGNEE, "로그인 구현", "OAuth", PROJECT)))
+    )
+    stack.enter_context(
+        patch.object(dispatch_mod, "resolve_member_identity",
+                     AsyncMock(return_value=SimpleNamespace(id=ASSIGNEE, type="agent")))
+    )
+    stack.enter_context(patch.object(dispatch_mod, "assign_recipient_seq", _assign_seq))
+    stack.enter_context(patch.object(dispatch_mod, "extract_activities_best_effort", AsyncMock()))
+    wake = stack.enter_context(patch.object(dispatch_mod, "wake_agent", MagicMock()))
+    stack.enter_context(patch("app.services.hypothesis.resolve_dispatch_anchor", AsyncMock(return_value=None)))
+    stack.enter_context(patch.object(webhook_mod, "deliver_injected_event_webhook", AsyncMock()))
+    return stack, wake
+
+
+def _make_db(added):
+    db = AsyncMock()
+    db.add = MagicMock(side_effect=added.append)
+    return db
+
+
+@pytest.mark.anyio
+async def test_status_changed_produces_exactly_one_dispatched_event_and_wake():
+    worker = L2TriggerWorker(use_advisory_lock=False)
+    added: list = []
+    db = _make_db(added)
+    stack, wake = _chain_patches(worker, added, claim_results=[True])
+    with stack:
+        await worker._poll_once(db)
+
+    # AC①: 정확히 1 Event(dispatched).
+    dispatched = [e for e in added if getattr(e, "event_type", None) == "dispatched"]
+    assert len(dispatched) == 1
+    ev = dispatched[0]
+    assert ev.recipient_type == "agent" and ev.recipient_id == ASSIGNEE
+
+    # AC②: recipient_seq 有 + commit 후 wake_agent 1회.
+    assert ev.recipient_seq == 42
+    wake.assert_called_once()
+    assert wake.call_args.args[0] == str(ASSIGNEE) and wake.call_args.args[1] == 42
+
+    # AC③: payload에 trigger_metadata(L2 출처) + anchor(entity).
+    tm = ev.payload["trigger_metadata"]
+    assert tm["source"] == "l2_heuristic" and tm["trigger_type"] == "status_changed"
+    assert tm["source_activity_seq"] == 101
+    assert ev.payload["entity_type"] == "story" and ev.payload["entity_id"] == str(STORY_ID)
+
+
+@pytest.mark.anyio
+async def test_reprocessing_same_activity_no_additional_wake():
+    """AC④: 같은 활동을 두 번 처리해도 dedup(같은 dedup_key)이라 추가 wake 0."""
+    worker = L2TriggerWorker(use_advisory_lock=False)
+    added: list = []
+    db = _make_db(added)
+    # 1차 승자(True), 2차 dedup 충돌(False).
+    stack, wake = _chain_patches(worker, added, claim_results=[True, False])
+    with stack:
+        await worker._poll_once(db)  # 1차 — wake.
+        await worker._poll_once(db)  # 2차 재처리 — dedup 충돌.
+
+    assert len([e for e in added if getattr(e, "event_type", None) == "dispatched"]) == 1
+    wake.assert_called_once()  # 추가 wake 0.
+
+
+def test_dedup_key_deterministic_for_same_activity():
+    """같은 활동 신호는 같은 dedup_key → 재처리가 동일 키로 충돌(AC④ 기반)."""
+    from app.services.l2_heuristics import TriggerDecision
+
+    d = TriggerDecision("status_changed", ASSIGNEE, "story", STORY_ID, "r", 101)
+    assert L2TriggerWorker._dedup_key(d) == L2TriggerWorker._dedup_key(d)
+    assert L2TriggerWorker._dedup_key(d).endswith(":a101")
+
+
+# ── AC⑤: LLM client import/call 0 ──────────────────────────────────────────────
+
+def test_l2_chain_modules_have_no_llm_imports():
+    from app.services import l1_activity_source, l2_heuristics, l2_trigger_worker
+
+    forbidden = ("openai", "anthropic", "litellm", "cohere", "google.generativeai", "vertexai")
+    for mod in (l2_heuristics, l1_activity_source, l2_trigger_worker):
+        src = inspect.getsource(mod)
+        for name in forbidden:
+            assert f"import {name}" not in src and f"from {name}" not in src, f"{mod.__name__}:{name}"


### PR DESCRIPTION
## L2-S7 — 끝단 E2E (status_changed → 정확히 1 wake)

블루프린트 §5 S7·§6 끝단 E2E. **L2 done 게이트.** status_changed 활동 1건이 전 체인(adapter→evaluator→dedup→dispatch→wake)을 타고 정확히 1 wake로 귀결됨을 입증. **DB변경 0.**

### 활동-구동 트리거 구현 (`_evaluate_signals`)
S6에서 비워둔 활동-구동 seam을 채움: **dispatchable 엔티티(epic/story/doc)의 `status_changed` 활동 → 해당 엔티티 assignee를 wake**(dispatch service가 동일 assignee 재해소). `dedup_key`가 `source_activity_seq`를 포함하므로 같은 활동 재처리는 추가 wake 0. `_ACTIVITY_TRIGGER_VERBS`로 verb 게이트(확장 지점).

### E2E 하니스
fake `poll_activities_after_seq`로 status_changed 활동 주입 → **외부 의존만 fake**(entity fetch·member resolve·seq·wake·CC 릴레이), evaluator/dedup/dispatch 본체는 실제 실행.

### Validation (신규 `test_l2_e2e_status_changed.py` 4 + 기존 worker 16 = 20 passed)
- **AC①**: status_changed → 정확히 1 `Event(event_type=dispatched)`.
- **AC②**: `event.recipient_seq=42` · commit 후 `wake_agent` 1회(assignee·seq 인자 검증).
- **AC③**: `payload.trigger_metadata`(source=l2_heuristic·trigger_type·source_activity_seq) + anchor(entity_type/entity_id).
- **AC④**: 같은 활동 2회 처리 → dedup 충돌(claim False) → **추가 wake 0** · `dedup_key` 결정성(`:a101`).
- **AC⑤**: L2 체인 3모듈(heuristics/adapter/worker) **LLM client import 0**.

heuristics/adapter/dispatch/eventbus **44 무회귀** · `app.main` import OK · py_compile.

> L2 에픽 `4e8d3405` S7(끝단 E2E). 다음 S8(config·관측성)로 L2 마무리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)