### PR TITLE
feat(h1): apply merge verdict gate at report-done merge stage (H1-S4)

### DIFF
--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -6,16 +6,23 @@ import uuid
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Response, status
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.dependencies.auth import AuthContext, get_current_user
 from app.dependencies.database import get_db
+from app.models.gate import Gate
 from app.models.pm import Story
 from app.models.team import TeamMember
 from app.repositories.story import StoryRepository
+from app.services.merge_verdict_gate import (
+    AUTO_MERGE,
+    BLOCK,
+    MergeGateDecision,
+    evaluate_merge_gate,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +98,33 @@ class ReportDoneResponse(BaseModel):
     next_stage: str
     memo_id: uuid.UUID | None = None
     story_status: str | None = None
+    # H1-S4: merge stage 게이트 결정(merge 단계에서만 채워짐).
+    gate_decision: str | None = None  # auto_merge | ask_human | block
+    gate_id: uuid.UUID | None = None
+    requires_human: bool | None = None
+    decision_basis: str | None = None
+
+
+def _evidence_status(decision: str) -> str:
+    if decision == AUTO_MERGE:
+        return "sufficient"
+    if decision == BLOCK:
+        return "blocked"
+    return "insufficient"
+
+
+async def _record_gate_evidence(session: AsyncSession, decision: MergeGateDecision) -> None:
+    """S3 gate evidence metadata 컬럼에 머지 게이트 결정을 기록(gate row 있을 때만)."""
+    if decision.gate_id is None:
+        return
+    gate = await session.get(Gate, decision.gate_id)
+    if gate is None:
+        return
+    gate.requires_human = decision.decision != AUTO_MERGE
+    gate.evidence_status = _evidence_status(decision.decision)
+    gate.decision_basis = decision.reason
+    gate.auto_decision_reason = decision.decision
+    await session.flush()
 
 # ─── Endpoint ─────────────────────────────────────────────────────────────────
 
@@ -98,6 +132,7 @@ class ReportDoneResponse(BaseModel):
 async def report_done(
     body: ReportDoneRequest,
     background_tasks: BackgroundTasks,
+    response: Response,
     session: AsyncSession = Depends(get_db),
     auth: AuthContext = Depends(get_current_user),
 ) -> ReportDoneResponse:
@@ -117,7 +152,40 @@ async def report_done(
     next_stage: str = transition["next_stage"]
     story_status: str | None = transition["story_status"]
 
-    # 스토리 상태 업데이트
+    # H1-S4: merge 단계는 status=done 전이 전에 merge verdict gate(S2)를 통과해야 한다.
+    # auto_merge만 done·ask_human은 status 유지+202·block은 status 유지+409. gate evidence(S3) 기록.
+    gate_info: MergeGateDecision | None = None
+    if body.stage == "merge":
+        ctx = body.context or {}
+        pr_number = ctx.get("pr_number")
+        gate_info = await evaluate_merge_gate(
+            session,
+            story.org_id,
+            story.id,
+            pr_number=int(pr_number) if pr_number else 0,
+            repo=str(ctx.get("repo") or ""),
+            ci_result=ctx.get("ci_result"),
+            pr_result=ctx.get("pr_result"),
+        )
+        await _record_gate_evidence(session, gate_info)
+        if gate_info.decision != AUTO_MERGE:
+            story_status = None  # done 전이 차단 — 현재 status 유지(AC①③).
+            if gate_info.decision == BLOCK:
+                # gate audit를 보존하고 차단(get_db는 예외 시 rollback이라 명시 commit).
+                await session.commit()
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "code": "MERGE_BLOCKED",
+                        "message": f"merge gate blocked: {gate_info.reason}",
+                        "decision": gate_info.decision,
+                        "gate_id": str(gate_info.gate_id) if gate_info.gate_id else None,
+                        "requires_human": True,
+                    },
+                )
+            response.status_code = status.HTTP_202_ACCEPTED  # ask_human — 사람 보류.
+
+    # 스토리 상태 업데이트 (merge에서 auto_merge가 아니면 story_status=None이라 skip)
     if story_status:
         story_repo = StoryRepository(session, story.org_id)
         await story_repo.update(story.id, status=story_status)
@@ -128,4 +196,8 @@ async def report_done(
         next_stage=next_stage,
         memo_id=None,
         story_status=story_status,
+        gate_decision=gate_info.decision if gate_info else None,
+        gate_id=gate_info.gate_id if gate_info else None,
+        requires_human=(gate_info.decision != AUTO_MERGE) if gate_info else None,
+        decision_basis=gate_info.reason if gate_info else None,
     )

--- a/backend/tests/test_h1_s4_merge_gate_wiring.py
+++ b/backend/tests/test_h1_s4_merge_gate_wiring.py
@@ -1,0 +1,188 @@
+"""H1-S4: report-done stage=merge 게이트 적용 테스트.
+
+merge 단계에서 evaluate_merge_gate(S2) decision으로 done 전이를 게이트(auto_merge만 done·
+ask_human 202·block 409)하고 gate evidence metadata(S3)를 기록하는지 검증.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.services.merge_verdict_gate import ASK_HUMAN, AUTO_MERGE, BLOCK, MergeGateDecision
+
+ORG_ID = uuid.uuid4()
+STORY_ID = uuid.uuid4()
+AGENT_ID = uuid.UUID("9cac9d96-5474-45f7-941e-787407597b52")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _mock_story(status="in-review"):
+    s = MagicMock()
+    s.id = STORY_ID
+    s.org_id = ORG_ID
+    s.project_id = uuid.uuid4()
+    s.title = "스토리"
+    s.status = status
+    return s
+
+
+async def _client():
+    from app.dependencies.auth import get_current_user
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    ctx = MagicMock()
+    ctx.user_id = str(AGENT_ID)
+    ctx.claims = {"app_metadata": {"org_id": str(ORG_ID)}}
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = _mock_story()
+    session.execute = AsyncMock(return_value=result)
+
+    async def override_db():
+        yield session
+
+    async def override_auth():
+        return ctx
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_auth
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test"), session, app
+
+
+def _decision(decision, **over):
+    base = dict(
+        decision=decision, reason="r", gate_id=uuid.uuid4(), gate_status="auto_passed",
+        disposition="allow_auto", trust=0.9, ci_result="pass",
+    )
+    base.update(over)
+    return MergeGateDecision(**base)
+
+
+def _body(stage="merge", ctx=None):
+    b = {"story_id": str(STORY_ID), "stage": stage, "agent_id": str(AGENT_ID)}
+    if ctx is not None:
+        b["context"] = ctx
+    return b
+
+
+# ── AC②: auto_merge → done(200) ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_auto_merge_sets_done():
+    client, _, app = await _client()
+    try:
+        with patch("app.routers.workflow_report.evaluate_merge_gate",
+                   new=AsyncMock(return_value=_decision(AUTO_MERGE))) as gate, \
+             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done",
+                                    json=_body(ctx={"pr_number": 9, "repo": "o/r", "ci_result": "pass", "pr_result": "pass"}))
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["story_status"] == "done" and data["gate_decision"] == "auto_merge"
+        assert data["requires_human"] is False
+        upd.assert_called_once()  # done 전이 발생.
+        gate.assert_awaited_once()  # AC⑤: 게이트 1회.
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── AC①: ask_human → status 유지(202) ─────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_ask_human_keeps_status_202():
+    client, _, app = await _client()
+    try:
+        with patch("app.routers.workflow_report.evaluate_merge_gate",
+                   new=AsyncMock(return_value=_decision(ASK_HUMAN, gate_status="pending", disposition="ask", trust=None))), \
+             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json=_body(ctx={"ci_result": "pass"}))
+        assert resp.status_code == 202  # 사람 보류.
+        data = resp.json()
+        assert data["story_status"] is None  # done 전이 안 함(유지).
+        assert data["gate_decision"] == "ask_human" and data["requires_human"] is True
+        upd.assert_not_called()  # status update 호출 0.
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── AC③: block → status 유지(409) ─────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_block_returns_409_keeps_status():
+    client, _, app = await _client()
+    try:
+        with patch("app.routers.workflow_report.evaluate_merge_gate",
+                   new=AsyncMock(return_value=_decision(BLOCK, reason="CI fail", ci_result="fail"))), \
+             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json=_body(ctx={"ci_result": "fail"}))
+        assert resp.status_code == 409
+        # main.py 핸들러가 dict detail을 envelope error로 패스스루(code/message + 추가 키).
+        err = resp.json()["error"]
+        assert err["code"] == "MERGE_BLOCKED" and err["decision"] == "block"
+        assert err["requires_human"] is True
+        upd.assert_not_called()  # done 전이 안 함.
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── AC④: 비-merge 단계는 게이트 미호출 ────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_non_merge_stage_does_not_invoke_gate():
+    client, _, app = await _client()
+    try:
+        with patch("app.routers.workflow_report.evaluate_merge_gate", new=AsyncMock()) as gate, \
+             patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock):
+            async with client as c:
+                resp = await c.post("/api/v2/workflow/report-done", json=_body(stage="review"))
+        assert resp.status_code == 200
+        gate.assert_not_awaited()  # merge 외 단계는 게이트 0.
+    finally:
+        app.dependency_overrides.clear()
+
+
+# ── gate evidence metadata 기록(S3 컬럼) ───────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_record_gate_evidence_sets_columns():
+    from app.routers.workflow_report import _record_gate_evidence
+
+    gate = SimpleNamespace(requires_human=False, evidence_status=None, decision_basis=None, auto_decision_reason=None)
+    session = AsyncMock()
+    session.get = AsyncMock(return_value=gate)
+    await _record_gate_evidence(session, _decision(ASK_HUMAN, reason="needs review"))
+    assert gate.requires_human is True  # auto_merge 아니면 사람 필요.
+    assert gate.evidence_status == "insufficient"
+    assert gate.decision_basis == "needs review" and gate.auto_decision_reason == "ask_human"
+
+    # auto_merge → requires_human False·evidence sufficient.
+    g2 = SimpleNamespace(requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None)
+    session.get = AsyncMock(return_value=g2)
+    await _record_gate_evidence(session, _decision(AUTO_MERGE, reason="ok"))
+    assert g2.requires_human is False and g2.evidence_status == "sufficient"
+
+
+@pytest.mark.anyio
+async def test_record_gate_evidence_noop_when_no_gate():
+    from app.routers.workflow_report import _record_gate_evidence
+
+    session = AsyncMock()
+    session.get = AsyncMock()
+    await _record_gate_evidence(session, _decision(ASK_HUMAN, gate_id=None))
+    session.get.assert_not_awaited()  # gate_id None이면 조회 0.

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -155,7 +155,9 @@ async def test_dev_to_review():
 
 @pytest.mark.anyio
 async def test_merge_to_done():
-    """merge 완료 → 스토리 done 전환, 메모 없음."""
+    """H1-S4: merge 완료 + 게이트 auto_merge → 스토리 done 전환(게이트 통과 시에만)."""
+    from app.services.merge_verdict_gate import AUTO_MERGE, MergeGateDecision
+
     client, session, app = await _client()
     try:
         story = _mock_story(status="in-review")
@@ -163,22 +165,26 @@ async def test_merge_to_done():
         mock_result.scalar_one_or_none.return_value = story
         session.execute = AsyncMock(return_value=mock_result)
 
-        with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update:
+        auto = MergeGateDecision(
+            decision=AUTO_MERGE, reason="ok", gate_id=uuid.uuid4(),
+            gate_status="auto_passed", disposition="allow_auto", trust=0.9, ci_result="pass",
+        )
+        with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update, \
+             patch("app.routers.workflow_report.evaluate_merge_gate", new=AsyncMock(return_value=auto)), \
+             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()):
             mock_update.return_value = story
-
             async with client as c:
                 resp = await c.post("/api/v2/workflow/report-done", json={
                     "story_id": str(STORY_ID),
                     "stage": "merge",
                     "agent_id": str(AGENT_ID),
+                    "context": {"pr_number": 12, "repo": "o/r", "ci_result": "pass", "pr_result": "pass"},
                 })
 
         assert resp.status_code == 200
         data = resp.json()
-        assert data["completed_stage"] == "merge"
-        assert data["next_stage"] == "done"
-        assert data["story_status"] == "done"
-        assert data["memo_id"] is None
+        assert data["completed_stage"] == "merge" and data["next_stage"] == "done"
+        assert data["story_status"] == "done" and data["gate_decision"] == "auto_merge"
         mock_update.assert_called_once()
     finally:
         app.dependency_overrides.clear()
@@ -210,9 +216,14 @@ async def test_context_field_accepted():
 
 @pytest.mark.anyio
 async def test_all_valid_stages():
-    """모든 유효 stage가 400 없이 처리된다."""
+    """모든 유효 stage가 400 없이 처리된다(merge는 게이트 auto_merge로 200)."""
     from app.routers.workflow_report import _VALID_STAGES
+    from app.services.merge_verdict_gate import AUTO_MERGE, MergeGateDecision
 
+    auto = MergeGateDecision(
+        decision=AUTO_MERGE, reason="ok", gate_id=None,
+        gate_status="auto_passed", disposition="allow_auto", trust=0.9, ci_result="pass",
+    )
     for stage in _VALID_STAGES:
         client, session, app = await _client()
         try:
@@ -221,7 +232,8 @@ async def test_all_valid_stages():
             mock_result.scalar_one_or_none.return_value = story
             session.execute = AsyncMock(return_value=mock_result)
 
-            with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock, return_value=story):
+            with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock, return_value=story), \
+                 patch("app.routers.workflow_report.evaluate_merge_gate", new=AsyncMock(return_value=auto)):
                 async with client as c:
                     resp = await c.post("/api/v2/workflow/report-done", json={
                         "story_id": str(STORY_ID),


### PR DESCRIPTION
## H1-S4 — report-done stage=merge 게이트 적용 (실 배선)

블루프린트 `E-H1-VERDICT-GATE` S4. `report-done`의 `stage=="merge"`에서 story `status=done` 전이 **전에** `evaluate_merge_gate`(S2)를 호출해 게이트한다. ⚠️ **기본켜짐 배선** — 머지 경로 verdict gate 상시 적용.

### 동작
- **auto_merge만** `status=done` 전이(**AC②**).
- **ask_human** → status 유지 + **HTTP 202**(**AC①**).
- **block** → status 유지 + **HTTP 409**(`MERGE_BLOCKED`·**AC③**).
- `pr_number`/`repo`/`ci_result`/`pr_result`는 report-done `body.context`에서.
- **gate evidence metadata(S3) 기록**: gate row에 `requires_human`(auto_merge 아니면 true)·`evidence_status`(sufficient|insufficient|blocked)·`decision_basis`(reason)·`auto_decision_reason`(decision).
- 비-merge 단계(kickoff/dev/review/qa)는 게이트 미호출·**기존 동작 동일**(**AC④**).

### 트랜잭션
block은 `get_db`가 예외 시 rollback이라 raise 前 **명시 commit으로 gate audit 보존**. 409 detail dict는 main.py 핸들러가 envelope `error`로 패스스루(`code=MERGE_BLOCKED`).

### ⚠️ 행동 변화 (의도된 기본켜짐)
머지 단계가 이제 게이트를 통과(auto_merge)해야 done. **초기엔 trust None(R5 전원 null)→ask_human(202)** 이라 머지 done은 신뢰가 verdict로 쌓일 때까지 보류 — 보수적 안전(블루프린트 접는조건 정합). 비-merge 단계는 무영향.

### Validation
신규 `test_h1_s4_merge_gate_wiring.py` **7** (auto_merge→done 200·ask_human→202+status유지+update 0회·block→409+update 0회·**비-merge 게이트 미호출**·evidence 컬럼 기록·gate 없으면 noop) + 기존 `test_workflow_report` **8 무파손**(merge 테스트는 게이트-인지로 업데이트·AC⑤ 게이트 1회) + merge gate service **16 무회귀**·`app.main` import OK.

> 에픽 `E-H1-VERDICT-GATE` S4. forward-verify: `workflow_report.py` merge stage·`_TRANSITIONS`·StoryRepository.update·get_db commit 동작 develop 실재 확인. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)