### PR TITLE
test(h1): end-to-end ready->verdict->gate->approve->done (H1-S10)

### DIFF
--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -1,0 +1,121 @@
+"""H1-S10: 끝단 E2E — ready→verdict→gate→approve→done (웨지 done 게이트·접는조건).
+
+전 H1 체인(S1-S7) 1발 통합: in-review story + implementation participation → CI pass verdict 캡처 →
+merge gate 생성(policy ask→pending) → 사람 approve(S7 verdict 환류) → done. 끝에서 verdict count
+증가·trust null 아님·merge gate 정확히 1개를 검증한다.
+
+⚠️ 이 E2E가 green이 아니면 웨지 출시(flag enable) 금지(접는조건).
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+_REAL_DB_URL = os.getenv("PARITY_TEST_DATABASE_URL") or os.getenv("ALEMBIC_DATABASE_URL")
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.skipif(not _REAL_DB_URL, reason="real Postgres 필요(PARITY/ALEMBIC_DATABASE_URL)")
+@pytest.mark.anyio
+async def test_h1_end_to_end_ready_to_done():
+    from sqlalchemy import text as _text
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from app.core.database import Base
+    import app.models  # noqa: F401
+    from app.models.gate import Gate
+    from app.models.hitl_config import OrgGatePolicy
+    from app.models.participation import Participation, ParticipationRole
+    from app.models.pm import Story
+    from app.services.gate_service import transition_gate
+    from app.services.merge_verdict_gate import ASK_HUMAN, evaluate_merge_gate
+    from app.services.trust_score import compute_member_trust_scores
+    from app.services.verdict_capture import capture_pr_ci_verdict
+
+    url = _REAL_DB_URL.replace("postgresql+psycopg2://", "postgresql+asyncpg://").replace(
+        "postgresql://", "postgresql+asyncpg://"
+    )
+    engine = create_async_engine(url)
+    org, project, story_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    member, role_id, resolver = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        # ── 준비: in-review story + impl participation + policy(ask) ──────────────
+        async with Session() as s:
+            await s.execute(_text("SET session_replication_role = replica"))
+            s.add_all([
+                ParticipationRole(id=role_id, org_id=org, key="implementation", label="구현", is_default=True),
+                Story(id=story_id, org_id=org, project_id=project, title="E2E", status="in-review", story_points=5),
+                Participation(id=uuid.uuid4(), org_id=org, story_id=story_id, member_id=member, role_id=role_id),
+                OrgGatePolicy(org_id=org, posture="conservative"),  # → disposition ask.
+            ])
+            await s.commit()
+
+        with patch("app.services.verdict_capture.fetch_pr_review_rounds", AsyncMock(return_value=0)):
+            # ── 1. CI pass verdict 캡처(웹훅 경로 모사) ──────────────────────────
+            async with Session() as s:
+                await s.execute(_text("SET session_replication_role = replica"))
+                cap = await capture_pr_ci_verdict(
+                    s, org, story_id, pr_number=42, repo="o/r", merged=True, ci_result="pass"
+                )
+                await s.commit()
+                assert cap["recorded"], "CI/PR verdict가 기록돼야"
+
+            # ── 2. merge gate 평가(policy ask→pending·decision ask_human) ────────
+            async with Session() as s:
+                await s.execute(_text("SET session_replication_role = replica"))
+                decision = await evaluate_merge_gate(
+                    s, org, story_id, pr_number=42, repo="o/r", ci_result="pass", pr_result="pass"
+                )
+                await s.commit()
+                assert decision.decision == ASK_HUMAN  # ask posture → 사람 보류.
+                assert decision.gate_id is not None and decision.gate_status == "pending"
+                gate_id = decision.gate_id
+
+            # ── 3. 사람 approve(S7: merge verdict 환류) ──────────────────────────
+            async with Session() as s:
+                await s.execute(_text("SET session_replication_role = replica"))
+                gate = await transition_gate(s, org, gate_id, "approved", resolver_id=resolver)
+                assert gate.status == "approved" and gate.resolver_id == resolver
+                # ── 4. done 전이(approve 후) ─────────────────────────────────────
+                await s.execute(
+                    _text("UPDATE stories SET status='done' WHERE id=:id"), {"id": story_id}
+                )
+                await s.commit()
+
+        # ── 끝단 검증: verdict 증가·trust non-null·merge gate 정확히 1개 ──────────
+        async with Session() as s:
+            vcount = (await s.execute(
+                _text("SELECT count(*) FROM verdict v JOIN participation p ON p.id=v.participation_id "
+                      "WHERE p.story_id=:sid AND v.result IS NOT NULL"), {"sid": story_id}
+            )).scalar()
+            assert vcount >= 2, f"verdict(pr/ci/merge) 증가해야, got {vcount}"
+
+            trust = await compute_member_trust_scores(s, org, member, role_key="implementation")
+            assert trust["scores"], "trust scores가 비지 않아야(verdict 누적)"
+            assert trust["scores"][0]["clean_pass_rate"] is not None, "trust null 아니어야"
+
+            merge_gates = (await s.execute(
+                _text("SELECT count(*) FROM gate WHERE work_item_id=:sid AND gate_type='merge'"),
+                {"sid": story_id}
+            )).scalar()
+            assert merge_gates == 1, f"merge gate 정확히 1개여야(멱등), got {merge_gates}"
+
+            done_status = (await s.execute(
+                _text("SELECT status FROM stories WHERE id=:id"), {"id": story_id}
+            )).scalar()
+            assert done_status == "done"
+    finally:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()


### PR DESCRIPTION
## H1-S10 — 끝단 E2E (ready→verdict→gate→approve→done) · 웨지 done 게이트

블루프린트 `E-H1-VERDICT-GATE` S10. **전 H1 체인(S1-S7) 1발 통합 E2E.** test-only(프로덕션 코드 변경 0).

### 흐름 (실 Postgres · full create_all)
1. **준비**: in-review story + implementation participation + `OrgGatePolicy(conservative→ask)`.
2. **CI pass verdict**: `capture_pr_ci_verdict`(merged·ci=pass) → pr/ci verdict 기록(`fetch_pr_review_rounds` mock).
3. **merge gate**: `evaluate_merge_gate` → policy ask → gate `pending` · decision `ask_human` · merge gate 생성.
4. **human approve**: `transition_gate(approved, resolver)` → S7 merge verdict 환류.
5. **done**: approve 후 story `done` 전이.

### 끝단 검증
- **verdict count ≥ 2**(pr/ci/merge·증가).
- `compute_member_trust_scores` scores 비지 않음·**`clean_pass_rate` non-null**(trust null 아님).
- **merge gate 정확히 1개**(`create_gate` 멱등).
- story `status=done`.

> ⚠️ **이 E2E가 green이 아니면 웨지 출시(`H1_MERGE_GATE_ENABLED` enable) 금지 = 접는조건 게이트.** `_REAL_DB_URL` 게이트(로컬 temp PG 실증·CI alembic-fresh-db 재검증).

### Validation
끝단 E2E **1발 PASS**(temp PG). forward-verify: capture_pr_ci_verdict·evaluate_merge_gate·transition_gate·compute_member_trust_scores 경로 develop 실재 확인.

> 에픽 `E-H1-VERDICT-GATE` S10(웨지 done 게이트). S8(FE·미르코)+S10 완료 시 웨지 완성·flag enable 준비. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)