### PR TITLE
fix(h1): persist decision metadata to gate row in evaluate_merge_gate (H1-FIX-1)

### DIFF
--- a/backend/app/services/merge_verdict_gate.py
+++ b/backend/app/services/merge_verdict_gate.py
@@ -41,6 +41,15 @@ BLOCK = "block"
 _STATUS_TO_DISPOSITION = {"auto_passed": "allow_auto", "pending": "ask", "rejected": "deny"}
 
 
+def _evidence_status(decision: str) -> str:
+    """decision → gate.evidence_status(S3 evidence 메타)."""
+    if decision == AUTO_MERGE:
+        return "sufficient"
+    if decision == BLOCK:
+        return "blocked"
+    return "insufficient"
+
+
 def _gate_org_allowlist() -> frozenset[uuid.UUID]:
     out: set[uuid.UUID] = set()
     for x in (settings.h1_merge_gate_org_allowlist or "").split(","):
@@ -212,6 +221,15 @@ async def evaluate_merge_gate(
         threshold=trust_threshold,
         self_report_only=self_report_only,
     )
+    # H1-FIX-1: decision 메타(S3 evidence 컬럼)를 gate row에 write-back — 모든 호출자(S4 report-done·
+    # S5 board preflight)가 영속화한다. 재평가 시 동일 키로 멱등 갱신. (이전엔 MergeGateDecision 리턴엔
+    # 있으나 gate row 영속화 0 → FE S8이 null을 읽어 GateInbox 액션 미노출 = dogfood 적발 버그.)
+    gate.requires_human = decision != AUTO_MERGE
+    gate.evidence_status = _evidence_status(decision)
+    gate.decision_basis = reason
+    gate.auto_decision_reason = decision
+    await session.flush()
+
     logger.info(
         "merge gate story=%s decision=%s (%s) gate_status=%s trust=%s",
         story_id, decision, reason, gate.status, trust,

--- a/backend/tests/test_h1_s10_e2e.py
+++ b/backend/tests/test_h1_s10_e2e.py
@@ -111,6 +111,15 @@ async def test_h1_end_to_end_ready_to_done():
             )).scalar()
             assert merge_gates == 1, f"merge gate 정확히 1개여야(멱등), got {merge_gates}"
 
+            # H1-FIX-1: gate row의 S3 evidence 메타가 decision으로 채워져야(영속화·FE S8이 읽음).
+            meta = (await s.execute(
+                _text("SELECT requires_human, evidence_status, decision_basis, auto_decision_reason "
+                      "FROM gate WHERE work_item_id=:sid AND gate_type='merge'"), {"sid": story_id}
+            )).one()
+            assert meta.requires_human is True, "ask_human 게이트는 requires_human=true여야(액션 노출)"
+            assert meta.evidence_status == "insufficient"
+            assert meta.decision_basis is not None and meta.auto_decision_reason == "ask_human"
+
             done_status = (await s.execute(
                 _text("SELECT status FROM stories WHERE id=:id"), {"id": story_id}
             )).scalar()

--- a/backend/tests/test_merge_verdict_gate.py
+++ b/backend/tests/test_merge_verdict_gate.py
@@ -272,3 +272,52 @@ async def test_new_contributor_no_self_bootstrap_real_db():
         async with engine.begin() as conn:
             await conn.run_sync(Base.metadata.drop_all)
         await engine.dispose()
+
+
+# ── H1-FIX-1: evaluate가 decision 메타를 gate row에 영속화 ────────────────────────
+
+@pytest.mark.anyio
+async def test_evaluate_persists_decision_metadata_on_gate():
+    """dogfood 버그 회귀: ask_human 게이트의 S3 evidence 메타가 gate row에 write-back돼야
+    (이전엔 리턴엔 있으나 영속화 0 → FE가 null 읽어 GateInbox 액션 미노출)."""
+    gate = SimpleNamespace(
+        id=uuid.uuid4(), status="pending",
+        requires_human=False, evidence_status=None, decision_basis=None, auto_decision_reason=None,
+    )
+    part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
+    with patch("app.services.merge_verdict_gate.resolve_implementation_participation",
+               AsyncMock(return_value=part)), \
+         patch("app.services.merge_verdict_gate._role_key", AsyncMock(return_value="implementation")), \
+         patch("app.services.merge_verdict_gate.capture_pr_ci_verdict",
+               AsyncMock(return_value={"recorded": [], "skipped_reason": "x"})), \
+         patch("app.services.merge_verdict_gate.compute_member_trust_scores",
+               AsyncMock(return_value={"scores": []})), \
+         patch("app.services.merge_verdict_gate.create_gate", AsyncMock(return_value=gate)):
+        res = await evaluate_merge_gate(
+            AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+            pr_number=1, repo="o/r", ci_result="pass", pr_result="pass",
+        )
+    assert res.decision == ASK_HUMAN  # trust None(pending) → ask_human.
+    # 메타가 decision과 일치하게 gate row에 영속화(write-back).
+    assert gate.requires_human is True
+    assert gate.evidence_status == "insufficient"
+    assert gate.decision_basis == res.reason
+    assert gate.auto_decision_reason == ASK_HUMAN
+
+
+@pytest.mark.anyio
+async def test_evaluate_auto_merge_metadata_sufficient():
+    gate = SimpleNamespace(id=uuid.uuid4(), status="auto_passed",
+                           requires_human=True, evidence_status=None, decision_basis=None, auto_decision_reason=None)
+    part = SimpleNamespace(member_id=uuid.uuid4(), role_id=uuid.uuid4())
+    with patch("app.services.merge_verdict_gate.resolve_implementation_participation", AsyncMock(return_value=part)), \
+         patch("app.services.merge_verdict_gate._role_key", AsyncMock(return_value="implementation")), \
+         patch("app.services.merge_verdict_gate.capture_pr_ci_verdict", AsyncMock(return_value={"recorded": ["pr"], "skipped_reason": None})), \
+         patch("app.services.merge_verdict_gate.compute_member_trust_scores",
+               AsyncMock(return_value={"scores": [{"role_key": "implementation", "clean_pass_rate": 0.95}]})), \
+         patch("app.services.merge_verdict_gate.create_gate", AsyncMock(return_value=gate)):
+        res = await evaluate_merge_gate(AsyncMock(), uuid.uuid4(), uuid.uuid4(),
+                                        pr_number=1, repo="o/r", ci_result="pass", pr_result="pass")
+    assert res.decision == AUTO_MERGE
+    assert gate.requires_human is False and gate.evidence_status == "sufficient"
+    assert gate.auto_decision_reason == AUTO_MERGE


### PR DESCRIPTION
## H1-FIX-1 — gate row에 decision 메타 영속화 (dogfood 적발)

dogfood 실 스모크(`in-review→done`·board 경로)가 잡은 실버그: ask_human pending gate는 생성되나(id `011c2098`·merge·pending) **gate row의 S3 evidence 메타가 다 빔**(API 실측 `requires_human=false`·`decision_basis`/`evidence_status`/`auto_decision_reason`=null).

### 근본
`evaluate_merge_gate`이 `create_gate`(bare) + `_decide`(decision 계산)인데 **decision 메타를 gate row에 write-back 안 함** — `MergeGateDecision` 리턴엔 있으나 영속화 0. S4 report-done은 `_record_gate_evidence`로 별도 기록했으나 **S5 board preflight 경로엔 그게 없어** 메타 미영속. → FE S8 GateInbox가 `gateNeedsAction = requires_human && !block`로 판정 → `requires_human=false`면 keep/kill 액션 미노출 → **사람이 게이트를 못 움직임.**

### Fix
`_decide` 직후 gate row에 4메타 write-back을 **`evaluate_merge_gate`(양 경로 S4·S5 공통점)**에 추가. 재평가 시 동일 키 **멱등 갱신**. `_evidence_status(decision)` → `sufficient|insufficient|blocked`.

```python
gate.requires_human = decision != AUTO_MERGE
gate.evidence_status = _evidence_status(decision)
gate.decision_basis = reason
gate.auto_decision_reason = decision
await session.flush()
```

### Validation
신규 단위 2(ask_human→`requires_human=true`·`evidence_status=insufficient`·`decision_basis`·`auto_decision_reason` 영속화 / auto_merge→`sufficient`) + **S10 E2E 보강**(gate 존재+메타 채움 동시 assert·실DB) + merge gate/S4/S5 **31 무회귀**·`app.main` import OK.

> ⚠️ 이 fix 스토리(`fcc26c37`) 자체가 게이트를 통과하며 dogfood — 고치면 메타 제대로 뜨는 게 증거. 까심 QA(codex 5.5)→PO 머지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)