### PR TITLE
[H1-S8] feat(cage): Gate evidence panel — 머지 verdict 게이트 증거 read-only

### DIFF
--- a/apps/web/messages/en.json
+++ b/apps/web/messages/en.json
@@ -2587,6 +2587,20 @@
     "corrections": "Rounds",
     "correctionRounds": "{count} correction(s)",
     "byRole": "By Role",
-    "gateTabLabel": "Gates"
+    "gateTabLabel": "Gates",
+    "decisionAutoMerge": "Auto-passed",
+    "decisionAskHuman": "Review needed",
+    "decisionBlock": "Blocked",
+    "ciLabel": "CI",
+    "ciPass": "Passed",
+    "ciFail": "Failed",
+    "ciUnknown": "Unknown",
+    "trustLabel": "Trust",
+    "trustScorePercent": "{score}%",
+    "selfReportTag": "Self-reported",
+    "reasonLabel": "Reason",
+    "gateReadonlyBlock": "Auto-blocked · read-only",
+    "gateReadonlyAuto": "Auto-passed · no action needed",
+    "mergeGateTitle": "Merge gate"
   }
 }

--- a/apps/web/messages/ko.json
+++ b/apps/web/messages/ko.json
@@ -2587,6 +2587,20 @@
     "corrections": "정정",
     "correctionRounds": "정정 {count}회",
     "byRole": "역할별",
-    "gateTabLabel": "게이트"
+    "gateTabLabel": "게이트",
+    "decisionAutoMerge": "자동 통과",
+    "decisionAskHuman": "확인 필요",
+    "decisionBlock": "차단됨",
+    "ciLabel": "CI",
+    "ciPass": "통과",
+    "ciFail": "실패",
+    "ciUnknown": "알 수 없음",
+    "trustLabel": "신뢰도",
+    "trustScorePercent": "{score}%",
+    "selfReportTag": "자기보고",
+    "reasonLabel": "사유",
+    "gateReadonlyBlock": "자동 차단 · 읽기 전용",
+    "gateReadonlyAuto": "자동 통과 · 액션 불필요",
+    "mergeGateTitle": "머지 게이트"
   }
 }

--- a/apps/web/src/components/cage/gate-evidence.tsx
+++ b/apps/web/src/components/cage/gate-evidence.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+import { Badge } from '@/components/ui/badge';
+import type { GateItem } from '@/components/kanban/types';
+
+/**
+ * H1-S8 머지 verdict 게이트 evidence(read-only 표시). 3 surface(GateInbox row·story detail·
+ * approve/reject facts) 공용. 신규 화면 0 — decision 배지 + facts(CI·신뢰도) + 사유.
+ *
+ * 🔑 핵심 가드(AC③): 신뢰도 None=`null`은 "데이터 없음"으로만 표시한다. 0%/빨강/낮음으로
+ * 절대 환원하지 않는다(null≠0 — 미측정과 0은 다르다). CI 미상도 동형(? 알 수 없음).
+ * 플랫폼은 위험도 판단을 하지 않는다(neutral_facts = 관찰 사실).
+ *
+ * decision 배지 3종(BE decision = auto_merge|ask_human|block). gate status=pending(미transition)은
+ * ask_human "확인 필요"로 통합(유나 정합 노트 — 별도 "대기" 배지 불필요). 리뷰 증거는 gate 응답에
+ * 미노출이라 v1 제외(억지 "없음"=오정보·디디 follow-up). evidence_status는 배지 X·맥락 보조만.
+ */
+
+type Decision = 'auto_merge' | 'ask_human' | 'block';
+
+const DECISION_META: Record<Decision, { variant: 'success' | 'warning' | 'destructive'; mark: string; labelKey: string }> = {
+  auto_merge: { variant: 'success', mark: '✓', labelKey: 'decisionAutoMerge' },
+  ask_human: { variant: 'warning', mark: '⏸', labelKey: 'decisionAskHuman' },
+  block: { variant: 'destructive', mark: '⛔', labelKey: 'decisionBlock' },
+};
+
+const DECISIONS = new Set(['auto_merge', 'ask_human', 'block']);
+
+/** auto_decision_reason(raw decision) 우선. 미상 + status=pending → ask_human 통합. 그 외 null. */
+export function gateDecision(gate: GateItem): Decision | null {
+  const raw = gate.auto_decision_reason;
+  if (raw && DECISIONS.has(raw)) return raw as Decision;
+  if (gate.status === 'pending') return 'ask_human';
+  return null;
+}
+
+/** requires_human=true면 사람 액션 대상. 단 block은 읽기 전용(override=BE 정책 미정·열린항목④). */
+export function gateNeedsAction(gate: GateItem): boolean {
+  return gate.requires_human === true && gateDecision(gate) !== 'block';
+}
+
+function ciResult(gate: GateItem): 'pass' | 'fail' | null {
+  const v = gate.neutral_facts?.['ci_result'];
+  return v === 'pass' || v === 'fail' ? v : null;
+}
+
+function trustScore(gate: GateItem): number | null {
+  const v = gate.neutral_facts?.['trust'];
+  return typeof v === 'number' ? v : null; // null≠0 — 미측정 보존(AC③)
+}
+
+export function GateEvidence({ gate, className }: { gate: GateItem; className?: string }) {
+  const t = useTranslations('cage');
+  const decision = gateDecision(gate);
+  const ci = ciResult(gate);
+  const trust = trustScore(gate);
+  const selfReportOnly = gate.neutral_facts?.['self_report_only'] === true;
+  const reason = gate.decision_basis ?? gate.auto_decision_reason ?? null;
+
+  return (
+    <div className={className}>
+      {decision ? (
+        <Badge variant={DECISION_META[decision].variant} className="shrink-0">
+          <span aria-hidden className="mr-0.5">{DECISION_META[decision].mark}</span>
+          {t(DECISION_META[decision].labelKey)}
+        </Badge>
+      ) : null}
+
+      {/* facts: CI · 신뢰도 (배지 아래·muted·· 구분). 리뷰는 gate 미노출이라 v1 제외. */}
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11.5px] text-muted-foreground">
+        <span>
+          {t('ciLabel')}:{' '}
+          {ci === 'pass' ? (
+            <span className="text-success">✓ {t('ciPass')}</span>
+          ) : ci === 'fail' ? (
+            <span className="text-destructive">✗ {t('ciFail')}</span>
+          ) : (
+            <span>? {t('ciUnknown')}</span>
+          )}
+        </span>
+        <span aria-hidden>·</span>
+        <span className="inline-flex items-center gap-1">
+          {t('trustLabel')}:{' '}
+          {trust === null ? (
+            <span className="italic text-muted-foreground">{t('trustScoreNoData')}</span>
+          ) : (
+            <span className="text-foreground">{t('trustScorePercent', { score: Math.round(trust * 100) })}</span>
+          )}
+          {/* 증거가 자기보고뿐(독립 CI verdict 부재) — 신뢰 맥락 보조 신호(보너스). */}
+          {selfReportOnly ? (
+            <span className="rounded bg-muted px-1 py-px text-[10px] text-muted-foreground">{t('selfReportTag')}</span>
+          ) : null}
+        </span>
+      </div>
+
+      {/* 사유 1줄(decision_basis·AC①②) */}
+      {reason ? (
+        <p className="mt-1 text-[11.5px] text-muted-foreground">
+          {t('reasonLabel')} · {reason}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/cage/gate-inbox.tsx
+++ b/apps/web/src/components/cage/gate-inbox.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { CheckCircle, XCircle } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { GateEvidence, gateNeedsAction, gateDecision } from '@/components/cage/gate-evidence';
 import type { GateItem } from '@/components/kanban/types';
 
 interface GateInboxProps {
@@ -82,38 +82,45 @@ export function GateInbox({ memberId }: GateInboxProps) {
         </div>
       ) : (
         gates.map((gate) => (
-          <div key={gate.id} className="flex items-center justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3">
-            <div className="min-w-0 space-y-1">
+          <div key={gate.id} className="flex items-start justify-between gap-3 rounded-xl border border-border bg-card px-4 py-3">
+            <div className="min-w-0 flex-1 space-y-1">
               <div className="flex items-center gap-2">
-                <Badge variant="info" className="shrink-0">
-                  <span className="mr-1">⏸</span>{gate.gate_type}
-                </Badge>
+                <span className="shrink-0 text-xs font-medium text-foreground">{gate.gate_type}</span>
                 <span className="truncate text-xs text-muted-foreground">#{gate.work_item_id.slice(0, 6)}</span>
+                <span className="shrink-0 text-[10px] text-muted-foreground/70">{new Date(gate.created_at).toLocaleDateString()}</span>
               </div>
-              <p className="text-[10px] text-muted-foreground">{new Date(gate.created_at).toLocaleDateString()}</p>
+              {/* H1-S8: decision 배지 + CI/신뢰도 facts + 사유(read-only evidence) */}
+              <GateEvidence gate={gate} className="mt-1" />
             </div>
-            <div className="flex shrink-0 items-center gap-1.5">
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
-                disabled={resolving === gate.id}
-                onClick={() => void handleApprove(gate.id)}
-              >
-                <CheckCircle className="size-3.5" />
-                {t('gateApprove')}
-              </Button>
-              <Button
-                size="sm"
-                variant="ghost"
-                className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
-                disabled={resolving === gate.id}
-                onClick={() => setRejectModal({ gateId: gate.id, note: '' })}
-              >
-                <XCircle className="size-3.5" />
-                {t('gateReject')}
-              </Button>
-            </div>
+            {/* 액션 = requires_human 기준(block 제외·읽기전용·AC⑤). 미충족 게이트는 표시만. */}
+            {gateNeedsAction(gate) ? (
+              <div className="flex shrink-0 items-center gap-1.5">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1 text-success hover:bg-success-tint hover:text-success"
+                  disabled={resolving === gate.id}
+                  onClick={() => void handleApprove(gate.id)}
+                >
+                  <CheckCircle className="size-3.5" />
+                  {t('gateApprove')}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  className="h-7 gap-1 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  disabled={resolving === gate.id}
+                  onClick={() => setRejectModal({ gateId: gate.id, note: '' })}
+                >
+                  <XCircle className="size-3.5" />
+                  {t('gateReject')}
+                </Button>
+              </div>
+            ) : (
+              <span className="shrink-0 self-center text-[11px] text-muted-foreground">
+                {gateDecision(gate) === 'block' ? t('gateReadonlyBlock') : t('gateReadonlyAuto')}
+              </span>
+            )}
           </div>
         ))
       )}

--- a/apps/web/src/components/cage/story-merge-gate.tsx
+++ b/apps/web/src/components/cage/story-merge-gate.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { GateEvidence } from '@/components/cage/gate-evidence';
+import type { GateItem } from '@/components/kanban/types';
+
+const MERGE_GATE_TYPE = 'merge';
+
+/**
+ * H1-S8 surface②: story-detail-panel 머지 게이트 evidence 섹션(read-only). 그 스토리에 merge
+ * 게이트가 있으면 `GateEvidence` 1개 노출(decision 배지 + CI/신뢰도 facts + 사유). 없으면 렌더 0
+ * (빈 섹션 미표시). 액션(승인/반려)은 surface①(GateInbox)에만 — 여기는 표시만.
+ *
+ * 데이터: GET /api/gates?work_item_id=<story>&work_item_type=story (raw 배열 패스스루). story↔gate
+ * 매핑 단순(BE list_gates work_item_id 필터)이라 v1 포함(유나 기준·추가 BE 0).
+ */
+export function StoryMergeGate({ storyId }: { storyId: string }) {
+  const t = useTranslations('cage');
+  const [gate, setGate] = useState<GateItem | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(`/api/gates?work_item_id=${storyId}&work_item_type=story`, { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : []))
+      .then((gates: GateItem[]) => {
+        if (cancelled) return;
+        const merge = Array.isArray(gates)
+          ? gates.find((g) => g.gate_type === MERGE_GATE_TYPE) ?? null
+          : null;
+        setGate(merge);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [storyId]);
+
+  if (!gate) return null;
+
+  return (
+    <section aria-label={t('mergeGateTitle')} className="rounded-xl border border-border bg-muted/20 p-3">
+      <h3 className="mb-2 text-sm font-semibold text-foreground">{t('mergeGateTitle')}</h3>
+      <GateEvidence gate={gate} />
+    </section>
+  );
+}

--- a/apps/web/src/components/kanban/story-detail-panel.tsx
+++ b/apps/web/src/components/kanban/story-detail-panel.tsx
@@ -16,6 +16,7 @@ import { LabelChip, LABEL_PRESET_COLORS, type LabelData } from '@/components/ui/
 import { DependencyGraph } from './dependency-graph';
 import { OutcomeResultCard, type OutcomeResult } from '@/components/outcome/outcome-result-card';
 import { StoryHypothesesSection } from '@/components/hypotheses/story-hypotheses-section';
+import { StoryMergeGate } from '@/components/cage/story-merge-gate';
 import { EntityDispatchPanel } from '@/components/dispatch/entity-dispatch-panel';
 import { Button } from '@/components/ui/button';
 import { StatusBadge } from '@/components/ui/status-badge';
@@ -1221,6 +1222,8 @@ export function StoryDetailPanel({ story, tasks, nextTasksCursor = null, loading
                   projectId={projectId}
                 />
               ) : null}
+              {/* H1-S8 surface②: 머지 게이트 evidence(read-only·gate 있을 때만 노출) */}
+              <StoryMergeGate storyId={story.id} />
             </div>
 
             {/* Tabs for Tasks, Comments, Activity */}

--- a/apps/web/src/components/kanban/types.ts
+++ b/apps/web/src/components/kanban/types.ts
@@ -35,6 +35,11 @@ export interface GateItem {
   resolved_at: string | null;
   resolution_note: string | null;
   neutral_facts: Record<string, unknown> | null;
+  // H1-S3 머지 verdict 게이트 evidence(GateResponse·additive·하위호환 default). null≠0(AC③).
+  requires_human?: boolean;
+  evidence_status?: string | null; // sufficient | blocked | insufficient
+  decision_basis?: string | null; // 사람 reason
+  auto_decision_reason?: string | null; // auto_merge | ask_human | block (raw decision)
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## 무엇을 (유나양 핸드오프 `h1-s8-gate-evidence-handoff`)

머지 verdict 게이트 evidence(decision + CI/신뢰도 + 사유)를 UI에 **read-only 노출**. 신규 화면 0 — 기존 `GateInbox`/`Badge` 확장. **3 surface**: ①GateInbox row ②Story detail 머지 게이트 섹션 ③approve/reject facts(=① 흡수).

## BE 계약 (코드 실측 · develop)

`GateResponse` evidence 4필드: `requires_human`·`evidence_status`(sufficient/blocked/insufficient)·`decision_basis`(사람 reason)·`auto_decision_reason`(`auto_merge`/`ask_human`/`block`). `neutral_facts`={ci_result(pass/fail/null)·**trust(clean_pass_rate 0~1 float·null)**·self_report_only}. approve/reject = 기존 `POST /api/gates/{id}/transition`(신규 0·AC④). list_gates `work_item_id`/`work_item_type`/`status` 필터.

## 구현

- **신규 `gate-evidence.tsx`**(3 surface 공용·display-only): decision **3배지**(auto_merge=success✓ / ask_human=warning⏸ / block=destructive⛔ — Badge variant 재사용 = 토큰 틴트·**매직 hex 0**) + facts(CI ✓/✗/? · 신뢰도 `N%`/데이터없음) + 사유(decision_basis·AC①②) + self-report 태그(보너스). 🔑 **신뢰도 `null`="데이터 없음"**(0%/빨강/낮음 절대 X · null≠0 · **AC③ 핵심 가드**). status=pending(미transition)→ask_human "확인 필요" 통합(3배지). `gateNeedsAction = requires_human && decision≠block`.
- **신규 `story-merge-gate.tsx`**(surface②): story-detail-panel outcome 영역에 "머지 게이트" evidence 섹션(read-only·gate 있을 때만 노출). `GET /api/gates?work_item_id=&work_item_type=story`(BE 필터 지원·**추가 BE 0**).
- **`gate-inbox.tsx`**(surface①): 각 행에 `GateEvidence` + **액션 게이팅**(`gateNeedsAction`·block 읽기전용·AC⑤). 비-action 게이트는 "자동 차단·읽기 전용"/"자동 통과·액션 불필요" 라벨.
- `GateItem` 타입에 evidence 4필드 additive. i18n `cage` ns 16키 en/ko.

## 유나 결정/실측 반영

- **block 읽기전용**(BE `requires_human=true` 무관·override=BE 정책 미정·열린항목④·FE 선제노출 금지). `requires_human && decision≠block`.
- **리뷰 fact v1 제외**(gate 응답 미노출 → 억지 "없음"=오정보 · 디디 follow-up). v1 facts = CI · 신뢰도 2종.
- **trust 0~1 float → `%` 표기**(`merge_verdict_gate._impl_trust`=clean_pass_rate 실측·열린항목② 해소).
- **surface② v1 포함**(story↔gate 매핑 단순 = work_item_id 필터·유나 기준).
- **pending → ask_human 통합**(decision 3종·별도 "대기" 배지 불필요).

## AC

- [x] ①② decision_basis 사유 노출 · [x] ③ 신뢰도 null≠0 ("데이터 없음")
- [x] ④ approve/reject = 기존 endpoint(신규 0) · [x] ⑤ read-only = requires_human(block 제외)

## 검증

BE 계약 **코드 실측** · `tsc` 0 · `eslint` 0 · `next build` PASS · i18n 키 패리티.

## 리뷰

base `develop`. 게이팅: **유나 가디언 픽셀 → 까심 QA + PO grep → 머지 → 유나 라이브 픽셀**. 열린항목(BE): trust 표기(% 확정)·evidence_status 맥락·gate badge 위치·block override 정책.

🤖 Generated with [Claude Code](https://claude.com/claude-code)