### PR TITLE
feat(h1): GitHub webhook for PR/CI runtime verdict capture (H1-S6)

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -87,6 +87,9 @@ class Settings(BaseSettings):
     polar_sandbox: bool = True  # dev=True(sandbox), prod=False
     polar_webhook_secret: str = ""  # HMAC signature 검증용
 
+    # E-H1-S6: GitHub webhook(PR/CI verdict 캡처) HMAC 검증 시크릿. 미설정이면 webhook 거부(inert).
+    github_webhook_secret: str = ""
+
     # S-COMM-07: 에이전트 inbox webhook HMAC 검증 시크릿
     agent_inbox_webhook_secret: str = ""
 

--- a/backend/app/routers/verdict_capture.py
+++ b/backend/app/routers/verdict_capture.py
@@ -1,24 +1,27 @@
-"""E-CAGE-REFEREE P1: PR·CI verdict 캡처 내부 엔드포인트.
+"""E-CAGE-REFEREE P1 / E-H1-S6: PR·CI verdict 캡처 엔드포인트.
 
-CRON_SECRET 인증 필요. 외부 노출 없음.
-풀 GitHub webhook은 후속 — MVP는 머지 후 수동/cron 트리거.
+CRON 수동 캡처(capture-pr/capture-review·CRON_SECRET) + H1-S6 GitHub webhook(github-webhook·HMAC).
+GitHub webhook이 R5 갭(capture_pr_ci_verdict 프로덕션 호출자 0)을 해소하는 실 runtime 경로다.
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
 import logging
 import uuid
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Header, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.dependencies.database import get_db
 from app.models.pm import Story
 from app.routers.cron import CRON_SECRET, _err, _ok, verify_cron
 from app.services.verdict_capture import capture_pr_ci_verdict, capture_review_verdict, parse_story_id
-from fastapi import Depends
 
 logger = logging.getLogger(__name__)
 
@@ -128,3 +131,131 @@ async def capture_review(
     except Exception as exc:
         logger.exception("review verdict capture failed: %s", exc)
         return _err("INTERNAL_ERROR", "review verdict capture failed", 500)
+
+
+# ── H1-S6: GitHub webhook (PR/CI runtime verdict 캡처·실 runtime 경로) ───────────
+#
+# capture_pr_ci_verdict의 R5 갭(프로덕션 호출자 0)을 해소한다 — GitHub PR/CI 이벤트가 도착하면
+# PR title/body/branch서 [SID:uuid]를 파싱해 story→org를 잡고 verdict를 기록한다. HMAC(X-Hub-
+# Signature-256) 검증. 시크릿 미설정이면 모든 webhook 거부(inert).
+
+# CI 결론 정규화 — success|failure|cancelled로. capture_pr_ci_verdict가 다시 pass(=success)/fail로
+# 환산하므로 success만 pass, 나머지(실패·취소)는 fail로 채점된다.
+_CI_SUCCESS = frozenset({"success"})
+_CI_FAILURE = frozenset({"failure", "timed_out", "action_required", "stale", "startup_failure", "error"})
+_CI_CANCELLED = frozenset({"cancelled", "canceled", "skipped", "neutral"})
+
+
+def _verify_github_signature(raw_body: bytes, signature_header: str | None) -> bool:
+    """X-Hub-Signature-256 HMAC-SHA256 검증. 시크릿 미설정/서명 불일치면 False."""
+    secret = settings.github_webhook_secret
+    if not secret or not signature_header:
+        return False
+    expected = hmac.new(secret.encode(), raw_body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header.removeprefix("sha256="))
+
+
+def _normalize_ci(conclusion: str | None) -> str | None:
+    """CI provider 결론 → success|failure|cancelled. 미완료(in_progress/queued 등)면 None(skip)."""
+    if not conclusion:
+        return None
+    c = conclusion.strip().lower()
+    if c in _CI_SUCCESS:
+        return "success"
+    if c in _CI_FAILURE:
+        return "failure"
+    if c in _CI_CANCELLED:
+        return "cancelled"
+    return None
+
+
+def _candidate_texts(payload: dict) -> list[str]:
+    """payload에서 [SID:] 태그가 있을 수 있는 텍스트들 — PR title/body/branch(이벤트 형태별)."""
+    texts: list[str] = []
+    pr = payload.get("pull_request") or {}
+    texts += [pr.get("title") or "", pr.get("body") or "", (pr.get("head") or {}).get("ref") or ""]
+    for node_key in ("workflow_run", "check_suite", "check_run"):
+        node = payload.get(node_key) or {}
+        texts.append(node.get("head_branch") or "")
+        for p in node.get("pull_requests") or []:
+            texts.append((p.get("head") or {}).get("ref") or "")
+    texts.append(payload.get("ref") or "")  # status/push
+    return [t for t in texts if t]
+
+
+def _extract_pr_ci(event: str, payload: dict) -> tuple[int, bool, str | None]:
+    """이벤트 형태에서 (pr_number, merged, ci_conclusion) 추출."""
+    pr_number = 0
+    merged = False
+    ci_conclusion: str | None = None
+    if event == "pull_request":
+        pr = payload.get("pull_request") or {}
+        pr_number = int(pr.get("number") or 0)
+        merged = bool(pr.get("merged")) and payload.get("action") == "closed"
+    elif event in ("workflow_run", "check_suite", "check_run"):
+        node = payload.get("workflow_run") or payload.get("check_suite") or payload.get("check_run") or {}
+        ci_conclusion = _normalize_ci(node.get("conclusion"))
+        prs = node.get("pull_requests") or []
+        pr_number = int((prs[0].get("number") if prs else 0) or 0)
+    elif event == "status":
+        ci_conclusion = _normalize_ci(payload.get("state"))
+    return pr_number, merged, ci_conclusion
+
+
+@router.post("/github-webhook")
+async def github_webhook(
+    request: Request,
+    session: AsyncSession = Depends(get_db),
+    x_github_event: str | None = Header(default=None),
+    x_hub_signature_256: str | None = Header(default=None),
+) -> JSONResponse:
+    """GitHub PR/CI webhook → [SID:uuid] 파싱 → capture_pr_ci_verdict (H1-S6 실 runtime 경로).
+
+    HMAC 검증 후 PR merge(=pr verdict)·CI 완료(=ci verdict)를 기록한다. SID 없거나(AC②) story
+    없으면(AC③) skip. duplicate webhook은 uq(participation,source) upsert로 멱등(AC⑤).
+    """
+    raw = await request.body()
+    if not _verify_github_signature(raw, x_hub_signature_256):
+        return _err("INVALID_SIGNATURE", "GitHub webhook 서명 검증 실패", 401)
+
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return _err("INVALID_PAYLOAD", "JSON 파싱 실패", 400)
+
+    # AC②: [SID:] 태그 없으면 skip(거짓기록 금지).
+    story_id = next((sid for t in _candidate_texts(payload) if (sid := parse_story_id(t))), None)
+    if story_id is None:
+        return _ok({"skipped_reason": "no_sid_tag", "recorded": []})
+
+    # AC③: story 없으면 skip.
+    story = (
+        await session.execute(
+            select(Story).where(Story.id == story_id, Story.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if story is None:
+        return _ok({"skipped_reason": "story_not_found", "recorded": []})
+
+    repo = (payload.get("repository") or {}).get("full_name") or ""
+    pr_number, merged, ci_conclusion = _extract_pr_ci(x_github_event or "", payload)
+
+    # 행동 가능한 신호(머지 또는 CI 완료)가 없으면 skip(in_progress 등).
+    if not merged and ci_conclusion is None:
+        return _ok({"skipped_reason": "no_actionable_signal", "recorded": []})
+
+    try:
+        result = await capture_pr_ci_verdict(
+            session=session,
+            org_id=story.org_id,
+            story_id=story_id,
+            pr_number=pr_number,
+            repo=repo,
+            merged=merged,
+            ci_result=ci_conclusion,  # AC④: failure→capture가 fail로 채점.
+        )
+        await session.commit()
+        return _ok(result)
+    except Exception as exc:
+        logger.exception("github webhook verdict capture failed: %s", exc)
+        return _err("INTERNAL_ERROR", "verdict capture failed", 500)

--- a/backend/tests/test_h1_s6_github_webhook.py
+++ b/backend/tests/test_h1_s6_github_webhook.py
@@ -1,0 +1,169 @@
+"""H1-S6: GitHub webhook PR/CI runtime verdict 캡처 테스트.
+
+HMAC 검증 + 이벤트 파싱(pull_request/workflow_run) + [SID:] 파싱 → capture_pr_ci_verdict 호출.
+R5 갭(프로덕션 호출자 0) 해소 = 실 runtime router 경로.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.routers import verdict_capture as mod
+from app.routers.verdict_capture import _candidate_texts, _extract_pr_ci, _normalize_ci, _verify_github_signature
+
+_SECRET = "testsecret"
+STORY_ID = uuid.uuid4()
+ORG_ID = uuid.uuid4()
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 단위: 정규화/추출/HMAC ──────────────────────────────────────────────────────
+
+def test_normalize_ci():
+    assert _normalize_ci("success") == "success"
+    assert _normalize_ci("FAILURE") == "failure" and _normalize_ci("timed_out") == "failure"
+    assert _normalize_ci("cancelled") == "cancelled" and _normalize_ci("skipped") == "cancelled"
+    assert _normalize_ci("in_progress") is None and _normalize_ci(None) is None  # 미완료 skip.
+
+
+def test_candidate_texts_collects_title_body_branch():
+    payload = {"pull_request": {"title": "feat [SID:x]", "body": "b", "head": {"ref": "feat/sid"}}}
+    texts = _candidate_texts(payload)
+    assert "feat [SID:x]" in texts and "b" in texts and "feat/sid" in texts
+
+
+def test_extract_pr_ci_pull_request_merged():
+    payload = {"action": "closed", "pull_request": {"number": 12, "merged": True}}
+    pr_number, merged, ci = _extract_pr_ci("pull_request", payload)
+    assert pr_number == 12 and merged is True and ci is None
+
+
+def test_extract_pr_ci_workflow_run_failure():
+    payload = {"workflow_run": {"conclusion": "failure", "pull_requests": [{"number": 7}]}}
+    pr_number, merged, ci = _extract_pr_ci("workflow_run", payload)
+    assert pr_number == 7 and merged is False and ci == "failure"  # AC④.
+
+
+def test_verify_signature():
+    body = b'{"a":1}'
+    sig = "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+    with patch.object(mod.settings, "github_webhook_secret", _SECRET):
+        assert _verify_github_signature(body, sig) is True
+        assert _verify_github_signature(body, "sha256=bad") is False
+    with patch.object(mod.settings, "github_webhook_secret", ""):
+        assert _verify_github_signature(body, sig) is False  # 시크릿 미설정 → 거부.
+
+
+# ── 엔드포인트(실 runtime 경로) ────────────────────────────────────────────────
+
+def _sign(body: bytes) -> str:
+    return "sha256=" + hmac.new(_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+async def _post(payload: dict, *, event: str, story=..., sign=True):
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    session = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = (
+        MagicMock(org_id=ORG_ID) if story is ... else story
+    )
+    session.execute = AsyncMock(return_value=result)
+
+    async def override_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_db
+    body = json.dumps(payload).encode()
+    headers = {"X-GitHub-Event": event}
+    headers["X-Hub-Signature-256"] = _sign(body) if sign else "sha256=bad"
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            with patch.object(mod.settings, "github_webhook_secret", _SECRET):
+                resp = await c.post("/api/v2/internal/verdict/github-webhook", content=body, headers=headers)
+        return resp
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.anyio
+async def test_invalid_signature_401():
+    resp = await _post({"pull_request": {"title": "x"}}, event="pull_request", sign=False)
+    assert resp.status_code == 401
+
+
+@pytest.mark.anyio
+async def test_pr_merged_calls_capture():
+    payload = {"action": "closed", "repository": {"full_name": "moonklabs/sprintable"},
+               "pull_request": {"number": 12, "merged": True, "title": f"feat [SID:{STORY_ID}]"}}
+    with patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
+        resp = await _post(payload, event="pull_request")
+    assert resp.status_code == 200  # AC①: runtime router가 capture 호출.
+    cap.assert_awaited_once()
+    kw = cap.await_args.kwargs
+    assert kw["story_id"] == STORY_ID and kw["merged"] is True and kw["pr_number"] == 12
+
+
+@pytest.mark.anyio
+async def test_ci_failure_calls_capture_with_failure():
+    payload = {"repository": {"full_name": "o/r"},
+               "workflow_run": {"conclusion": "failure", "head_branch": f"feat-[SID:{STORY_ID}]",
+                                "pull_requests": [{"number": 7}]}}
+    with patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["ci"], "skipped_reason": None})) as cap:
+        resp = await _post(payload, event="workflow_run")
+    assert resp.status_code == 200
+    kw = cap.await_args.kwargs
+    assert kw["ci_result"] == "failure" and kw["merged"] is False  # AC④.
+
+
+@pytest.mark.anyio
+async def test_no_sid_skips():
+    with patch.object(mod, "capture_pr_ci_verdict", new=AsyncMock()) as cap:
+        resp = await _post({"pull_request": {"title": "no tag", "number": 1, "merged": True}, "action": "closed"},
+                           event="pull_request")
+    assert resp.status_code == 200 and resp.json()["data"]["skipped_reason"] == "no_sid_tag"
+    cap.assert_not_awaited()  # AC②.
+
+
+@pytest.mark.anyio
+async def test_no_story_skips():
+    payload = {"action": "closed", "pull_request": {"number": 1, "merged": True, "title": f"[SID:{STORY_ID}]"}}
+    with patch.object(mod, "capture_pr_ci_verdict", new=AsyncMock()) as cap:
+        resp = await _post(payload, event="pull_request", story=None)  # story 없음.
+    assert resp.status_code == 200 and resp.json()["data"]["skipped_reason"] == "story_not_found"
+    cap.assert_not_awaited()  # AC③.
+
+
+@pytest.mark.anyio
+async def test_no_actionable_signal_skips():
+    # CI 미완료(in_progress) → conclusion None → skip.
+    payload = {"workflow_run": {"conclusion": "in_progress", "head_branch": f"x-[SID:{STORY_ID}]"}}
+    with patch.object(mod, "capture_pr_ci_verdict", new=AsyncMock()) as cap:
+        resp = await _post(payload, event="workflow_run")
+    assert resp.json()["data"]["skipped_reason"] == "no_actionable_signal"
+    cap.assert_not_awaited()
+
+
+@pytest.mark.anyio
+async def test_duplicate_webhook_calls_capture_each_time():
+    """AC⑤: duplicate webhook도 capture 호출(멱등은 record_verdict의 uq(participation,source) upsert)."""
+    payload = {"action": "closed", "repository": {"full_name": "o/r"},
+               "pull_request": {"number": 3, "merged": True, "title": f"[SID:{STORY_ID}]"}}
+    with patch.object(mod, "capture_pr_ci_verdict",
+                      new=AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})) as cap:
+        await _post(payload, event="pull_request")
+        await _post(payload, event="pull_request")
+    assert cap.await_count == 2  # 두 번 호출되나 record_verdict가 upsert로 1 verdict 유지.


### PR DESCRIPTION
## H1-S6 — PR/CI runtime capture 배선 (GitHub webhook)

블루프린트 `E-H1-VERDICT-GATE` S6. **`capture_pr_ci_verdict`의 R5 갭(프로덕션 호출자 0)을 해소하는 실 runtime 경로** — 기존 `capture-pr`은 CRON 수동(MVP)이었고, 이 PR이 "풀 GitHub webhook 후속"을 채운다.

### `POST /api/v2/internal/verdict/github-webhook`
- **HMAC**(X-Hub-Signature-256·`GITHUB_WEBHOOK_SECRET`) 검증 후 `X-GitHub-Event`별 `(pr_number, merged, ci_conclusion)` 추출 → `capture_pr_ci_verdict` 호출. 시크릿 미설정/서명 불일치면 **401**(미설정 시 inert).
- `[SID:uuid]` 파싱은 기존 `parse_story_id`(`_SID_RE`) 재사용 · PR **title/body/branch**(이벤트 형태별) 후보 텍스트 순회.
- CI 결론 `success|failure|cancelled` 정규화(미완료 `in_progress` 등 → None→skip). `capture_pr_ci_verdict`가 success→pass, 나머지→fail 채점.

### AC
- **①** 비-테스트 runtime router에서 `capture_pr_ci_verdict` 호출 — `verdict_capture.py:248`(grep 입증). **R5 프로덕션 호출자 0 해소.**
- **②** SID 없으면 skip(`no_sid_tag`). **③** story 없으면 skip(`story_not_found`).
- **④** CI failure → `ci_result=failure` → capture가 `source=ci result=fail`.
- **⑤** duplicate webhook은 `record_verdict`의 `uq(participation,source)` upsert로 멱등.

### Validation
신규 `test_h1_s6_github_webhook.py` **12** (정규화·후보텍스트·이벤트추출·HMAC valid/invalid/no-secret·엔드포인트 401·PR merged capture·CI failure capture·no-SID/no-story/no-signal skip·duplicate 2회) + 기존 verdict capture **13 무회귀**·`app.main` import OK. config `github_webhook_secret`(기본 "" → inert)·HMAC 패턴 agent_inbox 선례 재사용.

> 에픽 `E-H1-VERDICT-GATE` S6. forward-verify: `capture_pr_ci_verdict` 시그니처·`parse_story_id`·verdict 라우터 패턴 develop 실재 확인. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)