### PR TITLE
feat(h1): L1 evidence read helper poll/latest_object_evidence (H1-S1)

### DIFF
--- a/backend/app/services/activity_stream.py
+++ b/backend/app/services/activity_stream.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import logging
 import uuid
+from datetime import datetime
 
 from sqlalchemy import select, text, tuple_
 from sqlalchemy.dialects.postgresql import insert as pg_insert
@@ -298,3 +299,112 @@ async def latest_activity_for_object(
         .limit(1)
     )
     return (await db.execute(query)).scalars().first()
+
+
+# ── H1-S1: L1 evidence read helper (verdict gate 소비·블루프린트 H1 §S1) ──────────
+#
+# 소스=activity_events(L1 canonical evidence·"evidence=L1 활동그래프" SSOT). activity_logs
+# (레거시 audit)는 evidence 레이어가 아니다. object_type/object_id로 스코프해 verdict gate가
+# "이 object에서 무슨 작업 활동이 있었나"를 증거로 읽는다. DB 신설 0(activity_events 재사용).
+# L2의 poll_activities_after_seq/latest_activity_for_object(전 org seq cursor)와는 다른 용도라
+# 별도 이름으로 신설한다(동명 재정의 시 L2 파손).
+
+
+async def _resolve_actor_types(
+    db: AsyncSession, actor_ids: set[uuid.UUID | None]
+) -> dict[uuid.UUID, str]:
+    """actor_id → actor_type(human|agent) 맵을 배치 1쿼리로 해소(N+1 회피).
+
+    activity_events엔 actor_type 컬럼이 없어(actor_id만) 멤버 해소로 보강한다. 해소 실패한
+    actor_id는 맵에서 빠진다(→ evidence dict의 actor_type=None).
+    """
+    ids = {a for a in actor_ids if a is not None}
+    if not ids:
+        return {}
+    from app.services.member_resolver import lookup_members_by_ids
+
+    members = await lookup_members_by_ids(ids, db)
+    return {aid: m.type for aid, m in members.items()}
+
+
+def _evidence_dict(row: ActivityEvent, actor_type: str | None) -> dict:
+    """ActivityEvent 1행 → 정규화 evidence dict(AC① 반환 계약)."""
+    return {
+        "activity_id": row.activity_id,
+        "activity_seq": row.activity_seq,
+        "actor_id": row.actor_id,
+        "actor_type": actor_type,
+        "verb": row.verb,
+        "object_type": row.object_type,
+        "object_id": row.object_id,
+        "timestamp": row.occurred_at,
+        "context": row.payload or {},
+    }
+
+
+async def poll_object_evidence(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    object_type: str,
+    object_id: uuid.UUID,
+    *,
+    after_seq: int | None = None,
+    after_time: datetime | None = None,
+    verbs: list[str] | None = None,
+    limit: int = 200,
+) -> list[dict]:
+    """object의 L1 활동 증거를 시간순(ASC)으로 반환한다(verdict gate 소비·AC①).
+
+    스코프=org_id+object_type+object_id. 증분=after_seq(activity_seq) 또는 after_time(occurred_at).
+    verbs 지정 시 해당 활동종류만. 정렬=occurred_at ASC(동시각은 activity_seq ASC tiebreak). 각 행은
+    {activity_id, activity_seq, actor_id, actor_type, verb, object_type, object_id, timestamp(=occurred_at),
+    context(=payload)}. actor_type은 배치 멤버해소.
+
+    **증거 없으면 빈 리스트 — 빈=빈이며 'pass'로 해석 금지(AC③). 게이트는 빈을 증거부재로 다뤄야 한다.**
+    """
+    query = select(ActivityEvent).where(
+        ActivityEvent.org_id == org_id,
+        ActivityEvent.object_type == object_type,
+        ActivityEvent.object_id == object_id,
+    )
+    if after_seq is not None:
+        query = query.where(ActivityEvent.activity_seq > after_seq)
+    if after_time is not None:
+        query = query.where(ActivityEvent.occurred_at > after_time)
+    if verbs:
+        query = query.where(ActivityEvent.verb.in_(verbs))
+    query = query.order_by(
+        ActivityEvent.occurred_at.asc(), ActivityEvent.activity_seq.asc()
+    ).limit(limit)
+    rows = list((await db.execute(query)).scalars().all())
+    if not rows:
+        return []
+    actor_types = await _resolve_actor_types(db, {r.actor_id for r in rows})
+    return [_evidence_dict(r, actor_types.get(r.actor_id)) for r in rows]
+
+
+async def latest_object_evidence(
+    db: AsyncSession,
+    org_id: uuid.UUID,
+    object_type: str,
+    object_id: uuid.UUID,
+    *,
+    verbs: list[str] | None = None,
+) -> dict | None:
+    """object의 가장 최근 L1 활동 증거 1건을 반환한다(activity_seq DESC). 없으면 None(AC③).
+
+    verbs 지정 시 해당 활동종류 중 최신. 반환 shape는 poll_object_evidence 항목과 동일.
+    """
+    query = select(ActivityEvent).where(
+        ActivityEvent.org_id == org_id,
+        ActivityEvent.object_type == object_type,
+        ActivityEvent.object_id == object_id,
+    )
+    if verbs:
+        query = query.where(ActivityEvent.verb.in_(verbs))
+    query = query.order_by(ActivityEvent.activity_seq.desc()).limit(1)
+    row = (await db.execute(query)).scalars().first()
+    if row is None:
+        return None
+    actor_types = await _resolve_actor_types(db, {row.actor_id})
+    return _evidence_dict(row, actor_types.get(row.actor_id))

--- a/backend/tests/test_object_evidence.py
+++ b/backend/tests/test_object_evidence.py
@@ -1,0 +1,149 @@
+"""H1-S1: L1 evidence read helper 테스트 (poll_object_evidence·latest_object_evidence).
+
+소스=activity_events. 단위(actor_type 배치해소·정규화) + 실 Postgres(스코프/ASC/verbs/after_seq/
+empty·AC④ status_changed seed→latest). DB 신설 0.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import activity_stream as mod
+from app.services.activity_stream import (
+    _evidence_dict,
+    latest_object_evidence,
+    poll_object_evidence,
+)
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 단위: 정규화 + actor_type 배치 해소 ────────────────────────────────────────
+
+def test_evidence_dict_normalizes_fields():
+    aid, oid, actor = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    ts = datetime(2026, 6, 12, tzinfo=timezone.utc)
+    row = SimpleNamespace(
+        activity_id=aid, activity_seq=7, actor_id=actor, verb="status_changed",
+        object_type="story", object_id=oid, occurred_at=ts, payload={"to": "in_review"},
+    )
+    d = _evidence_dict(row, "agent")
+    assert d["activity_id"] == aid and d["activity_seq"] == 7
+    assert d["actor_id"] == actor and d["actor_type"] == "agent"
+    assert d["verb"] == "status_changed" and d["object_type"] == "story" and d["object_id"] == oid
+    assert d["timestamp"] == ts and d["context"] == {"to": "in_review"}
+
+
+def test_evidence_dict_null_payload_to_empty():
+    row = SimpleNamespace(
+        activity_id=uuid.uuid4(), activity_seq=1, actor_id=None, verb="x",
+        object_type="story", object_id=uuid.uuid4(), occurred_at=datetime.now(timezone.utc),
+        payload=None,
+    )
+    assert _evidence_dict(row, None)["context"] == {} and _evidence_dict(row, None)["actor_type"] is None
+
+
+@pytest.mark.anyio
+async def test_resolve_actor_types_batches_lookup():
+    a1, a2 = uuid.uuid4(), uuid.uuid4()
+    fake = {a1: SimpleNamespace(type="agent"), a2: SimpleNamespace(type="human")}
+    with patch("app.services.member_resolver.lookup_members_by_ids", AsyncMock(return_value=fake)) as lk:
+        out = await mod._resolve_actor_types(AsyncMock(), {a1, a2, None})
+    assert out == {a1: "agent", a2: "human"}
+    # None 제외 + 단일 배치 호출.
+    lk.assert_awaited_once()
+    assert lk.await_args.args[0] == {a1, a2}
+
+
+@pytest.mark.anyio
+async def test_resolve_actor_types_empty_skips_query():
+    with patch("app.services.member_resolver.lookup_members_by_ids", AsyncMock()) as lk:
+        assert await mod._resolve_actor_types(AsyncMock(), {None}) == {}
+    lk.assert_not_awaited()
+
+
+# ── 실 Postgres: 스코프/정렬/verbs/after_seq/empty (AC①③④) ─────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_object_evidence_real_db():
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.models.activity_event import ActivityEvent
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org = uuid.uuid4()
+    proj = uuid.uuid4()
+    story_a = uuid.uuid4()
+    story_b = uuid.uuid4()
+    actor = uuid.uuid4()
+    base = datetime(2026, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _row(seq, obj_id, verb, mins):
+        return ActivityEvent(
+            activity_id=uuid.uuid4(), org_id=org, project_id=proj, actor_id=actor,
+            verb=verb, object_type="story", object_id=obj_id,
+            occurred_at=base + timedelta(minutes=mins),
+            source_event_ids=[], recipient_ids=[], recipient_types=[],
+            payload={"seq": seq}, dedup_key=f"dk-{uuid.uuid4()}", activity_seq=seq,
+        )
+
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(ActivityEvent.__table__.create, checkfirst=True)
+        Session = async_sessionmaker(engine, expire_on_commit=False)
+        async with Session() as s:
+            s.add_all([
+                _row(101, story_a, "commented", 1),
+                _row(103, story_a, "status_changed", 3),
+                _row(105, story_a, "status_changed", 5),
+                _row(104, story_b, "status_changed", 4),  # 다른 object — 격리돼야.
+            ])
+            await s.commit()
+
+        # actor_type 해소는 멤버 테이블 의존이라 격리(쿼리/정규화에 집중).
+        with patch.object(mod, "_resolve_actor_types", AsyncMock(return_value={actor: "agent"})):
+            async with Session() as s:
+                # AC④: status_changed seed → latest 반환(최신=seq105).
+                latest = await latest_object_evidence(s, org, "story", story_a, verbs=["status_changed"])
+                assert latest is not None and latest["activity_seq"] == 105
+                assert latest["verb"] == "status_changed" and latest["actor_type"] == "agent"
+                assert latest["object_id"] == story_a
+
+                # AC①: 시간순 ASC·object 스코프(story_b 격리).
+                allv = await poll_object_evidence(s, org, "story", story_a)
+                assert [r["activity_seq"] for r in allv] == [101, 103, 105]
+
+                # verbs 필터.
+                sc = await poll_object_evidence(s, org, "story", story_a, verbs=["status_changed"])
+                assert [r["activity_seq"] for r in sc] == [103, 105]
+
+                # after_seq 증분.
+                after = await poll_object_evidence(s, org, "story", story_a, after_seq=103)
+                assert [r["activity_seq"] for r in after] == [105]
+
+                # after_time 증분.
+                at = await poll_object_evidence(s, org, "story", story_a, after_time=base + timedelta(minutes=3))
+                assert [r["activity_seq"] for r in at] == [105]
+
+                # AC③: 증거 없는 object → [] / None(빈=빈).
+                empty_id = uuid.uuid4()
+                assert await poll_object_evidence(s, org, "story", empty_id) == []
+                assert await latest_object_evidence(s, org, "story", empty_id) is None
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(ActivityEvent.__table__.drop, checkfirst=True)
+        await engine.dispose()


### PR DESCRIPTION
## H1-S1 — L1 evidence read helper

블루프린트 H1(`E-H1-VERDICT-GATE`) S1. verdict gate가 "이 object에서 무슨 작업 활동이 있었나"를 **L1 활동그래프**에서 증거로 읽는 object-scoped read helper. **소스=`activity_events`**(L1 canonical evidence SSOT·`activity_logs` 레거시 audit 아님). **DB 신설 0**(activity_events 재사용).

### 신규 함수 (`activity_stream.py`)
- **`poll_object_evidence(db, org_id, object_type, object_id, *, after_seq=None, after_time=None, verbs=None, limit=200)`** → object 스코프 활동을 **occurred_at ASC**(동시각 activity_seq tiebreak)로 정규화 evidence dict 리스트. 증분=`after_seq`(activity_seq) | `after_time`(occurred_at). `verbs` 활동종류 필터.
- **`latest_object_evidence(...)`** → 최근 1건(activity_seq DESC) 또는 `None`.
- **반환 dict (AC①)**: `activity_id/activity_seq/actor_id/actor_type/verb/object_type/object_id/timestamp(=occurred_at)/context(=payload)`.

### actor_type — 배치 해소 (필드 보강)
`activity_events`엔 `actor_type` 컬럼이 없어(`actor_id`만) `lookup_members_by_ids`로 **배치 1쿼리**(N+1 회피) 해소 → `human|agent`. 해소 실패 actor는 `None`.

### 설계 결정 (구현 전 PO와 확정)
- ⚠️ 킥의 함수명 `poll_activities_after_seq`/`latest_activity_for_object`는 **이미 존재**(BE-6·L2 사용 중·activity_events seq cursor). 동명 재정의 시 L2 파손 → **별도 이름으로 신설**(기존 무손상). 근본: H1 blueprint가 b20 브랜치 grounded라 develop의 L1 helper 미인지.
- 소스: blueprint SSOT "evidence=L1 활동그래프" → `activity_events`(activity_logs 아님).
- **AC③**: 증거 없으면 `[]`/`None` — 빈=빈(게이트가 `pass`로 해석 금지). 주석 명시.

### Validation
단위 4(정규화·null payload→{}·actor_type 배치해소·None skip) + **실 Postgres 1**(AC④ `status_changed` seed→latest=seq105·occurred_at ASC·object 스코프 격리·verbs 필터·after_seq/after_time 증분·빈 object→`[]`/`None`). L2/eventbus **32 무회귀**·`app.main` import OK·기존 L2 helper와 공존 import 확인.

> 에픽 `E-H1-VERDICT-GATE` S1(no-dep·BE). S2(gate service)가 이 헬퍼 import. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)