### PR TITLE
feat(l2): operational config + observability (L2-S8)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -61,6 +61,10 @@ class Settings(BaseSettings):
     # advisory_lock=on이면 멀티인스턴스 중 pg_try_advisory_lock holder 1개만 poll/evaluate.
     l2_trigger_enabled: bool = False
     l2_trigger_advisory_lock: bool = False
+    # S8 운영 config(안전 rollout). 모두 기본값=무제약/무필터.
+    l2_trigger_disabled_types: str = ""  # CSV — 비활성화할 trigger_type(예 "velocity_spike,scope_creep")
+    l2_trigger_org_allowlist: str = ""  # CSV org_id — 비면 전 org, 지정 시 해당 org만 발사
+    l2_trigger_max_wakes_per_org_per_hour: int = 0  # >0이면 org 시간당 wake 상한(초과 skip), 0=무제한
 
     # E-MEMBER-SSOT AC2-3: 신원 해소를 anchor(members+member_identity_aliases) 기반으로 전환하는
     # shadow 플래그. off(기본)=레거시 resolver(org_members/team_members). on=anchor resolver.

--- a/backend/app/services/l2_trigger_worker.py
+++ b/backend/app/services/l2_trigger_worker.py
@@ -52,6 +52,23 @@ def _utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
+def _csv_set(raw: str) -> frozenset[str]:
+    return frozenset(x.strip() for x in (raw or "").split(",") if x.strip())
+
+
+def _uuid_set(raw: str) -> frozenset[uuid.UUID]:
+    out: set[uuid.UUID] = set()
+    for x in (raw or "").split(","):
+        x = x.strip()
+        if not x:
+            continue
+        try:
+            out.add(uuid.UUID(x))
+        except ValueError:
+            logger.warning("L2 org allowlist 무효 org_id 무시: %r", x)
+    return frozenset(out)
+
+
 class L2TriggerWorker:
     """L2 휴리스틱 트리거 워커. lifespan startup에서 `asyncio.create_task(worker.run())`."""
 
@@ -72,6 +89,9 @@ class L2TriggerWorker:
         backoff_max: float = 30.0,
         thresholds: HeuristicThresholds | None = None,
         use_advisory_lock: bool | None = None,
+        disabled_types: set[str] | None = None,
+        org_allowlist: set[uuid.UUID] | None = None,
+        max_wakes_per_hour: int | None = None,
     ) -> None:
         self.poll_interval_s = poll_interval_s
         self.deadline_scan_interval_s = deadline_scan_interval_s
@@ -83,6 +103,25 @@ class L2TriggerWorker:
         self.use_advisory_lock = (
             settings.l2_trigger_advisory_lock if use_advisory_lock is None else use_advisory_lock
         )
+        # S8 운영 config(env override 가능).
+        self._disabled_types = (
+            _csv_set(settings.l2_trigger_disabled_types) if disabled_types is None else frozenset(disabled_types)
+        )
+        self._org_allowlist = (
+            _uuid_set(settings.l2_trigger_org_allowlist) if org_allowlist is None else frozenset(org_allowlist)
+        )
+        self._max_wakes_per_hour = (
+            settings.l2_trigger_max_wakes_per_org_per_hour if max_wakes_per_hour is None else max_wakes_per_hour
+        )
+        # S8 관측성 카운터(in-process). run() 루프가 주기적으로 요약 로깅.
+        self.metrics: dict[str, int] = {
+            "fired": 0,
+            "skipped_duplicate": 0,
+            "skipped_disabled": 0,
+            "skipped_allowlist": 0,
+            "skipped_rate_limited": 0,
+            "non_dispatchable": 0,
+        }
         self._lock_conn = None  # 전용 AsyncConnection — advisory lock 보유 동안 유지.
         self._holds_lock = False
 
@@ -112,6 +151,7 @@ class L2TriggerWorker:
                         if now_mono - last_deadline_scan >= self.deadline_scan_interval_s:
                             await self._scan_deadlines(db)
                             last_deadline_scan = now_mono
+                            self._log_metrics()  # AC③: 주기 관측 요약(deadline-scan 케이던스).
 
                     delay = self.backoff_min  # 성공 → backoff 리셋(AC backoff).
                     await asyncio.sleep(self.poll_interval_s)
@@ -174,11 +214,20 @@ class L2TriggerWorker:
         )
         if not signals:
             return []
+        eval_started = time.monotonic()  # AC③: eval latency.
         firings = await self._evaluate_signals(db, signals)
+        logger.debug(
+            "L2 eval batch signals=%d decisions=%d eval_latency=%.3fs",
+            len(signals), len(firings), time.monotonic() - eval_started,
+        )
         await self._dispatch_decisions(db, firings)
         # 처리 중 예외가 났다면 여기 도달 못 함 → cursor 미전진 → 다음 iter 재처리(AC②).
         await self._write_cursor(db, signals[-1].activity_seq)
         return firings
+
+    def _log_metrics(self) -> None:
+        """AC③: in-process 카운터 요약(firing/skip 분해)을 1줄로 관측 로깅."""
+        logger.info("L2 metrics: %s", " ".join(f"{k}={v}" for k, v in self.metrics.items()))
 
     async def _read_cursor(self, db) -> int:
         row = (
@@ -346,18 +395,41 @@ class L2TriggerWorker:
                 )
 
     async def _fire_one(self, db, decision: TriggerDecision, org_id: uuid.UUID) -> None:
+        # AC①: trigger type 비활성화.
+        if decision.trigger_type in self._disabled_types:
+            self.metrics["skipped_disabled"] += 1
+            logger.debug("L2 skip — type disabled: %s", decision.trigger_type)
+            return
+        # AC②: org allowlist(비면 전 org).
+        if self._org_allowlist and org_id not in self._org_allowlist:
+            self.metrics["skipped_allowlist"] += 1
+            logger.debug("L2 skip — org not in allowlist: %s", org_id)
+            return
+        # AC⑤: org 시간당 wake rate limit.
+        if self._max_wakes_per_hour > 0:
+            recent = await self._org_hourly_wake_count(db, org_id)
+            if recent >= self._max_wakes_per_hour:
+                self.metrics["skipped_rate_limited"] += 1
+                logger.warning(
+                    "L2 rate-limit org=%s recent=%d max=%d/h — skip wake",
+                    org_id, recent, self._max_wakes_per_hour,
+                )
+                return
+
         dedup_key = self._dedup_key(decision)
-        # AC①④: dedup insert. 동일 dedup_key를 두 워커가 동시에 넣어도 unique로 1행만 — 패자는
+        # AC①④(S6): dedup insert. 동일 dedup_key를 두 워커가 동시에 넣어도 unique로 1행만 — 패자는
         # ON CONFLICT DO NOTHING으로 0행(RETURNING 없음)이라 dispatch를 호출하지 않는다.
         won = await self._claim_firing(db, decision, org_id, dedup_key)
         if not won:
             await db.rollback()
+            self.metrics["skipped_duplicate"] += 1
             logger.debug("L2 firing dedup conflict — wake skip: %s", dedup_key)
             return
 
         if decision.anchor_type not in _DISPATCHABLE_ANCHORS:
             # firing은 기록(같은 트랜잭션 commit)하되 wake는 미지원 타입이라 skip.
             await db.commit()
+            self.metrics["non_dispatchable"] += 1
             logger.info(
                 "L2 firing recorded (anchor=%s non-dispatchable, wake skip): %s",
                 decision.anchor_type,
@@ -365,10 +437,11 @@ class L2TriggerWorker:
             )
             return
 
-        # AC②③: 승자만 dispatch service 호출 → Event(event_type=dispatched·기존 allow-list 재사용,
-        # 신규 type 0) 생성 + commit + wake. firing은 같은 세션이라 event와 원자 commit.
+        # AC②③(S6): 승자만 dispatch service 호출 → Event(event_type=dispatched·기존 allow-list
+        # 재사용, 신규 type 0) 생성 + commit + wake. firing은 같은 세션이라 event와 원자 commit.
         from app.services.agent_dispatch import dispatch_entity_to_assignee
 
+        wake_started = time.monotonic()
         resp, delivery = await dispatch_entity_to_assignee(
             db,
             org_id,
@@ -388,15 +461,51 @@ class L2TriggerWorker:
         else:
             await db.commit()
 
-        if resp.dispatched and delivery is not None:
-            # CC 릴레이(member webhook) — 라우터의 background_tasks 대신 워커는 직접 await.
-            from app.services.conversation_webhook import deliver_injected_event_webhook
+        if resp.dispatched:
+            self.metrics["fired"] += 1
+            # AC③: wake latency + firing 관측 로그.
+            logger.info(
+                "L2 wake fired type=%s anchor=%s/%s org=%s wake_latency=%.3fs",
+                decision.trigger_type, decision.anchor_type, decision.anchor_id, org_id,
+                time.monotonic() - wake_started,
+            )
+            if delivery is not None:
+                # CC 릴레이(member webhook) — 라우터의 background_tasks 대신 워커는 직접 await.
+                from app.services.conversation_webhook import deliver_injected_event_webhook
 
-            await deliver_injected_event_webhook(**delivery)
+                await deliver_injected_event_webhook(**delivery)
+
+    async def _org_hourly_wake_count(self, db, org_id: uuid.UUID) -> int:
+        """직전 1시간 org firing 수(AC⑤ rate limit 판정). 0117 firings 사용·DB변경 0."""
+        row = (
+            await db.execute(
+                text(
+                    "SELECT count(*) FROM l2_trigger_firings "
+                    "WHERE org_id = :org AND fired_at >= now() - interval '1 hour'"
+                ),
+                {"org": org_id},
+            )
+        ).scalar()
+        return int(row or 0)
 
     async def _claim_firing(
         self, db, decision: TriggerDecision, org_id: uuid.UUID, dedup_key: str
     ) -> bool:
+        # AC④: false-wake 조사용 reason + features 스냅샷을 firing payload에 박제.
+        payload = json.dumps(
+            {
+                "reason": decision.reason,
+                "source": "l2_heuristic",
+                "features": {
+                    "trigger_type": decision.trigger_type,
+                    "anchor_type": decision.anchor_type,
+                    "anchor_id": str(decision.anchor_id),
+                    "target_agent_id": str(decision.target_agent_id),
+                    "source_activity_seq": decision.source_activity_seq,
+                    "evaluated_at": _utcnow().isoformat(),
+                },
+            }
+        )
         res = await db.execute(
             text(
                 "INSERT INTO l2_trigger_firings "
@@ -413,7 +522,7 @@ class L2TriggerWorker:
                 "aid": decision.anchor_id,
                 "dk": dedup_key,
                 "seq": decision.source_activity_seq,
-                "payload": json.dumps({"reason": decision.reason, "source": "l2_heuristic"}),
+                "payload": payload,
             },
         )
         return res.first() is not None

--- a/backend/tests/test_l2_config_observability.py
+++ b/backend/tests/test_l2_config_observability.py
@@ -1,0 +1,203 @@
+"""L2-S8: 운영 config + 관측성 단위 테스트.
+
+AC① trigger type disable·AC② org allowlist·AC③ metrics·AC④ firing payload features snapshot·
+AC⑤ org 시간당 wake rate limit. DB변경 0(0117 firings 사용).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.config import settings
+from app.services.l2_heuristics import TriggerDecision
+from app.services.l2_trigger_worker import L2TriggerWorker, _csv_set, _uuid_set
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _decision(trigger_type="status_changed", anchor_type="epic"):
+    return TriggerDecision(
+        trigger_type=trigger_type,
+        target_agent_id=uuid.uuid4(),
+        anchor_type=anchor_type,
+        anchor_id=uuid.uuid4(),
+        reason="r",
+        source_activity_seq=7,
+    )
+
+
+def _worker(**kw):
+    return L2TriggerWorker(use_advisory_lock=False, **kw)
+
+
+# ── 기본값 안전(전부 무제약) ────────────────────────────────────────────────────
+
+def test_config_defaults_unconstrained():
+    assert settings.l2_trigger_disabled_types == ""
+    assert settings.l2_trigger_org_allowlist == ""
+    assert settings.l2_trigger_max_wakes_per_org_per_hour == 0
+    w = _worker()
+    assert w._disabled_types == frozenset() and w._org_allowlist == frozenset()
+    assert w._max_wakes_per_hour == 0
+    assert all(v == 0 for v in w.metrics.values())
+
+
+def test_csv_and_uuid_parsers():
+    assert _csv_set(" a, b ,,c ") == frozenset({"a", "b", "c"})
+    u = uuid.uuid4()
+    assert _uuid_set(f"{u}, not-a-uuid, ") == frozenset({u})  # 무효 무시.
+
+
+# ── AC①: trigger type disable ──────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_disabled_trigger_type_skips_before_claim():
+    w = _worker(disabled_types={"velocity_spike"})
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock()) as claim:
+        await w._fire_one(db, _decision("velocity_spike"), uuid.uuid4())
+    claim.assert_not_awaited()  # 게이트가 claim 이전에 차단.
+    assert w.metrics["skipped_disabled"] == 1
+
+
+@pytest.mark.anyio
+async def test_enabled_type_passes_gate():
+    w = _worker(disabled_types={"velocity_spike"})
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=False)) as claim:
+        await w._fire_one(db, _decision("deadline_approaching"), uuid.uuid4())
+    claim.assert_awaited_once()  # 다른 타입은 통과.
+
+
+# ── AC②: org allowlist ─────────────────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_org_not_in_allowlist_skips():
+    allowed = uuid.uuid4()
+    w = _worker(org_allowlist={allowed})
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock()) as claim:
+        await w._fire_one(db, _decision(), uuid.uuid4())  # 다른 org.
+    claim.assert_not_awaited()
+    assert w.metrics["skipped_allowlist"] == 1
+
+
+@pytest.mark.anyio
+async def test_org_in_allowlist_passes():
+    allowed = uuid.uuid4()
+    w = _worker(org_allowlist={allowed})
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=False)) as claim:
+        await w._fire_one(db, _decision(), allowed)
+    claim.assert_awaited_once()
+
+
+# ── AC⑤: org 시간당 wake rate limit ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_rate_limit_blocks_when_over_cap():
+    w = _worker(max_wakes_per_hour=3)
+    db = AsyncMock()
+    with patch.object(w, "_org_hourly_wake_count", AsyncMock(return_value=3)), \
+         patch.object(w, "_claim_firing", AsyncMock()) as claim:
+        await w._fire_one(db, _decision(), uuid.uuid4())
+    claim.assert_not_awaited()  # cap 도달 → claim 이전 skip.
+    assert w.metrics["skipped_rate_limited"] == 1
+
+
+@pytest.mark.anyio
+async def test_rate_limit_allows_under_cap():
+    w = _worker(max_wakes_per_hour=3)
+    db = AsyncMock()
+    with patch.object(w, "_org_hourly_wake_count", AsyncMock(return_value=2)), \
+         patch.object(w, "_claim_firing", AsyncMock(return_value=False)) as claim:
+        await w._fire_one(db, _decision(), uuid.uuid4())
+    claim.assert_awaited_once()
+
+
+@pytest.mark.anyio
+async def test_rate_limit_disabled_skips_count_query():
+    w = _worker(max_wakes_per_hour=0)  # 0=무제한.
+    db = AsyncMock()
+    with patch.object(w, "_org_hourly_wake_count", AsyncMock()) as cnt, \
+         patch.object(w, "_claim_firing", AsyncMock(return_value=False)):
+        await w._fire_one(db, _decision(), uuid.uuid4())
+    cnt.assert_not_awaited()  # 0이면 카운트 쿼리 자체 skip.
+
+
+@pytest.mark.anyio
+async def test_org_hourly_wake_count_query():
+    w = _worker()
+    db = AsyncMock()
+    res = MagicMock()
+    res.scalar.return_value = 5
+    db.execute = AsyncMock(return_value=res)
+    n = await w._org_hourly_wake_count(db, uuid.uuid4())
+    assert n == 5
+    sql = str(db.execute.await_args.args[0])
+    assert "count(*)" in sql and "1 hour" in sql and "l2_trigger_firings" in sql
+
+
+# ── AC④: firing payload features snapshot ──────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_claim_firing_payload_has_reason_and_features():
+    w = _worker()
+    d = _decision("deadline_approaching", "epic")
+    db = AsyncMock()
+    res = MagicMock()
+    res.first.return_value = ("id",)
+    db.execute = AsyncMock(return_value=res)
+    won = await w._claim_firing(db, d, uuid.uuid4(), "dk1")
+    assert won is True
+    params = db.execute.await_args.args[1]
+    payload = json.loads(params["payload"])
+    assert payload["reason"] == "r" and payload["source"] == "l2_heuristic"
+    feat = payload["features"]
+    assert feat["trigger_type"] == "deadline_approaching"
+    assert feat["anchor_type"] == "epic" and feat["anchor_id"] == str(d.anchor_id)
+    assert feat["target_agent_id"] == str(d.target_agent_id)
+    assert feat["source_activity_seq"] == 7 and "evaluated_at" in feat
+
+
+# ── AC③: metrics 카운터 + 요약 로깅 ────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_fired_metric_increments_on_dispatch():
+    w = _worker()
+    d = _decision("status_changed", "epic")
+    db = AsyncMock()
+    resp = MagicMock(dispatched=True, event_id=uuid.uuid4())
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=True)), \
+         patch.object(w, "_link_event", AsyncMock()), \
+         patch("app.services.agent_dispatch.dispatch_entity_to_assignee",
+               AsyncMock(return_value=(resp, None))):
+        await w._fire_one(db, d, uuid.uuid4())
+    assert w.metrics["fired"] == 1
+
+
+@pytest.mark.anyio
+async def test_duplicate_metric_increments_on_conflict():
+    w = _worker()
+    db = AsyncMock()
+    with patch.object(w, "_claim_firing", AsyncMock(return_value=False)):
+        await w._fire_one(db, _decision(), uuid.uuid4())
+    assert w.metrics["skipped_duplicate"] == 1
+    db.rollback.assert_awaited_once()
+
+
+def test_log_metrics_emits_summary(caplog):
+    import logging
+
+    w = _worker()
+    w.metrics["fired"] = 2
+    w.metrics["skipped_duplicate"] = 1
+    with caplog.at_level(logging.INFO):
+        w._log_metrics()
+    assert any("L2 metrics" in r.message and "fired=2" in r.message for r in caplog.records)


### PR DESCRIPTION
## L2-S8 — 운영 config + 관측성 (rate limit · metrics) · **L2 마지막**

블루프린트 §3·§5·§6 S8. L2 트리거 워커 **안전 rollout**용 운영 config + 관측성. 끝나면 **L2 Phase 1 완결**(default-off·rollout 준비 완료). **DB변경 0**(0117 firings 사용).

- **AC①** `L2_TRIGGER_DISABLED_TYPES`(CSV): 특정 `trigger_type` 비활성화 — claim 이전 게이트.
- **AC②** `L2_TRIGGER_ORG_ALLOWLIST`(CSV org_id): 지정 시 해당 org만 발사(비면 전 org)·무효 id 무시.
- **AC③** 관측성: in-process 카운터(`fired`/`skipped_duplicate`/`skipped_disabled`/`skipped_allowlist`/`skipped_rate_limited`/`non_dispatchable`) + per-fire `wake_latency`·batch `eval_latency` 로그 + deadline-scan 케이던스 `_log_metrics` 요약.
- **AC④** firing `payload`에 `reason` + **features 스냅샷**(trigger_type/anchor/target/source_activity_seq/evaluated_at) — false-wake 사후 조사용.
- **AC⑤** `L2_TRIGGER_MAX_WAKES_PER_ORG_PER_HOUR`: >0이면 직전 1h org firing 수 ≥ cap → skip(0=무제한). 0117 firings count로 판정.

게이트 순서(_fire_one): type disable → org allowlist → rate limit → dedup claim → dispatch. **기본값 전부 무제약**(disabled=∅·allowlist=∅·max=0)이라 활성화 전 거동 무변경.

### Validation
신규 `test_l2_config_observability.py` **14 passed** — 기본값 무제약·CSV/UUID 파서(무효 무시)·type disable(claim 차단)·allowlist in/out·rate-limit over/under/disabled·hourly-count 쿼리·**payload features 스냅샷**·fired/duplicate metric·요약 로깅. 전 L2 체인(worker/E2E/heuristics/adapter/dispatch/eventbus) **78 무회귀**·`app.main` import OK·py_compile.

> L2 에픽 `4e8d3405` S8(마지막). **L2 Phase 1 완결** — 활동 그래프(L1)→휴리스틱 트리거(L2) 전 파이프라인·default-off·안전 rollout 준비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)