### PR TITLE
fix(mcp): surface backend 4xx detail in MCP tool errors

### DIFF
--- a/backend/sprintable_mcp/api_client.py
+++ b/backend/sprintable_mcp/api_client.py
@@ -8,12 +8,101 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
+# 백엔드 에러 본문을 MCP 에러 문자열에 노출할 때, 비정상적으로 큰 body가
+# 에이전트 컨텍스트를 잠식하지 않도록 자르는 상한.
+_ERROR_BODY_MAX = 1500
+
 
 class SprintableApiError(Exception):
     def __init__(self, status: int, message: str, body: Any = None) -> None:
         super().__init__(message)
         self.status = status
         self.body = body
+
+
+def _format_validation_errors(detail: list) -> str | None:
+    """FastAPI 422 RequestValidationError 배열 → 'field: msg' 요약.
+
+    detail 항목 shape: {"loc": ["body", "metric_definition", "source"], "msg": "...", "type": "..."}.
+    loc의 선행 "body"/"query"/"path" 토큰은 노이즈라 제거하고 남은 경로를 '.'로 잇는다.
+    """
+    parts: list[str] = []
+    for item in detail:
+        if not isinstance(item, dict):
+            parts.append(str(item))
+            continue
+        loc = item.get("loc") or []
+        trimmed = [str(p) for p in loc if p not in ("body", "query", "path")]
+        field = ".".join(trimmed) if trimmed else "(request)"
+        msg = item.get("msg") or item.get("type") or "invalid"
+        parts.append(f"{field}: {msg}")
+    return "; ".join(parts) if parts else None
+
+
+def _extract_error_message(status: int, body: Any) -> str:
+    """백엔드 4xx/5xx 응답 본문에서 사람이 읽을 수 있는 사유를 추출한다.
+
+    지원 shape (우선순위 순):
+      1. {"error": {"code", "message", ...}}  — 앱 표준 엔벨로프(main.py http_exception_handler)
+      2. {"detail": {"code", "message"}}      — dict detail HTTPException(엔벨로프 전 raw, 방어적)
+      3. {"detail": [ {loc, msg, type}, ... ]} — FastAPI 422 pydantic 검증 배열
+      4. {"detail": "...문자열..."}            — 평문 detail
+      5. JSON이 아니거나 미지의 shape         — 본문 텍스트를 잘라서 그대로 노출
+
+    이전 구현은 1만 보고 2~5를 버려(특히 422 검증 배열) 'Sprintable API 422'로 삼켜버렸다.
+    """
+    # 5: JSON 파싱 실패 → 원문 텍스트(잘림)로 폴백.
+    if isinstance(body, str):
+        text = body.strip()
+        if not text:
+            return f"Sprintable API {status}"
+        if len(text) > _ERROR_BODY_MAX:
+            text = text[:_ERROR_BODY_MAX] + "…(truncated)"
+        return f"Sprintable API {status}: {text}"
+
+    if isinstance(body, dict):
+        # 1: 표준 {error: {code, message}} 엔벨로프.
+        env = body.get("error")
+        if isinstance(env, dict):
+            code = env.get("code")
+            message = env.get("message") or ""
+            if code and message:
+                return f"{code}: {message}"
+            if message:
+                return str(message)
+            if code:
+                return str(code)
+        elif isinstance(env, str) and env:
+            return env
+
+        detail = body.get("detail")
+        # 2: dict detail({code, message}) — 엔벨로프 미적용 raw HTTPException 방어.
+        if isinstance(detail, dict):
+            code = detail.get("code")
+            message = detail.get("message") or ""
+            if code and message:
+                return f"{code}: {message}"
+            if message:
+                return str(message)
+        # 3: 422 검증 배열.
+        if isinstance(detail, list):
+            summary = _format_validation_errors(detail)
+            if summary:
+                return f"Sprintable API {status} validation: {summary}"
+        # 4: 평문 detail.
+        if isinstance(detail, str) and detail.strip():
+            return f"Sprintable API {status}: {detail.strip()}"
+
+    # 미지의 shape — 직렬화해서 잘라 노출(완전 삼킴 방지).
+    try:
+        import json as _json
+
+        text = _json.dumps(body, ensure_ascii=False)
+        if len(text) > _ERROR_BODY_MAX:
+            text = text[:_ERROR_BODY_MAX] + "…(truncated)"
+        return f"Sprintable API {status}: {text}"
+    except Exception:
+        return f"Sprintable API {status}"
 
 
 class SprintableClient:
@@ -100,14 +189,13 @@ class SprintableClient:
             try:
                 body = resp.json()
             except Exception:
-                pass
-            error = body or {}
-            message = (
-                (error.get("error") or {}).get("message")
-                if isinstance(error.get("error"), dict)
-                else error.get("error")
-            ) or f"Sprintable API {resp.status_code}"
-            raise SprintableApiError(resp.status_code, str(message), body)
+                # 비-JSON 본문(HTML 502, 평문 등)도 삼키지 않고 노출.
+                try:
+                    body = resp.text
+                except Exception:
+                    body = None
+            message = _extract_error_message(resp.status_code, body)
+            raise SprintableApiError(resp.status_code, message, body)
 
         data = resp.json()
         # {data: T} 래핑이면 언래핑, 그 외(배열 등)는 직접 반환

--- a/backend/sprintable_mcp/server.py
+++ b/backend/sprintable_mcp/server.py
@@ -277,7 +277,13 @@ _TOOL_DEFS: list[tuple] = [
      "가설 단건 조회 (full).",
      GetHypothesisInput, get_hypothesis),
     ("sprintable_create_hypothesis",
-     "가설 생성. agent 호출은 proposed로 강제.",
+     "가설 생성. agent 호출은 status='proposed'로 강제된다.\n"
+     "metric_definition(dict) 필수 키: metric(str), source(enum: ga4|internal_ops|manual), "
+     "target(number), direction(enum: up|down). "
+     "source='ga4'이면 추가 필수: property_id, ga4_metric(enum: activeUsers|newUsers|sessions|"
+     "conversions|eventCount|screenPageViews), date_range_days(양의 정수).\n"
+     "owner_member_id: agent 호출은 휴먼 멤버 owner_member_id를 반드시 명시해야 한다"
+     "(미지정 시 백엔드가 400 HUMAN_OWNER_REQUIRED 반환). list_team_members로 휴먼 멤버 id 조회.",
      CreateHypothesisInput, create_hypothesis),
     ("sprintable_update_hypothesis",
      "가설 수정 (문장/지표/측정일/owner). 상태 전이는 confirm으로.",

--- a/backend/sprintable_mcp/tools/hypotheses.py
+++ b/backend/sprintable_mcp/tools/hypotheses.py
@@ -112,7 +112,18 @@ async def get_hypothesis(args: GetHypothesisInput) -> list[TextContent]:
 
 
 async def create_hypothesis(args: CreateHypothesisInput) -> list[TextContent]:
-    """가설 생성. agent/API key 호출은 서버가 status='proposed'로 강제한다(§4.1.3)."""
+    """가설 생성. agent/API key 호출은 서버가 status='proposed'로 강제한다(§4.1.3).
+
+    metric_definition(dict) 계약(backend _validate_metric_definition·검증 SSOT):
+      필수: metric(str), source(ga4|internal_ops|manual), target(number), direction(up|down).
+      source='ga4'이면 추가 필수: property_id, ga4_metric, date_range_days(양의 정수).
+
+    owner_member_id(휴먼 멤버) — agent 호출은 명시 필수다. 백엔드(services/hypothesis.create_hypothesis)는
+    휴먼 caller만 self를 owner로 기본 적용하고, agent caller가 생략하면 400 HUMAN_OWNER_REQUIRED를 낸다.
+    MCP auth context의 member_id는 *에이전트* 멤버라 휴먼 default로 쓸 수 없고(다시 같은 400),
+    임의 휴먼을 추측-주입하는 것은 owner 의미를 왜곡한다. 따라서 여기서는 default를 만들지 않고,
+    개선된 에러 표면화(api_client._extract_error_message)로 사유를 명확히 전달하는 쪽을 택한다.
+    """
     body: dict = {
         "project_id": client.project_id,
         "statement": args.statement,

--- a/backend/tests/test_mcp_phase1.py
+++ b/backend/tests/test_mcp_phase1.py
@@ -133,3 +133,113 @@ def test_err_returns_call_tool_result_with_is_error():
     assert len(result) == 1
     assert result[0].type == "text"
     assert result[0].text == "Error: something went wrong"
+
+
+# ─── fix/mcp-error-surfacing: 4xx 본문 표면화 ───────────────────────────────
+#
+# 이전 구현은 {error:{message}} 엔벨로프만 보고 FastAPI 422 검증 배열·dict detail·
+# 평문 본문을 버려 'Sprintable API 422'로 삼켰다. 아래 테스트는 공유 헬퍼(request)가
+# 백엔드 사유를 SprintableApiError.message(= 도구 err() 문자열)에 노출함을 보장한다.
+
+
+async def _make_error_client(status: int, json_body=None, *, raise_on_json=False, text_body=""):
+    """status/본문을 가진 4xx 응답을 mock해 request 호출 → SprintableApiError 반환."""
+    c = SprintableClient()
+    c.configure("https://api.sprintable.ai", "sk_live_test")
+
+    mock_resp = MagicMock()
+    mock_resp.is_success = False
+    mock_resp.status_code = status
+    if raise_on_json:
+        mock_resp.json.side_effect = ValueError("not json")
+        mock_resp.text = text_body
+    else:
+        mock_resp.json.return_value = json_body
+
+    with patch("httpx.AsyncClient.request", new_callable=AsyncMock, return_value=mock_resp):
+        with pytest.raises(SprintableApiError) as exc_info:
+            await c.post("/api/v2/hypotheses", json={"statement": "x"})
+    return exc_info.value
+
+
+@pytest.mark.anyio
+async def test_error_surfaces_422_validation_array():
+    """FastAPI 422 pydantic 배열 → 'field: msg' 요약이 메시지에 포함."""
+    err_obj = await _make_error_client(
+        422,
+        {
+            "detail": [
+                {
+                    "loc": ["body", "metric_definition", "source"],
+                    "msg": "value is not a valid enumeration member",
+                    "type": "value_error",
+                },
+                {
+                    "loc": ["body", "metric_definition", "target"],
+                    "msg": "value is not a valid float",
+                    "type": "type_error.float",
+                },
+            ]
+        },
+    )
+    assert err_obj.status == 422
+    msg = str(err_obj)
+    assert "metric_definition.source" in msg
+    assert "value is not a valid enumeration member" in msg
+    assert "metric_definition.target" in msg
+    # 회귀 가드: 더 이상 본문을 삼킨 bare 문자열이 아니다.
+    assert msg != "Sprintable API 422"
+
+
+@pytest.mark.anyio
+async def test_error_surfaces_human_owner_required_envelope():
+    """{error:{code,message}} 엔벨로프(400 HUMAN_OWNER_REQUIRED) → 'CODE: message'."""
+    err_obj = await _make_error_client(
+        400,
+        {
+            "data": None,
+            "error": {
+                "code": "HUMAN_OWNER_REQUIRED",
+                "message": "agent caller는 휴먼 owner_member_id를 명시해야 합니다.",
+            },
+            "meta": None,
+        },
+    )
+    assert err_obj.status == 400
+    msg = str(err_obj)
+    assert msg.startswith("HUMAN_OWNER_REQUIRED:")
+    assert "owner_member_id" in msg
+
+
+@pytest.mark.anyio
+async def test_error_surfaces_dict_detail_code():
+    """엔벨로프 미적용 raw dict detail({code,message})도 표면화."""
+    err_obj = await _make_error_client(
+        400,
+        {"detail": {"code": "NO_VALID_FIELDS", "message": "no updatable fields"}},
+    )
+    msg = str(err_obj)
+    assert "NO_VALID_FIELDS" in msg
+    assert "no updatable fields" in msg
+
+
+@pytest.mark.anyio
+async def test_error_surfaces_non_json_body():
+    """JSON 파싱 실패(HTML/평문 502 등) → 원문 텍스트 노출(삼키지 않음)."""
+    err_obj = await _make_error_client(
+        502, raise_on_json=True, text_body="<html>Bad Gateway</html>"
+    )
+    msg = str(err_obj)
+    assert err_obj.status == 502
+    assert "Bad Gateway" in msg
+
+
+@pytest.mark.anyio
+async def test_error_truncates_large_body():
+    """비정상적으로 큰 본문은 잘려 에이전트 컨텍스트를 잠식하지 않는다."""
+    err_obj = await _make_error_client(
+        500, raise_on_json=True, text_body="x" * 5000
+    )
+    msg = str(err_obj)
+    assert "truncated" in msg
+    assert len(msg) < 2000


### PR DESCRIPTION
## Problem

When an MCP tool calls the FastAPI backend and the backend returns a 4xx (422 validation, 400 domain error), the shared HTTP client returned a bare string like `Error: Sprintable API 422` — it swallowed the backend's response body, so the calling agent could not see *why* the request failed.

Found via dogfood story `5f373c5a`: `create_hypothesis` returned `Error: Sprintable API 422`, but the real reasons (only visible by curling the backend) were:
- `metric_definition.source` must be one of `ga4 | internal_ops | manual`
- `metric_definition.target` must be a number
- agent callers must pass a human `owner_member_id` (backend 400 `HUMAN_OWNER_REQUIRED`)

### Root cause

`SprintableClient.request` (`backend/sprintable_mcp/api_client.py`) built the error message only from the `{error:{message}}` envelope. FastAPI's pydantic **request validation** errors (`RequestValidationError`) are *not* routed through the app's custom `HTTPException` handler — they return FastAPI's default `{"detail": [{loc, msg, type}, ...]}` array, which the client ignored, falling back to the bare `Sprintable API {status}` string.

## Changes

- **`backend/sprintable_mcp/api_client.py`** — new `_extract_error_message()` in the **single shared helper** (applies to all tools). Handles every backend error shape in priority order:
  1. `{error:{code,message}}` standard envelope → `CODE: message`
  2. `{detail:{code,message}}` raw dict detail
  3. `{detail:[{loc,msg,type}]}` FastAPI 422 array → `field: msg; field: msg`
  4. plain-string `detail`
  5. non-JSON / unknown → serialized body
  Bodies are truncated (`_ERROR_BODY_MAX = 1500`) to guard agent context. `request()` now captures `resp.text` when `resp.json()` fails, so HTML/plain 5xx bodies surface too.
- **`backend/sprintable_mcp/server.py`** — `sprintable_create_hypothesis` tool description now documents the `metric_definition` contract (`metric` str, `source` enum `ga4|internal_ops|manual`, `target` number, `direction` enum `up|down`, plus GA4 extras) and the human `owner_member_id` requirement for agent callers.
- **`backend/sprintable_mcp/tools/hypotheses.py`** — `create_hypothesis` docstring documents the same contract and the owner decision.
- **`backend/tests/test_mcp_phase1.py`** — 5 new tests: 422 validation array, `HUMAN_OWNER_REQUIRED` envelope, dict detail, non-JSON body, truncation.

### `owner_member_id` decision (task #3): surface-only, no guessed default

The backend (`services/hypothesis.create_hypothesis`) requires agent callers to specify a **human** `owner_member_id`; the owner must pass `_verify_human_owner` (type=`human`). The MCP auth context's `member_id` is the **agent's own** member, so auto-defaulting it would just produce another `HUMAN_OWNER_REQUIRED`. Injecting an arbitrary human/project owner would be a guess that misattributes ownership. So this PR does **not** invent a default — it relies on the now-clear surfaced error plus the documented tool contract.

## Verification

Contract verified by grep, not guessed — against `backend/app/schemas/story.py::_validate_metric_definition` (the SSOT reused by `schemas/hypothesis.py`) and `backend/app/services/hypothesis.py::create_hypothesis`.

```
uv run pytest tests/test_mcp_phase1.py -v
=> 14 passed (9 existing, no regression + 5 new)
```

Dogfood story: `5f373c5a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)