### PR TITLE
feat(h1): gate evidence metadata migration 0118 (H1-S3)

### DIFF
--- a/backend/alembic/versions/0118_add_gate_evidence_metadata.py
+++ b/backend/alembic/versions/0118_add_gate_evidence_metadata.py
@@ -1,0 +1,60 @@
+"""H1-S3: gate evidence metadata 컬럼 (additive).
+
+Revision ID: 0118
+Revises: 0117
+Create Date: 2026-06-12
+
+블루프린트 E-H1-VERDICT-GATE S3. merge verdict gate가 결정 근거/증거상태/사람필요 여부를 게이트
+행에 남기도록 `gate`에 4컬럼 추가. additive — 기존 스키마/행 무손상.
+
+- requires_human  bool NOT NULL default false — 기존 행은 false backfill(server_default·AC②).
+- evidence_status text NULL — 증거 상태(예: present|absent|self_report_only).
+- decision_basis  text NULL — 결정 근거(정책+증거 합성 사유).
+- auto_decision_reason text NULL — 자동 결정 사유(auto_merge/ask/block 설명).
+
+idempotent: 컬럼 단위 inspect 가드(0117 선례). AC⑤: 마이그 외 수동 SQL 없음.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0118"
+down_revision = "0117"
+branch_labels = None
+depends_on = None
+
+_TABLE = "gate"
+_COLUMNS = ("requires_human", "evidence_status", "decision_basis", "auto_decision_reason")
+
+
+def _existing_columns(conn) -> set[str]:
+    insp = sa.inspect(conn)
+    if _TABLE not in insp.get_table_names():
+        return set()
+    return {c["name"] for c in insp.get_columns(_TABLE)}
+
+
+def upgrade() -> None:
+    existing = _existing_columns(op.get_bind())
+
+    if "requires_human" not in existing:
+        # NOT NULL + server_default false → 기존 행 자동 backfill(AC②).
+        op.add_column(
+            _TABLE,
+            sa.Column("requires_human", sa.Boolean(), nullable=False, server_default=sa.text("false")),
+        )
+    if "evidence_status" not in existing:
+        op.add_column(_TABLE, sa.Column("evidence_status", sa.Text(), nullable=True))
+    if "decision_basis" not in existing:
+        op.add_column(_TABLE, sa.Column("decision_basis", sa.Text(), nullable=True))
+    if "auto_decision_reason" not in existing:
+        op.add_column(_TABLE, sa.Column("auto_decision_reason", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    existing = _existing_columns(op.get_bind())
+    # 추가 역순으로 drop(존재 시에만).
+    for col in reversed(_COLUMNS):
+        if col in existing:
+            op.drop_column(_TABLE, col)

--- a/backend/app/models/gate.py
+++ b/backend/app/models/gate.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import DateTime, String, Text, func
+from sqlalchemy import Boolean, DateTime, String, Text, func, text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -43,6 +43,11 @@ class Gate(Base):
     resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     resolution_note: Mapped[str | None] = mapped_column(Text, nullable=True)
     neutral_facts: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # H1-S3: merge verdict gate evidence metadata (0118).
+    requires_human: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("false"))
+    evidence_status: Mapped[str | None] = mapped_column(Text, nullable=True)
+    decision_basis: Mapped[str | None] = mapped_column(Text, nullable=True)
+    auto_decision_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/routers/gates.py
+++ b/backend/app/routers/gates.py
@@ -60,6 +60,11 @@ class GateResponse(BaseModel):
     resolved_at: datetime | None = None
     resolution_note: str | None = None
     neutral_facts: dict[str, Any] | None = None
+    # H1-S3: merge verdict gate evidence metadata (0118)·additive·하위호환 default.
+    requires_human: bool = False
+    evidence_status: str | None = None
+    decision_basis: str | None = None
+    auto_decision_reason: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/tests/test_gate_evidence_metadata.py
+++ b/backend/tests/test_gate_evidence_metadata.py
@@ -1,0 +1,44 @@
+"""H1-S3: gate evidence metadata 컬럼/스키마 노출 테스트(0118).
+
+실 마이그 up/down·backfill은 CI alembic-fresh-db + 로컬 실 PG로 검증. 여기선 모델/스키마 계약(AC③)을
+DB 없이 잠근다.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from app.models.gate import Gate
+from app.routers.gates import GateResponse
+
+_NEW_FIELDS = ("requires_human", "evidence_status", "decision_basis", "auto_decision_reason")
+
+
+def test_gate_model_has_evidence_columns():
+    cols = set(Gate.__table__.c.keys())
+    for f in _NEW_FIELDS:
+        assert f in cols, f
+    # requires_human은 NOT NULL + server_default false.
+    rh = Gate.__table__.c.requires_human
+    assert rh.nullable is False and rh.server_default is not None
+
+
+def test_gate_response_exposes_new_fields_with_defaults():
+    # 새 필드 미지정 객체도 검증 통과(하위호환 default) — AC③.
+    base = dict(
+        id=uuid.uuid4(), org_id=uuid.uuid4(), work_item_id=uuid.uuid4(),
+        work_item_type="story", gate_type="merge", status="pending",
+        resolver_id=None, resolved_at=None, resolution_note=None, neutral_facts=None,
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+    )
+    obj = type("G", (), base)()
+    r = GateResponse.model_validate(obj)
+    assert r.requires_human is False  # default.
+    assert r.evidence_status is None and r.decision_basis is None and r.auto_decision_reason is None
+
+    # 값이 있으면 그대로 노출.
+    obj2 = type("G", (), {**base, "requires_human": True, "evidence_status": "self_report_only",
+                          "decision_basis": "policy+evidence", "auto_decision_reason": "ask_human"})()
+    r2 = GateResponse.model_validate(obj2)
+    assert r2.requires_human is True and r2.evidence_status == "self_report_only"
+    assert r2.decision_basis == "policy+evidence" and r2.auto_decision_reason == "ask_human"


### PR DESCRIPTION
## H1-S3 — Gate evidence metadata 마이그레이션

블루프린트 `E-H1-VERDICT-GATE` S3. merge verdict gate가 결정 근거/증거상태/사람필요 여부를 게이트 행에 남기도록 `gate`에 4컬럼 추가(additive). ⚠️ **마이그 동반**(머지 + migrate-dev 원자).

### `0118` (head 0117 → 0118)
- `gate.requires_human` bool **NOT NULL server_default false** → 기존 행 자동 backfill(**AC②**).
- `gate.evidence_status` text null
- `gate.decision_basis` text null
- `gate.auto_decision_reason` text null

컬럼 단위 inspect 가드(0117 선례)·**up/down 모두**(AC①)·마이그 외 수동 SQL 0(**AC⑤**).

### 모델/스키마
- `Gate` 모델: 4컬럼 미러(`Boolean` import 추가).
- `GateResponse`: 4필드 노출·하위호환 default(`requires_human=False`·나머지 None·**AC③**).

### Validation
- **실 Postgres**(Operations API): upgrade/downgrade OK·기존 행 `requires_human=false` backfill·`evidence_status` NULL·신규 insert `requires_human` 생략→default false·downgrade 후 4컬럼 제거.
- 신규 단위 2(모델 컬럼·NOT NULL+server_default·GateResponse 노출 default/값) + **기존 gate API 22 무파손**(**AC④** `test_e_cage_referee_p3_gate_object`)·`app.main` import OK·단일 head `0118`←`0117`.

> 에픽 `E-H1-VERDICT-GATE` S3. forward-verify: Gate 모델·GateResponse develop 실재 확인. **머지 후 CB 완료 확인 → migrate-dev 0118**(PO 실행). S4(merge hook가 이 metadata 기록·decision 배선).

🤖 Generated with [Claude Code](https://claude.com/claude-code)