### PR TITLE
feat(h1): merge gate metrics endpoint (H1-S9)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -53,7 +53,7 @@ async def lifespan(app: FastAPI):
             await engine.dispose()
 
 
-from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
+from app.routers import account, activity_logs, activity_stream, agent_deployments, agent_gateway, agent_inbox, agent_message_policy, agent_personas, agent_routing_rules, agent_runs, agent_sessions, analytics, api_keys, attachments, audit_logs, auth, bridge, channel, conversations, cron, current_project, dashboard, dependencies, dispatch, docs, entities, epics, event_notifications, events, exclusion, file_locks, gates, health, hitl, hitl_config, hypotheses, integrations, invite_accept, labels, mcp, me, meetings, members, merge_gate, mockups, notification_preferences, notifications, open_api_keys, org_invites, org_members, organizations, oss, participation, plan_features, policy_documents, presence, project_access, project_settings, projects, public_docs, retros, rewards, sprints, standups, stories, subscription, tasks, team_members, team_presence, trust_scores, verdict_capture, verdicts, webhooks, workflow_executions, workflow_recipes, workflow_report, workflow_templates, workflow_trigger, workflow_trigger_types, workflow_versions, ws_chat
 
 app = FastAPI(
     title="Sprintable API v2",
@@ -181,6 +181,7 @@ app.include_router(audit_logs.router)
 app.include_router(dashboard.router)
 app.include_router(current_project.router)
 app.include_router(members.router)
+app.include_router(merge_gate.router)
 app.include_router(organizations.router)
 app.include_router(org_invites.router)
 app.include_router(invite_accept.router)

--- a/backend/app/routers/merge_gate.py
+++ b/backend/app/routers/merge_gate.py
@@ -1,0 +1,46 @@
+"""H1-S9: merge verdict gate 관측 지표 엔드포인트.
+
+GET /api/v2/merge-gate/metrics — gate/verdict/story on-the-fly 집계(읽기전용). 접는조건·rollout
+대시보드용. project/window filter·null(데이터 없음)/0(실제 0) 구분.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel
+
+from app.dependencies.auth import AuthContext, get_current_user, get_verified_org_id
+from app.dependencies.database import get_db
+from app.services.merge_gate_metrics import compute_merge_gate_metrics
+from sqlalchemy.ext.asyncio import AsyncSession
+
+router = APIRouter(prefix="/api/v2/merge-gate", tags=["merge-gate"])
+
+
+class MergeGateMetricsResponse(BaseModel):
+    merge_gate_coverage: float | None = None
+    verdict_coverage: float | None = None
+    trustworthy_merge_throughput: int = 0
+    human_review_minutes: float | None = None
+    rubber_stamp_rate: float | None = None
+    post_merge_regret_rate: float | None = None
+    project_id: str | None = None
+    window: dict
+
+
+@router.get("/metrics", response_model=MergeGateMetricsResponse)
+async def get_merge_gate_metrics(
+    project_id: uuid.UUID | None = Query(default=None),
+    start: datetime | None = Query(default=None, description="window 시작(이상)"),
+    end: datetime | None = Query(default=None, description="window 끝(이하)"),
+    session: AsyncSession = Depends(get_db),
+    org_id: uuid.UUID = Depends(get_verified_org_id),
+    _auth: AuthContext = Depends(get_current_user),
+) -> MergeGateMetricsResponse:
+    """merge verdict gate 6지표 on-the-fly 집계. denom 0이면 ratio=null, 데이터 있고 0이면 0."""
+    data = await compute_merge_gate_metrics(
+        session, org_id, project_id=project_id, start=start, end=end
+    )
+    return MergeGateMetricsResponse(**data)

--- a/backend/app/services/merge_gate_metrics.py
+++ b/backend/app/services/merge_gate_metrics.py
@@ -1,0 +1,153 @@
+"""H1-S9: merge verdict gate 관측 지표 on-the-fly 집계.
+
+gate/verdict/story를 읽어 6지표를 산출한다. 신규 신설 0(읽기전용). null/0 구분: ratio는 분모 0이면
+None(데이터 없음), 데이터 있고 num 0이면 0.0. throughput은 count(0=실제 무).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import and_, case, distinct, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.gate import Gate
+from app.models.participation import Participation, ParticipationRole
+from app.models.pm import Story
+from app.models.verdict import Verdict
+
+_RESOLVED_MERGE_STATUSES = ("auto_passed", "approved")
+
+
+def _window(stmt, col, start: datetime | None, end: datetime | None):
+    if start is not None:
+        stmt = stmt.where(col >= start)
+    if end is not None:
+        stmt = stmt.where(col <= end)
+    return stmt
+
+
+def _ratio(num: int | None, denom: int | None) -> float | None:
+    """분모 0/None이면 None(데이터 없음), 아니면 round(num/denom, 4)."""
+    if not denom:
+        return None
+    return round((num or 0) / denom, 4)
+
+
+async def compute_merge_gate_metrics(
+    session: AsyncSession,
+    org_id: uuid.UUID,
+    *,
+    project_id: uuid.UUID | None = None,
+    start: datetime | None = None,
+    end: datetime | None = None,
+) -> dict[str, Any]:
+    # ── 1. merge_gate_coverage = (done & merge gate 보유)/(done story) ──────────
+    cov = (
+        select(
+            func.count(distinct(Story.id)).label("denom"),
+            func.count(distinct(case((Gate.id.isnot(None), Story.id)))).label("num"),
+        )
+        .select_from(Story)
+        .outerjoin(
+            Gate,
+            and_(
+                Gate.work_item_id == Story.id,
+                Gate.work_item_type == "story",
+                Gate.gate_type == "merge",
+            ),
+        )
+        .where(Story.org_id == org_id, Story.status == "done")
+    )
+    cov = _window(cov, Story.updated_at, start, end)
+    if project_id is not None:
+        cov = cov.where(Story.project_id == project_id)
+    cov_row = (await session.execute(cov)).one()
+    merge_gate_coverage = _ratio(cov_row.num, cov_row.denom)
+
+    # ── 2. verdict_coverage = (verdict 보유 impl participation)/(impl participation) ─
+    vc = (
+        select(
+            func.count(distinct(Participation.id)).label("denom"),
+            func.count(distinct(case((Verdict.result.isnot(None), Participation.id)))).label("num"),
+        )
+        .select_from(Participation)
+        .join(ParticipationRole, ParticipationRole.id == Participation.role_id)
+        .join(Story, Story.id == Participation.story_id)
+        .outerjoin(Verdict, Verdict.participation_id == Participation.id)
+        .where(Participation.org_id == org_id, ParticipationRole.is_default.is_(True))
+    )
+    vc = _window(vc, Participation.created_at, start, end)
+    if project_id is not None:
+        vc = vc.where(Story.project_id == project_id)
+    vc_row = (await session.execute(vc)).one()
+    verdict_coverage = _ratio(vc_row.num, vc_row.denom)
+
+    # ── 3. trustworthy_merge_throughput = auto_passed merge gate count ──────────
+    tp = select(func.count(distinct(Gate.id))).where(
+        Gate.org_id == org_id, Gate.gate_type == "merge", Gate.status == "auto_passed"
+    )
+    tp = _window(tp, Gate.created_at, start, end)
+    if project_id is not None:
+        tp = tp.join(Story, Story.id == Gate.work_item_id).where(Story.project_id == project_id)
+    trustworthy_merge_throughput = int((await session.execute(tp)).scalar() or 0)
+
+    # ── 4. human_review_minutes = Σ(resolved-created)/60 for 사람해소 gate ──────
+    hr = select(
+        (func.sum(func.extract("epoch", Gate.resolved_at - Gate.created_at)) / 60.0).label("minutes"),
+        func.count(distinct(Gate.id)).label("cnt"),
+    ).where(Gate.org_id == org_id, Gate.resolver_id.isnot(None), Gate.resolved_at.isnot(None))
+    hr = _window(hr, Gate.resolved_at, start, end)
+    if project_id is not None:
+        hr = hr.join(Story, Story.id == Gate.work_item_id).where(Story.project_id == project_id)
+    hr_row = (await session.execute(hr)).one()
+    human_review_minutes = round(float(hr_row.minutes), 2) if hr_row.cnt else None
+
+    # ── 5. rubber_stamp_rate = (rubber_stamp_candidate)/(사람 approve) ──────────
+    rs = select(
+        func.count(distinct(Gate.id)).label("denom"),
+        func.count(distinct(Gate.id))
+        .filter(Gate.neutral_facts["rubber_stamp_candidate"].astext == "true")
+        .label("num"),
+    ).where(Gate.org_id == org_id, Gate.status == "approved", Gate.resolver_id.isnot(None))
+    rs = _window(rs, Gate.resolved_at, start, end)
+    if project_id is not None:
+        rs = rs.join(Story, Story.id == Gate.work_item_id).where(Story.project_id == project_id)
+    rs_row = (await session.execute(rs)).one()
+    rubber_stamp_rate = _ratio(rs_row.num, rs_row.denom)
+
+    # ── 6. post_merge_regret_rate = (머지 해소 story 중 현재 status≠done)/(머지 해소 story) ─
+    # regret 신호 = 머지(merge gate auto_passed|approved) 후 done 이탈(현재상태 proxy).
+    rg = (
+        select(
+            func.count(distinct(Story.id)).label("denom"),
+            func.count(distinct(case((Story.status != "done", Story.id)))).label("num"),
+        )
+        .select_from(Gate)
+        .join(Story, Story.id == Gate.work_item_id)
+        .where(
+            Gate.org_id == org_id,
+            Gate.gate_type == "merge",
+            Gate.status.in_(_RESOLVED_MERGE_STATUSES),
+        )
+    )
+    rg = _window(rg, Gate.created_at, start, end)
+    if project_id is not None:
+        rg = rg.where(Story.project_id == project_id)
+    rg_row = (await session.execute(rg)).one()
+    post_merge_regret_rate = _ratio(rg_row.num, rg_row.denom)
+
+    return {
+        "merge_gate_coverage": merge_gate_coverage,
+        "verdict_coverage": verdict_coverage,
+        "trustworthy_merge_throughput": trustworthy_merge_throughput,
+        "human_review_minutes": human_review_minutes,
+        "rubber_stamp_rate": rubber_stamp_rate,
+        "post_merge_regret_rate": post_merge_regret_rate,
+        "project_id": str(project_id) if project_id else None,
+        "window": {
+            "start": start.isoformat() if start else None,
+            "end": end.isoformat() if end else None,
+        },
+    }

--- a/backend/tests/test_h1_s9_merge_gate_metrics.py
+++ b/backend/tests/test_h1_s9_merge_gate_metrics.py
@@ -1,0 +1,152 @@
+"""H1-S9: merge gate metrics 집계 테스트.
+
+_ratio 단위(null/0 구분) + 실DB 6지표 시나리오(coverage·throughput·review minutes·rubber stamp·regret).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.services.merge_gate_metrics import _ratio, compute_merge_gate_metrics
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── 단위: null/0 구분 ──────────────────────────────────────────────────────────
+
+def test_ratio_null_when_no_denominator():
+    assert _ratio(0, 0) is None and _ratio(5, 0) is None and _ratio(0, None) is None
+
+
+def test_ratio_zero_when_data_but_no_num():
+    assert _ratio(0, 4) == 0.0  # 데이터 있고 num 0 → 0(null 아님).
+
+
+def test_ratio_rounds():
+    assert _ratio(2, 3) == 0.6667
+
+
+# ── 실DB: 6지표 시나리오 ───────────────────────────────────────────────────────
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_metrics_real_db():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.gate import Gate
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.models.verdict import Verdict
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project = uuid.uuid4(), uuid.uuid4()
+    role_id = uuid.uuid4()
+    A, B, C, D = (uuid.uuid4() for _ in range(4))
+    pA, pB, pC = (uuid.uuid4() for _ in range(3))
+    base = datetime(2026, 6, 12, 12, 0, tzinfo=timezone.utc)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+                # stories: A/B/C done, D in-progress
+                Story(id=A, org_id=org, project_id=project, title="A", status="done", story_points=3),
+                Story(id=B, org_id=org, project_id=project, title="B", status="done", story_points=3),
+                Story(id=C, org_id=org, project_id=project, title="C", status="done", story_points=3),
+                Story(id=D, org_id=org, project_id=project, title="D", status="in-progress", story_points=3),
+                # participations(impl) for A/B/C
+                Participation(id=pA, org_id=org, story_id=A, member_id=uuid.uuid4(), role_id=role_id),
+                Participation(id=pB, org_id=org, story_id=B, member_id=uuid.uuid4(), role_id=role_id),
+                Participation(id=pC, org_id=org, story_id=C, member_id=uuid.uuid4(), role_id=role_id),
+                # verdicts: A(merge pass), C(qa pass) — B 없음
+                Verdict(id=uuid.uuid4(), org_id=org, participation_id=pA, source="merge", result="pass"),
+                Verdict(id=uuid.uuid4(), org_id=org, participation_id=pC, source="qa", result="pass"),
+                # gates: A auto_passed, C approved(human·rubber stamp·10min), D auto_passed(regret), B 없음
+                Gate(id=uuid.uuid4(), org_id=org, work_item_id=A, work_item_type="story",
+                     gate_type="merge", status="auto_passed"),
+                Gate(id=uuid.uuid4(), org_id=org, work_item_id=C, work_item_type="story",
+                     gate_type="merge", status="approved", resolver_id=uuid.uuid4(),
+                     created_at=base, resolved_at=base + timedelta(minutes=10),
+                     neutral_facts={"rubber_stamp_candidate": True}),
+                Gate(id=uuid.uuid4(), org_id=org, work_item_id=D, work_item_type="story",
+                     gate_type="merge", status="auto_passed"),
+            ])
+            await s.commit()
+
+        async with Session() as s:
+            m = await compute_merge_gate_metrics(s, org, project_id=project)
+
+        assert m["merge_gate_coverage"] == 0.6667  # done A/B/C 중 gate A/C = 2/3
+        assert m["verdict_coverage"] == 0.6667     # impl pA/pB/pC 중 verdict A/C = 2/3
+        assert m["trustworthy_merge_throughput"] == 2  # auto_passed A/D
+        assert m["human_review_minutes"] == 10.0   # C 사람해소 10분
+        assert m["rubber_stamp_rate"] == 1.0       # 사람 approve C 1건 모두 rubber stamp
+        assert m["post_merge_regret_rate"] == 0.3333  # 머지 A/C/D 중 status≠done = D = 1/3
+
+        # 빈 org → null/0 구분.
+        async with Session() as s:
+            empty = await compute_merge_gate_metrics(s, uuid.uuid4())
+        assert empty["merge_gate_coverage"] is None  # 데이터 없음 → null.
+        assert empty["verdict_coverage"] is None and empty["rubber_stamp_rate"] is None
+        assert empty["post_merge_regret_rate"] is None and empty["human_review_minutes"] is None
+        assert empty["trustworthy_merge_throughput"] == 0  # count는 0(실제 무).
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+# ── 엔드포인트 라우팅/응답 shape ───────────────────────────────────────────────
+
+@pytest.mark.anyio
+async def test_metrics_endpoint_routes_and_shape():
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    from httpx import ASGITransport, AsyncClient
+
+    from app.dependencies.auth import get_current_user, get_verified_org_id
+    from app.dependencies.database import get_db
+    from app.main import app
+
+    org = uuid.uuid4()
+    fake = {
+        "merge_gate_coverage": 0.9, "verdict_coverage": None, "trustworthy_merge_throughput": 3,
+        "human_review_minutes": 12.5, "rubber_stamp_rate": 0.0, "post_merge_regret_rate": None,
+        "project_id": None, "window": {"start": None, "end": None},
+    }
+
+    async def _db():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_db] = _db
+    app.dependency_overrides[get_current_user] = lambda: MagicMock()
+    app.dependency_overrides[get_verified_org_id] = lambda: org
+    try:
+        with patch("app.routers.merge_gate.compute_merge_gate_metrics", new=AsyncMock(return_value=fake)):
+            async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+                resp = await c.get("/api/v2/merge-gate/metrics")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["merge_gate_coverage"] == 0.9 and data["verdict_coverage"] is None
+        assert data["trustworthy_merge_throughput"] == 3 and data["human_review_minutes"] == 12.5
+        assert data["rubber_stamp_rate"] == 0.0 and data["post_merge_regret_rate"] is None
+    finally:
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## H1-S9 — H1 metrics endpoint

블루프린트 `E-H1-VERDICT-GATE` S9. **`GET /api/v2/merge-gate/metrics`** — gate/verdict/story **on-the-fly 집계**(읽기전용·신규 신설 0). 접는조건·rollout 대시보드용. project/window filter.

### 지표 6종 (PO 정의 승인)
- **`merge_gate_coverage`** = (done & merge gate)/(done story) — ⭐접는조건 핵심(dogfood 20머지 중 <90%면 rollout 중단).
- **`verdict_coverage`** = (verdict 보유 impl participation)/(impl participation).
- **`trustworthy_merge_throughput`** = auto_passed merge gate **count**(초기 trust null→0·신뢰 쌓이며 증가 = auto 효율 순증분 격리).
- **`human_review_minutes`** = Σ(resolved−created)/60 for resolver≠null gate(사람해소 0이면 null).
- **`rubber_stamp_rate`** = (`neutral_facts.rubber_stamp_candidate`)/(사람 approve).
- **`post_merge_regret_rate`** = (머지 해소 story 중 현재 status≠done)/(머지 해소 story). regret=현재상태 proxy **v1**(status_changed 이력 정밀판은 follow-up).
- **null/0 구분**: ratio는 분모 0이면 `null`(데이터 없음)·데이터 있고 num 0이면 `0`. throughput은 count.

router `merge_gate`(`get_verified_org_id`·`project_id`/`start`/`end` Query)·`main.py` 등록.

### Validation
신규 `test_h1_s9_merge_gate_metrics.py`: 단위 3(`_ratio` null/0/round) + **실DB 1**(6지표 정확값 — coverage 0.6667·verdict 0.6667·throughput 2·minutes 10.0·rubber 1.0·regret 0.3333 + **빈 org → null/0 구분**) + 엔드포인트 1(라우팅·응답 shape)·`app.main` import OK.

> 에픽 `E-H1-VERDICT-GATE` S9(S3·S7 의존 머지 완료). forward-verify: gate/verdict/participation/story 모델·집계 컬럼 develop 실재 확인. S10 E2E는 S8(FE)+S9 머지 후. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)