### PR TITLE
feat(h1): board in-review->done gate + rollout-safety flag (H1-S5)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -66,6 +66,12 @@ class Settings(BaseSettings):
     l2_trigger_org_allowlist: str = ""  # CSV org_id — 비면 전 org, 지정 시 해당 org만 발사
     l2_trigger_max_wakes_per_org_per_hour: int = 0  # >0이면 org 시간당 wake 상한(초과 skip), 0=무제한
 
+    # E-H1 머지 verdict 게이트(report-done merge·board in-review→done 직접 PATCH). default-off —
+    # 팀 워크플로 경로라 켜면 trust None일 때 done이 전부 보류돼 team stall. 실 enable은 S10 E2E+
+    # 접는조건 後 의도적으로. allowlist 지정 시 해당 org만 게이트(점진 rollout).
+    h1_merge_gate_enabled: bool = False
+    h1_merge_gate_org_allowlist: str = ""  # CSV org_id — 비면 enabled 시 전 org, 지정 시 해당 org만
+
     # E-MEMBER-SSOT AC2-3: 신원 해소를 anchor(members+member_identity_aliases) 기반으로 전환하는
     # shadow 플래그. off(기본)=레거시 resolver(org_members/team_members). on=anchor resolver.
     # 라이브 cutover는 AC3-1 — 여기선 shadow(parity 검증용), 기본 off라 실 read 경로 무변경.

--- a/backend/app/routers/stories.py
+++ b/backend/app/routers/stories.py
@@ -18,6 +18,7 @@ from app.routers.events import publish_event
 from app.services.event_seq import assign_recipient_seq
 from app.schemas.story import StoryCreate, StoryResponse, StoryStatusUpdate, StoryUpdate
 from app.services.member_resolver import canonicalize_member_id
+from app.services.merge_verdict_gate import AUTO_MERGE, evaluate_merge_gate, merge_gate_active
 from app.services.notification_dispatch import dispatch_notification
 from app.services.webhook_dispatch import fire_webhooks
 from app.services.workflow_pipeline import process_event
@@ -139,6 +140,36 @@ async def _upsert_assignee_participation(
     p_repo = ParticipationRepository(session, org_id)
     if not await p_repo.exists(story_id, assignee_id, default_role.id):
         await p_repo.create(story_id=story_id, member_id=assignee_id, role_id=default_role.id)
+
+
+async def _preflight_merge_gate(
+    db: AsyncSession, org_id: uuid.UUID, story, new_status: str | None
+) -> None:
+    """H1-S5: board 직접 PATCH로 in-review→done 전이 시 merge verdict gate preflight.
+
+    게이트 active(`merge_gate_active`·flag+allowlist)이고 in-review→done일 때만 동작 — auto_merge가
+    아니면 409로 전이 차단(status 유지). 플래그 off면 즉시 반환해 기존 PATCH 동작 무변경(AC①).
+    board PATCH엔 PR/CI 컨텍스트가 없으므로(ci_result=None) 증거 없이 done 시도는 보류된다.
+    """
+    if new_status != "done" or story is None or getattr(story, "status", None) != "in-review":
+        return
+    if not merge_gate_active(org_id):
+        return
+    decision = await evaluate_merge_gate(
+        db, org_id, story.id, pr_number=0, repo="", ci_result=None, pr_result=None
+    )
+    if decision.decision != AUTO_MERGE:
+        await db.commit()  # gate audit 보존(get_db는 예외 시 rollback).
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "MERGE_GATE_PENDING",
+                "message": f"in-review→done은 merge 게이트 통과 필요: {decision.reason}",
+                "decision": decision.decision,
+                "gate_id": str(decision.gate_id) if decision.gate_id else None,
+                "requires_human": True,
+            },
+        )
 
 
 @router.post("", response_model=StoryResponse, status_code=201)
@@ -273,10 +304,15 @@ async def update_story(
     if assignee_ids_in is not None and "assignee_id" not in data:
         data["assignee_id"] = assignee_ids_in[0] if assignee_ids_in else None
     old_assignee_id: uuid.UUID | None = None
+    story_before = None
     if "assignee_id" in data:
         story_before = await repo.get(id)
         if story_before:
             old_assignee_id = story_before.assignee_id
+    # H1-S5: PATCH /{id} 로 status=done 전이 시도도 board 경로와 동일하게 preflight 게이트(AC②).
+    if data.get("status") == "done":
+        gate_story = story_before or await repo.get(id)
+        await _preflight_merge_gate(db, repo.org_id, gate_story, "done")
     story = await repo.update(id, **data)
     if story is None:
         raise HTTPException(status_code=404, detail="Story not found")
@@ -484,6 +520,10 @@ async def update_story_status(
     _violation = check_transition(old_status, body.status, _violation_level)
     if _violation.violated and _violation_level == "block":
         raise HTTPException(status_code=400, detail=_violation.reason or "워크플로우 위반으로 상태 전이가 거부되었습니다.")
+
+    # H1-S5: in-review→done 직접 PATCH는 merge verdict gate preflight(플래그 active 시·AC②).
+    # transition rule(check_transition)과 직교 — 전이 유효성 통과 후 증거 게이트를 얹는다(AC④).
+    await _preflight_merge_gate(db, repo.org_id, story_before, body.status)
 
     try:
         # AC2: violation_level 전달 → warn 모드이면 set_status hard block 우회

--- a/backend/app/routers/workflow_report.py
+++ b/backend/app/routers/workflow_report.py
@@ -22,6 +22,7 @@ from app.services.merge_verdict_gate import (
     BLOCK,
     MergeGateDecision,
     evaluate_merge_gate,
+    merge_gate_active,
 )
 
 logger = logging.getLogger(__name__)
@@ -154,8 +155,9 @@ async def report_done(
 
     # H1-S4: merge 단계는 status=done 전이 전에 merge verdict gate(S2)를 통과해야 한다.
     # auto_merge만 done·ask_human은 status 유지+202·block은 status 유지+409. gate evidence(S3) 기록.
+    # H1-S5: 전 게이트 단일 스위치 — 플래그 off(또는 allowlist 밖)면 게이트 미호출(기존 merge→done 동작).
     gate_info: MergeGateDecision | None = None
-    if body.stage == "merge":
+    if body.stage == "merge" and merge_gate_active(story.org_id):
         ctx = body.context or {}
         pr_number = ctx.get("pr_number")
         gate_info = await evaluate_merge_gate(

--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -18,6 +18,7 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.participation import ParticipationRole
 from app.services.gate_service import create_gate
 from app.services.trust_score import compute_member_trust_scores
@@ -38,6 +39,31 @@ BLOCK = "block"
 
 # gate status(정책 disposition 아티팩트) → 원 disposition 역추론(관측용).
 _STATUS_TO_DISPOSITION = {"auto_passed": "allow_auto", "pending": "ask", "rejected": "deny"}
+
+
+def _gate_org_allowlist() -> frozenset[uuid.UUID]:
+    out: set[uuid.UUID] = set()
+    for x in (settings.h1_merge_gate_org_allowlist or "").split(","):
+        x = x.strip()
+        if not x:
+            continue
+        try:
+            out.add(uuid.UUID(x))
+        except ValueError:
+            logger.warning("H1 merge gate allowlist 무효 org_id 무시: %r", x)
+    return frozenset(out)
+
+
+def merge_gate_active(org_id: uuid.UUID) -> bool:
+    """H1 머지 게이트 활성 여부 — report-done·board 전 게이트의 단일 스위치(롤아웃 안전).
+
+    default-off(`H1_MERGE_GATE_ENABLED`). enabled여도 allowlist 지정 시 해당 org만(비면 전 org).
+    off면 게이트 미호출 → 기존 PATCH/머지 동작 무변경(team stall 방지).
+    """
+    if not settings.h1_merge_gate_enabled:
+        return False
+    allow = _gate_org_allowlist()
+    return (not allow) or (org_id in allow)
 
 
 @dataclass(frozen=True)

--- a/backend/tests/test_h1_s4_merge_gate_wiring.py
+++ b/backend/tests/test_h1_s4_merge_gate_wiring.py
@@ -84,6 +84,7 @@ async def test_auto_merge_sets_done():
         with patch("app.routers.workflow_report.evaluate_merge_gate",
                    new=AsyncMock(return_value=_decision(AUTO_MERGE))) as gate, \
              patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.routers.workflow_report.merge_gate_active", return_value=True), \
              patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
             async with client as c:
                 resp = await c.post("/api/v2/workflow/report-done",
@@ -107,6 +108,7 @@ async def test_ask_human_keeps_status_202():
         with patch("app.routers.workflow_report.evaluate_merge_gate",
                    new=AsyncMock(return_value=_decision(ASK_HUMAN, gate_status="pending", disposition="ask", trust=None))), \
              patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.routers.workflow_report.merge_gate_active", return_value=True), \
              patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
             async with client as c:
                 resp = await c.post("/api/v2/workflow/report-done", json=_body(ctx={"ci_result": "pass"}))
@@ -128,6 +130,7 @@ async def test_block_returns_409_keeps_status():
         with patch("app.routers.workflow_report.evaluate_merge_gate",
                    new=AsyncMock(return_value=_decision(BLOCK, reason="CI fail", ci_result="fail"))), \
              patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.routers.workflow_report.merge_gate_active", return_value=True), \
              patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as upd:
             async with client as c:
                 resp = await c.post("/api/v2/workflow/report-done", json=_body(ctx={"ci_result": "fail"}))

--- a/backend/tests/test_h1_s5_board_gate.py
+++ b/backend/tests/test_h1_s5_board_gate.py
@@ -1,0 +1,114 @@
+"""H1-S5: board in-review→done 게이트 + 롤아웃 안전 플래그 테스트.
+
+merge_gate_active(flag+allowlist 단일 스위치) + _preflight_merge_gate(board 직접 PATCH 게이팅).
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.merge_verdict_gate import ASK_HUMAN, AUTO_MERGE, MergeGateDecision, merge_gate_active
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── merge_gate_active: 단일 스위치(flag + allowlist) ───────────────────────────
+
+def test_gate_inactive_when_flag_off():
+    with patch("app.services.merge_verdict_gate.settings") as s:
+        s.h1_merge_gate_enabled = False
+        s.h1_merge_gate_org_allowlist = ""
+        assert merge_gate_active(uuid.uuid4()) is False  # AC①: off=미호출.
+
+
+def test_gate_active_all_orgs_when_enabled_empty_allowlist():
+    with patch("app.services.merge_verdict_gate.settings") as s:
+        s.h1_merge_gate_enabled = True
+        s.h1_merge_gate_org_allowlist = ""
+        assert merge_gate_active(uuid.uuid4()) is True
+
+
+def test_gate_active_only_allowlisted_org():
+    org = uuid.uuid4()
+    with patch("app.services.merge_verdict_gate.settings") as s:
+        s.h1_merge_gate_enabled = True
+        s.h1_merge_gate_org_allowlist = f"{org}, {uuid.uuid4()}"
+        assert merge_gate_active(org) is True  # allowlist 안.
+        assert merge_gate_active(uuid.uuid4()) is False  # allowlist 밖.
+
+
+def test_gate_allowlist_ignores_invalid_ids():
+    org = uuid.uuid4()
+    with patch("app.services.merge_verdict_gate.settings") as s:
+        s.h1_merge_gate_enabled = True
+        s.h1_merge_gate_org_allowlist = f"not-a-uuid, {org}"
+        assert merge_gate_active(org) is True
+        assert merge_gate_active(uuid.uuid4()) is False
+
+
+# ── _preflight_merge_gate: board 직접 PATCH 게이팅 ─────────────────────────────
+
+def _story(status="in-review"):
+    return SimpleNamespace(id=uuid.uuid4(), status=status)
+
+
+def _decision(decision):
+    return MergeGateDecision(
+        decision=decision, reason="r", gate_id=uuid.uuid4(), gate_status="pending",
+        disposition="ask", trust=None, ci_result=None,
+    )
+
+
+@pytest.mark.anyio
+async def test_preflight_noop_when_not_done():
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
+        await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "in-progress")
+    ev.assert_not_awaited()  # done 아니면 게이트 0.
+
+
+@pytest.mark.anyio
+async def test_preflight_noop_when_not_in_review():
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
+        await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("todo"), "done")
+    ev.assert_not_awaited()  # in-review→done만 대상.
+
+
+@pytest.mark.anyio
+async def test_preflight_noop_when_flag_off():
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.merge_gate_active", return_value=False), \
+         patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock()) as ev:
+        await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "done")
+    ev.assert_not_awaited()  # AC①: 플래그 off면 in-review→done이어도 게이트 0(기존 PATCH 무변경).
+
+
+@pytest.mark.anyio
+async def test_preflight_passes_when_auto_merge():
+    from app.routers.stories import _preflight_merge_gate
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock(return_value=_decision(AUTO_MERGE))):
+        await _preflight_merge_gate(AsyncMock(), uuid.uuid4(), _story("in-review"), "done")
+    # 예외 없음 = 전이 허용.
+
+
+@pytest.mark.anyio
+async def test_preflight_blocks_409_when_not_auto_merge():
+    from fastapi import HTTPException
+
+    from app.routers.stories import _preflight_merge_gate
+    db = AsyncMock()
+    with patch("app.routers.stories.merge_gate_active", return_value=True), \
+         patch("app.routers.stories.evaluate_merge_gate", new=AsyncMock(return_value=_decision(ASK_HUMAN))):
+        with pytest.raises(HTTPException) as ei:
+            await _preflight_merge_gate(db, uuid.uuid4(), _story("in-review"), "done")
+    assert ei.value.status_code == 409  # AC②: active+증거부족 → 전이 차단.
+    assert ei.value.detail["code"] == "MERGE_GATE_PENDING"
+    db.commit.assert_awaited_once()  # gate audit 보존.

--- a/backend/tests/test_workflow_report.py
+++ b/backend/tests/test_workflow_report.py
@@ -171,7 +171,8 @@ async def test_merge_to_done():
         )
         with patch("app.repositories.story.StoryRepository.update", new_callable=AsyncMock) as mock_update, \
              patch("app.routers.workflow_report.evaluate_merge_gate", new=AsyncMock(return_value=auto)), \
-             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()):
+             patch("app.routers.workflow_report._record_gate_evidence", new=AsyncMock()), \
+             patch("app.routers.workflow_report.merge_gate_active", return_value=True):
             mock_update.return_value = story
             async with client as c:
                 resp = await c.post("/api/v2/workflow/report-done", json={


### PR DESCRIPTION
## H1-S5 — Board in-review→done 게이트 + 롤아웃 안전 플래그

블루프린트 `E-H1-VERDICT-GATE` S5. board **직접 status PATCH**(in-review→done·팀 워크플로 경로)에 merge verdict gate preflight를 적용하되, **팀 stall 방지**를 위해 L2 패턴 플래그로 전 게이트를 **단일 스위치**화.

### 롤아웃 안전 플래그 (default-off)
- config: `H1_MERGE_GATE_ENABLED`(기본 false)·`H1_MERGE_GATE_ORG_ALLOWLIST`(CSV).
- **`merge_gate_active(org_id)`**: `enabled AND (allowlist 비면 전 org OR org∈allowlist)`. **report-done·board 전 게이트의 단일 스위치.** off면 게이트 미호출 → 기존 PATCH/머지 동작 무변경.

### board preflight (`stories.py`)
`_preflight_merge_gate`: **in-review→done & active**일 때만 `evaluate_merge_gate`(S2) — auto_merge가 아니면 **409 `MERGE_GATE_PENDING`**(status 유지·gate audit commit). `update_story_status`(팀 board) + `update_story`(`data['status']=='done'`) 양 경로 배선. transition rule(`check_transition`)과 **직교**(AC④). board PATCH엔 PR/CI 없으므로 증거 없는 done 시도는 보류.

### S4 hook 통합 (AC⑤)
`workflow_report.py`의 merge hook도 `merge_gate_active`로 wrap — 전 게이트 1스위치. off면 기존 merge→done.

> ⚠️ 실 enable은 **S10 E2E+접는조건 後 의도적으로**. 현재 default-off라 전 경로 inert(team 무영향).

### Validation
신규 `test_h1_s5_board_gate.py` **9** (merge_gate_active off/on/allowlist in·out/무효id 무시 · `_preflight` noop[non-done/non-in-review/**flag-off**]/auto-merge 통과/non-auto **409+commit**) + 기존 **stories 100 무회귀**(플래그 off=무변경·**AC①③④**) + workflow_report/merge gate **40 무회귀**·`app.main` import OK·`.pyc` 제외(명시 add).

> 에픽 `E-H1-VERDICT-GATE` S5. forward-verify: `stories.py` update_story/update_story_status·check_transition·get_db commit 동작 develop 실재 확인. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)